### PR TITLE
Tests: Add vagrant.boxes gradle property

### DIFF
--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-
 import org.elasticsearch.gradle.FileContentsTask
 import org.elasticsearch.gradle.vagrant.BatsOverVagrantTask
 import org.elasticsearch.gradle.vagrant.VagrantCommandTask
@@ -25,18 +24,37 @@ import org.elasticsearch.gradle.vagrant.VagrantCommandTask
 String testScripts = '*.bats'
 String testCommand = "cd \$TESTROOT && sudo bats --tap \$BATS/$testScripts"
 String smokeTestCommand = 'echo I work'
-List<String> representativeBoxes = ['ubuntu-1404', 'centos-7']
-List<String> boxes = representativeBoxes + [
-        'ubuntu-1204',
-        'ubuntu-1504',
-        'debian-8',
-        'centos-6',
-        'oel-6',
-        'oel-7',
-        'fedora-22',
-        'opensuse-13',
-        'sles-12'
+
+// the images we allow testing with
+List<String> availableBoxes = [
+    'centos-6',
+    'centos-7',
+    'debian-8',
+    'fedora-22',
+    'oel-6',
+    'oel-7',
+    'opensuse-13',
+    'sles-12',
+    'ubuntu-1204',
+    'ubuntu-1404',
+    'ubuntu-1504'
 ]
+
+List<String> boxes = []
+for (String box : getProperties().get('vagrant.boxes', 'sample').split(',')) {
+  if (box == 'sample') {
+    boxes.add('centos-7')
+    boxes.add('ubuntu-1404')
+  } else if (box == 'all') {
+    boxes = availableBoxes
+    break
+  } else {
+    if (availableBoxes.contains(box) == false) {
+      throw new IllegalArgumentException("Unknown vagrant box '${box}'")
+    }
+    boxes.add(box)
+  }
+}
 
 /* The version of elasticsearch that we upgrade *from* as part of testing
  * upgrades. */
@@ -65,18 +83,6 @@ dependencies {
   // The version of elasticsearch that we upgrade *from*
   test "org.elasticsearch.distribution.deb:elasticsearch:$upgradeFromVersion@deb"
   test "org.elasticsearch.distribution.rpm:elasticsearch:$upgradeFromVersion@rpm"
-}
-
-task checkPackages {
-  group 'Verification'
-  description 'Check the packages against a representative sample of the ' +
-    'linux distributions we have in our Vagrantfile'
-}
-
-task checkPackagesAllDistros {
-  group 'Verification'
-  description 'Check the packages against all the linux distributions we ' +
-    'have in our Vagrantfile'
 }
 
 task clean(type: Delete) {
@@ -113,8 +119,6 @@ task prepareTestRoot(type: Copy) {
 }
 
 task checkVagrantVersion(type: Exec) {
-  group 'Package Verification'
-  description 'Check that the version of vagrant is ok'
   commandLine 'vagrant', '--version'
   standardOutput = new ByteArrayOutputStream()
   doLast {
@@ -127,21 +131,22 @@ task checkVagrantVersion(type: Exec) {
 }
 
 task vagrantSmokeTest {
-  group 'Vagrant'
-  description 'Smoke test some representative distros from the Vagrantfile'
+  group 'Verification'
+  description 'Smoke test the specified vagrant boxes'
 }
 
-task vagrantSmokeTestAllDistros {
-  group 'Vagrant'
-  description 'Smoke test all distros from the Vagrantfile'
+task packagingTest {
+  group 'Verification'
+  description "Tests yum/apt packages using vagrant and bats.\n" +
+              "    Specify the vagrant boxes to test using the gradle property 'vagrant.boxes'.\n" +
+              "    'sample' can be used to test a single yum and apt box. 'all' can be used to\n" +
+              "    test all available boxes. The available boxes are: \n    ${availableBoxes}"
 }
 
 // Each box gets it own set of tasks
-boxes.each { box ->
-  String boxTask = taskifyBoxName box
-  task "vagrantUp${boxTask}"(type: VagrantCommandTask) {
-    group 'Vagrant'
-    description "Startup a vagrant VM running ${box}"
+for (String box : boxes) {
+  String boxTask = box.capitalize().replace('-', '')
+  Task up = tasks.create("vagrant${boxTask}#up", VagrantCommandTask) {
     boxName box
     /* Its important that we try to reprovision the box even if it already
       exists. That way updates to the vagrant configuration take automatically.
@@ -158,43 +163,27 @@ boxes.each { box ->
       SKIPPED but that would require running vagrant status which is slow! */
     dependsOn checkVagrantVersion
   }
-  task "vagrantHalt${boxTask}"(type: VagrantCommandTask) {
-    group 'Vagrant'
-    description "Shutdown the vagrant VM running $box"
+  Task halt = tasks.create("vagrant${boxTask}#halt", VagrantCommandTask) {
     boxName box
     commandLine 'halt', box
   }
+  clean.dependsOn(halt)
 
-  task "smokeTest${boxTask}"(type: Exec) {
-    group 'Vagrant'
-    description "Smoke test the ${box} VM"
-    dependsOn "vagrantUp${boxTask}"
-    finalizedBy "vagrantHalt${boxTask}"
+  Task smoke = tasks.create("vagrant${boxTask}#smoketest", Exec) {
+    dependsOn up
+    finalizedBy halt
     commandLine 'vagrant', 'ssh', box, '--command',
       "set -o pipefail && ${smokeTestCommand} | sed -ue \'s/^/    ${box}: /'"
-    vagrantSmokeTestAllDistros.dependsOn name
-    if (representativeBoxes.contains(box)) {
-      vagrantSmokeTest.dependsOn name
-    }
   }
+  vagrantSmokeTest.dependsOn(smoke) 
 
-  task "check${boxTask}"(type: BatsOverVagrantTask) {
-    group 'Package Verification'
-    description "Run packaging tests against ${box}"
-    dependsOn "vagrantUp${boxTask}"
-    finalizedBy "vagrantHalt${boxTask}"
+  Task packaging = tasks.create("packagingTest${boxTask}", BatsOverVagrantTask) {
+    dependsOn up
+    finalizedBy halt
     boxName box
     command testCommand
     dependsOn prepareTestRoot
-    checkPackagesAllDistros.dependsOn name
-    if (representativeBoxes.contains(box)) {
-      checkPackages.dependsOn name
-    }
   }
+  packagingTest.dependsOn(packaging)
 }
 
-
-// Twists the box name into a sensible task name
-String taskifyBoxName(box) {
-  box.capitalize().replace('-', '')
-}

--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -144,8 +144,20 @@ task packagingTest {
 }
 
 // Each box gets it own set of tasks
-for (String box : boxes) {
+for (String box : availableBoxes) {
   String boxTask = box.capitalize().replace('-', '')
+
+  // always add a halt task for all boxes, so clean makes sure they are all shutdown
+  Task halt = tasks.create("vagrant${boxTask}#halt", VagrantCommandTask) {
+    boxName box
+    commandLine 'halt', box
+  }
+  clean.dependsOn(halt)
+  if (boxes.contains(box) == false) {
+    // we only need a halt task if this box was not specified
+    continue;
+  }
+
   Task up = tasks.create("vagrant${boxTask}#up", VagrantCommandTask) {
     boxName box
     /* Its important that we try to reprovision the box even if it already
@@ -163,11 +175,6 @@ for (String box : boxes) {
       SKIPPED but that would require running vagrant status which is slow! */
     dependsOn checkVagrantVersion
   }
-  Task halt = tasks.create("vagrant${boxTask}#halt", VagrantCommandTask) {
-    boxName box
-    commandLine 'halt', box
-  }
-  clean.dependsOn(halt)
 
   Task smoke = tasks.create("vagrant${boxTask}#smoketest", Exec) {
     dependsOn up

--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -140,7 +140,8 @@ task packagingTest {
   description "Tests yum/apt packages using vagrant and bats.\n" +
               "    Specify the vagrant boxes to test using the gradle property 'vagrant.boxes'.\n" +
               "    'sample' can be used to test a single yum and apt box. 'all' can be used to\n" +
-              "    test all available boxes. The available boxes are: \n    ${availableBoxes}"
+              "    test all available boxes. The available boxes are: \n" +
+              "    ${availableBoxes}"
 }
 
 // Each box gets it own set of tasks


### PR DESCRIPTION
This change makes specifying which boxes to run vagrant tests on a
little easier. Previously there were two tasks, checkPackages and
checkPackagesAllDistros. With this change, there is a single
packagingTest task. The boxes to run on are specified using the
gradle property vagrant.boxes, which can be easily specified on the
command line, or in a gradle properties file. There are also two
alias names, 'sample' for a yum and apt box, and 'all' for all boxes.
