### PR TITLE
Document breaking change in ClusterHealthResponse in 2.2

### DIFF
--- a/docs/reference/migration/migrate_2_2.asciidoc
+++ b/docs/reference/migration/migrate_2_2.asciidoc
@@ -44,6 +44,21 @@ to inherit this setting (these are the defaults for systemd). These
 settings can be modified by editing the `elasticsearch.service` file.
 
 [float]
+=== Java Client
+
+Previously it was possible to iterate over `ClusterHealthResponse` to get information about `ClusterIndexHealth`.
+While this is still possible, it requires now iterating over the values returned from `getIndices()`:
+
+[source,java]
+---------------
+ClusterHealthResponse clusterHealthResponse = client.admin().cluster().prepareHealth().get();
+for (Map.Entry<String, ClusterIndexHealth> index : clusterHealthResponse.getIndices().entrySet()) {
+    String indexName = index.getKey();
+    ClusterIndexHealth health = index.getValue();
+}
+---------------
+
+[float]
 === Cloud AWS Plugin
 
 Proxy settings have been deprecated and renamed:


### PR DESCRIPTION
With this PR we add documentation of a breaking change related to `ClusterHealthResponse` as [reported on the forums](https://discuss.elastic.co/t/java-client-2-1-1-2-2-0-unexpected-compilation-errors-not-backward-compatible/43782).
