### PR TITLE
Add default settings filters for password, key, access_key etc

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/SettingsFilter.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/SettingsFilter.java
@@ -44,12 +44,24 @@ public final class SettingsFilter extends AbstractComponent {
      */
     public static String SETTINGS_FILTER_PARAM = "settings_filter";
 
+    public static String[] DEFAULT_SETTINGS_FILTERS = new String[]{
+            "password",
+            "*.password",
+            "key",
+            "*.key",
+            "service_api_key",
+            "*.service_api_key",
+            "access_key",
+            "*.access_key",
+            "secret_key",
+            "*.secret_key"
+    };
+
     private final Set<String> patterns;
     private final String patternString;
 
     public SettingsFilter(Settings settings, Collection<String> patterns) {
         super(settings);
-        HashSet<String> set = new HashSet<>();
         for (String pattern : patterns) {
             if (isValidPattern(pattern) == false) {
                 throw new IllegalArgumentException("invalid pattern: " + pattern);

--- a/core/src/main/java/org/elasticsearch/common/settings/SettingsModule.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/SettingsModule.java
@@ -47,6 +47,9 @@ public class SettingsModule extends AbstractModule {
         for (Setting<?> setting : IndexScopedSettings.BUILT_IN_INDEX_SETTINGS) {
             registerSetting(setting);
         }
+        for (String filter : SettingsFilter.DEFAULT_SETTINGS_FILTERS) {
+            registerSettingsFilter(filter);
+        }
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingsModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingsModuleTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.inject.ModuleTestCase;
 import org.elasticsearch.common.settings.Setting.Property;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
 
 public class SettingsModuleTests extends ModuleTestCase {
 
@@ -151,6 +150,23 @@ public class SettingsModuleTests extends ModuleTestCase {
         assertInstanceBinding(module, SettingsFilter.class, (s) -> s.filter(settings).getAsMap().containsKey("bar.baz"));
         assertInstanceBinding(module, SettingsFilter.class, (s) -> s.filter(settings).getAsMap().get("bar.baz").equals("false"));
 
+    }
+
+    public void testDefaultSettingsFilters() {
+        final String secret = "secret";
+
+        Settings.Builder settingsBuilder = Settings.builder();
+        for (String filter : SettingsFilter.DEFAULT_SETTINGS_FILTERS) {
+            settingsBuilder.put(filter.replace("*.", randomFrom("", "foo.", "bar.baz.")), secret);
+        }
+
+        Settings settings = settingsBuilder.build();
+        SettingsModule module = new SettingsModule(settings);
+        for (String settingName : settings.getAsMap().keySet()) {
+            module.registerSetting(Setting.simpleString(settingName, Property.NodeScope));
+        }
+
+        assertInstanceBinding(module, SettingsFilter.class, (s) -> s.filter(settings).getAsMap().size() == 0);
     }
 
     public void testMutuallyExclusiveScopes() {


### PR DESCRIPTION
This commit adds some default settings filters for settings like  `*.password` or `secret_key`. It's a simple safeguard in case a setting is registered but not marked as filtered.
