### PR TITLE
Clarify expunge deletes option on completion suggester

### DIFF
--- a/docs/reference/search/suggesters/completion-suggest.asciidoc
+++ b/docs/reference/search/suggesters/completion-suggest.asciidoc
@@ -138,7 +138,13 @@ payloads or weights. This form does still work inside of multi fields.
 NOTE: The suggest data structure might not reflect deletes on
 documents immediately. You may need to do an <<indices-optimize>> for that.
 You can call optimize with the `only_expunge_deletes=true` to only target
-deletions for merging.
+deletions for merging. By default `only_expunge_deletes=true` will only select
+segments for merge where the percentage of deleted documents is greater than `10%` of
+the number of document in that segment. To adjust this `index.merge.policy.expunge_deletes_allowed` can
+be updated to a value between `[0..100]`. Please remember even with this option set, optimize
+is considered a extremely heavy operation and should be called rarely.
+
+
 
 [[querying]]
 ==== Querying


### PR DESCRIPTION
It's confusing that we advertise `expunge deletes` as an option
without clarifying it's relationship to the merge policy. By default
segments with less than `10%` deleted docs will not be merged / selected
for merge. This means, deletes don't _go away_ in the suggester.

Relates to #7761
