### PR TITLE
Exploit DiscoveryNode immutability in toString

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -87,6 +87,7 @@ public class DiscoveryNode implements Writeable<DiscoveryNode>, ToXContent {
     private final Map<String, String> attributes;
     private final Version version;
     private final Set<Role> roles;
+    private final String toString;
 
     /**
      * Creates a new {@link DiscoveryNode} by reading from the stream provided as argument
@@ -114,6 +115,7 @@ public class DiscoveryNode implements Writeable<DiscoveryNode>, ToXContent {
             this.roles.add(Role.values()[ordinal]);
         }
         this.version = Version.readVersion(in);
+        this.toString = toString(this.nodeName, this.nodeId, this.hostName, this.address, this.attributes);
     }
 
     /**
@@ -202,6 +204,33 @@ public class DiscoveryNode implements Writeable<DiscoveryNode>, ToXContent {
         Set<Role> rolesSet = EnumSet.noneOf(Role.class);
         rolesSet.addAll(roles);
         this.roles = Collections.unmodifiableSet(rolesSet);
+        this.toString = toString(this.nodeName, this.nodeId, this.hostName, this.address, this.attributes);
+    }
+
+    private static String toString(
+            final String nodeName,
+            final String nodeId,
+            final String hostName,
+            final TransportAddress address,
+            final Map<String, String> attributes
+    ) {
+        StringBuilder sb = new StringBuilder();
+        if (nodeName.length() > 0) {
+            sb.append('{').append(nodeName).append('}');
+        }
+        if (nodeId != null) {
+            sb.append('{').append(nodeId).append('}');
+        }
+        if (Strings.hasLength(hostName)) {
+            sb.append('{').append(hostName).append('}');
+        }
+        if (address != null) {
+            sb.append('{').append(address).append('}');
+        }
+        if (!attributes.isEmpty()) {
+            sb.append(attributes);
+        }
+        return sb.toString();
     }
 
     /**
@@ -312,29 +341,8 @@ public class DiscoveryNode implements Writeable<DiscoveryNode>, ToXContent {
         return nodeId.hashCode();
     }
 
-    private String toString;
-
     @Override
     public String toString() {
-        if (toString == null) {
-            StringBuilder sb = new StringBuilder();
-            if (nodeName.length() > 0) {
-                sb.append('{').append(nodeName).append('}');
-            }
-            if (nodeId != null) {
-                sb.append('{').append(nodeId).append('}');
-            }
-            if (Strings.hasLength(hostName)) {
-                sb.append('{').append(hostName).append('}');
-            }
-            if (address != null) {
-                sb.append('{').append(address).append('}');
-            }
-            if (!attributes.isEmpty()) {
-                sb.append(attributes);
-            }
-            toString = sb.toString();
-        }
         return toString;
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -87,7 +87,6 @@ public class DiscoveryNode implements Writeable<DiscoveryNode>, ToXContent {
     private final Map<String, String> attributes;
     private final Version version;
     private final Set<Role> roles;
-    private final String toString;
 
     /**
      * Creates a new {@link DiscoveryNode} by reading from the stream provided as argument
@@ -115,7 +114,6 @@ public class DiscoveryNode implements Writeable<DiscoveryNode>, ToXContent {
             this.roles.add(Role.values()[ordinal]);
         }
         this.version = Version.readVersion(in);
-        this.toString = toString(this.nodeName, this.nodeId, this.hostName, this.address, this.attributes);
     }
 
     /**
@@ -204,33 +202,6 @@ public class DiscoveryNode implements Writeable<DiscoveryNode>, ToXContent {
         Set<Role> rolesSet = EnumSet.noneOf(Role.class);
         rolesSet.addAll(roles);
         this.roles = Collections.unmodifiableSet(rolesSet);
-        this.toString = toString(this.nodeName, this.nodeId, this.hostName, this.address, this.attributes);
-    }
-
-    private static String toString(
-            final String nodeName,
-            final String nodeId,
-            final String hostName,
-            final TransportAddress address,
-            final Map<String, String> attributes
-    ) {
-        StringBuilder sb = new StringBuilder();
-        if (nodeName.length() > 0) {
-            sb.append('{').append(nodeName).append('}');
-        }
-        if (nodeId != null) {
-            sb.append('{').append(nodeId).append('}');
-        }
-        if (Strings.hasLength(hostName)) {
-            sb.append('{').append(hostName).append('}');
-        }
-        if (address != null) {
-            sb.append('{').append(address).append('}');
-        }
-        if (!attributes.isEmpty()) {
-            sb.append(attributes);
-        }
-        return sb.toString();
     }
 
     /**
@@ -341,8 +312,29 @@ public class DiscoveryNode implements Writeable<DiscoveryNode>, ToXContent {
         return nodeId.hashCode();
     }
 
+    private String toString;
+
     @Override
     public String toString() {
+        if (toString == null) {
+            StringBuilder sb = new StringBuilder();
+            if (nodeName.length() > 0) {
+                sb.append('{').append(nodeName).append('}');
+            }
+            if (nodeId != null) {
+                sb.append('{').append(nodeId).append('}');
+            }
+            if (Strings.hasLength(hostName)) {
+                sb.append('{').append(hostName).append('}');
+            }
+            if (address != null) {
+                sb.append('{').append(address).append('}');
+            }
+            if (!attributes.isEmpty()) {
+                sb.append(attributes);
+            }
+            toString = sb.toString();
+        }
         return toString;
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -312,25 +312,30 @@ public class DiscoveryNode implements Writeable<DiscoveryNode>, ToXContent {
         return nodeId.hashCode();
     }
 
+    private String toString;
+
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        if (nodeName.length() > 0) {
-            sb.append('{').append(nodeName).append('}');
+        if (toString == null) {
+            StringBuilder sb = new StringBuilder();
+            if (nodeName.length() > 0) {
+                sb.append('{').append(nodeName).append('}');
+            }
+            if (nodeId != null) {
+                sb.append('{').append(nodeId).append('}');
+            }
+            if (Strings.hasLength(hostName)) {
+                sb.append('{').append(hostName).append('}');
+            }
+            if (address != null) {
+                sb.append('{').append(address).append('}');
+            }
+            if (!attributes.isEmpty()) {
+                sb.append(attributes);
+            }
+            toString = sb.toString();
         }
-        if (nodeId != null) {
-            sb.append('{').append(nodeId).append('}');
-        }
-        if (Strings.hasLength(hostName)) {
-            sb.append('{').append(hostName).append('}');
-        }
-        if (address != null) {
-            sb.append('{').append(address).append('}');
-        }
-        if (!attributes.isEmpty()) {
-            sb.append(attributes);
-        }
-        return sb.toString();
+        return toString;
     }
 
     @Override


### PR DESCRIPTION
DiscoveryNode is immutable yet we rebuild DiscoveryNode#toString on
every invocation. Most importantly, this just leads to unnecessary
allocations. This is most germane to ZenDiscovery and the processing of
cluster states where DiscoveryNode#toString is invoked when submitting
update tasks and processing cluster state updates.
