### PR TITLE
Clarify how `-Djava.security.policy=someURL` must be passed

### DIFF
--- a/docs/reference/modules/scripting/security.asciidoc
+++ b/docs/reference/modules/scripting/security.asciidoc
@@ -102,6 +102,10 @@ Security Policy either:
 * for just the `elasticsearch` user: `/home/elasticsearch/.java.policy`, or
 * from a file specified on the command line: `-Djava.security.policy=someURL`
 
+Note: If the command line options is used, JVM parameters must be passed to the elasticsearch start script
+via the `JAVA_OPTS` environment variable otherwise these arguments won't have any effect,
+ie. `JAVA_OPTS="${JAVA_OPTS} -Djava.security.policy=someURL`
+
 Permissions may be granted at the class, package, or global level.  For instance:
 
 [source,js]


### PR DESCRIPTION
JVM specific options must be passed via `JAVA_OPTS` to the elasticsearch
process. If they are passed as a cmd arg they are simply ignored today which
can be very very confusing and should be addressed in a different issue.

@clintongormley can you take a look at this
