### PR TITLE
Throttling support for reindex

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -961,6 +961,10 @@ public final class XContentBuilder implements BytesStream, Releasable {
         return this;
     }
 
+    public XContentBuilder timeValueField(String rawFieldName, String readableFieldName, TimeValue timeValue) throws IOException {
+        return timeValueField(rawFieldName, readableFieldName, timeValue.millis(), TimeUnit.MILLISECONDS);
+    }
+
     public XContentBuilder timeValueField(String rawFieldName, String readableFieldName, long rawTime, TimeUnit timeUnit) throws
         IOException {
         if (humanReadable) {

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -299,7 +299,8 @@ POST /_reindex
 === URL Parameters
 
 In addition to the standard parameters like `pretty`, the Reindex API also
-supports `refresh`, `wait_for_completion`, `consistency`, and `timeout`.
+supports `refresh`, `wait_for_completion`, `consistency`, `timeout`, and
+`requests_per_second`.
 
 Sending the `refresh` url parameter will cause all indexes to which the request
 wrote to be refreshed. This is different than the Index API's `refresh`
@@ -317,8 +318,14 @@ request. `timeout` controls how long each write request waits for unavailable
 shards to become available. Both work exactly how they work in the
 {ref}/docs-bulk.html[Bulk API].
 
-`timeout` controls how long each batch waits for the target shard to become
-available. It works exactly how it works in the {ref}/docs-bulk.html[Bulk API].
+`requests_per_second` can be set to any decimal number (1.4, 6, 1000, etc) and
+throttle the number of requests per second that the reindex issues. The
+throttling is done waiting between bulk batches so that it can manipulate the
+scroll timeout. The wait time is the difference between the time it took the
+batch to complete and the time `requests_per_second * requests_in_the_batch`.
+Since the batch isn't broken into multiple bulk requests large batch sizes will
+cause Elasticsearch to create many requests and then wait for a while before
+starting the next set. This is "bursty" instead of "smooth".
 
 [float]
 === Response body
@@ -333,6 +340,8 @@ The JSON response looks like this:
   "created": 123,
   "batches": 1,
   "version_conflicts": 2,
+  "retries": 0,
+  "throttled_millis": 0,
   "failures" : [ ]
 }
 --------------------------------------------------
@@ -356,6 +365,14 @@ The number of scroll responses pulled back by the the reindex.
 `version_conflicts`::
 
 The number of version conflicts that reindex hit.
+
+`retries`::
+
+The number of retries that the reindex did in response to a full queue.
+
+`throttled_millis`::
+
+Number of milliseconds the request slept to conform to `requests_per_second`.
 
 `failures`::
 
@@ -403,7 +420,9 @@ The responses looks like:
           "deleted" : 0,
           "batches" : 36,
           "version_conflicts" : 0,
-          "noops" : 0
+          "noops" : 0,
+          "retries": 0,
+          "throttled_millis": 0
         },
         "description" : ""
       } ]

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -169,8 +169,14 @@ request. `timeout` controls how long each write request waits for unavailable
 shards to become available. Both work exactly how they work in the
 {ref}/docs-bulk.html[Bulk API].
 
-`timeout` controls how long each batch waits for the target shard to become
-available. It works exactly how it works in the {ref}/docs-bulk.html[Bulk API].
+`requests_per_second` can be set to any decimal number (1.4, 6, 1000, etc) and
+throttle the number of requests per second that the update by query issues. The
+throttling is done waiting between bulk batches so that it can manipulate the
+scroll timeout. The wait time is the difference between the time it took the
+batch to complete and the time `requests_per_second * requests_in_the_batch`.
+Since the batch isn't broken into multiple bulk requests large batch sizes will
+cause Elasticsearch to create many requests and then wait for a while before
+starting the next set. This is "bursty" instead of "smooth".
 
 [float]
 === Response body
@@ -184,6 +190,8 @@ The JSON response looks like this:
   "updated": 0,
   "batches": 1,
   "version_conflicts": 2,
+  "retries": 0,
+  "throttled_millis": 0,
   "failures" : [ ]
 }
 --------------------------------------------------
@@ -203,6 +211,14 @@ The number of scroll responses pulled back by the the update by query.
 `version_conflicts`::
 
 The number of version conflicts that the update by query hit.
+
+`retries`::
+
+The number of retries that the update by query did in response to a full queue.
+
+`throttled_millis`::
+
+Number of milliseconds the request slept to conform to `requests_per_second`.
 
 `failures`::
 
@@ -251,7 +267,9 @@ The responses looks like:
           "deleted" : 0,
           "batches" : 36,
           "version_conflicts" : 0,
-          "noops" : 0
+          "noops" : 0,
+          "retries": 0,
+          "throttled_millis": 0
         },
         "description" : ""
       } ]

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBaseReindexRestHandler.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBaseReindexRestHandler.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.reindex;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.Client;
@@ -39,8 +38,11 @@ import org.elasticsearch.tasks.Task;
 
 import java.io.IOException;
 
-public abstract class AbstractBaseReindexRestHandler<Request extends ActionRequest<Request>, Response extends BulkIndexByScrollResponse,
-        TA extends TransportAction<Request, Response>> extends BaseRestHandler {
+public abstract class AbstractBaseReindexRestHandler<
+                Request extends AbstractBulkByScrollRequest<Request>,
+                Response extends BulkIndexByScrollResponse,
+                TA extends TransportAction<Request, Response>
+            > extends BaseRestHandler {
     protected final IndicesQueriesRegistry indicesQueriesRegistry;
     protected final AggregatorParsers aggParsers;
     protected final Suggesters suggesters;
@@ -59,6 +61,7 @@ public abstract class AbstractBaseReindexRestHandler<Request extends ActionReque
     }
 
     protected void execute(RestRequest request, Request internalRequest, RestChannel channel) throws IOException {
+        internalRequest.setRequestsPerSecond(request.paramAsFloat("requests_per_second", internalRequest.getRequestsPerSecond()));
         if (request.paramAsBoolean("wait_for_completion", true)) {
             action.execute(internalRequest, new BulkIndexByScrollResponseContentListener<Response>(channel));
             return;

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.reindex;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
@@ -29,6 +30,8 @@ import org.elasticsearch.tasks.Task;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static org.elasticsearch.common.unit.TimeValue.timeValueNanos;
 
 /**
  * Task storing information about a currently running BulkByScroll request.
@@ -46,6 +49,7 @@ public class BulkByScrollTask extends CancellableTask {
     private final AtomicInteger batch = new AtomicInteger(0);
     private final AtomicLong versionConflicts = new AtomicLong(0);
     private final AtomicLong retries = new AtomicLong(0);
+    private final AtomicLong throttledNanos = new AtomicLong();
 
     public BulkByScrollTask(long id, String type, String action, String description) {
         super(id, type, action, description);
@@ -54,7 +58,7 @@ public class BulkByScrollTask extends CancellableTask {
     @Override
     public Status getStatus() {
         return new Status(total.get(), updated.get(), created.get(), deleted.get(), batch.get(), versionConflicts.get(), noops.get(),
-                retries.get(), getReasonCancelled());
+                retries.get(), timeValueNanos(throttledNanos.get()), getReasonCancelled());
     }
 
     /**
@@ -65,7 +69,7 @@ public class BulkByScrollTask extends CancellableTask {
     }
 
     public static class Status implements Task.Status {
-        public static final Status PROTOTYPE = new Status(0, 0, 0, 0, 0, 0, 0, 0, null);
+        public static final Status PROTOTYPE = new Status(0, 0, 0, 0, 0, 0, 0, 0, timeValueNanos(0), null);
 
         private final long total;
         private final long updated;
@@ -75,10 +79,11 @@ public class BulkByScrollTask extends CancellableTask {
         private final long versionConflicts;
         private final long noops;
         private final long retries;
+        private final TimeValue throttled;
         private final String reasonCancelled;
 
         public Status(long total, long updated, long created, long deleted, int batches, long versionConflicts, long noops, long retries,
-                @Nullable String reasonCancelled) {
+                TimeValue throttled, @Nullable String reasonCancelled) {
             this.total = checkPositive(total, "total");
             this.updated = checkPositive(updated, "updated");
             this.created = checkPositive(created, "created");
@@ -87,6 +92,7 @@ public class BulkByScrollTask extends CancellableTask {
             this.versionConflicts = checkPositive(versionConflicts, "versionConflicts");
             this.noops = checkPositive(noops, "noops");
             this.retries = checkPositive(retries, "retries");
+            this.throttled = throttled;
             this.reasonCancelled = reasonCancelled;
         }
 
@@ -99,6 +105,7 @@ public class BulkByScrollTask extends CancellableTask {
             versionConflicts = in.readVLong();
             noops = in.readVLong();
             retries = in.readVLong();
+            throttled = TimeValue.readTimeValue(in);
             reasonCancelled = in.readOptionalString();
         }
 
@@ -112,6 +119,7 @@ public class BulkByScrollTask extends CancellableTask {
             out.writeVLong(versionConflicts);
             out.writeVLong(noops);
             out.writeVLong(retries);
+            throttled.writeTo(out);
             out.writeOptionalString(reasonCancelled);
         }
 
@@ -136,6 +144,7 @@ public class BulkByScrollTask extends CancellableTask {
             builder.field("version_conflicts", versionConflicts);
             builder.field("noops", noops);
             builder.field("retries", retries);
+            builder.timeValueField("throttled_millis", "throttled", throttled);
             if (reasonCancelled != null) {
                 builder.field("canceled", reasonCancelled);
             }
@@ -235,6 +244,13 @@ public class BulkByScrollTask extends CancellableTask {
         }
 
         /**
+         * The total time this request has throttled itself.
+         */
+        public TimeValue getThrottled() {
+            return throttled;
+        }
+
+        /**
          * The reason that the request was canceled or null if it hasn't been.
          */
         public String getReasonCancelled() {
@@ -286,5 +302,12 @@ public class BulkByScrollTask extends CancellableTask {
 
     void countRetry() {
         retries.incrementAndGet();
+    }
+
+    public void countThrottle(TimeValue delay) {
+        long nanos = delay.nanos();
+        if (nanos > 0) {
+            throttledNanos.addAndGet(nanos);
+        }
     }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/BulkByScrollTaskTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/BulkByScrollTaskTests.java
@@ -19,8 +19,11 @@
 
 package org.elasticsearch.index.reindex;
 
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
+
+import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
 
 public class BulkByScrollTaskTests extends ESTestCase {
     private BulkByScrollTask task;
@@ -101,13 +104,14 @@ public class BulkByScrollTaskTests extends ESTestCase {
     }
 
     public void testStatusHatesNegatives() {
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(-1, 0, 0, 0, 0, 0, 0, 0, null));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, -1, 0, 0, 0, 0, 0, 0, null));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, -1, 0, 0, 0, 0, 0, null));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, -1, 0, 0, 0, 0, null));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, -1, 0, 0, 0, null));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, -1, 0, 0, null));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, 0, -1, 0, null));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, 0, 0, -1, null));
+        TimeValue throttle = parseTimeValue(randomPositiveTimeValue(), "test");
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(-1, 0, 0, 0, 0, 0, 0, 0, throttle, null));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, -1, 0, 0, 0, 0, 0, 0, throttle, null));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, -1, 0, 0, 0, 0, 0, throttle, null));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, -1, 0, 0, 0, 0, throttle, null));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, -1, 0, 0, 0, throttle, null));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, -1, 0, 0, throttle, null));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, 0, -1, 0, throttle, null));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, 0, 0, -1, throttle, null));
     }
 }

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/10_basic.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/10_basic.yaml
@@ -21,6 +21,7 @@
   - match: {version_conflicts: 0}
   - match: {batches: 1}
   - match: {failures: []}
+  - match: {throttled_millis: 0}
   - is_true: took
   - is_false: task
 
@@ -53,6 +54,7 @@
   - match: {version_conflicts: 0}
   - match: {batches: 1}
   - match: {failures: []}
+  - match: {throttled_millis: 0}
   - is_true: took
   - is_false: task
 
@@ -84,6 +86,7 @@
   - is_false: failures
   - is_false: noops
   - is_false: took
+  - is_false: throttled_millis
   - is_false: created
 
   - do:
@@ -163,6 +166,7 @@
   - match: {version_conflicts: 1}
   - match: {batches: 1}
   - match: {failures: []}
+  - match: {throttled_millis: 0}
   - is_true: took
 
 ---

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/80_throttle.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/80_throttle.yaml
@@ -1,0 +1,53 @@
+---
+"Throttle the request":
+  # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
+  # and a small batch size on the request
+  - do:
+      indices.create:
+        index: source
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+  - do:
+      cluster.health:
+          wait_for_status: yellow
+  - do:
+      index:
+        index:   source
+        type:    foo
+        id:      1
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        type:    foo
+        id:      2
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        type:    foo
+        id:      3
+        body:    { "text": "test" }
+  - do:
+      indices.refresh: {}
+
+  - do:
+      reindex:
+        requests_per_second: 1
+        body:
+          source:
+            index: source
+            size: 1
+          dest:
+            index: dest
+  - match: {created: 3}
+  - match: {updated: 0}
+  - match: {version_conflicts: 0}
+  - match: {batches: 3}
+  - match: {failures: []}
+  - gt: {throttled_millis: 1000}
+  - lt: {throttled_millis: 4000}
+  - is_true: took
+  - is_false: task

--- a/modules/reindex/src/test/resources/rest-api-spec/test/update-by-query/10_basic.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/update-by-query/10_basic.yaml
@@ -18,6 +18,7 @@
   - match: {batches: 1}
   - match: {failures: []}
   - match: {noops: 0}
+  - match: {throttled_millis: 0}
   - is_true: took
   - is_false: created # Update by query can't create
   - is_false: task
@@ -45,6 +46,7 @@
   - is_false: failures
   - is_false: noops
   - is_false: took
+  - is_false: throttled_millis
   - is_false: created
 
   - do:
@@ -125,6 +127,7 @@
   - match: {batches: 1}
   - match: {noops: 0}
   - match: {failures: []}
+  - match: {throttled_millis: 0}
   - is_true: took
 
 ---
@@ -182,6 +185,7 @@
   - match: {version_conflicts: 0}
   - match: {batches: 1}
   - match: {failures: []}
+  - match: {throttled_millis: 0}
   - is_true: took
 
 ---

--- a/modules/reindex/src/test/resources/rest-api-spec/test/update-by-query/70_throttle.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/update-by-query/70_throttle.yaml
@@ -1,0 +1,39 @@
+"Throttle the request":
+  # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
+  # and a small batch size on the request
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_shards: 1
+  - do:
+      cluster.health:
+          wait_for_status: yellow
+  - do:
+      index:
+        index:   test
+        type:    foo
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   test
+        type:    foo
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   test
+        type:    foo
+        body:    { "text": "test" }
+  - do:
+      indices.refresh: {}
+
+  - do:
+      update-by-query:
+        index: test
+        scroll_size: 1
+        requests_per_second: 1
+  - match: {batches: 3}
+  - match: {updated: 3}
+  - gt: {throttled_millis: 1000}
+  - lt: {throttled_millis: 4000}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
@@ -22,9 +22,14 @@
           "description" : "Explicit write consistency setting for the operation"
         },
         "wait_for_completion": {
-           "type" : "boolean",
-           "default": false,
-           "description" : "Should the request should block until the reindex is complete."
+          "type" : "boolean",
+          "default": false,
+          "description" : "Should the request should block until the reindex is complete."
+        },
+        "requests_per_second": {
+          "type": "float",
+          "default": 0,
+          "description": "The throttle for this request in sub-requests per second. 0 means set no throttle."
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update-by-query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update-by-query.json
@@ -198,6 +198,11 @@
            "type" : "boolean",
            "default": false,
            "description" : "Should the request should block until the reindex is complete."
+        },
+        "requests_per_second": {
+          "type": "float",
+          "default": 0,
+          "description": "The throttle for this request in sub-requests per second. 0 means set no throttle."
         }
       }
     },


### PR DESCRIPTION
The throttling is done between batches so that we can add the wait time to the scroll timeout.
