### PR TITLE
Don't wait for completion of list tasks tasks when wait_for_completion flag is set

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
@@ -84,7 +84,13 @@ public class TransportListTasksAction extends TransportTasksAction<Task, ListTas
         long timeoutTime = System.nanoTime() + timeout.nanos();
         super.processTasks(request, operation.andThen((Task t) -> {
             while (System.nanoTime() - timeoutTime < 0) {
-                if (taskManager.getTask(t.getId()) == null) {
+                Task task = taskManager.getTask(t.getId());
+                if (task == null) {
+                    return;
+                }
+                if (task.getAction().startsWith(ListTasksAction.NAME)) {
+                    // It doesn't make sense to wait for List Tasks and it can cause an infinite loop of the task waiting
+                    // for itself of one of its child tasks
                     return;
                 }
                 try {

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/tasks/RestListTasksAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/tasks/RestListTasksAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
@@ -51,6 +52,7 @@ public class RestListTasksAction extends BaseRestHandler {
         String[] actions = Strings.splitStringByCommaToArray(request.param("actions"));
         TaskId parentTaskId = new TaskId(request.param("parent_task_id"));
         boolean waitForCompletion = request.paramAsBoolean("wait_for_completion", false);
+        TimeValue timeout = request.paramAsTime("timeout", null);
 
         ListTasksRequest listTasksRequest = new ListTasksRequest();
         listTasksRequest.setTaskId(taskId);
@@ -59,6 +61,7 @@ public class RestListTasksAction extends BaseRestHandler {
         listTasksRequest.setActions(actions);
         listTasksRequest.setParentTaskId(parentTaskId);
         listTasksRequest.setWaitForCompletion(waitForCompletion);
+        listTasksRequest.setTimeout(timeout);
         client.admin().cluster().listTasks(listTasksRequest, new RestToXContentListener<>(channel));
     }
 }


### PR DESCRIPTION
Waiting for completion of list tasks tasks can cause an infinite loop of a list tasks task waiting for its own completion or completion of its children. To reproduce run:

```
curl "localhost:9200/_tasks?wait_for_completion"
```
