### PR TITLE
removed automatic index creation from delete api

### DIFF
--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -75,17 +75,6 @@ index with the automatically generated (and indexed)
 field _parent, which is in the format parent_type#parent_id.
 
 [float]
-[[delete-index-creation]]
-=== Automatic index creation
-
-The delete operation automatically creates an index if it has not been
-created before (check out the <<indices-create-index,create index API>>
-for manually creating an index), and also automatically creates a
-dynamic type mapping for the specific type if it has not been created
-before (check out the <<indices-put-mapping,put mapping>>
-API for manually creating type mapping).
-
-[float]
 [[delete-distributed]]
 === Distributed
 


### PR DESCRIPTION
The delete Api raises "index_not_found_exception" if index is not created before. The documentation mentions "The delete operation automatically creates an index if it has not been created before" which is not the actual behaviour.
