### PR TITLE
Don't try to use system jna for naming conventions

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/NamingConventionsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/NamingConventionsTask.groovy
@@ -68,6 +68,7 @@ public class NamingConventionsTask extends LoggedExec {
          */
         project.afterEvaluate {
             doFirst {
+                args('-Djna.nosys=true')
                 args('-cp', classpath.asPath, 'org.elasticsearch.test.NamingConventionsCheck')
                 if (skipIntegTestInDisguise) {
                     args('--skip-integ-tests-in-disguise')


### PR DESCRIPTION
When we test we add `-Djna.nosys=true` to the system properties but
we don't add it to system properties when running the naming conventions
test. This was causing the build to fail on a newly minted Ubuntu 15.10
machine, presumably because I made the mistake of installing maven using
the system package manager.
