### PR TITLE
Removed `total` score mode in favour for `sum` score mode.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
@@ -189,7 +189,7 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
         builder.field(HasChildQueryParser.QUERY_FIELD.getPreferredName());
         query.toXContent(builder, params);
         builder.field(HasChildQueryParser.TYPE_FIELD.getPreferredName(), type);
-        builder.field(HasChildQueryParser.SCORE_MODE_FIELD.getPreferredName(), scoreMode.name().toLowerCase(Locale.ROOT));
+        builder.field(HasChildQueryParser.SCORE_MODE_FIELD.getPreferredName(), HasChildQueryParser.scoreModeAsString(scoreMode));
         builder.field(HasChildQueryParser.MIN_CHILDREN_FIELD.getPreferredName(), minChildren);
         builder.field(HasChildQueryParser.MAX_CHILDREN_FIELD.getPreferredName(), maxChildren);
         printBoostAndQueryName(builder);

--- a/core/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
@@ -257,12 +257,7 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
         innerQuery = Queries.filtered(innerQuery, childDocMapper.typeFilter());
 
         final ParentChildIndexFieldData parentChildIndexFieldData = context.getForField(parentFieldMapper.fieldType());
-        int maxChildren = maxChildren();
-        // 0 in pre 2.x p/c impl means unbounded
-        if (maxChildren == 0) {
-            maxChildren = Integer.MAX_VALUE;
-        }
-        return new LateParsingQuery(parentDocMapper.typeFilter(), innerQuery, minChildren(), maxChildren,
+        return new LateParsingQuery(parentDocMapper.typeFilter(), innerQuery, minChildren(), maxChildren(),
                                     parentType, scoreMode, parentChildIndexFieldData, context.getSearchSimilarity());
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.support.QueryInnerHits;
 
 import java.io.IOException;
+import java.util.Locale;
 
 /**
  * A query parser for <tt>has_child</tt> queries.
@@ -104,10 +105,19 @@ public class HasChildQueryParser implements QueryParser<HasChildQueryBuilder> {
             return ScoreMode.Max;
         } else if ("avg".equals(scoreModeString)) {
             return ScoreMode.Avg;
-        } else if ("total".equals(scoreModeString)) {
+        } else if ("sum".equals(scoreModeString)) {
             return ScoreMode.Total;
         }
         throw new IllegalArgumentException("No score mode for child query [" + scoreModeString + "] found");
+    }
+
+    public static String scoreModeAsString(ScoreMode scoreMode) {
+        if (scoreMode == ScoreMode.Total) {
+            // Lucene uses 'total' but 'sum' is more consistent with other elasticsearch APIs
+            return "sum";
+        } else {
+            return scoreMode.name().toLowerCase(Locale.ROOT);
+        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -121,7 +121,7 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
         query.toXContent(builder, params);
         builder.field(NestedQueryParser.PATH_FIELD.getPreferredName(), path);
         if (scoreMode != null) {
-            builder.field(NestedQueryParser.SCORE_MODE_FIELD.getPreferredName(), scoreMode.name().toLowerCase(Locale.ROOT));
+            builder.field(NestedQueryParser.SCORE_MODE_FIELD.getPreferredName(), HasChildQueryParser.scoreModeAsString(scoreMode));
         }
         printBoostAndQueryName(builder);
         if (queryInnerHits != null) {

--- a/core/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
@@ -68,20 +68,7 @@ public class NestedQueryParser implements QueryParser<NestedQueryBuilder> {
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.BOOST_FIELD)) {
                     boost = parser.floatValue();
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, SCORE_MODE_FIELD)) {
-                    String sScoreMode = parser.text();
-                    if ("avg".equals(sScoreMode)) {
-                        scoreMode = ScoreMode.Avg;
-                    } else if ("min".equals(sScoreMode)) {
-                        scoreMode = ScoreMode.Min;
-                    } else if ("max".equals(sScoreMode)) {
-                        scoreMode = ScoreMode.Max;
-                    } else if ("total".equals(sScoreMode) || "sum".equals(sScoreMode)) {
-                        scoreMode = ScoreMode.Total;
-                    } else if ("none".equals(sScoreMode)) {
-                        scoreMode = ScoreMode.None;
-                    } else {
-                        throw new ParsingException(parser.getTokenLocation(), "illegal score_mode for nested query [" + sScoreMode + "]");
-                    }
+                    scoreMode = HasChildQueryParser.parseScoreMode(parser.text());
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.NAME_FIELD)) {
                     queryName = parser.text();
                 } else {

--- a/core/src/test/java/org/elasticsearch/index/query/HasChildQueryParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/HasChildQueryParserTests.java
@@ -27,22 +27,27 @@ import static org.hamcrest.Matchers.is;
 public class HasChildQueryParserTests extends ESTestCase {
     public void testMinFromString() {
         assertThat("fromString(min) != MIN", ScoreMode.Min, equalTo(HasChildQueryParser.parseScoreMode("min")));
+        assertThat("min", equalTo(HasChildQueryParser.scoreModeAsString(ScoreMode.Min)));
     }
 
     public void testMaxFromString() {
         assertThat("fromString(max) != MAX", ScoreMode.Max, equalTo(HasChildQueryParser.parseScoreMode("max")));
+        assertThat("max", equalTo(HasChildQueryParser.scoreModeAsString(ScoreMode.Max)));
     }
 
     public void testAvgFromString() {
         assertThat("fromString(avg) != AVG", ScoreMode.Avg, equalTo(HasChildQueryParser.parseScoreMode("avg")));
+        assertThat("avg", equalTo(HasChildQueryParser.scoreModeAsString(ScoreMode.Avg)));
     }
 
     public void testSumFromString() {
-        assertThat("fromString(total) != SUM", ScoreMode.Total, equalTo(HasChildQueryParser.parseScoreMode("total")));
+        assertThat("fromString(total) != SUM", ScoreMode.Total, equalTo(HasChildQueryParser.parseScoreMode("sum")));
+        assertThat("sum", equalTo(HasChildQueryParser.scoreModeAsString(ScoreMode.Total)));
     }
 
     public void testNoneFromString() {
         assertThat("fromString(none) != NONE", ScoreMode.None, equalTo(HasChildQueryParser.parseScoreMode("none")));
+        assertThat("none", equalTo(HasChildQueryParser.scoreModeAsString(ScoreMode.None)));
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/search/child/ChildQuerySearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/child/ChildQuerySearchIT.java
@@ -1561,7 +1561,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         SearchResponse response;
 
         // Score mode = NONE
-        response = minMaxQuery(ScoreMode.None, 0, 0);
+        response = minMaxQuery(ScoreMode.None, 0, null);
 
         assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("2"));
@@ -1571,7 +1571,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         assertThat(response.getHits().hits()[2].id(), equalTo("4"));
         assertThat(response.getHits().hits()[2].score(), equalTo(1f));
 
-        response = minMaxQuery(ScoreMode.None, 1, 0);
+        response = minMaxQuery(ScoreMode.None, 1, null);
 
         assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("2"));
@@ -1581,7 +1581,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         assertThat(response.getHits().hits()[2].id(), equalTo("4"));
         assertThat(response.getHits().hits()[2].score(), equalTo(1f));
 
-        response = minMaxQuery(ScoreMode.None, 2, 0);
+        response = minMaxQuery(ScoreMode.None, 2, null);
 
         assertThat(response.getHits().totalHits(), equalTo(2L));
         assertThat(response.getHits().hits()[0].id(), equalTo("3"));
@@ -1589,13 +1589,13 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         assertThat(response.getHits().hits()[1].id(), equalTo("4"));
         assertThat(response.getHits().hits()[1].score(), equalTo(1f));
 
-        response = minMaxQuery(ScoreMode.None, 3, 0);
+        response = minMaxQuery(ScoreMode.None, 3, null);
 
         assertThat(response.getHits().totalHits(), equalTo(1L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(1f));
 
-        response = minMaxQuery(ScoreMode.None, 4, 0);
+        response = minMaxQuery(ScoreMode.None, 4, null);
 
         assertThat(response.getHits().totalHits(), equalTo(0L));
 
@@ -1641,7 +1641,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         }
 
         // Score mode = SUM
-        response = minMaxQuery(ScoreMode.Total, 0, 0);
+        response = minMaxQuery(ScoreMode.Total, 0, null);
 
         assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
@@ -1651,7 +1651,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         assertThat(response.getHits().hits()[2].id(), equalTo("2"));
         assertThat(response.getHits().hits()[2].score(), equalTo(1f));
 
-        response = minMaxQuery(ScoreMode.Total, 1, 0);
+        response = minMaxQuery(ScoreMode.Total, 1, null);
 
         assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
@@ -1661,7 +1661,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         assertThat(response.getHits().hits()[2].id(), equalTo("2"));
         assertThat(response.getHits().hits()[2].score(), equalTo(1f));
 
-        response = minMaxQuery(ScoreMode.Total, 2, 0);
+        response = minMaxQuery(ScoreMode.Total, 2, null);
 
         assertThat(response.getHits().totalHits(), equalTo(2L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
@@ -1669,13 +1669,13 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
         assertThat(response.getHits().hits()[1].score(), equalTo(3f));
 
-        response = minMaxQuery(ScoreMode.Total, 3, 0);
+        response = minMaxQuery(ScoreMode.Total, 3, null);
 
         assertThat(response.getHits().totalHits(), equalTo(1L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(6f));
 
-        response = minMaxQuery(ScoreMode.Total, 4, 0);
+        response = minMaxQuery(ScoreMode.Total, 4, null);
 
         assertThat(response.getHits().totalHits(), equalTo(0L));
 
@@ -1721,7 +1721,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         }
 
         // Score mode = MAX
-        response = minMaxQuery(ScoreMode.Max, 0, 0);
+        response = minMaxQuery(ScoreMode.Max, 0, null);
 
         assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
@@ -1731,7 +1731,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         assertThat(response.getHits().hits()[2].id(), equalTo("2"));
         assertThat(response.getHits().hits()[2].score(), equalTo(1f));
 
-        response = minMaxQuery(ScoreMode.Max, 1, 0);
+        response = minMaxQuery(ScoreMode.Max, 1, null);
 
         assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
@@ -1741,7 +1741,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         assertThat(response.getHits().hits()[2].id(), equalTo("2"));
         assertThat(response.getHits().hits()[2].score(), equalTo(1f));
 
-        response = minMaxQuery(ScoreMode.Max, 2, 0);
+        response = minMaxQuery(ScoreMode.Max, 2, null);
 
         assertThat(response.getHits().totalHits(), equalTo(2L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
@@ -1749,13 +1749,13 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
         assertThat(response.getHits().hits()[1].score(), equalTo(2f));
 
-        response = minMaxQuery(ScoreMode.Max, 3, 0);
+        response = minMaxQuery(ScoreMode.Max, 3, null);
 
         assertThat(response.getHits().totalHits(), equalTo(1L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(3f));
 
-        response = minMaxQuery(ScoreMode.Max, 4, 0);
+        response = minMaxQuery(ScoreMode.Max, 4, null);
 
         assertThat(response.getHits().totalHits(), equalTo(0L));
 
@@ -1801,7 +1801,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         }
 
         // Score mode = AVG
-        response = minMaxQuery(ScoreMode.Avg, 0, 0);
+        response = minMaxQuery(ScoreMode.Avg, 0, null);
 
         assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
@@ -1811,7 +1811,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         assertThat(response.getHits().hits()[2].id(), equalTo("2"));
         assertThat(response.getHits().hits()[2].score(), equalTo(1f));
 
-        response = minMaxQuery(ScoreMode.Avg, 1, 0);
+        response = minMaxQuery(ScoreMode.Avg, 1, null);
 
         assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
@@ -1821,7 +1821,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         assertThat(response.getHits().hits()[2].id(), equalTo("2"));
         assertThat(response.getHits().hits()[2].score(), equalTo(1f));
 
-        response = minMaxQuery(ScoreMode.Avg, 2, 0);
+        response = minMaxQuery(ScoreMode.Avg, 2, null);
 
         assertThat(response.getHits().totalHits(), equalTo(2L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
@@ -1829,13 +1829,13 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
         assertThat(response.getHits().hits()[1].score(), equalTo(1.5f));
 
-        response = minMaxQuery(ScoreMode.Avg, 3, 0);
+        response = minMaxQuery(ScoreMode.Avg, 3, null);
 
         assertThat(response.getHits().totalHits(), equalTo(1L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(2f));
 
-        response = minMaxQuery(ScoreMode.Avg, 4, 0);
+        response = minMaxQuery(ScoreMode.Avg, 4, null);
 
         assertThat(response.getHits().totalHits(), equalTo(0L));
 

--- a/docs/reference/migration/migrate_5_0/search.asciidoc
+++ b/docs/reference/migration/migrate_5_0/search.asciidoc
@@ -116,11 +116,11 @@ in favour of `query` and `no_match_query`.
 * The `score_type` parameter to the `nested`, has_child` and `has_parent` queries has been removed in favour of `score_mode`.
   Also, the `total` score mode has been removed in favour of the `sum` mode.
 
-*  When the `max_children` parameter was set to `0` on the `has_child` query
-   then there was no upper limit on how many child documents were allowed to
-   match. Now, `0` really means that zero child documents are allowed. If no
-   upper limit is needed then the `max_children` parameter shouldn't be specified
-   at all.
+* When the `max_children` parameter was set to `0` on the `has_child` query
+  then there was no upper limit on how many child documents were allowed to
+  match. Now, `0` really means that zero child documents are allowed. If no
+  upper limit is needed then the `max_children` parameter shouldn't be specified
+  at all.
 
 
 ==== Top level `filter` parameter

--- a/docs/reference/migration/migrate_5_0/search.asciidoc
+++ b/docs/reference/migration/migrate_5_0/search.asciidoc
@@ -113,8 +113,8 @@ in favour of `query` and `no_match_query`.
 
 * The `collect_payloads` parameter of the `span_near` query has been deprecated.  Payloads will be loaded when needed.
 
-* The `score_type` parameter to the `has_child` and `has_parent` queries has been removed in favour of `score_mode`.
-  Also, the `sum` score mode has been removed in favour of the `total` mode.
+* The `score_type` parameter to the `nested`, has_child` and `has_parent` queries has been removed in favour of `score_mode`.
+  Also, the `total` score mode has been removed in favour of the `sum` mode.
 
 *  When the `max_children` parameter was set to `0` on the `has_child` query
    then there was no upper limit on how many child documents were allowed to


### PR DESCRIPTION
PR for #17083

This also removes some old 1.x `max_children` logic, that turns a value of `0` into `Integer.MAX_VALUE`.
This should have been removed via #13470 but found its way back.
