### PR TITLE
Add a more descriptive example to Index Template

### DIFF
--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -21,7 +21,12 @@ curl -XPUT localhost:9200/_template/template_1 -d '
     },
     "mappings" : {
         "type1" : {
-            "_source" : { "enabled" : false }
+            "_source" : { "enabled" : false },
+            "properties" : { 
+                "coordinates" : { "type" : "geo_shape" },
+                "created_at" : { "type":"date" , "format" : "EEE MMM dd HH:mm:ss Z YYYY" },
+                "text" : {"type" : "string" }
+                }
         }
     }
 }


### PR DESCRIPTION
The current example in the documentation for Index Templates lacks any properties values. This is helpful to many devs that aren't sure how to take a regular Index Mapping and convert it to a template.
