### PR TITLE
Build: Allow for file based deploy, sign packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@
  */
 
 import com.bmuschko.gradle.nexus.NexusPlugin
+import org.eclipse.jgit.lib.Repository
+import org.eclipse.jgit.lib.RepositoryBuilder
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 
 // common maven publishing configuration
@@ -50,21 +52,37 @@ subprojects {
       javadoc = true
       tests = false
     }
+    nexus {
+      Repository repo = new RepositoryBuilder().findGitDir(new File('.')).build()
+      String shortHash = repo.resolve('HEAD')?.name?.substring(0,7)
+      String buildSnapshot = System.getProperty('build.snapshot', 'true')
+      if (buildSnapshot == 'false') {
+        repositoryUrl = project.hasProperty('build.repository') ? project.property('build.repository') : "file://${System.getenv('HOME')}/elasticsearch-releases/${version}-${shortHash}/"
+      }
+    }
     // we have our own username/password prompts so that they only happen once
-    // TODO: add gpg signing prompts
+    // TODO: add gpg signing prompts, which is tricky, as the buildDeb/buildRpm tasks are executed before this code block
     project.gradle.taskGraph.whenReady { taskGraph ->
       if (taskGraph.allTasks.any { it.name == 'uploadArchives' }) {
         Console console = System.console()
-        if (project.hasProperty('nexusUsername') == false) {
-          String nexusUsername = console.readLine('\nNexus username: ')
+        // no need for username/password on local deploy
+        if (project.nexus.repositoryUrl.startsWith('file://')) {
           project.rootProject.allprojects.each {
-            it.ext.nexusUsername = nexusUsername
+            it.ext.nexusUsername = 'foo'
+            it.ext.nexusPassword = 'bar'
           }
-        }
-        if (project.hasProperty('nexusPassword') == false) {
-          String nexusPassword = new String(console.readPassword('\nNexus password: '))
-          project.rootProject.allprojects.each {
-            it.ext.nexusPassword = nexusPassword
+        } else {
+          if (project.hasProperty('nexusUsername') == false) {
+            String nexusUsername = console.readLine('\nNexus username: ')
+            project.rootProject.allprojects.each {
+              it.ext.nexusUsername = nexusUsername
+            }
+          }
+          if (project.hasProperty('nexusPassword') == false) {
+            String nexusPassword = new String(console.readPassword('\nNexus password: '))
+            project.rootProject.allprojects.each {
+              it.ext.nexusPassword = nexusPassword
+            }
           }
         }
       }

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -287,6 +287,15 @@ configure(subprojects.findAll { ['deb', 'rpm'].contains(it.name) }) {
       we see it. We'll add it back on to the file name though. */
     version project.version.replace('-SNAPSHOT', '')
 
+    // signing setup
+    if (project.hasProperty('signing.password') && System.getProperty('build.snapshot', 'true') == 'false') {
+      signingKeyId = project.hasProperty('signing.keyId') ? project.property('signing.keyId') : 'D88E42B4'
+      signingKeyPassphrase = project.property('signing.password')
+      signingKeyRingFile = project.hasProperty('signing.secretKeyRingFile') ?
+                           project.file(project.property('signing.secretKeyRingFile')) :
+                           new File(new File(System.getProperty('user.home'), '.gnupg'), 'secring.gpg')
+    }
+
     String scripts = "${packagingFiles}/scripts"
     preInstall file("${scripts}/preinst")
     postInstall file("${scripts}/postinst")

--- a/distribution/tar/build.gradle
+++ b/distribution/tar/build.gradle
@@ -26,5 +26,8 @@ task buildTar(type: Tar) {
 
 artifacts {
   'default' buildTar
-  archives buildTar
+  project.afterEvaluate {
+    // gradle is broken for extensions that contain a dot, so we must be explicit about the name of the .asc file
+    project.signArchives.singleSignature.type = 'tar.gz.asc'
+  }
 }


### PR DESCRIPTION
This allows for a local file based deploy without needed nexus
auth information.

Also signing of packages has been added, either via gradle.properties
or using system properties as a fallback.

The property build.repository allows to configure another endpoint if no
snapshot build is done.
