### PR TITLE
Remove MappedFieldType.value.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/core/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -250,9 +250,6 @@ public final class ShardGetService extends AbstractIndexShardComponent {
                         } else if (shouldGetFromSource(ignoreErrorsOnGeneratedFields, docMapper, fieldMapper)) {
                             List<Object> values = searchLookup.source().extractRawValues(field);
                             if (!values.isEmpty()) {
-                                for (int i = 0; i < values.size(); i++) {
-                                    values.set(i, fieldMapper.fieldType().valueForSearch(values.get(i)));
-                                }
                                 value = values;
                             }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -302,12 +302,9 @@ public abstract class MappedFieldType extends FieldType {
         this.nullValueAsString = nullValue == null ? null : nullValue.toString();
     }
 
-    /** Returns the actual value of the field. */
-    public Object value(Object value) {
-        return value;
-    }
-
-    /** Returns the value that will be used as a result for search. Can be only of specific types... */
+    /** Given a value that comes from the stored fields API, convert it to the
+     *  expected type. For instance a date field would store dates as longs and
+     *  format it back to a string in this method. */
     public Object valueForSearch(Object value) {
         return value;
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
@@ -107,7 +107,7 @@ public class BinaryFieldMapper extends FieldMapper {
 
 
         @Override
-        public BytesReference value(Object value) {
+        public BytesReference valueForSearch(Object value) {
             if (value == null) {
                 return null;
             }
@@ -127,11 +127,6 @@ public class BinaryFieldMapper extends FieldMapper {
                 }
             }
             return bytes;
-        }
-
-        @Override
-        public Object valueForSearch(Object value) {
-            return value(value);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
@@ -169,26 +169,18 @@ public class BooleanFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Boolean value(Object value) {
+        public Boolean valueForSearch(Object value) {
             if (value == null) {
-                return Boolean.FALSE;
+                return null;
             }
-            String sValue = value.toString();
-            if (sValue.length() == 0) {
-                return Boolean.FALSE;
+            switch(value.toString()) {
+            case "F":
+                return false;
+            case "T":
+                return true;
+            default:
+                throw new IllegalArgumentException("Expected [T] or [F] but got [" + value + "]");
             }
-            if (sValue.length() == 1 && sValue.charAt(0) == 'F') {
-                return Boolean.FALSE;
-            }
-            if (Booleans.parseBoolean(sValue, false)) {
-                return Boolean.TRUE;
-            }
-            return Boolean.FALSE;
-        }
-
-        @Override
-        public Object valueForSearch(Object value) {
-            return value(value);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
@@ -143,17 +143,11 @@ public class ByteFieldMapper extends NumberFieldMapper {
         }
 
         @Override
-        public Byte value(Object value) {
+        public Byte valueForSearch(Object value) {
             if (value == null) {
                 return null;
             }
-            if (value instanceof Number) {
-                return ((Number) value).byteValue();
-            }
-            if (value instanceof BytesRef) {
-                return ((BytesRef) value).bytes[((BytesRef) value).offset];
-            }
-            return Byte.parseByte(value.toString());
+            return ((Number) value).byteValue();
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -336,14 +336,6 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
             }
         }
 
-        @Override
-        public String value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            return value.toString();
-        }
-
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -345,20 +345,6 @@ public class DateFieldMapper extends NumberFieldMapper {
         }
 
         @Override
-        public Long value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            if (value instanceof Number) {
-                return ((Number) value).longValue();
-            }
-            if (value instanceof BytesRef) {
-                return Numbers.bytesToLong((BytesRef) value);
-            }
-            return parseStringValue(value.toString());
-        }
-
-        @Override
         public BytesRef indexedValueForSearch(Object value) {
             BytesRefBuilder bytesRef = new BytesRefBuilder();
             LegacyNumericUtils.longToPrefixCoded(parseValue(value), 0, bytesRef); // 0 because of exact match
@@ -367,11 +353,7 @@ public class DateFieldMapper extends NumberFieldMapper {
 
         @Override
         public Object valueForSearch(Object value) {
-            if (value instanceof String) {
-                // assume its the string that was indexed, just return it... (for example, with get)
-                return value;
-            }
-            Long val = value(value);
+            Long val = (Long) value;
             if (val == null) {
                 return null;
             }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
@@ -145,7 +145,7 @@ public class DoubleFieldMapper extends NumberFieldMapper {
         }
 
         @Override
-        public Double value(Object value) {
+        public Double valueForSearch(Object value) {
             if (value == null) {
                 return null;
             }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
@@ -146,20 +146,6 @@ public class FloatFieldMapper extends NumberFieldMapper {
         }
 
         @Override
-        public Float value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            if (value instanceof Number) {
-                return ((Number) value).floatValue();
-            }
-            if (value instanceof BytesRef) {
-                return Numbers.bytesToFloat((BytesRef) value);
-            }
-            return Float.parseFloat(value.toString());
-        }
-
-        @Override
         public BytesRef indexedValueForSearch(Object value) {
             int intValue = NumericUtils.floatToSortableInt(parseValue(value));
             BytesRefBuilder bytesRef = new BytesRefBuilder();

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
@@ -152,20 +152,6 @@ public class IntegerFieldMapper extends NumberFieldMapper {
         }
 
         @Override
-        public Integer value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            if (value instanceof Number) {
-                return ((Number) value).intValue();
-            }
-            if (value instanceof BytesRef) {
-                return Numbers.bytesToInt((BytesRef) value);
-            }
-            return Integer.parseInt(value.toString());
-        }
-
-        @Override
         public BytesRef indexedValueForSearch(Object value) {
             BytesRefBuilder bytesRef = new BytesRefBuilder();
             LegacyNumericUtils.intToPrefixCoded(parseValue(value), 0, bytesRef); // 0 because of exact match

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/KeywordFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/KeywordFieldMapper.java
@@ -158,14 +158,6 @@ public final class KeywordFieldMapper extends FieldMapper implements AllFieldMap
         }
 
         @Override
-        public String value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            return value.toString();
-        }
-
-        @Override
         public Query nullValueQuery() {
             if (nullValue() == null) {
                 return null;

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
@@ -150,20 +150,6 @@ public class LongFieldMapper extends NumberFieldMapper {
         }
 
         @Override
-        public Long value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            if (value instanceof Number) {
-                return ((Number) value).longValue();
-            }
-            if (value instanceof BytesRef) {
-                return Numbers.bytesToLong((BytesRef) value);
-            }
-            return Long.parseLong(value.toString());
-        }
-
-        @Override
         public BytesRef indexedValueForSearch(Object value) {
             BytesRefBuilder bytesRef = new BytesRefBuilder();
             LegacyNumericUtils.longToPrefixCoded(parseLongValue(value), 0, bytesRef);  // 0 because of exact match

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
@@ -162,14 +162,6 @@ public abstract class NumberFieldMapper extends FieldMapper implements AllFieldM
         public abstract NumberFieldType clone();
 
         @Override
-        public abstract Object value(Object value);
-
-        @Override
-        public Object valueForSearch(Object value) {
-            return value(value);
-        }
-
-        @Override
         public abstract Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions, boolean transpositions);
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
@@ -33,7 +33,6 @@ import org.apache.lucene.util.LegacyNumericUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.fieldstats.FieldStats;
 import org.elasticsearch.common.Explicit;
-import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
@@ -148,17 +147,11 @@ public class ShortFieldMapper extends NumberFieldMapper {
         }
 
         @Override
-        public Short value(Object value) {
+        public Short valueForSearch(Object value) {
             if (value == null) {
                 return null;
             }
-            if (value instanceof Number) {
-                return ((Number) value).shortValue();
-            }
-            if (value instanceof BytesRef) {
-                return Numbers.bytesToShort((BytesRef) value);
-            }
-            return Short.parseShort(value.toString());
+            return ((Number) value).shortValue();
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -451,14 +451,6 @@ public class StringFieldMapper extends FieldMapper implements AllFieldMapper.Inc
         }
 
         @Override
-        public String value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            return value.toString();
-        }
-
-        @Override
         public Query nullValueQuery() {
             if (nullValue() == null) {
                 return null;

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/TextFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/TextFieldMapper.java
@@ -279,14 +279,6 @@ public class TextFieldMapper extends FieldMapper implements AllFieldMapper.Inclu
         }
 
         @Override
-        public String value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            return value.toString();
-        }
-
-        @Override
         public Query nullValueQuery() {
             if (nullValue() == null) {
                 return null;

--- a/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
@@ -412,11 +412,6 @@ public class GeoShapeFieldMapper extends FieldMapper {
             throw new IllegalArgumentException("Unknown prefix tree strategy [" + strategyName + "]");
         }
 
-        @Override
-        public String value(Object value) {
-            throw new UnsupportedOperationException("GeoShape fields cannot be converted to String values");
-        }
-
     }
 
     protected Explicit<Boolean> coerce;

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
@@ -198,14 +198,6 @@ public class AllFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public String value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            return value.toString();
-        }
-
-        @Override
         public Query queryStringTermQuery(Term term) {
             return new AllTermQuery(term);
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
@@ -181,14 +181,6 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public String value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            return value.toString();
-        }
-
-        @Override
         public Query termQuery(Object value, QueryShardContext context) {
             if (isEnabled() == false) {
                 throw new IllegalStateException("Cannot run [exists] queries if the [_field_names] field is disabled");

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
@@ -129,14 +129,6 @@ public class IdFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public String value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            return value.toString();
-        }
-
-        @Override
         public Query termQuery(Object value, @Nullable QueryShardContext context) {
             if (indexOptions() != IndexOptions.NONE || context == null) {
                 return super.termQuery(value, context);

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
@@ -170,14 +170,6 @@ public class IndexFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public String value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            return value.toString();
-        }
-
-        @Override
         public IndexFieldData.Builder fielddataBuilder() {
             return new IndexIndexFieldData.Builder();
         }
@@ -196,11 +188,6 @@ public class IndexFieldMapper extends MetadataFieldMapper {
 
     public boolean enabled() {
         return this.enabledState.enabled;
-    }
-
-    public String value(Document document) {
-        Field field = (Field) document.getField(fieldType().name());
-        return field == null ? null : (String)fieldType().value(field);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
@@ -125,14 +125,6 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
         public String typeName() {
             return CONTENT_TYPE;
         }
-
-        @Override
-        public String value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            return value.toString();
-        }
     }
 
     private boolean required;
@@ -152,11 +144,6 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
 
     public boolean required() {
         return this.required;
-    }
-
-    public String value(Document document) {
-        Field field = (Field) document.getField(fieldType().name());
-        return field == null ? null : (String)fieldType().value(field);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
@@ -22,14 +22,10 @@ package org.elasticsearch.index.mapper.internal;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
@@ -170,24 +166,6 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         @Override
         public String typeName() {
             return CONTENT_TYPE;
-        }
-
-        @Override
-        public byte[] value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            BytesReference bValue;
-            if (value instanceof BytesRef) {
-                bValue = new BytesArray((BytesRef) value);
-            } else {
-                bValue = (BytesReference) value;
-            }
-            try {
-                return CompressorFactory.uncompressIfNeeded(bValue).toBytes();
-            } catch (IOException e) {
-                throw new ElasticsearchParseException("failed to decompress source", e);
-            }
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
@@ -151,7 +151,7 @@ public class TTLFieldMapper extends MetadataFieldMapper {
             } else {
                 now = System.currentTimeMillis();
             }
-            long val = value(value);
+            Long val = (Long) super.valueForSearch(value);
             return val - now;
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -182,12 +182,9 @@ public class TimestampFieldMapper extends MetadataFieldMapper {
             return new TimestampFieldType(this);
         }
 
-        /**
-         * Override the default behavior to return a timestamp
-         */
         @Override
         public Object valueForSearch(Object value) {
-            return value(value);
+            return value;
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
@@ -119,14 +119,6 @@ public class TypeFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public String value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            return value.toString();
-        }
-
-        @Override
         public Query termQuery(Object value, @Nullable QueryShardContext context) {
             if (indexOptions() == IndexOptions.NONE) {
                 throw new AssertionError();

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
@@ -120,14 +120,6 @@ public class UidFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public Uid value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            return Uid.createUid(value.toString());
-        }
-
-        @Override
         public IndexFieldData.Builder fielddataBuilder() {
             // TODO: add doc values support?
             return new PagedBytesIndexFieldData.Builder(

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
@@ -96,15 +96,6 @@ public class VersionFieldMapper extends MetadataFieldMapper {
         public String typeName() {
             return CONTENT_TYPE;
         }
-
-        @Override
-        public Long value(Object value) {
-            if (value == null || (value instanceof Long)) {
-                return (Long) value;
-            } else {
-                return Long.parseLong(value.toString());
-            }
-        }
     }
 
     private VersionFieldMapper(Settings indexSettings) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
@@ -183,26 +183,12 @@ public class IpFieldMapper extends NumberFieldMapper {
             return CONTENT_TYPE;
         }
 
-        @Override
-        public Long value(Object value) {
-            if (value == null) {
-                return null;
-            }
-            if (value instanceof Number) {
-                return ((Number) value).longValue();
-            }
-            if (value instanceof BytesRef) {
-                return Numbers.bytesToLong((BytesRef) value);
-            }
-            return ipToLong(value.toString());
-        }
-
         /**
          * IPs should return as a string.
          */
         @Override
         public Object valueForSearch(Object value) {
-            Long val = value(value);
+            Long val = (Long) value;
             if (val == null) {
                 return null;
             }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/BooleanFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/BooleanFieldTypeTests.java
@@ -38,4 +38,13 @@ public class BooleanFieldTypeTests extends FieldTypeTestCase {
         assertEquals("false", ft.docValueFormat(null, null).format(0));
         assertEquals("true", ft.docValueFormat(null, null).format(1));
     }
+
+    public void testValueForSearch() {
+        MappedFieldType ft = createDefaultFieldType();
+        assertEquals(true, ft.valueForSearch("T"));
+        assertEquals(false, ft.valueForSearch("F"));
+        expectThrows(IllegalArgumentException.class, () -> ft.valueForSearch(0));
+        expectThrows(IllegalArgumentException.class, () -> ft.valueForSearch("true"));
+        expectThrows(IllegalArgumentException.class, () -> ft.valueForSearch("G"));
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/ByteFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/ByteFieldTypeTests.java
@@ -32,4 +32,10 @@ public class ByteFieldTypeTests extends FieldTypeTestCase {
     public void setupProperties() {
         setDummyNullValue((byte)10);
     }
+
+    public void testValueForSearch() {
+        MappedFieldType ft = createDefaultFieldType();
+        // bytes are stored as ints
+        assertEquals(Byte.valueOf((byte) 3), ft.valueForSearch(Integer.valueOf(3)));
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/DateFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/DateFieldTypeTests.java
@@ -140,4 +140,11 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         assertEquals(DateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime("2015-10-13").getMillis() - 1,
                 ft.docValueFormat(null, DateTimeZone.UTC).parseLong("2015-10-12||/d", true, null));
     }
+
+    public void testValueForSearch() {
+        MappedFieldType ft = createDefaultFieldType();
+        String date = "2015-10-12T12:09:55.000Z";
+        long instant = DateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime(date).getMillis();
+        assertEquals(date, ft.valueForSearch(instant));
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/DoubleFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/DoubleFieldTypeTests.java
@@ -43,4 +43,9 @@ public class DoubleFieldTypeTests extends FieldTypeTestCase {
         assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(null, randomDouble(), randomDouble(),
                 randomBoolean(), randomBoolean(), null, null));
     }
+
+    public void testValueForSearch() {
+        MappedFieldType ft = createDefaultFieldType();
+        assertEquals(Double.valueOf(1.2), ft.valueForSearch(1.2));
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/FloatFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/FloatFieldTypeTests.java
@@ -29,12 +29,12 @@ import java.io.IOException;
 public class FloatFieldTypeTests extends FieldTypeTestCase {
     @Override
     protected MappedFieldType createDefaultFieldType() {
-        return new DoubleFieldMapper.DoubleFieldType();
+        return new FloatFieldMapper.FloatFieldType();
     }
 
     @Before
     public void setupProperties() {
-        setDummyNullValue(10.0);
+        setDummyNullValue(10.0f);
     }
 
     public void testIsFieldWithinQuery() throws IOException {
@@ -42,5 +42,10 @@ public class FloatFieldTypeTests extends FieldTypeTestCase {
         // current impl ignores args and shourd always return INTERSECTS
         assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(null, randomFloat(), randomFloat(),
                 randomBoolean(), randomBoolean(), null, null));
+    }
+
+    public void testValueForSearch() {
+        MappedFieldType ft = createDefaultFieldType();
+        assertEquals(Float.valueOf(1.2f), ft.valueForSearch(1.2f));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/IntegerFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/IntegerFieldTypeTests.java
@@ -43,4 +43,9 @@ public class IntegerFieldTypeTests extends FieldTypeTestCase {
         assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(null, randomInt(), randomInt(),
                 randomBoolean(), randomBoolean(), null, null));
     }
+
+    public void testValueForSearch() {
+        MappedFieldType ft = createDefaultFieldType();
+        assertEquals(Integer.valueOf(3), ft.valueForSearch(Integer.valueOf(3)));
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/LongFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/LongFieldTypeTests.java
@@ -43,4 +43,9 @@ public class LongFieldTypeTests extends FieldTypeTestCase {
         assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(null, randomLong(), randomLong(),
                 randomBoolean(), randomBoolean(), null, null));
     }
+
+    public void testValueForSearch() {
+        MappedFieldType ft = createDefaultFieldType();
+        assertEquals(Long.valueOf(3), ft.valueForSearch(Long.valueOf(3)));
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/ShortFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/ShortFieldTypeTests.java
@@ -32,4 +32,10 @@ public class ShortFieldTypeTests extends FieldTypeTestCase {
     public void setupProperties() {
         setDummyNullValue((short)10);
     }
+
+    public void testValueForSearch() {
+        MappedFieldType ft = createDefaultFieldType();
+        // shorts are stored as ints
+        assertEquals(Short.valueOf((short) 3), ft.valueForSearch(Integer.valueOf(3)));
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/internal/TimestampFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/internal/TimestampFieldTypeTests.java
@@ -19,11 +19,20 @@
 package org.elasticsearch.index.mapper.internal;
 
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.core.DateFieldMapper;
 import org.elasticsearch.index.mapper.core.DateFieldTypeTests;
 
 public class TimestampFieldTypeTests extends DateFieldTypeTests {
     @Override
     protected MappedFieldType createDefaultFieldType() {
         return new TimestampFieldMapper.TimestampFieldType();
+    }
+
+    @Override
+    public void testValueForSearch() {
+        MappedFieldType ft = createDefaultFieldType();
+        String date = "2015-10-12T12:09:55.000Z";
+        long instant = DateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime(date).getMillis();
+        assertEquals(instant, ft.valueForSearch(instant));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/lucene/StoredNumericValuesTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/lucene/StoredNumericValuesTests.java
@@ -19,16 +19,11 @@
 
 package org.elasticsearch.index.mapper.lucene;
 
-import org.apache.lucene.document.Document;
-import org.apache.lucene.document.FieldType;
-import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.store.RAMDirectory;
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -37,9 +32,7 @@ import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Collections;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -54,9 +47,15 @@ public class StoredNumericValuesTests extends ESSingleNodeTestCase {
                 .startObject()
                     .startObject("type")
                         .startObject("properties")
-                            .startObject("field1").field("type", "integer").field("store", true).endObject()
-                            .startObject("field2").field("type", "float").field("store", true).endObject()
-                            .startObject("field3").field("type", "long").field("store", true).endObject()
+                            .startObject("field1").field("type", "byte").field("store", true).endObject()
+                            .startObject("field2").field("type", "short").field("store", true).endObject()
+                            .startObject("field3").field("type", "integer").field("store", true).endObject()
+                            .startObject("field4").field("type", "float").field("store", true).endObject()
+                            .startObject("field5").field("type", "long").field("store", true).endObject()
+                            .startObject("field6").field("type", "double").field("store", true).endObject()
+                            .startObject("field7").field("type", "ip").field("store", true).endObject()
+                            .startObject("field8").field("type", "date").field("store", true).endObject()
+                            .startObject("field9").field("type", "boolean").field("store", true).endObject()
                         .endObject()
                     .endObject()
                 .endObject()
@@ -66,55 +65,55 @@ public class StoredNumericValuesTests extends ESSingleNodeTestCase {
         ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                     .field("field1", 1)
-                    .field("field2", 1.1)
-                    .startArray("field3").value(1).value(2).value(3).endArray()
+                    .field("field2", 1)
+                    .field("field3", 1)
+                    .field("field4", 1.1)
+                    .startArray("field5").value(1).value(2).value(3).endArray()
+                    .field("field6", 1.1)
+                    .field("field7", "192.168.1.1")
+                    .field("field8", "2016-04-05")
+                    .field("field9", true)
                 .endObject()
                 .bytes());
 
         writer.addDocument(doc.rootDoc());
 
-        // Indexing a doc in the old way
-        FieldType fieldType = new FieldType();
-        fieldType.setStored(true);
-        fieldType.setNumericType(FieldType.LegacyNumericType.INT);
-        Document doc2 = new Document();
-        doc2.add(new StoredField("field1", new BytesRef(Numbers.intToBytes(1))));
-        doc2.add(new StoredField("field2", new BytesRef(Numbers.floatToBytes(1.1f))));
-        doc2.add(new StoredField("field3", new BytesRef(Numbers.longToBytes(1L))));
-        doc2.add(new StoredField("field3", new BytesRef(Numbers.longToBytes(2L))));
-        doc2.add(new StoredField("field3", new BytesRef(Numbers.longToBytes(3L))));
-        writer.addDocument(doc2);
-
         DirectoryReader reader = DirectoryReader.open(writer);
         IndexSearcher searcher = new IndexSearcher(reader);
 
-        Set<String> fields = new HashSet<>(Arrays.asList("field1", "field2", "field3"));
-        CustomFieldsVisitor fieldsVisitor = new CustomFieldsVisitor(fields, false);
+        CustomFieldsVisitor fieldsVisitor = new CustomFieldsVisitor(
+                Collections.emptySet(), Collections.singletonList("field*"), false);
         searcher.doc(0, fieldsVisitor);
         fieldsVisitor.postProcess(mapper);
-        assertThat(fieldsVisitor.fields().size(), equalTo(3));
+        assertThat(fieldsVisitor.fields().size(), equalTo(9));
         assertThat(fieldsVisitor.fields().get("field1").size(), equalTo(1));
-        assertThat((Integer) fieldsVisitor.fields().get("field1").get(0), equalTo(1));
-        assertThat(fieldsVisitor.fields().get("field2").size(), equalTo(1));
-        assertThat((Float) fieldsVisitor.fields().get("field2").get(0), equalTo(1.1f));
-        assertThat(fieldsVisitor.fields().get("field3").size(), equalTo(3));
-        assertThat((Long) fieldsVisitor.fields().get("field3").get(0), equalTo(1L));
-        assertThat((Long) fieldsVisitor.fields().get("field3").get(1), equalTo(2L));
-        assertThat((Long) fieldsVisitor.fields().get("field3").get(2), equalTo(3L));
+        assertThat(fieldsVisitor.fields().get("field1").get(0), equalTo((byte) 1));
 
-        // Make sure the doc gets loaded as if it was stored in the new way
-        fieldsVisitor.reset();
-        searcher.doc(1, fieldsVisitor);
-        fieldsVisitor.postProcess(mapper);
-        assertThat(fieldsVisitor.fields().size(), equalTo(3));
-        assertThat(fieldsVisitor.fields().get("field1").size(), equalTo(1));
-        assertThat((Integer) fieldsVisitor.fields().get("field1").get(0), equalTo(1));
         assertThat(fieldsVisitor.fields().get("field2").size(), equalTo(1));
-        assertThat((Float) fieldsVisitor.fields().get("field2").get(0), equalTo(1.1f));
-        assertThat(fieldsVisitor.fields().get("field3").size(), equalTo(3));
-        assertThat((Long) fieldsVisitor.fields().get("field3").get(0), equalTo(1L));
-        assertThat((Long) fieldsVisitor.fields().get("field3").get(1), equalTo(2L));
-        assertThat((Long) fieldsVisitor.fields().get("field3").get(2), equalTo(3L));
+        assertThat(fieldsVisitor.fields().get("field2").get(0), equalTo((short) 1));
+
+        assertThat(fieldsVisitor.fields().get("field3").size(), equalTo(1));
+        assertThat(fieldsVisitor.fields().get("field3").get(0), equalTo(1));
+
+        assertThat(fieldsVisitor.fields().get("field4").size(), equalTo(1));
+        assertThat(fieldsVisitor.fields().get("field4").get(0), equalTo(1.1f));
+
+        assertThat(fieldsVisitor.fields().get("field5").size(), equalTo(3));
+        assertThat(fieldsVisitor.fields().get("field5").get(0), equalTo(1L));
+        assertThat(fieldsVisitor.fields().get("field5").get(1), equalTo(2L));
+        assertThat(fieldsVisitor.fields().get("field5").get(2), equalTo(3L));
+
+        assertThat(fieldsVisitor.fields().get("field6").size(), equalTo(1));
+        assertThat(fieldsVisitor.fields().get("field6").get(0), equalTo(1.1));
+
+        assertThat(fieldsVisitor.fields().get("field7").size(), equalTo(1));
+        assertThat(fieldsVisitor.fields().get("field7").get(0), equalTo("192.168.1.1"));
+
+        assertThat(fieldsVisitor.fields().get("field8").size(), equalTo(1));
+        assertThat(fieldsVisitor.fields().get("field8").get(0), equalTo("2016-04-05T00:00:00.000Z"));
+
+        assertThat(fieldsVisitor.fields().get("field9").size(), equalTo(1));
+        assertThat(fieldsVisitor.fields().get("field9").get(0), equalTo(true));
 
         reader.close();
         writer.close();

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/BulkTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/BulkTests.java
@@ -105,12 +105,12 @@ public class BulkTests extends ESIntegTestCase {
                 .actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(2L));
-        assertThat(((Long) getResponse.getField("field").getValue()), equalTo(2L));
+        assertThat(((Number) getResponse.getField("field").getValue()).longValue(), equalTo(2L));
 
         getResponse = client().prepareGet().setIndex("test").setType("type1").setId("2").setFields("field").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(2L));
-        assertThat(((Long) getResponse.getField("field").getValue()), equalTo(3L));
+        assertThat(((Number) getResponse.getField("field").getValue()).longValue(), equalTo(3L));
 
         getResponse = client().prepareGet().setIndex("test").setType("type1").setId("3").setFields("field1").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
@@ -143,7 +143,7 @@ public class BulkTests extends ESIntegTestCase {
         getResponse = client().prepareGet().setIndex("test").setType("type1").setId("6").setFields("field").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(1L));
-        assertThat(((Long) getResponse.getField("field").getValue()), equalTo(0L));
+        assertThat(((Number) getResponse.getField("field").getValue()).longValue(), equalTo(0L));
 
         getResponse = client().prepareGet().setIndex("test").setType("type1").setId("7").setFields("field").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(false));
@@ -151,7 +151,7 @@ public class BulkTests extends ESIntegTestCase {
         getResponse = client().prepareGet().setIndex("test").setType("type1").setId("2").setFields("field").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(3L));
-        assertThat(((Long) getResponse.getField("field").getValue()), equalTo(4L));
+        assertThat(((Number) getResponse.getField("field").getValue()).longValue(), equalTo(4L));
     }
 
     public void testBulkVersioning() throws Exception {
@@ -276,7 +276,7 @@ public class BulkTests extends ESIntegTestCase {
                         .actionGet();
                 assertThat(getResponse.isExists(), equalTo(true));
                 assertThat(getResponse.getVersion(), equalTo(1L));
-                assertThat((Long) getResponse.getField("counter").getValue(), equalTo(1L));
+                assertThat(((Number) getResponse.getField("counter").getValue()).longValue(), equalTo(1L));
             }
         }
 

--- a/plugins/mapper-attachments/src/main/java/org/elasticsearch/mapper/attachments/AttachmentMapper.java
+++ b/plugins/mapper-attachments/src/main/java/org/elasticsearch/mapper/attachments/AttachmentMapper.java
@@ -117,11 +117,6 @@ public class AttachmentMapper extends FieldMapper {
         public String typeName() {
             return CONTENT_TYPE;
         }
-
-        @Override
-        public String value(Object value) {
-            return value == null?null:value.toString();
-        }
     }
 
     public static class Builder extends FieldMapper.Builder<Builder, AttachmentMapper> {


### PR DESCRIPTION
This commit removes `MappedFieldType.value` and simplifies
`MappedFieldType.valueforSearch`. `valueforSearch` was used to post-process
values that come for stored fields (eg. to convert a long back to a string
representation of a date in the case of a date field) and also values that
are extracted from the source but only in the case of GET calls: it would
not be called when performing source filtering on search requests.

`valueforSearch` is now only called for stored fields, since values that are
extracted from the source should already be formatted as expected.
