### PR TITLE
Add randomization of XContentBuilder output to query tests

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
@@ -383,7 +383,7 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
         for (int runs = 0; runs < NUMBER_OF_TESTQUERIES; runs++) {
             QB testQuery = createTestQueryBuilder();
             XContentBuilder builder = toXContent(testQuery, randomFrom(XContentType.values()));
-            XContentBuilder shuffled = shuffleXContent(builder, provideShuffleproofFields());
+            XContentBuilder shuffled = shuffleXContent(builder, shuffleProtectedFields());
             assertParsedQuery(shuffled.bytes(), testQuery);
             for (Map.Entry<String, QB> alternateVersion : getAlternateVersions().entrySet()) {
                 String queryAsString = alternateVersion.getKey();
@@ -393,10 +393,10 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
     }
 
     /**
-     * subclasses should override this method in case some fields in xContent should be protected from random
-     * shuffling in the {@link #testFromXContent()} test case
+     * Subclasses can override this method and return a set of fields which should be protected from
+     * recursive random shuffling in the {@link #testFromXContent()} test case
      */
-    protected Set<String> provideShuffleproofFields() {
+    protected Set<String> shuffleProtectedFields() {
         return Collections.emptySet();
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.query;
 import com.carrotsearch.randomizedtesting.generators.CodepointSetGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
+
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -382,12 +383,21 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
         for (int runs = 0; runs < NUMBER_OF_TESTQUERIES; runs++) {
             QB testQuery = createTestQueryBuilder();
             XContentBuilder builder = toXContent(testQuery, randomFrom(XContentType.values()));
-            assertParsedQuery(builder.bytes(), testQuery);
+            XContentBuilder shuffled = shuffleXContent(builder, provideShuffleproofFields());
+            assertParsedQuery(shuffled.bytes(), testQuery);
             for (Map.Entry<String, QB> alternateVersion : getAlternateVersions().entrySet()) {
                 String queryAsString = alternateVersion.getKey();
                 assertParsedQuery(new BytesArray(queryAsString), alternateVersion.getValue(), ParseFieldMatcher.EMPTY);
             }
         }
+    }
+
+    /**
+     * subclasses should override this method in case some fields in xContent should be protected from random
+     * shuffling in the {@link #testFromXContent()} test case
+     */
+    protected Set<String> provideShuffleproofFields() {
+        return Collections.emptySet();
     }
 
     protected static XContentBuilder toXContent(QueryBuilder<?> query, XContentType contentType) throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/query/PercolatorQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/PercolatorQueryBuilderTests.java
@@ -38,7 +38,6 @@ import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
@@ -46,6 +45,8 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class PercolatorQueryBuilderTests extends AbstractQueryTestCase<PercolatorQueryBuilder> {
 
+    private static final Set<String> SHUFFLE_PROTECTED_FIELDS =
+            Collections.singleton(PercolatorQueryParser.DOCUMENT_FIELD.getPreferredName());
     private String indexedDocumentIndex;
     private String indexedDocumentType;
     private String indexedDocumentId;
@@ -84,10 +85,8 @@ public class PercolatorQueryBuilderTests extends AbstractQueryTestCase<Percolato
      * BytesReference
      */
     @Override
-    protected Set<String> provideShuffleproofFields() {
-        Set<String> fieldNames = new HashSet<>();
-        fieldNames.add(PercolatorQueryParser.DOCUMENT_FIELD.getPreferredName());
-        return fieldNames;
+    protected Set<String> shuffleProtectedFields() {
+        return SHUFFLE_PROTECTED_FIELDS;
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/PercolatorQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/PercolatorQueryBuilderTests.java
@@ -80,9 +80,9 @@ public class PercolatorQueryBuilderTests extends AbstractQueryTestCase<Percolato
     }
 
     /**
-     * prevent fields in the "document" field from being shuffled randomly, because it later is parsed to
-     * a {@link BytesReference} and even though the documents are the same, equals will fail when comparing
-     * BytesReference
+     * we don't want to shuffle the "document" field internally in {@link #testFromXContent()} because even though the
+     * documents would be functionally the same, their {@link BytesReference} representation isn't and thats what we
+     * compare when check for equality of the original and the shuffled builder
      */
     @Override
     protected Set<String> shuffleProtectedFields() {

--- a/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.search;
 
-import java.io.IOException;
-
 import org.elasticsearch.common.inject.ModuleTestCase;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
@@ -31,8 +29,9 @@ import org.elasticsearch.search.highlight.CustomHighlighter;
 import org.elasticsearch.search.highlight.Highlighter;
 import org.elasticsearch.search.highlight.PlainHighlighter;
 import org.elasticsearch.search.suggest.CustomSuggester;
-import org.elasticsearch.search.suggest.Suggester;
 import org.elasticsearch.search.suggest.phrase.PhraseSuggester;
+
+import java.io.IOException;
 
 import static org.hamcrest.Matchers.containsString;
 /**

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -622,7 +622,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     private static Map<String, Object> shuffleMap(Map<String, Object> map, Set<String> exceptFieldNames) {
         List<String> keys = new ArrayList<>(map.keySet());
         // even though we shuffle later, we need this to make tests reproduce on different jvms
-        //Collections.sort(keys);
+        Collections.sort(keys);
         Map<String, Object> targetMap = new TreeMap<>();
         Collections.shuffle(keys, random());
         for (String key : keys) {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.test;
 
-import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.annotations.Listeners;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakLingering;
@@ -29,6 +28,7 @@ import com.carrotsearch.randomizedtesting.generators.RandomInts;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import com.carrotsearch.randomizedtesting.rules.TestRuleAdapter;
+
 import org.apache.lucene.uninverting.UninvertingReader;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.LuceneTestCase.SuppressCodecs;
@@ -40,6 +40,7 @@ import org.elasticsearch.bootstrap.BootstrapForTesting;
 import org.elasticsearch.cache.recycler.MockPageCacheRecycler;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.io.PathUtilsForTesting;
 import org.elasticsearch.common.logging.ESLogger;
@@ -47,6 +48,9 @@ import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
@@ -73,7 +77,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -596,6 +603,30 @@ public abstract class ESTestCase extends LuceneTestCase {
         List<T> tempList = new ArrayList<>(collection);
         Collections.shuffle(tempList, random());
         return tempList.subList(0, size);
+    }
+
+    public static XContentBuilder shuffleXContent(XContentBuilder builder, Set<String> exceptFieldNames) throws IOException {
+        BytesReference bytes = builder.bytes();
+        XContentParser parser = XContentFactory.xContent(bytes).createParser(bytes);
+        // use ordered maps for reproducibility
+        Map<String, Object> shuffledMap = shuffleMap(parser.mapOrdered(), exceptFieldNames, random());
+        XContentBuilder jsonBuilder = XContentFactory.jsonBuilder();
+        return jsonBuilder.map(shuffledMap);
+    }
+
+    private static Map<String, Object> shuffleMap(Map<String, Object> map, Set<String> exceptFieldNames, Random r) {
+        List<String> keys = new ArrayList<>(map.keySet());
+        Map<String, Object> targetMap = new TreeMap<>();
+        Collections.shuffle(keys, random());
+        for (String key : keys) {
+            Object value = map.get(key);
+            if (value instanceof Map && exceptFieldNames.contains(key) == false) {
+                targetMap.put(key, shuffleMap((Map) value, exceptFieldNames, r));
+            } else {
+                targetMap.put(key, value);
+            }
+        }
+        return targetMap;
     }
 
     /**

--- a/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
@@ -20,9 +20,21 @@
 package org.elasticsearch.test.test;
 
 import junit.framework.AssertionFailedError;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 public class ESTestCaseTests extends ESTestCase {
+
     public void testExpectThrows() {
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
             throw new IllegalArgumentException("bad arg");
@@ -47,5 +59,53 @@ public class ESTestCaseTests extends ESTestCase {
             assertNull(assertFailed.getCause());
             assertEquals("Expected exception IllegalArgumentException", assertFailed.getMessage());
         }
+    }
+
+    public void testShuffleXContent() throws IOException {
+        Map<String, Object> randomStringObjectMap = randomStringObjectMap(5);
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.map(randomStringObjectMap);
+        XContentBuilder shuffleXContent = shuffleXContent(builder, Collections.emptySet());
+        XContentParser parser = XContentFactory.xContent(shuffleXContent.bytes()).createParser(shuffleXContent.bytes());
+        Map<String, Object> resultMap = parser.map();
+        assertEquals("both maps should contain the same mappings", randomStringObjectMap, resultMap);
+        assertNotEquals("Both builders string representations should be different", builder.string(), shuffleXContent.string());
+    }
+
+    private static Map<String, Object> randomStringObjectMap(int depth) {
+        Map<String, Object> result = new HashMap<>();
+        int entries = randomInt(10);
+        for (int i = 0; i < entries; i++) {
+            String key = randomAsciiOfLengthBetween(5, 15);
+            int suprise = randomIntBetween(0, 4);
+            switch (suprise) {
+            case 0:
+                result.put(key, randomUnicodeOfCodepointLength(20));
+                break;
+            case 1:
+                result.put(key, randomInt(100));
+                break;
+            case 2:
+                result.put(key, randomDoubleBetween(-100.0, 100.0, true));
+                break;
+            case 3:
+                result.put(key, randomBoolean());
+                break;
+            case 4:
+                List<String> stringList = new ArrayList<>();
+                int size = randomInt(5);
+                for (int s = 0; s < size; s++) {
+                    stringList.add(randomUnicodeOfCodepointLength(20));
+                }
+                result.put(key, stringList);
+                break;
+            default:
+                throw new IllegalArgumentException("unexpected random option: " + suprise);
+            }
+        }
+        if (depth > 0) {
+            result.put(randomAsciiOfLengthBetween(5, 15), randomStringObjectMap(depth - 1));
+        }
+        return result;
     }
 }

--- a/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
@@ -24,6 +24,7 @@ import junit.framework.AssertionFailedError;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -63,13 +64,13 @@ public class ESTestCaseTests extends ESTestCase {
 
     public void testShuffleXContent() throws IOException {
         Map<String, Object> randomStringObjectMap = randomStringObjectMap(5);
-        XContentBuilder builder = XContentFactory.jsonBuilder();
+        XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
         builder.map(randomStringObjectMap);
         XContentBuilder shuffleXContent = shuffleXContent(builder, Collections.emptySet());
         XContentParser parser = XContentFactory.xContent(shuffleXContent.bytes()).createParser(shuffleXContent.bytes());
         Map<String, Object> resultMap = parser.map();
         assertEquals("both maps should contain the same mappings", randomStringObjectMap, resultMap);
-        assertNotEquals("Both builders string representations should be different", builder.string(), shuffleXContent.string());
+        assertNotEquals("Both builders string representations should be different", builder.bytes(), shuffleXContent.bytes());
     }
 
     private static Map<String, Object> randomStringObjectMap(int depth) {


### PR DESCRIPTION
Currently our testing of parsing query builders is limited to the default order of the parameters that each builders toXContent() method produces. To better test real queries where the order of parameters can be different, this change adds a helper method to ESTestCase that takes a XContentBuilder and randomly shuffles the order of the fields inside an object. This is now used in AbstractQueryTestCase, but it can be used in other similar places in the future.
