### PR TITLE
`constant_score` query should throw error on more than one filter

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
@@ -54,12 +54,44 @@ public class ConstantScoreQueryBuilderTests extends AbstractQueryTestCase<Consta
      * test that missing "filter" element causes {@link ParsingException}
      */
     public void testFilterElement() throws IOException {
-        String queryString = "{ \"" + ConstantScoreQueryBuilder.NAME + "\" : {}";
+        String queryString = "{ \"" + ConstantScoreQueryBuilder.NAME + "\" : {} }";
         try {
             parseQuery(queryString);
             fail("Expected ParsingException");
         } catch (ParsingException e) {
             assertThat(e.getMessage(), containsString("requires a 'filter' element"));
+        }
+    }
+
+    /**
+     * test that multiple "filter" elements causes {@link ParsingException}
+     */
+    public void testMultipleFilterElements() throws IOException {
+        String queryString = "{ \"" + ConstantScoreQueryBuilder.NAME + "\" : {\n" +
+                                    "\"filter\" : { \"term\": { \"foo\": \"a\" } },\n" +
+                                    "\"filter\" : { \"term\": { \"foo\": \"x\" } },\n" +
+                            "} }";
+        try {
+            parseQuery(queryString);
+            fail("Expected ParsingException");
+        } catch (ParsingException e) {
+            assertThat(e.getMessage(), containsString("accepts only one 'filter' element"));
+        }
+    }
+
+    /**
+     * test that "filter" does not accept an array of queries, throws {@link ParsingException}
+     */
+    public void testNoArrayAsFilterElements() throws IOException {
+        String queryString = "{ \"" + ConstantScoreQueryBuilder.NAME + "\" : {\n" +
+                                    "\"filter\" : [ { \"term\": { \"foo\": \"a\" } },\n" +
+                                                   "{ \"term\": { \"foo\": \"x\" } } ]\n" +
+                            "} }";
+        try {
+            parseQuery(queryString);
+            fail("Expected ParsingException");
+        } catch (ParsingException e) {
+            assertThat(e.getMessage(), containsString("unexpected token [START_ARRAY]"));
         }
     }
 
@@ -79,16 +111,16 @@ public class ConstantScoreQueryBuilderTests extends AbstractQueryTestCase<Consta
 
     public void testFromJson() throws IOException {
         String json =
-                "{\n" + 
-                "  \"constant_score\" : {\n" + 
-                "    \"filter\" : {\n" + 
-                "      \"terms\" : {\n" + 
-                "        \"user\" : [ \"kimchy\", \"elasticsearch\" ],\n" + 
-                "        \"boost\" : 42.0\n" + 
-                "      }\n" + 
-                "    },\n" + 
-                "    \"boost\" : 23.0\n" + 
-                "  }\n" + 
+                "{\n" +
+                "  \"constant_score\" : {\n" +
+                "    \"filter\" : {\n" +
+                "      \"terms\" : {\n" +
+                "        \"user\" : [ \"kimchy\", \"elasticsearch\" ],\n" +
+                "        \"boost\" : 42.0\n" +
+                "      }\n" +
+                "    },\n" +
+                "    \"boost\" : 23.0\n" +
+                "  }\n" +
                 "}";
 
         ConstantScoreQueryBuilder parsed = (ConstantScoreQueryBuilder) parseQuery(json);


### PR DESCRIPTION
When specifying more than one `filter` in a `constant_score` query, the last one will be the only one that will be executed, overwriting previous filters. It should rather raise a ParseException to notify the user that only one filter query is accepted.

Closes #17126
