### PR TITLE
Standardize state format type for global and index level metadata

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -46,6 +46,8 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.gateway.MetaDataStateFormat;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.rest.RestStatus;
@@ -215,6 +217,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
             .numberOfShards(1).numberOfReplicas(0).build();
 
     public static final String KEY_ACTIVE_ALLOCATIONS = "active_allocations";
+    public static final String INDEX_STATE_FILE_PREFIX = "state-";
 
     private final int numberOfShards;
     private final int numberOfReplicas;
@@ -1023,4 +1026,21 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
         return builder.build();
     }
 
+    private static final ToXContent.Params FORMAT_PARAMS = new MapParams(Collections.singletonMap("binary", "true"));
+
+    /**
+     * State format for {@link IndexMetaData} to write to and load from disk
+     */
+    public static final MetaDataStateFormat<IndexMetaData> FORMAT = new MetaDataStateFormat<IndexMetaData>(XContentType.SMILE, INDEX_STATE_FILE_PREFIX) {
+
+        @Override
+        public void toXContent(XContentBuilder builder, IndexMetaData state) throws IOException {
+            Builder.toXContent(state, builder, FORMAT_PARAMS);
+        }
+
+        @Override
+        public IndexMetaData fromXContent(XContentParser parser) throws IOException {
+            return Builder.fromXContent(parser);
+        }
+    };
 }

--- a/core/src/main/java/org/elasticsearch/gateway/MetaStateService.java
+++ b/core/src/main/java/org/elasticsearch/gateway/MetaStateService.java
@@ -25,19 +25,13 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.Index;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Predicate;
 
 /**
@@ -45,41 +39,12 @@ import java.util.function.Predicate;
  */
 public class MetaStateService extends AbstractComponent {
 
-    static final String FORMAT_SETTING = "gateway.format";
-
-    static final String GLOBAL_STATE_FILE_PREFIX = "global-";
-    public static final String INDEX_STATE_FILE_PREFIX = "state-";
-
     private final NodeEnvironment nodeEnv;
-
-    private final XContentType format;
-    private final ToXContent.Params formatParams;
-    private final ToXContent.Params gatewayModeFormatParams;
-    private final MetaDataStateFormat<IndexMetaData> indexStateFormat;
-    private final MetaDataStateFormat<MetaData> globalStateFormat;
 
     @Inject
     public MetaStateService(Settings settings, NodeEnvironment nodeEnv) {
         super(settings);
         this.nodeEnv = nodeEnv;
-        this.format = XContentType.fromMediaTypeOrFormat(settings.get(FORMAT_SETTING, "smile"));
-        if (this.format == XContentType.SMILE) {
-            Map<String, String> params = new HashMap<>();
-            params.put("binary", "true");
-            formatParams = new ToXContent.MapParams(params);
-            Map<String, String> gatewayModeParams = new HashMap<>();
-            gatewayModeParams.put("binary", "true");
-            gatewayModeParams.put(MetaData.CONTEXT_MODE_PARAM, MetaData.CONTEXT_MODE_GATEWAY);
-            gatewayModeFormatParams = new ToXContent.MapParams(gatewayModeParams);
-        } else {
-            formatParams = ToXContent.EMPTY_PARAMS;
-            Map<String, String> gatewayModeParams = new HashMap<>();
-            gatewayModeParams.put(MetaData.CONTEXT_MODE_PARAM, MetaData.CONTEXT_MODE_GATEWAY);
-            gatewayModeFormatParams = new ToXContent.MapParams(gatewayModeParams);
-        }
-        indexStateFormat = indexStateFormat(format, formatParams);
-        globalStateFormat = globalStateFormat(format, gatewayModeFormatParams);
-
     }
 
     /**
@@ -95,7 +60,7 @@ public class MetaStateService extends AbstractComponent {
             metaDataBuilder = MetaData.builder();
         }
         for (String indexFolderName : nodeEnv.availableIndexFolders()) {
-            IndexMetaData indexMetaData = indexStateFormat.loadLatestState(logger, nodeEnv.resolveIndexFolder(indexFolderName));
+            IndexMetaData indexMetaData = IndexMetaData.FORMAT.loadLatestState(logger, nodeEnv.resolveIndexFolder(indexFolderName));
             if (indexMetaData != null) {
                 metaDataBuilder.put(indexMetaData, false);
             } else {
@@ -110,7 +75,7 @@ public class MetaStateService extends AbstractComponent {
      */
     @Nullable
     IndexMetaData loadIndexState(Index index) throws IOException {
-        return indexStateFormat.loadLatestState(logger, nodeEnv.indexPaths(index));
+        return IndexMetaData.FORMAT.loadLatestState(logger, nodeEnv.indexPaths(index));
     }
 
     /**
@@ -122,7 +87,7 @@ public class MetaStateService extends AbstractComponent {
             if (excludeIndexPathIdsPredicate.test(indexFolderName)) {
                 continue;
             }
-            IndexMetaData indexMetaData = indexStateFormat.loadLatestState(logger,
+            IndexMetaData indexMetaData = IndexMetaData.FORMAT.loadLatestState(logger,
                 nodeEnv.resolveIndexFolder(indexFolderName));
             if (indexMetaData != null) {
                 final String indexPathId = indexMetaData.getIndex().getUUID();
@@ -142,7 +107,7 @@ public class MetaStateService extends AbstractComponent {
      * Loads the global state, *without* index state, see {@link #loadFullState()} for that.
      */
     MetaData loadGlobalState() throws IOException {
-        MetaData globalState = globalStateFormat.loadLatestState(logger, nodeEnv.nodeDataPaths());
+        MetaData globalState = MetaData.FORMAT.loadLatestState(logger, nodeEnv.nodeDataPaths());
         // ES 2.0 now requires units for all time and byte-sized settings, so we add the default unit if it's missing
         // TODO: can we somehow only do this for pre-2.0 cluster state?
         if (globalState != null) {
@@ -167,7 +132,7 @@ public class MetaStateService extends AbstractComponent {
         final Index index = indexMetaData.getIndex();
         logger.trace("[{}] writing state, reason [{}]", index, reason);
         try {
-            indexStateFormat.write(indexMetaData, indexMetaData.getVersion(), locations);
+            IndexMetaData.FORMAT.write(indexMetaData, indexMetaData.getVersion(), locations);
         } catch (Throwable ex) {
             logger.warn("[{}]: failed to write index state", ex, index);
             throw new IOException("failed to write state for [" + index + "]", ex);
@@ -180,45 +145,10 @@ public class MetaStateService extends AbstractComponent {
     void writeGlobalState(String reason, MetaData metaData) throws Exception {
         logger.trace("[_global] writing state, reason [{}]",  reason);
         try {
-            globalStateFormat.write(metaData, metaData.version(), nodeEnv.nodeDataPaths());
+            MetaData.FORMAT.write(metaData, metaData.version(), nodeEnv.nodeDataPaths());
         } catch (Throwable ex) {
             logger.warn("[_global]: failed to write global state", ex);
             throw new IOException("failed to write global state", ex);
         }
-    }
-
-    /**
-     * Returns a StateFormat that can read and write {@link MetaData}
-     */
-    static MetaDataStateFormat<MetaData> globalStateFormat(XContentType format, final ToXContent.Params formatParams) {
-        return new MetaDataStateFormat<MetaData>(format, GLOBAL_STATE_FILE_PREFIX) {
-
-            @Override
-            public void toXContent(XContentBuilder builder, MetaData state) throws IOException {
-                MetaData.Builder.toXContent(state, builder, formatParams);
-            }
-
-            @Override
-            public MetaData fromXContent(XContentParser parser) throws IOException {
-                return MetaData.Builder.fromXContent(parser);
-            }
-        };
-    }
-
-    /**
-     * Returns a StateFormat that can read and write {@link IndexMetaData}
-     */
-    static MetaDataStateFormat<IndexMetaData> indexStateFormat(XContentType format, final ToXContent.Params formatParams) {
-        return new MetaDataStateFormat<IndexMetaData>(format, INDEX_STATE_FILE_PREFIX) {
-
-            @Override
-            public void toXContent(XContentBuilder builder, IndexMetaData state) throws IOException {
-                IndexMetaData.Builder.toXContent(state, builder, formatParams);            }
-
-            @Override
-            public IndexMetaData fromXContent(XContentParser parser) throws IOException {
-                return IndexMetaData.Builder.fromXContent(parser);
-            }
-        };
     }
 }

--- a/core/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
@@ -32,7 +32,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
-import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -63,7 +62,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.startsWith;
 
 @LuceneTestCase.SuppressFileSystems("ExtrasFS") // TODO: fix test to work with ExtrasFS
 public class MetaDataStateFormatTests extends ESTestCase {
@@ -232,85 +230,6 @@ public class MetaDataStateFormatTests extends ESTestCase {
         }
     }
 
-    // If the latest version doesn't use the legacy format while previous versions do, then fail hard
-    public void testLatestVersionDoesNotUseLegacy() throws IOException {
-        MetaDataStateFormat<MetaData> format = metaDataFormat(randomFrom(XContentType.values()));
-        final Path[] dirs = new Path[2];
-        dirs[0] = createTempDir();
-        dirs[1] = createTempDir();
-        for (Path dir : dirs) {
-            Files.createDirectories(dir.resolve(MetaDataStateFormat.STATE_DIR_NAME));
-        }
-        final Path dir1 = randomFrom(dirs);
-        final int v1 = randomInt(10);
-        // write a first state file in the new format
-        format.write(randomMeta(), v1, dir1);
-
-        // write older state files in the old format but with a newer version
-        final int numLegacyFiles = randomIntBetween(1, 5);
-        for (int i = 0; i < numLegacyFiles; ++i) {
-            final Path dir2 = randomFrom(dirs);
-            final int v2 = v1 + 1 + randomInt(10);
-            try (XContentBuilder xcontentBuilder = XContentFactory.contentBuilder(format.format(),
-                Files.newOutputStream(dir2.resolve(MetaDataStateFormat.STATE_DIR_NAME).resolve(MetaData.GLOBAL_STATE_FILE_PREFIX + v2)))) {
-                xcontentBuilder.startObject();
-                MetaData.Builder.toXContent(randomMeta(), xcontentBuilder, ToXContent.EMPTY_PARAMS);
-                xcontentBuilder.endObject();
-            }
-        }
-
-        try {
-            format.loadLatestState(logger, dirs);
-            fail("latest version can not be read");
-        } catch (IllegalStateException ex) {
-            assertThat(ex.getMessage(), startsWith("Could not find a state file to recover from among "));
-        }
-        // write the next state file in the new format and ensure it get's a higher ID
-        final MetaData meta = randomMeta();
-        format.write(meta, v1, dirs);
-        final MetaData metaData = format.loadLatestState(logger, dirs);
-        assertEquals(meta.clusterUUID(), metaData.clusterUUID());
-        final Path path = randomFrom(dirs);
-        final Path[] files = FileSystemUtils.files(path.resolve("_state"));
-        assertEquals(1, files.length);
-        assertEquals("global-" + format.findMaxStateId("global-", dirs) + ".st", files[0].getFileName().toString());
-
-    }
-
-    // If both the legacy and the new format are available for the latest version, prefer the new format
-    public void testPrefersNewerFormat() throws IOException {
-        MetaDataStateFormat<MetaData> format = metaDataFormat(randomFrom(XContentType.values()));
-        final Path[] dirs = new Path[2];
-        dirs[0] = createTempDir();
-        dirs[1] = createTempDir();
-        for (Path dir : dirs) {
-            Files.createDirectories(dir.resolve(MetaDataStateFormat.STATE_DIR_NAME));
-        }
-        final long v = randomInt(10);
-
-        MetaData meta = randomMeta();
-        String uuid = meta.clusterUUID();
-
-        // write a first state file in the old format
-        final Path dir2 = randomFrom(dirs);
-        MetaData meta2 = randomMeta();
-        assertFalse(meta2.clusterUUID().equals(uuid));
-        try (XContentBuilder xcontentBuilder = XContentFactory.contentBuilder(MetaData.FORMAT.format(),
-            Files.newOutputStream(dir2.resolve(MetaDataStateFormat.STATE_DIR_NAME).resolve(MetaData.GLOBAL_STATE_FILE_PREFIX + v)))) {
-            xcontentBuilder.startObject();
-            MetaData.Builder.toXContent(randomMeta(), xcontentBuilder, ToXContent.EMPTY_PARAMS);
-            xcontentBuilder.endObject();
-        }
-
-        // write a second state file in the new format but with the same version
-        format.write(meta, v, dirs);
-
-        MetaData state = format.loadLatestState(logger, dirs);
-        final Path path = randomFrom(dirs);
-        assertTrue(Files.exists(path.resolve(MetaDataStateFormat.STATE_DIR_NAME).resolve("global-" + (v+1) + ".st")));
-        assertEquals(state.clusterUUID(), uuid);
-    }
-
     public void testLoadState() throws IOException {
         final Path[] dirs = new Path[randomIntBetween(1, 5)];
         int numStates = randomIntBetween(1, 5);
@@ -330,7 +249,7 @@ public class MetaDataStateFormatTests extends ESTestCase {
                     Path file = dirs[i].resolve(MetaDataStateFormat.STATE_DIR_NAME).resolve("global-"+j);
                     Files.createFile(file); // randomly create 0-byte files -- there is extra logic to skip them
                 } else {
-                    try (XContentBuilder xcontentBuilder = XContentFactory.contentBuilder(MetaData.FORMAT.format(),
+                    try (XContentBuilder xcontentBuilder = XContentFactory.contentBuilder(type,
                         Files.newOutputStream(dirs[i].resolve(MetaDataStateFormat.STATE_DIR_NAME).resolve("global-" + j)))) {
                         xcontentBuilder.startObject();
                         MetaData.Builder.toXContent(meta.get(j), xcontentBuilder, ToXContent.EMPTY_PARAMS);

--- a/core/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
@@ -254,7 +254,7 @@ public class MetaDataStateFormatTests extends ESTestCase {
             try (XContentBuilder xcontentBuilder = XContentFactory.contentBuilder(format.format(),
                 Files.newOutputStream(dir2.resolve(MetaDataStateFormat.STATE_DIR_NAME).resolve(MetaData.GLOBAL_STATE_FILE_PREFIX + v2)))) {
                 xcontentBuilder.startObject();
-                format.toXContent(xcontentBuilder, randomMeta());
+                MetaData.Builder.toXContent(randomMeta(), xcontentBuilder, ToXContent.EMPTY_PARAMS);
                 xcontentBuilder.endObject();
             }
         }
@@ -298,7 +298,7 @@ public class MetaDataStateFormatTests extends ESTestCase {
         try (XContentBuilder xcontentBuilder = XContentFactory.contentBuilder(MetaData.FORMAT.format(),
             Files.newOutputStream(dir2.resolve(MetaDataStateFormat.STATE_DIR_NAME).resolve(MetaData.GLOBAL_STATE_FILE_PREFIX + v)))) {
             xcontentBuilder.startObject();
-            format.toXContent(xcontentBuilder, randomMeta());
+            MetaData.Builder.toXContent(randomMeta(), xcontentBuilder, ToXContent.EMPTY_PARAMS);
             xcontentBuilder.endObject();
         }
 
@@ -333,7 +333,7 @@ public class MetaDataStateFormatTests extends ESTestCase {
                     try (XContentBuilder xcontentBuilder = XContentFactory.contentBuilder(MetaData.FORMAT.format(),
                         Files.newOutputStream(dirs[i].resolve(MetaDataStateFormat.STATE_DIR_NAME).resolve("global-" + j)))) {
                         xcontentBuilder.startObject();
-                        format.toXContent(xcontentBuilder, meta.get(j));
+                        MetaData.Builder.toXContent(meta.get(j), xcontentBuilder, ToXContent.EMPTY_PARAMS);
                         xcontentBuilder.endObject();
                     }
                 }

--- a/core/src/test/java/org/elasticsearch/gateway/MetaStateServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/MetaStateServiceTests.java
@@ -41,7 +41,7 @@ public class MetaStateServiceTests extends ESTestCase {
 
     public void testWriteLoadIndex() throws Exception {
         try (NodeEnvironment env = newNodeEnvironment()) {
-            MetaStateService metaStateService = new MetaStateService(randomSettings(), env);
+            MetaStateService metaStateService = new MetaStateService(Settings.EMPTY, env);
 
             IndexMetaData index = IndexMetaData.builder("test1").settings(indexSettings).build();
             metaStateService.writeIndex("test_write", index);
@@ -51,14 +51,14 @@ public class MetaStateServiceTests extends ESTestCase {
 
     public void testLoadMissingIndex() throws Exception {
         try (NodeEnvironment env = newNodeEnvironment()) {
-            MetaStateService metaStateService = new MetaStateService(randomSettings(), env);
+            MetaStateService metaStateService = new MetaStateService(Settings.EMPTY, env);
             assertThat(metaStateService.loadIndexState(new Index("test1", "test1UUID")), nullValue());
         }
     }
 
     public void testWriteLoadGlobal() throws Exception {
         try (NodeEnvironment env = newNodeEnvironment()) {
-            MetaStateService metaStateService = new MetaStateService(randomSettings(), env);
+            MetaStateService metaStateService = new MetaStateService(Settings.EMPTY, env);
 
             MetaData metaData = MetaData.builder()
                     .persistentSettings(Settings.builder().put("test1", "value1").build())
@@ -70,7 +70,7 @@ public class MetaStateServiceTests extends ESTestCase {
 
     public void testWriteGlobalStateWithIndexAndNoIndexIsLoaded() throws Exception {
         try (NodeEnvironment env = newNodeEnvironment()) {
-            MetaStateService metaStateService = new MetaStateService(randomSettings(), env);
+            MetaStateService metaStateService = new MetaStateService(Settings.EMPTY, env);
 
             MetaData metaData = MetaData.builder()
                     .persistentSettings(Settings.builder().put("test1", "value1").build())
@@ -86,7 +86,7 @@ public class MetaStateServiceTests extends ESTestCase {
 
     public void testLoadGlobal() throws Exception {
         try (NodeEnvironment env = newNodeEnvironment()) {
-            MetaStateService metaStateService = new MetaStateService(randomSettings(), env);
+            MetaStateService metaStateService = new MetaStateService(Settings.EMPTY, env);
 
             IndexMetaData index = IndexMetaData.builder("test1").settings(indexSettings).build();
             MetaData metaData = MetaData.builder()
@@ -102,13 +102,5 @@ public class MetaStateServiceTests extends ESTestCase {
             assertThat(loadedState.hasIndex("test1"), equalTo(true));
             assertThat(loadedState.index("test1"), equalTo(index));
         }
-    }
-
-    private Settings randomSettings() {
-        Settings.Builder builder = Settings.builder();
-        if (randomBoolean()) {
-            builder.put(MetaStateService.FORMAT_SETTING, randomFrom(XContentType.values()).shortName());
-        }
-        return builder.build();
     }
 }

--- a/docs/reference/migration/migrate_5_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_5_0/settings.asciidoc
@@ -17,6 +17,11 @@ method.
 The `name` setting has been removed and is replaced by `node.name`. Usage of
 `-Dname=some_node_name` is not supported anymore.
 
+==== Gateway settings
+
+The `gateway.format` setting for configuring global and index state serialization
+format has been removed. By default, `smile` is used as the format.
+
 ==== Transport Settings
 
 All settings with a `netty` infix have been replaced by their already existing


### PR DESCRIPTION
Followup from https://github.com/elastic/elasticsearch/pull/16442#discussion_r55978382

Currently, global and index level state format type can be configured through `gateway.format`.
This commit removes the ability to configure format type for these states. 
Now we always store these states in `SMILE` format and ensure we always write them 
to disk in the most compact way.
