### PR TITLE
Update store.asciidoc

### DIFF
--- a/docs/reference/index-modules/store.asciidoc
+++ b/docs/reference/index-modules/store.asciidoc
@@ -14,13 +14,6 @@ in memory storage is required to maintain index consistency. This is
 required since the local gateway constructs its state from the local
 index state of each node.
 
-Another important aspect of memory based storage is the fact that
-Elasticsearch supports storing the index in memory *outside of the JVM
-heap space* using the "Memory" (see below) storage type. It translates
-to the fact that there is no need for extra large JVM heaps (with their
-own consequences) for storing the index in memory.
-
-
 [float]
 [[store-throttling]]
 === Store Level Throttling
@@ -127,4 +120,4 @@ dictionaries are large.
 === Memory
 
 The `memory` type stores the index in main memory, using Lucene's
-`RamIndexStore`.
+`RAMDirectory`.


### PR DESCRIPTION
It looks like the real off-heap memory store was removed in 1.2

The memory store is really based on lucene's RAMDirectory, which is on-heap.
