### PR TITLE
Testing: Simplify exception handling in tests

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -1228,7 +1228,6 @@
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]parent[/\\]ParentMappingTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]path[/\\]PathMapperTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]routing[/\\]RoutingTypeMapperTests.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]simple[/\\]SimpleMapperTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]source[/\\]DefaultSourceMappingTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]string[/\\]SimpleStringMappingTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]string[/\\]StringFieldMapperPositionIncrementGapTests.java" checks="LineLength" />

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertionsTest.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertionsTest.java
@@ -1,0 +1,29 @@
+package org.elasticsearch.test.hamcrest;
+
+import junit.framework.AssertionFailedError;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThrows;
+import static org.hamcrest.core.Is.is;
+
+public class ElasticsearchAssertionsTest extends ESTestCase {
+
+    public void testThatAssertThrowsCorrectlyFailsOnNotHappenedException() {
+        try {
+            assertThrows(ElasticsearchException.class, () -> logger.trace("Some code inside a lambda, ignore"));
+            fail("Expected Assertion Error to be thrown, but did not happen");
+        } catch (AssertionFailedError e) {
+            assertThat(e.getMessage(), is("Expected [org.elasticsearch.ElasticsearchException] to be thrown, but nothing was thrown."));
+        }
+    }
+
+    public void testThatAssertThrowsCorrectlyFailsOnWrongException() {
+        try {
+            assertThrows(ElasticsearchException.class, () -> { throw new IndexOutOfBoundsException(); } );
+        } catch (AssertionFailedError e) {
+            assertThat(e.getMessage(), is("Unexpected exception type thrown, expected [org.elasticsearch.ElasticsearchException], got " +
+                    "[java.lang.IndexOutOfBoundsException]"));
+        }
+    }
+}


### PR DESCRIPTION
In order to test for exceptions and their content one always had to use
a fair share of boiler plate code.

```
try {
  foo.methodThrowsException();
  fail("...");
} catch (Exception e) {
  assertThat(e.getMessage(), is(""));
}
```

This can be wrapped into a lambda to shorten it like this

```
Exception e = assertThrows(Exception.class, () -> foo.methodThrowsException() );
assertThat(e.getMessage(), is(""));
```

The assertion checks for wrongly or none thrown exceptions and throws an AssertionError
if that is the case.

SimpleMapperTests was changed to show how it works.
