### PR TITLE
Root rest api delegates to a transport action

### DIFF
--- a/core/src/main/java/org/elasticsearch/Build.java
+++ b/core/src/main/java/org/elasticsearch/Build.java
@@ -128,4 +128,33 @@ public class Build {
     public String toString() {
         return "[" + shortHash + "][" + date + "]";
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Build build = (Build) o;
+
+        if (isSnapshot != build.isSnapshot) {
+            return false;
+        }
+        if (!shortHash.equals(build.shortHash)) {
+            return false;
+        }
+        return date.equals(build.date);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (isSnapshot ? 1 : 0);
+        result = 31 * result + shortHash.hashCode();
+        result = 31 * result + date.hashCode();
+        return result;
+    }
 }

--- a/core/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -163,6 +163,8 @@ import org.elasticsearch.action.ingest.PutPipelineAction;
 import org.elasticsearch.action.ingest.PutPipelineTransportAction;
 import org.elasticsearch.action.ingest.SimulatePipelineAction;
 import org.elasticsearch.action.ingest.SimulatePipelineTransportAction;
+import org.elasticsearch.action.main.MainAction;
+import org.elasticsearch.action.main.TransportMainAction;
 import org.elasticsearch.action.percolate.MultiPercolateAction;
 import org.elasticsearch.action.percolate.PercolateAction;
 import org.elasticsearch.action.percolate.TransportMultiPercolateAction;
@@ -259,6 +261,7 @@ public class ActionModule extends AbstractModule {
         bind(ActionFilters.class).asEagerSingleton();
         bind(AutoCreateIndex.class).asEagerSingleton();
         bind(DestructiveOperations.class).asEagerSingleton();
+        registerAction(MainAction.INSTANCE, TransportMainAction.class);
         registerAction(NodesInfoAction.INSTANCE, TransportNodesInfoAction.class);
         registerAction(NodesStatsAction.INSTANCE, TransportNodesStatsAction.class);
         registerAction(NodesHotThreadsAction.INSTANCE, TransportNodesHotThreadsAction.class);

--- a/core/src/main/java/org/elasticsearch/action/main/MainAction.java
+++ b/core/src/main/java/org/elasticsearch/action/main/MainAction.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.main;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.client.ElasticsearchClient;
+
+public class MainAction extends Action<MainRequest, MainResponse, MainRequestBuilder> {
+
+    public static final String NAME = "cluster:monitor/main";
+    public static final MainAction INSTANCE = new MainAction();
+
+    public MainAction() {
+        super(NAME);
+    }
+
+    @Override
+    public MainRequestBuilder newRequestBuilder(ElasticsearchClient client) {
+        return new MainRequestBuilder(client, INSTANCE);
+    }
+
+    @Override
+    public MainResponse newResponse() {
+        return new MainResponse();
+    }
+}

--- a/core/src/main/java/org/elasticsearch/action/main/MainRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/main/MainRequest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.main;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+
+public class MainRequest extends ActionRequest<MainRequest> {
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/action/main/MainRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/main/MainRequestBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.main;
+
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.client.ElasticsearchClient;
+
+public class MainRequestBuilder extends ActionRequestBuilder<MainRequest, MainResponse, MainRequestBuilder> {
+
+    public MainRequestBuilder(ElasticsearchClient client, MainAction action) {
+        super(client, action, new MainRequest());
+    }
+}

--- a/core/src/main/java/org/elasticsearch/action/main/MainResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/main/MainResponse.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.main;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+public class MainResponse extends ActionResponse implements ToXContent {
+
+    private String nodeName;
+    private Version version;
+    private ClusterName clusterName;
+    private Build build;
+    private boolean available;
+
+    MainResponse() {
+    }
+
+    public MainResponse(String nodeName, Version version, ClusterName clusterName, Build build, boolean available) {
+        this.nodeName = nodeName;
+        this.version = version;
+        this.clusterName = clusterName;
+        this.build = build;
+        this.available = available;
+    }
+
+    public String getNodeName() {
+        return nodeName;
+    }
+
+    public Version getVersion() {
+        return version;
+    }
+
+    public ClusterName getClusterName() {
+        return clusterName;
+    }
+
+    public Build getBuild() {
+        return build;
+    }
+
+    public boolean isAvailable() {
+        return available;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(nodeName);
+        Version.writeVersion(version, out);
+        clusterName.writeTo(out);
+        Build.writeBuild(build, out);
+        out.writeBoolean(available);
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        nodeName = in.readString();
+        version = Version.readVersion(in);
+        clusterName = ClusterName.readClusterName(in);
+        build = Build.readBuild(in);
+        available = in.readBoolean();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("name", nodeName);
+        builder.field("cluster_name", clusterName.value());
+        builder.startObject("version")
+            .field("number", version.toString())
+            .field("build_hash", build.shortHash())
+            .field("build_date", build.date())
+            .field("build_snapshot", build.isSnapshot())
+            .field("lucene_version", version.luceneVersion.toString())
+            .endObject();
+        builder.field("tagline", "You Know, for Search");
+        builder.endObject();
+        return builder;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/action/main/TransportMainAction.java
+++ b/core/src/main/java/org/elasticsearch/action/main/TransportMainAction.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.main;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+public class TransportMainAction extends HandledTransportAction<MainRequest, MainResponse> {
+
+    private final ClusterService clusterService;
+    private final Version version;
+
+    @Inject
+    public TransportMainAction(Settings settings, ThreadPool threadPool, TransportService transportService,
+                               ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
+                               ClusterService clusterService, Version version) {
+        super(settings, MainAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, MainRequest::new);
+        this.clusterService = clusterService;
+        this.version = version;
+    }
+
+    @Override
+    protected void doExecute(MainRequest request, ActionListener<MainResponse> listener) {
+        ClusterState clusterState = clusterService.state();
+        assert Node.NODE_NAME_SETTING.exists(settings);
+        final boolean available = clusterState.getBlocks().hasGlobalBlock(RestStatus.SERVICE_UNAVAILABLE) == false;
+        listener.onResponse(
+            new MainResponse(Node.NODE_NAME_SETTING.get(settings), version, clusterState.getClusterName(), Build.CURRENT, available));
+    }
+}

--- a/core/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
@@ -19,21 +19,24 @@
 
 package org.elasticsearch.rest.action.main;
 
-import org.elasticsearch.Build;
-import org.elasticsearch.Version;
+import org.elasticsearch.action.main.MainAction;
+import org.elasticsearch.action.main.MainRequest;
+import org.elasticsearch.action.main.MainResponse;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.cluster.ClusterName;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.action.support.RestBuilderListener;
+
+import java.io.IOException;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.HEAD;
@@ -43,53 +46,34 @@ import static org.elasticsearch.rest.RestRequest.Method.HEAD;
  */
 public class RestMainAction extends BaseRestHandler {
 
-    private final Version version;
-    private final ClusterName clusterName;
-    private final ClusterService clusterService;
-
     @Inject
-    public RestMainAction(Settings settings, Version version, RestController controller, ClusterName clusterName, Client client, ClusterService clusterService) {
+    public RestMainAction(Settings settings, RestController controller, Client client) {
         super(settings, client);
-        this.version = version;
-        this.clusterName = clusterName;
-        this.clusterService = clusterService;
         controller.registerHandler(GET, "/", this);
         controller.registerHandler(HEAD, "/", this);
     }
 
     @Override
-    public void handleRequest(final RestRequest request, RestChannel channel, final Client client) throws Exception {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) throws Exception {
+        client.execute(MainAction.INSTANCE, new MainRequest(), new RestBuilderListener<MainResponse>(channel) {
+            @Override
+            public RestResponse buildResponse(MainResponse mainResponse, XContentBuilder builder) throws Exception {
+                return convertMainResponse(mainResponse, request, builder);
+            }
+        });
+    }
 
-        RestStatus status = RestStatus.OK;
-        if (clusterService.state().blocks().hasGlobalBlock(RestStatus.SERVICE_UNAVAILABLE)) {
-            status = RestStatus.SERVICE_UNAVAILABLE;
-        }
+    static BytesRestResponse convertMainResponse(MainResponse response, RestRequest request, XContentBuilder builder) throws IOException {
+        RestStatus status = response.isAvailable() ? RestStatus.OK : RestStatus.SERVICE_UNAVAILABLE;
         if (request.method() == RestRequest.Method.HEAD) {
-            channel.sendResponse(new BytesRestResponse(status));
-            return;
+            return new BytesRestResponse(status);
         }
-
-        XContentBuilder builder = channel.newBuilder();
 
         // Default to pretty printing, but allow ?pretty=false to disable
-        if (!request.hasParam("pretty")) {
+        if (request.hasParam("pretty") == false) {
             builder.prettyPrint().lfAtEnd();
         }
-
-        builder.startObject();
-        assert settings.get("node.name") != null;
-        builder.field("name", Node.NODE_NAME_SETTING.get(settings));
-        builder.field("cluster_name", clusterName.value());
-        builder.startObject("version")
-                .field("number", version.toString())
-                .field("build_hash", Build.CURRENT.shortHash())
-                .field("build_date", Build.CURRENT.date())
-                .field("build_snapshot", Build.CURRENT.isSnapshot())
-                .field("lucene_version", version.luceneVersion.toString())
-                .endObject();
-        builder.field("tagline", "You Know, for Search");
-        builder.endObject();
-
-        channel.sendResponse(new BytesRestResponse(status, builder));
+        response.toXContent(builder, request);
+        return new BytesRestResponse(status, builder);
     }
 }

--- a/core/src/test/java/org/elasticsearch/BuildTests.java
+++ b/core/src/test/java/org/elasticsearch/BuildTests.java
@@ -36,4 +36,20 @@ public class BuildTests extends ESTestCase {
         assertNotNull(Build.CURRENT.date());
         assertNotNull(Build.CURRENT.shortHash());
     }
+
+    public void testEqualsAndHashCode() {
+        Build build = Build.CURRENT;
+        Build another = new Build(build.shortHash(), build.date(), build.isSnapshot());
+        assertEquals(build, another);
+        assertEquals(build.hashCode(), another.hashCode());
+
+        Build differentHash = new Build(randomAsciiOfLengthBetween(3, 10), build.date(), build.isSnapshot());
+        assertNotEquals(build, differentHash);
+
+        Build differentDate = new Build(build.shortHash(), "1970-01-01", build.isSnapshot());
+        assertNotEquals(build, differentDate);
+
+        Build differentSnapshot = new Build(build.shortHash(), build.date(), !build.isSnapshot());
+        assertNotEquals(build, differentSnapshot);
+    }
 }

--- a/core/src/test/java/org/elasticsearch/action/main/MainActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/main/MainActionTests.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.main;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.ByteBufferStreamInput;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MainActionTests extends ESTestCase {
+
+    public void testMainResponseSerialization() throws IOException {
+        final String nodeName = "node1";
+        final ClusterName clusterName = new ClusterName("cluster1");
+        final boolean available = randomBoolean();
+        final Version version = Version.CURRENT;
+        final Build build = Build.CURRENT;
+
+        final MainResponse mainResponse = new MainResponse(nodeName, version, clusterName, build, available);
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+        mainResponse.writeTo(streamOutput);
+        final MainResponse serialized = new MainResponse();
+        serialized.readFrom(new ByteBufferStreamInput(ByteBuffer.wrap(streamOutput.bytes().toBytes())));
+
+        assertThat(serialized.getNodeName(), equalTo(nodeName));
+        assertThat(serialized.getClusterName(), equalTo(clusterName));
+        assertThat(serialized.getBuild(), equalTo(build));
+        assertThat(serialized.isAvailable(), equalTo(available));
+        assertThat(serialized.getVersion(), equalTo(version));
+    }
+
+    public void testMainResponseXContent() throws IOException {
+        final MainResponse mainResponse = new MainResponse("node1", Version.CURRENT, new ClusterName("cluster1"), Build.CURRENT, false);
+        final String expected = "{\"name\":\"node1\",\"cluster_name\":\"cluster1\",\"version\":{\"number\":\"" + Version.CURRENT.toString()
+            + "\",\"build_hash\":\"" + Build.CURRENT.shortHash() + "\",\"build_date\":\"" + Build.CURRENT.date() + "\"," +
+            "\"build_snapshot\":" + Build.CURRENT.isSnapshot() + ",\"lucene_version\":\"" + Version.CURRENT.luceneVersion.toString() +
+            "\"},\"tagline\":\"You Know, for Search\"}";
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        mainResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String xContent = builder.string();
+
+        assertEquals(expected, xContent);
+    }
+
+    public void testMainActionClusterAvailable() {
+        final ClusterService clusterService = mock(ClusterService.class);
+        final ClusterName clusterName = new ClusterName("elasticsearch");
+        final Settings settings = Settings.builder().put("node.name", "my-node").build();
+        final boolean available = randomBoolean();
+        ClusterBlocks blocks;
+        if (available) {
+            if (randomBoolean()) {
+                blocks = ClusterBlocks.EMPTY_CLUSTER_BLOCK;
+            } else {
+                blocks = ClusterBlocks.builder()
+                    .addGlobalBlock(new ClusterBlock(randomIntBetween(1, 16), "test global block 400", randomBoolean(), randomBoolean(),
+                        RestStatus.BAD_REQUEST, ClusterBlockLevel.ALL))
+                    .build();
+            }
+        } else {
+            blocks = ClusterBlocks.builder()
+                .addGlobalBlock(new ClusterBlock(randomIntBetween(1, 16), "test global block 503", randomBoolean(), randomBoolean(),
+                    RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.ALL))
+                .build();
+        }
+        ClusterState state = ClusterState.builder(clusterName).blocks(blocks).build();
+        when(clusterService.state()).thenReturn(state);
+
+        TransportMainAction action = new TransportMainAction(settings, mock(ThreadPool.class), mock(TransportService.class),
+            mock(ActionFilters.class), mock(IndexNameExpressionResolver.class), clusterService, Version.CURRENT);
+        AtomicReference<MainResponse> responseRef = new AtomicReference<>();
+        action.doExecute(new MainRequest(), new ActionListener<MainResponse>() {
+            @Override
+            public void onResponse(MainResponse mainResponse) {
+                responseRef.set(mainResponse);
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+                logger.error("unexpected error", e);
+            }
+        });
+
+        assertNotNull(responseRef.get());
+        assertEquals(available, responseRef.get().isAvailable());
+        verify(clusterService, times(1)).state();
+    }
+}

--- a/core/src/test/java/org/elasticsearch/rest/action/main/RestMainActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/main/RestMainActionTests.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.main;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.main.MainResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class RestMainActionTests extends ESTestCase {
+
+    public void testHeadResponse() throws Exception {
+        final String nodeName = "node1";
+        final ClusterName clusterName = new ClusterName("cluster1");
+        final boolean available = randomBoolean();
+        final RestStatus expectedStatus = available ? RestStatus.OK : RestStatus.SERVICE_UNAVAILABLE;
+        final Version version = Version.CURRENT;
+        final Build build = Build.CURRENT;
+
+        final MainResponse mainResponse = new MainResponse(nodeName, version, clusterName, build, available);
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        RestRequest restRequest = new FakeRestRequest() {
+            @Override
+            public Method method() {
+                return Method.HEAD;
+            }
+        };
+
+        BytesRestResponse response = RestMainAction.convertMainResponse(mainResponse, restRequest, builder);
+        assertNotNull(response);
+        assertEquals(expectedStatus, response.status());
+        assertEquals(0, response.content().length());
+
+        assertEquals(0, builder.bytes().length());
+    }
+
+    public void testGetResponse() throws Exception {
+        final String nodeName = "node1";
+        final ClusterName clusterName = new ClusterName("cluster1");
+        final boolean available = randomBoolean();
+        final RestStatus expectedStatus = available ? RestStatus.OK : RestStatus.SERVICE_UNAVAILABLE;
+        final Version version = Version.CURRENT;
+        final Build build = Build.CURRENT;
+        final boolean prettyPrint = randomBoolean();
+
+        final MainResponse mainResponse = new MainResponse(nodeName, version, clusterName, build, available);
+        XContentBuilder builder = JsonXContent.contentBuilder();
+
+        Map<String, String> params = new HashMap<>();
+        if (prettyPrint == false) {
+            params.put("pretty", String.valueOf(prettyPrint));
+        }
+        RestRequest restRequest = new FakeRestRequest(Collections.emptyMap(), params);
+
+        BytesRestResponse response = RestMainAction.convertMainResponse(mainResponse, restRequest, builder);
+        assertNotNull(response);
+        assertEquals(expectedStatus, response.status());
+        assertThat(response.content().length(), greaterThan(0));
+
+        XContentBuilder responseBuilder = JsonXContent.contentBuilder();
+        if (prettyPrint) {
+            // do this to mimic what the rest layer does
+            responseBuilder.prettyPrint().lfAtEnd();
+        }
+        mainResponse.toXContent(responseBuilder, ToXContent.EMPTY_PARAMS);
+        BytesReference xcontentBytes = responseBuilder.bytes();
+        assertTrue(BytesReference.Helper.bytesEqual(xcontentBytes, response.content()));
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
@@ -36,8 +36,12 @@ public class FakeRestRequest extends RestRequest {
     }
 
     public FakeRestRequest(Map<String, String> headers) {
+        this(headers, new HashMap<>());
+    }
+
+    public FakeRestRequest(Map<String, String> headers, Map<String, String> params) {
         this.headers = headers;
-        this.params = new HashMap<>();
+        this.params = params;
     }
 
     @Override


### PR DESCRIPTION
This change makes the root (/) rest api delegate to a transport action to get the
data for the response. This aligns this rest api with all of the other apis, which
delegate to one or more actions.

In doing this, unit tests were added to provide coverage of the RestMainAction
and the associated classes.
