### PR TITLE
Fixed broken links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Once your changes and tests are ready to submit for review:
 1. Test your changes
 
     Run the test suite to make sure that nothing is broken. See the
-[TESTING](../TESTING.asciidoc) file for help running tests.
+[TESTING](TESTING.asciidoc) file for help running tests.
 
 2. Sign the Contributor License Agreement
 
@@ -102,5 +102,3 @@ Before submitting your changes, run the test suite to make sure that nothing is 
 ```sh
 gradle check
 ```
-
-Source: [Contributing to elasticsearch](https://www.elastic.co/contributing-to-elasticsearch/)


### PR DESCRIPTION
Fixed broken links in CONTRIBUTING.md:
- fixed TESTING.asciidoc link
- removed Contributing to elasticsearch link (redirects back to CONTRIBUTING.md).
