### PR TITLE
Take filterNodeIds into consideration while sending task requests to nodes

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
@@ -207,8 +207,8 @@ public abstract class TransportTasksAction<
             this.nodesIds = filterNodeIds(clusterState.nodes(), nodesIds);
             ImmutableOpenMap<String, DiscoveryNode> nodes = clusterState.nodes().nodes();
             this.nodes = new DiscoveryNode[nodesIds.length];
-            for (int i = 0; i < nodesIds.length; i++) {
-                this.nodes[i] = nodes.get(nodesIds[i]);
+            for (int i = 0; i < this.nodesIds.length; i++) {
+                this.nodes[i] = nodes.get(this.nodesIds[i]);
             }
             this.responses = new AtomicReferenceArray<>(this.nodesIds.length);
         }

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
@@ -219,6 +219,10 @@ public abstract class TaskManagerTestCase extends ESTestCase {
             clusterService.close();
             transportService.close();
         }
+
+        public String getNodeId() {
+            return discoveryNode.getId();
+        }
     }
 
     public static void connectNodes(TestNode... nodes) {


### PR DESCRIPTION
Port of 83d2caaa05424cc5e1bc2885ac46e73cec1c6b9d to master.
