### PR TITLE
Add build methods to create CompletionSuggestionBuilder from query and parse contexts

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -717,13 +717,6 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
-     * Reads a completion {@link QueryContext} from the current stream
-     */
-    public QueryContext readCompletionSuggestionQueryContext() throws IOException {
-        return readNamedWriteable(QueryContext.class);
-    }
-
-    /**
      * Reads a {@link org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder} from the current stream
      */
     public ScoreFunctionBuilder<?> readScoreFunction() throws IOException {

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -740,10 +740,4 @@ public abstract class StreamOutput extends OutputStream {
         writeNamedWriteable(suggestion);
     }
 
-    /**
-     * Writes a completion {@link QueryContext} to the current stream
-     */
-    public void writeCompletionSuggestionQueryContext(QueryContext queryContext) throws IOException {
-        writeNamedWriteable(queryContext);
-    }
 }

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
@@ -84,7 +84,7 @@ public class CompletionSuggester extends Suggester<CompletionSuggestionContext> 
             }
             // collect payloads
             final Map<String, List<Object>> payload = new HashMap<>(0);
-            Set<String> payloadFields = suggestionContext.getPayloadFields();
+            List<String> payloadFields = suggestionContext.getPayloadFields();
             if (payloadFields.isEmpty() == false) {
                 final int readerIndex = ReaderUtil.subIndex(suggestDoc.doc, leaves);
                 final LeafReaderContext subReaderContext = leaves.get(readerIndex);

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionContext.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionContext.java
@@ -44,7 +44,7 @@ public class CompletionSuggestionContext extends SuggestionSearchContext.Suggest
     private CompletionFieldMapper.CompletionFieldType fieldType;
     private FuzzyOptions fuzzyOptions;
     private RegexOptions regexOptions;
-    private Map<String, List<ContextMapping.QueryContext>> queryContexts = Collections.emptyMap();
+    private Map<String, List<ContextMapping.InternalQueryContext>> queryContexts = Collections.emptyMap();
     private Set<String> payloadFields = Collections.emptySet();
 
     CompletionFieldMapper.CompletionFieldType getFieldType() {
@@ -55,15 +55,15 @@ public class CompletionSuggestionContext extends SuggestionSearchContext.Suggest
         this.fieldType = fieldType;
     }
 
-    void setRegexOptionsBuilder(RegexOptions.Builder regexOptionsBuilder) {
-        this.regexOptions = regexOptionsBuilder.build();
+    void setRegexOptions(RegexOptions regexOptions) {
+        this.regexOptions = regexOptions;
     }
 
-    void setFuzzyOptionsBuilder(FuzzyOptions.Builder fuzzyOptionsBuilder) {
-        this.fuzzyOptions = fuzzyOptionsBuilder.build();
+    void setFuzzyOptions(FuzzyOptions fuzzyOptions) {
+        this.fuzzyOptions = fuzzyOptions;
     }
 
-    void setQueryContexts(Map<String, List<ContextMapping.QueryContext>> queryContexts) {
+    void setQueryContexts(Map<String, List<ContextMapping.InternalQueryContext>> queryContexts) {
         this.queryContexts = queryContexts;
     }
 
@@ -77,6 +77,18 @@ public class CompletionSuggestionContext extends SuggestionSearchContext.Suggest
 
     Set<String> getPayloadFields() {
         return payloadFields;
+    }
+
+    public FuzzyOptions getFuzzyOptions() {
+        return fuzzyOptions;
+    }
+
+    public RegexOptions getRegexOptions() {
+        return regexOptions;
+    }
+
+    public Map<String, List<ContextMapping.InternalQueryContext>> getQueryContexts() {
+        return queryContexts;
     }
 
     CompletionQuery toQuery() {

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionContext.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionContext.java
@@ -27,10 +27,8 @@ import org.elasticsearch.search.suggest.completion.context.ContextMapping;
 import org.elasticsearch.search.suggest.completion.context.ContextMappings;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  *
@@ -45,7 +43,7 @@ public class CompletionSuggestionContext extends SuggestionSearchContext.Suggest
     private FuzzyOptions fuzzyOptions;
     private RegexOptions regexOptions;
     private Map<String, List<ContextMapping.InternalQueryContext>> queryContexts = Collections.emptyMap();
-    private Set<String> payloadFields = Collections.emptySet();
+    private List<String> payloadFields = Collections.emptyList();
 
     CompletionFieldMapper.CompletionFieldType getFieldType() {
         return this.fieldType;
@@ -67,15 +65,11 @@ public class CompletionSuggestionContext extends SuggestionSearchContext.Suggest
         this.queryContexts = queryContexts;
     }
 
-    void setPayloadFields(Set<String> fields) {
+    void setPayloadFields(List<String> fields) {
         this.payloadFields = fields;
     }
 
-    void setPayloadFields(List<String> fields) {
-        setPayloadFields(new HashSet<>(fields));
-    }
-
-    Set<String> getPayloadFields() {
+    List<String> getPayloadFields() {
         return payloadFields;
     }
 

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/FuzzyOptions.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/FuzzyOptions.java
@@ -40,20 +40,20 @@ import java.util.Objects;
  */
 public class FuzzyOptions implements ToXContent, Writeable<FuzzyOptions> {
     static final ParseField FUZZY_OPTIONS = new ParseField("fuzzy");
-    static final ParseField TRANSPOSITION_FIELD = new ParseField("transpositions");
-    static final ParseField MIN_LENGTH_FIELD = new ParseField("min_length");
-    static final ParseField PREFIX_LENGTH_FIELD = new ParseField("prefix_length");
-    static final ParseField UNICODE_AWARE_FIELD = new ParseField("unicode_aware");
-    static final ParseField MAX_DETERMINIZED_STATES_FIELD = new ParseField("max_determinized_states");
+    private static final ParseField TRANSPOSITION_FIELD = new ParseField("transpositions");
+    private static final ParseField MIN_LENGTH_FIELD = new ParseField("min_length");
+    private static final ParseField PREFIX_LENGTH_FIELD = new ParseField("prefix_length");
+    private static final ParseField UNICODE_AWARE_FIELD = new ParseField("unicode_aware");
+    private static final ParseField MAX_DETERMINIZED_STATES_FIELD = new ParseField("max_determinized_states");
 
-    static ObjectParser<FuzzyOptions.Builder, Void> FUZZY_PARSER = new ObjectParser<>(FUZZY_OPTIONS.getPreferredName(), Builder::new);
+    private static ObjectParser<Builder, Void> PARSER = new ObjectParser<>(FUZZY_OPTIONS.getPreferredName(), Builder::new);
     static {
-        FUZZY_PARSER.declareInt(FuzzyOptions.Builder::setFuzzyMinLength, MIN_LENGTH_FIELD);
-        FUZZY_PARSER.declareInt(FuzzyOptions.Builder::setMaxDeterminizedStates, MAX_DETERMINIZED_STATES_FIELD);
-        FUZZY_PARSER.declareBoolean(FuzzyOptions.Builder::setUnicodeAware, UNICODE_AWARE_FIELD);
-        FUZZY_PARSER.declareInt(FuzzyOptions.Builder::setFuzzyPrefixLength, PREFIX_LENGTH_FIELD);
-        FUZZY_PARSER.declareBoolean(FuzzyOptions.Builder::setTranspositions, TRANSPOSITION_FIELD);
-        FUZZY_PARSER.declareValue((a, b) -> {
+        PARSER.declareInt(Builder::setFuzzyMinLength, MIN_LENGTH_FIELD);
+        PARSER.declareInt(Builder::setMaxDeterminizedStates, MAX_DETERMINIZED_STATES_FIELD);
+        PARSER.declareBoolean(Builder::setUnicodeAware, UNICODE_AWARE_FIELD);
+        PARSER.declareInt(Builder::setFuzzyPrefixLength, PREFIX_LENGTH_FIELD);
+        PARSER.declareBoolean(Builder::setTranspositions, TRANSPOSITION_FIELD);
+        PARSER.declareValue((a, b) -> {
             try {
                 a.setFuzziness(Fuzziness.parse(b).asDistance());
             } catch (IOException e) {
@@ -82,8 +82,8 @@ public class FuzzyOptions implements ToXContent, Writeable<FuzzyOptions> {
     private FuzzyOptions() {
     }
 
-    public static FuzzyOptions parse(XContentParser parser) throws IOException {
-        return FUZZY_PARSER.parse(parser).build();
+    static FuzzyOptions parse(XContentParser parser) throws IOException {
+        return PARSER.parse(parser).build();
     }
 
     public static Builder builder() {

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/RegexOptions.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/RegexOptions.java
@@ -38,17 +38,14 @@ import java.io.IOException;
  * Regular expression options for completion suggester
  */
 public class RegexOptions implements ToXContent, Writeable<RegexOptions> {
-    static final String NAME = "regex";
-    static final ParseField REGEX_OPTIONS = new ParseField(NAME);
-    static final ParseField FLAGS_VALUE = new ParseField("flags", "flags_value");
-    static final ParseField MAX_DETERMINIZED_STATES = new ParseField("max_determinized_states");
+    static final ParseField REGEX_OPTIONS = new ParseField("regex");
+    private static final ParseField FLAGS_VALUE = new ParseField("flags", "flags_value");
+    private static final ParseField MAX_DETERMINIZED_STATES = new ParseField("max_determinized_states");
 
-
-    private static ObjectParser<RegexOptions.Builder, Void> REGEXP_PARSER =
-        new ObjectParser<>(REGEX_OPTIONS.getPreferredName(), RegexOptions.Builder::new);
+    private static ObjectParser<Builder, Void> PARSER = new ObjectParser<>(REGEX_OPTIONS.getPreferredName(), Builder::new);
     static {
-        REGEXP_PARSER.declareInt(RegexOptions.Builder::setMaxDeterminizedStates, MAX_DETERMINIZED_STATES);
-        REGEXP_PARSER.declareField((parser, builder, aVoid) -> {
+        PARSER.declareInt(Builder::setMaxDeterminizedStates, MAX_DETERMINIZED_STATES);
+        PARSER.declareField((parser, builder, aVoid) -> {
             if (parser.currentToken() == XContentParser.Token.VALUE_STRING) {
                 builder.setFlags(parser.text());
             } else if (parser.currentToken() == XContentParser.Token.VALUE_NUMBER) {
@@ -58,7 +55,7 @@ public class RegexOptions implements ToXContent, Writeable<RegexOptions> {
                     + " " + FLAGS_VALUE.getPreferredName() + " supports string or number");
             }
         }, FLAGS_VALUE, ObjectParser.ValueType.VALUE);
-        REGEXP_PARSER.declareStringOrNull(RegexOptions.Builder::setFlags, FLAGS_VALUE);
+        PARSER.declareStringOrNull(Builder::setFlags, FLAGS_VALUE);
     }
 
     private int flagsValue;
@@ -91,8 +88,8 @@ public class RegexOptions implements ToXContent, Writeable<RegexOptions> {
         return new Builder();
     }
 
-    public static RegexOptions parse(XContentParser parser) throws IOException {
-        return REGEXP_PARSER.parse(parser).build();
+    static RegexOptions parse(XContentParser parser) throws IOException {
+        return PARSER.parse(parser).build();
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryContextMapping.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryContextMapping.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A {@link ContextMapping} that uses a simple string as a criteria
@@ -44,7 +45,7 @@ import java.util.Set;
  * {@link CategoryQueryContext} defines options for constructing
  * a unit of query context for this context type
  */
-public class CategoryContextMapping extends ContextMapping {
+public class CategoryContextMapping extends ContextMapping<CategoryQueryContext> {
 
     private static final String FIELD_FIELDNAME = "path";
 
@@ -137,6 +138,11 @@ public class CategoryContextMapping extends ContextMapping {
         return (values == null) ? Collections.<CharSequence>emptySet() : values;
     }
 
+    @Override
+    protected CategoryQueryContext prototype() {
+        return CategoryQueryContext.PROTOTYPE;
+    }
+
     /**
      * Parse a list of {@link CategoryQueryContext}
      * using <code>parser</code>. A QueryContexts accepts one of the following forms:
@@ -154,19 +160,13 @@ public class CategoryContextMapping extends ContextMapping {
      *  </ul>
      */
     @Override
-    public List<QueryContext> parseQueryContext(XContentParser parser) throws IOException, ElasticsearchParseException {
-        List<QueryContext> queryContexts = new ArrayList<>();
-        Token token = parser.nextToken();
-        if (token == Token.START_OBJECT || token == Token.VALUE_STRING) {
-            CategoryQueryContext parse = CategoryQueryContext.PROTOTYPE.fromXContext(parser);
-            queryContexts.add(new QueryContext(parse.getCategory(), parse.getBoost(), parse.isPrefix()));
-        } else if (token == Token.START_ARRAY) {
-            while (parser.nextToken() != Token.END_ARRAY) {
-                CategoryQueryContext parse = CategoryQueryContext.PROTOTYPE.fromXContext(parser);
-                queryContexts.add(new QueryContext(parse.getCategory(), parse.getBoost(), parse.isPrefix()));
-            }
-        }
-        return queryContexts;
+    public List<InternalQueryContext> toInternalQueryContexts(List<CategoryQueryContext> queryContexts) {
+        List<InternalQueryContext> internalInternalQueryContexts = new ArrayList<>(queryContexts.size());
+        internalInternalQueryContexts.addAll(
+            queryContexts.stream()
+                .map(queryContext -> new InternalQueryContext(queryContext.getCategory(), queryContext.getBoost(), queryContext.isPrefix()))
+                .collect(Collectors.toList()));
+        return internalInternalQueryContexts;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryQueryContext.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryQueryContext.java
@@ -21,14 +21,11 @@ package org.elasticsearch.search.suggest.completion.context;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Objects;
 
 import static org.elasticsearch.search.suggest.completion.context.CategoryContextMapping.CONTEXT_BOOST;
@@ -98,11 +95,6 @@ public final class CategoryQueryContext implements QueryContext {
         return result;
     }
 
-    @Override
-    public String getWriteableName() {
-        return NAME;
-    }
-
     private static ObjectParser<Builder, Void> CATEGORY_PARSER = new ObjectParser<>(NAME, null);
     static {
         CATEGORY_PARSER.declareString(Builder::setCategory, new ParseField(CONTEXT_VALUE));
@@ -132,22 +124,6 @@ public final class CategoryQueryContext implements QueryContext {
         builder.field(CONTEXT_PREFIX, isPrefix);
         builder.endObject();
         return builder;
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeBoolean(isPrefix);
-        out.writeVInt(boost);
-        out.writeString(category);
-    }
-
-    @Override
-    public QueryContext readFrom(StreamInput in) throws IOException {
-        Builder builder = new Builder();
-        builder.isPrefix = in.readBoolean();
-        builder.boost = in.readVInt();
-        builder.category = in.readString();
-        return builder.build();
     }
 
     public static class Builder {

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMapping.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMapping.java
@@ -96,12 +96,15 @@ public abstract class ContextMapping<T extends QueryContext> implements ToXConte
      */
     protected abstract Set<CharSequence> parseContext(ParseContext.Document document);
 
+    /**
+     * Prototype for the query context
+     */
     protected abstract T prototype();
 
     /**
      * Parses query contexts for this mapper
      */
-    public List<InternalQueryContext> parseQueryContext(XContentParser parser) throws IOException, ElasticsearchParseException {
+    public final List<InternalQueryContext> parseQueryContext(XContentParser parser) throws IOException, ElasticsearchParseException {
         List<T> queryContexts = new ArrayList<>();
         Token token = parser.nextToken();
         if (token == Token.START_OBJECT || token == Token.VALUE_STRING) {
@@ -114,6 +117,9 @@ public abstract class ContextMapping<T extends QueryContext> implements ToXConte
         return toInternalQueryContexts(queryContexts);
     }
 
+    /**
+     * Convert query contexts to common representation
+     */
     protected abstract List<InternalQueryContext> toInternalQueryContexts(List<T> queryContexts);
 
     /**

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMappings.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMappings.java
@@ -152,7 +152,7 @@ public class ContextMappings implements ToXContent {
      * @param queryContexts a map of context mapping name and collected query contexts
      * @return a context-enabled query
      */
-    public ContextQuery toContextQuery(CompletionQuery query, Map<String, List<ContextMapping.QueryContext>> queryContexts) {
+    public ContextQuery toContextQuery(CompletionQuery query, Map<String, List<ContextMapping.InternalQueryContext>> queryContexts) {
         ContextQuery typedContextQuery = new ContextQuery(query);
         if (queryContexts.isEmpty() == false) {
             CharsRefBuilder scratch = new CharsRefBuilder();
@@ -161,9 +161,9 @@ public class ContextMappings implements ToXContent {
                 scratch.setCharAt(0, (char) typeId);
                 scratch.setLength(1);
                 ContextMapping mapping = contextMappings.get(typeId);
-                List<ContextMapping.QueryContext> queryContext = queryContexts.get(mapping.name());
-                if (queryContext != null) {
-                    for (ContextMapping.QueryContext context : queryContext) {
+                List<ContextMapping.InternalQueryContext> internalQueryContext = queryContexts.get(mapping.name());
+                if (internalQueryContext != null) {
+                    for (ContextMapping.InternalQueryContext context : internalQueryContext) {
                         scratch.append(context.context);
                         typedContextQuery.addContext(scratch.toCharsRef(), context.boost, !context.isPrefix);
                         scratch.setLength(1);

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoQueryContext.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoQueryContext.java
@@ -23,14 +23,11 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -114,11 +111,6 @@ public final class GeoQueryContext implements QueryContext {
         return new Builder();
     }
 
-    @Override
-    public String getWriteableName() {
-        return NAME;
-    }
-
     private static ObjectParser<GeoQueryContext.Builder, Void> GEO_CONTEXT_PARSER = new ObjectParser<>(NAME, null);
     static {
         GEO_CONTEXT_PARSER.declareField((parser, geoQueryContext, geoContextMapping) -> geoQueryContext.setGeoPoint(GeoUtils.parseGeoPoint(parser)), new ParseField(CONTEXT_VALUE), ObjectParser.ValueType.OBJECT);
@@ -157,33 +149,6 @@ public final class GeoQueryContext implements QueryContext {
         builder.field(CONTEXT_PRECISION, precision);
         builder.endObject();
         return builder;
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeGeoPoint(geoPoint);
-        out.writeVInt(boost);
-        out.writeInt(precision);
-        out.writeVInt(neighbours.size());
-        for (Integer neighbour : neighbours) {
-            out.writeVInt(neighbour);
-        }
-    }
-
-    @Override
-    public QueryContext readFrom(StreamInput in) throws IOException {
-        Builder builder = new Builder();
-        builder.geoPoint = in.readGeoPoint();
-        builder.boost = in.readVInt();
-        builder.precision = in.readInt();
-        int nNeighbour = in.readVInt();
-        if (nNeighbour != 0) {
-            builder.neighbours = new ArrayList<>(nNeighbour);
-            for (int i = 0; i < nNeighbour; i++) {
-                builder.neighbours.add(in.readVInt());
-            }
-        }
-        return builder.build();
     }
 
     public static class Builder {

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/QueryContext.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/QueryContext.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.suggest.completion.context;
 
-import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentParser;
 
@@ -28,7 +27,7 @@ import java.io.IOException;
 /**
  * Interface for serializing/de-serializing completion query context
  */
-public interface QueryContext extends ToXContent, NamedWriteable<QueryContext> {
+public interface QueryContext extends ToXContent {
 
     QueryContext fromXContext(XContentParser parser) throws IOException;
 }

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
@@ -190,11 +190,11 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
         XContentBuilder builder = jsonBuilder().value("context1");
         XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.bytes());
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        List<ContextMapping.QueryContext> queryContexts = mapping.parseQueryContext(parser);
-        assertThat(queryContexts.size(), equalTo(1));
-        assertThat(queryContexts.get(0).context, equalTo("context1"));
-        assertThat(queryContexts.get(0).boost, equalTo(1));
-        assertThat(queryContexts.get(0).isPrefix, equalTo(false));
+        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+        assertThat(internalQueryContexts.size(), equalTo(1));
+        assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
+        assertThat(internalQueryContexts.get(0).boost, equalTo(1));
+        assertThat(internalQueryContexts.get(0).isPrefix, equalTo(false));
     }
 
     public void testQueryContextParsingArray() throws Exception {
@@ -204,14 +204,14 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endArray();
         XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.bytes());
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        List<ContextMapping.QueryContext> queryContexts = mapping.parseQueryContext(parser);
-        assertThat(queryContexts.size(), equalTo(2));
-        assertThat(queryContexts.get(0).context, equalTo("context1"));
-        assertThat(queryContexts.get(0).boost, equalTo(1));
-        assertThat(queryContexts.get(0).isPrefix, equalTo(false));
-        assertThat(queryContexts.get(1).context, equalTo("context2"));
-        assertThat(queryContexts.get(1).boost, equalTo(1));
-        assertThat(queryContexts.get(1).isPrefix, equalTo(false));
+        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+        assertThat(internalQueryContexts.size(), equalTo(2));
+        assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
+        assertThat(internalQueryContexts.get(0).boost, equalTo(1));
+        assertThat(internalQueryContexts.get(0).isPrefix, equalTo(false));
+        assertThat(internalQueryContexts.get(1).context, equalTo("context2"));
+        assertThat(internalQueryContexts.get(1).boost, equalTo(1));
+        assertThat(internalQueryContexts.get(1).isPrefix, equalTo(false));
     }
 
     public void testQueryContextParsingObject() throws Exception {
@@ -222,11 +222,11 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endObject();
         XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.bytes());
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        List<ContextMapping.QueryContext> queryContexts = mapping.parseQueryContext(parser);
-        assertThat(queryContexts.size(), equalTo(1));
-        assertThat(queryContexts.get(0).context, equalTo("context1"));
-        assertThat(queryContexts.get(0).boost, equalTo(10));
-        assertThat(queryContexts.get(0).isPrefix, equalTo(true));
+        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+        assertThat(internalQueryContexts.size(), equalTo(1));
+        assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
+        assertThat(internalQueryContexts.get(0).boost, equalTo(10));
+        assertThat(internalQueryContexts.get(0).isPrefix, equalTo(true));
     }
 
 
@@ -245,14 +245,14 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endArray();
         XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.bytes());
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        List<ContextMapping.QueryContext> queryContexts = mapping.parseQueryContext(parser);
-        assertThat(queryContexts.size(), equalTo(2));
-        assertThat(queryContexts.get(0).context, equalTo("context1"));
-        assertThat(queryContexts.get(0).boost, equalTo(2));
-        assertThat(queryContexts.get(0).isPrefix, equalTo(true));
-        assertThat(queryContexts.get(1).context, equalTo("context2"));
-        assertThat(queryContexts.get(1).boost, equalTo(3));
-        assertThat(queryContexts.get(1).isPrefix, equalTo(false));
+        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+        assertThat(internalQueryContexts.size(), equalTo(2));
+        assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
+        assertThat(internalQueryContexts.get(0).boost, equalTo(2));
+        assertThat(internalQueryContexts.get(0).isPrefix, equalTo(true));
+        assertThat(internalQueryContexts.get(1).context, equalTo("context2"));
+        assertThat(internalQueryContexts.get(1).boost, equalTo(3));
+        assertThat(internalQueryContexts.get(1).isPrefix, equalTo(false));
     }
 
     public void testQueryContextParsingMixed() throws Exception {
@@ -266,14 +266,14 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endArray();
         XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.bytes());
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        List<ContextMapping.QueryContext> queryContexts = mapping.parseQueryContext(parser);
-        assertThat(queryContexts.size(), equalTo(2));
-        assertThat(queryContexts.get(0).context, equalTo("context1"));
-        assertThat(queryContexts.get(0).boost, equalTo(2));
-        assertThat(queryContexts.get(0).isPrefix, equalTo(true));
-        assertThat(queryContexts.get(1).context, equalTo("context2"));
-        assertThat(queryContexts.get(1).boost, equalTo(1));
-        assertThat(queryContexts.get(1).isPrefix, equalTo(false));
+        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+        assertThat(internalQueryContexts.size(), equalTo(2));
+        assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
+        assertThat(internalQueryContexts.get(0).boost, equalTo(2));
+        assertThat(internalQueryContexts.get(0).isPrefix, equalTo(true));
+        assertThat(internalQueryContexts.get(1).context, equalTo("context2"));
+        assertThat(internalQueryContexts.get(1).boost, equalTo(1));
+        assertThat(internalQueryContexts.get(1).isPrefix, equalTo(false));
     }
 
     public void testParsingContextFromDocument() throws Exception {

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CategoryQueryContextTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CategoryQueryContextTests.java
@@ -39,25 +39,6 @@ public class CategoryQueryContextTests extends QueryContextTestCase<CategoryQuer
     }
 
     @Override
-    protected CategoryQueryContext createMutation(CategoryQueryContext original) throws IOException {
-        final CategoryQueryContext.Builder builder = CategoryQueryContext.builder();
-        builder.setCategory(original.getCategory()).setBoost(original.getBoost()).setPrefix(original.isPrefix());
-        switch (randomIntBetween(0, 2)) {
-            case 0:
-                builder.setCategory(randomValueOtherThan(original.getCategory(), () -> randomAsciiOfLength(10)));
-                break;
-            case 1:
-                builder.setBoost(randomValueOtherThan(original.getBoost(), () -> randomIntBetween(1, 5)));
-                break;
-            case 2:
-                builder.setPrefix(!original.isPrefix());
-                break;
-
-        }
-        return builder.build();
-    }
-
-    @Override
     protected CategoryQueryContext prototype() {
         return CategoryQueryContext.PROTOTYPE;
     }

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggesterBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggesterBuilderTests.java
@@ -113,6 +113,7 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
         assertThat(newSuggestion, instanceOf(CompletionSuggestionContext.class));
         CompletionSuggestionContext oldCompletionSuggestion = (CompletionSuggestionContext) oldSuggestion;
         CompletionSuggestionContext newCompletionSuggestion = (CompletionSuggestionContext) newSuggestion;
+        assertEquals(oldCompletionSuggestion.getFieldType(), newCompletionSuggestion.getFieldType());
         assertEquals(oldCompletionSuggestion.getPayloadFields(), newCompletionSuggestion.getPayloadFields());
         assertEquals(oldCompletionSuggestion.getFuzzyOptions(), newCompletionSuggestion.getFuzzyOptions());
         assertEquals(oldCompletionSuggestion.getRegexOptions(), newCompletionSuggestion.getRegexOptions());

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggesterBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggesterBuilderTests.java
@@ -122,25 +122,17 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
     }
 
     @Override
-    protected Tuple<MapperService, CompletionSuggestionBuilder> mockMapperServiceAndSuggestionBuilder(
-        IndexSettings idxSettings, AnalysisService mockAnalysisService, CompletionSuggestionBuilder suggestBuilder) {
+    protected Tuple<MappedFieldType, CompletionSuggestionBuilder> randomFieldTypeAndSuggestionBuilder() {
         final BuilderAndInfo builderAndInfo = randomSuggestionBuilderWithContextInfo();
-        final MapperService mapperService = new MapperService(idxSettings, mockAnalysisService, null,
-            new IndicesModule().getMapperRegistry(), null) {
-            @Override
-            public MappedFieldType fullName(String fullName) {
-                CompletionFieldMapper.CompletionFieldType type = new CompletionFieldMapper.CompletionFieldType();
-                List<ContextMapping> contextMappings = builderAndInfo.catContexts.stream()
-                    .map(catContext -> new CategoryContextMapping.Builder(catContext).build())
-                    .collect(Collectors.toList());
-                contextMappings.addAll(builderAndInfo.geoContexts.stream()
-                    .map(geoContext -> new GeoContextMapping.Builder(geoContext).build())
-                    .collect(Collectors.toList()));
-                type.setContextMappings(new ContextMappings(contextMappings));
-                return type;
-            }
-        };
-        return new Tuple<>(mapperService, builderAndInfo.builder);
+        CompletionFieldMapper.CompletionFieldType type = new CompletionFieldMapper.CompletionFieldType();
+        List<ContextMapping> contextMappings = builderAndInfo.catContexts.stream()
+            .map(catContext -> new CategoryContextMapping.Builder(catContext).build())
+            .collect(Collectors.toList());
+        contextMappings.addAll(builderAndInfo.geoContexts.stream()
+            .map(geoContext -> new GeoContextMapping.Builder(geoContext).build())
+            .collect(Collectors.toList()));
+        type.setContextMappings(new ContextMappings(contextMappings));
+        return new Tuple<>(type, builderAndInfo.builder);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggesterBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggesterBuilderTests.java
@@ -140,8 +140,7 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
                 return type;
             }
         };
-        final CompletionSuggestionBuilder builder = builderAndInfo.builder;
-        return new Tuple<>(mapperService, builder);
+        return new Tuple<>(mapperService, builderAndInfo.builder);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/GeoContextMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/GeoContextMappingTests.java
@@ -202,15 +202,15 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
         XContentBuilder builder = jsonBuilder().value("ezs42e44yx96");
         XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.bytes());
         GeoContextMapping mapping = ContextBuilder.geo("geo").build();
-        List<ContextMapping.QueryContext> queryContexts = mapping.parseQueryContext(parser);
-        assertThat(queryContexts.size(), equalTo(1 + 8));
+        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+        assertThat(internalQueryContexts.size(), equalTo(1 + 8));
         Collection<String> locations = new ArrayList<>();
         locations.add("ezs42e");
         addNeighbors("ezs42e", GeoContextMapping.DEFAULT_PRECISION, locations);
-        for (ContextMapping.QueryContext queryContext : queryContexts) {
-            assertThat(queryContext.context, isIn(locations));
-            assertThat(queryContext.boost, equalTo(1));
-            assertThat(queryContext.isPrefix, equalTo(false));
+        for (ContextMapping.InternalQueryContext internalQueryContext : internalQueryContexts) {
+            assertThat(internalQueryContext.context, isIn(locations));
+            assertThat(internalQueryContext.boost, equalTo(1));
+            assertThat(internalQueryContext.isPrefix, equalTo(false));
         }
     }
 
@@ -221,15 +221,15 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
                 .endObject();
         XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.bytes());
         GeoContextMapping mapping = ContextBuilder.geo("geo").build();
-        List<ContextMapping.QueryContext> queryContexts = mapping.parseQueryContext(parser);
-        assertThat(queryContexts.size(), equalTo(1 + 8));
+        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+        assertThat(internalQueryContexts.size(), equalTo(1 + 8));
         Collection<String> locations = new ArrayList<>();
         locations.add("wh0n94");
         addNeighbors("wh0n94", GeoContextMapping.DEFAULT_PRECISION, locations);
-        for (ContextMapping.QueryContext queryContext : queryContexts) {
-            assertThat(queryContext.context, isIn(locations));
-            assertThat(queryContext.boost, equalTo(1));
-            assertThat(queryContext.isPrefix, equalTo(false));
+        for (ContextMapping.InternalQueryContext internalQueryContext : internalQueryContexts) {
+            assertThat(internalQueryContext.context, isIn(locations));
+            assertThat(internalQueryContext.boost, equalTo(1));
+            assertThat(internalQueryContext.isPrefix, equalTo(false));
         }
     }
 
@@ -244,8 +244,8 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
                 .endObject();
         XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.bytes());
         GeoContextMapping mapping = ContextBuilder.geo("geo").build();
-        List<ContextMapping.QueryContext> queryContexts = mapping.parseQueryContext(parser);
-        assertThat(queryContexts.size(), equalTo(1 + 1 + 8 + 1 + 8 + 1 + 8));
+        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+        assertThat(internalQueryContexts.size(), equalTo(1 + 1 + 8 + 1 + 8 + 1 + 8));
         Collection<String> locations = new ArrayList<>();
         locations.add("wh0n94");
         locations.add("w");
@@ -254,10 +254,10 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
         addNeighbors("wh", 2, locations);
         locations.add("wh0");
         addNeighbors("wh0", 3, locations);
-        for (ContextMapping.QueryContext queryContext : queryContexts) {
-            assertThat(queryContext.context, isIn(locations));
-            assertThat(queryContext.boost, equalTo(10));
-            assertThat(queryContext.isPrefix, equalTo(queryContext.context.length() < GeoContextMapping.DEFAULT_PRECISION));
+        for (ContextMapping.InternalQueryContext internalQueryContext : internalQueryContexts) {
+            assertThat(internalQueryContext.context, isIn(locations));
+            assertThat(internalQueryContext.boost, equalTo(10));
+            assertThat(internalQueryContext.isPrefix, equalTo(internalQueryContext.context.length() < GeoContextMapping.DEFAULT_PRECISION));
         }
     }
 
@@ -282,8 +282,8 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
                 .endArray();
         XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.bytes());
         GeoContextMapping mapping = ContextBuilder.geo("geo").build();
-        List<ContextMapping.QueryContext> queryContexts = mapping.parseQueryContext(parser);
-        assertThat(queryContexts.size(), equalTo(1 + 1 + 8 + 1 + 8 + 1 + 8 + 1 + 1 + 8));
+        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+        assertThat(internalQueryContexts.size(), equalTo(1 + 1 + 8 + 1 + 8 + 1 + 8 + 1 + 1 + 8));
         Collection<String> firstLocations = new ArrayList<>();
         firstLocations.add("wh0n94");
         firstLocations.add("w");
@@ -296,15 +296,15 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
         secondLocations.add("w5cx04");
         secondLocations.add("w5cx0");
         addNeighbors("w5cx0", 5, secondLocations);
-        for (ContextMapping.QueryContext queryContext : queryContexts) {
-            if (firstLocations.contains(queryContext.context)) {
-                assertThat(queryContext.boost, equalTo(10));
-            } else if (secondLocations.contains(queryContext.context)) {
-                assertThat(queryContext.boost, equalTo(2));
+        for (ContextMapping.InternalQueryContext internalQueryContext : internalQueryContexts) {
+            if (firstLocations.contains(internalQueryContext.context)) {
+                assertThat(internalQueryContext.boost, equalTo(10));
+            } else if (secondLocations.contains(internalQueryContext.context)) {
+                assertThat(internalQueryContext.boost, equalTo(2));
             } else {
-                fail(queryContext.context + " was not expected");
+                fail(internalQueryContext.context + " was not expected");
             }
-            assertThat(queryContext.isPrefix, equalTo(queryContext.context.length() < GeoContextMapping.DEFAULT_PRECISION));
+            assertThat(internalQueryContext.isPrefix, equalTo(internalQueryContext.context.length() < GeoContextMapping.DEFAULT_PRECISION));
         }
     }
 
@@ -325,8 +325,8 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
                 .endArray();
         XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.bytes());
         GeoContextMapping mapping = ContextBuilder.geo("geo").build();
-        List<ContextMapping.QueryContext> queryContexts = mapping.parseQueryContext(parser);
-        assertThat(queryContexts.size(), equalTo(1 + 1 + 8 + 1 + 8 + 1 + 8));
+        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+        assertThat(internalQueryContexts.size(), equalTo(1 + 1 + 8 + 1 + 8 + 1 + 8));
         Collection<String> firstLocations = new ArrayList<>();
         firstLocations.add("wh0n94");
         firstLocations.add("w");
@@ -336,15 +336,15 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
         Collection<String> secondLocations = new ArrayList<>();
         secondLocations.add("w5cx04");
         addNeighbors("w5cx04", 6, secondLocations);
-        for (ContextMapping.QueryContext queryContext : queryContexts) {
-            if (firstLocations.contains(queryContext.context)) {
-                assertThat(queryContext.boost, equalTo(10));
-            } else if (secondLocations.contains(queryContext.context)) {
-                assertThat(queryContext.boost, equalTo(1));
+        for (ContextMapping.InternalQueryContext internalQueryContext : internalQueryContexts) {
+            if (firstLocations.contains(internalQueryContext.context)) {
+                assertThat(internalQueryContext.boost, equalTo(10));
+            } else if (secondLocations.contains(internalQueryContext.context)) {
+                assertThat(internalQueryContext.boost, equalTo(1));
             } else {
-                fail(queryContext.context + " was not expected");
+                fail(internalQueryContext.context + " was not expected");
             }
-            assertThat(queryContext.isPrefix, equalTo(queryContext.context.length() < GeoContextMapping.DEFAULT_PRECISION));
+            assertThat(internalQueryContext.isPrefix, equalTo(internalQueryContext.context.length() < GeoContextMapping.DEFAULT_PRECISION));
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/GeoQueryContextTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/GeoQueryContextTests.java
@@ -50,35 +50,6 @@ public class GeoQueryContextTests extends QueryContextTestCase<GeoQueryContext> 
     }
 
     @Override
-    protected GeoQueryContext createMutation(GeoQueryContext original) throws IOException {
-        final GeoQueryContext.Builder builder = GeoQueryContext.builder();
-        builder.setGeoPoint(original.getGeoPoint()).setBoost(original.getBoost())
-            .setNeighbours(original.getNeighbours()).setPrecision(original.getPrecision());
-        switch (randomIntBetween(0, 3)) {
-            case 0:
-                builder.setGeoPoint(randomValueOtherThan(original.getGeoPoint() ,() ->
-                    new GeoPoint(randomDouble(), randomDouble())));
-                break;
-            case 1:
-                builder.setBoost(randomValueOtherThan(original.getBoost() ,() -> randomIntBetween(1, 5)));
-                break;
-            case 2:
-                builder.setPrecision(randomValueOtherThan(original.getPrecision() ,() -> randomIntBetween(1, 12)));
-                break;
-            case 3:
-                builder.setNeighbours(randomValueOtherThan(original.getNeighbours(), () -> {
-                    List<Integer> newNeighbours = new ArrayList<>();
-                    for (int i = 0; i < randomIntBetween(1, 12); i++) {
-                        newNeighbours.add(randomIntBetween(1, 12));
-                    }
-                    return newNeighbours;
-                }));
-                break;
-        }
-        return builder.build();
-    }
-
-    @Override
     protected GeoQueryContext prototype() {
         return GeoQueryContext.PROTOTYPE;
     }

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/QueryContextTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/QueryContextTestCase.java
@@ -26,23 +26,26 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.suggest.completion.context.QueryContext;
+import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 
+import static junit.framework.TestCase.assertEquals;
 
-public abstract class QueryContextTestCase<QC extends QueryContext> extends WritableTestCase<QC> {
+
+public abstract class QueryContextTestCase<QC extends QueryContext> extends ESTestCase {
 
     private static final int NUMBER_OF_RUNS = 20;
+
+    /**
+     * create random model that is put under test
+     */
+    protected abstract QC createTestModel();
 
     /**
      * query context prototype to read serialized format
      */
     protected abstract QC prototype();
-
-    @Override
-    protected QC readFrom(StreamInput in) throws IOException {
-        return (QC) prototype().readFrom(in);
-    }
 
     public void testToXContext() throws IOException {
         for (int i = 0; i < NUMBER_OF_RUNS; i++) {


### PR DESCRIPTION
This implements methods in CompletionSuggestionBuilder to construct a builder given query and parse contexts respectively. Now we ensure that the builder outputs identical output when used directly or through json parsing by storing query contexts as binary in the builder. All validation requiring `MapperService` are done once the suggestion is built on the shard level. 
