### PR TITLE
Enable the indices request cache by default

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
@@ -70,7 +70,7 @@ public final class IndicesRequestCache extends AbstractComponent implements Remo
      * since we are checking on the cluster state IndexMetaData always.
      */
     public static final Setting<Boolean> INDEX_CACHE_REQUEST_ENABLED_SETTING =
-        Setting.boolSetting("index.requests.cache.enable", false, Property.Dynamic, Property.IndexScope);
+        Setting.boolSetting("index.requests.cache.enable", true, Property.Dynamic, Property.IndexScope);
     public static final Setting<ByteSizeValue> INDICES_CACHE_QUERY_SIZE =
         Setting.byteSizeSetting("indices.requests.cache.size", "1%", Property.NodeScope);
     public static final Setting<TimeValue> INDICES_CACHE_QUERY_EXPIRE =


### PR DESCRIPTION
Now we have #16870 we can enable the request cache by default. The caching can still be disabled on a per request basis and can still be disabled in the settings, only the default value has changed. For now this is done regardless of whether the shard is active or inactive. The reasons for not looking at whether the shard is active or inactive are:
1. result caching is cheap. 
2. the cache is small and easy to GC 
3. Users press refresh frequently which, without caching, would result in the same query being rerun on an active shard.  This way we reduce the load for very little cost

Closes #17134
