### PR TITLE
Other bucket now shows if enabled on empty buckets

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersAggregator.java
@@ -194,6 +194,11 @@ public class FiltersAggregator extends BucketsAggregator {
             InternalFilters.InternalBucket bucket = new InternalFilters.InternalBucket(keys[i], 0, subAggs, keyed);
             buckets.add(bucket);
         }
+        // other bucket
+        if (showOtherBucket) {
+            InternalFilters.InternalBucket bucket = new InternalFilters.InternalBucket(otherBucketKey, 0, subAggs, keyed);
+            buckets.add(bucket);
+        }
         return new InternalFilters(name, buckets, keyed, pipelineAggregators(), metaData());
     }
 


### PR DESCRIPTION
Previous to this commit empty buckets (with a doc count of zero) would not show the 'other' bucket in the filters aggregation. Now the buildEmptyBucket() method in FiltersAggregator checks to see if the other bucket is enabled when building an empty aggregation and adds it if it is enabled.

Closes #16546
