### PR TITLE
Fixes NPE when no window is specified in moving average request

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/MovAvgParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/MovAvgParser.java
@@ -163,7 +163,7 @@ public class MovAvgParser implements PipelineAggregator.Parser {
 
             MovAvgModel movAvgModel;
             try {
-                movAvgModel = modelParser.parse(settings, pipelineAggregatorName, window, context.parseFieldMatcher());
+                movAvgModel = modelParser.parse(settings, pipelineAggregatorName, factory.window(), context.parseFieldMatcher());
             } catch (ParseException exception) {
                 throw new ParsingException(parser.getTokenLocation(), "Could not parse settings for model [" + model + "].", exception);
             }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/BasePipelineAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/BasePipelineAggregationTestCase.java
@@ -102,9 +102,9 @@ public abstract class BasePipelineAggregationTestCase<AF extends PipelineAggrega
 
     private static NamedWriteableRegistry namedWriteableRegistry;
 
-    private static AggregatorParsers aggParsers;
-    private static ParseFieldMatcher parseFieldMatcher;
-    private static IndicesQueriesRegistry queriesRegistry;
+    protected static AggregatorParsers aggParsers;
+    protected static ParseFieldMatcher parseFieldMatcher;
+    protected static IndicesQueriesRegistry queriesRegistry;
 
     protected abstract AF createTestAggregatorFactory();
 


### PR DESCRIPTION
This PR fixes a bug where a NPE was thrown when parsing a moving average pipeline aggregation request which did not specify a window size.

Closes #17516
