### PR TITLE
Adding exclude_template to ignore templates that match

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestBuilder.java
@@ -49,6 +49,14 @@ public class PutIndexTemplateRequestBuilder extends MasterNodeOperationRequestBu
     }
 
     /**
+     * Sets the exclude template match expression that will be used to match on indices created, and ignore them if they match.
+     */
+    public PutIndexTemplateRequestBuilder setExcludeTemplate(String excludeTemplate) {
+        request.excludeTemplate(excludeTemplate);
+        return this;
+    }
+
+    /**
      * Sets the order of this template if more than one template matches.
      */
     public PutIndexTemplateRequestBuilder setOrder(int order) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
@@ -78,6 +78,7 @@ public class TransportPutIndexTemplateAction extends TransportMasterNodeAction<P
         indexScopedSettings.validate(templateSettingsBuilder);
         indexTemplateService.putTemplate(new MetaDataIndexTemplateService.PutRequest(cause, request.name())
                 .template(request.template())
+                .excludeTemplate(request.excludeTemplate())
                 .order(request.order())
                 .settings(templateSettingsBuilder.build())
                 .mappings(request.mappings())

--- a/core/src/main/java/org/elasticsearch/common/Strings.java
+++ b/core/src/main/java/org/elasticsearch/common/Strings.java
@@ -44,6 +44,7 @@ import java.util.TreeSet;
 
 import static java.util.Collections.unmodifiableSet;
 import static org.elasticsearch.common.util.set.Sets.newHashSet;
+import static org.elasticsearch.common.util.set.Sets.union;
 
 /**
  *
@@ -456,23 +457,34 @@ public class Strings {
         return sb.toString();
     }
 
+    public static final Set<Character> INVALID_FILENAME_CHARS_EXCLUDING_ASTERISK = unmodifiableSet(
+            newHashSet('\\', '/', '?', '"', '<', '>', '|', ' ', ','));
+
     public static final Set<Character> INVALID_FILENAME_CHARS = unmodifiableSet(
-            newHashSet('\\', '/', '*', '?', '"', '<', '>', '|', ' ', ','));
+            union(newHashSet('*'), INVALID_FILENAME_CHARS_EXCLUDING_ASTERISK));
 
     public static boolean validFileName(String fileName) {
-        for (int i = 0; i < fileName.length(); i++) {
-            char c = fileName.charAt(i);
-            if (INVALID_FILENAME_CHARS.contains(c)) {
-                return false;
-            }
-        }
-        return true;
+        return validName(fileName, INVALID_FILENAME_CHARS);
     }
 
+    /**
+     * @see #INVALID_FILENAME_CHARS_EXCLUDING_ASTERISK
+     */
     public static boolean validFileNameExcludingAstrix(String fileName) {
-        for (int i = 0; i < fileName.length(); i++) {
-            char c = fileName.charAt(i);
-            if (c != '*' && INVALID_FILENAME_CHARS.contains(c)) {
+        return validName(fileName, INVALID_FILENAME_CHARS_EXCLUDING_ASTERISK);
+    }
+
+    /**
+     * Ensure that the {@code name} does not contain any of the {@code invalidChars}.
+     *
+     * @param name The name to test
+     * @param invalidChars Invalid characters that must not exist in the {@code name}
+     * @return {@code false} if {@code name} contains any {@code invalidChars}.
+     */
+    private static boolean validName(String name, Set<Character> invalidChars) {
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            if (invalidChars.contains(c)) {
                 return false;
             }
         }

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/template/put/RestPutIndexTemplateAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/template/put/RestPutIndexTemplateAction.java
@@ -46,6 +46,7 @@ public class RestPutIndexTemplateAction extends BaseRestHandler {
     public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         PutIndexTemplateRequest putRequest = new PutIndexTemplateRequest(request.param("name"));
         putRequest.template(request.param("template", putRequest.template()));
+        putRequest.excludeTemplate(request.param("exclude_template", putRequest.excludeTemplate()));
         putRequest.order(request.paramAsInt("order", putRequest.order()));
         putRequest.masterNodeTimeout(request.paramAsTime("master_timeout", putRequest.masterNodeTimeout()));
         putRequest.create(request.paramAsBoolean("create", false));

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/template/put/MetaDataIndexTemplateServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/template/put/MetaDataIndexTemplateServiceTests.java
@@ -58,7 +58,8 @@ public class MetaDataIndexTemplateServiceTests extends ESTestCase {
 
     public void testIndexTemplateValidationAccumulatesValidationErrors() {
         PutRequest request = new PutRequest("test", "putTemplate shards");
-        request.template("_test_shards*");
+        request.template("_test_shards#*");
+        request.excludeTemplate("#invalid");
 
         Map<String, Object> map = new HashMap<>();
         map.put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, "0");
@@ -69,6 +70,8 @@ public class MetaDataIndexTemplateServiceTests extends ESTestCase {
         assertThat(throwables.get(0), instanceOf(InvalidIndexTemplateException.class));
         assertThat(throwables.get(0).getMessage(), containsString("name must not contain a space"));
         assertThat(throwables.get(0).getMessage(), containsString("template must not start with '_'"));
+        assertThat(throwables.get(0).getMessage(), containsString("template must not contain a '#'"));
+        assertThat(throwables.get(0).getMessage(), containsString("exclude_template must not contain a '#'"));
         assertThat(throwables.get(0).getMessage(), containsString("index must have 1 or more primary shards"));
     }
 
@@ -94,7 +97,11 @@ public class MetaDataIndexTemplateServiceTests extends ESTestCase {
                 new HashSet<>(),
                 null,
                 null, null);
-        MetaDataIndexTemplateService service = new MetaDataIndexTemplateService(Settings.EMPTY, null, createIndexService, new AliasValidator(Settings.EMPTY));
+        MetaDataIndexTemplateService service = new MetaDataIndexTemplateService(
+                Settings.EMPTY,
+                null,
+                createIndexService,
+                new AliasValidator(Settings.EMPTY));
 
         final List<Throwable> throwables = new ArrayList<>();
         service.putTemplate(request, new MetaDataIndexTemplateService.PutListener() {

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
@@ -551,6 +551,11 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
             @Override
             public IndexTemplateMetaData randomCreate(String name) {
                 IndexTemplateMetaData.Builder builder = IndexTemplateMetaData.builder(name);
+
+                if (randomBoolean()) {
+                    builder.excludeTemplate(randomName("skip"));
+                }
+
                 builder.order(randomInt(1000))
                         .template(randomName("temp"))
                         .settings(randomSettings(Settings.EMPTY));

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetaDataTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetaDataTests.java
@@ -117,6 +117,7 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
                         .putAlias(newAliasMetaDataBuilder("alias4").filter(ALIAS_FILTER2)))
                 .put(IndexTemplateMetaData.builder("foo")
                         .template("bar")
+                        .excludeTemplate("baz")
                         .order(1)
                         .settings(Settings.builder()
                                 .put("setting1", "value1")
@@ -138,6 +139,7 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
                         .putAlias(newAliasMetaDataBuilder("alias4").filter(ALIAS_FILTER2)))
                 .put(IndexTemplateMetaData.builder("foo")
                         .template("bar")
+                        .excludeTemplate("baz")
                         .order(1)
                         .settings(Settings.builder()
                                 .put("setting1", "value1")
@@ -296,6 +298,7 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
         // templates
         assertThat(parsedMetaData.templates().get("foo").name(), is("foo"));
         assertThat(parsedMetaData.templates().get("foo").template(), is("bar"));
+        assertThat(parsedMetaData.templates().get("foo").excludeTemplate(), is("baz"));
         assertThat(parsedMetaData.templates().get("foo").settings().get("index.setting1"), is("value1"));
         assertThat(parsedMetaData.templates().get("foo").settings().getByPrefix("index.").get("setting2"), is("value2"));
         assertThat(parsedMetaData.templates().get("foo").aliases().size(), equalTo(3));

--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -70,6 +70,34 @@ curl -XPUT localhost:9200/_template/template_1 -d '
 <1> the `{index}` placeholder within the alias name will be replaced with the
 actual index name that the template gets applied to during index creation.
 
+In general, templates should apply to every index that they match. However, for
+global templates (`"template" : "*"`), they match literally every index. This
+is great for your own indices, but it can be a problem for administrative indices
+created by tools, such as Kibana with its `.kibana` index.
+
+For this purpose, there is an extra template pattern called the `exclude_template`
+that allows you to exclude indices from having the template applied to them. When
+the template is the global template, then the `exclude_template` defaults to `".*"`,
+which means that global templates do not impact any index prefixed by a `.`, such
+as `.kibana`.
+
+[source,js]
+--------------------------------------------------
+curl -XPUT localhost:9200/_template/global_template_1 -d '
+{
+    "template" : "*",
+    "exclude_template" : ".*", <1>
+    "settings" : {
+        "number_of_shards" : 1
+    }
+}
+'
+--------------------------------------------------
+
+<1> This field is implicitly defined with this value when `template` is set to `"*"`.
+To remove this behavior, so that it truly applies to all indices, you can define
+`exclude_template` with any value, including `"exclude_template" : ""`.
+
 [float]
 [[delete]]
 === Deleting a Template

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_template/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_template/10_basic.yaml
@@ -15,6 +15,7 @@
         flat_settings: true
 
   - match: {test.template: "test-*"}
+  - match: {test.exclude_template: ".*"}
   - match: {test.settings: {index.number_of_shards: '1', index.number_of_replicas: '0'}}
 
 ---
@@ -48,6 +49,7 @@
         create: true
         body:
           template: test-*
+          exclude_template: skip-*
           settings:
             number_of_shards:   1
             number_of_replicas: 0
@@ -58,6 +60,7 @@
         flat_settings: true
 
   - match: {test.template: "test-*"}
+  - match: {test.exclude_template: "skip-*"}
   - match: {test.settings: {index.number_of_shards: '1', index.number_of_replicas: '0'}}
 
   - do:


### PR DESCRIPTION
Generally, you want your template to match all indices. However, when you supply a global template, you
do not always want that to be the case. For example, administrative indexes, like .kibana should generally not be impacted by your templates.

This adds generic support for exclude templates, but the general intent is the default behavior that it adds
surrounding global templates (`*`). If no exclude template is supplied with a global template, then it will
be ignored for any index that is prefixed by a '.' (e.g., `.kibana`).

This behavior can be overridden by supplying either an empty "exclude_template" (literally "") or specifying
any other non-null value.

Closes #17247
