### PR TITLE
Deprecate mlt, in and geo_bbox query name shortcuts

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -505,60 +505,12 @@
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]percolator[/\\]PercolatorFieldMapper.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]percolator[/\\]PercolatorQueriesRegistry.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]AbstractQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]BoolQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]BoostingQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]CommonTermsQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]CommonTermsQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]ConstantScoreQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]ExistsQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]ExistsQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]FieldMaskingSpanQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]FieldMaskingSpanQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]GeoBoundingBoxQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]GeoDistanceQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]GeoDistanceQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]GeoDistanceRangeQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]GeoPolygonQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]GeoPolygonQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]GeoShapeQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]GeohashCellQuery.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]HasChildQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]HasChildQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]HasParentQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]HasParentQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]IdsQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]MatchAllQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]MatchNoneQueryParser.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]MatchQueryParser.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]MoreLikeThisQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]MultiMatchQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]NestedQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]Operator.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]PrefixQueryParser.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]QueryBuilders.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]QueryShardContext.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]QueryStringQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]QueryStringQueryParser.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]QueryValidationException.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]RangeQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]RangeQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]RegexpQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]ScriptQueryParser.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]SimpleQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]SimpleQueryStringParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]SpanContainingQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]SpanContainingQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]SpanMultiTermQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]SpanMultiTermQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]SpanTermQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]SpanWithinQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]SpanWithinQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]TemplateQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]TermQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]TermsQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]TypeQueryParser.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]WildcardQueryBuilder.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]WildcardQueryParser.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]functionscore[/\\]DecayFunctionBuilder.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]functionscore[/\\]FunctionScoreQueryBuilder.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]functionscore[/\\]FunctionScoreQueryParser.java" checks="LineLength" />
@@ -707,7 +659,6 @@
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]script[/\\]ScriptSettings.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]script[/\\]Template.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]MultiValueMode.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]SearchModule.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]SearchService.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]AggregatorFactories.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]AggregatorFactory.java" checks="LineLength" />
@@ -1178,7 +1129,6 @@
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]BoostingQueryBuilderTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]CommonTermsQueryBuilderTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]FieldMaskingSpanQueryBuilderTests.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]GeoBoundingBoxQueryBuilderTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]GeoDistanceQueryBuilderTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]HasChildQueryBuilderTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]query[/\\]HasParentQueryBuilderTests.java" checks="LineLength" />
@@ -1299,7 +1249,6 @@
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]script[/\\]ScriptServiceTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]script[/\\]ScriptSettingsTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]MultiValueModeTests.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]SearchModuleTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]SearchWithRejectionsIT.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]MissingValueIT.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]ChildrenIT.java" checks="LineLength" />

--- a/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -245,7 +245,8 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
         builder.endObject();
     }
 
-    private static void doXArrayContent(String field, List<QueryBuilder<?>> clauses, XContentBuilder builder, Params params) throws IOException {
+    private static void doXArrayContent(String field, List<QueryBuilder<?>> clauses, XContentBuilder builder, Params params)
+            throws IOException {
         if (clauses.isEmpty()) {
             return;
         }
@@ -284,7 +285,8 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
         return adjustPureNegative ? fixNegativeQueryIfNeeded(query) : query;
     }
 
-    private static void addBooleanClauses(QueryShardContext context, BooleanQuery.Builder booleanQueryBuilder, List<QueryBuilder<?>> clauses, Occur occurs) throws IOException {
+    private static void addBooleanClauses(QueryShardContext context, BooleanQuery.Builder booleanQueryBuilder,
+                                          List<QueryBuilder<?>> clauses, Occur occurs) throws IOException {
         for (QueryBuilder<?> query : clauses) {
             Query luceneQuery = null;
             switch (occurs) {
@@ -373,7 +375,8 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
         return this;
     }
 
-    private static boolean rewriteClauses(QueryRewriteContext queryRewriteContext, List<QueryBuilder<?>> builders, Consumer<QueryBuilder<?>> consumer) throws IOException {
+    private static boolean rewriteClauses(QueryRewriteContext queryRewriteContext, List<QueryBuilder<?>> builders,
+                                          Consumer<QueryBuilder<?>> consumer) throws IOException {
         boolean changed = false;
         for (QueryBuilder builder : builders) {
             QueryBuilder result = builder.rewrite(queryRewriteContext);

--- a/core/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
@@ -19,19 +19,20 @@
 
 package org.elasticsearch.index.query;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Parser for bool query
  */
 public class BoolQueryParser implements QueryParser<BoolQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(BoolQueryBuilder.NAME);
     public static final String MUSTNOT = "mustNot";
     public static final String MUST_NOT = "must_not";
     public static final String FILTER = "filter";
@@ -41,11 +42,6 @@ public class BoolQueryParser implements QueryParser<BoolQueryBuilder> {
     public static final ParseField MINIMUM_SHOULD_MATCH = new ParseField("minimum_should_match");
     public static final ParseField MINIMUM_NUMBER_SHOULD_MATCH = new ParseField("minimum_number_should_match");
     public static final ParseField ADJUST_PURE_NEGATIVE = new ParseField("adjust_pure_negative");
-
-    @Override
-    public String[] names() {
-        return new String[]{BoolQueryBuilder.NAME};
-    }
 
     @Override
     public BoolQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, ParsingException {

--- a/core/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
@@ -30,14 +30,10 @@ import java.io.IOException;
  */
 public class BoostingQueryParser implements QueryParser<BoostingQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(BoostingQueryBuilder.NAME);
     public static final ParseField POSITIVE_FIELD = new ParseField("positive");
     public static final ParseField NEGATIVE_FIELD = new ParseField("negative");
     public static final ParseField NEGATIVE_BOOST_FIELD = new ParseField("negative_boost");
-
-    @Override
-    public String[] names() {
-        return new String[]{BoostingQueryBuilder.NAME};
-    }
 
     @Override
     public BoostingQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -86,7 +82,8 @@ public class BoostingQueryParser implements QueryParser<BoostingQueryBuilder> {
             throw new ParsingException(parser.getTokenLocation(), "[boosting] query requires 'negative' query to be set'");
         }
         if (negativeBoost < 0) {
-            throw new ParsingException(parser.getTokenLocation(), "[boosting] query requires 'negative_boost' to be set to be a positive value'");
+            throw new ParsingException(parser.getTokenLocation(),
+                    "[boosting] query requires 'negative_boost' to be set to be a positive value'");
         }
 
         BoostingQueryBuilder boostingQuery = new BoostingQueryBuilder(positiveQuery, negativeQuery);

--- a/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
@@ -257,7 +257,8 @@ public class CommonTermsQueryBuilder extends AbstractQueryBuilder<CommonTermsQue
         Occur highFreqOccur = highFreqOperator.toBooleanClauseOccur();
         Occur lowFreqOccur = lowFreqOperator.toBooleanClauseOccur();
 
-        ExtendedCommonTermsQuery commonsQuery = new ExtendedCommonTermsQuery(highFreqOccur, lowFreqOccur, cutoffFrequency, disableCoord, fieldType);
+        ExtendedCommonTermsQuery commonsQuery = new ExtendedCommonTermsQuery(highFreqOccur, lowFreqOccur,
+                cutoffFrequency, disableCoord, fieldType);
         return parseQueryString(commonsQuery, text, field, analyzerObj, lowFreqMinimumShouldMatch, highFreqMinimumShouldMatch);
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
@@ -30,6 +30,7 @@ import java.io.IOException;
  */
 public class CommonTermsQueryParser implements QueryParser<CommonTermsQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(CommonTermsQueryBuilder.NAME);
     public static final ParseField CUTOFF_FREQUENCY_FIELD = new ParseField("cutoff_frequency");
     public static final ParseField MINIMUM_SHOULD_MATCH_FIELD = new ParseField("minimum_should_match");
     public static final ParseField LOW_FREQ_OPERATOR_FIELD = new ParseField("low_freq_operator");
@@ -39,11 +40,6 @@ public class CommonTermsQueryParser implements QueryParser<CommonTermsQueryBuild
     public static final ParseField QUERY_FIELD = new ParseField("query");
     public static final ParseField HIGH_FREQ_FIELD = new ParseField("high_freq");
     public static final ParseField LOW_FREQ_FIELD = new ParseField("low_freq");
-
-    @Override
-    public String[] names() {
-        return new String[] { CommonTermsQueryBuilder.NAME };
-    }
 
     @Override
     public CommonTermsQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -81,16 +77,19 @@ public class CommonTermsQueryParser implements QueryParser<CommonTermsQueryBuild
                                 } else if (parseContext.parseFieldMatcher().match(innerFieldName, HIGH_FREQ_FIELD)) {
                                     highFreqMinimumShouldMatch = parser.text();
                                 } else {
-                                    throw new ParsingException(parser.getTokenLocation(), "[" + CommonTermsQueryBuilder.NAME + "] query does not support [" + innerFieldName
+                                    throw new ParsingException(parser.getTokenLocation(), "[" + CommonTermsQueryBuilder.NAME +
+                                            "] query does not support [" + innerFieldName
                                             + "] for [" + currentFieldName + "]");
                                 }
                             } else {
-                                throw new ParsingException(parser.getTokenLocation(), "[" + CommonTermsQueryBuilder.NAME + "] unexpected token type [" + token
+                                throw new ParsingException(parser.getTokenLocation(), "[" + CommonTermsQueryBuilder.NAME +
+                                        "] unexpected token type [" + token
                                         + "] after [" + innerFieldName + "]");
                             }
                         }
                     } else {
-                        throw new ParsingException(parser.getTokenLocation(), "[" + CommonTermsQueryBuilder.NAME + "] query does not support [" + currentFieldName + "]");
+                        throw new ParsingException(parser.getTokenLocation(), "[" + CommonTermsQueryBuilder.NAME +
+                                "] query does not support [" + currentFieldName + "]");
                     }
                 } else if (token.isValue()) {
                     if (parseContext.parseFieldMatcher().match(currentFieldName, QUERY_FIELD)) {
@@ -112,7 +111,8 @@ public class CommonTermsQueryParser implements QueryParser<CommonTermsQueryBuild
                     } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.NAME_FIELD)) {
                         queryName = parser.text();
                     } else {
-                        throw new ParsingException(parser.getTokenLocation(), "[" + CommonTermsQueryBuilder.NAME + "] query does not support [" + currentFieldName + "]");
+                        throw new ParsingException(parser.getTokenLocation(), "[" + CommonTermsQueryBuilder.NAME +
+                                "] query does not support [" + currentFieldName + "]");
                     }
                 }
             }
@@ -123,7 +123,8 @@ public class CommonTermsQueryParser implements QueryParser<CommonTermsQueryBuild
             token = parser.nextToken();
             if (token != XContentParser.Token.END_OBJECT) {
                 throw new ParsingException(parser.getTokenLocation(),
-                        "[common] query parsed in simplified form, with direct field name, but included more options than just the field name, possibly use its 'options' form, with 'query' element?");
+                        "[common] query parsed in simplified form, with direct field name, but included more options than just " +
+                                "the field name, possibly use its 'options' form, with 'query' element?");
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -31,12 +30,8 @@ import java.io.IOException;
  */
 public class ConstantScoreQueryParser implements QueryParser<ConstantScoreQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(ConstantScoreQueryBuilder.NAME);
     public static final ParseField INNER_QUERY_FIELD = new ParseField("filter", "query");
-
-    @Override
-    public String[] names() {
-        return new String[]{ConstantScoreQueryBuilder.NAME, Strings.toCamelCase(ConstantScoreQueryBuilder.NAME)};
-    }
 
     @Override
     public ConstantScoreQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -63,7 +58,8 @@ public class ConstantScoreQueryParser implements QueryParser<ConstantScoreQueryB
                     query = parseContext.parseInnerQueryBuilder();
                     queryFound = true;
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[constant_score] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "[constant_score] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.NAME_FIELD)) {
@@ -71,7 +67,8 @@ public class ConstantScoreQueryParser implements QueryParser<ConstantScoreQueryB
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.BOOST_FIELD)) {
                     boost = parser.floatValue();
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[constant_score] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "[constant_score] query does not support [" + currentFieldName + "]");
                 }
             } else {
                 throw new ParsingException(parser.getTokenLocation(), "unexpected token [" + token + "]");

--- a/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -33,13 +32,9 @@ import java.util.List;
  */
 public class DisMaxQueryParser implements QueryParser<DisMaxQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(DisMaxQueryBuilder.NAME);
     public static final ParseField TIE_BREAKER_FIELD = new ParseField("tie_breaker");
     public static final ParseField QUERIES_FIELD = new ParseField("queries");
-
-    @Override
-    public String[] names() {
-        return new String[]{DisMaxQueryBuilder.NAME, Strings.toCamelCase(DisMaxQueryBuilder.NAME)};
-    }
 
     @Override
     public DisMaxQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {

--- a/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -74,7 +74,8 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
     }
 
     public static Query newFilter(QueryShardContext context, String fieldPattern) {
-        final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType)context.getMapperService().fullName(FieldNamesFieldMapper.NAME);
+        final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType =
+                (FieldNamesFieldMapper.FieldNamesFieldType)context.getMapperService().fullName(FieldNamesFieldMapper.NAME);
         if (fieldNamesFieldType == null) {
             // can only happen when no types exist, so no docs exist either
             return Queries.newMatchNoDocsQuery();

--- a/core/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
@@ -30,12 +30,8 @@ import java.io.IOException;
  */
 public class ExistsQueryParser implements QueryParser<ExistsQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(ExistsQueryBuilder.NAME);
     public static final ParseField FIELD_FIELD = new ParseField("field");
-
-    @Override
-    public String[] names() {
-        return new String[]{ExistsQueryBuilder.NAME};
-    }
 
     @Override
     public ExistsQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -58,10 +54,12 @@ public class ExistsQueryParser implements QueryParser<ExistsQueryBuilder> {
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.BOOST_FIELD)) {
                     boost = parser.floatValue();
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[" + ExistsQueryBuilder.NAME + "] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(), "[" + ExistsQueryBuilder.NAME +
+                            "] query does not support [" + currentFieldName + "]");
                 }
             } else {
-                throw new ParsingException(parser.getTokenLocation(), "[" + ExistsQueryBuilder.NAME + "] unknown token [" + token + "] after [" + currentFieldName + "]");
+                throw new ParsingException(parser.getTokenLocation(), "[" + ExistsQueryBuilder.NAME +
+                        "] unknown token [" + token + "] after [" + currentFieldName + "]");
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
@@ -31,7 +31,8 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import java.io.IOException;
 import java.util.Objects;
 
-public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMaskingSpanQueryBuilder> implements SpanQueryBuilder<FieldMaskingSpanQueryBuilder>{
+public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMaskingSpanQueryBuilder>
+        implements SpanQueryBuilder<FieldMaskingSpanQueryBuilder>{
 
     public static final String NAME = "field_masking_span";
 
@@ -39,7 +40,8 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
 
     private final String fieldName;
 
-    static final FieldMaskingSpanQueryBuilder PROTOTYPE = new FieldMaskingSpanQueryBuilder(new SpanTermQueryBuilder("field", "text"), "field");
+    static final FieldMaskingSpanQueryBuilder PROTOTYPE =
+            new FieldMaskingSpanQueryBuilder(new SpanTermQueryBuilder("field", "text"), "field");
 
     /**
      * Constructs a new {@link FieldMaskingSpanQueryBuilder} given an inner {@link SpanQueryBuilder} for

--- a/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -31,13 +30,9 @@ import java.io.IOException;
  */
 public class FieldMaskingSpanQueryParser implements QueryParser<FieldMaskingSpanQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(FieldMaskingSpanQueryBuilder.NAME);
     public static final ParseField FIELD_FIELD = new ParseField("field");
     public static final ParseField QUERY_FIELD = new ParseField("query");
-
-    @Override
-    public String[] names() {
-        return new String[]{FieldMaskingSpanQueryBuilder.NAME, Strings.toCamelCase(FieldMaskingSpanQueryBuilder.NAME)};
-    }
 
     @Override
     public FieldMaskingSpanQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -73,7 +68,8 @@ public class FieldMaskingSpanQueryParser implements QueryParser<FieldMaskingSpan
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.NAME_FIELD)) {
                     queryName = parser.text();
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[field_masking_span] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "[field_masking_span] query does not support [" + currentFieldName + "]");
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
@@ -33,17 +33,13 @@ import java.io.IOException;
 @Deprecated
 public class FuzzyQueryParser implements QueryParser<FuzzyQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(FuzzyQueryBuilder.NAME);
     public static final ParseField TERM_FIELD = new ParseField("term");
     public static final ParseField VALUE_FIELD = new ParseField("value");
     public static final ParseField PREFIX_LENGTH_FIELD = new ParseField("prefix_length");
     public static final ParseField MAX_EXPANSIONS_FIELD = new ParseField("max_expansions");
     public static final ParseField TRANSPOSITIONS_FIELD = new ParseField("transpositions");
     public static final ParseField REWRITE_FIELD = new ParseField("rewrite");
-
-    @Override
-    public String[] names() {
-        return new String[]{ FuzzyQueryBuilder.NAME };
-    }
 
     @Override
     public FuzzyQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {

--- a/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
@@ -48,7 +48,7 @@ import java.util.Objects;
  * */
 public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBoundingBoxQueryBuilder> {
     /** Name of the query. */
-    public static final String NAME = "geo_bbox";
+    public static final String NAME = "geo_bounding_box";
     /** Default type for executing this query (memory as of this writing). */
     public static final GeoExecType DEFAULT_TYPE = GeoExecType.MEMORY;
     /** Needed for serialization. */

--- a/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
@@ -30,8 +30,7 @@ import java.io.IOException;
 
 public class GeoBoundingBoxQueryParser implements QueryParser<GeoBoundingBoxQueryBuilder> {
 
-    public static final String NAME = "geo_bbox";
-
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(GeoBoundingBoxQueryBuilder.NAME, "geo_bbox");
     public static final ParseField IGNORE_MALFORMED_FIELD = new ParseField("ignore_malformed");
     public static final ParseField TYPE_FIELD = new ParseField("type");
     public static final ParseField VALIDATION_METHOD_FIELD = new ParseField("validation_method");
@@ -45,11 +44,6 @@ public class GeoBoundingBoxQueryParser implements QueryParser<GeoBoundingBoxQuer
     public static final ParseField BOTTOM_RIGHT_FIELD = new ParseField("bottom_right");
     public static final ParseField TOP_RIGHT_FIELD = new ParseField("top_right");
     public static final ParseField BOTTOM_LEFT_FIELD = new ParseField("bottom_left");
-
-    @Override
-    public String[] names() {
-        return new String[]{GeoBoundingBoxQueryBuilder.NAME, "geoBbox", "geo_bounding_box", "geoBoundingBox"};
-    }
 
     @Override
     public GeoBoundingBoxQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -114,11 +108,13 @@ public class GeoBoundingBoxQueryParser implements QueryParser<GeoBoundingBoxQuer
                                 bottom = sparse.getLat();
                                 left = sparse.getLon();
                             } else {
-                                throw new ElasticsearchParseException("failed to parse [{}] query. unexpected field [{}]", NAME, currentFieldName);
+                                throw new ElasticsearchParseException("failed to parse [{}] query. unexpected field [{}]",
+                                        QUERY_NAME_FIELD.getPreferredName(), currentFieldName);
                             }
                         }
                     } else {
-                        throw new ElasticsearchParseException("failed to parse [{}] query. field name expected but [{}] found", NAME, token);
+                        throw new ElasticsearchParseException("failed to parse [{}] query. field name expected but [{}] found",
+                                QUERY_NAME_FIELD.getPreferredName(), token);
                     }
                 }
             } else if (token.isValue()) {
@@ -138,7 +134,8 @@ public class GeoBoundingBoxQueryParser implements QueryParser<GeoBoundingBoxQuer
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, IGNORE_MALFORMED_FIELD)) {
                     ignoreMalformed = parser.booleanValue();
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "failed to parse [{}] query. unexpected field [{}]", NAME, currentFieldName);
+                    throw new ParsingException(parser.getTokenLocation(), "failed to parse [{}] query. unexpected field [{}]",
+                            QUERY_NAME_FIELD.getPreferredName(), currentFieldName);
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
@@ -234,7 +234,8 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
         if (indexVersionCreated.before(Version.V_2_2_0)) {
             GeoPointFieldMapperLegacy.GeoPointFieldType geoFieldType = ((GeoPointFieldMapperLegacy.GeoPointFieldType) fieldType);
             IndexGeoPointFieldData indexFieldData = shardContext.getForField(fieldType);
-            return new GeoDistanceRangeQuery(center, null, normDistance, true, false, geoDistance, geoFieldType, indexFieldData, optimizeBbox);
+            return new GeoDistanceRangeQuery(center, null, normDistance, true, false, geoDistance,
+                    geoFieldType, indexFieldData, optimizeBbox);
         }
 
         // if index created V_2_2 use (soon to be legacy) numeric encoding postings format

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
@@ -42,6 +42,7 @@ import java.io.IOException;
  */
 public class GeoDistanceQueryParser implements QueryParser<GeoDistanceQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(GeoDistanceQueryBuilder.NAME);
     public static final ParseField VALIDATION_METHOD_FIELD = new ParseField("validation_method");
     public static final ParseField IGNORE_MALFORMED_FIELD = new ParseField("ignore_malformed");
     public static final ParseField COERCE_FIELD = new ParseField("coerce", "normalize");
@@ -49,11 +50,6 @@ public class GeoDistanceQueryParser implements QueryParser<GeoDistanceQueryBuild
     public static final ParseField DISTANCE_TYPE_FIELD = new ParseField("distance_type");
     public static final ParseField UNIT_FIELD = new ParseField("unit");
     public static final ParseField DISTANCE_FIELD = new ParseField("distance");
-
-    @Override
-    public String[] names() {
-        return new String[]{GeoDistanceQueryBuilder.NAME, "geoDistance"};
-    }
 
     @Override
     public GeoDistanceQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -98,8 +94,8 @@ public class GeoDistanceQueryParser implements QueryParser<GeoDistanceQueryBuild
                         } else if (currentName.equals(GeoPointFieldMapper.Names.GEOHASH)) {
                             point.resetFromGeoHash(parser.text());
                         } else {
-                            throw new ParsingException(parser.getTokenLocation(), "[geo_distance] query does not support [" + currentFieldName
-                                    + "]");
+                            throw new ParsingException(parser.getTokenLocation(),
+                                    "[geo_distance] query does not support [" + currentFieldName + "]");
                         }
                     }
                 }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryParser.java
@@ -40,6 +40,7 @@ import java.io.IOException;
  */
 public class GeoDistanceRangeQueryParser implements QueryParser<GeoDistanceRangeQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(GeoDistanceRangeQueryBuilder.NAME);
     public static final ParseField FROM_FIELD = new ParseField("from");
     public static final ParseField TO_FIELD = new ParseField("to");
     public static final ParseField INCLUDE_LOWER_FIELD = new ParseField("include_lower");
@@ -56,11 +57,6 @@ public class GeoDistanceRangeQueryParser implements QueryParser<GeoDistanceRange
     public static final ParseField COERCE_FIELD = new ParseField("coerce", "normalize");
     public static final ParseField IGNORE_MALFORMED_FIELD = new ParseField("ignore_malformed");
     public static final ParseField VALIDATION_METHOD = new ParseField("validation_method");
-
-    @Override
-    public String[] names() {
-        return new String[]{GeoDistanceRangeQueryBuilder.NAME, "geoDistanceRange"};
-    }
 
     @Override
     public GeoDistanceRangeQueryBuilder getBuilderPrototype() {
@@ -173,7 +169,8 @@ public class GeoDistanceRangeQueryParser implements QueryParser<GeoDistanceRange
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, DISTANCE_TYPE_FIELD)) {
                     geoDistance = GeoDistance.fromString(parser.text());
                 } else if (currentFieldName.endsWith(GeoPointFieldMapper.Names.LAT_SUFFIX)) {
-                    String maybeFieldName = currentFieldName.substring(0, currentFieldName.length() - GeoPointFieldMapper.Names.LAT_SUFFIX.length());
+                    String maybeFieldName = currentFieldName.substring(0,
+                            currentFieldName.length() - GeoPointFieldMapper.Names.LAT_SUFFIX.length());
                     if (fieldName == null || fieldName.equals(maybeFieldName)) {
                         fieldName = maybeFieldName;
                     } else {
@@ -185,7 +182,8 @@ public class GeoDistanceRangeQueryParser implements QueryParser<GeoDistanceRange
                     }
                     point.resetLat(parser.doubleValue());
                 } else if (currentFieldName.endsWith(GeoPointFieldMapper.Names.LON_SUFFIX)) {
-                    String maybeFieldName = currentFieldName.substring(0, currentFieldName.length() - GeoPointFieldMapper.Names.LON_SUFFIX.length());
+                    String maybeFieldName = currentFieldName.substring(0,
+                            currentFieldName.length() - GeoPointFieldMapper.Names.LON_SUFFIX.length());
                     if (fieldName == null || fieldName.equals(maybeFieldName)) {
                         fieldName = maybeFieldName;
                     } else {

--- a/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
@@ -44,8 +44,8 @@ public class GeoPolygonQueryBuilder extends AbstractQueryBuilder<GeoPolygonQuery
 
     public static final String NAME = "geo_polygon";
 
-    private static final List<GeoPoint> PROTO_SHAPE = Arrays.asList(new GeoPoint[] { new GeoPoint(1.0, 1.0), new GeoPoint(1.0, 2.0),
-            new GeoPoint(2.0, 1.0) });
+    private static final List<GeoPoint> PROTO_SHAPE = Arrays.asList(new GeoPoint(1.0, 1.0), new GeoPoint(1.0, 2.0),
+            new GeoPoint(2.0, 1.0));
 
     static final GeoPolygonQueryBuilder PROTOTYPE = new GeoPolygonQueryBuilder("field", PROTO_SHAPE);
 
@@ -171,7 +171,8 @@ public class GeoPolygonQueryBuilder extends AbstractQueryBuilder<GeoPolygonQuery
         builder.endObject();
 
         builder.field(GeoPolygonQueryParser.COERCE_FIELD.getPreferredName(), GeoValidationMethod.isCoerce(validationMethod));
-        builder.field(GeoPolygonQueryParser.IGNORE_MALFORMED_FIELD.getPreferredName(), GeoValidationMethod.isIgnoreMalformed(validationMethod));
+        builder.field(GeoPolygonQueryParser.IGNORE_MALFORMED_FIELD.getPreferredName(),
+                GeoValidationMethod.isIgnoreMalformed(validationMethod));
 
         printBoostAndQueryName(builder);
         builder.endObject();

--- a/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryParser.java
@@ -44,15 +44,11 @@ import java.util.List;
  */
 public class GeoPolygonQueryParser implements QueryParser<GeoPolygonQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(GeoPolygonQueryBuilder.NAME);
     public static final ParseField COERCE_FIELD = new ParseField("coerce", "normalize");
     public static final ParseField IGNORE_MALFORMED_FIELD = new ParseField("ignore_malformed");
     public static final ParseField VALIDATION_METHOD = new ParseField("validation_method");
     public static final ParseField POINTS_FIELD = new ParseField("points");
-
-    @Override
-    public String[] names() {
-        return new String[]{GeoPolygonQueryBuilder.NAME, "geoPolygon"};
-    }
 
     @Override
     public GeoPolygonQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -88,12 +84,12 @@ public class GeoPolygonQueryParser implements QueryParser<GeoPolygonQueryBuilder
                                 shell.add(GeoUtils.parseGeoPoint(parser));
                             }
                         } else {
-                            throw new ParsingException(parser.getTokenLocation(), "[geo_polygon] query does not support [" + currentFieldName
-                                    + "]");
+                            throw new ParsingException(parser.getTokenLocation(),
+                                    "[geo_polygon] query does not support [" + currentFieldName + "]");
                         }
                     } else {
-                        throw new ParsingException(parser.getTokenLocation(), "[geo_polygon] query does not support token type [" + token.name()
-                                + "] under [" + currentFieldName + "]");
+                        throw new ParsingException(parser.getTokenLocation(),
+                                "[geo_polygon] query does not support token type [" + token.name() + "] under [" + currentFieldName + "]");
                     }
                 }
             } else if (token.isValue()) {
@@ -103,7 +99,7 @@ public class GeoPolygonQueryParser implements QueryParser<GeoPolygonQueryBuilder
                     boost = parser.floatValue();
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, COERCE_FIELD)) {
                     coerce = parser.booleanValue();
-                    if (coerce == true) {
+                    if (coerce) {
                         ignoreMalformed = true;
                     }
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, IGNORE_MALFORMED_FIELD)) {
@@ -111,7 +107,8 @@ public class GeoPolygonQueryParser implements QueryParser<GeoPolygonQueryBuilder
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, VALIDATION_METHOD)) {
                     validationMethod = GeoValidationMethod.fromString(parser.text());
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[geo_polygon] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "[geo_polygon] query does not support [" + currentFieldName + "]");
                 }
             } else {
                 throw new ParsingException(parser.getTokenLocation(), "[geo_polygon] unexpected token type [" + token.name() + "]");

--- a/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.geo.SpatialStrategy;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
@@ -31,6 +30,7 @@ import java.io.IOException;
 
 public class GeoShapeQueryParser implements QueryParser<GeoShapeQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(GeoShapeQueryBuilder.NAME);
     public static final ParseField SHAPE_FIELD = new ParseField("shape");
     public static final ParseField STRATEGY_FIELD = new ParseField("strategy");
     public static final ParseField RELATION_FIELD = new ParseField("relation");
@@ -39,11 +39,6 @@ public class GeoShapeQueryParser implements QueryParser<GeoShapeQueryBuilder> {
     public static final ParseField SHAPE_TYPE_FIELD = new ParseField("type");
     public static final ParseField SHAPE_INDEX_FIELD = new ParseField("index");
     public static final ParseField SHAPE_PATH_FIELD = new ParseField("path");
-
-    @Override
-    public String[] names() {
-        return new String[]{GeoShapeQueryBuilder.NAME, Strings.toCamelCase(GeoShapeQueryBuilder.NAME)};
-    }
 
     @Override
     public GeoShapeQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -69,7 +64,8 @@ public class GeoShapeQueryParser implements QueryParser<GeoShapeQueryBuilder> {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (fieldName != null) {
-                    throw new ParsingException(parser.getTokenLocation(), "[" + GeoShapeQueryBuilder.NAME + "] point specified twice. [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(), "[" +
+                            GeoShapeQueryBuilder.NAME + "] point specified twice. [" + currentFieldName + "]");
                 }
                 fieldName = currentFieldName;
                 while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -104,11 +100,13 @@ public class GeoShapeQueryParser implements QueryParser<GeoShapeQueryBuilder> {
                                         shapePath = parser.text();
                                     }
                                 } else {
-                                    throw new ParsingException(parser.getTokenLocation(), "[" + GeoShapeQueryBuilder.NAME + "] unknown token [" + token + "] after [" + currentFieldName + "]");
+                                    throw new ParsingException(parser.getTokenLocation(), "[" + GeoShapeQueryBuilder.NAME +
+                                            "] unknown token [" + token + "] after [" + currentFieldName + "]");
                                 }
                             }
                         } else {
-                            throw new ParsingException(parser.getTokenLocation(), "[" + GeoShapeQueryBuilder.NAME + "] query does not support [" + currentFieldName + "]");
+                            throw new ParsingException(parser.getTokenLocation(), "[" + GeoShapeQueryBuilder.NAME +
+                                    "] query does not support [" + currentFieldName + "]");
                         }
                     }
                 }
@@ -118,7 +116,8 @@ public class GeoShapeQueryParser implements QueryParser<GeoShapeQueryBuilder> {
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.NAME_FIELD)) {
                     queryName = parser.text();
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[" + GeoShapeQueryBuilder.NAME + "] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(), "[" + GeoShapeQueryBuilder.NAME +
+                            "] query does not support [" + currentFieldName + "]");
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
@@ -75,7 +75,8 @@ public class GeohashCellQuery {
      * @param geohashes   optional array of additional geohashes
      * @return a new GeoBoundinboxfilter
      */
-    public static Query create(QueryShardContext context, BaseGeoPointFieldMapper.GeoPointFieldType fieldType, String geohash, @Nullable List<CharSequence> geohashes) {
+    public static Query create(QueryShardContext context, BaseGeoPointFieldMapper.GeoPointFieldType fieldType,
+                               String geohash, @Nullable List<CharSequence> geohashes) {
         MappedFieldType geoHashMapper = fieldType.geoHashFieldType();
         if (geoHashMapper == null) {
             throw new IllegalArgumentException("geohash filter needs geohash_prefix to be enabled");
@@ -270,13 +271,10 @@ public class GeohashCellQuery {
 
     public static class Parser implements QueryParser<Builder> {
 
+        public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
+
         @Inject
         public Parser() {
-        }
-
-        @Override
-        public String[] names() {
-            return new String[]{NAME, Strings.toCamelCase(NAME)};
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
@@ -77,7 +77,8 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
 
     static final HasChildQueryBuilder PROTOTYPE = new HasChildQueryBuilder("", EmptyQueryBuilder.PROTOTYPE);
 
-    public HasChildQueryBuilder(String type, QueryBuilder query, int maxChildren, int minChildren, ScoreMode scoreMode, InnerHitBuilder innerHitBuilder) {
+    public HasChildQueryBuilder(String type, QueryBuilder query, int maxChildren, int minChildren, ScoreMode scoreMode,
+                                InnerHitBuilder innerHitBuilder) {
         this(type, query);
         scoreMode(scoreMode);
         this.maxChildren = maxChildren;
@@ -288,7 +289,8 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
                 indexSearcher.setSimilarity(similarity);
                 IndexParentChildFieldData indexParentChildFieldData = parentChildIndexFieldData.loadGlobal((DirectoryReader) reader);
                 MultiDocValues.OrdinalMap ordinalMap = ParentChildIndexFieldData.getOrdinalMap(indexParentChildFieldData, parentType);
-                return JoinUtil.createJoinQuery(joinField, innerQuery, toQuery, indexSearcher, scoreMode, ordinalMap, minChildren, maxChildren);
+                return JoinUtil.createJoinQuery(joinField, innerQuery, toQuery, indexSearcher, scoreMode,
+                        ordinalMap, minChildren, maxChildren);
             } else {
                 if (reader.leaves().isEmpty() && reader.numDocs() == 0) {
                     // asserting reader passes down a MultiReader during rewrite which makes this
@@ -297,7 +299,8 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
                     // and rewrite to match nothing
                     return new MatchNoDocsQuery();
                 }
-                throw new IllegalStateException("can't load global ordinals for reader of type: " + reader.getClass() + " must be a DirectoryReader");
+                throw new IllegalStateException("can't load global ordinals for reader of type: " +
+                        reader.getClass() + " must be a DirectoryReader");
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.support.InnerHitBuilder;
 
@@ -34,17 +33,13 @@ import java.util.Locale;
  */
 public class HasChildQueryParser implements QueryParser<HasChildQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(HasChildQueryBuilder.NAME);
     public static final ParseField QUERY_FIELD = new ParseField("query", "filter");
     public static final ParseField TYPE_FIELD = new ParseField("type", "child_type");
     public static final ParseField MAX_CHILDREN_FIELD = new ParseField("max_children");
     public static final ParseField MIN_CHILDREN_FIELD = new ParseField("min_children");
     public static final ParseField SCORE_MODE_FIELD = new ParseField("score_mode");
     public static final ParseField INNER_HITS_FIELD = new ParseField("inner_hits");
-
-    @Override
-    public String[] names() {
-        return new String[] { HasChildQueryBuilder.NAME, Strings.toCamelCase(HasChildQueryBuilder.NAME) };
-    }
 
     @Override
     public HasChildQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -90,7 +85,8 @@ public class HasChildQueryParser implements QueryParser<HasChildQueryBuilder> {
                 }
             }
         }
-        HasChildQueryBuilder hasChildQueryBuilder = new HasChildQueryBuilder(childType, iqb, maxChildren, minChildren, scoreMode, innerHitBuilder);
+        HasChildQueryBuilder hasChildQueryBuilder = new HasChildQueryBuilder(childType, iqb, maxChildren, minChildren,
+                scoreMode, innerHitBuilder);
         hasChildQueryBuilder.queryName(queryName);
         hasChildQueryBuilder.boost(boost);
         return hasChildQueryBuilder;

--- a/core/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.support.InnerHitBuilder;
 
@@ -30,17 +29,12 @@ import java.io.IOException;
 public class HasParentQueryParser implements QueryParser<HasParentQueryBuilder>  {
 
     private static final HasParentQueryBuilder PROTOTYPE = new HasParentQueryBuilder("", EmptyQueryBuilder.PROTOTYPE);
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(HasParentQueryBuilder.NAME);
     public static final ParseField QUERY_FIELD = new ParseField("query", "filter");
-    //public static final ParseField SCORE_MODE_FIELD = new ParseField("score_mode").withAllDeprecated("score");
     public static final ParseField SCORE_MODE_FIELD = new ParseField("score_mode").withAllDeprecated("score");
     public static final ParseField TYPE_FIELD = new ParseField("parent_type", "type");
     public static final ParseField SCORE_FIELD = new ParseField("score");
     public static final ParseField INNER_HITS_FIELD = new ParseField("inner_hits");
-
-    @Override
-    public String[] names() {
-        return new String[]{HasParentQueryBuilder.NAME, Strings.toCamelCase(HasParentQueryBuilder.NAME)};
-    }
 
     @Override
     public HasParentQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -75,7 +69,8 @@ public class HasParentQueryParser implements QueryParser<HasParentQueryBuilder> 
                     } else if ("none".equals(scoreModeValue)) {
                         score = false;
                     } else {
-                        throw new ParsingException(parser.getTokenLocation(), "[has_parent] query does not support [" + scoreModeValue + "] as an option for score_mode");
+                        throw new ParsingException(parser.getTokenLocation(), "[has_parent] query does not support [" +
+                                scoreModeValue + "] as an option for score_mode");
                     }
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, SCORE_FIELD)) {
                     score = parser.booleanValue();

--- a/core/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
@@ -33,14 +33,9 @@ import java.util.List;
  */
 public class IdsQueryParser implements QueryParser<IdsQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(IdsQueryBuilder.NAME);
     public static final ParseField TYPE_FIELD = new ParseField("type", "types", "_type");
-    
     public static final ParseField VALUES_FIELD = new ParseField("values");
-
-    @Override
-    public String[] names() {
-        return new String[]{IdsQueryBuilder.NAME};
-    }
 
     /**
      * @return a QueryBuilder representation of the query passed in as XContent in the parse context
@@ -71,8 +66,8 @@ public class IdsQueryParser implements QueryParser<IdsQueryBuilder> {
                             }
                             ids.add(id);
                         } else {
-                            throw new ParsingException(parser.getTokenLocation(), "Illegal value for id, expecting a string or number, got: "
-                                    + token);
+                            throw new ParsingException(parser.getTokenLocation(),
+                                    "Illegal value for id, expecting a string or number, got: " + token);
                         }
                     }
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, TYPE_FIELD)) {
@@ -84,7 +79,8 @@ public class IdsQueryParser implements QueryParser<IdsQueryBuilder> {
                         types.add(value);
                     }
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[" + IdsQueryBuilder.NAME + "] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(), "[" + IdsQueryBuilder.NAME +
+                            "] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if (parseContext.parseFieldMatcher().match(currentFieldName, TYPE_FIELD)) {
@@ -94,10 +90,12 @@ public class IdsQueryParser implements QueryParser<IdsQueryBuilder> {
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.NAME_FIELD)) {
                     queryName = parser.text();
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[" + IdsQueryBuilder.NAME + "] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(), "[" + IdsQueryBuilder.NAME +
+                            "] query does not support [" + currentFieldName + "]");
                 }
             } else {
-                throw new ParsingException(parser.getTokenLocation(), "[" + IdsQueryBuilder.NAME + "] unknown token [" + token + "] after [" + currentFieldName + "]");
+                throw new ParsingException(parser.getTokenLocation(), "[" + IdsQueryBuilder.NAME +
+                        "] unknown token [" + token + "] after [" + currentFieldName + "]");
             }
         }
         if (!idsProvided) {

--- a/core/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
@@ -32,16 +32,11 @@ import java.util.Collection;
  */
 public class IndicesQueryParser implements QueryParser {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(IndicesQueryBuilder.NAME);
     public static final ParseField QUERY_FIELD = new ParseField("query");
     public static final ParseField NO_MATCH_QUERY = new ParseField("no_match_query");
     public static final ParseField INDEX_FIELD = new ParseField("index");
     public static final ParseField INDICES_FIELD = new ParseField("indices");
-    
-
-    @Override
-    public String[] names() {
-        return new String[]{IndicesQueryBuilder.NAME};
-    }
 
     @Override
     public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, ParsingException {

--- a/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.index.query;
 
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -30,10 +30,7 @@ import java.io.IOException;
  */
 public class MatchAllQueryParser implements QueryParser<MatchAllQueryBuilder> {
 
-    @Override
-    public String[] names() {
-        return new String[]{MatchAllQueryBuilder.NAME, Strings.toCamelCase(MatchAllQueryBuilder.NAME)};
-    }
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(MatchAllQueryBuilder.NAME);
 
     @Override
     public MatchAllQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -52,10 +49,12 @@ public class MatchAllQueryParser implements QueryParser<MatchAllQueryBuilder> {
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.BOOST_FIELD)) {
                     boost = parser.floatValue();
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[" + MatchAllQueryBuilder.NAME + "] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(), "[" + MatchAllQueryBuilder.NAME +
+                            "] query does not support [" + currentFieldName + "]");
                 }
             } else {
-                throw new ParsingException(parser.getTokenLocation(), "[" + MatchAllQueryBuilder.NAME + "] unknown token [" + token + "] after [" + currentFieldName + "]");
+                throw new ParsingException(parser.getTokenLocation(), "[" + MatchAllQueryBuilder.NAME +
+                        "] unknown token [" + token + "] after [" + currentFieldName + "]");
             }
         }
         MatchAllQueryBuilder queryBuilder = new MatchAllQueryBuilder();

--- a/core/src/main/java/org/elasticsearch/index/query/MatchNoneQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchNoneQueryParser.java
@@ -19,18 +19,15 @@
 
 package org.elasticsearch.index.query;
 
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 
 public class MatchNoneQueryParser implements QueryParser<MatchNoneQueryBuilder> {
 
-    @Override
-    public String[] names() {
-        return new String[]{MatchNoneQueryBuilder.NAME, Strings.toCamelCase(MatchNoneQueryBuilder.NAME)};
-    }
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(MatchNoneQueryBuilder.NAME);
 
     @Override
     public MatchNoneQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -49,10 +46,12 @@ public class MatchNoneQueryParser implements QueryParser<MatchNoneQueryBuilder> 
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.BOOST_FIELD)) {
                     boost = parser.floatValue();
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "["+MatchNoneQueryBuilder.NAME+"] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(), "["+MatchNoneQueryBuilder.NAME +
+                            "] query does not support [" + currentFieldName + "]");
                 }
             } else {
-                throw new ParsingException(parser.getTokenLocation(), "[" + MatchNoneQueryBuilder.NAME + "] unknown token [" + token + "] after [" + currentFieldName + "]");
+                throw new ParsingException(parser.getTokenLocation(), "[" + MatchNoneQueryBuilder.NAME +
+                        "] unknown token [" + token + "] after [" + currentFieldName + "]");
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/query/MatchPhrasePrefixQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchPhrasePrefixQueryBuilder.java
@@ -38,9 +38,9 @@ import java.util.Objects;
  */
 public class MatchPhrasePrefixQueryBuilder extends AbstractQueryBuilder<MatchPhrasePrefixQueryBuilder> {
 
-    public static final ParseField MAX_EXPANSIONS_FIELD = new ParseField("max_expansions");
-
     public static final String NAME = "match_phrase_prefix";
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
+    public static final ParseField MAX_EXPANSIONS_FIELD = new ParseField("max_expansions");
 
     public static final MatchPhrasePrefixQueryBuilder PROTOTYPE = new MatchPhrasePrefixQueryBuilder("", "");
 

--- a/core/src/main/java/org/elasticsearch/index/query/MatchPhraseQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchPhraseQueryBuilder.java
@@ -36,9 +36,9 @@ import java.util.Objects;
  */
 public class MatchPhraseQueryBuilder extends AbstractQueryBuilder<MatchPhraseQueryBuilder> {
 
-    public static final ParseField SLOP_FIELD = new ParseField("slop", "phrase_slop");
-
     public static final String NAME = "match_phrase";
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
+    public static final ParseField SLOP_FIELD = new ParseField("slop", "phrase_slop");
 
     public static final MatchPhraseQueryBuilder PROTOTYPE = new MatchPhraseQueryBuilder("", "");
 

--- a/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -61,6 +61,8 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
     /** The name for the match query */
     public static final String NAME = "match";
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME, "match_fuzzy", "fuzzy_match");
+
     /** The default mode terms are combined in a match query */
     public static final Operator DEFAULT_OPERATOR = Operator.OR;
 

--- a/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -79,7 +79,7 @@ import static org.elasticsearch.index.mapper.Uid.createUidAsBytes;
  */
 public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQueryBuilder> {
 
-    public static final String NAME = "mlt";
+    public static final String NAME = "more_like_this";
 
     public static final int DEFAULT_MAX_QUERY_TERMS = XMoreLikeThis.DEFAULT_MAX_QUERY_TERMS;
     public static final int DEFAULT_MIN_TERM_FREQ = XMoreLikeThis.DEFAULT_MIN_TERM_FREQ;
@@ -478,10 +478,10 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
     public MoreLikeThisQueryBuilder(@Nullable String[] fields, @Nullable String[] likeTexts, @Nullable Item[] likeItems) {
         // TODO we allow null here for the _all field, but this is forbidden in the parser. Re-check
         if (fields != null && fields.length == 0) {
-            throw new IllegalArgumentException("mlt query requires 'fields' to be specified");
+            throw new IllegalArgumentException(NAME + " query requires 'fields' to be specified");
         }
         if ((likeTexts == null || likeTexts.length == 0) && (likeItems == null || likeItems.length == 0)) {
-            throw new IllegalArgumentException("mlt query requires either 'like' texts or items to be specified.");
+            throw new IllegalArgumentException(NAME + " query requires either 'like' texts or items to be specified.");
         }
         this.fields = fields;
         this.likeTexts = Optional.ofNullable(likeTexts).orElse(Strings.EMPTY_ARRAY);
@@ -811,7 +811,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
         if (moreLikeFields.isEmpty()) {
             return null;
         }
-        mltQuery.setMoreLikeFields(moreLikeFields.toArray(Strings.EMPTY_ARRAY));
+        mltQuery.setMoreLikeFields(moreLikeFields.toArray(new String[moreLikeFields.size()]));
 
         // handle like texts
         if (likeTexts.length > 0) {
@@ -950,7 +950,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
             uids.add(createUidAsBytes(item.type(), item.id()));
         }
         if (!uids.isEmpty()) {
-            TermsQuery query = new TermsQuery(UidFieldMapper.NAME, uids.toArray(new BytesRef[0]));
+            TermsQuery query = new TermsQuery(UidFieldMapper.NAME, uids.toArray(new BytesRef[uids.size()]));
             boolQuery.add(query, BooleanClause.Occur.MUST_NOT);
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -35,6 +35,8 @@ import java.util.List;
  */
 public class MoreLikeThisQueryParser implements QueryParser<MoreLikeThisQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(MoreLikeThisQueryBuilder.NAME, "mlt");
+
     public interface Field {
         ParseField FIELDS = new ParseField("fields");
         ParseField LIKE = new ParseField("like");
@@ -54,11 +56,6 @@ public class MoreLikeThisQueryParser implements QueryParser<MoreLikeThisQueryBui
         ParseField BOOST_TERMS = new ParseField("boost_terms");
         ParseField INCLUDE = new ParseField("include");
         ParseField FAIL_ON_UNSUPPORTED_FIELD = new ParseField("fail_on_unsupported_field");
-    }
-
-    @Override
-    public String[] names() {
-        return new String[]{MoreLikeThisQueryBuilder.NAME, "more_like_this", "moreLikeThis"};
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -34,6 +34,7 @@ import java.util.Map;
  */
 public class MultiMatchQueryParser implements QueryParser<MultiMatchQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(MultiMatchQueryBuilder.NAME);
     public static final ParseField SLOP_FIELD = new ParseField("slop", "phrase_slop");
     public static final ParseField ZERO_TERMS_QUERY_FIELD = new ParseField("zero_terms_query");
     public static final ParseField LENIENT_FIELD = new ParseField("lenient");
@@ -49,13 +50,6 @@ public class MultiMatchQueryParser implements QueryParser<MultiMatchQueryBuilder
     public static final ParseField TYPE_FIELD = new ParseField("type");
     public static final ParseField QUERY_FIELD = new ParseField("query");
     public static final ParseField FIELDS_FIELD = new ParseField("fields");
-
-    @Override
-    public String[] names() {
-        return new String[]{
-                MultiMatchQueryBuilder.NAME, "multiMatch"
-        };
-    }
 
     @Override
     public MultiMatchQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -94,7 +88,8 @@ public class MultiMatchQueryParser implements QueryParser<MultiMatchQueryBuilder
                 } else if (token.isValue()) {
                     parseFieldAndBoost(parser, fieldsBoosts);
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[" + MultiMatchQueryBuilder.NAME + "] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(), "[" + MultiMatchQueryBuilder.NAME +
+                            "] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if (parseContext.parseFieldMatcher().match(currentFieldName, QUERY_FIELD)) {
@@ -139,10 +134,12 @@ public class MultiMatchQueryParser implements QueryParser<MultiMatchQueryBuilder
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.NAME_FIELD)) {
                     queryName = parser.text();
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[" + MultiMatchQueryBuilder.NAME + "] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(), "[" + MultiMatchQueryBuilder.NAME +
+                            "] query does not support [" + currentFieldName + "]");
                 }
             } else {
-                throw new ParsingException(parser.getTokenLocation(), "[" + MultiMatchQueryBuilder.NAME + "] unknown token [" + token + "] after [" + currentFieldName + "]");
+                throw new ParsingException(parser.getTokenLocation(), "[" + MultiMatchQueryBuilder.NAME +
+                        "] unknown token [" + token + "] after [" + currentFieldName + "]");
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
@@ -19,26 +19,22 @@
 
 package org.elasticsearch.index.query;
 
-import java.io.IOException;
-
 import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.support.InnerHitBuilder;
 
+import java.io.IOException;
+
 public class NestedQueryParser implements QueryParser<NestedQueryBuilder> {
 
     private static final NestedQueryBuilder PROTOTYPE = new NestedQueryBuilder("", EmptyQueryBuilder.PROTOTYPE);
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(NestedQueryBuilder.NAME);
     public static final ParseField SCORE_MODE_FIELD = new ParseField("score_mode");
     public static final ParseField PATH_FIELD = new ParseField("path");
     public static final ParseField QUERY_FIELD = new ParseField("query");
     public static final ParseField INNER_HITS_FIELD = new ParseField("inner_hits");
-
-    @Override
-    public String[] names() {
-        return new String[]{NestedQueryBuilder.NAME};
-    }
 
     @Override
     public NestedQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {

--- a/core/src/main/java/org/elasticsearch/index/query/Operator.java
+++ b/core/src/main/java/org/elasticsearch/index/query/Operator.java
@@ -71,6 +71,7 @@ public enum Operator implements Writeable<Operator> {
     }
 
     private static IllegalArgumentException newOperatorException(String op) {
-        return new IllegalArgumentException("operator needs to be either " + CollectionUtils.arrayAsArrayList(values()) + ", but not [" + op + "]");
+        return new IllegalArgumentException("operator needs to be either " +
+                CollectionUtils.arrayAsArrayList(values()) + ", but not [" + op + "]");
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/ParentIdQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ParentIdQueryParser.java
@@ -27,13 +27,9 @@ import java.io.IOException;
 
 public final class ParentIdQueryParser implements QueryParser<ParentIdQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(ParentIdQueryBuilder.NAME);
     public static final ParseField ID_FIELD = new ParseField("id");
     public static final ParseField TYPE_FIELD = new ParseField("type", "child_type");
-
-    @Override
-    public String[] names() {
-        return new String[]{ParentIdQueryBuilder.NAME};
-    }
 
     @Override
     public ParentIdQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {

--- a/core/src/main/java/org/elasticsearch/index/query/PercolatorQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/PercolatorQueryParser.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 
 public class PercolatorQueryParser implements QueryParser<PercolatorQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(PercolatorQueryBuilder.NAME);
     public static final ParseField DOCUMENT_FIELD = new ParseField("document");
     public static final ParseField DOCUMENT_TYPE_FIELD = new ParseField("document_type");
     public static final ParseField INDEXED_DOCUMENT_FIELD_INDEX = new ParseField("index");
@@ -38,11 +39,6 @@ public class PercolatorQueryParser implements QueryParser<PercolatorQueryBuilder
     public static final ParseField INDEXED_DOCUMENT_FIELD_ROUTING = new ParseField("routing");
     public static final ParseField INDEXED_DOCUMENT_FIELD_PREFERENCE = new ParseField("preference");
     public static final ParseField INDEXED_DOCUMENT_FIELD_VERSION = new ParseField("version");
-
-    @Override
-    public String[] names() {
-        return new String[]{PercolatorQueryBuilder.NAME};
-    }
 
     @Override
     public PercolatorQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {

--- a/core/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
@@ -30,13 +30,9 @@ import java.io.IOException;
  */
 public class PrefixQueryParser implements QueryParser<PrefixQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(PrefixQueryBuilder.NAME);
     public static final ParseField PREFIX_FIELD = new ParseField("value", "prefix");
     public static final ParseField REWRITE_FIELD = new ParseField("rewrite");
-
-    @Override
-    public String[] names() {
-        return new String[]{PrefixQueryBuilder.NAME};
-    }
 
     @Override
     public PrefixQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -70,7 +66,8 @@ public class PrefixQueryParser implements QueryParser<PrefixQueryBuilder> {
                         } else if (parseContext.parseFieldMatcher().match(currentFieldName, REWRITE_FIELD)) {
                             rewrite = parser.textOrNull();
                         } else {
-                            throw new ParsingException(parser.getTokenLocation(), "[regexp] query does not support [" + currentFieldName + "]");
+                            throw new ParsingException(parser.getTokenLocation(),
+                                    "[regexp] query does not support [" + currentFieldName + "]");
                         }
                     }
                 }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -117,12 +117,7 @@ public class QueryParseContext {
         if (token != XContentParser.Token.START_OBJECT && token != XContentParser.Token.START_ARRAY) {
             throw new ParsingException(parser.getTokenLocation(), "[_na] query malformed, no field after start_object");
         }
-
-        QueryParser queryParser = queryParser(queryName);
-        if (queryParser == null) {
-            throw new ParsingException(parser.getTokenLocation(), "No query registered for [" + queryName + "]");
-        }
-
+        QueryParser queryParser = indicesQueriesRegistry.getQueryParser(queryName, parseFieldMatcher, parser.getTokenLocation());
         QueryBuilder result = queryParser.fromXContent(this);
         if (parser.currentToken() == XContentParser.Token.END_OBJECT || parser.currentToken() == XContentParser.Token.END_ARRAY) {
             // if we are at END_OBJECT, move to the next one...
@@ -137,14 +132,5 @@ public class QueryParseContext {
 
     public void parser(XContentParser innerParser) {
         this.parser = innerParser;
-    }
-
-    /**
-     * Get the query parser for a specific type of query registered under its name
-     * @param name the name of the parser to retrieve
-     * @return the query parser
-     */
-    private QueryParser queryParser(String name) {
-        return indicesQueriesRegistry.queryParsers().get(name);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryParser.java
@@ -29,13 +29,6 @@ import java.io.IOException;
 public interface QueryParser<QB extends QueryBuilder<QB>> {
 
     /**
-     * The names this query parser is registered under.
-     */
-    default String[] names() { // TODO remove this when nothing implements it
-        throw new UnsupportedOperationException();
-    }
-
-    /**
      * Creates a new {@link QueryBuilder} from the query held by the {@link QueryParseContext}
      * in {@link org.elasticsearch.common.xcontent.XContent} format
      *

--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -155,7 +155,8 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
     }
 
     /**
-     * Adds a field to run the query string against. The field will be associated with the default boost of {@link AbstractQueryBuilder#DEFAULT_BOOST}.
+     * Adds a field to run the query string against. The field will be associated with the
+     * default boost of {@link AbstractQueryBuilder#DEFAULT_BOOST}.
      * Use {@link #field(String, float)} to set a specific boost for the field.
      */
     public QueryStringQueryBuilder field(String field) {
@@ -484,7 +485,8 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         builder.endArray();
         builder.field(QueryStringQueryParser.USE_DIS_MAX_FIELD.getPreferredName(), this.useDisMax);
         builder.field(QueryStringQueryParser.TIE_BREAKER_FIELD.getPreferredName(), this.tieBreaker);
-        builder.field(QueryStringQueryParser.DEFAULT_OPERATOR_FIELD.getPreferredName(), this.defaultOperator.name().toLowerCase(Locale.ROOT));
+        builder.field(QueryStringQueryParser.DEFAULT_OPERATOR_FIELD.getPreferredName(),
+                this.defaultOperator.name().toLowerCase(Locale.ROOT));
         if (this.analyzer != null) {
             builder.field(QueryStringQueryParser.ANALYZER_FIELD.getPreferredName(), this.analyzer);
         }
@@ -634,7 +636,8 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
                 Objects.equals(rewrite, other.rewrite) &&
                 Objects.equals(minimumShouldMatch, other.minimumShouldMatch) &&
                 Objects.equals(lenient, other.lenient) &&
-                timeZone == null ? other.timeZone == null : other.timeZone != null && Objects.equals(timeZone.getID(), other.timeZone.getID()) &&
+                timeZone == null ? other.timeZone == null : other.timeZone != null &&
+                Objects.equals(timeZone.getID(), other.timeZone.getID()) &&
                 Objects.equals(escape, other.escape) &&
                 Objects.equals(maxDeterminizedStates, other.maxDeterminizedStates);
     }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentParser;
 
@@ -35,6 +34,7 @@ import java.util.Map;
  */
 public class QueryStringQueryParser implements QueryParser {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(QueryStringQueryBuilder.NAME);
     public static final ParseField QUERY_FIELD = new ParseField("query");
     public static final ParseField FIELDS_FIELD = new ParseField("fields");
     public static final ParseField DEFAULT_FIELD_FIELD = new ParseField("default_field");
@@ -61,11 +61,6 @@ public class QueryStringQueryParser implements QueryParser {
     public static final ParseField LOCALE_FIELD = new ParseField("locale");
     public static final ParseField TIME_ZONE_FIELD = new ParseField("time_zone");
   
-    @Override
-    public String[] names() {
-        return new String[]{QueryStringQueryBuilder.NAME, Strings.toCamelCase(QueryStringQueryBuilder.NAME)};
-    }
-
     @Override
     public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
         XContentParser parser = parseContext.parser();
@@ -123,7 +118,8 @@ public class QueryStringQueryParser implements QueryParser {
                         fieldsAndWeights.put(fField, fBoost);
                     }
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[" + QueryStringQueryBuilder.NAME + "] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(), "[" + QueryStringQueryBuilder.NAME +
+                            "] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if (parseContext.parseFieldMatcher().match(currentFieldName, QUERY_FIELD)) {
@@ -181,15 +177,18 @@ public class QueryStringQueryParser implements QueryParser {
                     try {
                         timeZone = parser.text();
                     } catch (IllegalArgumentException e) {
-                        throw new ParsingException(parser.getTokenLocation(), "[" + QueryStringQueryBuilder.NAME + "] time_zone [" + parser.text() + "] is unknown");
+                        throw new ParsingException(parser.getTokenLocation(), "[" + QueryStringQueryBuilder.NAME +
+                                "] time_zone [" + parser.text() + "] is unknown");
                     }
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.NAME_FIELD)) {
                     queryName = parser.text();
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[" + QueryStringQueryBuilder.NAME + "] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(), "[" + QueryStringQueryBuilder.NAME +
+                            "] query does not support [" + currentFieldName + "]");
                 }
             } else {
-                throw new ParsingException(parser.getTokenLocation(), "[" + QueryStringQueryBuilder.NAME + "] unknown token [" + token + "] after [" + currentFieldName + "]");
+                throw new ParsingException(parser.getTokenLocation(), "[" + QueryStringQueryBuilder.NAME +
+                        "] unknown token [" + token + "] after [" + currentFieldName + "]");
             }
         }
         if (queryString == null) {

--- a/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -270,7 +270,8 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
             return MappedFieldType.Relation.DISJOINT;
         } else {
             DateMathParser dateMathParser = format == null ? null : new DateMathParser(format);
-            return fieldType.isFieldWithinQuery(queryRewriteContext.getIndexReader(), from, to, includeLower, includeUpper, timeZone, dateMathParser);
+            return fieldType.isFieldWithinQuery(queryRewriteContext.getIndexReader(), from, to, includeLower,
+                    includeUpper, timeZone, dateMathParser);
         }
     }
 
@@ -308,7 +309,8 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
                 if (this.format  != null) {
                     forcedDateParser = new DateMathParser(this.format);
                 }
-                query = ((DateFieldMapper.DateFieldType) mapper).rangeQuery(from, to, includeLower, includeUpper, timeZone, forcedDateParser);
+                query = ((DateFieldMapper.DateFieldType) mapper).rangeQuery(from, to, includeLower, includeUpper,
+                        timeZone, forcedDateParser);
             } else  {
                 if (timeZone != null) {
                     throw new QueryShardException(context, "[range] time_zone can not be applied to non date field ["

--- a/core/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -30,8 +30,10 @@ import java.io.IOException;
  */
 public class RangeQueryParser implements QueryParser<RangeQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(RangeQueryBuilder.NAME);
     public static final ParseField FIELDDATA_FIELD = new ParseField("fielddata").withAllDeprecated("[no replacement]");
-    public static final ParseField NAME_FIELD = new ParseField("_name").withAllDeprecated("query name is not supported in short version of range query");
+    public static final ParseField NAME_FIELD = new ParseField("_name")
+            .withAllDeprecated("query name is not supported in short version of range query");
     public static final ParseField LTE_FIELD = new ParseField("lte", "le");
     public static final ParseField GTE_FIELD = new ParseField("gte", "ge");
     public static final ParseField FROM_FIELD = new ParseField("from");
@@ -42,11 +44,6 @@ public class RangeQueryParser implements QueryParser<RangeQueryBuilder> {
     public static final ParseField LT_FIELD = new ParseField("lt");
     public static final ParseField TIME_ZONE_FIELD = new ParseField("time_zone");
     public static final ParseField FORMAT_FIELD = new ParseField("format");
-
-    @Override
-    public String[] names() {
-        return new String[]{RangeQueryBuilder.NAME};
-    }
 
     @Override
     public RangeQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -104,7 +101,8 @@ public class RangeQueryParser implements QueryParser<RangeQueryBuilder> {
                         } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.NAME_FIELD)) {
                             queryName = parser.text();
                         } else {
-                            throw new ParsingException(parser.getTokenLocation(), "[range] query does not support [" + currentFieldName + "]");
+                            throw new ParsingException(parser.getTokenLocation(),
+                                    "[range] query does not support [" + currentFieldName + "]");
                         }
                     }
                 }

--- a/core/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
@@ -30,17 +30,14 @@ import java.io.IOException;
  */
 public class RegexpQueryParser implements QueryParser<RegexpQueryBuilder> {
 
-    public static final ParseField NAME_FIELD = new ParseField("_name").withAllDeprecated("query name is not supported in short version of regexp query");
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(RegexpQueryBuilder.NAME);
+    public static final ParseField NAME_FIELD = new ParseField("_name")
+            .withAllDeprecated("query name is not supported in short version of regexp query");
     public static final ParseField FLAGS_VALUE_FIELD = new ParseField("flags_value");
     public static final ParseField MAX_DETERMINIZED_STATES_FIELD = new ParseField("max_determinized_states");
     public static final ParseField FLAGS_FIELD = new ParseField("flags");
     public static final ParseField REWRITE_FIELD = new ParseField("rewrite");
     public static final ParseField VALUE_FIELD = new ParseField("value");
-
-    @Override
-    public String[] names() {
-        return new String[]{RegexpQueryBuilder.NAME};
-    }
 
     @Override
     public RegexpQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -83,7 +80,8 @@ public class RegexpQueryParser implements QueryParser<RegexpQueryBuilder> {
                         } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.NAME_FIELD)) {
                             queryName = parser.text();
                         } else {
-                            throw new ParsingException(parser.getTokenLocation(), "[regexp] query does not support [" + currentFieldName + "]");
+                            throw new ParsingException(parser.getTokenLocation(),
+                                    "[regexp] query does not support [" + currentFieldName + "]");
                         }
                     }
                 }

--- a/core/src/main/java/org/elasticsearch/index/query/ScriptQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ScriptQueryParser.java
@@ -36,12 +36,8 @@ import java.util.Map;
  */
 public class ScriptQueryParser implements QueryParser<ScriptQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(ScriptQueryBuilder.NAME);
     public static final ParseField PARAMS_FIELD = new ParseField("params");
-
-    @Override
-    public String[] names() {
-        return new String[]{ScriptQueryBuilder.NAME};
-    }
 
     @Override
     public ScriptQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -65,7 +61,8 @@ public class ScriptQueryParser implements QueryParser<ScriptQueryBuilder> {
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (parseContext.parseFieldMatcher().match(currentFieldName, ScriptField.SCRIPT)) {
                     script = Script.parse(parser, parseContext.parseFieldMatcher());
-                } else if (parseContext.parseFieldMatcher().match(currentFieldName, PARAMS_FIELD)) { // TODO remove in 3.0 (here to support old script APIs)
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, PARAMS_FIELD)) {
+                    // TODO remove in 3.0 (here to support old script APIs)
                     params = parser.map();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "[script] query does not support [" + currentFieldName + "]");
@@ -90,7 +87,8 @@ public class ScriptQueryParser implements QueryParser<ScriptQueryBuilder> {
                 script = new Script(scriptValue.script(), scriptValue.scriptType(), scriptParameterParser.lang(), params);
             }
         } else if (params != null) {
-            throw new ParsingException(parser.getTokenLocation(), "script params must be specified inside script object in a [script] filter");
+            throw new ParsingException(parser.getTokenLocation(),
+                    "script params must be specified inside script object in a [script] filter");
         }
 
         if (script == null) {

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -61,6 +60,7 @@ import java.util.Map;
  */
 public class SimpleQueryStringParser implements QueryParser<SimpleQueryStringBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(SimpleQueryStringBuilder.NAME);
     public static final ParseField MINIMUM_SHOULD_MATCH_FIELD = new ParseField("minimum_should_match");
     public static final ParseField ANALYZE_WILDCARD_FIELD = new ParseField("analyze_wildcard");
     public static final ParseField LENIENT_FIELD = new ParseField("lenient");
@@ -71,11 +71,6 @@ public class SimpleQueryStringParser implements QueryParser<SimpleQueryStringBui
     public static final ParseField ANALYZER_FIELD = new ParseField("analyzer");
     public static final ParseField QUERY_FIELD = new ParseField("query");
     public static final ParseField FIELDS_FIELD = new ParseField("fields");
-
-    @Override
-    public String[] names() {
-        return new String[]{SimpleQueryStringBuilder.NAME, Strings.toCamelCase(SimpleQueryStringBuilder.NAME)};
-    }
 
     @Override
     public SimpleQueryStringBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -120,7 +115,8 @@ public class SimpleQueryStringParser implements QueryParser<SimpleQueryStringBui
                         fieldsAndWeights.put(fField, fBoost);
                     }
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[" + SimpleQueryStringBuilder.NAME + "] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(), "[" + SimpleQueryStringBuilder.NAME +
+                            "] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if (parseContext.parseFieldMatcher().match(currentFieldName, QUERY_FIELD)) {
@@ -156,10 +152,12 @@ public class SimpleQueryStringParser implements QueryParser<SimpleQueryStringBui
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, MINIMUM_SHOULD_MATCH_FIELD)) {
                     minimumShouldMatch = parser.textOrNull();
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[" + SimpleQueryStringBuilder.NAME + "] unsupported field [" + parser.currentName() + "]");
+                    throw new ParsingException(parser.getTokenLocation(), "[" + SimpleQueryStringBuilder.NAME +
+                            "] unsupported field [" + parser.currentName() + "]");
                 }
             } else {
-                throw new ParsingException(parser.getTokenLocation(), "[" + SimpleQueryStringBuilder.NAME + "] unknown token [" + token + "] after [" + currentFieldName + "]");
+                throw new ParsingException(parser.getTokenLocation(), "[" + SimpleQueryStringBuilder.NAME +
+                        "] unknown token [" + token + "] after [" + currentFieldName + "]");
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
@@ -32,12 +32,14 @@ import java.util.Objects;
 /**
  * Builder for {@link org.apache.lucene.search.spans.SpanContainingQuery}.
  */
-public class SpanContainingQueryBuilder extends AbstractQueryBuilder<SpanContainingQueryBuilder> implements SpanQueryBuilder<SpanContainingQueryBuilder> {
+public class SpanContainingQueryBuilder extends AbstractQueryBuilder<SpanContainingQueryBuilder>
+        implements SpanQueryBuilder<SpanContainingQueryBuilder> {
 
     public static final String NAME = "span_containing";
     private final SpanQueryBuilder big;
     private final SpanQueryBuilder little;
-    static final SpanContainingQueryBuilder PROTOTYPE = new SpanContainingQueryBuilder(SpanTermQueryBuilder.PROTOTYPE, SpanTermQueryBuilder.PROTOTYPE);
+    static final SpanContainingQueryBuilder PROTOTYPE =
+            new SpanContainingQueryBuilder(SpanTermQueryBuilder.PROTOTYPE, SpanTermQueryBuilder.PROTOTYPE);
 
     /**
      * @param big the big clause, it must enclose {@code little} for a match.

--- a/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -31,14 +30,10 @@ import java.io.IOException;
  */
 public class SpanContainingQueryParser implements QueryParser<SpanContainingQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(SpanContainingQueryBuilder.NAME);
     public static final ParseField BIG_FIELD = new ParseField("big");
     public static final ParseField LITTLE_FIELD = new ParseField("little");
   
-    @Override
-    public String[] names() {
-        return new String[]{SpanContainingQueryBuilder.NAME, Strings.toCamelCase(SpanContainingQueryBuilder.NAME)};
-    }
-
     @Override
     public SpanContainingQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
         XContentParser parser = parseContext.parser();
@@ -66,14 +61,16 @@ public class SpanContainingQueryParser implements QueryParser<SpanContainingQuer
                     }
                     little = (SpanQueryBuilder<?>) query;
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[span_containing] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "[span_containing] query does not support [" + currentFieldName + "]");
                 }
             } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.BOOST_FIELD)) {
                 boost = parser.floatValue();
             } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.NAME_FIELD)) {
                 queryName = parser.text();
             } else {
-                throw new ParsingException(parser.getTokenLocation(), "[span_containing] query does not support [" + currentFieldName + "]");
+                throw new ParsingException(parser.getTokenLocation(),
+                        "[span_containing] query does not support [" + currentFieldName + "]");
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -31,14 +30,10 @@ import java.io.IOException;
  */
 public class SpanFirstQueryParser implements QueryParser<SpanFirstQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(SpanFirstQueryBuilder.NAME);
     public static final ParseField MATCH_FIELD = new ParseField("match");
     public static final ParseField END_FIELD = new ParseField("end");
   
-    @Override
-    public String[] names() {
-        return new String[]{SpanFirstQueryBuilder.NAME, Strings.toCamelCase(SpanFirstQueryBuilder.NAME)};
-    }
-
     @Override
     public SpanFirstQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
         XContentParser parser = parseContext.parser();

--- a/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
@@ -35,7 +35,8 @@ import java.util.Objects;
  * Query that allows wraping a {@link MultiTermQueryBuilder} (one of wildcard, fuzzy, prefix, term, range or regexp query)
  * as a {@link SpanQueryBuilder} so it can be nested.
  */
-public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTermQueryBuilder> implements SpanQueryBuilder<SpanMultiTermQueryBuilder> {
+public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTermQueryBuilder>
+        implements SpanQueryBuilder<SpanMultiTermQueryBuilder> {
 
     public static final String NAME = "span_multi";
     private final MultiTermQueryBuilder multiTermQueryBuilder;

--- a/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
@@ -20,7 +20,6 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -30,12 +29,8 @@ import java.io.IOException;
  */
 public class SpanMultiTermQueryParser implements QueryParser<SpanMultiTermQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(SpanMultiTermQueryBuilder.NAME);
     public static final ParseField MATCH_FIELD = new ParseField("match");
-
-    @Override
-    public String[] names() {
-        return new String[]{SpanMultiTermQueryBuilder.NAME, Strings.toCamelCase(SpanMultiTermQueryBuilder.NAME)};
-    }
 
     @Override
     public SpanMultiTermQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -52,7 +47,8 @@ public class SpanMultiTermQueryParser implements QueryParser<SpanMultiTermQueryB
                 if (parseContext.parseFieldMatcher().match(currentFieldName, MATCH_FIELD)) {
                     QueryBuilder innerQuery = parseContext.parseInnerQueryBuilder();
                     if (innerQuery instanceof MultiTermQueryBuilder == false) {
-                        throw new ParsingException(parser.getTokenLocation(), "[span_multi] [" + MATCH_FIELD.getPreferredName() + "] must be of type multi term query");
+                        throw new ParsingException(parser.getTokenLocation(),
+                                "[span_multi] [" + MATCH_FIELD.getPreferredName() + "] must be of type multi term query");
                     }
                     subQuery = (MultiTermQueryBuilder) innerQuery;
                 } else {
@@ -70,7 +66,8 @@ public class SpanMultiTermQueryParser implements QueryParser<SpanMultiTermQueryB
         }
 
         if (subQuery == null) {
-            throw new ParsingException(parser.getTokenLocation(), "[span_multi] must have [" + MATCH_FIELD.getPreferredName() + "] multi term query clause");
+            throw new ParsingException(parser.getTokenLocation(),
+                    "[span_multi] must have [" + MATCH_FIELD.getPreferredName() + "] multi term query clause");
         }
 
         return new SpanMultiTermQueryBuilder(subQuery).queryName(queryName).boost(boost);

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -33,15 +32,11 @@ import java.util.List;
  */
 public class SpanNearQueryParser implements QueryParser<SpanNearQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(SpanNearQueryBuilder.NAME);
     public static final ParseField SLOP_FIELD = new ParseField("slop");
     public static final ParseField COLLECT_PAYLOADS_FIELD = new ParseField("collect_payloads").withAllDeprecated("no longer supported");
     public static final ParseField CLAUSES_FIELD = new ParseField("clauses");
     public static final ParseField IN_ORDER_FIELD = new ParseField("in_order");
-
-    @Override
-    public String[] names() {
-        return new String[]{SpanNearQueryBuilder.NAME, Strings.toCamelCase(SpanNearQueryBuilder.NAME)};
-    }
 
     @Override
     public SpanNearQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -31,17 +30,13 @@ import java.io.IOException;
  */
 public class SpanNotQueryParser implements QueryParser<SpanNotQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(SpanNotQueryBuilder.NAME);
     public static final ParseField POST_FIELD = new ParseField("post");
     public static final ParseField PRE_FIELD = new ParseField("pre");
     public static final ParseField DIST_FIELD = new ParseField("dist");
     public static final ParseField EXCLUDE_FIELD = new ParseField("exclude");
     public static final ParseField INCLUDE_FIELD = new ParseField("include");
   
-    @Override
-    public String[] names() {
-        return new String[]{SpanNotQueryBuilder.NAME, Strings.toCamelCase(SpanNotQueryBuilder.NAME)};
-    }
-
     @Override
     public SpanNotQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
         XContentParser parser = parseContext.parser();

--- a/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
@@ -33,12 +33,8 @@ import java.util.List;
  */
 public class SpanOrQueryParser implements QueryParser<SpanOrQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(SpanOrQueryBuilder.NAME);
     public static final ParseField CLAUSES_FIELD = new ParseField("clauses");
-
-    @Override
-    public String[] names() {
-        return new String[]{SpanOrQueryBuilder.NAME, Strings.toCamelCase(SpanOrQueryBuilder.NAME)};
-    }
 
     @Override
     public SpanOrQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {

--- a/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -31,13 +30,9 @@ import java.io.IOException;
  */
 public class SpanTermQueryParser implements QueryParser<SpanTermQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(SpanTermQueryBuilder.NAME);
     public static final ParseField TERM_FIELD = new ParseField("term");
   
-    @Override
-    public String[] names() {
-        return new String[]{SpanTermQueryBuilder.NAME, Strings.toCamelCase(SpanTermQueryBuilder.NAME)};
-    }
-
     @Override
     public SpanTermQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, ParsingException {
         XContentParser parser = parseContext.parser();
@@ -70,7 +65,8 @@ public class SpanTermQueryParser implements QueryParser<SpanTermQueryBuilder> {
                     } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.NAME_FIELD)) {
                         queryName = parser.text();
                     } else {
-                        throw new ParsingException(parser.getTokenLocation(), "[span_term] query does not support [" + currentFieldName + "]");
+                        throw new ParsingException(parser.getTokenLocation(),
+                                "[span_term] query does not support [" + currentFieldName + "]");
                     }
                 }
             }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
@@ -32,12 +32,14 @@ import java.util.Objects;
 /**
  * Builder for {@link org.apache.lucene.search.spans.SpanWithinQuery}.
  */
-public class SpanWithinQueryBuilder extends AbstractQueryBuilder<SpanWithinQueryBuilder> implements SpanQueryBuilder<SpanWithinQueryBuilder> {
+public class SpanWithinQueryBuilder extends AbstractQueryBuilder<SpanWithinQueryBuilder>
+        implements SpanQueryBuilder<SpanWithinQueryBuilder> {
 
     public static final String NAME = "span_within";
     private final SpanQueryBuilder big;
     private final SpanQueryBuilder little;
-    static final SpanWithinQueryBuilder PROTOTYPE = new SpanWithinQueryBuilder(SpanTermQueryBuilder.PROTOTYPE, SpanTermQueryBuilder.PROTOTYPE);
+    static final SpanWithinQueryBuilder PROTOTYPE =
+            new SpanWithinQueryBuilder(SpanTermQueryBuilder.PROTOTYPE, SpanTermQueryBuilder.PROTOTYPE);
 
     /**
      * Query that returns spans from <code>little</code> that are contained in a spans from <code>big</code>.

--- a/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -31,14 +30,10 @@ import java.io.IOException;
  */
 public class SpanWithinQueryParser implements QueryParser<SpanWithinQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(SpanWithinQueryBuilder.NAME);
     public static final ParseField BIG_FIELD = new ParseField("big");
     public static final ParseField LITTLE_FIELD = new ParseField("little");
   
-    @Override
-    public String[] names() {
-        return new String[]{SpanWithinQueryBuilder.NAME, Strings.toCamelCase(SpanWithinQueryBuilder.NAME)};
-    }
-
     @Override
     public SpanWithinQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
         XContentParser parser = parseContext.parser();
@@ -67,7 +62,8 @@ public class SpanWithinQueryParser implements QueryParser<SpanWithinQueryBuilder
                     }
                     little = (SpanQueryBuilder) query;
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[span_within] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "[span_within] query does not support [" + currentFieldName + "]");
                 }
             } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.BOOST_FIELD)) {
                 boost = parser.floatValue();

--- a/core/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.script.ScriptService;
@@ -41,10 +42,7 @@ public class TemplateQueryParser implements QueryParser<TemplateQueryBuilder> {
         parametersToTypes.put("id", ScriptService.ScriptType.INDEXED);
     }
 
-    @Override
-    public String[] names() {
-        return new String[] {TemplateQueryBuilder.NAME};
-    }
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(TemplateQueryBuilder.NAME);
 
     /**
      * Parses the template query replacing template parameters with provided
@@ -69,7 +67,8 @@ public class TemplateQueryParser implements QueryParser<TemplateQueryBuilder> {
         return parse(parser, parameterMap, parseFieldMatcher);
     }
 
-    public static Template parse(String defaultLang, XContentParser parser, ParseFieldMatcher parseFieldMatcher, String... parameters) throws IOException {
+    public static Template parse(String defaultLang, XContentParser parser,
+                                 ParseFieldMatcher parseFieldMatcher, String... parameters) throws IOException {
 
         Map<String, ScriptService.ScriptType> parameterMap = new HashMap<>(parametersToTypes);
         for (String parameter : parameters) {
@@ -82,7 +81,8 @@ public class TemplateQueryParser implements QueryParser<TemplateQueryBuilder> {
         return parse(parser, parametersToTypes, parseFieldMatcher);
     }
 
-    public static Template parse(XContentParser parser, Map<String, ScriptService.ScriptType> parameterMap, ParseFieldMatcher parseFieldMatcher) throws IOException {
+    public static Template parse(XContentParser parser, Map<String, ScriptService.ScriptType> parameterMap,
+                                 ParseFieldMatcher parseFieldMatcher) throws IOException {
         return Template.parse(parser, parameterMap, parseFieldMatcher);
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
@@ -30,13 +30,9 @@ import java.io.IOException;
  */
 public class TermQueryParser implements QueryParser<TermQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(TermQueryBuilder.NAME);
     public static final ParseField TERM_FIELD = new ParseField("term");
     public static final ParseField VALUE_FIELD = new ParseField("value");
-
-    @Override
-    public String[] names() {
-        return new String[]{TermQueryBuilder.NAME};
-    }
 
     @Override
     public TermQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -56,7 +52,8 @@ public class TermQueryParser implements QueryParser<TermQueryBuilder> {
             } else if (token == XContentParser.Token.START_OBJECT) {
                 // also support a format of "term" : {"field_name" : { ... }}
                 if (fieldName != null) {
-                    throw new ParsingException(parser.getTokenLocation(), "[term] query does not support different field names, use [bool] query instead");
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "[term] query does not support different field names, use [bool] query instead");
                 }
                 fieldName = currentFieldName;
                 while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -72,13 +69,15 @@ public class TermQueryParser implements QueryParser<TermQueryBuilder> {
                         } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.BOOST_FIELD)) {
                             boost = parser.floatValue();
                         } else {
-                            throw new ParsingException(parser.getTokenLocation(), "[term] query does not support [" + currentFieldName + "]");
+                            throw new ParsingException(parser.getTokenLocation(),
+                                    "[term] query does not support [" + currentFieldName + "]");
                         }
                     }
                 }
             } else if (token.isValue()) {
                 if (fieldName != null) {
-                    throw new ParsingException(parser.getTokenLocation(), "[term] query does not support different field names, use [bool] query instead");
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "[term] query does not support different field names, use [bool] query instead");
                 }
                 fieldName = currentFieldName;
                 value = parser.objectBytes();

--- a/core/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.indices.TermsLookup;
@@ -37,10 +38,7 @@ import java.util.List;
  */
 public class TermsQueryParser implements QueryParser {
 
-    @Override
-    public String[] names() {
-        return new String[]{TermsQueryBuilder.NAME, "in"};
-    }
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(TermsQueryBuilder.NAME, "in");
 
     @Override
     public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -62,13 +60,15 @@ public class TermsQueryParser implements QueryParser {
                 // skip
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if  (fieldName != null) {
-                    throw new ParsingException(parser.getTokenLocation(), "[" + TermsQueryBuilder.NAME + "] query does not support multiple fields");
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "[" + TermsQueryBuilder.NAME + "] query does not support multiple fields");
                 }
                 fieldName = currentFieldName;
                 values = parseValues(parser);
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if  (fieldName != null) {
-                    throw new ParsingException(parser.getTokenLocation(), "[" + TermsQueryBuilder.NAME + "] query does not support more than one field. "
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "[" + TermsQueryBuilder.NAME + "] query does not support more than one field. "
                             + "Already got: [" + fieldName + "] but also found [" + currentFieldName +"]");
                 }
                 fieldName = currentFieldName;
@@ -79,15 +79,18 @@ public class TermsQueryParser implements QueryParser {
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.NAME_FIELD)) {
                     queryName = parser.text();
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[" + TermsQueryBuilder.NAME + "] query does not support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "[" + TermsQueryBuilder.NAME + "] query does not support [" + currentFieldName + "]");
                 }
             } else {
-                throw new ParsingException(parser.getTokenLocation(), "[" + TermsQueryBuilder.NAME + "] unknown token [" + token + "] after [" + currentFieldName + "]");
+                throw new ParsingException(parser.getTokenLocation(),
+                        "[" + TermsQueryBuilder.NAME + "] unknown token [" + token + "] after [" + currentFieldName + "]");
             }
         }
 
         if (fieldName == null) {
-            throw new ParsingException(parser.getTokenLocation(), "[" + TermsQueryBuilder.NAME + "] query requires a field name, followed by array of terms or a document lookup specification");
+            throw new ParsingException(parser.getTokenLocation(), "[" + TermsQueryBuilder.NAME + "] query requires a field name, " +
+                    "followed by array of terms or a document lookup specification");
         }
         return new TermsQueryBuilder(fieldName, values, termsLookup)
                 .boost(boost)

--- a/core/src/main/java/org/elasticsearch/index/query/TypeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TypeQueryParser.java
@@ -31,12 +31,8 @@ import java.io.IOException;
  */
 public class TypeQueryParser implements QueryParser<TypeQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(TypeQueryBuilder.NAME);
     public static final ParseField VALUE_FIELD = new ParseField("value");
-
-    @Override
-    public String[] names() {
-        return new String[]{TypeQueryBuilder.NAME};
-    }
 
     @Override
     public TypeQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -59,15 +55,18 @@ public class TypeQueryParser implements QueryParser<TypeQueryBuilder> {
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, VALUE_FIELD)) {
                     type = parser.utf8Bytes();
                 } else {
-                    throw new ParsingException(parser.getTokenLocation(), "[" + TypeQueryBuilder.NAME + "] filter doesn't support [" + currentFieldName + "]");
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "[" + TypeQueryBuilder.NAME + "] filter doesn't support [" + currentFieldName + "]");
                 }
             } else {
-                throw new ParsingException(parser.getTokenLocation(), "[" + TypeQueryBuilder.NAME + "] filter doesn't support [" + currentFieldName + "]");
+                throw new ParsingException(parser.getTokenLocation(),
+                        "[" + TypeQueryBuilder.NAME + "] filter doesn't support [" + currentFieldName + "]");
             }
         }
 
         if (type == null) {
-            throw new ParsingException(parser.getTokenLocation(), "[" + TypeQueryBuilder.NAME + "] filter needs to be provided with a value for the type");
+            throw new ParsingException(parser.getTokenLocation(),
+                    "[" + TypeQueryBuilder.NAME + "] filter needs to be provided with a value for the type");
         }
         return new TypeQueryBuilder(type)
                 .boost(boost)

--- a/core/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -42,7 +42,8 @@ import java.util.Objects;
  * a Wildcard term should not start with one of the wildcards <tt>*</tt> or
  * <tt>?</tt>.
  */
-public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuilder> implements MultiTermQueryBuilder<WildcardQueryBuilder> {
+public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuilder>
+        implements MultiTermQueryBuilder<WildcardQueryBuilder> {
 
     public static final String NAME = "wildcard";
 

--- a/core/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
@@ -30,14 +30,10 @@ import java.io.IOException;
  */
 public class WildcardQueryParser implements QueryParser<WildcardQueryBuilder> {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(WildcardQueryBuilder.NAME);
     public static final ParseField WILDCARD_FIELD = new ParseField("wildcard");
     public static final ParseField VALUE_FIELD = new ParseField("value");
     public static final ParseField REWRITE_FIELD = new ParseField("rewrite");
-
-    @Override
-    public String[] names() {
-        return new String[]{WildcardQueryBuilder.NAME};
-    }
 
     @Override
     public WildcardQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -71,7 +67,8 @@ public class WildcardQueryParser implements QueryParser<WildcardQueryBuilder> {
                     } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.NAME_FIELD)) {
                         queryName = parser.text();
                     } else {
-                        throw new ParsingException(parser.getTokenLocation(), "[wildcard] query does not support [" + currentFieldName + "]");
+                        throw new ParsingException(parser.getTokenLocation(),
+                                "[wildcard] query does not support [" + currentFieldName + "]");
                     }
                 }
             }

--- a/core/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
@@ -30,12 +30,8 @@ import java.io.IOException;
  */
 public class WrapperQueryParser implements QueryParser {
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(WrapperQueryBuilder.NAME);
     public static final ParseField QUERY_FIELD = new ParseField("query");
-
-    @Override
-    public String[] names() {
-        return new String[]{WrapperQueryBuilder.NAME};
-    }
 
     @Override
     public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -63,6 +63,8 @@ public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScor
 
     public static final String NAME = "function_score";
 
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
+
     // For better readability of error message
     static final String MISPLACED_FUNCTION_MESSAGE_PREFIX = "you can either define [functions] array or a single function, not both. ";
 

--- a/core/src/main/java/org/elasticsearch/indices/query/IndicesQueriesRegistry.java
+++ b/core/src/main/java/org/elasticsearch/indices/query/IndicesQueriesRegistry.java
@@ -19,24 +19,44 @@
 
 package org.elasticsearch.indices.query;
 
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.index.query.QueryParser;
 
 import java.util.Map;
 
 public class IndicesQueriesRegistry extends AbstractComponent {
-    private Map<String, QueryParser<?>> queryParsers;
+    private Map<String, Tuple<ParseField, QueryParser<?>>> queryParsers;
 
-    public IndicesQueriesRegistry(Settings settings, Map<String, QueryParser<?>> queryParsers) {
+    public IndicesQueriesRegistry(Settings settings, Map<String, Tuple<ParseField, QueryParser<?>>> queryParsers) {
         super(settings);
         this.queryParsers = queryParsers;
     }
 
     /**
-     * Returns all the registered query parsers
+     * Get the query parser for a specific type of query registered under its name.
+     * Uses {@link ParseField} internally so that deprecation warnings/errors can be logged/thrown.
+     * @param name the name of the parser to retrieve
+     * @param parseFieldMatcher the {@link ParseFieldMatcher} to match the query name against
+     * @param xContentLocation the current location of the {@link org.elasticsearch.common.xcontent.XContentParser}
+     * @return the query parser
+     * @throws IllegalArgumentException of there's no query or parser registered under the provided name
      */
-    public Map<String, QueryParser<?>> queryParsers() {
-        return queryParsers;
+    public QueryParser<?> getQueryParser(String name, ParseFieldMatcher parseFieldMatcher, XContentLocation xContentLocation) {
+        Tuple<ParseField, QueryParser<?>> parseFieldQueryParserTuple = queryParsers.get(name);
+        if (parseFieldQueryParserTuple == null) {
+            throw new ParsingException(xContentLocation, "No query registered for [" + name + "]");
+        }
+        ParseField parseField = parseFieldQueryParserTuple.v1();
+        QueryParser<?> queryParser = parseFieldQueryParserTuple.v2();
+        boolean match = parseFieldMatcher.match(name, parseField);
+        //this is always expected to match, ParseField is useful for deprecation warnings etc. here
+        assert match : "registered ParseField did not match the query name it was registered for: [" + name + "]";
+        return queryParser;
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -20,7 +20,8 @@
 package org.elasticsearch.search;
 
 import org.apache.lucene.search.BooleanQuery;
-import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.geo.ShapesAvailability;
 import org.elasticsearch.common.geo.builders.ShapeBuilders;
 import org.elasticsearch.common.inject.AbstractModule;
@@ -40,6 +41,7 @@ import org.elasticsearch.index.query.EmptyQueryBuilder;
 import org.elasticsearch.index.query.ExistsQueryParser;
 import org.elasticsearch.index.query.FieldMaskingSpanQueryParser;
 import org.elasticsearch.index.query.FuzzyQueryParser;
+import org.elasticsearch.index.query.GeoBoundingBoxQueryBuilder;
 import org.elasticsearch.index.query.GeoBoundingBoxQueryParser;
 import org.elasticsearch.index.query.GeoDistanceQueryParser;
 import org.elasticsearch.index.query.GeoDistanceRangeQueryParser;
@@ -56,8 +58,11 @@ import org.elasticsearch.index.query.MatchPhrasePrefixQueryBuilder;
 import org.elasticsearch.index.query.MatchPhraseQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.MoreLikeThisQueryParser;
+import org.elasticsearch.index.query.MultiMatchQueryBuilder;
 import org.elasticsearch.index.query.MultiMatchQueryParser;
+import org.elasticsearch.index.query.NestedQueryBuilder;
 import org.elasticsearch.index.query.NestedQueryParser;
+import org.elasticsearch.index.query.ParentIdQueryBuilder;
 import org.elasticsearch.index.query.ParentIdQueryParser;
 import org.elasticsearch.index.query.PercolatorQueryParser;
 import org.elasticsearch.index.query.PrefixQueryParser;
@@ -80,6 +85,7 @@ import org.elasticsearch.index.query.SpanWithinQueryParser;
 import org.elasticsearch.index.query.TemplateQueryParser;
 import org.elasticsearch.index.query.TermQueryParser;
 import org.elasticsearch.index.query.TermsQueryParser;
+import org.elasticsearch.index.query.TypeQueryBuilder;
 import org.elasticsearch.index.query.TypeQueryParser;
 import org.elasticsearch.index.query.WildcardQueryParser;
 import org.elasticsearch.index.query.WrapperQueryParser;
@@ -229,8 +235,10 @@ import org.elasticsearch.search.sort.ScriptSortBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.suggest.Suggester;
 import org.elasticsearch.search.suggest.Suggesters;
+import org.elasticsearch.search.suggest.completion.FuzzyOptions;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -257,8 +265,7 @@ public class SearchModule extends AbstractModule {
      * at configure time because they depend on things that are registered by
      * plugins (function score parsers).
      */
-    private final List<QueryRegistration<?>> queries = new ArrayList<>();
-    private final List<Supplier<QueryParser<?>>> queryParsers = new ArrayList<>();
+    private final Map<String, Tuple<ParseField, QueryParser<?>>> queryParsers = new HashMap<>();
     private final Set<Class<? extends FetchSubPhase>> fetchSubPhases = new HashSet<>();
     private final Set<SignificanceHeuristicParser> heuristicParsers = new HashSet<>();
     private final Set<MovAvgModel.AbstractModelParser> modelParsers = new HashSet<>();
@@ -307,20 +314,39 @@ public class SearchModule extends AbstractModule {
      *
      * @param reader the reader registered for this query's builder. Typically a reference to a constructor that takes a
      *        {@link org.elasticsearch.common.io.stream.StreamInput}
-     * @param parser the parser the reads the query builder from xcontent
-     * @param names all names by which this query might be parsed. The first name is special as it is the name by under which the reader is
-     *        registered. So it is the name that the query should use as its {@link NamedWriteable#getWriteableName()}.
+     * @param queryParser the parser the reads the query builder from xcontent
+     * @param queryName holds the names by which this query might be parsed. The {@link ParseField#getPreferredName()} is special as it
+     *        is the name by under which the reader is registered. So it is the name that the query should use as its
+     *        {@link NamedWriteable#getWriteableName()} too.
      */
-    public <QB extends QueryBuilder<QB>> void registerQuery(Writeable.Reader<QB> reader, QueryParser<QB> parser, String... names) {
-        queries.add(new QueryRegistration<QB>(names, reader, parser));
+    public <QB extends QueryBuilder<QB>> void registerQuery(Writeable.Reader<QB> reader, QueryParser<QB> queryParser,
+                                                                         ParseField queryName) {
+        innerRegisterQueryParser(queryParser, queryName);
+        namedWriteableRegistry.register(QueryBuilder.class, queryName.getPreferredName(), reader);
     }
 
     /**
      * Register a query.
-     * TODO remove this in favor of registerQuery
+     * TODO remove this in favor of registerQuery and rename innerRegisterQueryParser
      */
-    public void registerQueryParser(Supplier<QueryParser<?>> parser) {
-        queryParsers.add(parser);
+    public void registerQueryParser(QueryParser<?> queryParser, ParseField queryName) {
+        innerRegisterQueryParser(queryParser, queryName);
+        namedWriteableRegistry.registerPrototype(QueryBuilder.class, queryParser.getBuilderPrototype());
+    }
+
+    private <QB extends QueryBuilder<QB>> void innerRegisterQueryParser(QueryParser<QB> parser, ParseField queryName) {
+        Tuple<ParseField, QueryParser<?>> parseFieldQueryParserTuple = new Tuple<>(queryName, parser);
+        for (String name: queryName.getAllNamesIncludedDeprecated()) {
+            Tuple<ParseField, QueryParser<?>> previousValue = queryParsers.putIfAbsent(name, parseFieldQueryParserTuple);
+            if (previousValue != null) {
+                throw new IllegalArgumentException("Query parser [" + queryParsers.get(name) + "] already registered for name [" +
+                        name + "] while trying to register [" + parser + "]");
+            }
+        }
+    }
+
+    Set<String> getRegisteredQueries() {
+        return queryParsers.keySet();
     }
 
     public void registerFetchSubPhase(Class<? extends FetchSubPhase> subPhase) {
@@ -378,31 +404,7 @@ public class SearchModule extends AbstractModule {
     }
 
     public IndicesQueriesRegistry buildQueryParserRegistry() {
-        Map<String, QueryParser<?>> queryParsersMap = new HashMap<>();
-
-        // TODO remove this when we retire registerQueryParser
-        for (Supplier<QueryParser<?>> parserSupplier : queryParsers) {
-            QueryParser<? extends QueryBuilder<?>> parser = parserSupplier.get();
-            for (String name: parser.names()) {
-                Object oldValue = queryParsersMap.putIfAbsent(name, parser);
-                if (oldValue != null) {
-                    throw new IllegalArgumentException("Query parser [" + oldValue + "] already registered for name [" + name + "] while trying to register [" + parser + "]");
-                }
-            }
-            namedWriteableRegistry.registerPrototype(QueryBuilder.class, parser.getBuilderPrototype());
-        }
-
-        for (QueryRegistration<?> query : queries) {
-            QueryParser<? extends QueryBuilder<?>> parser = query.parser;
-            for (String name: query.names) {
-                Object oldValue = queryParsersMap.putIfAbsent(name, parser);
-                if (oldValue != null) {
-                    throw new IllegalArgumentException("Query parser [" + oldValue + "] already registered for name [" + name + "] while trying to register [" + parser + "]");
-                }
-            }
-            namedWriteableRegistry.register(QueryBuilder.class, query.names[0], query.reader);
-        }
-        return new IndicesQueriesRegistry(settings, queryParsersMap);
+        return new IndicesQueriesRegistry(settings, queryParsers);
     }
 
     protected void configureHighlighters() {
@@ -515,64 +517,62 @@ public class SearchModule extends AbstractModule {
     }
 
     private void registerBuiltinQueryParsers() {
-        registerQuery(MatchQueryBuilder.PROTOTYPE::readFrom, MatchQueryBuilder::fromXContent, MatchQueryBuilder.NAME, "matchFuzzy",
-                "match_fuzzy", "fuzzy_match");
-        registerQuery(MatchPhraseQueryBuilder.PROTOTYPE::readFrom, MatchPhraseQueryBuilder::fromXContent, MatchPhraseQueryBuilder.NAME,
-                "matchPhrase");
+        registerQuery(MatchQueryBuilder.PROTOTYPE::readFrom, MatchQueryBuilder::fromXContent, MatchQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(MatchPhraseQueryBuilder.PROTOTYPE::readFrom, MatchPhraseQueryBuilder::fromXContent,
+                MatchPhraseQueryBuilder.QUERY_NAME_FIELD);
         registerQuery(MatchPhrasePrefixQueryBuilder.PROTOTYPE::readFrom, MatchPhrasePrefixQueryBuilder::fromXContent,
-                MatchPhrasePrefixQueryBuilder.NAME, "matchPhrasePrefix");
-        registerQueryParser(MultiMatchQueryParser::new);
-        registerQueryParser(NestedQueryParser::new);
-        registerQueryParser(HasChildQueryParser::new);
-        registerQueryParser(HasParentQueryParser::new);
-        registerQueryParser(DisMaxQueryParser::new);
-        registerQueryParser(IdsQueryParser::new);
-        registerQueryParser(MatchAllQueryParser::new);
-        registerQueryParser(QueryStringQueryParser::new);
-        registerQueryParser(BoostingQueryParser::new);
+                MatchPhrasePrefixQueryBuilder.QUERY_NAME_FIELD);
+        registerQueryParser(new MultiMatchQueryParser(), MultiMatchQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new NestedQueryParser(), NestedQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new HasChildQueryParser(), HasChildQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new HasParentQueryParser(), HasParentQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new DisMaxQueryParser(), DisMaxQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new IdsQueryParser(), IdsQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new MatchAllQueryParser(), MatchAllQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new QueryStringQueryParser(), QueryStringQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new BoostingQueryParser(), BoostingQueryParser.QUERY_NAME_FIELD);
         BooleanQuery.setMaxClauseCount(settings.getAsInt("index.query.bool.max_clause_count",
                 settings.getAsInt("indices.query.bool.max_clause_count", BooleanQuery.getMaxClauseCount())));
-        registerQueryParser(BoolQueryParser::new);
-        registerQueryParser(TermQueryParser::new);
-        registerQueryParser(TermsQueryParser::new);
-        registerQueryParser(FuzzyQueryParser::new);
-        registerQueryParser(RegexpQueryParser::new);
-        registerQueryParser(RangeQueryParser::new);
-        registerQueryParser(PrefixQueryParser::new);
-        registerQueryParser(WildcardQueryParser::new);
-        registerQueryParser(ConstantScoreQueryParser::new);
-        registerQueryParser(SpanTermQueryParser::new);
-        registerQueryParser(SpanNotQueryParser::new);
-        registerQueryParser(SpanWithinQueryParser::new);
-        registerQueryParser(SpanContainingQueryParser::new);
-        registerQueryParser(FieldMaskingSpanQueryParser::new);
-        registerQueryParser(SpanFirstQueryParser::new);
-        registerQueryParser(SpanNearQueryParser::new);
-        registerQueryParser(SpanOrQueryParser::new);
-        registerQueryParser(MoreLikeThisQueryParser::new);
-        registerQueryParser(WrapperQueryParser::new);
-        registerQueryParser(IndicesQueryParser::new);
-        registerQueryParser(CommonTermsQueryParser::new);
-        registerQueryParser(SpanMultiTermQueryParser::new);
+        registerQueryParser(new BoolQueryParser(), BoolQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new TermQueryParser(), TermQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new TermsQueryParser(), TermsQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new FuzzyQueryParser(), FuzzyQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new RegexpQueryParser(), RegexpQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new RangeQueryParser(), RangeQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new PrefixQueryParser(), PrefixQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new WildcardQueryParser(), WildcardQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new ConstantScoreQueryParser(), ConstantScoreQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new SpanTermQueryParser(), SpanTermQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new SpanNotQueryParser(), SpanNotQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new SpanWithinQueryParser(), SpanWithinQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new SpanContainingQueryParser(), SpanContainingQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new FieldMaskingSpanQueryParser(), FieldMaskingSpanQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new SpanFirstQueryParser(), SpanFirstQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new SpanNearQueryParser(), SpanNearQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new SpanOrQueryParser(), SpanOrQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new MoreLikeThisQueryParser(), MoreLikeThisQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new WrapperQueryParser(), WrapperQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new IndicesQueryParser(), IndicesQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new CommonTermsQueryParser(), CommonTermsQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new SpanMultiTermQueryParser(), SpanMultiTermQueryParser.QUERY_NAME_FIELD);
         QueryParser<FunctionScoreQueryBuilder> functionScoreParser = (QueryParseContext c) -> FunctionScoreQueryBuilder
                 .fromXContent((String name) -> functionScoreParsers.get(name), c);
-        registerQuery(FunctionScoreQueryBuilder.PROTOTYPE::readFrom, functionScoreParser, FunctionScoreQueryBuilder.NAME,
-                Strings.toCamelCase(FunctionScoreQueryBuilder.NAME));
-        registerQueryParser(SimpleQueryStringParser::new);
-        registerQueryParser(TemplateQueryParser::new);
-        registerQueryParser(TypeQueryParser::new);
-        registerQueryParser(ScriptQueryParser::new);
-        registerQueryParser(GeoDistanceQueryParser::new);
-        registerQueryParser(GeoDistanceRangeQueryParser::new);
-        registerQueryParser(GeoBoundingBoxQueryParser::new);
-        registerQueryParser(GeohashCellQuery.Parser::new);
-        registerQueryParser(GeoPolygonQueryParser::new);
-        registerQueryParser(ExistsQueryParser::new);
-        registerQueryParser(MatchNoneQueryParser::new);
-        registerQueryParser(ParentIdQueryParser::new);
-        registerQueryParser(PercolatorQueryParser::new);
+        registerQuery(FunctionScoreQueryBuilder.PROTOTYPE::readFrom, functionScoreParser, FunctionScoreQueryBuilder.QUERY_NAME_FIELD);
+        registerQueryParser(new SimpleQueryStringParser(), SimpleQueryStringParser.QUERY_NAME_FIELD);
+        registerQueryParser(new TemplateQueryParser(), TemplateQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new TypeQueryParser(), TypeQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new ScriptQueryParser(), ScriptQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new GeoDistanceQueryParser(), GeoDistanceQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new GeoDistanceRangeQueryParser(), GeoDistanceRangeQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new GeoBoundingBoxQueryParser(), GeoBoundingBoxQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new GeohashCellQuery.Parser(), GeohashCellQuery.Parser.QUERY_NAME_FIELD);
+        registerQueryParser(new GeoPolygonQueryParser(), GeoPolygonQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new ExistsQueryParser(), ExistsQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new MatchNoneQueryParser(), MatchNoneQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new ParentIdQueryParser(), ParentIdQueryParser.QUERY_NAME_FIELD);
+        registerQueryParser(new PercolatorQueryParser(), PercolatorQueryParser.QUERY_NAME_FIELD);
         if (ShapesAvailability.JTS_AVAILABLE && ShapesAvailability.SPATIAL4J_AVAILABLE) {
-            registerQueryParser(GeoShapeQueryParser::new);
+            registerQueryParser(new GeoShapeQueryParser(), GeoShapeQueryParser.QUERY_NAME_FIELD);
         }
         // EmptyQueryBuilder is not registered as query parser but used internally.
         // We need to register it with the NamedWriteableRegistry in order to serialize it
@@ -643,17 +643,5 @@ public class SearchModule extends AbstractModule {
 
     public Suggesters getSuggesters() {
         return suggesters;
-    }
-
-    private static class QueryRegistration<QB extends QueryBuilder<QB>> {
-        private final String[] names;
-        private final Writeable.Reader<QB> reader;
-        private final QueryParser<QB> parser;
-
-        private QueryRegistration(String[] names, Reader<QB> reader, QueryParser<QB> parser) {
-            this.names = names;
-            this.reader = reader;
-            this.parser = parser;
-        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -19,15 +19,15 @@
 
 package org.elasticsearch.action.search;
 
-import java.io.IOException;
-
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.MatchAllQueryParser;
 import org.elasticsearch.indices.query.IndicesQueriesRegistry;
 import org.elasticsearch.rest.action.search.RestMultiSearchAction;
@@ -35,14 +35,17 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.StreamsUtils;
 
-import static java.util.Collections.singletonMap;
+import java.io.IOException;
+import java.util.Collections;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
 public class MultiSearchRequestTests extends ESTestCase {
     public void testSimpleAdd() throws Exception {
-        IndicesQueriesRegistry registry = new IndicesQueriesRegistry(Settings.EMPTY, singletonMap("match_all", new MatchAllQueryParser()));
+        IndicesQueriesRegistry registry = new IndicesQueriesRegistry(Settings.EMPTY,
+                Collections.singletonMap(MatchAllQueryBuilder.NAME,
+                        new Tuple<>(MatchAllQueryParser.QUERY_NAME_FIELD, new MatchAllQueryParser())));
         byte[] data = StreamsUtils.copyToBytesFromClasspath("/org/elasticsearch/action/search/simple-msearch1.json");
         MultiSearchRequest request = RestMultiSearchAction.parseRequest(new MultiSearchRequest(), new BytesArray(data), false, null, null,
                 null, null, IndicesOptions.strictExpandOpenAndForbidClosed(), true, registry, ParseFieldMatcher.EMPTY, null, null);
@@ -69,7 +72,9 @@ public class MultiSearchRequestTests extends ESTestCase {
     }
 
     public void testSimpleAdd2() throws Exception {
-        IndicesQueriesRegistry registry = new IndicesQueriesRegistry(Settings.EMPTY, singletonMap("match_all", new MatchAllQueryParser()));
+        IndicesQueriesRegistry registry = new IndicesQueriesRegistry(Settings.EMPTY,
+                Collections.singletonMap(MatchAllQueryBuilder.NAME,
+                        new Tuple<>(MatchAllQueryParser.QUERY_NAME_FIELD, new MatchAllQueryParser())));
         byte[] data = StreamsUtils.copyToBytesFromClasspath("/org/elasticsearch/action/search/simple-msearch2.json");
         MultiSearchRequest request = RestMultiSearchAction.parseRequest(new MultiSearchRequest(), new BytesArray(data), false, null, null,
                 null, null, IndicesOptions.strictExpandOpenAndForbidClosed(), true, registry, ParseFieldMatcher.EMPTY, null, null);
@@ -88,7 +93,9 @@ public class MultiSearchRequestTests extends ESTestCase {
     }
 
     public void testSimpleAdd3() throws Exception {
-        IndicesQueriesRegistry registry = new IndicesQueriesRegistry(Settings.EMPTY, singletonMap("match_all", new MatchAllQueryParser()));
+        IndicesQueriesRegistry registry = new IndicesQueriesRegistry(Settings.EMPTY,
+                Collections.singletonMap(MatchAllQueryBuilder.NAME,
+                        new Tuple<>(MatchAllQueryParser.QUERY_NAME_FIELD, new MatchAllQueryParser())));
         byte[] data = StreamsUtils.copyToBytesFromClasspath("/org/elasticsearch/action/search/simple-msearch3.json");
         MultiSearchRequest request = RestMultiSearchAction.parseRequest(new MultiSearchRequest(), new BytesArray(data), false, null, null,
                 null, null, IndicesOptions.strictExpandOpenAndForbidClosed(), true, registry, ParseFieldMatcher.EMPTY, null, null);
@@ -108,7 +115,9 @@ public class MultiSearchRequestTests extends ESTestCase {
     }
 
     public void testSimpleAdd4() throws Exception {
-        IndicesQueriesRegistry registry = new IndicesQueriesRegistry(Settings.EMPTY, singletonMap("match_all", new MatchAllQueryParser()));
+        IndicesQueriesRegistry registry = new IndicesQueriesRegistry(Settings.EMPTY,
+                Collections.singletonMap(MatchAllQueryBuilder.NAME,
+                        new Tuple<>(MatchAllQueryParser.QUERY_NAME_FIELD, new MatchAllQueryParser())));
         byte[] data = StreamsUtils.copyToBytesFromClasspath("/org/elasticsearch/action/search/simple-msearch4.json");
         MultiSearchRequest request = RestMultiSearchAction.parseRequest(new MultiSearchRequest(), new BytesArray(data), false, null, null,
                 null, null, IndicesOptions.strictExpandOpenAndForbidClosed(), true, registry, ParseFieldMatcher.EMPTY, null, null);
@@ -130,7 +139,9 @@ public class MultiSearchRequestTests extends ESTestCase {
     }
 
     public void testSimpleAdd5() throws Exception {
-        IndicesQueriesRegistry registry = new IndicesQueriesRegistry(Settings.EMPTY, singletonMap("match_all", new MatchAllQueryParser()));
+        IndicesQueriesRegistry registry = new IndicesQueriesRegistry(Settings.EMPTY,
+                Collections.singletonMap(MatchAllQueryBuilder.NAME,
+                        new Tuple<>(MatchAllQueryParser.QUERY_NAME_FIELD, new MatchAllQueryParser())));
         byte[] data = StreamsUtils.copyToBytesFromClasspath("/org/elasticsearch/action/search/simple-msearch5.json");
         MultiSearchRequest request = RestMultiSearchAction.parseRequest(new MultiSearchRequest(), new BytesArray(data), true, null, null,
                 null, null, IndicesOptions.strictExpandOpenAndForbidClosed(), true, registry, ParseFieldMatcher.EMPTY, null, null);

--- a/core/src/test/java/org/elasticsearch/index/percolator/PercolatorQueryCacheTests.java
+++ b/core/src/test/java/org/elasticsearch/index/percolator/PercolatorQueryCacheTests.java
@@ -42,7 +42,9 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.settings.Settings;
@@ -57,12 +59,15 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
 import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
+import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.BoolQueryParser;
 import org.elasticsearch.index.query.PercolatorQuery;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryParser;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.TermQueryParser;
+import org.elasticsearch.index.query.WildcardQueryBuilder;
 import org.elasticsearch.index.query.WildcardQueryParser;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
@@ -99,10 +104,10 @@ public class PercolatorQueryCacheTests extends ESTestCase {
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
                 .build();
 
-        Map<String, QueryParser<?>> queryParsers = new HashMap<>();
-        queryParsers.put("term", new TermQueryParser());
-        queryParsers.put("wildcard", new WildcardQueryParser());
-        queryParsers.put("bool", new BoolQueryParser());
+        Map<String, Tuple<ParseField, QueryParser<?>>> queryParsers = new HashMap<>();
+        queryParsers.put(TermQueryBuilder.NAME, new Tuple<>(TermQueryParser.QUERY_NAME_FIELD, new TermQueryParser()));
+        queryParsers.put(WildcardQueryBuilder.NAME, new Tuple<>(WildcardQueryParser.QUERY_NAME_FIELD, new WildcardQueryParser()));
+        queryParsers.put(BoolQueryBuilder.NAME, new Tuple<>(BoolQueryParser.QUERY_NAME_FIELD, new BoolQueryParser()));
         IndicesQueriesRegistry indicesQueriesRegistry = new IndicesQueriesRegistry(settings, queryParsers);
 
         Settings indexSettings = Settings.settingsBuilder()

--- a/core/src/test/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilderTests.java
@@ -305,7 +305,7 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
     public void testFromJson() throws IOException {
         String json =
                 "{\n" + 
-                "  \"mlt\" : {\n" + 
+                "  \"more_like_this\" : {\n" +
                 "    \"fields\" : [ \"title\", \"description\" ],\n" + 
                 "    \"like\" : [ \"and potentially some more text here as well\", {\n" + 
                 "      \"_index\" : \"imdb\",\n" + 
@@ -335,5 +335,42 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
 
         assertEquals(json, 2, parsed.fields().length);
         assertEquals(json, "and potentially some more text here as well", parsed.likeTexts()[0]);
+
+        json =
+                "{\n" +
+                        "  \"mlt\" : {\n" +
+                        "    \"fields\" : [ \"title\", \"description\" ],\n" +
+                        "    \"like\" : [ \"and potentially some more text here as well\", {\n" +
+                        "      \"_index\" : \"imdb\",\n" +
+                        "      \"_type\" : \"movies\",\n" +
+                        "      \"_id\" : \"1\"\n" +
+                        "    }, {\n" +
+                        "      \"_index\" : \"imdb\",\n" +
+                        "      \"_type\" : \"movies\",\n" +
+                        "      \"_id\" : \"2\"\n" +
+                        "    } ],\n" +
+                        "    \"max_query_terms\" : 12,\n" +
+                        "    \"min_term_freq\" : 1,\n" +
+                        "    \"min_doc_freq\" : 5,\n" +
+                        "    \"max_doc_freq\" : 2147483647,\n" +
+                        "    \"min_word_length\" : 0,\n" +
+                        "    \"max_word_length\" : 0,\n" +
+                        "    \"minimum_should_match\" : \"30%\",\n" +
+                        "    \"boost_terms\" : 0.0,\n" +
+                        "    \"include\" : false,\n" +
+                        "    \"fail_on_unsupported_field\" : true,\n" +
+                        "    \"boost\" : 1.0\n" +
+                        "  }\n" +
+                        "}";
+
+        MoreLikeThisQueryBuilder parsedQueryMltShortcut = (MoreLikeThisQueryBuilder) parseQuery(json, ParseFieldMatcher.EMPTY);
+        assertThat(parsedQueryMltShortcut, equalTo(parsed));
+
+        try {
+            parseQuery(json);
+            fail("parse query should have failed in strict mode");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("Deprecated field [mlt] used, expected [more_like_this] instead"));
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
@@ -28,6 +28,7 @@ import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -270,8 +271,24 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
 
         TermsQueryBuilder parsed = (TermsQueryBuilder) parseQuery(json);
         checkGeneratedJson(json, parsed);
-
         assertEquals(json, 2, parsed.values().size());
+
+        json =
+                "{\n" +
+                        "  \"in\" : {\n" +
+                        "    \"user\" : [ \"kimchy\", \"elasticsearch\" ],\n" +
+                        "    \"boost\" : 1.0\n" +
+                        "  }\n" +
+                        "}";
+        QueryBuilder<?> inShortcutParsed = parseQuery(json, ParseFieldMatcher.EMPTY);
+        assertThat(inShortcutParsed, equalTo(parsed));
+
+        try {
+            parseQuery(json);
+            fail("parse query should have failed in strict mode");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("Deprecated field [in] used, expected [terms] instead"));
+        }
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/plugin/DummyQueryParserPlugin.java
+++ b/core/src/test/java/org/elasticsearch/index/query/plugin/DummyQueryParserPlugin.java
@@ -19,12 +19,11 @@
 
 package org.elasticsearch.index.query.plugin;
 
-import java.io.IOException;
-
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Weight;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -35,6 +34,8 @@ import org.elasticsearch.index.query.QueryParser;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchModule;
+
+import java.io.IOException;
 
 public class DummyQueryParserPlugin extends Plugin {
 
@@ -49,7 +50,7 @@ public class DummyQueryParserPlugin extends Plugin {
     }
 
     public void onModule(SearchModule module) {
-        module.registerQueryParser(DummyQueryParser::new);
+        module.registerQueryParser(new DummyQueryParser(), new ParseField(DummyQueryBuilder.NAME));
     }
 
     public static class DummyQueryBuilder extends AbstractQueryBuilder<DummyQueryBuilder> {
@@ -92,11 +93,6 @@ public class DummyQueryParserPlugin extends Plugin {
     }
 
     public static class DummyQueryParser implements QueryParser<DummyQueryBuilder> {
-        @Override
-        public String[] names() {
-            return new String[]{DummyQueryBuilder.NAME};
-        }
-
         @Override
         public DummyQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
             XContentParser.Token token = parseContext.parser().nextToken();

--- a/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -32,8 +32,12 @@ import org.elasticsearch.search.suggest.CustomSuggester;
 import org.elasticsearch.search.suggest.phrase.PhraseSuggester;
 
 import java.io.IOException;
+import java.util.Map;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
 /**
  */
 public class SearchModuleTests extends ModuleTestCase {
@@ -80,6 +84,97 @@ public class SearchModuleTests extends ModuleTestCase {
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("already registered for name [term] while trying to register [org.elasticsearch.index."));
         }
+    }
+
+    public void testRegisteredQueries() {
+        SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry());
+        Map<String, QueryParser<?>> queryParserMap = module.buildQueryParserRegistry().queryParsers();
+        assertThat(queryParserMap.size(), equalTo(84));
+        assertThat(queryParserMap.keySet(), containsInAnyOrder(
+                "bool",
+                "boosting",
+                "common",
+                "constantScore",
+                "constant_score",
+                "disMax",
+                "dis_max",
+                "exists",
+                "fieldMaskingSpan",
+                "field_masking_span",
+                "functionScore",
+                "function_score",
+                "fuzzy",
+                "fuzzy_match",
+                "geoBbox",
+                "geoBoundingBox",
+                "geoDistance",
+                "geoDistanceRange",
+                "geoPolygon",
+                "geoShape",
+                "geo_bbox",
+                "geo_bounding_box",
+                "geo_distance",
+                "geo_distance_range",
+                "geo_polygon",
+                "geo_shape",
+                "geohashCell",
+                "geohash_cell",
+                "hasChild",
+                "hasParent",
+                "has_child",
+                "has_parent",
+                "ids",
+                "in",
+                "indices",
+                "match",
+                "matchAll",
+                "matchFuzzy",
+                "matchNone",
+                "matchPhrase",
+                "matchPhrasePrefix",
+                "match_all",
+                "match_fuzzy",
+                "match_none",
+                "match_phrase",
+                "match_phrase_prefix",
+                "mlt",
+                "moreLikeThis",
+                "more_like_this",
+                "multiMatch",
+                "multi_match",
+                "nested",
+                "parent_id",
+                "percolator",
+                "prefix",
+                "queryString",
+                "query_string",
+                "range",
+                "regexp",
+                "script",
+                "simpleQueryString",
+                "simple_query_string",
+                "spanContaining",
+                "spanFirst",
+                "spanMulti",
+                "spanNear",
+                "spanNot",
+                "spanOr",
+                "spanTerm",
+                "spanWithin",
+                "span_containing",
+                "span_first",
+                "span_multi",
+                "span_near",
+                "span_not",
+                "span_or",
+                "span_term",
+                "span_within",
+                "template",
+                "term",
+                "terms",
+                "type",
+                "wildcard",
+                "wrapper"));
     }
 
     static class FakeQueryParser implements QueryParser {

--- a/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -18,25 +18,26 @@
  */
 package org.elasticsearch.search;
 
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.inject.ModuleTestCase;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.index.query.QueryParser;
-import org.elasticsearch.index.query.TermQueryParser;
+import org.elasticsearch.indices.query.IndicesQueriesRegistry;
 import org.elasticsearch.search.highlight.CustomHighlighter;
 import org.elasticsearch.search.highlight.Highlighter;
 import org.elasticsearch.search.highlight.PlainHighlighter;
 import org.elasticsearch.search.suggest.CustomSuggester;
 import org.elasticsearch.search.suggest.phrase.PhraseSuggester;
 
-import java.io.IOException;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 /**
  */
@@ -78,120 +79,132 @@ public class SearchModuleTests extends ModuleTestCase {
 
     public void testRegisterQueryParserDuplicate() {
         SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry());
-        module.registerQueryParser(TermQueryParser::new);
         try {
             module.buildQueryParserRegistry();
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("already registered for name [term] while trying to register [org.elasticsearch.index."));
+            assertThat(e.getMessage(),
+                    containsString("already registered for name [term] while trying to register [org.elasticsearch.index."));
         }
     }
 
     public void testRegisteredQueries() {
         SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry());
-        Map<String, QueryParser<?>> queryParserMap = module.buildQueryParserRegistry().queryParsers();
-        assertThat(queryParserMap.size(), equalTo(84));
-        assertThat(queryParserMap.keySet(), containsInAnyOrder(
-                "bool",
-                "boosting",
-                "common",
-                "constantScore",
-                "constant_score",
-                "disMax",
-                "dis_max",
-                "exists",
-                "fieldMaskingSpan",
-                "field_masking_span",
-                "functionScore",
-                "function_score",
-                "fuzzy",
-                "fuzzy_match",
-                "geoBbox",
-                "geoBoundingBox",
-                "geoDistance",
-                "geoDistanceRange",
-                "geoPolygon",
-                "geoShape",
-                "geo_bbox",
-                "geo_bounding_box",
-                "geo_distance",
-                "geo_distance_range",
-                "geo_polygon",
-                "geo_shape",
-                "geohashCell",
-                "geohash_cell",
-                "hasChild",
-                "hasParent",
-                "has_child",
-                "has_parent",
-                "ids",
-                "in",
-                "indices",
-                "match",
-                "matchAll",
-                "matchFuzzy",
-                "matchNone",
-                "matchPhrase",
-                "matchPhrasePrefix",
-                "match_all",
-                "match_fuzzy",
-                "match_none",
-                "match_phrase",
-                "match_phrase_prefix",
-                "mlt",
-                "moreLikeThis",
-                "more_like_this",
-                "multiMatch",
-                "multi_match",
-                "nested",
-                "parent_id",
-                "percolator",
-                "prefix",
-                "queryString",
-                "query_string",
-                "range",
-                "regexp",
-                "script",
-                "simpleQueryString",
-                "simple_query_string",
-                "spanContaining",
-                "spanFirst",
-                "spanMulti",
-                "spanNear",
-                "spanNot",
-                "spanOr",
-                "spanTerm",
-                "spanWithin",
-                "span_containing",
-                "span_first",
-                "span_multi",
-                "span_near",
-                "span_not",
-                "span_or",
-                "span_term",
-                "span_within",
-                "template",
-                "term",
-                "terms",
-                "type",
-                "wildcard",
-                "wrapper"));
-    }
+        List<String> allSupportedQueries = new ArrayList<>();
+        Collections.addAll(allSupportedQueries, NON_DEPRECATED_QUERIES);
+        Collections.addAll(allSupportedQueries, DEPRECATED_QUERIES);
+        String[] supportedQueries = allSupportedQueries.toArray(new String[allSupportedQueries.size()]);
+        assertThat(module.getRegisteredQueries(), containsInAnyOrder(supportedQueries));
 
-    static class FakeQueryParser implements QueryParser {
-        @Override
-        public String[] names() {
-            return new String[] {"fake-query-parser"};
+        IndicesQueriesRegistry indicesQueriesRegistry = module.buildQueryParserRegistry();
+        for (String queryName : supportedQueries) {
+            QueryParser<?> queryParser = indicesQueriesRegistry.getQueryParser(queryName,
+                    ParseFieldMatcher.EMPTY, new XContentLocation(-1, -1));
+            assertThat(queryParser, notNullValue());
         }
-
-        @Override
-        public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
-            return null;
+        for (String queryName : NON_DEPRECATED_QUERIES) {
+            QueryParser<?> queryParser = indicesQueriesRegistry.getQueryParser(queryName,
+                    ParseFieldMatcher.STRICT, new XContentLocation(-1, -1));
+            assertThat(queryParser, notNullValue());
         }
-
-        @Override
-        public QueryBuilder getBuilderPrototype() {
-            return null;
+        for (String queryName : DEPRECATED_QUERIES) {
+            try {
+                indicesQueriesRegistry.getQueryParser(queryName, ParseFieldMatcher.STRICT, new XContentLocation(-1, -1));
+                fail("query is deprecated, getQueryParser should have failed in strict mode");
+            } catch(IllegalArgumentException e) {
+                assertThat(e.getMessage(), containsString("Deprecated field [" + queryName + "] used"));
+            }
         }
     }
 
+    private static final String[] NON_DEPRECATED_QUERIES = new String[] {
+            "bool",
+            "boosting",
+            "common",
+            "constantScore",
+            "constant_score",
+            "disMax",
+            "dis_max",
+            "exists",
+            "fieldMaskingSpan",
+            "field_masking_span",
+            "functionScore",
+            "function_score",
+            "fuzzy",
+            "geoBoundingBox",
+            "geoDistance",
+            "geoDistanceRange",
+            "geoPolygon",
+            "geoShape",
+            "geo_bounding_box",
+            "geo_distance",
+            "geo_distance_range",
+            "geo_polygon",
+            "geo_shape",
+            "geohashCell",
+            "geohash_cell",
+            "hasChild",
+            "hasParent",
+            "has_child",
+            "has_parent",
+            "ids",
+            "indices",
+            "match",
+            "matchAll",
+            "matchNone",
+            "matchPhrase",
+            "matchPhrasePrefix",
+            "match_all",
+            "match_none",
+            "match_phrase",
+            "match_phrase_prefix",
+            "moreLikeThis",
+            "more_like_this",
+            "multiMatch",
+            "multi_match",
+            "nested",
+            "parentId",
+            "parent_id",
+            "percolator",
+            "prefix",
+            "queryString",
+            "query_string",
+            "range",
+            "regexp",
+            "script",
+            "simpleQueryString",
+            "simple_query_string",
+            "spanContaining",
+            "spanFirst",
+            "spanMulti",
+            "spanNear",
+            "spanNot",
+            "spanOr",
+            "spanTerm",
+            "spanWithin",
+            "span_containing",
+            "span_first",
+            "span_multi",
+            "span_near",
+            "span_not",
+            "span_or",
+            "span_term",
+            "span_within",
+            "template",
+            "term",
+            "terms",
+            "type",
+            "wildcard",
+            "wrapper"
+    };
+
+    private static final String[] DEPRECATED_QUERIES = new String[] {
+            "fuzzyMatch",
+            "fuzzy_match",
+            "geoBbox",
+            "geo_bbox",
+            "in",
+            "matchFuzzy",
+            "match_fuzzy",
+            "mlt"
+    };
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.QueryParseContext;
-import org.elasticsearch.index.query.QueryParser;
 import org.elasticsearch.indices.query.IndicesQueriesRegistry;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -61,13 +60,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.elasticsearch.search.aggregations.AggregationBuilders.significantTerms;
 import static org.elasticsearch.test.VersionUtils.randomVersion;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.significantTerms;
 
 /**
  *
@@ -241,7 +240,7 @@ public class SignificanceHeuristicTests extends ESTestCase {
     protected void checkParseException(SignificanceHeuristicParserMapper heuristicParserMapper, SearchContext searchContext,
             String faultyHeuristicDefinition, String expectedError) throws IOException {
 
-        IndicesQueriesRegistry registry = new IndicesQueriesRegistry(Settings.EMPTY, new HashMap<String, QueryParser<?>>());
+        IndicesQueriesRegistry registry = new IndicesQueriesRegistry(Settings.EMPTY, Collections.emptyMap());
         try {
             XContentParser stParser = JsonXContent.jsonXContent.createParser("{\"field\":\"text\", " + faultyHeuristicDefinition + ",\"min_doc_count\":200}");
             QueryParseContext parseContext = new QueryParseContext(registry);
@@ -266,7 +265,7 @@ public class SignificanceHeuristicTests extends ESTestCase {
 
     private SignificanceHeuristic parseSignificanceHeuristic(SignificanceHeuristicParserMapper heuristicParserMapper,
             SearchContext searchContext, XContentParser stParser) throws IOException {
-        IndicesQueriesRegistry registry = new IndicesQueriesRegistry(Settings.EMPTY, new HashMap<String, QueryParser<?>>());
+        IndicesQueriesRegistry registry = new IndicesQueriesRegistry(Settings.EMPTY, Collections.emptyMap());
         QueryParseContext parseContext = new QueryParseContext(registry);
         parseContext.reset(stParser);
         parseContext.parseFieldMatcher(ParseFieldMatcher.STRICT);

--- a/core/src/test/java/org/elasticsearch/search/searchafter/SearchAfterBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/searchafter/SearchAfterBuilderTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.search.searchafter;
 
 import org.elasticsearch.common.ParseFieldMatcher;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -31,6 +32,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.MatchAllQueryParser;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.indices.query.IndicesQueriesRegistry;
@@ -55,8 +57,10 @@ public class SearchAfterBuilderTests extends ESTestCase {
     @BeforeClass
     public static void init() {
         namedWriteableRegistry = new NamedWriteableRegistry();
-        indicesQueriesRegistry = new IndicesQueriesRegistry(Settings.settingsBuilder().build(),
-            Collections.singletonMap("match_all", new MatchAllQueryParser()));
+        indicesQueriesRegistry = new IndicesQueriesRegistry(
+                Settings.settingsBuilder().build(),
+                Collections.singletonMap(
+                        MatchAllQueryBuilder.NAME, new Tuple<>(MatchAllQueryParser.QUERY_NAME_FIELD, new MatchAllQueryParser())));
     }
 
     @AfterClass

--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -6,7 +6,7 @@ set of documents. In order to do so, MLT selects a set of representative terms
 of these input documents, forms a query using these terms, executes the query
 and returns the results. The user controls the input documents, how the terms
 should be selected and how the query is formed. `more_like_this` can be
-shortened to `mlt`.
+shortened to `mlt` deprecated[5.0.0,use `more_like_this` instead).
 
 The simplest use case consists of asking for documents that are similar to a
 provided piece of text. Here, we are asking for all movies that have some text

--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -16,7 +16,7 @@ Filters documents that have fields that match any of the provided terms
 --------------------------------------------------
 
 The `terms` query is also aliased with `in` as the filter name for
-simpler usage.
+simpler usage deprecated[5.0.0,use `terms` instead].
 
 [float]
 [[query-dsl-terms-lookup]]


### PR DESCRIPTION
If we have a deprecated query name, at the moment we don't have a way to log any deprecation warning. With this PR we use ParseField, so that we can properly deprecate query synonyms and have one single name for each query. This PR effectively deprecates  `in`, `mlt` and `geo_bbox` in favour of their complete names `terms`, `more_like_this` and `geo_bounding_box`.
