### PR TITLE
30500m is safer than 31g to avoid long pointers

### DIFF
--- a/distribution/deb/src/main/packaging/init.d/elasticsearch
+++ b/distribution/deb/src/main/packaging/init.d/elasticsearch
@@ -47,7 +47,7 @@ ES_GROUP=elasticsearch
 ES_HOME=/usr/share/$NAME
 
 # Heap size defaults to 256m min, 1g max
-# Set ES_HEAP_SIZE to 50% of available RAM, but no more than 31g
+# Set ES_HEAP_SIZE to 50% of available RAM, but no more than 30500m
 #ES_HEAP_SIZE=2g
 
 # Heap new generation

--- a/distribution/src/main/packaging/env/elasticsearch
+++ b/distribution/src/main/packaging/env/elasticsearch
@@ -21,7 +21,7 @@
 #PID_DIR=/var/run/elasticsearch
 
 # Heap size defaults to ${heap.min} min, ${heap.max} max
-# Set ES_HEAP_SIZE to 50% of available RAM, but no more than 31g
+# Set ES_HEAP_SIZE to 50% of available RAM, but no more than 30500m
 #ES_HEAP_SIZE=2g
 
 # Heap new generation


### PR DESCRIPTION
Changed maximum memory from 31g to 30500m to be sure to avoid long pointers
