### PR TITLE
Shorten GPG keypath by symlinking to tmp

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -48,7 +48,21 @@
         <!-- By default we sign RPMs and DEBs using a dummy gpg directory that we check into
              source control. Releases will override this with the real information. -->
         <gpg.key>16E55242</gpg.key>
-        <gpg.keypath>${project.parent.basedir}/src/test/resources/dummyGpg</gpg.keypath>
+        <!-- We're not using project.parent.basedir here by intention because it causes trouble
+        (i.e. the property does not get resolved; verified with
+        mvn help:effective-pom -pl distribution/rpm -Prpm). -->
+        <gpg.long.keypath>${project.basedir}/../src/test/resources/dummyGpg</gpg.long.keypath>
+        <!-- This is the path that is used internally for signing. gpg-agent allows this path to
+        be at most 108 characters on Linux (see struct sockaddr_un in <sys/un.h>) and even less
+        on other systems. By symlinking to the tmp directory, we reduce the path name length.
+
+        We use an internal property "gpg.default.keypath" which is not intended to be overridden
+        on the command line. Instead, when signing a package in the release process,
+        "gpg.keypath" should be provided (as it has been before). The build script will detect
+        this and will not use symlinking magic in this case.
+         -->
+        <gpg.default.keypath>${java.io.tmpdir}/shortGpg</gpg.default.keypath>
+        <gpg.keypath>${gpg.default.keypath}</gpg.keypath>
         <gpg.keyring>${gpg.keypath}/secring.gpg</gpg.keyring>
         <gpg.passphrase>dummy</gpg.passphrase>
         <deb.sign>true</deb.sign>

--- a/distribution/rpm/correct-sign-path.xml
+++ b/distribution/rpm/correct-sign-path.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="correct-sign-path">
+    <target name="check-keypath-override">
+        <condition property="gpg.keypath.overridden" value="true" else="false">
+            <not>
+                <equals arg1="${gpg.keypath}" arg2="${gpg.default.keypath}"/>
+            </not>
+        </condition>
+    </target>
+
+    <!--in case the gpg.keypath has been overwritten externally we don't do any symlink magic -->
+    <target name="shorten-gpg-path" depends="check-keypath-override" unless="${gpg.keypath.overridden}">
+        <echo level="info" message="Symlinking ${gpg.long.keypath} to ${gpg.keypath}"/>
+        <symlink link="${gpg.keypath}" resource="${gpg.long.keypath}" overwrite="true"/>
+    </target>
+</project>

--- a/distribution/rpm/pom.xml
+++ b/distribution/rpm/pom.xml
@@ -356,6 +356,18 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
+                    <execution>
+                        <id>shorten-gpg-key-path</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <ant antfile="correct-sign-path.xml" target="shorten-gpg-path"/>
+                            </target>
+                        </configuration>
+                    </execution>
                     <!-- start up external cluster -->
                     <execution>
                         <id>integ-setup</id>


### PR DESCRIPTION
With this commit we symlink to the tmp directory in order to avoid
a too long socket path for GPG agent when signing an RPM package.

Closes #17053
