### PR TITLE
Use `mmapfs` by default.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -283,6 +283,7 @@ public final class IndexModule {
         MMAPFS,
         SIMPLEFS,
         FS,
+        @Deprecated
         DEFAULT;
 
         public String getSettingsKey() {

--- a/core/src/main/java/org/elasticsearch/index/store/FsDirectoryService.java
+++ b/core/src/main/java/org/elasticsearch/index/store/FsDirectoryService.java
@@ -110,10 +110,12 @@ public class FsDirectoryService extends DirectoryService implements StoreRateLim
 
     protected Directory newFSDirectory(Path location, LockFactory lockFactory) throws IOException {
         final String storeType = indexSettings.getSettings().get(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(),
-            IndexModule.Type.DEFAULT.getSettingsKey());
-        if (IndexModule.Type.FS.match(storeType) || IndexModule.Type.DEFAULT.match(storeType)) {
+            IndexModule.Type.FS.getSettingsKey());
+        if (IndexModule.Type.FS.match(storeType) || isDefault(storeType)) {
             final FSDirectory open = FSDirectory.open(location, lockFactory); // use lucene defaults
-            if (open instanceof MMapDirectory && Constants.WINDOWS == false) {
+            if (open instanceof MMapDirectory
+                    && isDefault(storeType)
+                    && Constants.WINDOWS == false) {
                 return newDefaultDir(location, (MMapDirectory) open, lockFactory);
             }
             return open;
@@ -125,6 +127,11 @@ public class FsDirectoryService extends DirectoryService implements StoreRateLim
             return new MMapDirectory(location, lockFactory);
         }
         throw new IllegalArgumentException("No directory found for type [" + storeType + "]");
+    }
+
+    @SuppressWarnings("deprecation")
+    private static boolean isDefault(String storeType) {
+        return IndexModule.Type.DEFAULT.match(storeType);
     }
 
     private Directory newDefaultDir(Path location, final MMapDirectory mmapDir, LockFactory lockFactory) throws IOException {

--- a/docs/reference/migration/migrate_5_0.asciidoc
+++ b/docs/reference/migration/migrate_5_0.asciidoc
@@ -40,6 +40,7 @@ way to do this is to upgrade to Elasticsearch 2.3 or later and to use the
 * <<breaking_50_java_api_changes>>
 * <<breaking_50_packaging>>
 * <<breaking_50_plugins>>
+* <<breaking_50_fs>>
 
 include::migrate_5_0/search.asciidoc[]
 
@@ -63,4 +64,4 @@ include::migrate_5_0/packaging.asciidoc[]
 
 include::migrate_5_0/plugins.asciidoc[]
 
-
+include::migrate_5_0/fs.asciidoc[]

--- a/docs/reference/migration/migrate_5_0/fs.asciidoc
+++ b/docs/reference/migration/migrate_5_0/fs.asciidoc
@@ -1,0 +1,10 @@
+[[breaking_50_fs]]
+=== Filesystem related changes
+
+Only a subset of index files were open with `mmap` on Elasticsearch 2.x. As of
+Elasticsearch 5.0, all index files will be open with `mmap` on 64-bit systems.
+While this may increase the amount of virtual memory used by Elasticsearch,
+there is nothing to worry about since this is only address space consumption
+and the actual memory usage of Elasticsearch will stay similar to what it was
+in 2.x. See http://blog.thetaphi.de/2012/07/use-lucenes-mmapdirectory-on-64bit.html
+for more information.


### PR DESCRIPTION
I case any problem was discovered, you can still enable the legacy `default`
directory instead. But the plan is to get rid of it in 6.0.

Closes #16983
