### PR TITLE
PluginManager: Add xpack as official plugin

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -127,7 +127,8 @@ class InstallPluginCommand extends Command {
             "repository-azure",
             "repository-hdfs",
             "repository-s3",
-            "store-smb")));
+            "store-smb",
+            "xpack")));
 
     private final Environment env;
     private final OptionSpec<Void> batchOption;


### PR DESCRIPTION
In order to be able to install `xpack` as a plugin easily and unless this works
for cross product packs, this adds xpack as an official plugin.
