### PR TITLE
Remove suggest threadpool

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
@@ -66,7 +66,6 @@ public class RestThreadPoolAction extends AbstractCatAction {
             ThreadPool.Names.REFRESH,
             ThreadPool.Names.SEARCH,
             ThreadPool.Names.SNAPSHOT,
-            ThreadPool.Names.SUGGEST,
             ThreadPool.Names.WARMER
     };
 
@@ -81,7 +80,6 @@ public class RestThreadPoolAction extends AbstractCatAction {
             "r",
             "s",
             "sn",
-            "su",
             "w"
     };
 

--- a/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -82,7 +82,6 @@ public class ThreadPool extends AbstractComponent implements Closeable {
         public static final String INDEX = "index";
         public static final String BULK = "bulk";
         public static final String SEARCH = "search";
-        public static final String SUGGEST = "suggest";
         public static final String MANAGEMENT = "management";
         public static final String FLUSH = "flush";
         public static final String REFRESH = "refresh";
@@ -139,7 +138,6 @@ public class ThreadPool extends AbstractComponent implements Closeable {
         map.put(Names.INDEX, ThreadPoolType.FIXED);
         map.put(Names.BULK, ThreadPoolType.FIXED);
         map.put(Names.SEARCH, ThreadPoolType.FIXED);
-        map.put(Names.SUGGEST, ThreadPoolType.FIXED);
         map.put(Names.MANAGEMENT, ThreadPoolType.SCALING);
         map.put(Names.FLUSH, ThreadPoolType.SCALING);
         map.put(Names.REFRESH, ThreadPoolType.SCALING);
@@ -227,7 +225,6 @@ public class ThreadPool extends AbstractComponent implements Closeable {
         add(defaultExecutorTypeSettings, new ExecutorSettingsBuilder(Names.BULK).size(availableProcessors).queueSize(50));
         add(defaultExecutorTypeSettings, new ExecutorSettingsBuilder(Names.GET).size(availableProcessors).queueSize(1000));
         add(defaultExecutorTypeSettings, new ExecutorSettingsBuilder(Names.SEARCH).size(((availableProcessors * 3) / 2) + 1).queueSize(1000));
-        add(defaultExecutorTypeSettings, new ExecutorSettingsBuilder(Names.SUGGEST).size(availableProcessors).queueSize(1000));
         add(defaultExecutorTypeSettings, new ExecutorSettingsBuilder(Names.MANAGEMENT).size(5).keepAlive("5m"));
         // no queue as this means clients will need to handle rejections on listener queue even if the operation succeeded
         // the assumption here is that the listeners should be very lightweight on the listeners side

--- a/core/src/test/java/org/elasticsearch/threadpool/ThreadPoolStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/threadpool/ThreadPoolStatsTests.java
@@ -65,7 +65,6 @@ public class ThreadPoolStatsTests extends ESTestCase {
         try (BytesStreamOutput os = new BytesStreamOutput()) {
 
             List<ThreadPoolStats.Stats> stats = new ArrayList<>();
-            stats.add(new ThreadPoolStats.Stats(ThreadPool.Names.SUGGEST, -1, 0, 0, 0, 0, 0L));
             stats.add(new ThreadPoolStats.Stats(ThreadPool.Names.SEARCH, -1, 0, 0, 0, 0, 0L));
             stats.add(new ThreadPoolStats.Stats(ThreadPool.Names.WARMER, -1, 0, 0, 0, 0, 0L));
             stats.add(new ThreadPoolStats.Stats(ThreadPool.Names.GENERIC, -1, 0, 0, 0, 0, 0L));
@@ -104,7 +103,6 @@ public class ThreadPoolStatsTests extends ESTestCase {
                         ThreadPool.Names.GENERIC,
                         ThreadPool.Names.SAME,
                         ThreadPool.Names.SEARCH,
-                        ThreadPool.Names.SUGGEST,
                         ThreadPool.Names.WARMER));
             }
         }

--- a/docs/reference/migration/migrate_5_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_5_0/settings.asciidoc
@@ -71,6 +71,10 @@ type for any thread pool has been removed. It is still possible to adjust
 relevant thread pool parameters for each of the thread pools (e.g., depending
 on the thread pool type, `keep_alive`, `queue_size`, etc.).
 
+==== Threadpool settings
+
+The `suggest` threadpool has been removed, now suggest requests use the
+`search` threadpool.
 
 ==== Analysis settings
 

--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -19,13 +19,8 @@ There are several thread pools, but the important ones include:
     queue_size of `200`.
 
 `search`::
-    For count/search operations. Thread pool type is `fixed`
+    For count/search/suggest operations. Thread pool type is `fixed`
     with a size of `int((# of available_processors * 3) / 2) + 1`,
-    queue_size of `1000`.
-
-`suggest`::
-    For suggest operations. Thread pool type is `fixed`
-    with a size of `# of available processors`,
     queue_size of `1000`.
 
 `get`::

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.thread_pool/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.thread_pool/10_basic.yaml
@@ -140,16 +140,6 @@
 
   - do:
       cat.thread_pool:
-          h: id,suggest.type,suggest.active,suggest.size,suggest.queue,suggest.queueSize,suggest.rejected,suggest.largest,suggest.completed,suggest.min,suggest.max,suggest.keepAlive
-          v: true
-
-  - match:
-      $body: |
-               /^  id  \s+  suggest.type             \s+  suggest.active  \s+  suggest.size  \s+  suggest.queue  \s+  suggest.queueSize  \s+  suggest.rejected  \s+  suggest.largest  \s+  suggest.completed  \s+  suggest.min  \s+  suggest.max  \s+  suggest.keepAlive    \n
-                  (\S+ \s+  (cached|fixed|scaling)?  \s+             \d+  \s+           \d+  \s+            \d+  \s+                \d*  \s+               \d+  \s+              \d+  \s+                \d+  \s+          \d*  \s+          \d*  \s+                \S*    \n)+  $/
-
-  - do:
-      cat.thread_pool:
           h: id,warmer.type,warmer.active,warmer.size,warmer.queue,warmer.queueSize,warmer.rejected,warmer.largest,warmer.completed,warmer.min,warmer.max,warmer.keepAlive
           v: true
 


### PR DESCRIPTION
In #17198, we removed suggest transport action, which
used the `suggest` threadpool to execute requests. Now
`suggest` threadpool is unused and suggest requests are
executed on the `search` threadpool.
