### PR TITLE
Remove MappedFieldType.isSortable().

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -99,7 +99,7 @@ public abstract class MappedFieldType extends FieldType {
 
     /** Return a fielddata builder for this field. */
     public IndexFieldData.Builder fielddataBuilder() {
-        throw new IllegalArgumentException("Fielddata is not supported on fields of type [" + typeName() + "]");
+        throw new IllegalArgumentException("Fielddata is not supported on field [" + name() + "] of type [" + typeName() + "]");
     }
 
     @Override
@@ -220,10 +220,6 @@ public abstract class MappedFieldType extends FieldType {
                 conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [eager_global_ordinals] across all types.");
             }
         }
-    }
-
-    public boolean isSortable() {
-        return true;
     }
 
     public String name() {

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -344,11 +344,6 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
             return value.toString();
         }
 
-        @Override
-        public boolean isSortable() {
-            return false;
-        }
-
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -263,10 +263,6 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
                 }
             }
 
-            if (!fieldType.isSortable()) {
-                throw new QueryShardException(context, "Sorting not supported for field[" + fieldName + "]");
-            }
-
             MultiValueMode localSortMode = null;
             if (sortMode != null) {
                 localSortMode = MultiValueMode.fromString(sortMode.toString());

--- a/core/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
@@ -834,7 +834,7 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
             fail("Expected an exception due to trying to sort on completion field, but did not happen");
         } catch (SearchPhaseExecutionException e) {
             assertThat(e.status().getStatus(), is(400));
-            assertThat(e.toString(), containsString("Sorting not supported for field[" + FIELD + "]"));
+            assertThat(e.toString(), containsString("Fielddata is not supported on field [" + FIELD + "] of type [completion]"));
         }
     }
 
@@ -1114,7 +1114,7 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
             // Exception must be thrown
             assertFalse(true);
         } catch (SearchPhaseExecutionException e) {
-            assertThat(e.toString(), containsString("Fielddata is not supported on fields of type [completion]"));
+            assertThat(e.toString(), containsString("Fielddata is not supported on field [" + FIELD + "] of type [completion]"));
         }
     }
 


### PR DESCRIPTION
It is not really needed since it is pretty equivalent to "supports fielddata or doc values". So we can just remove it and expect an exception when calling `MappedFieldType.fielddataBuilder()` if the field does not support fielddata.
