### PR TITLE
Improve error message if resource files have illegal encoding

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -441,7 +441,6 @@
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]MergeSchedulerConfig.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]NodeServicesProvider.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]SearchSlowLog.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]analysis[/\\]Analysis.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]analysis[/\\]AnalysisRegistry.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]analysis[/\\]AnalysisService.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]analysis[/\\]CommonGramsTokenFilterFactory.java" checks="LineLength" />

--- a/core/src/test/java/org/elasticsearch/index/analysis/AnalysisTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/AnalysisTests.java
@@ -21,7 +21,22 @@ package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.util.CharArraySet;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.test.ESTestCase;
+
+import java.io.BufferedWriter;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.MalformedInputException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.hamcrest.Matchers.is;
@@ -41,5 +56,56 @@ public class AnalysisTests extends ESTestCase {
         assertThat(set.contains("foo"), is(true));
         assertThat(set.contains("bar"), is(true));
         assertThat(set.contains("baz"), is(false));
+    }
+
+    public void testParseNonExistingFile() {
+        Path tempDir = createTempDir();
+        Settings nodeSettings = Settings.builder()
+            .put("foo.bar_path", tempDir.resolve("foo.dict"))
+            .put(Environment.PATH_HOME_SETTING.getKey(), tempDir).build();
+        Environment env = new Environment(nodeSettings);
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
+            () -> Analysis.getWordList(env, nodeSettings, "foo.bar"));
+        assertEquals("IOException while reading foo.bar_path: " +  tempDir.resolve("foo.dict").toString(), ex.getMessage());
+        assertTrue(ex.getCause().toString(), ex.getCause() instanceof FileNotFoundException
+            || ex.getCause() instanceof NoSuchFileException);
+    }
+
+
+    public void testParseFalseEncodedFile() throws IOException {
+        Path tempDir = createTempDir();
+        Path dict = tempDir.resolve("foo.dict");
+        Settings nodeSettings = Settings.builder()
+            .put("foo.bar_path", dict)
+            .put(Environment.PATH_HOME_SETTING.getKey(), tempDir).build();
+        try (OutputStream writer = Files.newOutputStream(dict)) {
+            writer.write(new byte[]{(byte) 0xff, 0x00, 0x00}); // some invalid UTF-8
+            writer.write('\n');
+        }
+        Environment env = new Environment(nodeSettings);
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
+            () -> Analysis.getWordList(env, nodeSettings, "foo.bar"));
+        assertEquals("Unsupported character encoding detected while reading foo.bar_path: " + tempDir.resolve("foo.dict").toString()
+            + " - files must be UTF-8 encoded" , ex.getMessage());
+        assertTrue(ex.getCause().toString(), ex.getCause() instanceof MalformedInputException
+            || ex.getCause() instanceof CharacterCodingException);
+    }
+
+    public void testParseWordList() throws IOException {
+        Path tempDir = createTempDir();
+        Path dict = tempDir.resolve("foo.dict");
+        Settings nodeSettings = Settings.builder()
+            .put("foo.bar_path", dict)
+            .put(Environment.PATH_HOME_SETTING.getKey(), tempDir).build();
+        try (BufferedWriter writer = Files.newBufferedWriter(dict, StandardCharsets.UTF_8)) {
+            writer.write("hello");
+            writer.write('\n');
+            writer.write("world");
+            writer.write('\n');
+        }
+        Environment env = new Environment(nodeSettings);
+        List<String> wordList = Analysis.getWordList(env, nodeSettings, "foo.bar");
+        assertEquals(Arrays.asList("hello", "world"), wordList);
+
     }
 }


### PR DESCRIPTION
This commit fixes string formatting issues in the error handling and
provides a better error message if malformed input is detected.
This commit also adds tests for both situations.

Relates to #17212
