### PR TITLE
Enable unmap hack for java 9

### DIFF
--- a/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -33,7 +33,10 @@ grant codeBase "${codebase.securesm-1.0.jar}" {
 
 grant codeBase "${codebase.lucene-core-6.0.0-snapshot-bea235f.jar}" {
   // needed to allow MMapDirectory's "unmap hack" (die unmap hack, die)
+  // java 8 package
   permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";
+  // java 9 "package"
+  permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.ref";
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   // NOTE: also needed for RAMUsageEstimator size calculations
   permission java.lang.RuntimePermission "accessDeclaredMembers";

--- a/core/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -109,7 +109,12 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         logger.info("--> check that old primary shard does not get promoted to primary again");
         // kick reroute and wait for all shard states to be fetched
         client(master).admin().cluster().prepareReroute().get();
-        assertBusy(() -> assertThat(internalCluster().getInstance(GatewayAllocator.class, master).getNumberOfInFlightFetch(), equalTo(0)));
+        assertBusy(new Runnable() { 
+            @Override
+            public void run() {
+                assertThat(internalCluster().getInstance(GatewayAllocator.class, master).getNumberOfInFlightFetch(), equalTo(0));
+            }
+        });
         // kick reroute a second time and check that all shards are unassigned
         assertThat(client(master).admin().cluster().prepareReroute().get().getState().getRoutingNodes().unassigned().size(), equalTo(2));
     }

--- a/core/src/test/java/org/elasticsearch/common/lucene/LuceneTests.java
+++ b/core/src/test/java/org/elasticsearch/common/lucene/LuceneTests.java
@@ -364,6 +364,6 @@ public class LuceneTests extends ESTestCase {
      */
     public void testMMapHackSupported() throws Exception {
         // add assume's here if needed for certain platforms, but we should know if it does not work.
-        assertTrue(MMapDirectory.UNMAP_SUPPORTED);
+        assertTrue("MMapDirectory does not support unmapping: " + MMapDirectory.UNMAP_NOT_SUPPORTED_REASON, MMapDirectory.UNMAP_SUPPORTED);
     }
 }


### PR DESCRIPTION
This mechanism changed for java 9: requires a "fake" permission of `accessClassInPackage.jdk.internal.ref`

Currently unmapping will not work with java 9 unless we make changes:

```
  2> REPRODUCE WITH: gradle :core:test -Dtests.seed=D11864EB2E98C3EF -Dtests.class=org.elasticsearch.common.lucene.LuceneTests -Dtests.method="testMMapHackSupported" -Des.logger.level=WARN -Dtests.security.manager=true -Dtests.locale=jmc-TZ -Dtests.timezone=Antarctica/DumontDUrville
FAILURE 0.13s J0 | LuceneTests.testMMapHackSupported <<< FAILURES!
   > Throwable #1: java.lang.AssertionError: MMapDirectory does not support unmapping: Unmapping is not supported, because not all required permissions are given to the Lucene JAR file: java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "accessClassInPackage.jdk.internal.ref") [Please grant at least the following permissions: RuntimePermission("accessClassInPackage.sun.misc"), RuntimePermission("accessClassInPackage.jdk.internal.ref"), and ReflectPermission("suppressAccessChecks")]
```

See https://issues.apache.org/jira/browse/LUCENE-6989 for more information. 

I also had to upgrade my gradle to the latest to work at all with java 9, and fix a test so the source code compiles at all. I only ran this small unit test because hotspot on java 9 has been broken for a long time.
