### PR TITLE
[TEST] Move yaml test requiring yaml, add skip:yaml

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yaml
@@ -50,31 +50,6 @@
                 $/
 
 ---
-"Simple alias with yaml body through format argument":
-
-  - do:
-        indices.create:
-            index: test
-
-  - do:
-        indices.put_alias:
-            index: test
-            name:  test_alias
-
-  - do:
-      cat.aliases:
-        format: yaml
-
-  - match:
-      $body: |
-        /^---\n
-          -\s+alias:\s+"test_alias"\s+
-              index:\s+"test"\s+
-              filter:\s+"-"\s+
-              routing.index:\s+"-"\s+
-              routing.search:\s+"-"\s+$/
-
----
 "Complex alias":
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/30_yaml.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/30_yaml.yaml
@@ -1,0 +1,29 @@
+---
+"Simple alias with yaml body through format argument":
+
+  - skip:
+      features: yaml
+
+  - do:
+        indices.create:
+            index: test
+
+  - do:
+        indices.put_alias:
+            index: test
+            name:  test_alias
+
+  - do:
+      cat.aliases:
+        format: yaml
+
+  - match:
+      $body: |
+        /^---\n
+          -\s+alias:\s+"test_alias"\s+
+              index:\s+"test"\s+
+              filter:\s+"-"\s+
+              routing.index:\s+"-"\s+
+              routing.search:\s+"-"\s+$/
+
+

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/support/Features.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/support/Features.java
@@ -34,7 +34,7 @@ import java.util.List;
  */
 public final class Features {
 
-    private static final List<String> SUPPORTED = Arrays.asList("stash_in_path", "groovy_scripting", "headers");
+    private static final List<String> SUPPORTED = Arrays.asList("stash_in_path", "groovy_scripting", "headers", "yaml");
 
     private Features() {
 


### PR DESCRIPTION
Clients don't ship with yaml (de)serializer by default so this test must be optionally skipped
