### PR TITLE
Build: Update ospackage gradle plugin

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -34,7 +34,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.netflix.nebula:gradle-ospackage-plugin:3.1.0'
+    classpath 'com.netflix.nebula:gradle-ospackage-plugin:3.4.0'
   }
 }
 


### PR DESCRIPTION
The older version did not support signing of the packages.
