### PR TITLE
Fix TaskId#isSet to return true when id is set and not other way around

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/TransportCancelTasksAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/TransportCancelTasksAction.java
@@ -84,7 +84,7 @@ public class TransportCancelTasksAction extends TransportTasksAction<Cancellable
     }
 
     protected void processTasks(CancelTasksRequest request, Consumer<CancellableTask> operation) {
-        if (request.getTaskId().isSet() == false) {
+        if (request.getTaskId().isSet()) {
             // we are only checking one task, we can optimize it
             CancellableTask task = taskManager.getCancellableTask(request.getTaskId().getId());
             if (task != null) {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TaskInfo.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TaskInfo.java
@@ -178,7 +178,7 @@ public class TaskInfo implements Writeable<TaskInfo>, ToXContent {
         }
         builder.dateValueField("start_time_in_millis", "start_time", startTime);
         builder.timeValueField("running_time_in_nanos", "running_time", runningTimeNanos, TimeUnit.NANOSECONDS);
-        if (parentTaskId.isSet() == false) {
+        if (parentTaskId.isSet()) {
             builder.field("parent_task_id", parentTaskId.toString());
         }
         return builder;

--- a/core/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksRequest.java
@@ -60,7 +60,7 @@ public class BaseTasksRequest<Request extends BaseTasksRequest<Request>> extends
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
-        if (taskId.isSet() == false && nodesIds.length > 0) {
+        if (taskId.isSet() && nodesIds.length > 0) {
             validationException = addValidationError("task id cannot be used together with node ids",
                 validationException);
         }
@@ -165,12 +165,12 @@ public class BaseTasksRequest<Request extends BaseTasksRequest<Request>> extends
         if (getActions() != null && getActions().length > 0 && Regex.simpleMatch(getActions(), task.getAction()) == false) {
             return false;
         }
-        if (getTaskId().isSet() == false) {
+        if (getTaskId().isSet()) {
             if(getTaskId().getId() != task.getId()) {
                 return false;
             }
         }
-        if (parentTaskId.isSet() == false) {
+        if (parentTaskId.isSet()) {
             if (parentTaskId.equals(task.getParentTaskId()) == false) {
                 return false;
             }

--- a/core/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
@@ -125,14 +125,14 @@ public abstract class TransportTasksAction<
 
     protected String[] resolveNodes(TasksRequest request, ClusterState clusterState) {
         if (request.getTaskId().isSet()) {
-            return clusterState.nodes().resolveNodesIds(request.getNodesIds());
-        } else {
             return new String[]{request.getTaskId().getNodeId()};
+        } else {
+            return clusterState.nodes().resolveNodesIds(request.getNodesIds());
         }
     }
 
     protected void processTasks(TasksRequest request, Consumer<OperationTask> operation) {
-        if (request.getTaskId().isSet() == false) {
+        if (request.getTaskId().isSet()) {
             // we are only checking one task, we can optimize it
             Task task = taskManager.getTask(request.getTaskId().getId());
             if (task != null) {

--- a/core/src/main/java/org/elasticsearch/tasks/TaskId.java
+++ b/core/src/main/java/org/elasticsearch/tasks/TaskId.java
@@ -73,15 +73,15 @@ public final class TaskId implements Writeable<TaskId> {
     }
 
     public boolean isSet() {
-        return id == -1L;
+        return id != -1L;
     }
 
     @Override
     public String toString() {
         if (isSet()) {
-            return "unset";
-        } else {
             return nodeId + ":" + id;
+        } else {
+            return "unset";
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/tasks/TaskManager.java
+++ b/core/src/main/java/org/elasticsearch/tasks/TaskManager.java
@@ -76,7 +76,7 @@ public class TaskManager extends AbstractComponent implements ClusterStateListen
                 CancellableTaskHolder oldHolder = cancellableTasks.put(task.getId(), holder);
                 assert oldHolder == null;
                 // Check if this task was banned before we start it
-                if (task.getParentTaskId().isSet() == false && banedParents.isEmpty() == false) {
+                if (task.getParentTaskId().isSet() && banedParents.isEmpty() == false) {
                     String reason = banedParents.get(task.getParentTaskId());
                     if (reason != null) {
                         try {
@@ -241,7 +241,7 @@ public class TaskManager extends AbstractComponent implements ClusterStateListen
                 CancellableTaskHolder holder = taskEntry.getValue();
                 CancellableTask task = holder.getTask();
                 TaskId parentTaskId = task.getParentTaskId();
-                if (parentTaskId.isSet() == false && lastDiscoveryNodes.nodeExists(parentTaskId.getNodeId()) == false) {
+                if (parentTaskId.isSet() && lastDiscoveryNodes.nodeExists(parentTaskId.getNodeId()) == false) {
                     if (task.cancelOnParentLeaving()) {
                         holder.cancel("Coordinating node [" + parentTaskId.getNodeId() + "] left the cluster");
                     }

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -118,9 +118,9 @@ public class TasksIT extends ESIntegTestCase {
 
         // Verify that one of these tasks is a parent of another task
         if (tasks.get(0).getParentTaskId().isSet()) {
-            assertParentTask(Collections.singletonList(tasks.get(1)), tasks.get(0));
-        } else {
             assertParentTask(Collections.singletonList(tasks.get(0)), tasks.get(1));
+        } else {
+            assertParentTask(Collections.singletonList(tasks.get(1)), tasks.get(0));
         }
     }
 
@@ -474,7 +474,7 @@ public class TasksIT extends ESIntegTestCase {
      */
     private void assertParentTask(List<TaskInfo> tasks, TaskInfo parentTask) {
         for (TaskInfo task : tasks) {
-            assertFalse(task.getParentTaskId().isSet());
+            assertTrue(task.getParentTaskId().isSet());
             assertEquals(parentTask.getNode().getId(), task.getParentTaskId().getNodeId());
             assertTrue(Strings.hasLength(task.getParentTaskId().getNodeId()));
             assertEquals(parentTask.getId(), task.getParentTaskId().getId());

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -604,7 +604,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
                 @Override
                 protected TestTaskResponse taskOperation(TestTasksRequest request, Task task) {
                     logger.info("Task action on node {}", node);
-                    if (failTaskOnNode == node && task.getParentTaskId().isSet() == false) {
+                    if (failTaskOnNode == node && task.getParentTaskId().isSet()) {
                         logger.info("Failing on node {}", node);
                         throw new RuntimeException("Task level failure");
                     }


### PR DESCRIPTION
During refactoring the name was changed, but the logic wasn't. This commit fixes the logic to match the name.
