### PR TITLE
Upgrade string fields to text/keyword also if `ignore_above` is set.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/core/KeywordFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/KeywordFieldMapper.java
@@ -192,6 +192,13 @@ public final class KeywordFieldMapper extends FieldMapper implements AllFieldMap
         this.ignoreAbove = ignoreAbove;
     }
 
+    /** Values that have more chars than the return value of this method will
+     *  be skipped at parsing time. */
+    // pkg-private for testing
+    int ignoreAbove() {
+        return ignoreAbove;
+    }
+
     @Override
     protected KeywordFieldMapper clone() {
         return (KeywordFieldMapper) super.clone();

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -63,10 +63,14 @@ public class StringFieldMapper extends FieldMapper implements AllFieldMapper.Inc
     public static final String CONTENT_TYPE = "string";
     private static final int POSITION_INCREMENT_GAP_USE_ANALYZER = -1;
 
+    // If a string field is created on 5.x and all parameters are in this list then we
+    // will automatically upgrade to a text/keyword field. Otherwise we will just fail
+    // saying that string fields are not supported anymore.
     private static final Set<String> SUPPORTED_PARAMETERS_FOR_AUTO_UPGRADE = new HashSet<>(Arrays.asList(
             "type",
             // most common parameters, for which the upgrade is straightforward
-            "index", "store", "doc_values", "omit_norms", "norms", "fields", "copy_to", "fielddata"));
+            "index", "store", "doc_values", "omit_norms", "norms", "fields", "copy_to",
+            "fielddata", "ignore_above"));
 
     public static class Defaults {
         public static double FIELDDATA_MIN_FREQUENCY = 0;

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/StringMappingUpgradeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/StringMappingUpgradeTests.java
@@ -151,6 +151,19 @@ public class StringMappingUpgradeTests extends ESSingleNodeTestCase {
         assertEquals("eager_global_ordinals".equals(loading), field.fieldType().eagerGlobalOrdinals());
     }
 
+    public void testUpgradeIgnoreAbove() throws IOException {
+        IndexService indexService = createIndex("test");
+        DocumentMapperParser parser = indexService.mapperService().documentMapperParser();
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "string")
+                .field("index", "not_analyzed").field("ignore_above", 200).endObject().endObject()
+                .endObject().endObject().string();
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+        FieldMapper field = mapper.mappers().getMapper("field");
+        assertThat(field, instanceOf(KeywordFieldMapper.class));
+        assertEquals(200, ((KeywordFieldMapper) field).ignoreAbove());
+    }
+
     public void testUpgradeRandomMapping() throws IOException {
         final int iters = 20;
         for (int i = 0; i < iters; ++i) {


### PR DESCRIPTION
Since this parameter is used in the logstash default template, it would be nice
to handle it.
