### PR TITLE
Bootstrapping bootstrap checks

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -184,8 +184,6 @@ final class Bootstrap {
                 .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING.getKey(), true)
                 .build();
 
-        BootstrapCheck.check(nodeSettings);
-
         node = new Node(nodeSettings);
     }
 
@@ -199,7 +197,7 @@ final class Bootstrap {
     }
 
     private void start() {
-        node.start();
+        node.start(BootstrapCheck::check);
         keepAliveThread.start();
     }
 

--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.monitor.os.OsProbe;
@@ -184,7 +185,12 @@ final class Bootstrap {
                 .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING.getKey(), true)
                 .build();
 
-        node = new Node(nodeSettings);
+        node = new Node(nodeSettings) {
+            @Override
+            protected void validateNotBeforeAcceptingRequests(Settings settings, BoundTransportAddress boundTransportAddress) {
+                BootstrapCheck.check(settings, boundTransportAddress);
+            }
+        };
     }
 
     private static Environment initialSettings(boolean foreground, String pidFile) {
@@ -197,7 +203,7 @@ final class Bootstrap {
     }
 
     private void start() {
-        node.start(BootstrapCheck::check);
+        node.start();
         keepAliveThread.start();
     }
 

--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -187,7 +187,7 @@ final class Bootstrap {
 
         node = new Node(nodeSettings) {
             @Override
-            protected void validateNotBeforeAcceptingRequests(Settings settings, BoundTransportAddress boundTransportAddress) {
+            protected void validateNodeBeforeAcceptingRequests(Settings settings, BoundTransportAddress boundTransportAddress) {
                 BootstrapCheck.check(settings, boundTransportAddress);
             }
         };

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
@@ -72,15 +72,26 @@ final class BootstrapCheck {
     static void check(final boolean enforceLimits, final List<Check> checks, final String nodeName) {
         final ESLogger logger = Loggers.getLogger(BootstrapCheck.class, nodeName);
 
+        final List<IllegalStateException> exceptions = new ArrayList<>();
+
         for (final Check check : checks) {
             final boolean fail = check.check();
             if (fail) {
                 if (enforceLimits) {
-                    throw new RuntimeException(check.errorMessage());
+                    exceptions.add(new IllegalStateException(check.errorMessage()));
                 } else {
                     logger.warn(check.errorMessage());
                 }
             }
+        }
+
+        if (!exceptions.isEmpty()) {
+            final List<String> messages = new ArrayList<>(1 + exceptions.size());
+            messages.add("bootstrap checks failed");
+            exceptions.forEach(e -> messages.add(e.getMessage()));
+            RuntimeException re = new RuntimeException(String.join("\n", messages));
+            exceptions.forEach(re::addSuppressed);
+            throw re;
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
@@ -84,7 +84,7 @@ final class BootstrapCheck {
             messages.add("bootstrap checks failed");
             exceptions.forEach(e -> messages.add(e.getMessage()));
             if (enforceLimits) {
-                RuntimeException re = new RuntimeException(String.join("\n", messages));
+                final RuntimeException re = new RuntimeException(String.join("\n", messages));
                 exceptions.forEach(re::addSuppressed);
                 throw re;
             } else {

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
@@ -103,8 +103,8 @@ final class BootstrapCheck {
      */
     // visible for testing
     static boolean enforceLimits(BoundTransportAddress boundTransportAddress) {
-        return !(Arrays.stream(boundTransportAddress.boundAddresses()).allMatch(TransportAddress::isLocalAddress) &&
-                boundTransportAddress.publishAddress().isLocalAddress());
+        return !(Arrays.stream(boundTransportAddress.boundAddresses()).allMatch(TransportAddress::isLoopbackOrLinkLocalAddress) &&
+                boundTransportAddress.publishAddress().isLoopbackOrLinkLocalAddress());
     }
 
     // the list of checks to execute

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
@@ -22,20 +22,18 @@ package org.elasticsearch.bootstrap;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.common.network.NetworkService;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.BoundTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.discovery.zen.elect.ElectMasterService;
 import org.elasticsearch.monitor.process.ProcessProbe;
-import org.elasticsearch.transport.TransportSettings;
+import org.elasticsearch.node.Node;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 
 /**
  * We enforce limits once any network host is configured. In this case we assume the node is running in production
@@ -54,10 +52,11 @@ final class BootstrapCheck {
      * checks the current limits against the snapshot or release build
      * checks
      *
-     * @param settings the current node settings
+     * @param settings              the current node settings
+     * @param boundTransportAddress the node network bindings
      */
-    public static void check(final Settings settings) {
-        check(enforceLimits(settings), checks(settings));
+    static void check(final Settings settings, final BoundTransportAddress boundTransportAddress) {
+        check(enforceLimits(boundTransportAddress), checks(settings), Node.NODE_NAME_SETTING.get(settings));
     }
 
     /**
@@ -67,10 +66,11 @@ final class BootstrapCheck {
      * @param enforceLimits true if the checks should be enforced or
      *                      warned
      * @param checks        the checks to execute
+     * @param nodeName      the node name to be used as a logging prefix
      */
     // visible for testing
-    static void check(final boolean enforceLimits, final List<Check> checks) {
-        final ESLogger logger = Loggers.getLogger(BootstrapCheck.class);
+    static void check(final boolean enforceLimits, final List<Check> checks, final String nodeName) {
+        final ESLogger logger = Loggers.getLogger(BootstrapCheck.class, nodeName);
 
         for (final Check check : checks) {
             final boolean fail = check.check();
@@ -85,32 +85,15 @@ final class BootstrapCheck {
     }
 
     /**
-     * The set of settings such that if any are set for the node, then
-     * the checks are enforced
-     *
-     * @return the enforcement settings
-     */
-    // visible for testing
-    static Set<Setting> enforceSettings() {
-        return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            TransportSettings.BIND_HOST,
-            TransportSettings.HOST,
-            TransportSettings.PUBLISH_HOST,
-            NetworkService.GLOBAL_NETWORK_HOST_SETTING,
-            NetworkService.GLOBAL_NETWORK_BINDHOST_SETTING,
-            NetworkService.GLOBAL_NETWORK_PUBLISHHOST_SETTING
-        )));
-    }
-
-    /**
      * Tests if the checks should be enforced
      *
-     * @param settings the current node settings
+     * @param boundTransportAddress the node network bindings
      * @return true if the checks should be enforced
      */
     // visible for testing
-    static boolean enforceLimits(final Settings settings) {
-        return enforceSettings().stream().anyMatch(s -> s.exists(settings));
+    static boolean enforceLimits(BoundTransportAddress boundTransportAddress) {
+        return !(Arrays.stream(boundTransportAddress.boundAddresses()).allMatch(TransportAddress::isLocalAddress) &&
+                boundTransportAddress.publishAddress().isLocalAddress());
     }
 
     // the list of checks to execute

--- a/core/src/main/java/org/elasticsearch/common/transport/DummyTransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/DummyTransportAddress.java
@@ -45,6 +45,11 @@ public class DummyTransportAddress implements TransportAddress {
     }
 
     @Override
+    public boolean isLoopbackOrLinkLocalAddress() {
+        return false;
+    }
+
+    @Override
     public String getHost() {
         return "dummy";
     }

--- a/core/src/main/java/org/elasticsearch/common/transport/InetSocketTransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/InetSocketTransportAddress.java
@@ -75,7 +75,7 @@ public final class InetSocketTransportAddress implements TransportAddress {
     }
 
     @Override
-    public boolean isLocalAddress() {
+    public boolean isLoopbackOrLinkLocalAddress() {
         return address.getAddress().isLinkLocalAddress() || address.getAddress().isLoopbackAddress();
     }
 

--- a/core/src/main/java/org/elasticsearch/common/transport/InetSocketTransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/InetSocketTransportAddress.java
@@ -75,6 +75,11 @@ public final class InetSocketTransportAddress implements TransportAddress {
     }
 
     @Override
+    public boolean isLocalAddress() {
+        return address.getAddress().isLinkLocalAddress() || address.getAddress().isLoopbackAddress();
+    }
+
+    @Override
     public String getHost() {
        return getAddress(); // just delegate no resolving
     }

--- a/core/src/main/java/org/elasticsearch/common/transport/LocalTransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/LocalTransportAddress.java
@@ -56,6 +56,11 @@ public final class LocalTransportAddress implements TransportAddress {
     }
 
     @Override
+    public boolean isLoopbackOrLinkLocalAddress() {
+        return false;
+    }
+
+    @Override
     public String getHost() {
         return "local";
     }

--- a/core/src/main/java/org/elasticsearch/common/transport/TransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/TransportAddress.java
@@ -46,7 +46,7 @@ public interface TransportAddress extends Writeable<TransportAddress> {
 
     boolean sameHost(TransportAddress other);
 
-    default boolean isLocalAddress() {
+    default boolean isLoopbackOrLinkLocalAddress() {
         return false;
     }
 

--- a/core/src/main/java/org/elasticsearch/common/transport/TransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/TransportAddress.java
@@ -46,5 +46,9 @@ public interface TransportAddress extends Writeable<TransportAddress> {
 
     boolean sameHost(TransportAddress other);
 
+    default boolean isLocalAddress() {
+        return false;
+    }
+
     public String toString();
 }

--- a/core/src/main/java/org/elasticsearch/common/transport/TransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/TransportAddress.java
@@ -46,9 +46,7 @@ public interface TransportAddress extends Writeable<TransportAddress> {
 
     boolean sameHost(TransportAddress other);
 
-    default boolean isLoopbackOrLinkLocalAddress() {
-        return false;
-    }
+    boolean isLoopbackOrLinkLocalAddress();
 
     public String toString();
 }

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -310,7 +310,7 @@ public class Node implements Closeable {
         TransportService transportService = injector.getInstance(TransportService.class);
         transportService.start();
 
-        validateNotBeforeAcceptingRequests(settings, transportService.boundAddress());
+        validateNodeBeforeAcceptingRequests(settings, transportService.boundAddress());
 
         DiscoveryNode localNode = injector.getInstance(DiscoveryNodeService.class)
                 .buildLocalNode(transportService.boundAddress().publishAddress());
@@ -532,7 +532,7 @@ public class Node implements Closeable {
      *                              bound and publishing to
      */
     @SuppressWarnings("unused")
-    protected void validateNotBeforeAcceptingRequests(Settings settings, BoundTransportAddress boundTransportAddress) {
+    protected void validateNodeBeforeAcceptingRequests(Settings settings, BoundTransportAddress boundTransportAddress) {
     }
 
     /** Writes a file to the logs dir containing the ports for the given transport type */

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -381,6 +381,9 @@ public class Node implements Closeable {
     }
 
     private Node stop() {
+        if (lifecycle.moveToStarted()) {
+            return this;
+        }
         if (!lifecycle.moveToStopped()) {
             return this;
         }

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCheckTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCheckTests.java
@@ -44,11 +44,18 @@ public class BootstrapCheckTests extends ESTestCase {
 
     public void testNonProductionMode() {
         // nothing should happen since we are in non-production mode
-        TransportAddress localTransportAddress = mock(TransportAddress.class);
-        when(localTransportAddress.isLoopbackOrLinkLocalAddress()).thenReturn(true);
+        final List<TransportAddress> transportAddresses = new ArrayList<>();
+        for (int i = 0; i < randomIntBetween(1, 8); i++) {
+            TransportAddress localTransportAddress = mock(TransportAddress.class);
+            when(localTransportAddress.isLoopbackOrLinkLocalAddress()).thenReturn(true);
+            transportAddresses.add(localTransportAddress);
+        }
+
+        TransportAddress publishAddress = mock(TransportAddress.class);
+        when(publishAddress.isLoopbackOrLinkLocalAddress()).thenReturn(true);
         BoundTransportAddress boundTransportAddress = mock(BoundTransportAddress.class);
-        when(boundTransportAddress.boundAddresses()).thenReturn(new TransportAddress[] { localTransportAddress });
-        when(boundTransportAddress.publishAddress()).thenReturn(localTransportAddress);
+        when(boundTransportAddress.boundAddresses()).thenReturn(transportAddresses.toArray(new TransportAddress[0]));
+        when(boundTransportAddress.publishAddress()).thenReturn(publishAddress);
         BootstrapCheck.check(Settings.EMPTY, boundTransportAddress);
     }
 

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCheckTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCheckTests.java
@@ -68,6 +68,7 @@ public class BootstrapCheckTests extends ESTestCase {
         when(publishAddress.isLocalAddress()).thenReturn(randomBoolean());
 
         final BoundTransportAddress boundTransportAddress = mock(BoundTransportAddress.class);
+        Collections.shuffle(transportAddresses, random());
         when(boundTransportAddress.boundAddresses()).thenReturn(transportAddresses.toArray(new TransportAddress[0]));
         when(boundTransportAddress.publishAddress()).thenReturn(publishAddress);
 

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCheckTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCheckTests.java
@@ -45,7 +45,7 @@ public class BootstrapCheckTests extends ESTestCase {
     public void testNonProductionMode() {
         // nothing should happen since we are in non-production mode
         TransportAddress localTransportAddress = mock(TransportAddress.class);
-        when(localTransportAddress.isLocalAddress()).thenReturn(true);
+        when(localTransportAddress.isLoopbackOrLinkLocalAddress()).thenReturn(true);
         BoundTransportAddress boundTransportAddress = mock(BoundTransportAddress.class);
         when(boundTransportAddress.boundAddresses()).thenReturn(new TransportAddress[] { localTransportAddress });
         when(boundTransportAddress.publishAddress()).thenReturn(localTransportAddress);
@@ -55,17 +55,17 @@ public class BootstrapCheckTests extends ESTestCase {
     public void testEnforceLimitsWhenBoundToNonLocalAddress() {
         final List<TransportAddress> transportAddresses = new ArrayList<>();
         final TransportAddress nonLocalTransportAddress = mock(TransportAddress.class);
-        when(nonLocalTransportAddress.isLocalAddress()).thenReturn(false);
+        when(nonLocalTransportAddress.isLoopbackOrLinkLocalAddress()).thenReturn(false);
         transportAddresses.add(nonLocalTransportAddress);
 
         for (int i = 0; i < randomIntBetween(0, 7); i++) {
             final TransportAddress randomTransportAddress = mock(TransportAddress.class);
-            when(randomTransportAddress.isLocalAddress()).thenReturn(randomBoolean());
+            when(randomTransportAddress.isLoopbackOrLinkLocalAddress()).thenReturn(randomBoolean());
             transportAddresses.add(randomTransportAddress);
         }
 
         final TransportAddress publishAddress = mock(TransportAddress.class);
-        when(publishAddress.isLocalAddress()).thenReturn(randomBoolean());
+        when(publishAddress.isLoopbackOrLinkLocalAddress()).thenReturn(randomBoolean());
 
         final BoundTransportAddress boundTransportAddress = mock(BoundTransportAddress.class);
         Collections.shuffle(transportAddresses, random());
@@ -80,12 +80,12 @@ public class BootstrapCheckTests extends ESTestCase {
 
         for (int i = 0; i < randomIntBetween(1, 8); i++) {
             final TransportAddress randomTransportAddress = mock(TransportAddress.class);
-            when(randomTransportAddress.isLocalAddress()).thenReturn(false);
+            when(randomTransportAddress.isLoopbackOrLinkLocalAddress()).thenReturn(false);
             transportAddresses.add(randomTransportAddress);
         }
 
         final TransportAddress publishAddress = mock(TransportAddress.class);
-        when(publishAddress.isLocalAddress()).thenReturn(true);
+        when(publishAddress.isLoopbackOrLinkLocalAddress()).thenReturn(true);
 
         final BoundTransportAddress boundTransportAddress = mock(BoundTransportAddress.class);
         when(boundTransportAddress.boundAddresses()).thenReturn(transportAddresses.toArray(new TransportAddress[0]));

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCheckTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCheckTests.java
@@ -20,26 +20,73 @@
 package org.elasticsearch.bootstrap;
 
 import org.apache.lucene.util.Constants;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.BoundTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class BootstrapCheckTests extends ESTestCase {
 
     public void testNonProductionMode() {
         // nothing should happen since we are in non-production mode
-        BootstrapCheck.check(Settings.EMPTY);
+        TransportAddress localTransportAddress = mock(TransportAddress.class);
+        when(localTransportAddress.isLocalAddress()).thenReturn(true);
+        BoundTransportAddress boundTransportAddress = mock(BoundTransportAddress.class);
+        when(boundTransportAddress.boundAddresses()).thenReturn(new TransportAddress[] { localTransportAddress });
+        when(boundTransportAddress.publishAddress()).thenReturn(localTransportAddress);
+        BootstrapCheck.check(Settings.EMPTY, boundTransportAddress);
+    }
+
+    public void testEnforceLimitsWhenBoundToNonLocalAddress() {
+        final List<TransportAddress> transportAddresses = new ArrayList<>();
+        final TransportAddress nonLocalTransportAddress = mock(TransportAddress.class);
+        when(nonLocalTransportAddress.isLocalAddress()).thenReturn(false);
+        transportAddresses.add(nonLocalTransportAddress);
+
+        for (int i = 0; i < randomIntBetween(0, 7); i++) {
+            final TransportAddress randomTransportAddress = mock(TransportAddress.class);
+            when(randomTransportAddress.isLocalAddress()).thenReturn(randomBoolean());
+            transportAddresses.add(randomTransportAddress);
+        }
+
+        final TransportAddress publishAddress = mock(TransportAddress.class);
+        when(publishAddress.isLocalAddress()).thenReturn(randomBoolean());
+
+        final BoundTransportAddress boundTransportAddress = mock(BoundTransportAddress.class);
+        when(boundTransportAddress.boundAddresses()).thenReturn(transportAddresses.toArray(new TransportAddress[0]));
+        when(boundTransportAddress.publishAddress()).thenReturn(publishAddress);
+
+        assertTrue(BootstrapCheck.enforceLimits(boundTransportAddress));
+    }
+
+    public void testEnforceLimitsWhenPublishingToNonLocalAddress() {
+        final List<TransportAddress> transportAddresses = new ArrayList<>();
+
+        for (int i = 0; i < randomIntBetween(1, 8); i++) {
+            final TransportAddress randomTransportAddress = mock(TransportAddress.class);
+            when(randomTransportAddress.isLocalAddress()).thenReturn(false);
+            transportAddresses.add(randomTransportAddress);
+        }
+
+        final TransportAddress publishAddress = mock(TransportAddress.class);
+        when(publishAddress.isLocalAddress()).thenReturn(true);
+
+        final BoundTransportAddress boundTransportAddress = mock(BoundTransportAddress.class);
+        when(boundTransportAddress.boundAddresses()).thenReturn(transportAddresses.toArray(new TransportAddress[0]));
+        when(boundTransportAddress.publishAddress()).thenReturn(publishAddress);
+
+        assertTrue(BootstrapCheck.enforceLimits(boundTransportAddress));
     }
 
     public void testFileDescriptorLimits() {
@@ -64,7 +111,7 @@ public class BootstrapCheckTests extends ESTestCase {
         }
 
         try {
-            BootstrapCheck.check(true, Collections.singletonList(check));
+            BootstrapCheck.check(true, Collections.singletonList(check), "testFileDescriptorLimits");
             fail("should have failed due to max file descriptors too low");
         } catch (final RuntimeException e) {
             assertThat(e.getMessage(), containsString("max file descriptors"));
@@ -72,12 +119,12 @@ public class BootstrapCheckTests extends ESTestCase {
 
         maxFileDescriptorCount.set(randomIntBetween(limit + 1, Integer.MAX_VALUE));
 
-        BootstrapCheck.check(true, Collections.singletonList(check));
+        BootstrapCheck.check(true, Collections.singletonList(check), "testFileDescriptorLimits");
 
         // nothing should happen if current file descriptor count is
         // not available
         maxFileDescriptorCount.set(-1);
-        BootstrapCheck.check(true, Collections.singletonList(check));
+        BootstrapCheck.check(true, Collections.singletonList(check), "testFileDescriptorLimits");
     }
 
     public void testFileDescriptorLimitsThrowsOnInvalidLimit() {
@@ -119,7 +166,7 @@ public class BootstrapCheckTests extends ESTestCase {
 
             if (testCase.shouldFail) {
                 try {
-                    BootstrapCheck.check(true, Collections.singletonList(check));
+                    BootstrapCheck.check(true, Collections.singletonList(check), "testFileDescriptorLimitsThrowsOnInvalidLimit");
                     fail("should have failed due to memory not being locked");
                 } catch (final RuntimeException e) {
                     assertThat(
@@ -128,7 +175,7 @@ public class BootstrapCheckTests extends ESTestCase {
                 }
             } else {
                 // nothing should happen
-                BootstrapCheck.check(true, Collections.singletonList(check));
+                BootstrapCheck.check(true, Collections.singletonList(check), "testFileDescriptorLimitsThrowsOnInvalidLimit");
             }
         }
     }
@@ -144,7 +191,7 @@ public class BootstrapCheckTests extends ESTestCase {
         };
 
         try {
-            BootstrapCheck.check(true, Collections.singletonList(check));
+            BootstrapCheck.check(true, Collections.singletonList(check), "testMaxNumberOfThreadsCheck");
             fail("should have failed due to max number of threads too low");
         } catch (final RuntimeException e) {
             assertThat(e.getMessage(), containsString("max number of threads"));
@@ -152,12 +199,12 @@ public class BootstrapCheckTests extends ESTestCase {
 
         maxNumberOfThreads.set(randomIntBetween(limit + 1, Integer.MAX_VALUE));
 
-        BootstrapCheck.check(true, Collections.singletonList(check));
+        BootstrapCheck.check(true, Collections.singletonList(check), "testMaxNumberOfThreadsCheck");
 
         // nothing should happen if current max number of threads is
         // not available
         maxNumberOfThreads.set(-1);
-        BootstrapCheck.check(true, Collections.singletonList(check));
+        BootstrapCheck.check(true, Collections.singletonList(check), "testMaxNumberOfThreadsCheck");
     }
 
     public void testMaxSizeVirtualMemory() {
@@ -176,7 +223,7 @@ public class BootstrapCheckTests extends ESTestCase {
         };
 
         try {
-            BootstrapCheck.check(true, Collections.singletonList(check));
+            BootstrapCheck.check(true, Collections.singletonList(check), "testMaxSizeVirtualMemory");
             fail("should have failed due to max size virtual memory too low");
         } catch (final RuntimeException e) {
             assertThat(e.getMessage(), containsString("max size virtual memory"));
@@ -184,19 +231,12 @@ public class BootstrapCheckTests extends ESTestCase {
 
         maxSizeVirtualMemory.set(rlimInfinity);
 
-        BootstrapCheck.check(true, Collections.singletonList(check));
+        BootstrapCheck.check(true, Collections.singletonList(check), "testMaxSizeVirtualMemory");
 
         // nothing should happen if max size virtual memory is not
         // available
         maxSizeVirtualMemory.set(Long.MIN_VALUE);
-        BootstrapCheck.check(true, Collections.singletonList(check));
-    }
-
-    public void testEnforceLimits() {
-        final Set<Setting> enforceSettings = BootstrapCheck.enforceSettings();
-        final Setting setting = randomFrom(Arrays.asList(enforceSettings.toArray(new Setting[enforceSettings.size()])));
-        final Settings settings = Settings.builder().put(setting.getKey(), randomAsciiOfLength(8)).build();
-        assertTrue(BootstrapCheck.enforceLimits(settings));
+        BootstrapCheck.check(true, Collections.singletonList(check), "testMaxSizeVirtualMemory");
     }
 
     public void testMinMasterNodes() {
@@ -205,6 +245,7 @@ public class BootstrapCheckTests extends ESTestCase {
         assertThat(check.check(), not(equalTo(isSet)));
         List<BootstrapCheck.Check> defaultChecks = BootstrapCheck.checks(Settings.EMPTY);
 
-        expectThrows(RuntimeException.class, () -> BootstrapCheck.check(true, defaultChecks));
+        expectThrows(RuntimeException.class, () -> BootstrapCheck.check(true, defaultChecks, "testMinMasterNodes"));
     }
+
 }


### PR DESCRIPTION
This pull request offers two enhancements to the bootstrap checks.

The first is to execute the bootstrap checks in a way that we can detect
whether or not we our bound to a non-loopback interface or publishing to
a non-loopback interface (instead of merely checking whether or not any
of the network settings are set but not what their value is). This is
accomplished by moving the execution of the bootstrap checks to after
the networking services are started; as a bonanza, this enables us to
output the node name with the failing checks, a capability that did not
exist before when these messages were logged before the node had even
started.

The second is a modification to the bootstrap checks to output all
failing checks instead of forcing the user to resolve them one-by-one.

Closes #17474, #17570 
