### PR TITLE
Add uuid to Index's toString

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/Index.java
+++ b/core/src/main/java/org/elasticsearch/index/Index.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index;
 
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -50,7 +51,14 @@ public class Index implements Writeable<Index> {
 
     @Override
     public String toString() {
-        return "[" + name + "]";
+        /*
+         * If we have a uuid we put it in the toString so it'll show up in logs which is useful as more and more things use the uuid rather
+         * than the name as the lookup key for the index.
+         */
+        if (ClusterState.UNKNOWN_UUID.equals(uuid)) {
+            return "[" + name + "]";
+        }
+        return "[" + name + "/" + uuid + "]";
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/IndexTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexTests.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.apache.lucene.util.TestUtil.randomSimpleString;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+public class IndexTests extends ESTestCase {
+    public void testToString() {
+        assertEquals("[name/uuid]", new Index("name", "uuid").toString());
+        assertEquals("[name]", new Index("name", ClusterState.UNKNOWN_UUID).toString());
+
+        Index random = new Index(randomSimpleString(random(), 1, 100),
+                usually() ? Strings.randomBase64UUID(random()) : ClusterState.UNKNOWN_UUID);
+        assertThat(random.toString(), containsString(random.getName()));
+        if (ClusterState.UNKNOWN_UUID.equals(random.getUUID())) {
+            assertThat(random.toString(), not(containsString(random.getUUID())));
+        } else {
+            assertThat(random.toString(), containsString(random.getUUID()));
+        }
+    }
+}


### PR DESCRIPTION
This is useful because uuid is starting to matter more and more in index
operations so it is nice that the uuid appears in the logs.
