### PR TITLE
Tests: Fix vagrant test on debian

### DIFF
--- a/qa/vagrant/src/test/resources/packaging/scripts/os_package.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/os_package.bash
@@ -48,6 +48,7 @@ install_package() {
         case $opt in
             u)
                 rpmCommand='-U'
+                dpkgCommand='--force-confnew'
                 ;;
             v)
                 version=$OPTARG
@@ -60,7 +61,7 @@ install_package() {
     if is_rpm; then
         rpm $rpmCommand elasticsearch-$version.rpm
     elif is_dpkg; then
-        dpkg -i elasticsearch-$version.deb
+        dpkg $dpkgCommand -i elasticsearch-$version.deb
     else
         skip "Only rpm or deb supported"
     fi


### PR DESCRIPTION
Debian asks during installation, if the configuration file should be updated.
This is asked via a prompt and thus hangs.

This adds an option to always update to the newer config file, so automated
installation keeps working.
