### PR TITLE
[docs] clarify where discovery.zen.minimum_master_node is required

### DIFF
--- a/docs/reference/migration/migrate_5_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_5_0/settings.asciidoc
@@ -213,8 +213,8 @@ name of the setting must be prefixed with `es.`.
 
 ==== Discovery Settings
 
-The `discovery.zen.minimum_master_node` must bet set for nodes that are bound
-to a non-loopback network interface. We see those nodes as in "production" mode and
-thus require the setting.
-
-
+The `discovery.zen.minimum_master_node` must bet set for nodes that have
+`network.host`, `network.bind_host`, `network.publish_host`,
+`transport.host`, `transport.bind_host`, or `transport.publish_host`
+configuration options set. We see those nodes as in "production" mode
+and thus require the setting.


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/17288 added a check to enforce that the `discovery.zen.minimum_master_nodes` configuration is set when nodes have the `host`, `port`, or `bind_host` set in either `transport` or general `network` configuration sections. This was documented incorrectly as "nodes that are bound to a non-loopback interface", which lead to confusion as I set `network.host: "localhost"` and the check was still failing.

This change updates the docs to detail the actual check. I think it also highlights how complex the check is and the need for a simpler solution.
