### PR TITLE
Shorten GPG keypath for deb packaging

### DIFF
--- a/distribution/correct-sign-path.xml
+++ b/distribution/correct-sign-path.xml
@@ -6,11 +6,43 @@
                 <equals arg1="${gpg.keypath}" arg2="${gpg.default.keypath}"/>
             </not>
         </condition>
+
+        <condition property="shorten.gpg.path" value="true" else="false">
+            <and>
+                <isfalse value="${gpg.keypath.overridden}"/>
+                <os family="unix"/>
+            </and>
+        </condition>
+
+        <condition property="copy.gpg.path" value="true" else="false">
+            <and>
+                <isfalse value="${gpg.keypath.overridden}"/>
+                <os family="windows"/>
+            </and>
+        </condition>
+
     </target>
 
-    <!--in case the gpg.keypath has been overwritten externally we don't do any symlink magic -->
-    <target name="shorten-gpg-path" depends="check-keypath-override" unless="${gpg.keypath.overridden}">
+    <!--
+        Either use a symlink (Unix) to shorten the GPG path or copy the directory (Windows).
+
+        In case the gpg.keypath has been overwritten externally we don't do any symlink magic
+    -->
+    <target name="symlink-gpg-path" depends="check-keypath-override" if="${shorten.gpg.path}">
+        <echo level="info" message="keypath = ${gpg.keypath}, default = ${gpg.default.keypath}"/>
+        <echo level="info" message="gpg.keypath.overridden = ${gpg.keypath.overridden}"/>
         <echo level="info" message="Symlinking ${gpg.long.keypath} to ${gpg.keypath}"/>
         <symlink link="${gpg.keypath}" resource="${gpg.long.keypath}" overwrite="true"/>
     </target>
+
+
+    <target name="copy-gpg-path" depends="check-keypath-override" if="${copy.gpg.path}">
+        <echo level="info" message="Copying ${gpg.long.keypath} to ${gpg.keypath}"/>
+        <copy todir="${gpg.keypath}">
+            <fileset dir="${gpg.long.keypath}"/>
+        </copy>
+    </target>
+
+    <target name="shorten-gpg-path" depends="symlink-gpg-path, copy-gpg-path"/>
+
 </project>

--- a/distribution/correct-sign-path.xml
+++ b/distribution/correct-sign-path.xml
@@ -29,8 +29,6 @@
         In case the gpg.keypath has been overwritten externally we don't do any symlink magic
     -->
     <target name="symlink-gpg-path" depends="check-keypath-override" if="${shorten.gpg.path}">
-        <echo level="info" message="keypath = ${gpg.keypath}, default = ${gpg.default.keypath}"/>
-        <echo level="info" message="gpg.keypath.overridden = ${gpg.keypath.overridden}"/>
         <echo level="info" message="Symlinking ${gpg.long.keypath} to ${gpg.keypath}"/>
         <symlink link="${gpg.keypath}" resource="${gpg.long.keypath}" overwrite="true"/>
     </target>

--- a/distribution/correct-sign-path.xml
+++ b/distribution/correct-sign-path.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project name="correct-sign-path">
+<project name="correct-sign-path" default="shorten-gpg-path">
     <target name="check-keypath-override">
         <condition property="gpg.keypath.overridden" value="true" else="false">
             <not>

--- a/distribution/deb/pom.xml
+++ b/distribution/deb/pom.xml
@@ -303,6 +303,18 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
+                    <execution>
+                        <id>shorten-gpg-key-path</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <ant antfile="${packaging.gpg.shortening.ant.script.dir}"/>
+                            </target>
+                        </configuration>
+                    </execution>
                     <!-- start up external cluster -->
                     <execution>
                         <id>integ-setup</id>

--- a/distribution/deb/pom.xml
+++ b/distribution/deb/pom.xml
@@ -311,7 +311,7 @@
                         </goals>
                         <configuration>
                             <target>
-                                <ant antfile="${packaging.gpg.shortening.ant.script.dir}"/>
+                                <ant antfile="${packaging.gpg.shortening.ant.script}"/>
                             </target>
                         </configuration>
                     </execution>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -45,6 +45,7 @@
         <!-- we expect packaging formats to have integration tests, but not unit tests -->
         <skip.unit.tests>true</skip.unit.tests>
 
+        <packaging.gpg.shortening.ant.script.dir>${project.basedir}/../correct-sign-path.xml</packaging.gpg.shortening.ant.script.dir>
         <!-- By default we sign RPMs and DEBs using a dummy gpg directory that we check into
              source control. Releases will override this with the real information. -->
         <gpg.key>16E55242</gpg.key>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -45,7 +45,7 @@
         <!-- we expect packaging formats to have integration tests, but not unit tests -->
         <skip.unit.tests>true</skip.unit.tests>
 
-        <packaging.gpg.shortening.ant.script.dir>${project.basedir}/../correct-sign-path.xml</packaging.gpg.shortening.ant.script.dir>
+        <packaging.gpg.shortening.ant.script>${project.basedir}/../correct-sign-path.xml</packaging.gpg.shortening.ant.script>
         <!-- By default we sign RPMs and DEBs using a dummy gpg directory that we check into
              source control. Releases will override this with the real information. -->
         <gpg.key>16E55242</gpg.key>

--- a/distribution/rpm/pom.xml
+++ b/distribution/rpm/pom.xml
@@ -364,7 +364,7 @@
                         </goals>
                         <configuration>
                             <target>
-                                <ant antfile="correct-sign-path.xml" target="shorten-gpg-path"/>
+                                <ant antfile="${packaging.gpg.shortening.ant.script.dir}"/>
                             </target>
                         </configuration>
                     </execution>

--- a/distribution/rpm/pom.xml
+++ b/distribution/rpm/pom.xml
@@ -364,7 +364,7 @@
                         </goals>
                         <configuration>
                             <target>
-                                <ant antfile="${packaging.gpg.shortening.ant.script.dir}"/>
+                                <ant antfile="${packaging.gpg.shortening.ant.script}"/>
                             </target>
                         </configuration>
                     </execution>


### PR DESCRIPTION
With this commit we apply the same GPG path shortening logic for
the RPM and the DEB packaging modules.

Relates #17053
