### PR TITLE
Always write shard state in SMILE format 

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/ShardStateMetaData.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShardStateMetaData.java
@@ -102,7 +102,7 @@ public final class ShardStateMetaData {
         return "version [" + legacyVersion + "], primary [" + primary + "], allocation [" + allocationId + "]";
     }
 
-    public static final MetaDataStateFormat<ShardStateMetaData> FORMAT = new MetaDataStateFormat<ShardStateMetaData>(XContentType.JSON, SHARD_STATE_FILE_PREFIX) {
+    public static final MetaDataStateFormat<ShardStateMetaData> FORMAT = new MetaDataStateFormat<ShardStateMetaData>(XContentType.SMILE, SHARD_STATE_FILE_PREFIX) {
 
         @Override
         protected XContentBuilder newXContentBuilder(XContentType type, OutputStream stream) throws IOException {


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/17123, we standardized writing global and index level states in `SMILE` format 
for efficient parsing and storage. In this PR, we change the format for shard level state 
