### PR TITLE
Do not assume term queries use the inverted index.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -20,6 +20,7 @@ package org.elasticsearch.index.mapper.core;
 
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.suggest.document.Completion50PostingsFormat;
 import org.apache.lucene.search.suggest.document.CompletionAnalyzer;
 import org.apache.lucene.search.suggest.document.CompletionQuery;
@@ -265,14 +266,14 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
          * Completion prefix query
          */
         public CompletionQuery prefixQuery(Object value) {
-            return new PrefixCompletionQuery(searchAnalyzer().analyzer(), createTerm(value));
+            return new PrefixCompletionQuery(searchAnalyzer().analyzer(), new Term(name(), indexedValueForSearch(value)));
         }
 
         /**
          * Completion prefix regular expression query
          */
         public CompletionQuery regexpQuery(Object value, int flags, int maxDeterminizedStates) {
-            return new RegexCompletionQuery(createTerm(value), flags, maxDeterminizedStates);
+            return new RegexCompletionQuery(new Term(name(), indexedValueForSearch(value)), flags, maxDeterminizedStates);
         }
 
         /**
@@ -281,7 +282,7 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
         public CompletionQuery fuzzyQuery(String value, Fuzziness fuzziness, int nonFuzzyPrefixLength,
                                           int minFuzzyPrefixLength, int maxExpansions, boolean transpositions,
                                           boolean unicodeAware) {
-            return new FuzzyCompletionQuery(searchAnalyzer().analyzer(), createTerm(value), null,
+            return new FuzzyCompletionQuery(searchAnalyzer().analyzer(), new Term(name(), indexedValueForSearch(value)), null,
                     fuzziness.asDistance(), transpositions, nonFuzzyPrefixLength, minFuzzyPrefixLength,
                     unicodeAware, maxExpansions);
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
@@ -204,7 +204,7 @@ public class AllFieldMapper extends MetadataFieldMapper {
 
         @Override
         public Query termQuery(Object value, QueryShardContext context) {
-            return queryStringTermQuery(createTerm(value));
+            return queryStringTermQuery(new Term(name(), indexedValueForSearch(value)));
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
@@ -185,10 +185,6 @@ public class UidFieldMapper extends MetadataFieldMapper {
         }
     }
 
-    public Term term(String uid) {
-        return new Term(fieldType().name(), fieldType().indexedValueForSearch(uid));
-    }
-
     @Override
     protected String contentType() {
         return CONTENT_TYPE;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.aggregations.bucket.significant;
 
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
@@ -145,8 +146,10 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
         return result;
     }
 
-    public long getBackgroundFrequency(long term) {
-        BytesRef indexedVal = fieldType.indexedValueForSearch(term);
+    public long getBackgroundFrequency(long value) {
+        Query query = fieldType.termQuery(value, null);
+        Term term = MappedFieldType.extractTerm(query);
+        BytesRef indexedVal = term.bytes();
         return getBackgroundFrequency(indexedVal);
     }
 
@@ -256,7 +259,6 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                     AggregationContext aggregationContext, Aggregator parent, SignificanceHeuristic significanceHeuristic,
                     SignificantTermsAggregatorFactory termsAggregatorFactory, List<PipelineAggregator> pipelineAggregators,
                     Map<String, Object> metaData) throws IOException {
-                ValuesSource.Bytes.WithOrdinals valueSourceWithOrdinals = (ValuesSource.Bytes.WithOrdinals) valuesSource;
                 final IncludeExclude.OrdinalsFilter filter = includeExclude == null ? null : includeExclude.convertToOrdinalsFilter();
                 return new GlobalOrdinalsSignificantTermsAggregator(name, factories,
                         (ValuesSource.Bytes.WithOrdinals.FieldData) valuesSource, format, bucketCountThresholds, filter,

--- a/core/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTests.java
@@ -19,9 +19,10 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.index.mapper.MappedFieldType;
 
@@ -44,8 +45,8 @@ public class SpanTermQueryBuilderTests extends AbstractTermQueryTestCase<SpanTer
         assertThat(spanTermQuery.getTerm().field(), equalTo(queryBuilder.fieldName()));
         MappedFieldType mapper = context.fieldMapper(queryBuilder.fieldName());
         if (mapper != null) {
-            BytesRef bytesRef = mapper.indexedValueForSearch(queryBuilder.value());
-            assertThat(spanTermQuery.getTerm().bytes(), equalTo(bytesRef));
+            Term term = ((TermQuery) mapper.termQuery(queryBuilder.value(), null)).getTerm();
+            assertThat(spanTermQuery.getTerm(), equalTo(term));
         } else {
             assertThat(spanTermQuery.getTerm().bytes(), equalTo(BytesRefs.toBytesRef(queryBuilder.value())));
         }

--- a/core/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -48,8 +48,8 @@ public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBu
         assertThat(termQuery.getTerm().field(), equalTo(queryBuilder.fieldName()));
         MappedFieldType mapper = context.fieldMapper(queryBuilder.fieldName());
         if (mapper != null) {
-            BytesRef bytesRef = mapper.indexedValueForSearch(queryBuilder.value());
-            assertThat(termQuery.getTerm().bytes(), equalTo(bytesRef));
+            Term term = ((TermQuery) mapper.termQuery(queryBuilder.value(), null)).getTerm();
+            assertThat(termQuery.getTerm(), equalTo(term));
         } else {
             assertThat(termQuery.getTerm().bytes(), equalTo(BytesRefs.toBytesRef(queryBuilder.value())));
         }

--- a/core/src/test/java/org/elasticsearch/index/search/MultiMatchQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/MultiMatchQueryTests.java
@@ -20,18 +20,24 @@
 package org.elasticsearch.index.search;
 
 import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.BlendedTermQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MockFieldMapper.FakeFieldType;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.search.MultiMatchQuery.FieldAndFieldType;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.junit.Before;
 
@@ -82,5 +88,70 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
             expected.add(new DisjunctionMaxQuery(Arrays.<Query>asList(tq1, tq2), 0f), BooleanClause.Occur.SHOULD);
             assertEquals(expected.build(), rewrittenQuery);
         }
+    }
+
+    public void testBlendTerms() {
+        FakeFieldType ft1 = new FakeFieldType();
+        ft1.setName("foo");
+        FakeFieldType ft2 = new FakeFieldType();
+        ft2.setName("bar");
+        Term[] terms = new Term[] { new Term("foo", "baz"), new Term("bar", "baz") };
+        float[] boosts = new float[] {2, 3};
+        Query expected = BlendedTermQuery.booleanBlendedQuery(terms, boosts, false);
+        Query actual = MultiMatchQuery.blendTerm(new BytesRef("baz"), null, 1f, new FieldAndFieldType(ft1, 2), new FieldAndFieldType(ft2, 3));
+        assertEquals(expected, actual);
+    }
+
+    public void testBlendTermsWithFieldBoosts() {
+        FakeFieldType ft1 = new FakeFieldType();
+        ft1.setName("foo");
+        ft1.setBoost(100);
+        FakeFieldType ft2 = new FakeFieldType();
+        ft2.setName("bar");
+        ft2.setBoost(10);
+        Term[] terms = new Term[] { new Term("foo", "baz"), new Term("bar", "baz") };
+        float[] boosts = new float[] {200, 30};
+        Query expected = BlendedTermQuery.booleanBlendedQuery(terms, boosts, false);
+        Query actual = MultiMatchQuery.blendTerm(new BytesRef("baz"), null, 1f, new FieldAndFieldType(ft1, 2), new FieldAndFieldType(ft2, 3));
+        assertEquals(expected, actual);
+    }
+
+    public void testBlendTermsUnsupportedValue() {
+        FakeFieldType ft1 = new FakeFieldType();
+        ft1.setName("foo");
+        FakeFieldType ft2 = new FakeFieldType() {
+            @Override
+            public Query termQuery(Object value, QueryShardContext context) {
+                throw new IllegalArgumentException();
+            }
+        };
+        ft2.setName("bar");
+        Term[] terms = new Term[] { new Term("foo", "baz") };
+        float[] boosts = new float[] {2};
+        Query expected = BlendedTermQuery.booleanBlendedQuery(terms, boosts, false);
+        Query actual = MultiMatchQuery.blendTerm(new BytesRef("baz"), null, 1f, new FieldAndFieldType(ft1, 2), new FieldAndFieldType(ft2, 3));
+        assertEquals(expected, actual);
+    }
+
+    public void testBlendNoTermQuery() {
+        FakeFieldType ft1 = new FakeFieldType();
+        ft1.setName("foo");
+        FakeFieldType ft2 = new FakeFieldType() {
+            @Override
+            public Query termQuery(Object value, QueryShardContext context) {
+                return new MatchAllDocsQuery();
+            }
+        };
+        ft2.setName("bar");
+        Term[] terms = new Term[] { new Term("foo", "baz") };
+        float[] boosts = new float[] {2};
+        Query expectedClause1 = BlendedTermQuery.booleanBlendedQuery(terms, boosts, false);
+        Query expectedClause2 = new BoostQuery(new MatchAllDocsQuery(), 3);
+        Query expected = new BooleanQuery.Builder().setDisableCoord(true)
+                .add(expectedClause1, Occur.SHOULD)
+                .add(expectedClause2, Occur.SHOULD)
+                .build();
+        Query actual = MultiMatchQuery.blendTerm(new BytesRef("baz"), null, 1f, new FieldAndFieldType(ft1, 2), new FieldAndFieldType(ft2, 3));
+        assertEquals(expected, actual);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 
 // this sucks how much must be overridden just do get a dummy field mapper...
@@ -50,7 +49,7 @@ public class MockFieldMapper extends FieldMapper {
         return fullName.substring(ndx + 1);
     }
 
-    static class FakeFieldType extends MappedFieldType {
+    public static class FakeFieldType extends MappedFieldType {
         public FakeFieldType() {
         }
 


### PR DESCRIPTION
We have a couple places in the code base that assume that search is always done
on the inverted index. However with the new points API in Lucene 6, this is not
true anymore. This commit makes MappedFieldType.indexedValueForSearch protected
and fixes call sites to keep working for field types that use the inverted
index and either work differently ar throw an exception otherwise. For instance,
it will still be possible to run cross_fields multi match queries on numeric
fields, but the score contributions will not be blended as well as before, and
significant terms aggregations on long terms will not be possible anymore since
points do not record document frequencies.
