### PR TITLE
NullPointerException from IndexingMemoryController when a version conflict happens during recovery

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
@@ -347,4 +347,16 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
     }
+
+    public void testSimpleQueryStringUsesFieldAnalyzer() throws Exception {
+        client().prepareIndex("test", "type1", "1").setSource("foo", 123, "bar", "abc").get();
+        client().prepareIndex("test", "type1", "2").setSource("foo", 234, "bar", "bcd").get();
+
+        refresh();
+
+        SearchResponse searchResponse = client().prepareSearch().setQuery(
+                simpleQueryStringQuery("123").field("foo").field("bar")).get();
+        assertHitCount(searchResponse, 1L);
+        assertSearchHits(searchResponse, "1");
+    }
 }


### PR DESCRIPTION
@dakrone hit this:

During recovery, if a version conflict happens, it's considered harmless (no exception thrown by the engine), because it just means Lucene already has a newer version of the document indexed, e.g. because translog has different order-of-operations.

But `IndexingMemoryController` hits an NPE in that case, because no `Translog.Location` will be set on the engine operation, and IMC uses that to estimate ram bytes used by that operation.

Lee's amazingly simple test for some reason tickles this; I included it here.

I believe this only affects 5.0.0.
