### PR TITLE
Link to named queries docs from bool query page

### DIFF
--- a/docs/reference/query-dsl/bool-query.asciidoc
+++ b/docs/reference/query-dsl/bool-query.asciidoc
@@ -141,3 +141,10 @@ GET _search
 }
 ---------------------------------
 // AUTOSENSE
+
+==== Using named queries to see which clauses matched
+
+If you need to know which of the clauses in the bool query matched the documents
+returned from the query, you can use
+<<search-request-named-queries-and-filters,named queries>> to assign a name to
+each clause.


### PR DESCRIPTION
The named queries feature only makes sense with bool queries, but was not cross-referenced from the bool query documentation page.
