### PR TITLE
Remove norelease comments in test classes

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/FiltersTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/FiltersTests.java
@@ -36,9 +36,6 @@ public class FiltersTests extends BaseAggregationTestCase<FiltersAggregatorBuild
         if (randomBoolean()) {
             KeyedFilter[] filters = new KeyedFilter[size];
             for (int i = 0; i < size; i++) {
-                // NORELEASE make RandomQueryBuilder work outside of the
-                // AbstractQueryTestCase
-                // builder.query(RandomQueryBuilder.createQuery(getRandom()));
                 filters[i] = new KeyedFilter(randomAsciiOfLengthBetween(1, 20),
                         QueryBuilders.termQuery(randomAsciiOfLengthBetween(5, 20), randomAsciiOfLengthBetween(5, 20)));
             }
@@ -46,9 +43,6 @@ public class FiltersTests extends BaseAggregationTestCase<FiltersAggregatorBuild
         } else {
             QueryBuilder<?>[] filters = new QueryBuilder<?>[size];
             for (int i = 0; i < size; i++) {
-                // NORELEASE make RandomQueryBuilder work outside of the
-                // AbstractQueryTestCase
-                // builder.query(RandomQueryBuilder.createQuery(getRandom()));
                 filters[i] = QueryBuilders.termQuery(randomAsciiOfLengthBetween(5, 20), randomAsciiOfLengthBetween(5, 20));
             }
             factory = new FiltersAggregatorBuilder(randomAsciiOfLengthBetween(1, 20), filters);

--- a/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -53,6 +53,7 @@ import org.elasticsearch.index.query.EmptyQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.support.InnerHitBuilderTests;
+import org.elasticsearch.index.query.support.InnerHitsBuilder;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
@@ -69,7 +70,6 @@ import org.elasticsearch.script.ScriptSettings;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorParsers;
-import org.elasticsearch.index.query.support.InnerHitsBuilder;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.highlight.HighlightBuilderTests;
 import org.elasticsearch.search.rescore.QueryRescoreBuilderTests;
@@ -321,15 +321,9 @@ public class SearchSourceBuilderTests extends ESTestCase {
             }
         }
         if (randomBoolean()) {
-            // NORELEASE make RandomQueryBuilder work outside of the
-            // AbstractQueryTestCase
-            // builder.query(RandomQueryBuilder.createQuery(getRandom()));
             builder.query(QueryBuilders.termQuery(randomAsciiOfLengthBetween(5, 20), randomAsciiOfLengthBetween(5, 20)));
         }
         if (randomBoolean()) {
-            // NORELEASE make RandomQueryBuilder work outside of the
-            // AbstractQueryTestCase
-            // builder.postFilter(RandomQueryBuilder.createQuery(getRandom()));
             builder.postFilter(QueryBuilders.termQuery(randomAsciiOfLengthBetween(5, 20), randomAsciiOfLengthBetween(5, 20)));
         }
         if (randomBoolean()) {
@@ -431,11 +425,9 @@ public class SearchSourceBuilderTests extends ESTestCase {
             }
         }
         if (randomBoolean()) {
-            // NORELEASE need a random aggregation builder method
             builder.aggregation(AggregationBuilders.avg(randomAsciiOfLengthBetween(5, 20)));
         }
         if (randomBoolean()) {
-            // NORELEASE need a method to randomly build content for ext
             XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
             xContentBuilder.startObject();
             xContentBuilder.field("term_vectors_fetch", randomAsciiOfLengthBetween(5, 20));


### PR DESCRIPTION
We added these comments to enhance our randomized test infrastructure, but since they are in tests they don't seem to serve their purpose of blocking a release. I propose we should turn these into issues rather than leave them in the code base.
