### PR TITLE
Remove dead code in FTL#simpleMatchToFullName

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -154,8 +154,6 @@ class FieldTypeLookup implements Iterable<MappedFieldType> {
         for (MappedFieldType fieldType : this) {
             if (Regex.simpleMatch(pattern, fieldType.name())) {
                 fields.add(fieldType.name());
-            } else if (Regex.simpleMatch(pattern, fieldType.name())) {
-                fields.add(fieldType.name());
             }
         }
         return fields;


### PR DESCRIPTION
This commit removes some dead code that resulted from removing the
ability for a field to have different names (after enforcing that fields
have the same full and index name).

Relates #15488
