### PR TITLE
ParseFieldMatcher should log when using deprecated settings.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/ParseField.java
+++ b/core/src/main/java/org/elasticsearch/common/ParseField.java
@@ -18,25 +18,22 @@
  */
 package org.elasticsearch.common;
 
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 
-import java.util.EnumSet;
 import java.util.HashSet;
 
 /**
  * Holds a field that can be found in a request while parsing and its different variants, which may be deprecated.
  */
 public class ParseField {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(ParseField.class));
+
     private final String camelCaseName;
     private final String underscoreName;
     private final String[] deprecatedNames;
     private String allReplacedWith = null;
-
-    static final EnumSet<Flag> EMPTY_FLAGS = EnumSet.noneOf(Flag.class);
-    static final EnumSet<Flag> STRICT_FLAGS = EnumSet.of(Flag.STRICT);
-
-    enum Flag {
-        STRICT
-    }
 
     public ParseField(String value, String... deprecatedNames) {
         camelCaseName = Strings.toCamelCase(value);
@@ -80,19 +77,21 @@ public class ParseField {
         return parseField;
     }
 
-    boolean match(String currentFieldName, EnumSet<Flag> flags) {
+    boolean match(String currentFieldName, boolean strict) {
         if (allReplacedWith == null && (currentFieldName.equals(camelCaseName) || currentFieldName.equals(underscoreName))) {
             return true;
         }
         String msg;
         for (String depName : deprecatedNames) {
             if (currentFieldName.equals(depName)) {
-                if (flags.contains(Flag.STRICT)) {
-                    msg = "Deprecated field [" + currentFieldName + "] used, expected [" + underscoreName + "] instead";
-                    if (allReplacedWith != null) {
-                        msg = "Deprecated field [" + currentFieldName + "] used, replaced by [" + allReplacedWith + "]";
-                    }
+                msg = "Deprecated field [" + currentFieldName + "] used, expected [" + underscoreName + "] instead";
+                if (allReplacedWith != null) {
+                    msg = "Deprecated field [" + currentFieldName + "] used, replaced by [" + allReplacedWith + "]";
+                }
+                if (strict) {
                     throw new IllegalArgumentException(msg);
+                } else {
+                    DEPRECATION_LOGGER.deprecated(msg);
                 }
                 return true;
             }

--- a/core/src/main/java/org/elasticsearch/common/ParseFieldMatcher.java
+++ b/core/src/main/java/org/elasticsearch/common/ParseFieldMatcher.java
@@ -21,29 +21,28 @@ package org.elasticsearch.common;
 
 import org.elasticsearch.common.settings.Settings;
 
-import java.util.EnumSet;
-
 /**
  * Matcher to use in combination with {@link ParseField} while parsing requests. Matches a {@link ParseField}
  * against a field name and throw deprecation exception depending on the current value of the {@link #PARSE_STRICT} setting.
  */
 public class ParseFieldMatcher {
     public static final String PARSE_STRICT = "index.query.parse.strict";
-    public static final ParseFieldMatcher EMPTY = new ParseFieldMatcher(ParseField.EMPTY_FLAGS);
-    public static final ParseFieldMatcher STRICT = new ParseFieldMatcher(ParseField.STRICT_FLAGS);
+    public static final ParseFieldMatcher EMPTY = new ParseFieldMatcher(false);
+    public static final ParseFieldMatcher STRICT = new ParseFieldMatcher(true);
 
-    private final EnumSet<ParseField.Flag> parseFlags;
+    private final boolean strict;
 
     public ParseFieldMatcher(Settings settings) {
-        if (settings.getAsBoolean(PARSE_STRICT, false)) {
-            this.parseFlags = EnumSet.of(ParseField.Flag.STRICT);
-        } else {
-            this.parseFlags = ParseField.EMPTY_FLAGS;
-        }
+        this(settings.getAsBoolean(PARSE_STRICT, false));
     }
 
-    public ParseFieldMatcher(EnumSet<ParseField.Flag> parseFlags) {
-        this.parseFlags = parseFlags;
+    public ParseFieldMatcher(boolean strict) {
+        this.strict = strict;
+    }
+
+    /** Should deprecated settings be rejected? */
+    public boolean isStrict() {
+        return strict;
     }
 
     /**
@@ -55,6 +54,6 @@ public class ParseFieldMatcher {
      * @return true whenever the parse field that we are looking for was found, false otherwise
      */
     public boolean match(String fieldName, ParseField parseField) {
-        return parseField.match(fieldName, parseFlags);
+        return parseField.match(fieldName, strict);
     }
 }


### PR DESCRIPTION
I always thought ParseFieldMatcher would log when using a deprecated setting,
but it does not.
