### PR TITLE
Don't call IR#leaves() after global field data has been constructed

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
@@ -305,13 +305,15 @@ public class ParentChildIndexFieldData extends AbstractIndexFieldData<AtomicPare
 
     public class GlobalFieldData implements IndexParentChildFieldData, Accountable {
 
+        private final Object coreCacheKey;
+        private final List<LeafReaderContext> leaves;
         private final AtomicParentChildFieldData[] fielddata;
-        private final IndexReader reader;
         private final long ramBytesUsed;
         private final Map<String, OrdinalMapAndAtomicFieldData> ordinalMapPerType;
 
         GlobalFieldData(IndexReader reader, AtomicParentChildFieldData[] fielddata, long ramBytesUsed, Map<String, OrdinalMapAndAtomicFieldData> ordinalMapPerType) {
-            this.reader = reader;
+            this.coreCacheKey = reader.getCoreCacheKey();
+            this.leaves = reader.leaves();
             this.ramBytesUsed = ramBytesUsed;
             this.fielddata = fielddata;
             this.ordinalMapPerType = ordinalMapPerType;
@@ -329,7 +331,7 @@ public class ParentChildIndexFieldData extends AbstractIndexFieldData<AtomicPare
 
         @Override
         public AtomicParentChildFieldData load(LeafReaderContext context) {
-            assert context.reader().getCoreCacheKey() == reader.leaves().get(context.ord).reader().getCoreCacheKey();
+            assert context.reader().getCoreCacheKey() == leaves.get(context.ord).reader().getCoreCacheKey();
             return fielddata[context.ord];
         }
 
@@ -365,7 +367,7 @@ public class ParentChildIndexFieldData extends AbstractIndexFieldData<AtomicPare
 
         @Override
         public IndexParentChildFieldData loadGlobal(DirectoryReader indexReader) {
-            if (indexReader.getCoreCacheKey() == reader.getCoreCacheKey()) {
+            if (indexReader.getCoreCacheKey() == coreCacheKey) {
                 return this;
             }
             throw new IllegalStateException();


### PR DESCRIPTION
This IR may already be closed and GlobalFieldData is cached and this can cause AlreadyClosedException while checking the assert.
