### PR TITLE
Make JNA calls optional

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -133,9 +133,8 @@ final class Bootstrap {
             // we've already logged this.
         }
 
-        JNANatives.trySetMaxNumberOfThreads();
-
-        JNANatives.trySetMaxSizeVirtualMemory();
+        Natives.trySetMaxNumberOfThreads();
+        Natives.trySetMaxSizeVirtualMemory();
 
         // init lucene random seed. it will use /dev/urandom where available:
         StringHelper.randomId();

--- a/core/src/main/java/org/elasticsearch/bootstrap/Natives.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Natives.java
@@ -90,7 +90,7 @@ final class Natives {
         }
         return JNANatives.LOCAL_MLOCKALL;
     }
-    
+
     static void trySeccomp(Path tmpFile) {
         if (!JNA_AVAILABLE) {
             logger.warn("cannot install syscall filters because JNA is not available");
@@ -98,7 +98,23 @@ final class Natives {
         }
         JNANatives.trySeccomp(tmpFile);
     }
-    
+
+    static void trySetMaxNumberOfThreads() {
+        if (!JNA_AVAILABLE) {
+            logger.warn("cannot getrlimit RLIMIT_NPROC because JNA is not available");
+            return;
+        }
+        JNANatives.trySetMaxNumberOfThreads();
+    }
+
+    static void trySetMaxSizeVirtualMemory() {
+        if (!JNA_AVAILABLE) {
+            logger.warn("cannot getrlimit RLIMIT_AS beacuse JNA is not available");
+            return;
+        }
+        JNANatives.trySetMaxSizeVirtualMemory();
+    }
+
     static boolean isSeccompInstalled() {
         if (!JNA_AVAILABLE) {
             return false;


### PR DESCRIPTION
The introduction of max number of processes and max size virtual memory
checks inadvertently made JNA non-optional on OS X and Linux. This
commit wraps these calls in a check to see if JNA is available so that
JNA remains optional.

Closes #17476
