### PR TITLE
Cutover to elastic Vagrant boxes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,15 +23,15 @@
 
 Vagrant.configure(2) do |config|
   config.vm.define "ubuntu-1204" do |config|
-    config.vm.box = "ubuntu/precise64"
+    config.vm.box = "elastic/ubuntu-12.04-x86_64"
     ubuntu_common config
   end
   config.vm.define "ubuntu-1404" do |config|
-    config.vm.box = "ubuntu/trusty64"
+    config.vm.box = "elastic/ubuntu-14.04-x86_64"
     ubuntu_common config
   end
   config.vm.define "ubuntu-1504" do |config|
-    config.vm.box = "ubuntu/vivid64"
+    config.vm.box = "elastic/ubuntu-15.04-x86_64"
     ubuntu_common config, extra: <<-SHELL
       # Install Jayatana so we can work around it being present.
       [ -f /usr/share/java/jayatanaag.jar ] || install jayatana
@@ -41,44 +41,35 @@ Vagrant.configure(2) do |config|
   # get the sun jdk on there just aren't worth it. We have jessie for testing
   # debian and it works fine.
   config.vm.define "debian-8" do |config|
-    config.vm.box = "debian/jessie64"
-    deb_common config,
-      'echo deb http://http.debian.net/debian jessie-backports main > /etc/apt/sources.list.d/backports.list', 'backports'
+    config.vm.box = "elastic/debian-8-x86_64"
+    deb_common config, 'echo deb http://http.debian.net/debian jessie-backports main > /etc/apt/sources.list.d/backports.list', 'backports'
   end
   config.vm.define "centos-6" do |config|
-    config.vm.box = "boxcutter/centos67"
+    config.vm.box = "elastic/centos-6-x86_64"
     rpm_common config
   end
   config.vm.define "centos-7" do |config|
-    # There is a centos/7 box but it doesn't have rsync or virtualbox guest
-    # stuff on there so its slow to use. So chef it is....
-    config.vm.box = "boxcutter/centos71"
+    config.vm.box = "elastic/centos-7-x86_64"
     rpm_common config
   end
-  # This box hangs _forever_ on ```yum check-update```. I have no idea why.
-  # config.vm.define "oel-6", autostart: false do |config|
-  #   config.vm.box = "boxcutter/oel66"
-  #   rpm_common(config)
-  # end
+  config.vm.define "oel-6" do |config|
+    config.vm.box = "elastic/oraclelinux-6-x86_64"
+    rpm_common config
+  end
   config.vm.define "oel-7" do |config|
-    config.vm.box = "boxcutter/oel70"
+    config.vm.box = "elastic/oraclelinux-7-x86_64"
     rpm_common config
   end
   config.vm.define "fedora-22" do |config|
-    # Fedora hosts their own 'cloud' images that aren't in Vagrant's Atlas but
-    # and are missing required stuff like rsync. It'd be nice if we could use
-    # them but they much slower to get up and running then the boxcutter image.
-    config.vm.box = "boxcutter/fedora22"
+    config.vm.box = "elastic/fedora-22-x86_64"
     dnf_common config
   end
   config.vm.define "opensuse-13" do |config|
-    config.vm.box = "chef/opensuse-13"
-    config.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_opensuse-13.2-x86_64_chef-provisionerless.box"
+    config.vm.box = "elastic/opensuse-13-x86_64"
     opensuse_common config
   end
-  # The SLES boxes are not considered to be highest quality, but seem to be sufficient for a test run
   config.vm.define "sles-12" do |config|
-    config.vm.box = "idar/sles12"
+    config.vm.box = "elastic/sles-12-x86_64"
     sles_common config
   end
   # Switch the default share for the project root from /vagrant to

--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -26,8 +26,17 @@ String testScripts = '*.bats'
 String testCommand = "cd \$TESTROOT && sudo bats --tap \$BATS/$testScripts"
 String smokeTestCommand = 'echo I work'
 List<String> representativeBoxes = ['ubuntu-1404', 'centos-7']
-List<String> boxes = representativeBoxes + ['ubuntu-1204', 'ubuntu-1504',
-  'debian-8', 'centos-6', 'oel-7', 'fedora-22', 'opensuse-13', 'sles-12']
+List<String> boxes = representativeBoxes + [
+        'ubuntu-1204',
+        'ubuntu-1504',
+        'debian-8',
+        'centos-6',
+        'oel-6',
+        'oel-7',
+        'fedora-22',
+        'opensuse-13',
+        'sles-12'
+]
 
 /* The version of elasticsearch that we upgrade *from* as part of testing
  * upgrades. */


### PR DESCRIPTION
This commit cuts the Vagrant tests over to the elastic Vagrant boxes.

Relates #16854
