### PR TITLE
Reindex shouldn't attempt to refresh on noops

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByScrollAction.java
@@ -354,7 +354,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
      * Start terminating a request that finished non-catastrophically.
      */
     void startNormalTermination(List<Failure> indexingFailures, List<ShardSearchFailure> searchFailures, boolean timedOut) {
-        if (task.isCancelled() || false == mainRequest.isRefresh()) {
+        if (task.isCancelled() || false == mainRequest.isRefresh() || destinationIndices.isEmpty()) {
             finishHim(null, indexingFailures, searchFailures, timedOut);
             return;
         }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/AsyncBulkByScrollActionTests.java
@@ -458,23 +458,29 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     }
 
     public void testRefreshIsFalseByDefault() throws Exception {
-        refreshTestCase(null, false);
+        refreshTestCase(null, true, false);
     }
 
-    public void testRefreshFalseDoesntMakeVisible() throws Exception {
-        refreshTestCase(false, false);
+    public void testRefreshFalseDoesntExecuteRefresh() throws Exception {
+        refreshTestCase(false, true, false);
     }
 
-    public void testRefreshTrueMakesVisible() throws Exception {
-        refreshTestCase(true, true);
+    public void testRefreshTrueExecutesRefresh() throws Exception {
+        refreshTestCase(true, true, true);
     }
 
-    private void refreshTestCase(Boolean refresh, boolean shouldRefresh) {
+    public void testRefreshTrueSkipsRefreshIfNoDestinationIndexes() throws Exception {
+        refreshTestCase(true, false, false);
+    }
+
+    private void refreshTestCase(Boolean refresh, boolean addDestinationIndexes, boolean shouldRefresh) {
         if (refresh != null) {
             mainRequest.setRefresh(refresh);
         }
         DummyAbstractAsyncBulkByScrollAction action = new DummyAbstractAsyncBulkByScrollAction();
-        action.addDestinationIndices(singleton("foo"));
+        if (addDestinationIndexes) {
+            action.addDestinationIndices(singleton("foo"));
+        }
         action.startNormalTermination(emptyList(), emptyList(), false);
         if (shouldRefresh) {
             assertArrayEquals(new String[] {"foo"}, client.lastRefreshRequest.get().indices());


### PR DESCRIPTION
If the user asks for a refresh but their reindex or update-by-query
operation touched no indexes we should just skip the resfresh call
entirely. Without this commit we refresh _all_ indexes which is totally
wrong.

Closes #17296
