### PR TITLE
Fix exit code

### DIFF
--- a/distribution/deb/src/main/packaging/init.d/elasticsearch
+++ b/distribution/deb/src/main/packaging/init.d/elasticsearch
@@ -109,10 +109,10 @@ export ES_GC_LOG_FILE
 export JAVA_HOME
 export ES_INCLUDE
 
-if [ ! -x "$DAEMON" ] {
-	echo "Could not find elasticsearch executable binary."
+if [ ! -x "$DAEMON" ]; then
+	echo "The elasticsearch startup script does not exists or it is not executable, tried: $DAEMON"
 	exit 1
-}
+fi
 
 checkJava() {
 	if [ -x "$JAVA_HOME/bin/java" ]; then

--- a/distribution/deb/src/main/packaging/init.d/elasticsearch
+++ b/distribution/deb/src/main/packaging/init.d/elasticsearch
@@ -109,8 +109,10 @@ export ES_GC_LOG_FILE
 export JAVA_HOME
 export ES_INCLUDE
 
-# Check DAEMON exists
-test -x $DAEMON || exit 0
+if [ ! -x "$DAEMON" ] {
+	echo "Could not find elasticsearch executable binary."
+	exit 1
+}
 
 checkJava() {
 	if [ -x "$JAVA_HOME/bin/java" ]; then

--- a/qa/vagrant/src/test/resources/packaging/scripts/70_sysv_initd.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/70_sysv_initd.bats
@@ -57,10 +57,16 @@ setup() {
     install_package
 }
 
-@test "[INIT.D] elasticsearch startup script exists and is executable" {
-    DAEMON="$ES_HOME/bin/elasticsearch"
-    run test -x "$DAEMON"
-    [ "$status" -eq 0 ]
+@test "[INIT.D] elasticsearch fails if startup script is not executable" {
+    local INIT="/etc/init.d/elasticsearch"
+    local DAEMON="$ES_HOME/bin/elasticsearch"
+    
+    sudo chmod -x "$DAEMON"
+    run "$INIT"
+    sudo chmod +x "$DAEMON"
+    
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"The elasticsearch startup script does not exists or it is not executable, tried: $DAEMON"* ]]
 }
 
 @test "[INIT.D] daemon isn't enabled on restart" {

--- a/qa/vagrant/src/test/resources/packaging/scripts/70_sysv_initd.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/70_sysv_initd.bats
@@ -59,7 +59,7 @@ setup() {
 
 @test "[INIT.D] elasticsearch fails if startup script is not executable" {
     local INIT="/etc/init.d/elasticsearch"
-    local DAEMON="$ES_HOME/bin/elasticsearch"
+    local DAEMON="$ESHOME/bin/elasticsearch"
     
     sudo chmod -x "$DAEMON"
     run "$INIT"

--- a/qa/vagrant/src/test/resources/packaging/scripts/70_sysv_initd.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/70_sysv_initd.bats
@@ -57,6 +57,12 @@ setup() {
     install_package
 }
 
+@test "[INIT.D] elasticsearch startup script exists and is executable" {
+    DAEMON="$ES_HOME/bin/elasticsearch"
+    run test -x "$DAEMON"
+    [ "$status" -eq 0 ]
+}
+
 @test "[INIT.D] daemon isn't enabled on restart" {
     # Rather than restart the VM which would be slow we check for the symlinks
     # that init.d uses to restart the application on startup.


### PR DESCRIPTION
Exit with proper exit code (1) and an error message if elasticsearch executable binary does not exists or has insufficient permissions to execute.
