### PR TITLE
Call ensureOpen on Translog#newView() to prevent IllegalStateException

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -610,6 +610,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         // we need to acquire the read lock to make sure no new translog is created
         // and will be missed by the view we're making
         try (ReleasableLock lock = readLock.acquire()) {
+            ensureOpen();
             ArrayList<TranslogReader> translogs = new ArrayList<>();
             try {
                 if (currentCommittingTranslog != null) {

--- a/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -2045,4 +2045,18 @@ public class TranslogTests extends ESTestCase {
             }
         }
     }
+
+    public void testPullViewOnClosed() throws IOException {
+        if (randomBoolean()) {
+            translog.prepareCommit();
+        }
+        translog.close();
+        try {
+
+            translog.newView();
+            fail("must throw ACE");
+        } catch (AlreadyClosedException ex) {
+            // all is well
+        }
+    }
 }


### PR DESCRIPTION
If a new view is pulled on a translog that was closed before the currently
committing translog was actually committed we run into odd IllegalStateExceptions
since we can't increment the ref count on the channel. This commit adds a missing
ensureOpen call to provide consistent AlreadyClosedExceptions.
