### PR TITLE
[TEST] fix incorrect indent in ingest/70_bulk.yaml

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/ingest/70_bulk.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/ingest/70_bulk.yaml
@@ -69,7 +69,7 @@ setup:
   - is_false: _source.field2
 
   - do:
-    cluster.state: {}
+      cluster.state: {}
     # Get master node id
   - set: { master_node: master }
 


### PR DESCRIPTION
Otherwise `do` and `cluster.state` are part of the same hash (json equivalent `{"do": null, "cluster.state": {}}`) which is invalid.
