### PR TITLE
Add support for alpha versions

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
@@ -68,11 +68,17 @@ class PluginPropertiesTask extends Copy {
     }
 
     Map generateSubstitutions() {
+        def stringSnap = { version ->
+            if (version.endsWith("-SNAPSHOT")) {
+               return version.substring(0, version.length() - 9)
+            }
+            return version
+        }
         return [
             'name': extension.name,
             'description': extension.description,
-            'version': extension.version,
-            'elasticsearchVersion': VersionProperties.elasticsearch,
+            'version': stringSnap(extension.version),
+            'elasticsearchVersion': stringSnap(VersionProperties.elasticsearch),
             'javaVersion': project.targetCompatibility as String,
             'isolated': extension.isolated as String,
             'classname': extension.classname

--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -35,8 +35,8 @@ import java.io.IOException;
 @SuppressWarnings("deprecation")
 public class Version {
 
-    // The logic for ID is: XXYYZZAA, where XX is major version, YY is minor version, ZZ is revision, and AA is Beta/RC indicator
-    // AA values below 50 are beta builds, and below 99 are RC builds, with 99 indicating a release
+    // The logic for ID is: XXYYZZAA, where XX is major version, YY is minor version, ZZ is revision, and AA is alpha/beta/rc indicator
+    // AA values below 25 are fro alpha builder (since 5.0), and above 25 and below 50 are beta builds, and below 99 are RC builds, with 99 indicating a release
     // the (internal) format of the id is there so we can easily do after/before checks on the id
 
 
@@ -143,9 +143,10 @@ public class Version {
         }
 
         try {
-
+            final int rawMajor = Integer.parseInt(parts[0]);
+            final int betaOffset = rawMajor < 5 ? 0 : 25;
             //we reverse the version id calculation based on some assumption as we can't reliably reverse the modulo
-            final int major = Integer.parseInt(parts[0]) * 1000000;
+            final int major = rawMajor * 1000000;
             final int minor = Integer.parseInt(parts[1]) * 10000;
             final int revision = Integer.parseInt(parts[2]) * 100;
 
@@ -153,11 +154,17 @@ public class Version {
             int build = 99;
             if (parts.length == 4) {
                 String buildStr = parts[3];
-                if (buildStr.startsWith("Beta") || buildStr.startsWith("beta")) {
-                    build = Integer.parseInt(buildStr.substring(4));
-                }
-                if (buildStr.startsWith("RC") || buildStr.startsWith("rc")) {
+                if (buildStr.startsWith("alpha")) {
+                    assert rawMajor >= 5 : "major must be >= 5 but was " + major;
+                    build = Integer.parseInt(buildStr.substring(5));
+                    assert build < 25 : "expected a beta build but " + build + " >= 25";
+                } else if (buildStr.startsWith("Beta") || buildStr.startsWith("beta")) {
+                    build = betaOffset + Integer.parseInt(buildStr.substring(4));
+                    assert build < 50 : "expected a beta build but " + build + " >= 50";
+                } else if (buildStr.startsWith("RC") || buildStr.startsWith("rc")) {
                     build = Integer.parseInt(buildStr.substring(2)) + 50;
+                } else {
+                    throw new IllegalArgumentException("unable to parse version " + version);
                 }
             }
 
@@ -220,13 +227,16 @@ public class Version {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append(major).append('.').append(minor).append('.').append(revision);
-        if (isBeta()) {
+        if (isAlpha()) {
+            sb.append("-alpha");
+            sb.append(build);
+        } else if (isBeta()) {
             if (major >= 2) {
                 sb.append("-beta");
             } else {
                 sb.append(".Beta");
             }
-            sb.append(build);
+            sb.append(major < 5 ? build : build-25);
         } else if (build < 99) {
             if (major >= 2) {
                 sb.append("-rc");
@@ -262,7 +272,16 @@ public class Version {
     }
 
     public boolean isBeta() {
-        return build < 50;
+        return major < 5 ? build < 50 : build >= 25 && build < 50;
+    }
+
+    /**
+     * Returns true iff this version is an alpha version
+     * Note: This has been introduced in elasticsearch version 5. Previous versions will never
+     * have an alpha version.
+     */
+    public boolean isAlpha() {
+        return major < 5 ? false :  build < 25;
     }
 
     public boolean isRC() {

--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 public class Version {
 
     // The logic for ID is: XXYYZZAA, where XX is major version, YY is minor version, ZZ is revision, and AA is alpha/beta/rc indicator
-    // AA values below 25 are fro alpha builder (since 5.0), and above 25 and below 50 are beta builds, and below 99 are RC builds, with 99 indicating a release
+    // AA values below 25 are for alpha builder (since 5.0), and above 25 and below 50 are beta builds, and below 99 are RC builds, with 99 indicating a release
     // the (internal) format of the id is there so we can easily do after/before checks on the id
 
 

--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -137,6 +137,10 @@ public class Version {
         if (!Strings.hasLength(version)) {
             return Version.CURRENT;
         }
+        final boolean snapshot; // this is some BWC for 2.x and before indices
+        if (snapshot = version.endsWith("-SNAPSHOT")) {
+            version = version.substring(0, version.length() - 9);
+        }
         String[] parts = version.split("\\.|\\-");
         if (parts.length < 3 || parts.length > 4) {
             throw new IllegalArgumentException("the version needs to contain major, minor, and revision, and optionally the build: " + version);
@@ -144,6 +148,9 @@ public class Version {
 
         try {
             final int rawMajor = Integer.parseInt(parts[0]);
+            if (rawMajor >= 5 && snapshot) { // we don't support snapshot as part of the version here anymore
+                throw new IllegalArgumentException("illegal version format - snapshots are only supported until version 2.x");
+            }
             final int betaOffset = rawMajor < 5 ? 0 : 25;
             //we reverse the version id calculation based on some assumption as we can't reliably reverse the modulo
             final int major = rawMajor * 1000000;

--- a/core/src/test/java/org/elasticsearch/VersionTests.java
+++ b/core/src/test/java/org/elasticsearch/VersionTests.java
@@ -198,6 +198,13 @@ public class VersionTests extends ESTestCase {
         expectThrows(IllegalArgumentException.class, () -> {
             Version.fromString("5.0.0-alph2");
         });
+        assertSame(Version.CURRENT, Version.fromString(Version.CURRENT.toString()));
+
+        assertSame(Version.fromString("2.0.0-SNAPSHOT"), Version.fromString("2.0.0"));
+
+        expectThrows(IllegalArgumentException.class, () -> {
+            Version.fromString("5.0.0-SNAPSHOT");
+        });
     }
 
     public void testParseLenient() {

--- a/core/src/test/java/org/elasticsearch/VersionTests.java
+++ b/core/src/test/java/org/elasticsearch/VersionTests.java
@@ -57,6 +57,12 @@ public class VersionTests extends ESTestCase {
         assertThat(V_2_2_0.onOrAfter(V_5_0_0), is(false));
         assertThat(V_2_2_0.onOrAfter(V_2_2_0), is(true));
         assertThat(V_5_0_0.onOrAfter(V_2_2_0), is(true));
+
+        assertTrue(Version.fromString("5.0.0-alpha2").onOrAfter(Version.fromString("5.0.0-alpha1")));
+        assertTrue(Version.fromString("5.0.0").onOrAfter(Version.fromString("5.0.0-beta2")));
+        assertTrue(Version.fromString("5.0.0-rc1").onOrAfter(Version.fromString("5.0.0-beta24")));
+        assertTrue(Version.fromString("5.0.0-alpha24").before(Version.fromString("5.0.0-beta0")));
+
     }
 
     public void testVersionConstantPresent() {
@@ -144,11 +150,39 @@ public class VersionTests extends ESTestCase {
         assertEquals("2.0.0-beta1", Version.V_2_0_0_beta1.toString());
         assertEquals("5.0.0", Version.V_5_0_0.toString());
         assertEquals("2.3.0", Version.V_2_3_0.toString());
+        assertEquals("0.90.0.Beta1", Version.fromString("0.90.0.Beta1").toString());
+        assertEquals("1.0.0.Beta1", Version.fromString("1.0.0.Beta1").toString());
+        assertEquals("2.0.0-beta1", Version.fromString("2.0.0-beta1").toString());
+        assertEquals("5.0.0-beta1", Version.fromString("5.0.0-beta1").toString());
+        assertEquals("5.0.0-alpha1", Version.fromString("5.0.0-alpha1").toString());
     }
 
     public void testIsBeta() {
         assertTrue(Version.V_2_0_0_beta1.isBeta());
+        assertTrue(Version.fromString("1.0.0.Beta1").isBeta());
+        assertTrue(Version.fromString("0.90.0.Beta1").isBeta());
     }
+
+
+    public void testIsAlpha() {
+        assertTrue(new Version(5000001, org.apache.lucene.util.Version.LUCENE_6_0_0).isAlpha());
+        assertFalse(new Version(4000002, org.apache.lucene.util.Version.LUCENE_6_0_0).isAlpha());
+        assertTrue(new Version(4000002, org.apache.lucene.util.Version.LUCENE_6_0_0).isBeta());
+        assertTrue(Version.fromString("5.0.0-alpha14").isAlpha());
+        assertEquals(5000014, Version.fromString("5.0.0-alpha14").id);
+        assertTrue(Version.fromId(5000015).isAlpha());
+
+        for (int i = 0 ; i < 25; i++) {
+            assertEquals(Version.fromString("5.0.0-alpha" + i).id, Version.fromId(5000000 + i).id);
+            assertEquals("5.0.0-alpha" + i, Version.fromId(5000000 + i).toString());
+        }
+
+        for (int i = 0 ; i < 25; i++) {
+            assertEquals(Version.fromString("5.0.0-beta" + i).id, Version.fromId(5000000 + i + 25).id);
+            assertEquals("5.0.0-beta" + i, Version.fromId(5000000 + i + 25).toString());
+        }
+    }
+
 
     public void testParseVersion() {
         final int iters = scaledRandomIntBetween(100, 1000);
@@ -160,6 +194,10 @@ public class VersionTests extends ESTestCase {
             Version parsedVersion = Version.fromString(version.toString());
             assertEquals(version, parsedVersion);
         }
+
+        expectThrows(IllegalArgumentException.class, () -> {
+            Version.fromString("5.0.0-alph2");
+        });
     }
 
     public void testParseLenient() {


### PR DESCRIPTION
Elasticsearch 5.0 will come with alpha versions which is not supported
in the current version scheme. This commit adds support for aplpha starting
with es 5.0.0 in a backwards compatible way.
