### PR TITLE
Improve test to not rely on thread slowness

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexService.java
@@ -780,7 +780,7 @@ public final class IndexService extends AbstractIndexComponent implements IndexC
         }
 
         @Override
-        public void close() {
+        public synchronized void close() {
             if (closed.compareAndSet(false, true)) {
                 FutureUtils.cancel(scheduledFuture);
                 scheduledFuture = null;


### PR DESCRIPTION
We have to swap the second latch before we count it down otherwise
threads might be faster than the test. This has happend on a recent
CI failure: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+multijob-os-compatibility/os=ubuntu/121/console

This commit also adds a synchronized on the close method since it's
canceling and modifying a member varialbe that is assigned under lock.
