### PR TITLE
Fix major version designator for 2.3

### DIFF
--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -3,7 +3,7 @@
 
 :version:       2.3.0
 :branch:        2.3
-:major-version: 2.3
+:major-version: 2.x
 :jdk:           1.8.0_73
 :defguide:      https://www.elastic.co/guide/en/elasticsearch/guide/current
 :plugins:       https://www.elastic.co/guide/en/elasticsearch/plugins/2.3


### PR DESCRIPTION
This commit fixes the major version designator for 2.3. This designator
is used in docs/reference/setup/repositories.asciidoc to specify the URL
for the package repositories.

Closes #17423 
