### PR TITLE
Elasticsearch ownership for data, logs, and configs

### DIFF
--- a/distribution/src/main/packaging/scripts/postinst
+++ b/distribution/src/main/packaging/scripts/postinst
@@ -96,4 +96,8 @@ elif [ "$RESTART_ON_UPGRADE" = "true" ]; then
     echo " OK"
 fi
 
+chown -R $ES_USER:$ES_GROUP /var/lib/elasticsearch
+chown -R $ES_USER:$ES_GROUP /var/log/elasticsearch
+chown -R root:$ES_GROUP /etc/elasticsearch
+
 ${scripts.footer}

--- a/qa/vagrant/src/test/resources/packaging/scripts/90_reinstall.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/90_reinstall.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+# Tests upgrading elasticsearch from a previous version with the deb or rpm
+# packages. Just uses a single node cluster on the current machine rather than
+# fancy rolling restarts.
+
+# WARNING: This testing file must be executed as root and can
+# dramatically change your system. It removes the 'elasticsearch'
+# user/group and also many directories. Do not execute this file
+# unless you know exactly what you are doing.
+
+# The test case can be executed with the Bash Automated
+# Testing System tool available at https://github.com/sstephenson/bats
+# Thanks to Sam Stephenson!
+
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Load test utilities
+load packaging_test_utils
+load os_package
+
+# Cleans everything for the 1st execution
+setup() {
+    skip_not_dpkg_or_rpm
+}
+
+@test "[REINSTALL] install" {
+    clean_before_test
+    install_package
+}
+
+@test "[REINSTALL] purge elasticsearch" {
+    purge_elasticsearch
+}
+
+@test "[REINSTALL] chown directories" {
+    # to simulate the loss of ownership
+    if [ -d /var/lib/elasticsearch ]; then
+      sudo chown -R root:root /var/lib/elasticsearch
+    fi
+    if [ -d "/var/log/elasticsearch" ]; then
+      sudo chown -R root:root /var/log/elasticsearch
+    fi
+    if [ -d /etc/elasticsearch ]; then
+      sudo chown -R root:root /etc/elasticsearch
+    fi
+}
+
+@test "[REINSTALL] reinstall elasticsearch" {
+    install_package
+}
+
+@test "[REINSTALL] check ownership" {
+    assert_recursive_ownership /var/lib/elasticsearch elasticsearch elasticsearch
+    assert_recursive_ownership /var/log/elasticsearch elasticsearch elasticsearch
+    assert_recursive_ownership /etc/elasticsearch root elasticsearch
+}

--- a/qa/vagrant/src/test/resources/packaging/scripts/packaging_test_utils.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/packaging_test_utils.bash
@@ -209,6 +209,17 @@ assert_output() {
     echo "$output" | grep -E "$1"
 }
 
+assert_recursive_ownership() {
+    local directory=$1
+    local user=$2
+    local group=$3
+
+    realuser=$(find $directory -printf "%u\n" | sort | uniq)
+    [ "$realuser" = "$user" ]
+    realgroup=$(find $directory -printf "%g\n" | sort | uniq)
+    [ "$realgroup" = "$group" ]
+}
+
 # Deletes everything before running a test file
 clean_before_test() {
 
@@ -235,6 +246,22 @@ clean_before_test() {
     # Kills all running Elasticsearch processes
     ps aux | grep -i "org.elasticsearch.bootstrap.Elasticsearch" | awk {'print $2'} | xargs kill -9 > /dev/null 2>&1 || true
 
+    purge_elasticsearch
+
+    # Removes user & group
+    userdel elasticsearch > /dev/null 2>&1 || true
+    groupdel elasticsearch > /dev/null 2>&1 || true
+
+
+    # Removes all files
+    for d in "${ELASTICSEARCH_TEST_FILES[@]}"; do
+        if [ -e "$d" ]; then
+            rm -rf "$d"
+        fi
+    done
+}
+
+purge_elasticsearch() {
     # Removes RPM package
     if is_rpm; then
         rpm --quiet -e elasticsearch > /dev/null 2>&1 || true
@@ -252,18 +279,6 @@ clean_before_test() {
     if [ -x "`which apt-get 2>/dev/null`" ]; then
         apt-get --quiet --yes purge elasticsearch > /dev/null 2>&1 || true
     fi
-
-    # Removes user & group
-    userdel elasticsearch > /dev/null 2>&1 || true
-    groupdel elasticsearch > /dev/null 2>&1 || true
-
-
-    # Removes all files
-    for d in "${ELASTICSEARCH_TEST_FILES[@]}"; do
-        if [ -e "$d" ]; then
-            rm -rf "$d"
-        fi
-    done
 }
 
 # Start elasticsearch and wait for it to come up with a status.


### PR DESCRIPTION
This pull request ensures that the data, logs, and configs directories have the correct ownership when Elasticsearch is installed from the packages.

Closes #12688
