### PR TITLE
In SLES 11, the chkconfig and service commands aren't on the path of …

### DIFF
--- a/distribution/src/main/packaging/scripts/postinst
+++ b/distribution/src/main/packaging/scripts/postinst
@@ -61,9 +61,9 @@ if [ "x$IS_UPGRADE" != "xtrue" ]; then
 
     elif command -v chkconfig >/dev/null; then
         echo "### NOT starting on installation, please execute the following statements to configure elasticsearch service to start automatically using chkconfig"
-        echo " sudo chkconfig --add elasticsearch"
+        echo " sudo -i chkconfig --add elasticsearch"
         echo "### You can start elasticsearch service by executing"
-        echo " sudo service elasticsearch start"
+        echo " sudo -i service elasticsearch start"
 
     elif command -v update-rc.d >/dev/null; then
         echo "### NOT starting on installation, please execute the following statements to configure elasticsearch service to start automatically using chkconfig"


### PR DESCRIPTION
When installing the RPM in SLES 11 SP4, the post install script says:

```
### NOT starting on installation, please execute the following statements to configure elasticsearch service to start automatically using chkconfig
 sudo chkconfig --add elasticsearch
### You can start elasticsearch service by executing
 sudo service elasticsearch start
```

But chkconfig and service aren't in the user's path, so these commands fail.  Instead, using `sudo -i` means that an initial login is simulated and sudo then uses root's path
