### PR TITLE
Remove reference to utils for generating REST docs

### DIFF
--- a/rest-api-spec/README.markdown
+++ b/rest-api-spec/README.markdown
@@ -46,20 +46,6 @@ The specification contains:
 The `methods` and `url.paths` elements list all possible HTTP methods and URLs for the endpoint;
 it is the responsibility of the developer to use this information for a sensible API on the target platform.
 
-# Utilities
-
-The repository contains some utilities in the `utils` directory:
-
-* The `thor api:generate:spec` will generate the basic JSON specification from Java source code
-* The `thor api:generate:code` generates Ruby source code and tests from the specs, and can be extended
-  to generate assets in another programming language
-
-Run `bundle install` and then `thor list` in the _utils_ folder.
-
-The full command to generate the api spec is:
-
-    thor api:spec:generate --output=myfolder --elasticsearch=/path/to/es
-
 ## License
 
 This software is licensed under the Apache License, version 2 ("ALv2").


### PR DESCRIPTION
This removes the reference to a no longer existing utils directory that used to be there for generating docs and tests from Java source.

According to @karmi and @HonzaKral there is no more support for this type of doc/test generation.
