### PR TITLE
Completion Suggester: Fix loss of precision of completion weights

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -51,7 +51,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
     private static final Comparator<Option> COMPARATOR = new Comparator<Suggest.Suggestion.Entry.Option>() {
         @Override
         public int compare(Option first, Option second) {
-            int cmp = Float.compare(second.getScore(), first.getScore());
+            int cmp = Double.compare(second.getScore(), first.getScore());
             if (cmp != 0) {
                 return cmp;
             }
@@ -517,10 +517,10 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
 
                 private Text text;
                 private Text highlighted;
-                private float score;
+                private double score;
                 private Boolean collateMatch;
 
-                public Option(Text text, Text highlighted, float score, Boolean collateMatch) {
+                public Option(Text text, Text highlighted, double score, Boolean collateMatch) {
                     this.text = text;
                     this.highlighted = highlighted;
                     this.score = score;
@@ -556,7 +556,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
                  * @return The score based on the edit distance difference between the suggested term and the
                  *         term in the suggest text.
                  */
-                public float getScore() {
+                public double getScore() {
                     return score;
                 }
 
@@ -568,14 +568,14 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
                     return (collateMatch != null) ? collateMatch : true;
                 }
 
-                protected void setScore(float score) {
+                protected void setScore(double score) {
                     this.score = score;
                 }
 
                 @Override
                 public void readFrom(StreamInput in) throws IOException {
                     text = in.readText();
-                    score = in.readFloat();
+                    score = in.readDouble();
                     highlighted = in.readOptionalText();
                     collateMatch = in.readOptionalBoolean();
                 }
@@ -583,7 +583,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
                 @Override
                 public void writeTo(StreamOutput out) throws IOException {
                     out.writeText(text);
-                    out.writeFloat(score);
+                    out.writeDouble(score);
                     out.writeOptionalText(highlighted);
                     out.writeOptionalBoolean(collateMatch);
                 }

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestion.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestion.java
@@ -173,7 +173,7 @@ public final class CompletionSuggestion extends Suggest.Suggestion<CompletionSug
             }
 
             @Override
-            public void setScore(float score) {
+            public void setScore(double score) {
                 super.setScore(score);
             }
 

--- a/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestion.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestion.java
@@ -57,7 +57,7 @@ public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
         @Override
         public int compare(Suggestion.Entry.Option first, Suggestion.Entry.Option second) {
             // first criteria: the distance
-            int cmp = Float.compare(second.getScore(), first.getScore());
+            int cmp = Double.compare(second.getScore(), first.getScore());
             if (cmp != 0) {
                 return cmp;
             }
@@ -80,7 +80,7 @@ public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
             }
 
             // second criteria (if first criteria is equal): the distance
-            cmp = Float.compare(second.getScore(), first.getScore());
+            cmp = Double.compare(second.getScore(), first.getScore());
             if (cmp != 0) {
                 return cmp;
             }


### PR DESCRIPTION
Currently suggester scores are treated as floats, which may lead to loss of precision
when using when using int weights that are greater than 2^23 in Completion Suggester.

This change treats the int weights as doubles rather than floats to ensure no loss in precision

Stalled: lucene-level change required

closes #11392
