### PR TITLE
string.asciidoc: fix for `position_increment_gap`

### DIFF
--- a/docs/reference/mapping/types/string.asciidoc
+++ b/docs/reference/mapping/types/string.asciidoc
@@ -144,11 +144,9 @@ Defaults depend on the <<mapping-index,`index`>> setting:
 
 <<position-increment-gap,`position_increment_gap`>>::
 
-    The number of fake term positions which should be inserted between
-    each element of an array of strings. Defaults to 0.
     The number of fake term position which should be inserted between each
-    element of an array of strings. Defaults to the position_increment_gap
-    configured on the analyzer which defaults to 100. 100 was chosen because it
+    element of an array of strings. Defaults to the `position_increment_gap`
+    configured on the analyzer which defaults to `100`. `100` was chosen because it
     prevents phrase queries with reasonably large slops (less than 100) from
     matching terms across field values.
 


### PR DESCRIPTION
Remove  outdated and duplicate description for the `position_increment_gap` parameter.
