### PR TITLE
[TEST] Move yaml test requiring header, add skip:headers

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yaml
@@ -50,31 +50,6 @@
                 $/
 
 ---
-"Simple alias with yaml body through Accept header":
-
-  - do:
-        indices.create:
-            index: test
-
-  - do:
-        indices.put_alias:
-            index: test
-            name:  test_alias
-
-  - do:
-      cat.aliases: {}
-      headers:
-        Accept: application/yaml
-
-  - match:
-      $body: |
-        /^---\n
-          -\s+alias:\s+"test_alias"\s+
-              index:\s+"test"\s+
-              filter:\s+"-"\s+
-              routing.index:\s+"-"\s+
-              routing.search:\s+"-"\s+$/
----
 "Simple alias with yaml body through format argument":
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/20_headers.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/20_headers.yaml
@@ -1,0 +1,28 @@
+---
+"Simple alias with yaml body through Accept header":
+  - skip:
+      features: headers
+
+  - do:
+        indices.create:
+            index: test
+
+  - do:
+        indices.put_alias:
+            index: test
+            name:  test_alias
+
+  - do:
+      cat.aliases: {}
+      headers:
+        Accept: application/yaml
+
+  - match:
+      $body: |
+        /^---\n
+          -\s+alias:\s+"test_alias"\s+
+              index:\s+"test"\s+
+              filter:\s+"-"\s+
+              routing.index:\s+"-"\s+
+              routing.search:\s+"-"\s+$/
+


### PR DESCRIPTION
all clients don't have this functionality so it should be marked with `skip` just as `get/50_with_headers.yaml` is
