### PR TITLE
Don't run `mkdir` when $DATA_DIR contains a comma-separated list

### DIFF
--- a/distribution/deb/src/main/packaging/init.d/elasticsearch
+++ b/distribution/deb/src/main/packaging/init.d/elasticsearch
@@ -117,7 +117,13 @@ case "$1" in
 	fi
 
 	# Prepare environment
-	mkdir -p "$LOG_DIR" "$DATA_DIR" && chown "$ES_USER":"$ES_GROUP" "$LOG_DIR" "$DATA_DIR"
+	# Check $DATA_DIR for a comma
+	if [ "${DATA_DIR#*,}" != "$DATA_DIR" ]; then
+		# $DATA_DIR contains a comma, so we should not mkdir it
+		mkdir -p "$LOG_DIR" && chown "$ES_USER":"$ES_GROUP" "$LOG_DIR"
+	else
+		mkdir -p "$LOG_DIR" "$DATA_DIR" && chown "$ES_USER":"$ES_GROUP" "$LOG_DIR" "$DATA_DIR"
+	fi
 
 	# Ensure that the PID_DIR exists (it is cleaned at OS startup time)
 	if [ -n "$PID_DIR" ] && [ ! -e "$PID_DIR" ]; then

--- a/qa/vagrant/src/test/resources/packaging/scripts/70_sysv_initd.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/70_sysv_initd.bats
@@ -117,6 +117,23 @@ setup() {
     [ "$status" -eq 3 ] || [ "$status" -eq 4 ]
 }
 
+@test "[INIT.D] don't mkdir when it contains a comma" {
+    # Remove these just in case they exist beforehand
+    rm -rf /tmp/aoeu,/tmp/asdf
+    rm -rf /tmp/aoeu,
+    # set DATA_DIR to DATA_DIR=/tmp/aoeu,/tmp/asdf
+    sed -i 's/DATA_DIR=.*/DATA_DIR=\/tmp\/aoeu,\/tmp\/asdf/' /etc/init.d/elasticsearch
+    cat /etc/init.d/elasticsearch | grep "DATA_DIR"
+    service elasticsearch start
+    wait_for_elasticsearch_status
+    assert_file_not_exist /tmp/aoeu,/tmp/asdf
+    assert_file_not_exist /tmp/aoeu,
+    service elasticsearch stop
+    run service elasticsearch status
+    # precise returns 4, trusty 3
+    [ "$status" -eq 3 ] || [ "$status" -eq 4 ]
+}
+
 # Simulates the behavior of a system restart:
 # the PID directory is deleted by the operating system
 # but it should not block ES from starting


### PR DESCRIPTION
Resolves #16992
Resolves https://github.com/elastic/cookbook-elasticsearch/issues/441
