### PR TITLE
Cleanup writing upgraded index state

### DIFF
--- a/core/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/core/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -234,8 +234,8 @@ public class GatewayMetaState extends AbstractComponent implements ClusterStateL
         // We successfully checked all indices for backward compatibility and found no non-upgradable indices, which
         // means the upgrade can continue. Now it's safe to overwrite index metadata with the new version.
         for (IndexMetaData indexMetaData : updateIndexMetaData) {
-            // since we still haven't upgraded the index folders, we write index state in the old folder
-            metaStateService.writeIndex("upgrade", indexMetaData, nodeEnv.resolveIndexFolder(indexMetaData.getIndex().getUUID()));
+            // since we upgraded the index folders already, write index state in the upgraded index folder
+            metaStateService.writeIndex("upgrade", indexMetaData);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/gateway/MetaStateService.java
+++ b/core/src/main/java/org/elasticsearch/gateway/MetaStateService.java
@@ -121,18 +121,11 @@ public class MetaStateService extends AbstractComponent {
      * Writes the index state.
      */
     void writeIndex(String reason, IndexMetaData indexMetaData) throws IOException {
-        writeIndex(reason, indexMetaData, nodeEnv.indexPaths(indexMetaData.getIndex()));
-    }
-
-    /**
-     * Writes the index state in <code>locations</code>, use {@link #writeGlobalState(String, MetaData)}
-     * to write index state in index paths
-     */
-    void writeIndex(String reason, IndexMetaData indexMetaData, Path[] locations) throws IOException {
         final Index index = indexMetaData.getIndex();
         logger.trace("[{}] writing state, reason [{}]", index, reason);
         try {
-            IndexMetaData.FORMAT.write(indexMetaData, indexMetaData.getVersion(), locations);
+            IndexMetaData.FORMAT.write(indexMetaData, indexMetaData.getVersion(),
+                nodeEnv.indexPaths(indexMetaData.getIndex()));
         } catch (Throwable ex) {
             logger.warn("[{}]: failed to write index state", ex, index);
             throw new IOException("failed to write state for [" + index + "]", ex);


### PR DESCRIPTION
In #17187, we upgrade index state after upgrading index folder structure. 
As we don't have to write the upgraded state in the old index folder structure,
we can cleanup how we write upgraded index state.
