### PR TITLE
Cli: Reject positional argument for bin/elasticsearch

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -76,6 +76,9 @@ class Elasticsearch extends Command {
 
     @Override
     protected void execute(Terminal terminal, OptionSet options) throws Exception {
+        if (options.nonOptionArguments().isEmpty() == false) {
+            throw new UserError(ExitCodes.USAGE, "Positional arguments not allowed, found " + options.nonOptionArguments());
+        }
         if (options.has(versionOption)) {
             if (options.has(daemonizeOption) || options.has(pidfileOption)) {
                 throw new UserError(ExitCodes.USAGE, "Elasticsearch version option is mutually exclusive with any other option");

--- a/core/src/test/java/org/elasticsearch/bootstrap/ElasticsearchCliTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/ElasticsearchCliTests.java
@@ -80,16 +80,23 @@ public class ElasticsearchCliTests extends ESTestCase {
         runTest(
             ExitCodes.USAGE,
             false,
-            output -> assertThat(output, containsString("Positional args not allowed, found [foo]")),
+            output -> assertThat(output, containsString("Positional arguments not allowed, found [foo]")),
             (foreground, pidFile, esSettings) -> {},
             "foo"
         );
         runTest(
             ExitCodes.USAGE,
             false,
-            output -> assertThat(output, containsString("Positional args not allowed, found [foo, bar]")),
+            output -> assertThat(output, containsString("Positional arguments not allowed, found [foo, bar]")),
             (foreground, pidFile, esSettings) -> {},
             "foo", "bar"
+        );
+        runTest(
+            ExitCodes.USAGE,
+            false,
+            output -> assertThat(output, containsString("Positional arguments not allowed, found [foo]")),
+            (foreground, pidFile, esSettings) -> {},
+            "-E", "something", "foo", "-E", "somethingelse"
         );
     }
 

--- a/core/src/test/java/org/elasticsearch/bootstrap/ElasticsearchCliTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/ElasticsearchCliTests.java
@@ -76,6 +76,23 @@ public class ElasticsearchCliTests extends ESTestCase {
         runTest(expectedStatus, false, outputConsumer, (foreground, pidFile, esSettings) -> {}, args);
     }
 
+    public void testPositionalArgs() throws Exception {
+        runTest(
+            ExitCodes.USAGE,
+            false,
+            output -> assertThat(output, containsString("Positional args not allowed, found [foo]")),
+            (foreground, pidFile, esSettings) -> {},
+            "foo"
+        );
+        runTest(
+            ExitCodes.USAGE,
+            false,
+            output -> assertThat(output, containsString("Positional args not allowed, found [foo, bar]")),
+            (foreground, pidFile, esSettings) -> {},
+            "foo", "bar"
+        );
+    }
+
     public void testThatPidFileCanBeConfigured() throws Exception {
         runPidFileTest(ExitCodes.USAGE, false, output -> assertThat(output, containsString("Option p/pidfile requires an argument")), "-p");
         runPidFileTest(ExitCodes.OK, true, output -> {}, "-p", "/tmp/pid");


### PR DESCRIPTION
This exits with a usage error when bin/elasticsearch recieves any
positional args.

closes #17287 

I labeled this as a non-issue since it is not yet released.
