### PR TITLE
Assert names of read writeables

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableAwareStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableAwareStreamInput.java
@@ -34,7 +34,7 @@ public class NamedWriteableAwareStreamInput extends FilterStreamInput {
     }
 
     @Override
-    <C> C readNamedWriteable(Class<C> categoryClass) throws IOException {
+    <C extends NamedWriteable<?>> C readNamedWriteable(Class<C> categoryClass) throws IOException {
         String name = readString();
         Writeable.Reader<? extends C> reader = namedWriteableRegistry.getReader(categoryClass, name);
         C c = reader.read(this);
@@ -42,6 +42,8 @@ public class NamedWriteableAwareStreamInput extends FilterStreamInput {
             throw new IOException(
                     "Writeable.Reader [" + reader + "] returned null which is not allowed and probably means it screwed up the stream.");
         }
+        assert name.equals(c.getWriteableName()) : c + " claims to have a different name [" + c.getWriteableName()
+                + "] than it was read from [" + name + "].";
         return c;
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -707,7 +707,7 @@ public abstract class StreamInput extends InputStream {
      * Default implementation throws {@link UnsupportedOperationException} as StreamInput doesn't hold a registry.
      * Use {@link FilterInputStream} instead which wraps a stream and supports a {@link NamedWriteableRegistry} too.
      */
-    <C> C readNamedWriteable(@SuppressWarnings("unused") Class<C> categoryClass) throws IOException {
+    <C extends NamedWriteable<?>> C readNamedWriteable(@SuppressWarnings("unused") Class<C> categoryClass) throws IOException {
         throw new UnsupportedOperationException("can't read named writeable from StreamInput");
     }
 


### PR DESCRIPTION
Adds an assertion that when reading a NamedWriteable it has the same name
you read. It'd be _super_ weird if it didn't.
