### PR TITLE
Implement available for all StreamInput classes

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/bytes/PagedBytesReference.java
+++ b/core/src/main/java/org/elasticsearch/common/bytes/PagedBytesReference.java
@@ -445,5 +445,10 @@ public class PagedBytesReference implements BytesReference {
             // do nothing
         }
 
+        @Override
+        public int available() throws IOException {
+            return length - pos;
+        }
+
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
@@ -60,6 +60,11 @@ public abstract class FilterStreamInput extends StreamInput {
     }
 
     @Override
+    public int available() throws IOException {
+        return delegate.available();
+    }
+
+    @Override
     public Version getVersion() {
         return delegate.getVersion();
     }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/InputStreamStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/InputStreamStreamInput.java
@@ -75,6 +75,11 @@ public class InputStreamStreamInput extends StreamInput {
     }
 
     @Override
+    public int available() throws IOException {
+        return is.available();
+    }
+
+    @Override
     public int read() throws IOException {
         return is.read();
     }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -37,10 +37,8 @@ import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
-import org.elasticsearch.ingest.IngestStats;
 import org.elasticsearch.search.rescore.RescoreBuilder;
 import org.elasticsearch.search.suggest.SuggestionBuilder;
-import org.elasticsearch.search.suggest.completion.context.QueryContext;
 import org.elasticsearch.search.suggest.phrase.SmoothingModel;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.search.aggregations.AggregatorBuilder;
@@ -68,7 +66,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.ElasticsearchException.readException;
@@ -374,6 +371,9 @@ public abstract class StreamInput extends InputStream {
      */
     @Override
     public abstract void close() throws IOException;
+
+    @Override
+    public abstract int available() throws IOException;
 
     public String[] readStringArray() throws IOException {
         int size = readVInt();

--- a/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -273,7 +273,9 @@ public class BytesStreamsTests extends ESTestCase {
         out.writeString("hello");
         out.writeString("goodbye");
         out.writeGenericValue(BytesRefs.toBytesRef("bytesref"));
+        final byte[] bytes = out.bytes().toBytes();
         StreamInput in = StreamInput.wrap(out.bytes().toBytes());
+        assertEquals(in.available(), bytes.length);
         assertThat(in.readBoolean(), equalTo(false));
         assertThat(in.readByte(), equalTo((byte)1));
         assertThat(in.readShort(), equalTo((short)-1));
@@ -302,9 +304,12 @@ public class BytesStreamsTests extends ESTestCase {
         namedWriteableRegistry.registerPrototype(BaseNamedWriteable.class, new TestNamedWriteable(null, null));
         TestNamedWriteable namedWriteableIn = new TestNamedWriteable(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10));
         out.writeNamedWriteable(namedWriteableIn);
-        StreamInput in = new NamedWriteableAwareStreamInput(StreamInput.wrap(out.bytes().toBytes()), namedWriteableRegistry);
+        byte[] bytes = out.bytes().toBytes();
+        StreamInput in = new NamedWriteableAwareStreamInput(StreamInput.wrap(bytes), namedWriteableRegistry);
+        assertEquals(in.available(), bytes.length);
         BaseNamedWriteable namedWriteableOut = in.readNamedWriteable(BaseNamedWriteable.class);
         assertEquals(namedWriteableOut, namedWriteableIn);
+        assertEquals(in.available(), 0);
     }
 
     public void testNamedWriteableDuplicates() throws IOException {

--- a/core/src/test/java/org/elasticsearch/common/io/stream/StreamTests.java
+++ b/core/src/test/java/org/elasticsearch/common/io/stream/StreamTests.java
@@ -23,7 +23,10 @@ import org.elasticsearch.common.bytes.ByteBufferBytesReference;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -92,5 +95,30 @@ public class StreamTests extends ESTestCase {
             assertEquals(list.get(index).v2(), entry.getValue());
             index++;
         }
+    }
+
+    public void testFilterStreamInputDelegatesAvailable() throws IOException {
+        final int length = randomIntBetween(1, 1024);
+        StreamInput delegate = StreamInput.wrap(new byte[length]);
+
+        FilterStreamInput filterInputStream = new FilterStreamInput(delegate) {};
+        assertEquals(filterInputStream.available(), length);
+
+        // read some bytes
+        final int bytesToRead = randomIntBetween(1, length);
+        filterInputStream.readBytes(new byte[bytesToRead], 0, bytesToRead);
+        assertEquals(filterInputStream.available(), length - bytesToRead);
+    }
+
+    public void testInputStreamStreamInputDelegatesAvailable() throws IOException {
+        final int length = randomIntBetween(1, 1024);
+        ByteArrayInputStream is = new ByteArrayInputStream(new byte[length]);
+        InputStreamStreamInput streamInput = new InputStreamStreamInput(is);
+        assertEquals(streamInput.available(), length);
+
+        // read some bytes
+        final int bytesToRead = randomIntBetween(1, length);
+        streamInput.readBytes(new byte[bytesToRead], 0, bytesToRead);
+        assertEquals(streamInput.available(), length - bytesToRead);
     }
 }


### PR DESCRIPTION
There are some implementation of StreamInput that implement the available method
and there are others that do not implement this method. This change makes the
available method abstract in the StreamInput class and implements the method where
it was not previously implemented.
