### PR TITLE
Quote path to java binary

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-plugin
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin
@@ -110,4 +110,4 @@ fi
 HOSTNAME=`hostname | cut -d. -f1`
 export HOSTNAME
 
-eval "$JAVA" -client -Delasticsearch -Des.path.home="\"$ES_HOME\"" $properties -cp "\"$ES_HOME/lib/*\"" org.elasticsearch.plugins.PluginCli $args
+eval "\"$JAVA\"" -client -Delasticsearch -Des.path.home="\"$ES_HOME\"" $properties -cp "\"$ES_HOME/lib/*\"" org.elasticsearch.plugins.PluginCli $args

--- a/qa/vagrant/src/test/resources/packaging/scripts/module_and_plugin_test_cases.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/module_and_plugin_test_cases.bash
@@ -455,3 +455,24 @@ fi
     fi
     remove_jvm_example
 }
+
+@test "[$GROUP] test java home with space" {
+    # preserve JAVA_HOME
+    local java_home=$JAVA_HOME
+
+    # create a JAVA_HOME with a space
+    local java=$(which java)
+    local temp=`mktemp -d --suffix="java home"`
+    mkdir -p "$temp/bin"
+    ln -s "$java" "$temp/bin/java"
+    export JAVA_HOME="$temp"
+
+    # this will fail if the elasticsearch-plugin script does not
+    # properly handle JAVA_HOME with spaces
+    "$ESHOME/bin/elasticsearch-plugin" list
+
+    rm -rf "$temp"
+
+    # restore JAVA_HOME
+    export JAVA_HOME=$java_home
+}


### PR DESCRIPTION
This commit quotes the variable that contains the path to the java
binary. Without these quotes, when the arguments to eval are evaluated
the existing quotes will be removed leading to unquoted use of the path
to the java binary. If this path contains spaces, evaluation will fail.

Closes #17495
