### PR TITLE
Remove unused methods and fields in NestedInnerQueryParseSupport

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/support/NestedInnerQueryParseSupport.java
+++ b/core/src/main/java/org/elasticsearch/index/query/support/NestedInnerQueryParseSupport.java
@@ -20,9 +20,7 @@
 package org.elasticsearch.index.query.support;
 
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.join.BitSetProducer;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -45,46 +43,18 @@ public class NestedInnerQueryParseSupport {
     protected final QueryParseContext parseContext;
 
     private BytesReference source;
-    private Query innerQuery;
     private Query innerFilter;
     protected String path;
 
     private boolean filterParsed = false;
-    private boolean queryParsed = false;
-    protected boolean queryFound = false;
     protected boolean filterFound = false;
 
-    protected BitSetProducer parentFilter;
-    protected Query childFilter;
-
     protected ObjectMapper nestedObjectMapper;
-    private ObjectMapper parentObjectMapper;
 
     public NestedInnerQueryParseSupport(XContentParser parser, QueryShardContext context) {
         shardContext = context;
         parseContext = shardContext.parseContext();
         shardContext.reset(parser);
-
-    }
-
-    public NestedInnerQueryParseSupport(QueryShardContext context) {
-        this.parseContext = context.parseContext();
-        this.shardContext = context;
-    }
-
-    public void query() throws IOException {
-        if (path != null) {
-            setPathLevel();
-            try {
-                innerQuery = parseContext.parseInnerQueryBuilder().toQuery(this.shardContext);
-            } finally {
-                resetPathLevel();
-            }
-            queryParsed = true;
-        } else {
-            source = XContentFactory.smileBuilder().copyCurrentStructure(parseContext.parser()).bytes();
-        }
-        queryFound = true;
     }
 
     public void filter() throws IOException {
@@ -101,35 +71,6 @@ public class NestedInnerQueryParseSupport {
             source = XContentFactory.smileBuilder().copyCurrentStructure(parseContext.parser()).bytes();
         }
         filterFound = true;
-    }
-
-    public Query getInnerQuery() throws IOException {
-        if (queryParsed) {
-            return innerQuery;
-        } else {
-            if (path == null) {
-                throw new QueryShardException(shardContext, "[nested] requires 'path' field");
-            }
-            if (!queryFound) {
-                throw new QueryShardException(shardContext, "[nested] requires either 'query' or 'filter' field");
-            }
-
-            XContentParser old = parseContext.parser();
-            try {
-                XContentParser innerParser = XContentHelper.createParser(source);
-                parseContext.parser(innerParser);
-                setPathLevel();
-                try {
-                    innerQuery = parseContext.parseInnerQueryBuilder().toQuery(this.shardContext);
-                } finally {
-                    resetPathLevel();
-                }
-                queryParsed = true;
-                return innerQuery;
-            } finally {
-                parseContext.parser(old);
-            }
-        }
     }
 
     public Query getInnerFilter() throws IOException {
@@ -178,27 +119,12 @@ public class NestedInnerQueryParseSupport {
         return nestedObjectMapper;
     }
 
-    public boolean queryFound() {
-        return queryFound;
-    }
-
     public boolean filterFound() {
         return filterFound;
     }
 
-    public ObjectMapper getParentObjectMapper() {
-        return parentObjectMapper;
-    }
-
     private void setPathLevel() {
-        ObjectMapper objectMapper = shardContext.nestedScope().getObjectMapper();
-        if (objectMapper == null) {
-            parentFilter = shardContext.bitsetFilter(Queries.newNonNestedFilter());
-        } else {
-            parentFilter = shardContext.bitsetFilter(objectMapper.nestedTypeFilter());
-        }
-        childFilter = nestedObjectMapper.nestedTypeFilter();
-        parentObjectMapper = shardContext.nestedScope().nextLevel(nestedObjectMapper);
+        shardContext.nestedScope().nextLevel(nestedObjectMapper);
     }
 
     private void resetPathLevel() {


### PR DESCRIPTION
While reaftoring the SortBuilders in #17205 I came upon a few places in NestedInnerQueryParseSupport that seemed unused. In order to reduce the complexity while doing the rest of the refactoring, this factores out this simplifications to get a separate review for it.
