### PR TITLE
Fix locahost typo and distro clarifications

### DIFF
--- a/docs/reference/setup/install/check-running.asciidoc
+++ b/docs/reference/setup/install/check-running.asciidoc
@@ -1,11 +1,11 @@
 ==== Checking that Elasticsearch is running
 
 You can test that your Elasticsearch node is running by sending an HTTP
-request to port `9200` on `127.0.0.1`:
+request to port `9200` on `localhost`:
 
 [source,sh]
 --------------------------------------------
-curl 127.0.0.1:9200
+curl localhost:9200
 --------------------------------------------
 
 which should give you a response something like this:

--- a/docs/reference/setup/install/check-running.asciidoc
+++ b/docs/reference/setup/install/check-running.asciidoc
@@ -1,11 +1,11 @@
 ==== Checking that Elasticsearch is running
 
 You can test that your Elasticsearch node is running by sending an HTTP
-request to port `9200` on `localhost`:
+request to port `9200` on `127.0.0.1`:
 
 [source,sh]
 --------------------------------------------
-curl locahost:9200
+curl 127.0.0.1:9200
 --------------------------------------------
 
 which should give you a response something like this:

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -55,9 +55,9 @@ sudo yum install elasticsearch <1>
 sudo dnf install elasticsearch <2>
 sudo zypper install elasticsearch <3>
 --------------------------------------------------
-<1> Use `yum` on Centos and older Red Hat distributions.
-<2> Use `dnf` on newer Red Hat distributions.
-<3> Use `zypper` on OpenSuSe based distributions
+<1> Use `yum` on CentOS and older Red Hat based distributions.
+<2> Use `dnf` on Fedora and other newer Red Hat distributions.
+<3> Use `zypper` on OpenSUSE based distributions
 
 [[install-rpm]]
 ==== Download and install the RPM manually


### PR DESCRIPTION
As per the commit log:
1. Apart from `locahost` typo, the issue is that localhost is not 100% safe
   for all distros with IPv6.
   For example fedora23 defines localhost4 and localhost6 (among other
   aliases) so `curl localhost:9200` doesn't work.
2. clarify that dnf is mostly for Fedora >=22
   RHEL7 and CentOS 7 are still on yum
