### PR TITLE
Remove hostname from NetworkAddress.format (2.x)

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/network/IfConfig.java
+++ b/core/src/main/java/org/elasticsearch/common/network/IfConfig.java
@@ -31,14 +31,14 @@ import java.net.SocketException;
 import java.util.List;
 import java.util.Locale;
 
-/** 
+/**
  * Simple class to log {@code ifconfig}-style output at DEBUG logging.
  */
 final class IfConfig {
 
-    private static final ESLogger logger = Loggers.getLogger(IfConfig.class);    
+    private static final ESLogger logger = Loggers.getLogger(IfConfig.class);
     private static final String INDENT = "        ";
-    
+
     /** log interface configuration at debug level, if its enabled */
     static void logIfNecessary() {
         if (logger.isDebugEnabled()) {
@@ -49,7 +49,7 @@ final class IfConfig {
             }
         }
     }
-    
+
     /** perform actual logging: might throw exception if things go wrong */
     private static void doLogging() throws IOException {
         StringBuilder msg = new StringBuilder();
@@ -59,14 +59,14 @@ final class IfConfig {
             // ordinary name
             msg.append(nic.getName());
             msg.append(System.lineSeparator());
-            
+
             // display name (e.g. on windows)
             if (!nic.getName().equals(nic.getDisplayName())) {
                 msg.append(INDENT);
                 msg.append(nic.getDisplayName());
                 msg.append(System.lineSeparator());
             }
-            
+
             // addresses: v4 first, then v6
             List<InterfaceAddress> addresses = nic.getInterfaceAddresses();
             for (InterfaceAddress address : addresses) {
@@ -76,7 +76,7 @@ final class IfConfig {
                     msg.append(System.lineSeparator());
                 }
             }
-            
+
             for (InterfaceAddress address : addresses) {
                 if (address.getAddress() instanceof Inet6Address) {
                     msg.append(INDENT);
@@ -84,7 +84,7 @@ final class IfConfig {
                     msg.append(System.lineSeparator());
                 }
             }
-            
+
             // hardware address
             byte hardware[] = nic.getHardwareAddress();
             if (hardware != null) {
@@ -98,7 +98,7 @@ final class IfConfig {
                 }
                 msg.append(System.lineSeparator());
             }
-             
+
             // attributes
             msg.append(INDENT);
             msg.append(formatFlags(nic));
@@ -106,30 +106,30 @@ final class IfConfig {
         }
         logger.debug("configuration:" + System.lineSeparator() + "{}", msg.toString());
     }
-    
+
     /** format internet address: java's default doesn't include everything useful */
     private static String formatAddress(InterfaceAddress interfaceAddress) throws IOException {
         StringBuilder sb = new StringBuilder();
-        
+
         InetAddress address = interfaceAddress.getAddress();
         if (address instanceof Inet6Address) {
             sb.append("inet6 ");
-            sb.append(NetworkAddress.formatAddress(address));
+            sb.append(NetworkAddress.format(address));
             sb.append(" prefixlen:");
             sb.append(interfaceAddress.getNetworkPrefixLength());
         } else {
             sb.append("inet ");
-            sb.append(NetworkAddress.formatAddress(address));
+            sb.append(NetworkAddress.format(address));
             int netmask = 0xFFFFFFFF << (32 - interfaceAddress.getNetworkPrefixLength());
-            sb.append(" netmask:" + NetworkAddress.formatAddress(InetAddress.getByAddress(new byte[] {
-                    (byte)(netmask >>> 24), 
-                    (byte)(netmask >>> 16 & 0xFF), 
-                    (byte)(netmask >>> 8 & 0xFF), 
-                    (byte)(netmask & 0xFF) 
+            sb.append(" netmask:" + NetworkAddress.format(InetAddress.getByAddress(new byte[] {
+                    (byte)(netmask >>> 24),
+                    (byte)(netmask >>> 16 & 0xFF),
+                    (byte)(netmask >>> 8 & 0xFF),
+                    (byte)(netmask & 0xFF)
             })));
             InetAddress broadcast = interfaceAddress.getBroadcast();
             if (broadcast != null) {
-                sb.append(" broadcast:" + NetworkAddress.formatAddress(broadcast));
+                sb.append(" broadcast:" + NetworkAddress.format(broadcast));
             }
         }
         if (address.isLoopbackAddress()) {
@@ -141,7 +141,7 @@ final class IfConfig {
         }
         return sb.toString();
     }
-    
+
     /** format network interface flags */
     private static String formatFlags(NetworkInterface nic) throws SocketException {
         StringBuilder flags = new StringBuilder();

--- a/core/src/main/java/org/elasticsearch/common/network/NetworkAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkAddress.java
@@ -21,14 +21,12 @@ package org.elasticsearch.common.network;
 
 import com.google.common.net.InetAddresses;
 
-import org.elasticsearch.common.SuppressForbidden;
-
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Objects;
 
-/** 
+/**
  * Utility functions for presentation of network addresses.
  * <p>
  * Java's address formatting is particularly bad, every address
@@ -44,7 +42,9 @@ import java.util.Objects;
  * <pre>
  *    {@code /0:0:0:0:0:0:0:1%1}
  * </pre>
- * This class provides sane address formatting instead, e.g. 
+ * Note: the {@code %1} is the "scopeid".
+ * <p>
+ * This class provides sane address formatting instead, e.g.
  * {@code 127.0.0.1} and {@code ::1} respectively. No methods do reverse
  * lookups.
  */
@@ -53,70 +53,10 @@ public final class NetworkAddress {
     private NetworkAddress() {}
 
     /**
-     * Formats a network address (with optional host) for display purposes.
-     * <p>
-     * If the host is already resolved (typically because, we looked up
-     * a name to do that), then we include it, otherwise it is
-     * omitted. See {@link #formatAddress(InetAddress)} if you only
-     * want the address.
-     * <p>
-     * IPv6 addresses are compressed and without scope
-     * identifiers.
-     * <p>
-     * Example output with already-resolved hostnames:
-     * <ul>
-     *   <li>IPv4: {@code localhost/127.0.0.1}</li>
-     *   <li>IPv6: {@code localhost/::1}</li>
-     * </ul>
-     * <p>
-     * Example output with just an address:
-     * <ul>
-     *   <li>IPv4: {@code 127.0.0.1}</li>
-     *   <li>IPv6: {@code ::1}</li>
-     * </ul>
-     * @param address IPv4 or IPv6 address
-     * @return formatted string
-     * @see #formatAddress(InetAddress)
-     */
-    public static String format(InetAddress address) {
-        return format(address, -1, true);
-    }
-
-    /**
-     * Formats a network address and port for display purposes.
-     * <p>
-     * If the host is already resolved (typically because, we looked up
-     * a name to do that), then we include it, otherwise it is
-     * omitted. See {@link #formatAddress(InetSocketAddress)} if you only
-     * want the address.
-     * <p>
-     * This formats the address with {@link #format(InetAddress)}
-     * and appends the port number. IPv6 addresses will be bracketed.
-     * <p>
-     * Example output with already-resolved hostnames:
-     * <ul>
-     *   <li>IPv4: {@code localhost/127.0.0.1:9300}</li>
-     *   <li>IPv6: {@code localhost/[::1]:9300}</li>
-     * </ul>
-     * <p>
-     * Example output with just an address:
-     * <ul>
-     *   <li>IPv4: {@code 127.0.0.1:9300}</li>
-     *   <li>IPv6: {@code [::1]:9300}</li>
-     * </ul>
-     * @param address IPv4 or IPv6 address with port
-     * @return formatted string
-     * @see #formatAddress(InetSocketAddress)
-     */
-    public static String format(InetSocketAddress address) {
-        return format(address.getAddress(), address.getPort(), true);
-    }
-    
-    /**
      * Formats a network address for display purposes.
      * <p>
      * This formats only the address, any hostname information,
-     * if present, is ignored. IPv6 addresses are compressed 
+     * if present, is ignored. IPv6 addresses are compressed
      * and without scope identifiers.
      * <p>
      * Example output with just an address:
@@ -127,14 +67,14 @@ public final class NetworkAddress {
      * @param address IPv4 or IPv6 address
      * @return formatted string
      */
-    public static String formatAddress(InetAddress address) {
-        return format(address, -1, false);
+    public static String format(InetAddress address) {
+        return format(address, -1);
     }
-    
+
     /**
      * Formats a network address and port for display purposes.
      * <p>
-     * This formats the address with {@link #formatAddress(InetAddress)}
+     * This formats the address with {@link #format(InetAddress)}
      * and appends the port number. IPv6 addresses will be bracketed.
      * Any host information, if present is ignored.
      * <p>
@@ -146,38 +86,27 @@ public final class NetworkAddress {
      * @param address IPv4 or IPv6 address with port
      * @return formatted string
      */
-    public static String formatAddress(InetSocketAddress address) {
-        return format(address.getAddress(), address.getPort(), false);
+    public static String format(InetSocketAddress address) {
+        return format(address.getAddress(), address.getPort());
     }
-    
+
     // note, we don't validate port, because we only allow InetSocketAddress
-    @SuppressForbidden(reason = "we call toString to avoid a DNS lookup")
-    static String format(InetAddress address, int port, boolean includeHost) {
+    static String format(InetAddress address, int port) {
         Objects.requireNonNull(address);
-        
+
         StringBuilder builder = new StringBuilder();
 
-        if (includeHost) {
-            // must use toString, to avoid DNS lookup. but the format is specified in the spec
-            String toString = address.toString();
-            int separator = toString.indexOf('/');
-            if (separator > 0) {
-                // append hostname, with the slash too
-                builder.append(toString, 0, separator + 1);
-            }
-        }
-                
         if (port != -1 && address instanceof Inet6Address) {
             builder.append(InetAddresses.toUriString(address));
         } else {
             builder.append(InetAddresses.toAddrString(address));
         }
-        
+
         if (port != -1) {
             builder.append(':');
             builder.append(port);
         }
-        
+
         return builder.toString();
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/transport/InetSocketTransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/InetSocketTransportAddress.java
@@ -81,7 +81,7 @@ public final class InetSocketTransportAddress implements TransportAddress {
 
     @Override
     public String getAddress() {
-        return NetworkAddress.formatAddress(address.getAddress());
+        return NetworkAddress.format(address.getAddress());
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -458,7 +458,7 @@ public class Node implements Releasable {
                     // no link local, just causes problems
                     continue;
                 }
-                writer.write(NetworkAddress.formatAddress(new InetSocketAddress(inetAddress, address.getPort())) + "\n");
+                writer.write(NetworkAddress.format(new InetSocketAddress(inetAddress, address.getPort())) + "\n");
             }
         } catch (IOException e) {
             throw new RuntimeException("Failed to write ports file", e);

--- a/core/src/test/java/org/elasticsearch/common/network/NetworkAddressTests.java
+++ b/core/src/test/java/org/elasticsearch/common/network/NetworkAddressTests.java
@@ -25,72 +25,76 @@ import java.io.IOException;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.Random;
 
 /**
  * Tests for network address formatting. Please avoid using any methods that cause DNS lookups!
  */
 public class NetworkAddressTests extends ESTestCase {
-    
+
     public void testFormatV4() throws Exception {
-        assertEquals("localhost/127.0.0.1", NetworkAddress.format(forge("localhost", "127.0.0.1")));
+        assertEquals("127.0.0.1", NetworkAddress.format(forge("localhost", "127.0.0.1")));
         assertEquals("127.0.0.1", NetworkAddress.format(forge(null, "127.0.0.1")));
     }
-    
+
     public void testFormatV6() throws Exception {
-        assertEquals("localhost/::1", NetworkAddress.format(forge("localhost", "::1")));
+        assertEquals("::1", NetworkAddress.format(forge("localhost", "::1")));
         assertEquals("::1", NetworkAddress.format(forge(null, "::1")));
     }
-    
-    public void testFormatAddressV4() throws Exception {
-        assertEquals("127.0.0.1", NetworkAddress.formatAddress(forge("localhost", "127.0.0.1")));
-        assertEquals("127.0.0.1", NetworkAddress.formatAddress(forge(null, "127.0.0.1")));
-    }
-    
-    public void testFormatAddressV6() throws Exception {
-        assertEquals("::1", NetworkAddress.formatAddress(forge("localhost", "::1")));
-        assertEquals("::1", NetworkAddress.formatAddress(forge(null, "::1")));
-    }
-    
+
     public void testFormatPortV4() throws Exception {
-        assertEquals("localhost/127.0.0.1:1234", NetworkAddress.format(new InetSocketAddress(forge("localhost", "127.0.0.1"), 1234)));
+        assertEquals("127.0.0.1:1234", NetworkAddress.format(new InetSocketAddress(forge("localhost", "127.0.0.1"), 1234)));
         assertEquals("127.0.0.1:1234", NetworkAddress.format(new InetSocketAddress(forge(null, "127.0.0.1"), 1234)));
     }
-    
+
     public void testFormatPortV6() throws Exception {
-        assertEquals("localhost/[::1]:1234", NetworkAddress.format(new InetSocketAddress(forge("localhost", "::1"), 1234)));
-        assertEquals("[::1]:1234",NetworkAddress.format(new InetSocketAddress(forge(null, "::1"), 1234)));
+        assertEquals("[::1]:1234", NetworkAddress.format(new InetSocketAddress(forge("localhost", "::1"), 1234)));
+        assertEquals("[::1]:1234", NetworkAddress.format(new InetSocketAddress(forge(null, "::1"), 1234)));
     }
-    
-    public void testFormatAddressPortV4() throws Exception {
-        assertEquals("127.0.0.1:1234", NetworkAddress.formatAddress(new InetSocketAddress(forge("localhost", "127.0.0.1"), 1234)));
-        assertEquals("127.0.0.1:1234", NetworkAddress.formatAddress(new InetSocketAddress(forge(null, "127.0.0.1"), 1234)));
-    }
-    
-    public void testFormatAddressPortV6() throws Exception {
-        assertEquals("[::1]:1234", NetworkAddress.formatAddress(new InetSocketAddress(forge("localhost", "::1"), 1234)));
-        assertEquals("[::1]:1234", NetworkAddress.formatAddress(new InetSocketAddress(forge(null, "::1"), 1234)));
-    }
-    
+
     public void testNoScopeID() throws Exception {
         assertEquals("::1", NetworkAddress.format(forgeScoped(null, "::1", 5)));
-        assertEquals("localhost/::1", NetworkAddress.format(forgeScoped("localhost", "::1", 5)));
-        
-        assertEquals("::1", NetworkAddress.formatAddress(forgeScoped(null, "::1", 5)));
-        assertEquals("::1", NetworkAddress.formatAddress(forgeScoped("localhost", "::1", 5)));
-        
+        assertEquals("::1", NetworkAddress.format(forgeScoped("localhost", "::1", 5)));
+
         assertEquals("[::1]:1234", NetworkAddress.format(new InetSocketAddress(forgeScoped(null, "::1", 5), 1234)));
-        assertEquals("localhost/[::1]:1234", NetworkAddress.format(new InetSocketAddress(forgeScoped("localhost", "::1", 5), 1234)));
-        
-        assertEquals("[::1]:1234", NetworkAddress.formatAddress(new InetSocketAddress(forgeScoped(null, "::1", 5), 1234)));
-        assertEquals("[::1]:1234", NetworkAddress.formatAddress(new InetSocketAddress(forgeScoped("localhost", "::1", 5), 1234)));
+        assertEquals("[::1]:1234", NetworkAddress.format(new InetSocketAddress(forgeScoped("localhost", "::1", 5), 1234)));
     }
-    
+
+    /** Test that ipv4 address formatting round trips */
+    public void testRoundTripV4() throws Exception {
+        roundTrip(new byte[4]);
+    }
+
+    /** Test that ipv6 address formatting round trips */
+    public void testRoundTripV6() throws Exception {
+        roundTrip(new byte[16]);
+    }
+
+    /**
+     * Round trip test code for both IPv4 and IPv6. {@link InetAddress} contains the {@code getByAddress} and
+     * {@code getbyName} methods for both IPv4 and IPv6, unless you also specify a {@code scopeid}, which this does not
+     * test.
+     *
+     * @param bytes 4 (32-bit for IPv4) or 16 bytes (128-bit for IPv6)
+     * @throws Exception if any error occurs while interacting with the network address
+     */
+    private void roundTrip(byte[] bytes) throws Exception {
+        Random random = random();
+        for (int i = 0; i < 10000; i++) {
+            random.nextBytes(bytes);
+            InetAddress expected = InetAddress.getByAddress(bytes);
+            String formatted = NetworkAddress.format(expected);
+            InetAddress actual = InetAddress.getByName(formatted);
+            assertEquals(expected, actual);
+        }
+    }
+
     /** creates address without any lookups. hostname can be null, for missing */
     private InetAddress forge(String hostname, String address) throws IOException {
         byte bytes[] = InetAddress.getByName(address).getAddress();
         return InetAddress.getByAddress(hostname, bytes);
     }
-    
+
     /** creates scoped ipv6 address without any lookups. hostname can be null, for missing */
     private InetAddress forgeScoped(String hostname, String address, int scopeid) throws IOException {
         byte bytes[] = InetAddress.getByName(address).getAddress();

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingIT.java
@@ -73,8 +73,8 @@ public class UnicastZenPingIT extends ESTestCase {
         InetSocketTransportAddress addressB = (InetSocketTransportAddress) transportB.boundAddress().publishAddress();
 
         Settings hostsSettings = Settings.settingsBuilder().putArray("discovery.zen.ping.unicast.hosts",
-                NetworkAddress.formatAddress(new InetSocketAddress(addressA.address().getAddress(), addressA.address().getPort())),
-                NetworkAddress.formatAddress(new InetSocketAddress(addressB.address().getAddress(), addressB.address().getPort())))
+                NetworkAddress.format(new InetSocketAddress(addressA.address().getAddress(), addressA.address().getPort())),
+                NetworkAddress.format(new InetSocketAddress(addressB.address().getAddress(), addressB.address().getPort())))
                 .build();
 
         UnicastZenPing zenPingA = new UnicastZenPing(hostsSettings, threadPool, transportServiceA, clusterName, Version.CURRENT, electMasterService, null);

--- a/core/src/test/java/org/elasticsearch/http/netty/pipelining/HttpPipeliningHandlerTests.java
+++ b/core/src/test/java/org/elasticsearch/http/netty/pipelining/HttpPipeliningHandlerTests.java
@@ -125,14 +125,14 @@ public class HttpPipeliningHandlerTests extends ESTestCase {
         assertTrue(connectionFuture.await(CONNECTION_TIMEOUT));
         final Channel clientChannel = connectionFuture.getChannel();
 
-        // NetworkAddress.formatAddress makes a proper HOST header.
+        // NetworkAddress.format makes a proper HOST header.
         final HttpRequest request1 = new DefaultHttpRequest(
                 HTTP_1_1, HttpMethod.GET, PATH1);
-        request1.headers().add(HOST, NetworkAddress.formatAddress(HOST_ADDR));
+        request1.headers().add(HOST, NetworkAddress.format(HOST_ADDR));
 
         final HttpRequest request2 = new DefaultHttpRequest(
                 HTTP_1_1, HttpMethod.GET, PATH2);
-        request2.headers().add(HOST, NetworkAddress.formatAddress(HOST_ADDR));
+        request2.headers().add(HOST, NetworkAddress.format(HOST_ADDR));
 
         clientChannel.write(request1);
         clientChannel.write(request2);

--- a/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -2070,7 +2070,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
         TransportAddress publishAddress = randomFrom(nodes).getHttp().address().publishAddress();
         assertEquals(1, publishAddress.uniqueAddressTypeId());
         InetSocketAddress address = ((InetSocketTransportAddress) publishAddress).address();
-        return new HttpRequestBuilder(HttpClients.createDefault()).host(NetworkAddress.formatAddress(address.getAddress())).port(address.getPort());
+        return new HttpRequestBuilder(HttpClients.createDefault()).host(NetworkAddress.format(address.getAddress())).port(address.getPort());
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/test/rest/client/RestClient.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/client/RestClient.java
@@ -250,7 +250,7 @@ public class RestClient implements Closeable {
         return new HttpRequestBuilder(httpClient)
                 .addHeaders(headers)
                 .protocol(protocol)
-                .host(NetworkAddress.formatAddress(address.getAddress())).port(address.getPort());
+                .host(NetworkAddress.format(address.getAddress())).port(address.getPort());
     }
 
     protected HttpRequestBuilder httpRequestBuilder() {

--- a/core/src/test/java/org/elasticsearch/test/rest/client/http/HttpRequestBuilder.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/client/http/HttpRequestBuilder.java
@@ -78,7 +78,7 @@ public class HttpRequestBuilder {
 
     public HttpRequestBuilder httpTransport(HttpServerTransport httpServerTransport) {
         InetSocketTransportAddress transportAddress = (InetSocketTransportAddress) httpServerTransport.boundAddress().publishAddress();
-        return host(NetworkAddress.formatAddress(transportAddress.address().getAddress())).port(transportAddress.address().getPort());
+        return host(NetworkAddress.format(transportAddress.address().getAddress())).port(transportAddress.address().getPort());
     }
 
     public HttpRequestBuilder port(int port) {

--- a/core/src/test/java/org/elasticsearch/transport/netty/NettyTransportMultiPortIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/transport/netty/NettyTransportMultiPortIntegrationIT.java
@@ -98,7 +98,7 @@ public class NettyTransportMultiPortIntegrationIT extends ESIntegTestCase {
             // publish address
             assertThat(nodeInfo.getTransport().getProfileAddresses().get("client1").publishAddress(), instanceOf(InetSocketTransportAddress.class));
             InetSocketTransportAddress publishAddress = (InetSocketTransportAddress) nodeInfo.getTransport().getProfileAddresses().get("client1").publishAddress();
-            assertThat(NetworkAddress.formatAddress(publishAddress.address().getAddress()), is("127.0.0.7"));
+            assertThat(NetworkAddress.format(publishAddress.address().getAddress()), is("127.0.0.7"));
             assertThat(publishAddress.address().getPort(), is(4321));
         }
     }

--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/discovery/azure/AzureUnicastHostsProvider.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/discovery/azure/AzureUnicastHostsProvider.java
@@ -221,7 +221,7 @@ public class AzureUnicastHostsProvider extends AbstractComponent implements Unic
                             if (privateIp.equals(ipAddress)) {
                                 logger.trace("adding ourselves {}", NetworkAddress.format(ipAddress));
                             }
-                            networkAddress = NetworkAddress.formatAddress(privateIp);
+                            networkAddress = NetworkAddress.format(privateIp);
                         } else {
                             logger.trace("no private ip provided. ignoring [{}]...", instance.getInstanceName());
                         }
@@ -234,7 +234,7 @@ public class AzureUnicastHostsProvider extends AbstractComponent implements Unic
                                 continue;
                             }
 
-                            networkAddress = NetworkAddress.formatAddress(new InetSocketAddress(endpoint.getVirtualIPAddress(), endpoint.getPort()));
+                            networkAddress = NetworkAddress.format(new InetSocketAddress(endpoint.getVirtualIPAddress(), endpoint.getPort()));
                         }
 
                         if (networkAddress == null) {

--- a/plugins/cloud-gce/src/main/java/org/elasticsearch/discovery/gce/GceUnicastHostsProvider.java
+++ b/plugins/cloud-gce/src/main/java/org/elasticsearch/discovery/gce/GceUnicastHostsProvider.java
@@ -112,7 +112,7 @@ public class GceUnicastHostsProvider extends AbstractComponent implements Unicas
         try {
             InetAddress inetAddress = networkService.resolvePublishHostAddresses(null);
             if (inetAddress != null) {
-                ipAddress = NetworkAddress.formatAddress(inetAddress);
+                ipAddress = NetworkAddress.format(inetAddress);
             }
         } catch (IOException e) {
             // We can't find the publish host address... Hmmm. Too bad :-(

--- a/plugins/site-example/src/test/java/org/elasticsearch/example/SiteContentsIT.java
+++ b/plugins/site-example/src/test/java/org/elasticsearch/example/SiteContentsIT.java
@@ -47,7 +47,7 @@ public class SiteContentsIT extends ESIntegTestCase {
             for (InetSocketAddress address :  externalCluster.httpAddresses()) {
                 RestResponse restResponse = new RestResponse(
                         new HttpRequestBuilder(httpClient)
-                        .host(NetworkAddress.formatAddress(address.getAddress())).port(address.getPort())
+                        .host(NetworkAddress.format(address.getAddress())).port(address.getPort())
                         .path("/_plugin/site-example/")
                         .method("GET").execute());
                 assertEquals(200, restResponse.getStatusCode());


### PR DESCRIPTION
This removes the inconsistent output of IP addresses. The format was parsing-unfriendly and it makes it hard to reason about API responses, such as to `_nodes`.

With this change in place, it will never print the hostname as part of the default format, which has the
added benefit that it can be used consistently for URIs, which was not the case when the hostname might appear at the front with "hostname/ip:port".

This is the 2.x port of #17601.

Closes #17604 (for 2.x)
