### PR TITLE
Cluster stats: fix memory available that is always set to 0

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodeResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodeResponse.java
@@ -69,12 +69,6 @@ public class ClusterStatsNodeResponse extends BaseNodeResponse {
         return this.shardsStats;
     }
 
-    public static ClusterStatsNodeResponse readNodeResponse(StreamInput in) throws IOException {
-        ClusterStatsNodeResponse nodeResponse = new ClusterStatsNodeResponse();
-        nodeResponse.readFrom(in);
-        return nodeResponse;
-    }
-
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -87,7 +87,7 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
                 continue;
             }
 
-            os.addNodeInfo(nodeResponse.nodeInfo());
+            os.addNodeInfoStats(nodeResponse.nodeInfo(), nodeResponse.nodeStats());
             if (nodeResponse.nodeStats().getFs() != null) {
                 fs.add(nodeResponse.nodeStats().getFs().total());
             }
@@ -309,12 +309,15 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
             names = new ObjectIntHashMap<>();
         }
 
-        public void addNodeInfo(NodeInfo nodeInfo) {
+        public void addNodeInfoStats(NodeInfo nodeInfo, NodeStats nodeStats) {
             availableProcessors += nodeInfo.getOs().getAvailableProcessors();
             allocatedProcessors += nodeInfo.getOs().getAllocatedProcessors();
 
             if (nodeInfo.getOs().getName() != null) {
                 names.addTo(nodeInfo.getOs().getName(), 1);
+            }
+            if (nodeStats.getOs() != null && nodeStats.getOs().getMem() != null) {
+                availableMemory += nodeStats.getOs().getMem().getFree().bytes();
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -99,7 +99,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
     @Override
     protected ClusterStatsNodeResponse nodeOperation(ClusterStatsNodeRequest nodeRequest) {
         NodeInfo nodeInfo = nodeService.info(false, true, false, true, false, true, false, true);
-        NodeStats nodeStats = nodeService.stats(CommonStatsFlags.NONE, false, true, true, false, true, false, false, false, false);
+        NodeStats nodeStats = nodeService.stats(CommonStatsFlags.NONE, true, true, true, false, true, false, false, false, false);
         List<ShardStats> shardsStats = new ArrayList<>();
         for (IndexService indexService : indicesService) {
             for (IndexShard indexShard : indexService) {


### PR DESCRIPTION
As discussed in #17278 I am fixing the memory available value in the cluster stats api, for the 2.x series, although we removed this field on master. The value is always set to 0 since 2.0 beta1.
