### PR TITLE
Show configured and remaining delay for an unassigned shard.

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
@@ -139,8 +139,14 @@ public class TransportClusterAllocationExplainAction
                 nodeToDecision.put(discoNode, d);
             }
         }
+        long remainingDelayNanos = 0;
+        if (ui != null) {
+            final MetaData metadata = allocation.metaData();
+            final Settings indexSettings = metadata.index(shard.index()).getSettings();
+            remainingDelayNanos = ui.getRemainingDelay(System.nanoTime(), metadata.settings(), indexSettings);
+        }
         return new ClusterAllocationExplanation(shard.shardId(), shard.primary(), shard.currentNodeId(), ui, nodeToDecision,
-                shardAllocator.weighShard(allocation, shard));
+                shardAllocator.weighShard(allocation, shard), remainingDelayNanos);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -236,7 +236,7 @@ public class UnassignedInfo implements ToXContent, Writeable<UnassignedInfo> {
      *
      * @return calculated delay in nanoseconds
      */
-    public long getRemainingDelay(long nanoTimeNow, Settings settings, Settings indexSettings) {
+    public long getRemainingDelay(final long nanoTimeNow, final Settings settings, final Settings indexSettings) {
         final long delayTimeoutNanos = getAllocationDelayTimeoutSettingNanos(settings, indexSettings);
         if (delayTimeoutNanos == 0L) {
             return 0L;
@@ -251,7 +251,7 @@ public class UnassignedInfo implements ToXContent, Writeable<UnassignedInfo> {
      *
      * @return updated delay in nanoseconds
      */
-    public long updateDelay(long nanoTimeNow, Settings settings, Settings indexSettings) {
+    public long updateDelay(final long nanoTimeNow, final Settings settings, final Settings indexSettings) {
         final long newComputedLeftDelayNanos = getRemainingDelay(nanoTimeNow, settings, indexSettings);
         lastComputedLeftDelayNanos = newComputedLeftDelayNanos;
         return newComputedLeftDelayNanos;

--- a/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -232,19 +232,27 @@ public class UnassignedInfo implements ToXContent, Writeable<UnassignedInfo> {
     }
 
     /**
+     * Calculates the delay left based on current time (in nanoseconds) and index/node settings.
+     *
+     * @return calculated delay in nanoseconds
+     */
+    public long getRemainingDelay(long nanoTimeNow, Settings settings, Settings indexSettings) {
+        final long delayTimeoutNanos = getAllocationDelayTimeoutSettingNanos(settings, indexSettings);
+        if (delayTimeoutNanos == 0L) {
+            return 0L;
+        } else {
+            assert nanoTimeNow >= unassignedTimeNanos;
+            return Math.max(0L, delayTimeoutNanos - (nanoTimeNow - unassignedTimeNanos));
+        }
+    }
+
+    /**
      * Updates delay left based on current time (in nanoseconds) and index/node settings.
      *
      * @return updated delay in nanoseconds
      */
     public long updateDelay(long nanoTimeNow, Settings settings, Settings indexSettings) {
-        long delayTimeoutNanos = getAllocationDelayTimeoutSettingNanos(settings, indexSettings);
-        final long newComputedLeftDelayNanos;
-        if (delayTimeoutNanos == 0L) {
-            newComputedLeftDelayNanos = 0L;
-        } else {
-            assert nanoTimeNow >= unassignedTimeNanos;
-            newComputedLeftDelayNanos = Math.max(0L, delayTimeoutNanos - (nanoTimeNow - unassignedTimeNanos));
-        }
+        final long newComputedLeftDelayNanos = getRemainingDelay(nanoTimeNow, settings, indexSettings);
         lastComputedLeftDelayNanos = newComputedLeftDelayNanos;
         return newComputedLeftDelayNanos;
     }

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.allocation;
+
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * Tests for the cluster allocation explanation
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
+public final class ClusterAllocationExplainIT extends ESIntegTestCase {
+    public void testDelayShards() throws Exception {
+        logger.info("--> starting 3 nodes");
+        List<String> nodes = internalCluster().startNodesAsync(3).get();
+
+        // Wait for all 3 nodes to be up
+        logger.info("--> waiting for 3 nodes to be up");
+        assertBusy(new Runnable() {
+            @Override
+            public void run() {
+                NodesStatsResponse resp = client().admin().cluster().prepareNodesStats().get();
+                assertThat(resp.getNodes().length, equalTo(3));
+            }
+        });
+
+        logger.info("--> creating 'test' index");
+        prepareCreate("test").setSettings(Settings.settingsBuilder()
+                .put("index.unassigned.node_left.delayed_timeout", "1m")
+                .put("number_of_shards", 5)
+                .put("number_of_replicas", 1)).get();
+        ensureGreen("test");
+
+        logger.info("--> stopping a random node");
+        assertTrue(internalCluster().stopRandomDataNode());
+
+        ensureYellow("test");
+
+        ClusterAllocationExplainResponse resp = client().admin().cluster().prepareAllocationExplain().useAnyUnassignedShard().get();
+        ClusterAllocationExplanation cae = resp.getExplanation();
+        assertThat(cae.getShard().getIndexName(), equalTo("test"));
+        assertFalse(cae.isPrimary());
+        assertFalse(cae.isAssigned());
+        assertThat("expecting a remaining delay, got: " + cae.getRemainingDelayNanos(), cae.getRemainingDelayNanos(), greaterThan(0L));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.action.admin.cluster.allocation;
 
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -51,9 +53,9 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
 
         logger.info("--> creating 'test' index");
         prepareCreate("test").setSettings(Settings.settingsBuilder()
-                .put("index.unassigned.node_left.delayed_timeout", "1m")
-                .put("number_of_shards", 5)
-                .put("number_of_replicas", 1)).get();
+                .put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), "1m")
+                .put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 5)
+                .put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1)).get();
         ensureGreen("test");
 
         logger.info("--> stopping a random node");

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanationTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanationTests.java
@@ -64,9 +64,10 @@ public final class ClusterAllocationExplanationTests extends ESTestCase {
             nodeToDecisions.put(dn, d);
             nodeToWeight.put(dn, randomFloat());
         }
-        
+
+        long remainingDelay = randomIntBetween(0, 500);
         ClusterAllocationExplanation cae = new ClusterAllocationExplanation(shard, true, "assignedNode", null,
-                nodeToDecisions, nodeToWeight);
+                nodeToDecisions, nodeToWeight, remainingDelay);
         BytesStreamOutput out = new BytesStreamOutput();
         cae.writeTo(out);
         StreamInput in = StreamInput.wrap(out.bytes());
@@ -80,5 +81,6 @@ public final class ClusterAllocationExplanationTests extends ESTestCase {
             assertEquals(nodeToDecisions.get(entry.getKey()), entry.getValue());
         }
         assertEquals(nodeToWeight, cae2.getNodeWeights());
+        assertEquals(remainingDelay, cae2.getRemainingDelayNanos());
     }
 }


### PR DESCRIPTION
When a shard is delayed, we now show output like:

``` json
{
  "shard" : {
    "index" : "i",
    "index_uuid" : "QzoKda9aQCG_hCaZQ18GEg",
    "id" : 3,
    "primary" : false
  },
  "assigned" : false,
  "unassigned_info" : {
    "reason" : "NODE_LEFT",
    "at" : "2016-04-04T16:44:47.520Z",
    "details" : "node_left[HyRLmMLxR5m_f58RKURApQ]"
  },
  "allocation_delay" : "59.9s",
  "allocation_delay_ms" : 59910,
  "remaining_delay" : "38.9s",
  "remaining_delay_ms" : 38991,
  "nodes" : {
    "jKiyQcWFTkyp3htyyjxoCw" : {
      "node_name" : "Landslide",
      "node_attributes" : { },
      "final_decision" : "YES",
      "weight" : 1.0,
      "decisions" : [ ]
    },
    "9bzF0SgoQh-G0F0sRW_qew" : {
      "node_name" : "Caretaker",
      "node_attributes" : { },
      "final_decision" : "NO",
      "weight" : 2.0,
      "decisions" : [ {
        "decider" : "same_shard",
        "decision" : "NO",
        "explanation" : "the shard cannot be allocated on the same node id [9bzF0SgoQh-G0F0sRW_qew] on which it already exists"
      } ]
    }
  }
}
```

Where the new addition is this section:

```
  "allocation_delay" : "59.9s",
  "allocation_delay_ms" : 59910,
  "remaining_delay" : "38.9s",
  "remaining_delay_ms" : 38991,
```

Which shows the configured delay as well as the remaining delay until
the shard can be considered "assignable". This data is only shown if the
shard is unassigned.

Relates to #17372
