### PR TITLE
Fix a potential parsing problem in GeoDistanceSortParser

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
@@ -111,8 +111,11 @@ public class GeoDistanceSortParser implements SortParser {
                     if (coerce == true) {
                         ignoreMalformed = true;
                     }
-                } else if ("ignore_malformed".equals(currentName) && coerce == false) {
-                    ignoreMalformed = parser.booleanValue();
+                } else if ("ignore_malformed".equals(currentName)) {
+                    boolean ignoreMalformedFlag = parser.booleanValue();
+                    if (coerce == false) {
+                        ignoreMalformed = ignoreMalformedFlag;
+                    }
                 } else if ("sort_mode".equals(currentName) || "sortMode".equals(currentName) || "mode".equals(currentName)) {
                     sortMode = MultiValueMode.fromString(parser.text());
                 } else if ("nested_path".equals(currentName) || "nestedPath".equals(currentName)) {

--- a/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderIT.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderIT.java
@@ -263,6 +263,14 @@ public class GeoDistanceSortBuilderIT extends ESIntegTestCase {
                         new SearchSourceBuilder().sort(SortBuilders.geoDistanceSort("location", 2.0, 2.0)
                                 .unit(DistanceUnit.KILOMETERS).geoDistance(GeoDistance.PLANE))).execute().actionGet();
         checkCorrectSortOrderForGeoSort(searchResponse);
+
+        searchResponse = client()
+                .prepareSearch()
+                .setSource(
+                        new SearchSourceBuilder().sort(SortBuilders.geoDistanceSort("location", 2.0, 2.0)
+                                .unit(DistanceUnit.KILOMETERS).geoDistance(GeoDistance.PLANE)
+                                .ignoreMalformed(true).coerce(true))).execute().actionGet();
+        checkCorrectSortOrderForGeoSort(searchResponse);
     }
 
     private static void checkCorrectSortOrderForGeoSort(SearchResponse searchResponse) {


### PR DESCRIPTION
A test revealed a potential problem in the current GeoDistanceSortParser. 
For an input like `{ [...], "coerce" = true, "ignore_malformed" = false }` the parser will fail to parse the `ignore_malformed` boolean flag and will fall through to the last else-branch where the boolean flag will be parsed as geo-hash and `ignore_malformed` treated as field name. 

Adding fix and modifying a test so that it would fail with the old parser code.
