### PR TITLE
Be much much much careful about context

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/Retry.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/Retry.java
@@ -156,7 +156,7 @@ public class Retry {
         }
 
         private BulkRequest createBulkRequestForRetry(BulkResponse bulkItemResponses) {
-            BulkRequest requestToReissue = new BulkRequest();
+            BulkRequest requestToReissue = new BulkRequest(currentBulkRequest);
             int index = 0;
             for (BulkItemResponse bulkItemResponse : bulkItemResponses.getItems()) {
                 if (bulkItemResponse.isFailed()) {

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByScrollAction.java
@@ -325,7 +325,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
             finishHim(null, indexingFailures, searchFailures, timedOut);
             return;
         }
-        RefreshRequest refresh = new RefreshRequest();
+        RefreshRequest refresh = new RefreshRequest(mainRequest);
         refresh.indices(destinationIndices.toArray(new String[destinationIndices.size()]));
         client.admin().indices().refresh(refresh, new ActionListener<RefreshResponse>() {
             @Override
@@ -364,7 +364,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
              * Fire off the clear scroll but don't wait for it it return before
              * we send the use their response.
              */
-            ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
+            ClearScrollRequest clearScrollRequest = new ClearScrollRequest(mainRequest);
             clearScrollRequest.addScrollId(scrollId);
             client.clearScroll(clearScrollRequest, new ActionListener<ClearScrollResponse>() {
                 @Override


### PR DESCRIPTION
Preserving the context allows plugins that use the context to actually
work. This preserves the context in important spots and adds much better
testing that context is preserved.
