### PR TITLE
Remove PROTOTYPEs from QueryBuilders

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
@@ -167,11 +167,8 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> {
         preference = in.readOptionalString();
         query = in.readQuery();
         filteringAlias = in.readStringArray();
-        if (in.readBoolean()) {
-            fields = in.readStringArray();
-        }
-
-        fetchSourceContext = FetchSourceContext.optionalReadFromStream(in);
+        fields = in.readOptionalStringArray();
+        fetchSourceContext = in.readOptionalStreamable(FetchSourceContext::new);
         nowInMillis = in.readVLong();
     }
 
@@ -184,14 +181,8 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> {
         out.writeOptionalString(preference);
         out.writeQuery(query);
         out.writeStringArray(filteringAlias);
-        if (fields != null) {
-            out.writeBoolean(true);
-            out.writeStringArray(fields);
-        } else {
-            out.writeBoolean(false);
-        }
-
-        FetchSourceContext.optionalWriteToStream(fetchSourceContext, out);
+        out.writeOptionalStringArray(fields);
+        out.writeOptionalStreamable(fetchSourceContext);
         out.writeVLong(nowInMillis);
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/get/GetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/GetRequest.java
@@ -287,8 +287,7 @@ public class GetRequest extends SingleShardRequest<GetRequest> implements Realti
 
         this.versionType = VersionType.fromValue(in.readByte());
         this.version = in.readLong();
-
-        fetchSourceContext = FetchSourceContext.optionalReadFromStream(in);
+        fetchSourceContext = in.readOptionalStreamable(FetchSourceContext::new);
     }
 
     @Override
@@ -319,8 +318,7 @@ public class GetRequest extends SingleShardRequest<GetRequest> implements Realti
         out.writeBoolean(ignoreErrorsOnGeneratedFields);
         out.writeByte(versionType.getValue());
         out.writeLong(version);
-
-        FetchSourceContext.optionalWriteToStream(fetchSourceContext, out);
+        out.writeOptionalStreamable(fetchSourceContext);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -198,7 +198,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
             version = in.readLong();
             versionType = VersionType.fromValue(in.readByte());
 
-            fetchSourceContext = FetchSourceContext.optionalReadFromStream(in);
+            fetchSourceContext = in.readOptionalStreamable(FetchSourceContext::new);
         }
 
         @Override
@@ -220,7 +220,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
             out.writeLong(version);
             out.writeByte(versionType.getValue());
 
-            FetchSourceContext.optionalWriteToStream(fetchSourceContext, out);
+            out.writeOptionalStreamable(fetchSourceContext);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/action/support/ToXContentToBytes.java
+++ b/core/src/main/java/org/elasticsearch/action/support/ToXContentToBytes.java
@@ -75,6 +75,7 @@ public abstract class ToXContentToBytes implements ToXContent {
             toXContent(builder, EMPTY_PARAMS);
             return builder.string();
         } catch (Exception e) {
+            // So we have a stack trace logged somewhere
             return "{ \"error\" : \"" + ExceptionsHelper.detailedMessage(e) + "\"}";
         }
     }

--- a/core/src/main/java/org/elasticsearch/common/geo/GeoDistance.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoDistance.java
@@ -136,7 +136,7 @@ public enum GeoDistance implements Writeable<GeoDistance> {
         return GeoDistance.values()[ord];
     }
 
-    public static GeoDistance readGeoDistanceFrom(StreamInput in) throws IOException {
+    public static GeoDistance readFromStream(StreamInput in) throws IOException {
         return DEFAULT.readFrom(in);
     }
 

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -511,6 +511,23 @@ public abstract class StreamInput extends InputStream {
         return new GeoPoint(readDouble(), readDouble());
     }
 
+    /**
+     * Read a {@linkplain DateTimeZone}.
+     */
+    public DateTimeZone readTimeZone() throws IOException {
+        return DateTimeZone.forID(readString());
+    }
+
+    /**
+     * Read an optional {@linkplain DateTimeZone}.
+     */
+    public DateTimeZone readOptionalTimeZone() throws IOException {
+        if (readBoolean()) {
+            return DateTimeZone.forID(readString());
+        }
+        return null;
+    }
+
     public int[] readIntArray() throws IOException {
         int length = readVInt();
         int[] values = new int[length];

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -44,6 +44,7 @@ import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.suggest.SuggestionBuilder;
 import org.elasticsearch.search.suggest.phrase.SmoothingModel;
 import org.elasticsearch.tasks.Task;
+import org.joda.time.DateTimeZone;
 import org.joda.time.ReadableInstant;
 
 import java.io.EOFException;
@@ -757,6 +758,25 @@ public abstract class StreamOutput extends OutputStream {
     public void writeGeoPoint(GeoPoint geoPoint) throws IOException {
         writeDouble(geoPoint.lat());
         writeDouble(geoPoint.lon());
+    }
+
+    /**
+     * Write a {@linkplain DateTimeZone} to the stream.
+     */
+    public void writeTimeZone(DateTimeZone timeZone) throws IOException {
+        writeString(timeZone.getID());
+    }
+
+    /**
+     * Write an optional {@linkplain DateTimeZone} to the stream.
+     */
+    public void writeOptionalTimeZone(DateTimeZone timeZone) throws IOException {
+        if (timeZone == null) {
+            writeBoolean(false);
+        } else {
+            writeBoolean(true);
+            writeTimeZone(timeZone);
+        }
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/CombineFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/CombineFunction.java
@@ -146,17 +146,12 @@ public enum CombineFunction implements Writeable<CombineFunction> {
         out.writeVInt(this.ordinal());
     }
 
-    @Override
-    public CombineFunction readFrom(StreamInput in) throws IOException {
+    public static CombineFunction readFromStream(StreamInput in) throws IOException {
         int ordinal = in.readVInt();
         if (ordinal < 0 || ordinal >= values().length) {
             throw new IOException("Unknown CombineFunction ordinal [" + ordinal + "]");
         }
         return values()[ordinal];
-    }
-
-    public static CombineFunction readCombineFunctionFrom(StreamInput in) throws IOException {
-        return CombineFunction.MULTIPLY.readFrom(in);
     }
 
     public static CombineFunction fromString(String combineFunction) {

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
@@ -83,17 +83,12 @@ public class FiltersFunctionScoreQuery extends Query {
             out.writeVInt(this.ordinal());
         }
 
-        @Override
-        public ScoreMode readFrom(StreamInput in) throws IOException {
+        public static ScoreMode readFromStream(StreamInput in) throws IOException {
             int ordinal = in.readVInt();
             if (ordinal < 0 || ordinal >= values().length) {
                 throw new IOException("Unknown ScoreMode ordinal [" + ordinal + "]");
             }
             return values()[ordinal];
-        }
-
-        public static ScoreMode readScoreModeFrom(StreamInput in) throws IOException {
-            return ScoreMode.MULTIPLY.readFrom(in);
         }
 
         public static ScoreMode fromString(String scoreMode) {

--- a/core/src/main/java/org/elasticsearch/common/unit/Fuzziness.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/Fuzziness.java
@@ -47,10 +47,6 @@ public final class Fuzziness implements ToXContent, Writeable<Fuzziness> {
 
     private final String fuzziness;
 
-    /** the prototype constant is intended for deserialization when used with
-     * {@link org.elasticsearch.common.io.stream.StreamableReader#readFrom(StreamInput)} */
-    static final Fuzziness PROTOTYPE = AUTO;
-
     private Fuzziness(int fuzziness) {
         if (fuzziness != 0 && fuzziness != 1 && fuzziness != 2) {
             throw new IllegalArgumentException("Valid edit distances are [0, 1, 2] but was [" + fuzziness + "]");
@@ -63,6 +59,18 @@ public final class Fuzziness implements ToXContent, Writeable<Fuzziness> {
             throw new IllegalArgumentException("fuzziness can't be null!");
         }
         this.fuzziness = fuzziness.toUpperCase(Locale.ROOT);
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public Fuzziness(StreamInput in) throws IOException {
+        fuzziness = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(fuzziness);
     }
 
     /**
@@ -236,19 +244,5 @@ public final class Fuzziness implements ToXContent, Writeable<Fuzziness> {
     @Override
     public int hashCode() {
         return fuzziness.hashCode();
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(fuzziness);
-    }
-
-    @Override
-    public Fuzziness readFrom(StreamInput in) throws IOException {
-        return new Fuzziness(in.readString());
-    }
-
-    public static Fuzziness readFuzzinessFrom(StreamInput in) throws IOException {
-        return PROTOTYPE.readFrom(in);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/VersionType.java
+++ b/core/src/main/java/org/elasticsearch/index/VersionType.java
@@ -381,7 +381,7 @@ public enum VersionType implements Writeable<VersionType> {
         throw new IllegalArgumentException("No version type match [" + value + "]");
     }
 
-    public static VersionType readVersionTypeFrom(StreamInput in) throws IOException {
+    public static VersionType readFromStream(StreamInput in) throws IOException {
         int ordinal = in.readVInt();
         assert (ordinal == 0 || ordinal == 1 || ordinal == 2 || ordinal == 3);
         return VersionType.values()[ordinal];

--- a/core/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
@@ -119,6 +119,21 @@ public abstract class BaseTermQueryBuilder<QB extends BaseTermQueryBuilder<QB>> 
         this.value = convertToBytesRefIfString(value);
     }
 
+    /**
+     * Read from a stream.
+     */
+    protected BaseTermQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        fieldName = in.readString();
+        value = in.readGenericValue();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeGenericValue(value);
+    }
+
     /** Returns the field name used in this query. */
     public String fieldName() {
         return this.fieldName;
@@ -151,18 +166,5 @@ public abstract class BaseTermQueryBuilder<QB extends BaseTermQueryBuilder<QB>> 
     protected final boolean doEquals(BaseTermQueryBuilder other) {
         return Objects.equals(fieldName, other.fieldName) &&
                Objects.equals(value, other.value);
-    }
-
-    @Override
-    protected final QB doReadFrom(StreamInput in) throws IOException {
-        return createBuilder(in.readString(), in.readGenericValue());
-    }
-
-    protected abstract QB createBuilder(String fieldName, Object value);
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(fieldName);
-        out.writeGenericValue(value);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -47,7 +47,6 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
 
     public static final String NAME = "bool";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(BoolQueryBuilder.NAME);
-    public static final BoolQueryBuilder PROTOTYPE = new BoolQueryBuilder();
 
     public static final boolean ADJUST_PURE_NEGATIVE_DEFAULT = true;
     public static final boolean DISABLE_COORD_DEFAULT = false;
@@ -75,6 +74,37 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
     private boolean adjustPureNegative = ADJUST_PURE_NEGATIVE_DEFAULT;
 
     private String minimumShouldMatch;
+
+    /**
+     * Build an empty bool query.
+     */
+    public BoolQueryBuilder() {
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public BoolQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        mustClauses.addAll(readQueries(in));
+        mustNotClauses.addAll(readQueries(in));
+        shouldClauses.addAll(readQueries(in));
+        filterClauses.addAll(readQueries(in));
+        adjustPureNegative = in.readBoolean();
+        disableCoord = in.readBoolean();
+        minimumShouldMatch = in.readOptionalString();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        writeQueries(out, mustClauses);
+        writeQueries(out, mustNotClauses);
+        writeQueries(out, shouldClauses);
+        writeQueries(out, filterClauses);
+        out.writeBoolean(adjustPureNegative);
+        out.writeBoolean(disableCoord);
+        out.writeOptionalString(minimumShouldMatch);
+    }
 
     /**
      * Adds a query that <b>must</b> appear in the matching documents and will
@@ -439,35 +469,6 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
                 Objects.equals(shouldClauses, other.shouldClauses) &&
                 Objects.equals(mustNotClauses, other.mustNotClauses) &&
                 Objects.equals(filterClauses, other.filterClauses);
-    }
-
-    @Override
-    protected BoolQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
-        List<QueryBuilder<?>> queryBuilders = readQueries(in);
-        boolQueryBuilder.mustClauses.addAll(queryBuilders);
-        queryBuilders = readQueries(in);
-        boolQueryBuilder.mustNotClauses.addAll(queryBuilders);
-        queryBuilders = readQueries(in);
-        boolQueryBuilder.shouldClauses.addAll(queryBuilders);
-        queryBuilders = readQueries(in);
-        boolQueryBuilder.filterClauses.addAll(queryBuilders);
-        boolQueryBuilder.adjustPureNegative = in.readBoolean();
-        boolQueryBuilder.disableCoord = in.readBoolean();
-        boolQueryBuilder.minimumShouldMatch = in.readOptionalString();
-        return boolQueryBuilder;
-
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        writeQueries(out, mustClauses);
-        writeQueries(out, mustNotClauses);
-        writeQueries(out, shouldClauses);
-        writeQueries(out, filterClauses);
-        out.writeBoolean(adjustPureNegative);
-        out.writeBoolean(disableCoord);
-        out.writeOptionalString(minimumShouldMatch);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
@@ -47,15 +47,14 @@ public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuil
 
     public static final String NAME = "boosting";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final BoostingQueryBuilder PROTOTYPE = new BoostingQueryBuilder(EmptyQueryBuilder.PROTOTYPE, EmptyQueryBuilder.PROTOTYPE);
 
     private static final ParseField POSITIVE_FIELD = new ParseField("positive");
     private static final ParseField NEGATIVE_FIELD = new ParseField("negative");
     private static final ParseField NEGATIVE_BOOST_FIELD = new ParseField("negative_boost");
 
-    private final QueryBuilder positiveQuery;
+    private final QueryBuilder<?> positiveQuery;
 
-    private final QueryBuilder negativeQuery;
+    private final QueryBuilder<?> negativeQuery;
 
     private float negativeBoost = -1;
 
@@ -66,7 +65,7 @@ public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuil
      * @param positiveQuery the positive query for this boosting query.
      * @param negativeQuery the negative query for this boosting query.
      */
-    public BoostingQueryBuilder(QueryBuilder positiveQuery, QueryBuilder negativeQuery) {
+    public BoostingQueryBuilder(QueryBuilder<?> positiveQuery, QueryBuilder<?> negativeQuery) {
         if (positiveQuery == null) {
             throw new IllegalArgumentException("inner clause [positive] cannot be null.");
         }
@@ -75,6 +74,23 @@ public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuil
         }
         this.positiveQuery = positiveQuery;
         this.negativeQuery = negativeQuery;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public BoostingQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        positiveQuery = in.readQuery();
+        negativeQuery = in.readQuery();
+        negativeBoost = in.readFloat();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeQuery(positiveQuery);
+        out.writeQuery(negativeQuery);
+        out.writeFloat(negativeBoost);
     }
 
     /**
@@ -206,22 +222,6 @@ public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuil
         return Objects.equals(negativeBoost, other.negativeBoost) &&
                 Objects.equals(positiveQuery, other.positiveQuery) &&
                 Objects.equals(negativeQuery, other.negativeQuery);
-    }
-
-    @Override
-    protected BoostingQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        QueryBuilder positiveQuery = in.readQuery();
-        QueryBuilder negativeQuery = in.readQuery();
-        BoostingQueryBuilder boostingQuery = new BoostingQueryBuilder(positiveQuery, negativeQuery);
-        boostingQuery.negativeBoost = in.readFloat();
-        return boostingQuery;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeQuery(positiveQuery);
-        out.writeQuery(negativeQuery);
-        out.writeFloat(negativeBoost);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
@@ -60,7 +60,6 @@ public class CommonTermsQueryBuilder extends AbstractQueryBuilder<CommonTermsQue
 
     public static final String NAME = "common";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final CommonTermsQueryBuilder PROTOTYPE = new CommonTermsQueryBuilder("field", "text");
 
     public static final float DEFAULT_CUTOFF_FREQ = 0.01f;
     public static final Operator DEFAULT_HIGH_FREQ_OCCUR = Operator.OR;
@@ -107,6 +106,35 @@ public class CommonTermsQueryBuilder extends AbstractQueryBuilder<CommonTermsQue
         }
         this.fieldName = fieldName;
         this.text = text;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public CommonTermsQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        fieldName = in.readString();
+        text = in.readGenericValue();
+        highFreqOperator = Operator.readFromStream(in);
+        lowFreqOperator = Operator.readFromStream(in);
+        analyzer = in.readOptionalString();
+        lowFreqMinimumShouldMatch = in.readOptionalString();
+        highFreqMinimumShouldMatch = in.readOptionalString();
+        disableCoord = in.readBoolean();
+        cutoffFrequency = in.readFloat();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(this.fieldName);
+        out.writeGenericValue(this.text);
+        highFreqOperator.writeTo(out);
+        lowFreqOperator.writeTo(out);
+        out.writeOptionalString(analyzer);
+        out.writeOptionalString(lowFreqMinimumShouldMatch);
+        out.writeOptionalString(highFreqMinimumShouldMatch);
+        out.writeBoolean(disableCoord);
+        out.writeFloat(cutoffFrequency);
     }
 
     public String fieldName() {
@@ -239,7 +267,7 @@ public class CommonTermsQueryBuilder extends AbstractQueryBuilder<CommonTermsQue
         XContentParser parser = parseContext.parser();
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new ParsingException(parser.getTokenLocation(), "[" + CommonTermsQueryBuilder.NAME + "] query malformed, no field");
+            throw new ParsingException(parser.getTokenLocation(), "[" + NAME + "] query malformed, no field");
         }
         String fieldName = parser.currentName();
         Object text = null;
@@ -395,32 +423,6 @@ public class CommonTermsQueryBuilder extends AbstractQueryBuilder<CommonTermsQue
         query.setLowFreqMinimumNumberShouldMatch(lowFreqMinimumShouldMatch);
         query.setHighFreqMinimumNumberShouldMatch(highFreqMinimumShouldMatch);
         return query;
-    }
-
-    @Override
-    protected CommonTermsQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        CommonTermsQueryBuilder commonTermsQueryBuilder = new CommonTermsQueryBuilder(in.readString(), in.readGenericValue());
-        commonTermsQueryBuilder.highFreqOperator = Operator.readOperatorFrom(in);
-        commonTermsQueryBuilder.lowFreqOperator = Operator.readOperatorFrom(in);
-        commonTermsQueryBuilder.analyzer = in.readOptionalString();
-        commonTermsQueryBuilder.lowFreqMinimumShouldMatch = in.readOptionalString();
-        commonTermsQueryBuilder.highFreqMinimumShouldMatch = in.readOptionalString();
-        commonTermsQueryBuilder.disableCoord = in.readBoolean();
-        commonTermsQueryBuilder.cutoffFrequency = in.readFloat();
-        return commonTermsQueryBuilder;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(this.fieldName);
-        out.writeGenericValue(this.text);
-        highFreqOperator.writeTo(out);
-        lowFreqOperator.writeTo(out);
-        out.writeOptionalString(analyzer);
-        out.writeOptionalString(lowFreqMinimumShouldMatch);
-        out.writeOptionalString(highFreqMinimumShouldMatch);
-        out.writeBoolean(disableCoord);
-        out.writeFloat(cutoffFrequency);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
@@ -43,16 +43,34 @@ public class DisMaxQueryBuilder extends AbstractQueryBuilder<DisMaxQueryBuilder>
 
     public static final String NAME = "dis_max";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final DisMaxQueryBuilder PROTOTYPE = new DisMaxQueryBuilder();
+
+    /** Default multiplication factor for breaking ties in document scores.*/
+    public static final float DEFAULT_TIE_BREAKER = 0.0f;
 
     private static final ParseField TIE_BREAKER_FIELD = new ParseField("tie_breaker");
     private static final ParseField QUERIES_FIELD = new ParseField("queries");
 
     private final List<QueryBuilder<?>> queries = new ArrayList<>();
 
-    /** Default multiplication factor for breaking ties in document scores.*/
-    public static float DEFAULT_TIE_BREAKER = 0.0f;
     private float tieBreaker = DEFAULT_TIE_BREAKER;
+
+    public DisMaxQueryBuilder() {
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public DisMaxQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        queries.addAll(readQueries(in));
+        tieBreaker = in.readFloat();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        writeQueries(out, queries);
+        out.writeFloat(tieBreaker);
+    }
 
     /**
      * Add a sub-query to this disjunction.
@@ -174,21 +192,6 @@ public class DisMaxQueryBuilder extends AbstractQueryBuilder<DisMaxQueryBuilder>
         }
 
         return new DisjunctionMaxQuery(luceneQueries, tieBreaker);
-    }
-
-    @Override
-    protected DisMaxQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        DisMaxQueryBuilder disMax = new DisMaxQueryBuilder();
-        List<QueryBuilder<?>> queryBuilders = readQueries(in);
-        disMax.queries.addAll(queryBuilders);
-        disMax.tieBreaker = in.readFloat();
-        return disMax;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        writeQueries(out, queries);
-        out.writeFloat(tieBreaker);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/EmptyQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/EmptyQueryBuilder.java
@@ -34,9 +34,24 @@ import java.io.IOException;
 public final class EmptyQueryBuilder extends AbstractQueryBuilder<EmptyQueryBuilder> {
 
     public static final String NAME = "empty_query";
-
-    /** the one and only empty query builder */
     public static final EmptyQueryBuilder PROTOTYPE = new EmptyQueryBuilder();
+
+    /**
+     * Construct an empty query. This query can *technically* be named and given a boost.
+     */
+    public EmptyQueryBuilder() {
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public EmptyQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+    }
 
     @Override
     public String getWriteableName() {
@@ -55,16 +70,6 @@ public final class EmptyQueryBuilder extends AbstractQueryBuilder<EmptyQueryBuil
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-    }
-
-
-    @Override
-    protected EmptyQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        return new EmptyQueryBuilder();
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -45,7 +45,6 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
 
     public static final String NAME = "exists";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final ExistsQueryBuilder PROTOTYPE = new ExistsQueryBuilder("field");
 
     public static final ParseField FIELD_FIELD = new ParseField("field");
 
@@ -56,6 +55,19 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
             throw new IllegalArgumentException("field name is null or empty");
         }
         this.fieldName = fieldName;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public ExistsQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        fieldName = in.readString();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
     }
 
     /**
@@ -150,16 +162,6 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
     @Override
     protected boolean doEquals(ExistsQueryBuilder other) {
         return Objects.equals(fieldName, other.fieldName);
-    }
-
-    @Override
-    protected ExistsQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        return new ExistsQueryBuilder(in.readString());
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(fieldName);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
@@ -39,13 +39,11 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
 
     public static final String NAME = "field_masking_span";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final FieldMaskingSpanQueryBuilder PROTOTYPE =
-            new FieldMaskingSpanQueryBuilder(new SpanTermQueryBuilder("field", "text"), "field");
 
     private static final ParseField FIELD_FIELD = new ParseField("field");
     private static final ParseField QUERY_FIELD = new ParseField("query");
 
-    private final SpanQueryBuilder queryBuilder;
+    private final SpanQueryBuilder<?> queryBuilder;
 
     private final String fieldName;
 
@@ -55,7 +53,7 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
      * @param queryBuilder inner {@link SpanQueryBuilder}
      * @param fieldName the field name
      */
-    public FieldMaskingSpanQueryBuilder(SpanQueryBuilder queryBuilder, String fieldName) {
+    public FieldMaskingSpanQueryBuilder(SpanQueryBuilder<?> queryBuilder, String fieldName) {
         if (Strings.isEmpty(fieldName)) {
             throw new IllegalArgumentException("field name is null or empty");
         }
@@ -64,6 +62,21 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
         }
         this.queryBuilder = queryBuilder;
         this.fieldName = fieldName;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public FieldMaskingSpanQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        queryBuilder = (SpanQueryBuilder<?>) in.readQuery();
+        fieldName = in.readString();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeQuery(queryBuilder);
+        out.writeString(fieldName);
     }
 
     /**
@@ -151,18 +164,6 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
         Query innerQuery = queryBuilder.toQuery(context);
         assert innerQuery instanceof SpanQuery;
         return new FieldMaskingSpanQuery((SpanQuery)innerQuery, fieldInQuery);
-    }
-
-    @Override
-    protected FieldMaskingSpanQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        QueryBuilder innerQueryBuilder = in.readQuery();
-        return new FieldMaskingSpanQueryBuilder((SpanQueryBuilder) innerQueryBuilder, in.readString());
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeQuery(queryBuilder);
-        out.writeString(fieldName);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -49,7 +49,6 @@ public class FuzzyQueryBuilder extends AbstractQueryBuilder<FuzzyQueryBuilder> i
 
     public static final String NAME = "fuzzy";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final FuzzyQueryBuilder PROTOTYPE = new FuzzyQueryBuilder();
 
     /** Default maximum edit distance. Defaults to AUTO. */
     public static final Fuzziness DEFAULT_FUZZINESS = Fuzziness.AUTO;
@@ -163,10 +162,29 @@ public class FuzzyQueryBuilder extends AbstractQueryBuilder<FuzzyQueryBuilder> i
         this.value = convertToBytesRefIfString(value);
     }
 
-    private FuzzyQueryBuilder() {
-        // for prototype
-        this.fieldName = null;
-        this.value = null;
+    /**
+     * Read from a stream.
+     */
+    public FuzzyQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        fieldName = in.readString();
+        value = in.readGenericValue();
+        fuzziness = new Fuzziness(in);
+        prefixLength = in.readVInt();
+        maxExpansions = in.readVInt();
+        transpositions = in.readBoolean();
+        rewrite = in.readOptionalString();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(this.fieldName);
+        out.writeGenericValue(this.value);
+        this.fuzziness.writeTo(out);
+        out.writeVInt(this.prefixLength);
+        out.writeVInt(this.maxExpansions);
+        out.writeBoolean(this.transpositions);
+        out.writeOptionalString(this.rewrite);
     }
 
     public String fieldName() {
@@ -334,28 +352,6 @@ public class FuzzyQueryBuilder extends AbstractQueryBuilder<FuzzyQueryBuilder> i
             QueryParsers.setRewriteMethod((MultiTermQuery) query, rewriteMethod);
         }
         return query;
-    }
-
-    @Override
-    protected FuzzyQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        FuzzyQueryBuilder fuzzyQueryBuilder = new FuzzyQueryBuilder(in.readString(), in.readGenericValue());
-        fuzzyQueryBuilder.fuzziness = Fuzziness.readFuzzinessFrom(in);
-        fuzzyQueryBuilder.prefixLength = in.readVInt();
-        fuzzyQueryBuilder.maxExpansions = in.readVInt();
-        fuzzyQueryBuilder.transpositions = in.readBoolean();
-        fuzzyQueryBuilder.rewrite = in.readOptionalString();
-        return fuzzyQueryBuilder;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(this.fieldName);
-        out.writeGenericValue(this.value);
-        this.fuzziness.writeTo(out);
-        out.writeVInt(this.prefixLength);
-        out.writeVInt(this.maxExpansions);
-        out.writeBoolean(this.transpositions);
-        out.writeOptionalString(this.rewrite);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
@@ -57,8 +57,6 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
 
     /** Default type for executing this query (memory as of this writing). */
     public static final GeoExecType DEFAULT_TYPE = GeoExecType.MEMORY;
-    /** Needed for serialization. */
-    public static final GeoBoundingBoxQueryBuilder PROTOTYPE = new GeoBoundingBoxQueryBuilder("");
 
     private static final ParseField IGNORE_MALFORMED_FIELD = new ParseField("ignore_malformed");
     private static final ParseField TYPE_FIELD = new ParseField("type");
@@ -94,6 +92,27 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
             throw new IllegalArgumentException("Field name must not be empty.");
         }
         this.fieldName = fieldName;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public GeoBoundingBoxQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        fieldName = in.readString();
+        topLeft = in.readGeoPoint();
+        bottomRight = in.readGeoPoint();
+        type = GeoExecType.readTypeFrom(in);
+        validationMethod = GeoValidationMethod.readFromStream(in);
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeGeoPoint(topLeft);
+        out.writeGeoPoint(bottomRight);
+        type.writeTo(out);
+        validationMethod.writeTo(out);
     }
 
     /**
@@ -451,26 +470,6 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
     @Override
     protected int doHashCode() {
         return Objects.hash(topLeft, bottomRight, type, validationMethod, fieldName);
-    }
-
-    @Override
-    protected GeoBoundingBoxQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        String fieldName = in.readString();
-        GeoBoundingBoxQueryBuilder geo = new GeoBoundingBoxQueryBuilder(fieldName);
-        geo.topLeft = in.readGeoPoint();
-        geo.bottomRight = in.readGeoPoint();
-        geo.type = GeoExecType.readTypeFrom(in);
-        geo.validationMethod = GeoValidationMethod.readGeoValidationMethodFrom(in);
-        return geo;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(fieldName);
-        out.writeGeoPoint(topLeft);
-        out.writeGeoPoint(bottomRight);
-        type.writeTo(out);
-        validationMethod.writeTo(out);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
@@ -66,8 +66,6 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
     /** Default for optimising query through pre computed bounding box query. */
     public static final String DEFAULT_OPTIMIZE_BBOX = "memory";
 
-    public static final GeoDistanceQueryBuilder PROTOTYPE = new GeoDistanceQueryBuilder("_na_");
-
     private static final ParseField VALIDATION_METHOD_FIELD = new ParseField("validation_method");
     private static final ParseField IGNORE_MALFORMED_FIELD = new ParseField("ignore_malformed");
     private static final ParseField COERCE_FIELD = new ParseField("coerce", "normalize");
@@ -97,6 +95,29 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
             throw new IllegalArgumentException("fieldName must not be null or empty");
         }
         this.fieldName = fieldName;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public GeoDistanceQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        fieldName = in.readString();
+        distance = in.readDouble();
+        validationMethod = GeoValidationMethod.readFromStream(in);
+        center = in.readGeoPoint();
+        optimizeBbox = in.readString();
+        geoDistance = GeoDistance.readFromStream(in);
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeDouble(distance);
+        validationMethod.writeTo(out);
+        out.writeGeoPoint(center);
+        out.writeString(optimizeBbox);
+        geoDistance.writeTo(out);
     }
 
     /** Name of the field this query is operating on. */
@@ -399,28 +420,6 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
                 Objects.equals(center, other.center) &&
                 Objects.equals(optimizeBbox, other.optimizeBbox) &&
                 Objects.equals(geoDistance, other.geoDistance);
-    }
-
-    @Override
-    protected GeoDistanceQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        String fieldName = in.readString();
-        GeoDistanceQueryBuilder result = new GeoDistanceQueryBuilder(fieldName);
-        result.distance = in.readDouble();
-        result.validationMethod = GeoValidationMethod.readGeoValidationMethodFrom(in);
-        result.center = in.readGeoPoint();
-        result.optimizeBbox = in.readString();
-        result.geoDistance = GeoDistance.readGeoDistanceFrom(in);
-        return result;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(fieldName);
-        out.writeDouble(distance);
-        validationMethod.writeTo(out);
-        out.writeGeoPoint(center);
-        out.writeString(optimizeBbox);
-        geoDistance.writeTo(out);
     }
 
     private QueryValidationException checkLatLon(boolean indexCreatedBeforeV2_0) {

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryBuilder.java
@@ -59,8 +59,6 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
     public static final DistanceUnit DEFAULT_UNIT = DistanceUnit.DEFAULT;
     public static final String DEFAULT_OPTIMIZE_BBOX = "memory";
 
-    public static final GeoDistanceRangeQueryBuilder PROTOTYPE = new GeoDistanceRangeQueryBuilder("_na_", new GeoPoint());
-
     private static final ParseField FROM_FIELD = new ParseField("from");
     private static final ParseField TO_FIELD = new ParseField("to");
     private static final ParseField INCLUDE_LOWER_FIELD = new ParseField("include_lower");
@@ -112,6 +110,37 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
 
     public GeoDistanceRangeQueryBuilder(String fieldName, String geohash) {
         this(fieldName, geohash == null ? null : new GeoPoint().resetFromGeoHash(geohash));
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public GeoDistanceRangeQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        fieldName = in.readString();
+        point = in.readGeoPoint();
+        from = in.readGenericValue();
+        to = in.readGenericValue();
+        includeLower = in.readBoolean();
+        includeUpper = in.readBoolean();
+        unit = DistanceUnit.valueOf(in.readString());
+        geoDistance = GeoDistance.readFromStream(in);
+        optimizeBbox = in.readString();
+        validationMethod = GeoValidationMethod.readFromStream(in);
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeGeoPoint(point);
+        out.writeGenericValue(from);
+        out.writeGenericValue(to);
+        out.writeBoolean(includeLower);
+        out.writeBoolean(includeUpper);
+        out.writeString(unit.name());
+        geoDistance.writeTo(out);;
+        out.writeString(optimizeBbox);
+        validationMethod.writeTo(out);
     }
 
     public String fieldName() {
@@ -534,34 +563,6 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
             queryBuilder.setValidationMethod(GeoValidationMethod.infer(coerce, ignoreMalformed));
         }
         return queryBuilder;
-    }
-
-    @Override
-    protected GeoDistanceRangeQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        GeoDistanceRangeQueryBuilder queryBuilder = new GeoDistanceRangeQueryBuilder(in.readString(), in.readGeoPoint());
-        queryBuilder.from = in.readGenericValue();
-        queryBuilder.to = in.readGenericValue();
-        queryBuilder.includeLower = in.readBoolean();
-        queryBuilder.includeUpper = in.readBoolean();
-        queryBuilder.unit = DistanceUnit.valueOf(in.readString());
-        queryBuilder.geoDistance = GeoDistance.readGeoDistanceFrom(in);
-        queryBuilder.optimizeBbox = in.readString();
-        queryBuilder.validationMethod = GeoValidationMethod.readGeoValidationMethodFrom(in);
-        return queryBuilder;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(fieldName);
-        out.writeGeoPoint(point);
-        out.writeGenericValue(from);
-        out.writeGenericValue(to);
-        out.writeBoolean(includeLower);
-        out.writeBoolean(includeUpper);
-        out.writeString(unit.name());
-        geoDistance.writeTo(out);;
-        out.writeString(optimizeBbox);
-        validationMethod.writeTo(out);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/GeoValidationMethod.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoValidationMethod.java
@@ -40,7 +40,7 @@ public enum GeoValidationMethod implements Writeable<GeoValidationMethod>{
     public static final GeoValidationMethod DEFAULT = STRICT;
     public static final boolean DEFAULT_LENIENT_PARSING = (DEFAULT != STRICT);
 
-    public static GeoValidationMethod readGeoValidationMethodFrom(StreamInput in) throws IOException {
+    public static GeoValidationMethod readFromStream(StreamInput in) throws IOException {
         return GeoValidationMethod.values()[in.readVInt()];
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
@@ -98,7 +98,6 @@ public class GeohashCellQuery {
      * <code>false</code>.
      */
     public static class Builder extends AbstractQueryBuilder<Builder> {
-        public static final Builder PROTOTYPE = new Builder("field", new GeoPoint());
         // we need to store the geohash rather than the corresponding point,
         // because a transformation from a geohash to a point an back to the
         // geohash will extend the accuracy of the hash to max precision
@@ -126,6 +125,25 @@ public class GeohashCellQuery {
             this.fieldName = field;
             this.geohash = geohash;
             this.neighbors = neighbors;
+        }
+
+        /**
+         * Read from a stream.
+         */
+        public Builder(StreamInput in) throws IOException {
+            super(in);
+            fieldName = in.readString();
+            geohash = in.readString();
+            levels = in.readOptionalVInt();
+            neighbors = in.readBoolean();
+        }
+
+        @Override
+        protected void doWriteTo(StreamOutput out) throws IOException {
+            out.writeString(fieldName);
+            out.writeString(geohash);
+            out.writeOptionalVInt(levels);
+            out.writeBoolean(neighbors);
         }
 
         public Builder point(GeoPoint point) {
@@ -305,30 +323,6 @@ public class GeohashCellQuery {
                 builder.boost(boost);
             }
             return builder;
-        }
-
-        @Override
-        protected Builder doReadFrom(StreamInput in) throws IOException {
-            String field = in.readString();
-            String geohash = in.readString();
-            Builder builder = new Builder(field, geohash);
-            if (in.readBoolean()) {
-                builder.precision(in.readVInt());
-            }
-            builder.neighbors(in.readBoolean());
-            return builder;
-        }
-
-        @Override
-        protected void doWriteTo(StreamOutput out) throws IOException {
-            out.writeString(fieldName);
-            out.writeString(geohash);
-            boolean hasLevels = levels != null;
-            out.writeBoolean(hasLevels);
-            if (hasLevels) {
-                out.writeVInt(levels);
-            }
-            out.writeBoolean(neighbors);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
@@ -68,8 +68,6 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
      */
     public static final ScoreMode DEFAULT_SCORE_MODE = ScoreMode.None;
 
-    public static final HasChildQueryBuilder PROTOTYPE = new HasChildQueryBuilder("", EmptyQueryBuilder.PROTOTYPE);
-
     private static final ParseField QUERY_FIELD = new ParseField("query", "filter");
     private static final ParseField TYPE_FIELD = new ParseField("type", "child_type");
     private static final ParseField MAX_CHILDREN_FIELD = new ParseField("max_children");
@@ -112,6 +110,29 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
         }
         this.type = type;
         this.query = query;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public HasChildQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        type = in.readString();
+        minChildren = in.readInt();
+        maxChildren = in.readInt();
+        scoreMode = ScoreMode.values()[in.readVInt()];
+        query = in.readQuery();
+        innerHitBuilder = in.readOptionalWriteable(InnerHitBuilder::new);
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(type);
+        out.writeInt(minChildren());
+        out.writeInt(maxChildren());
+        out.writeVInt(scoreMode.ordinal());
+        out.writeQuery(query);
+        out.writeOptionalWriteable(innerHitBuilder);
     }
 
     /**
@@ -449,36 +470,6 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
     @Override
     protected int doHashCode() {
         return Objects.hash(query, type, scoreMode, minChildren, maxChildren, innerHitBuilder);
-    }
-
-    protected HasChildQueryBuilder(StreamInput in) throws IOException {
-        type = in.readString();
-        minChildren = in.readInt();
-        maxChildren = in.readInt();
-        final int ordinal = in.readVInt();
-        scoreMode = ScoreMode.values()[ordinal];
-        query = in.readQuery();
-        innerHitBuilder = InnerHitBuilder.optionalReadFromStream(in);
-    }
-
-    @Override
-    protected HasChildQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        return new HasChildQueryBuilder(in);
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(type);
-        out.writeInt(minChildren());
-        out.writeInt(maxChildren());
-        out.writeVInt(scoreMode.ordinal());
-        out.writeQuery(query);
-        if (innerHitBuilder != null) {
-            out.writeBoolean(true);
-            innerHitBuilder.writeTo(out);
-        } else {
-            out.writeBoolean(false);
-        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/HasParentQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasParentQueryBuilder.java
@@ -46,7 +46,6 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
 
     public static final String NAME = "has_parent";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final HasParentQueryBuilder PROTOTYPE = new HasParentQueryBuilder("", EmptyQueryBuilder.PROTOTYPE);
 
     public static final boolean DEFAULT_SCORE = false;
 
@@ -84,6 +83,25 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
             this.innerHit.setParentChildType(type);
             this.innerHit.setQuery(query);
         }
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public HasParentQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        type = in.readString();
+        score = in.readBoolean();
+        query = in.readQuery();
+        innerHit = in.readOptionalWriteable(InnerHitBuilder::new);
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(type);
+        out.writeBoolean(score);
+        out.writeQuery(query);
+        out.writeOptionalWriteable(innerHit);
     }
 
     /**
@@ -261,31 +279,6 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
     @Override
     public String getWriteableName() {
         return NAME;
-    }
-
-    protected HasParentQueryBuilder(StreamInput in) throws IOException {
-        type = in.readString();
-        score = in.readBoolean();
-        query = in.readQuery();
-        innerHit = InnerHitBuilder.optionalReadFromStream(in);
-    }
-
-    @Override
-    protected HasParentQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        return new HasParentQueryBuilder(in);
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(type);
-        out.writeBoolean(score);
-        out.writeQuery(query);
-        if (innerHit != null) {
-            out.writeBoolean(true);
-            innerHit.writeTo(out);
-        } else {
-            out.writeBoolean(false);
-        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -49,7 +49,6 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
 
     public static final String NAME = "ids";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final IdsQueryBuilder PROTOTYPE = new IdsQueryBuilder();
 
     private static final ParseField TYPE_FIELD = new ParseField("type", "types", "_type");
     private static final ParseField VALUES_FIELD = new ParseField("values");
@@ -57,7 +56,6 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
     private final Set<String> ids = new HashSet<>();
 
     private final String[] types;
-
 
     /**
      * Creates a new IdsQueryBuilder without providing the types of the documents to look for
@@ -74,6 +72,21 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
             throw new IllegalArgumentException("[ids] types cannot be null");
         }
         this.types = types;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public IdsQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        types = in.readStringArray();
+        Collections.addAll(ids, in.readStringArray());
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeStringArray(types);
+        out.writeStringArray(ids.toArray(new String[ids.size()]));
     }
 
     /**
@@ -206,19 +219,6 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
             query = new TermsQuery(UidFieldMapper.NAME, Uid.createUidsForTypesAndIds(typesForQuery, ids));
         }
         return query;
-    }
-
-    @Override
-    protected IdsQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        IdsQueryBuilder idsQueryBuilder = new IdsQueryBuilder(in.readStringArray());
-        idsQueryBuilder.addIds(in.readStringArray());
-        return idsQueryBuilder;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeStringArray(types);
-        out.writeStringArray(ids.toArray(new String[ids.size()]));
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/IndicesQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IndicesQueryBuilder.java
@@ -41,7 +41,6 @@ public class IndicesQueryBuilder extends AbstractQueryBuilder<IndicesQueryBuilde
 
     public static final String NAME = "indices";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final IndicesQueryBuilder PROTOTYPE = new IndicesQueryBuilder(EmptyQueryBuilder.PROTOTYPE, "index");
 
     private static final ParseField QUERY_FIELD = new ParseField("query");
     private static final ParseField NO_MATCH_QUERY = new ParseField("no_match_query");
@@ -63,6 +62,23 @@ public class IndicesQueryBuilder extends AbstractQueryBuilder<IndicesQueryBuilde
         }
         this.innerQuery = Objects.requireNonNull(innerQuery);
         this.indices = indices;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public IndicesQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        innerQuery = in.readQuery();
+        indices = in.readStringArray();
+        noMatchQuery = in.readQuery();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeQuery(innerQuery);
+        out.writeStringArray(indices);
+        out.writeQuery(noMatchQuery);
     }
 
     public QueryBuilder<?> innerQuery() {
@@ -200,20 +216,6 @@ public class IndicesQueryBuilder extends AbstractQueryBuilder<IndicesQueryBuilde
             return innerQuery.toQuery(context);
         }
         return noMatchQuery.toQuery(context);
-    }
-
-    @Override
-    protected IndicesQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        IndicesQueryBuilder indicesQueryBuilder = new IndicesQueryBuilder(in.readQuery(), in.readStringArray());
-        indicesQueryBuilder.noMatchQuery = in.readQuery();
-        return indicesQueryBuilder;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeQuery(innerQuery);
-        out.writeStringArray(indices);
-        out.writeQuery(noMatchQuery);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -37,7 +37,21 @@ public class MatchAllQueryBuilder extends AbstractQueryBuilder<MatchAllQueryBuil
 
     public static final String NAME = "match_all";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final MatchAllQueryBuilder PROTOTYPE = new MatchAllQueryBuilder();
+
+    public MatchAllQueryBuilder() {
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public MatchAllQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        // only superclass has state
+    }
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
@@ -89,16 +103,6 @@ public class MatchAllQueryBuilder extends AbstractQueryBuilder<MatchAllQueryBuil
     @Override
     protected int doHashCode() {
         return 0;
-    }
-
-    @Override
-    protected MatchAllQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        return new MatchAllQueryBuilder();
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        //nothing to write really
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/MatchNoneQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchNoneQueryBuilder.java
@@ -38,7 +38,20 @@ public class MatchNoneQueryBuilder extends AbstractQueryBuilder<MatchNoneQueryBu
     public static final String NAME = "match_none";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
 
-    public static final MatchNoneQueryBuilder PROTOTYPE = new MatchNoneQueryBuilder();
+    public MatchNoneQueryBuilder() {
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public MatchNoneQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        // all state is in the superclass
+    }
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
@@ -91,16 +104,6 @@ public class MatchNoneQueryBuilder extends AbstractQueryBuilder<MatchNoneQueryBu
     @Override
     protected int doHashCode() {
         return 0;
-    }
-
-    @Override
-    protected MatchNoneQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        return new MatchNoneQueryBuilder();
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        //nothing to write really
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/MatchPhrasePrefixQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchPhrasePrefixQueryBuilder.java
@@ -42,8 +42,6 @@ public class MatchPhrasePrefixQueryBuilder extends AbstractQueryBuilder<MatchPhr
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
     public static final ParseField MAX_EXPANSIONS_FIELD = new ParseField("max_expansions");
 
-    public static final MatchPhrasePrefixQueryBuilder PROTOTYPE = new MatchPhrasePrefixQueryBuilder("", "");
-
     private final String fieldName;
 
     private final Object value;
@@ -63,6 +61,27 @@ public class MatchPhrasePrefixQueryBuilder extends AbstractQueryBuilder<MatchPhr
         }
         this.fieldName = fieldName;
         this.value = value;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public MatchPhrasePrefixQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        fieldName = in.readString();
+        value = in.readGenericValue();
+        slop = in.readVInt();
+        maxExpansions = in.readVInt();
+        analyzer = in.readOptionalString();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeGenericValue(value);
+        out.writeVInt(slop);
+        out.writeVInt(maxExpansions);
+        out.writeOptionalString(analyzer);
     }
 
     /** Returns the field name used in this query. */
@@ -156,24 +175,6 @@ public class MatchPhrasePrefixQueryBuilder extends AbstractQueryBuilder<MatchPhr
         matchQuery.setMaxExpansions(maxExpansions);
 
         return matchQuery.parse(MatchQuery.Type.PHRASE_PREFIX, fieldName, value);
-    }
-
-    @Override
-    protected MatchPhrasePrefixQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        MatchPhrasePrefixQueryBuilder matchQuery = new MatchPhrasePrefixQueryBuilder(in.readString(), in.readGenericValue());
-        matchQuery.slop = in.readVInt();
-        matchQuery.maxExpansions = in.readVInt();
-        matchQuery.analyzer = in.readOptionalString();
-        return matchQuery;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(fieldName);
-        out.writeGenericValue(value);
-        out.writeVInt(slop);
-        out.writeVInt(maxExpansions);
-        out.writeOptionalString(analyzer);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/MatchPhraseQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchPhraseQueryBuilder.java
@@ -40,8 +40,6 @@ public class MatchPhraseQueryBuilder extends AbstractQueryBuilder<MatchPhraseQue
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
     public static final ParseField SLOP_FIELD = new ParseField("slop", "phrase_slop");
 
-    public static final MatchPhraseQueryBuilder PROTOTYPE = new MatchPhraseQueryBuilder("", "");
-
     private final String fieldName;
 
     private final Object value;
@@ -59,6 +57,25 @@ public class MatchPhraseQueryBuilder extends AbstractQueryBuilder<MatchPhraseQue
         }
         this.fieldName = fieldName;
         this.value = value;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public MatchPhraseQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        fieldName = in.readString();
+        value = in.readGenericValue();
+        slop = in.readVInt();
+        analyzer = in.readOptionalString();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeGenericValue(value);
+        out.writeVInt(slop);
+        out.writeOptionalString(analyzer);
     }
 
     /** Returns the field name used in this query. */
@@ -131,22 +148,6 @@ public class MatchPhraseQueryBuilder extends AbstractQueryBuilder<MatchPhraseQue
         matchQuery.setPhraseSlop(slop);
 
         return matchQuery.parse(MatchQuery.Type.PHRASE, fieldName, value);
-    }
-
-    @Override
-    protected MatchPhraseQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        MatchPhraseQueryBuilder matchQuery = new MatchPhraseQueryBuilder(in.readString(), in.readGenericValue());
-        matchQuery.slop = in.readVInt();
-        matchQuery.analyzer = in.readOptionalString();
-        return matchQuery;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(fieldName);
-        out.writeGenericValue(value);
-        out.writeVInt(slop);
-        out.writeOptionalString(analyzer);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -102,8 +102,6 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
 
     private Float cutoffFrequency = null;
 
-    public static final MatchQueryBuilder PROTOTYPE = new MatchQueryBuilder("","");
-
     /**
      * Constructs a new match query.
      */
@@ -116,6 +114,49 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
         }
         this.fieldName = fieldName;
         this.value = value;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public MatchQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        fieldName = in.readString();
+        value = in.readGenericValue();
+        type = MatchQuery.Type.readFromStream(in);
+        operator = Operator.readFromStream(in);
+        slop = in.readVInt();
+        prefixLength = in.readVInt();
+        maxExpansions = in.readVInt();
+        fuzzyTranspositions = in.readBoolean();
+        lenient = in.readBoolean();
+        zeroTermsQuery = MatchQuery.ZeroTermsQuery.readFromStream(in);
+        // optional fields
+        analyzer = in.readOptionalString();
+        minimumShouldMatch = in.readOptionalString();
+        fuzzyRewrite = in.readOptionalString();
+        fuzziness = in.readOptionalWriteable(Fuzziness::new);
+        cutoffFrequency = in.readOptionalFloat();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeGenericValue(value);
+        type.writeTo(out);
+        operator.writeTo(out);
+        out.writeVInt(slop);
+        out.writeVInt(prefixLength);
+        out.writeVInt(maxExpansions);
+        out.writeBoolean(fuzzyTranspositions);
+        out.writeBoolean(lenient);
+        zeroTermsQuery.writeTo(out);
+        // optional fields
+        out.writeOptionalString(analyzer);
+        out.writeOptionalString(minimumShouldMatch);
+        out.writeOptionalString(fuzzyRewrite);
+        out.writeOptionalWriteable(fuzziness);
+        out.writeOptionalFloat(cutoffFrequency);
     }
 
     /** Returns the field name used in this query. */
@@ -459,60 +500,6 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
         return Objects.hash(fieldName, value, type, operator, analyzer, slop,
                 fuzziness, prefixLength, maxExpansions, minimumShouldMatch,
                 fuzzyRewrite, lenient, fuzzyTranspositions, zeroTermsQuery, cutoffFrequency);
-    }
-
-    @Override
-    protected MatchQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        MatchQueryBuilder matchQuery = new MatchQueryBuilder(in.readString(), in.readGenericValue());
-        matchQuery.type = MatchQuery.Type.readTypeFrom(in);
-        matchQuery.operator = Operator.readOperatorFrom(in);
-        matchQuery.slop = in.readVInt();
-        matchQuery.prefixLength = in.readVInt();
-        matchQuery.maxExpansions = in.readVInt();
-        matchQuery.fuzzyTranspositions = in.readBoolean();
-        matchQuery.lenient = in.readBoolean();
-        matchQuery.zeroTermsQuery = MatchQuery.ZeroTermsQuery.readZeroTermsQueryFrom(in);
-        // optional fields
-        matchQuery.analyzer = in.readOptionalString();
-        matchQuery.minimumShouldMatch = in.readOptionalString();
-        matchQuery.fuzzyRewrite = in.readOptionalString();
-        if (in.readBoolean()) {
-            matchQuery.fuzziness = Fuzziness.readFuzzinessFrom(in);
-        }
-        if (in.readBoolean()) {
-            matchQuery.cutoffFrequency = in.readFloat();
-        }
-        return matchQuery;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(fieldName);
-        out.writeGenericValue(value);
-        type.writeTo(out);
-        operator.writeTo(out);
-        out.writeVInt(slop);
-        out.writeVInt(prefixLength);
-        out.writeVInt(maxExpansions);
-        out.writeBoolean(fuzzyTranspositions);
-        out.writeBoolean(lenient);
-        zeroTermsQuery.writeTo(out);
-        // optional fields
-        out.writeOptionalString(analyzer);
-        out.writeOptionalString(minimumShouldMatch);
-        out.writeOptionalString(fuzzyRewrite);
-        if (fuzziness == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            fuzziness.writeTo(out);
-        }
-        if (cutoffFrequency == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            out.writeFloat(cutoffFrequency);
-        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -43,7 +43,6 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
      */
     public static final String NAME = "nested";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final NestedQueryBuilder PROTOTYPE = new NestedQueryBuilder("", EmptyQueryBuilder.PROTOTYPE);
 
     /**
      * The default score move for nested queries.
@@ -82,6 +81,25 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
             this.innerHitBuilder.setNestedPath(path);
             this.innerHitBuilder.setQuery(query);
         }
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public NestedQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        path = in.readString();
+        scoreMode = ScoreMode.values()[in.readVInt()];
+        query = in.readQuery();
+        innerHitBuilder = in.readOptionalWriteable(InnerHitBuilder::new);
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(path);
+        out.writeVInt(scoreMode.ordinal());
+        out.writeQuery(query);
+        out.writeOptionalWriteable(innerHitBuilder);
     }
 
     /**
@@ -196,32 +214,6 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
     @Override
     protected int doHashCode() {
         return Objects.hash(query, path, scoreMode, innerHitBuilder);
-    }
-
-    private NestedQueryBuilder(StreamInput in) throws IOException {
-        path = in.readString();
-        final int ordinal = in.readVInt();
-        scoreMode = ScoreMode.values()[ordinal];
-        query = in.readQuery();
-        innerHitBuilder = InnerHitBuilder.optionalReadFromStream(in);
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(path);
-        out.writeVInt(scoreMode.ordinal());
-        out.writeQuery(query);
-        if (innerHitBuilder != null) {
-            out.writeBoolean(true);
-            innerHitBuilder.writeTo(out);
-        } else {
-            out.writeBoolean(false);
-        }
-    }
-
-    @Override
-    protected NestedQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        return new NestedQueryBuilder(in);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/Operator.java
+++ b/core/src/main/java/org/elasticsearch/index/query/Operator.java
@@ -53,7 +53,7 @@ public enum Operator implements Writeable<Operator> {
         }
     }
 
-    public static Operator readOperatorFrom(StreamInput in) throws IOException {
+    public static Operator readFromStream(StreamInput in) throws IOException {
         int ordinal = in.readVInt();
         if (ordinal < 0 || ordinal >= values().length) {
             throw new IOException("Unknown Operator ordinal [" + ordinal + "]");

--- a/core/src/main/java/org/elasticsearch/index/query/ParentIdQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ParentIdQueryBuilder.java
@@ -43,8 +43,6 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
     public static final String NAME = "parent_id";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
 
-    public static final ParentIdQueryBuilder PROTO = new ParentIdQueryBuilder(null, null);
-
     private static final ParseField ID_FIELD = new ParseField("id");
     private static final ParseField TYPE_FIELD = new ParseField("type", "child_type");
 
@@ -54,6 +52,21 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
     public ParentIdQueryBuilder(String type, String id) {
         this.type = type;
         this.id = id;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public ParentIdQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        type = in.readString();
+        id = in.readString();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(type);
+        out.writeString(id);
     }
 
     public String getType() {
@@ -124,19 +137,6 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
         // Need to take child type into account, otherwise a child doc of different type with the same id could match
         query.add(new TermQuery(new Term(TypeFieldMapper.NAME, type)), BooleanClause.Occur.FILTER);
         return query.build();
-    }
-
-    @Override
-    protected ParentIdQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        String type = in.readString();
-        String id = in.readString();
-        return new ParentIdQueryBuilder(type, id);
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(type);
-        out.writeString(id);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/PercolatorQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/PercolatorQueryBuilder.java
@@ -71,8 +71,6 @@ public class PercolatorQueryBuilder extends AbstractQueryBuilder<PercolatorQuery
     public static final String NAME = "percolator";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
 
-    public static final PercolatorQueryBuilder PROTO = new PercolatorQueryBuilder(null, null, null, null, null, null, null, null);
-
     static final ParseField DOCUMENT_FIELD = new ParseField("document");
     private static final ParseField DOCUMENT_TYPE_FIELD = new ParseField("document_type");
     private static final ParseField INDEXED_DOCUMENT_FIELD_INDEX = new ParseField("index");
@@ -134,17 +132,40 @@ public class PercolatorQueryBuilder extends AbstractQueryBuilder<PercolatorQuery
         this.document = null;
     }
 
-    private PercolatorQueryBuilder(String documentType, BytesReference document, String indexedDocumentIndex, String indexedDocumentType,
-                                   String indexedDocumentId, String indexedDocumentRouting, String indexedDocumentPreference,
-                                   Long indexedDocumentVersion) {
-        this.documentType = documentType;
-        this.document = document;
-        this.indexedDocumentIndex = indexedDocumentIndex;
-        this.indexedDocumentType = indexedDocumentType;
-        this.indexedDocumentId = indexedDocumentId;
-        this.indexedDocumentRouting = indexedDocumentRouting;
-        this.indexedDocumentPreference = indexedDocumentPreference;
-        this.indexedDocumentVersion = indexedDocumentVersion;
+    /**
+     * Read from a stream.
+     */
+    public PercolatorQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        documentType = in.readString();
+        indexedDocumentIndex = in.readOptionalString();
+        indexedDocumentType = in.readOptionalString();
+        indexedDocumentId = in.readOptionalString();
+        indexedDocumentRouting = in.readOptionalString();
+        indexedDocumentPreference = in.readOptionalString();
+        if (in.readBoolean()) {
+            indexedDocumentVersion = in.readVLong();
+        } else {
+            indexedDocumentVersion = null;
+        }
+        document = in.readOptionalBytesReference();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(documentType);
+        out.writeOptionalString(indexedDocumentIndex);
+        out.writeOptionalString(indexedDocumentType);
+        out.writeOptionalString(indexedDocumentId);
+        out.writeOptionalString(indexedDocumentRouting);
+        out.writeOptionalString(indexedDocumentPreference);
+        if (indexedDocumentVersion != null) {
+            out.writeBoolean(true);
+            out.writeVLong(indexedDocumentVersion);
+        } else {
+            out.writeBoolean(false);
+        }
+        out.writeOptionalBytesReference(document);
     }
 
     @Override
@@ -265,48 +286,6 @@ public class PercolatorQueryBuilder extends AbstractQueryBuilder<PercolatorQuery
         queryBuilder.queryName(queryName);
         queryBuilder.boost(boost);
         return queryBuilder;
-    }
-
-    @Override
-    protected PercolatorQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        String docType = in.readString();
-        String documentIndex = in.readOptionalString();
-        String documentType = in.readOptionalString();
-        String documentId = in.readOptionalString();
-        String documentRouting = in.readOptionalString();
-        String documentPreference = in.readOptionalString();
-        Long documentVersion = null;
-        if (in.readBoolean()) {
-            documentVersion = in.readVLong();
-        }
-        BytesReference documentSource = null;
-        if (in.readBoolean()) {
-            documentSource = in.readBytesReference();
-        }
-        return new PercolatorQueryBuilder(docType, documentSource, documentIndex, documentType, documentId,
-                documentRouting, documentPreference, documentVersion);
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(documentType);
-        out.writeOptionalString(indexedDocumentIndex);
-        out.writeOptionalString(indexedDocumentType);
-        out.writeOptionalString(indexedDocumentId);
-        out.writeOptionalString(indexedDocumentRouting);
-        out.writeOptionalString(indexedDocumentPreference);
-        if (indexedDocumentVersion != null) {
-            out.writeBoolean(true);
-            out.writeVLong(indexedDocumentVersion);
-        } else {
-            out.writeBoolean(false);
-        }
-        if (document != null) {
-            out.writeBoolean(true);
-            out.writeBytesReference(document);
-        } else {
-            out.writeBoolean(false);
-        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
@@ -44,7 +44,6 @@ public class PrefixQueryBuilder extends AbstractQueryBuilder<PrefixQueryBuilder>
 
     public static final String NAME = "prefix";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final PrefixQueryBuilder PROTOTYPE = new PrefixQueryBuilder("field", "value");
 
     private static final ParseField PREFIX_FIELD = new ParseField("value", "prefix");
     private static final ParseField REWRITE_FIELD = new ParseField("rewrite");
@@ -70,6 +69,23 @@ public class PrefixQueryBuilder extends AbstractQueryBuilder<PrefixQueryBuilder>
         }
         this.fieldName = fieldName;
         this.value = value;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public PrefixQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        fieldName = in.readString();
+        value = in.readString();
+        rewrite = in.readOptionalString();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeString(value);
+        out.writeOptionalString(rewrite);
     }
 
     public String fieldName() {
@@ -176,20 +192,6 @@ public class PrefixQueryBuilder extends AbstractQueryBuilder<PrefixQueryBuilder>
         }
 
         return query;
-    }
-
-    @Override
-    protected PrefixQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        PrefixQueryBuilder prefixQueryBuilder = new PrefixQueryBuilder(in.readString(), in.readString());
-        prefixQueryBuilder.rewrite = in.readOptionalString();
-        return prefixQueryBuilder;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(fieldName);
-        out.writeString(value);
-        out.writeOptionalString(rewrite);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -45,7 +45,6 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
 
     public static final String NAME = "regexp";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final RegexpQueryBuilder PROTOTYPE = new RegexpQueryBuilder("field", "value");
 
     public static final int DEFAULT_FLAGS_VALUE = RegexpFlag.ALL.value();
     public static final int DEFAULT_MAX_DETERMINIZED_STATES = Operations.DEFAULT_MAX_DETERMINIZED_STATES;
@@ -83,6 +82,27 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
         }
         this.fieldName = fieldName;
         this.value = value;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public RegexpQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        fieldName = in.readString();
+        value = in.readString();
+        flagsValue = in.readVInt();
+        maxDeterminizedStates = in.readVInt();
+        rewrite = in.readOptionalString();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeString(value);
+        out.writeVInt(flagsValue);
+        out.writeVInt(maxDeterminizedStates);
+        out.writeOptionalString(rewrite);
     }
 
     /** Returns the field name used in this query. */
@@ -247,24 +267,6 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
             query = regexpQuery;
         }
         return query;
-    }
-
-    @Override
-    protected RegexpQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        RegexpQueryBuilder regexpQueryBuilder = new RegexpQueryBuilder(in.readString(), in.readString());
-        regexpQueryBuilder.flagsValue = in.readVInt();
-        regexpQueryBuilder.maxDeterminizedStates = in.readVInt();
-        regexpQueryBuilder.rewrite = in.readOptionalString();
-        return regexpQueryBuilder;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(fieldName);
-        out.writeString(value);
-        out.writeVInt(flagsValue);
-        out.writeVInt(maxDeterminizedStates);
-        out.writeOptionalString(rewrite);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
@@ -52,8 +52,6 @@ public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder>
     public static final String NAME = "script";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
 
-    public static final ScriptQueryBuilder PROTOTYPE = new ScriptQueryBuilder(new Script(""));
-
     private static final ParseField PARAMS_FIELD = new ParseField("params");
 
     private final Script script;
@@ -63,6 +61,19 @@ public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder>
             throw new IllegalArgumentException("script cannot be null");
         }
         this.script = script;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public ScriptQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        script = Script.readScript(in);
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        script.writeTo(out);
     }
 
     public Script script() {
@@ -215,16 +226,6 @@ public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder>
                 }
             };
         }
-    }
-
-    @Override
-    protected ScriptQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        return new ScriptQueryBuilder(Script.readScript(in));
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        script.writeTo(out);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
@@ -40,20 +40,18 @@ public class SpanContainingQueryBuilder extends AbstractQueryBuilder<SpanContain
 
     public static final String NAME = "span_containing";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final SpanContainingQueryBuilder PROTOTYPE =
-            new SpanContainingQueryBuilder(SpanTermQueryBuilder.PROTOTYPE, SpanTermQueryBuilder.PROTOTYPE);
 
     private static final ParseField BIG_FIELD = new ParseField("big");
     private static final ParseField LITTLE_FIELD = new ParseField("little");
 
-    private final SpanQueryBuilder big;
-    private final SpanQueryBuilder little;
+    private final SpanQueryBuilder<?> big;
+    private final SpanQueryBuilder<?> little;
 
     /**
      * @param big the big clause, it must enclose {@code little} for a match.
      * @param little the little clause, it must be contained within {@code big} for a match.
      */
-    public SpanContainingQueryBuilder(SpanQueryBuilder big, SpanQueryBuilder little) {
+    public SpanContainingQueryBuilder(SpanQueryBuilder<?> big, SpanQueryBuilder<?> little) {
         if (big == null) {
             throw new IllegalArgumentException("inner clause [big] cannot be null.");
         }
@@ -62,6 +60,21 @@ public class SpanContainingQueryBuilder extends AbstractQueryBuilder<SpanContain
         }
         this.little = little;
         this.big = big;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public SpanContainingQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        big = (SpanQueryBuilder<?>) in.readQuery();
+        little = (SpanQueryBuilder<?>) in.readQuery();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeQuery(big);
+        out.writeQuery(little);
     }
 
     /**
@@ -140,19 +153,6 @@ public class SpanContainingQueryBuilder extends AbstractQueryBuilder<SpanContain
         Query innerLittle = little.toQuery(context);
         assert innerLittle instanceof SpanQuery;
         return new SpanContainingQuery((SpanQuery) innerBig, (SpanQuery) innerLittle);
-    }
-
-    @Override
-    protected SpanContainingQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        SpanQueryBuilder big = (SpanQueryBuilder)in.readQuery();
-        SpanQueryBuilder little = (SpanQueryBuilder)in.readQuery();
-        return new SpanContainingQueryBuilder(big, little);
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeQuery(big);
-        out.writeQuery(little);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
@@ -44,20 +44,31 @@ public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTer
     public static final String NAME = "span_multi";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
 
-    public static final SpanMultiTermQueryBuilder PROTOTYPE = new SpanMultiTermQueryBuilder(RangeQueryBuilder.PROTOTYPE);
-
     private static final ParseField MATCH_FIELD = new ParseField("match");
 
-    private final MultiTermQueryBuilder multiTermQueryBuilder;
+    private final MultiTermQueryBuilder<?> multiTermQueryBuilder;
 
-    public SpanMultiTermQueryBuilder(MultiTermQueryBuilder multiTermQueryBuilder) {
+    public SpanMultiTermQueryBuilder(MultiTermQueryBuilder<?> multiTermQueryBuilder) {
         if (multiTermQueryBuilder == null) {
             throw new IllegalArgumentException("inner multi term query cannot be null");
         }
         this.multiTermQueryBuilder = multiTermQueryBuilder;
     }
 
-    public MultiTermQueryBuilder innerQuery() {
+    /**
+     * Read from a stream.
+     */
+    public SpanMultiTermQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        multiTermQueryBuilder = (MultiTermQueryBuilder<?>) in.readQuery();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeQuery(multiTermQueryBuilder);
+    }
+
+    public MultiTermQueryBuilder<?> innerQuery() {
         return this.multiTermQueryBuilder;
     }
 
@@ -131,17 +142,6 @@ public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTer
             wrapper = new SpanBoostQuery(wrapper, boost);
         }
         return wrapper;
-    }
-
-    @Override
-    protected SpanMultiTermQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        MultiTermQueryBuilder multiTermBuilder = (MultiTermQueryBuilder)in.readQuery();
-        return new SpanMultiTermQueryBuilder(multiTermBuilder);
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeQuery(multiTermQueryBuilder);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
@@ -36,8 +36,6 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
 
     public static final String NAME = "span_not";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final SpanNotQueryBuilder PROTOTYPE = new SpanNotQueryBuilder(SpanTermQueryBuilder.PROTOTYPE,
-            SpanTermQueryBuilder.PROTOTYPE);
 
     /** the default pre parameter size */
     public static final int DEFAULT_PRE = 0;
@@ -50,9 +48,9 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
     private static final ParseField EXCLUDE_FIELD = new ParseField("exclude");
     private static final ParseField INCLUDE_FIELD = new ParseField("include");
 
-    private final SpanQueryBuilder include;
+    private final SpanQueryBuilder<?> include;
 
-    private final SpanQueryBuilder exclude;
+    private final SpanQueryBuilder<?> exclude;
 
     private int pre = DEFAULT_PRE;
 
@@ -64,7 +62,7 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
      * @param include the span query whose matches are filtered
      * @param exclude the span query whose matches must not overlap
      */
-    public SpanNotQueryBuilder(SpanQueryBuilder include, SpanQueryBuilder exclude) {
+    public SpanNotQueryBuilder(SpanQueryBuilder<?> include, SpanQueryBuilder<?> exclude) {
         if (include == null) {
             throw new IllegalArgumentException("inner clause [include] cannot be null.");
         }
@@ -73,6 +71,25 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
         }
         this.include = include;
         this.exclude = exclude;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public SpanNotQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        include = (SpanQueryBuilder<?>) in.readQuery();
+        exclude = (SpanQueryBuilder<?>) in.readQuery();
+        pre = in.readVInt();
+        post = in.readVInt();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeQuery(include);
+        out.writeQuery(exclude);
+        out.writeVInt(pre);
+        out.writeVInt(post);
     }
 
     /**
@@ -230,24 +247,6 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
         assert excludeQuery instanceof SpanQuery;
 
         return new SpanNotQuery((SpanQuery) includeQuery, (SpanQuery) excludeQuery, pre, post);
-    }
-
-    @Override
-    protected SpanNotQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        SpanQueryBuilder include = (SpanQueryBuilder)in.readQuery();
-        SpanQueryBuilder exclude = (SpanQueryBuilder)in.readQuery();
-        SpanNotQueryBuilder queryBuilder = new SpanNotQueryBuilder(include, exclude);
-        queryBuilder.pre(in.readVInt());
-        queryBuilder.post(in.readVInt());
-        return queryBuilder;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeQuery(include);
-        out.writeQuery(exclude);
-        out.writeVInt(pre);
-        out.writeVInt(post);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
@@ -41,7 +41,6 @@ public class SpanOrQueryBuilder extends AbstractQueryBuilder<SpanOrQueryBuilder>
 
     public static final String NAME = "span_or";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final SpanOrQueryBuilder PROTOTYPE = new SpanOrQueryBuilder(SpanTermQueryBuilder.PROTOTYPE);
 
     private static final ParseField CLAUSES_FIELD = new ParseField("clauses");
 
@@ -52,6 +51,21 @@ public class SpanOrQueryBuilder extends AbstractQueryBuilder<SpanOrQueryBuilder>
             throw new IllegalArgumentException("query must include at least one clause");
         }
         clauses.add(initialClause);
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public SpanOrQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        for (QueryBuilder<?> clause: readQueries(in)) {
+            clauses.add((SpanQueryBuilder<?>) clause);
+        }
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        writeQueries(out, clauses);
     }
 
     public SpanOrQueryBuilder clause(SpanQueryBuilder<?> clause) {
@@ -139,22 +153,6 @@ public class SpanOrQueryBuilder extends AbstractQueryBuilder<SpanOrQueryBuilder>
             spanQueries[i] = (SpanQuery) query;
         }
         return new SpanOrQuery(spanQueries);
-    }
-
-    @Override
-    protected SpanOrQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        List<QueryBuilder<?>> clauses = readQueries(in);
-        SpanOrQueryBuilder queryBuilder = new SpanOrQueryBuilder((SpanQueryBuilder<?>)clauses.get(0));
-        for (int i = 1; i < clauses.size(); i++) {
-            queryBuilder.clauses.add((SpanQueryBuilder<?>)clauses.get(i));
-        }
-        return queryBuilder;
-
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        writeQueries(out, clauses);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
@@ -25,6 +25,7 @@ import org.apache.lucene.search.spans.SpanQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -71,6 +72,13 @@ public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuil
     /** @see BaseTermQueryBuilder#BaseTermQueryBuilder(String, Object) */
     public SpanTermQueryBuilder(String name, Object value) {
         super(name, value);
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public SpanTermQueryBuilder(StreamInput in) throws IOException {
+        super(in);
     }
 
     @Override
@@ -136,11 +144,6 @@ public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuil
         SpanTermQueryBuilder result = new SpanTermQueryBuilder(fieldName, value);
         result.boost(boost).queryName(queryName);
         return result;
-    }
-
-    @Override
-    protected SpanTermQueryBuilder createBuilder(String fieldName, Object value) {
-        return new SpanTermQueryBuilder(fieldName, value);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
@@ -40,21 +40,19 @@ public class SpanWithinQueryBuilder extends AbstractQueryBuilder<SpanWithinQuery
 
     public static final String NAME = "span_within";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final SpanWithinQueryBuilder PROTOTYPE =
-            new SpanWithinQueryBuilder(SpanTermQueryBuilder.PROTOTYPE, SpanTermQueryBuilder.PROTOTYPE);
 
     private static final ParseField BIG_FIELD = new ParseField("big");
     private static final ParseField LITTLE_FIELD = new ParseField("little");
 
-    private final SpanQueryBuilder big;
-    private final SpanQueryBuilder little;
+    private final SpanQueryBuilder<?> big;
+    private final SpanQueryBuilder<?> little;
 
     /**
      * Query that returns spans from <code>little</code> that are contained in a spans from <code>big</code>.
      * @param big clause that must enclose {@code little} for a match.
      * @param little the little clause, it must be contained within {@code big} for a match.
      */
-    public SpanWithinQueryBuilder(SpanQueryBuilder big, SpanQueryBuilder little) {
+    public SpanWithinQueryBuilder(SpanQueryBuilder<?> big, SpanQueryBuilder<?> little) {
         if (big == null) {
             throw new IllegalArgumentException("inner clause [big] cannot be null.");
         }
@@ -63,6 +61,21 @@ public class SpanWithinQueryBuilder extends AbstractQueryBuilder<SpanWithinQuery
         }
         this.little = little;
         this.big = big;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public SpanWithinQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        big = (SpanQueryBuilder<?>) in.readQuery();
+        little = (SpanQueryBuilder<?>) in.readQuery();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeQuery(big);
+        out.writeQuery(little);
     }
 
     /**
@@ -152,19 +165,6 @@ public class SpanWithinQueryBuilder extends AbstractQueryBuilder<SpanWithinQuery
         Query innerLittle = little.toQuery(context);
         assert innerLittle instanceof SpanQuery;
         return new SpanWithinQuery((SpanQuery) innerBig, (SpanQuery) innerLittle);
-    }
-
-    @Override
-    protected SpanWithinQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        SpanQueryBuilder big = (SpanQueryBuilder)in.readQuery();
-        SpanQueryBuilder little = (SpanQueryBuilder)in.readQuery();
-        return new SpanWithinQueryBuilder(big, little);
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeQuery(big);
-        out.writeQuery(little);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
@@ -56,8 +56,6 @@ public class TemplateQueryBuilder extends AbstractQueryBuilder<TemplateQueryBuil
     /** Template to fill. */
     private final Template template;
 
-    public static final TemplateQueryBuilder PROTOTYPE = new TemplateQueryBuilder(new Template("proto"));
-
     /**
      * @param template
      *            the template to use for that query.
@@ -97,6 +95,19 @@ public class TemplateQueryBuilder extends AbstractQueryBuilder<TemplateQueryBuil
     @Deprecated
     public TemplateQueryBuilder(String template, ScriptService.ScriptType templateType, Map<String, Object> vars) {
         this(new Template(template, templateType, null, null, vars));
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public TemplateQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        template = Template.readTemplate(in);
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        template.writeTo(out);
     }
 
     @Override
@@ -149,17 +160,6 @@ public class TemplateQueryBuilder extends AbstractQueryBuilder<TemplateQueryBuil
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
         throw new UnsupportedOperationException("this query must be rewritten first");
-    }
-
-    @Override
-    protected TemplateQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        TemplateQueryBuilder templateQueryBuilder = new TemplateQueryBuilder(Template.readTemplate(in));
-        return templateQueryBuilder;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        template.writeTo(out);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -24,6 +24,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -37,7 +38,6 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
 
     public static final String NAME = "term";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final TermQueryBuilder PROTOTYPE = new TermQueryBuilder("name", "value");
 
     private static final ParseField TERM_FIELD = new ParseField("term");
     private static final ParseField VALUE_FIELD = new ParseField("value");
@@ -75,6 +75,13 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
     /** @see BaseTermQueryBuilder#BaseTermQueryBuilder(String, Object) */
     public TermQueryBuilder(String fieldName, Object value) {
         super(fieldName, value);
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public TermQueryBuilder(StreamInput in) throws IOException {
+        super(in);
     }
 
     public static TermQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
@@ -147,11 +154,6 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
             query = new TermQuery(new Term(this.fieldName, BytesRefs.toBytesRef(this.value)));
         }
         return query;
-    }
-
-    @Override
-    protected TermQueryBuilder createBuilder(String fieldName, Object value) {
-        return new TermQueryBuilder(fieldName, value);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
@@ -42,8 +42,6 @@ public class TypeQueryBuilder extends AbstractQueryBuilder<TypeQueryBuilder> {
 
     private final BytesRef type;
 
-    public static final TypeQueryBuilder PROTOTYPE = new TypeQueryBuilder("type");
-
     public TypeQueryBuilder(String type) {
         if (type == null) {
             throw new IllegalArgumentException("[type] cannot be null");
@@ -56,6 +54,19 @@ public class TypeQueryBuilder extends AbstractQueryBuilder<TypeQueryBuilder> {
             throw new IllegalArgumentException("[type] cannot be null");
         }
         this.type = type;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public TypeQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        type = in.readBytesRef();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeBytesRef(type);
     }
 
     public String type() {
@@ -124,16 +135,6 @@ public class TypeQueryBuilder extends AbstractQueryBuilder<TypeQueryBuilder> {
         } else {
             return documentMapper.typeFilter();
         }
-    }
-
-    @Override
-    protected TypeQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        return new TypeQueryBuilder(in.readBytesRef());
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeBytesRef(type);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -50,7 +50,6 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
 
     public static final String NAME = "wildcard";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
-    public static final WildcardQueryBuilder PROTOTYPE = new WildcardQueryBuilder("field", "value");
 
     private static final ParseField WILDCARD_FIELD = new ParseField("wildcard");
     private static final ParseField VALUE_FIELD = new ParseField("value");
@@ -82,6 +81,23 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
         }
         this.fieldName = fieldName;
         this.value = value;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public WildcardQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        fieldName = in.readString();
+        value = in.readString();
+        rewrite = in.readOptionalString();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeString(value);
+        out.writeOptionalString(rewrite);
     }
 
     public String fieldName() {
@@ -162,7 +178,7 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
         }
 
         if (value == null) {
-            throw new ParsingException(parser.getTokenLocation(), "No value specified for prefix query");
+            throw new ParsingException(parser.getTokenLocation(), "No value specified for wildcard query");
         }
         return new WildcardQueryBuilder(fieldName, value)
                 .rewrite(rewrite)
@@ -185,20 +201,6 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
         MultiTermQuery.RewriteMethod rewriteMethod = QueryParsers.parseRewriteMethod(context.parseFieldMatcher(), rewrite, null);
         QueryParsers.setRewriteMethod(query, rewriteMethod);
         return query;
-    }
-
-    @Override
-    protected WildcardQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        WildcardQueryBuilder wildcardQueryBuilder = new WildcardQueryBuilder(in.readString(), in.readString());
-        wildcardQueryBuilder.rewrite = in.readOptionalString();
-        return wildcardQueryBuilder;
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(fieldName);
-        out.writeString(value);
-        out.writeOptionalString(rewrite);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
@@ -53,8 +53,6 @@ public class WrapperQueryBuilder extends AbstractQueryBuilder<WrapperQueryBuilde
     public static final String NAME = "wrapper";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
 
-    public static final WrapperQueryBuilder PROTOTYPE = new WrapperQueryBuilder((byte[]) new byte[]{0});
-
     private static final ParseField QUERY_FIELD = new ParseField("query");
 
     private final byte[] source;
@@ -87,6 +85,19 @@ public class WrapperQueryBuilder extends AbstractQueryBuilder<WrapperQueryBuilde
             throw new IllegalArgumentException("query source text cannot be null or empty");
         }
         this.source = source.array();
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public WrapperQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        source = in.readByteArray();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeByteArray(this.source);
     }
 
     public byte[] source() {
@@ -136,16 +147,6 @@ public class WrapperQueryBuilder extends AbstractQueryBuilder<WrapperQueryBuilde
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
         throw new UnsupportedOperationException("this query must be rewritten first");
-    }
-
-    @Override
-    protected WrapperQueryBuilder doReadFrom(StreamInput in) throws IOException {
-        return new WrapperQueryBuilder(in.readByteArray());
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeByteArray(this.source);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/support/InnerHitBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/support/InnerHitBuilder.java
@@ -116,14 +116,6 @@ public final class InnerHitBuilder extends ToXContentToBytes implements Writeabl
         }, SearchSourceBuilder.INNER_HITS_FIELD);
     }
 
-    public static InnerHitBuilder optionalReadFromStream(StreamInput in) throws IOException {
-        if (in.readBoolean()) {
-            return new InnerHitBuilder(in);
-        } else {
-            return null;
-        }
-    }
-
     private String name;
     private String nestedPath;
     private String parentChildType;
@@ -143,8 +135,13 @@ public final class InnerHitBuilder extends ToXContentToBytes implements Writeabl
     private InnerHitsBuilder innerHitsBuilder;
     private FetchSourceContext fetchSourceContext;
 
-    // pkg protected, because is used in InnerHitsBuilder
-    InnerHitBuilder(StreamInput in) throws IOException {
+    public InnerHitBuilder() {
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public InnerHitBuilder(StreamInput in) throws IOException {
         name = in.readOptionalString();
         nestedPath = in.readOptionalString();
         parentChildType = in.readOptionalString();
@@ -156,9 +153,9 @@ public final class InnerHitBuilder extends ToXContentToBytes implements Writeabl
         fieldNames = (List<String>) in.readGenericValue();
         fieldDataFields = (List<String>) in.readGenericValue();
         if (in.readBoolean()) {
-            scriptFields = in.readList(t -> ScriptField.PROTOTYPE.readFrom(in));
+            scriptFields = in.readList(ScriptField.PROTOTYPE::readFrom);
         }
-        fetchSourceContext = FetchSourceContext.optionalReadFromStream(in);
+        fetchSourceContext = in.readOptionalStreamable(FetchSourceContext::new);
         if (in.readBoolean()) {
             int size = in.readVInt();
             sorts = new ArrayList<>(size);
@@ -171,7 +168,35 @@ public final class InnerHitBuilder extends ToXContentToBytes implements Writeabl
         innerHitsBuilder = in.readOptionalWriteable(InnerHitsBuilder.PROTO::readFrom);
     }
 
-    public InnerHitBuilder() {
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalString(name);
+        out.writeOptionalString(nestedPath);
+        out.writeOptionalString(parentChildType);
+        out.writeVInt(from);
+        out.writeVInt(size);
+        out.writeBoolean(explain);
+        out.writeBoolean(version);
+        out.writeBoolean(trackScores);
+        out.writeGenericValue(fieldNames);
+        out.writeGenericValue(fieldDataFields);
+        boolean hasScriptFields = scriptFields != null;
+        out.writeBoolean(hasScriptFields);
+        if (hasScriptFields) {
+            out.writeList(scriptFields);
+        }
+        out.writeOptionalStreamable(fetchSourceContext);
+        boolean hasSorts = sorts != null;
+        out.writeBoolean(hasSorts);
+        if (hasSorts) {
+            out.writeVInt(sorts.size());
+            for (SortBuilder<?> sort : sorts) {
+                out.writeSortBuilder(sort);
+            }
+        }
+        out.writeOptionalWriteable(highlightBuilder);
+        out.writeQuery(query);
+        out.writeOptionalWriteable(innerHitsBuilder);
     }
 
     public InnerHitBuilder setParentChildType(String parentChildType) {
@@ -458,37 +483,6 @@ public final class InnerHitBuilder extends ToXContentToBytes implements Writeabl
         }
         ParsedQuery parsedQuery = new ParsedQuery(query.toQuery(context), context.copyNamedQueries());
         innerHitsContext.parsedQuery(parsedQuery);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeOptionalString(name);
-        out.writeOptionalString(nestedPath);
-        out.writeOptionalString(parentChildType);
-        out.writeVInt(from);
-        out.writeVInt(size);
-        out.writeBoolean(explain);
-        out.writeBoolean(version);
-        out.writeBoolean(trackScores);
-        out.writeGenericValue(fieldNames);
-        out.writeGenericValue(fieldDataFields);
-        boolean hasScriptFields = scriptFields != null;
-        out.writeBoolean(hasScriptFields);
-        if (hasScriptFields) {
-            out.writeList(scriptFields);
-        }
-        FetchSourceContext.optionalWriteToStream(fetchSourceContext, out);
-        boolean hasSorts = sorts != null;
-        out.writeBoolean(hasSorts);
-        if (hasSorts) {
-            out.writeVInt(sorts.size());
-            for (SortBuilder<?> sort : sorts) {
-                out.writeSortBuilder(sort);
-            }
-        }
-        out.writeOptionalWriteable(highlightBuilder);
-        out.writeQuery(query);
-        out.writeOptionalWriteable(innerHitsBuilder);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -64,14 +64,11 @@ public class MatchQuery {
 
         private final int ordinal;
 
-        private static final Type PROTOTYPE = BOOLEAN;
-
         private Type(int ordinal) {
             this.ordinal = ordinal;
         }
 
-        @Override
-        public Type readFrom(StreamInput in) throws IOException {
+        public static Type readFromStream(StreamInput in) throws IOException {
             int ord = in.readVInt();
             for (Type type : Type.values()) {
                 if (type.ordinal == ord) {
@@ -79,10 +76,6 @@ public class MatchQuery {
                 }
             }
             throw new ElasticsearchException("unknown serialized type [" + ord + "]");
-        }
-
-        public static Type readTypeFrom(StreamInput in) throws IOException {
-            return PROTOTYPE.readFrom(in);
         }
 
         @Override
@@ -97,14 +90,11 @@ public class MatchQuery {
 
         private final int ordinal;
 
-        private static final ZeroTermsQuery PROTOTYPE = NONE;
-
         private ZeroTermsQuery(int ordinal) {
             this.ordinal = ordinal;
         }
 
-        @Override
-        public ZeroTermsQuery readFrom(StreamInput in) throws IOException {
+        public static ZeroTermsQuery readFromStream(StreamInput in) throws IOException {
             int ord = in.readVInt();
             for (ZeroTermsQuery zeroTermsQuery : ZeroTermsQuery.values()) {
                 if (zeroTermsQuery.ordinal == ord) {
@@ -112,10 +102,6 @@ public class MatchQuery {
                 }
             }
             throw new ElasticsearchException("unknown serialized type [" + ord + "]");
-        }
-
-        public static ZeroTermsQuery readZeroTermsQueryFrom(StreamInput in) throws IOException {
-            return PROTOTYPE.readFrom(in);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/indices/TermsLookup.java
+++ b/core/src/main/java/org/elasticsearch/indices/TermsLookup.java
@@ -35,8 +35,6 @@ import java.util.Objects;
  * Encapsulates the parameters needed to fetch terms.
  */
 public class TermsLookup implements Writeable<TermsLookup>, ToXContent {
-    static final TermsLookup PROTOTYPE = new TermsLookup("index", "type", "id", "path");
-
     private String index;
     private final String type;
     private final String id;
@@ -62,6 +60,26 @@ public class TermsLookup implements Writeable<TermsLookup>, ToXContent {
         this.type = type;
         this.id = id;
         this.path = path;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public TermsLookup(StreamInput in) throws IOException {
+        type = in.readString();
+        id = in.readString();
+        path = in.readString();
+        index = in.readOptionalString();
+        routing = in.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(type);
+        out.writeString(id);
+        out.writeString(path);
+        out.writeOptionalString(index);
+        out.writeOptionalString(routing);
     }
 
     public String index() {
@@ -137,30 +155,6 @@ public class TermsLookup implements Writeable<TermsLookup>, ToXContent {
     @Override
     public String toString() {
         return index + "/" + type + "/" + id + "/" + path;
-    }
-
-    @Override
-    public TermsLookup readFrom(StreamInput in) throws IOException {
-        String type = in.readString();
-        String id = in.readString();
-        String path = in.readString();
-        String index = in.readOptionalString();
-        TermsLookup termsLookup = new TermsLookup(index, type, id, path);
-        termsLookup.routing = in.readOptionalString();
-        return termsLookup;
-    }
-
-    public static TermsLookup readTermsLookupFrom(StreamInput in) throws IOException {
-        return PROTOTYPE.readFrom(in);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(type);
-        out.writeString(id);
-        out.writeString(path);
-        out.writeOptionalString(index);
-        out.writeOptionalString(routing);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -535,85 +535,68 @@ public class SearchModule extends AbstractModule {
     }
 
     private void registerBuiltinQueryParsers() {
-        registerQuery(MatchQueryBuilder.PROTOTYPE::readFrom, MatchQueryBuilder::fromXContent, MatchQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(MatchPhraseQueryBuilder.PROTOTYPE::readFrom, MatchPhraseQueryBuilder::fromXContent,
-                MatchPhraseQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(MatchPhrasePrefixQueryBuilder.PROTOTYPE::readFrom, MatchPhrasePrefixQueryBuilder::fromXContent,
+        registerQuery(MatchQueryBuilder::new, MatchQueryBuilder::fromXContent, MatchQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(MatchPhraseQueryBuilder::new, MatchPhraseQueryBuilder::fromXContent, MatchPhraseQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(MatchPhrasePrefixQueryBuilder::new, MatchPhrasePrefixQueryBuilder::fromXContent,
                 MatchPhrasePrefixQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(MultiMatchQueryBuilder.PROTOTYPE::readFrom, MultiMatchQueryBuilder::fromXContent,
-                MultiMatchQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(NestedQueryBuilder.PROTOTYPE::readFrom, NestedQueryBuilder::fromXContent, NestedQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(HasChildQueryBuilder.PROTOTYPE::readFrom, HasChildQueryBuilder::fromXContent, HasChildQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(HasParentQueryBuilder.PROTOTYPE::readFrom, HasParentQueryBuilder::fromXContent,
-                HasParentQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(DisMaxQueryBuilder.PROTOTYPE::readFrom, DisMaxQueryBuilder::fromXContent, DisMaxQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(IdsQueryBuilder.PROTOTYPE::readFrom, IdsQueryBuilder::fromXContent, IdsQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(MatchAllQueryBuilder.PROTOTYPE::readFrom, MatchAllQueryBuilder::fromXContent, MatchAllQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(QueryStringQueryBuilder.PROTOTYPE::readFrom, QueryStringQueryBuilder::fromXContent,
-                QueryStringQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(BoostingQueryBuilder.PROTOTYPE::readFrom, BoostingQueryBuilder::fromXContent, BoostingQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(MultiMatchQueryBuilder::new, MultiMatchQueryBuilder::fromXContent, MultiMatchQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(NestedQueryBuilder::new, NestedQueryBuilder::fromXContent, NestedQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(HasChildQueryBuilder::new, HasChildQueryBuilder::fromXContent, HasChildQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(HasParentQueryBuilder::new, HasParentQueryBuilder::fromXContent, HasParentQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(DisMaxQueryBuilder::new, DisMaxQueryBuilder::fromXContent, DisMaxQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(IdsQueryBuilder::new, IdsQueryBuilder::fromXContent, IdsQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(MatchAllQueryBuilder::new, MatchAllQueryBuilder::fromXContent, MatchAllQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(QueryStringQueryBuilder::new, QueryStringQueryBuilder::fromXContent, QueryStringQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(BoostingQueryBuilder::new, BoostingQueryBuilder::fromXContent, BoostingQueryBuilder.QUERY_NAME_FIELD);
         BooleanQuery.setMaxClauseCount(settings.getAsInt("index.query.bool.max_clause_count",
                 settings.getAsInt("indices.query.bool.max_clause_count", BooleanQuery.getMaxClauseCount())));
-        registerQuery(BoolQueryBuilder.PROTOTYPE::readFrom, BoolQueryBuilder::fromXContent, BoolQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(TermQueryBuilder.PROTOTYPE::readFrom, TermQueryBuilder::fromXContent, TermQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(TermsQueryBuilder.PROTOTYPE::readFrom, TermsQueryBuilder::fromXContent, TermsQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(FuzzyQueryBuilder.PROTOTYPE::readFrom, FuzzyQueryBuilder::fromXContent, FuzzyQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(RegexpQueryBuilder.PROTOTYPE::readFrom, RegexpQueryBuilder::fromXContent, RegexpQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(RangeQueryBuilder.PROTOTYPE::readFrom, RangeQueryBuilder::fromXContent, RangeQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(PrefixQueryBuilder.PROTOTYPE::readFrom, PrefixQueryBuilder::fromXContent, PrefixQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(WildcardQueryBuilder.PROTOTYPE::readFrom, WildcardQueryBuilder::fromXContent, WildcardQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(ConstantScoreQueryBuilder.PROTOTYPE::readFrom, ConstantScoreQueryBuilder::fromXContent,
-                ConstantScoreQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(SpanTermQueryBuilder.PROTOTYPE::readFrom, SpanTermQueryBuilder::fromXContent, SpanTermQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(SpanNotQueryBuilder.PROTOTYPE::readFrom, SpanNotQueryBuilder::fromXContent, SpanNotQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(SpanWithinQueryBuilder.PROTOTYPE::readFrom, SpanWithinQueryBuilder::fromXContent,
-                SpanWithinQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(SpanContainingQueryBuilder.PROTOTYPE::readFrom, SpanContainingQueryBuilder::fromXContent,
+        registerQuery(BoolQueryBuilder::new, BoolQueryBuilder::fromXContent, BoolQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(TermQueryBuilder::new, TermQueryBuilder::fromXContent, TermQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(TermsQueryBuilder::new, TermsQueryBuilder::fromXContent, TermsQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(FuzzyQueryBuilder::new, FuzzyQueryBuilder::fromXContent, FuzzyQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(RegexpQueryBuilder::new, RegexpQueryBuilder::fromXContent, RegexpQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(RangeQueryBuilder::new, RangeQueryBuilder::fromXContent, RangeQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(PrefixQueryBuilder::new, PrefixQueryBuilder::fromXContent, PrefixQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(WildcardQueryBuilder::new, WildcardQueryBuilder::fromXContent, WildcardQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(ConstantScoreQueryBuilder::new, ConstantScoreQueryBuilder::fromXContent, ConstantScoreQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(SpanTermQueryBuilder::new, SpanTermQueryBuilder::fromXContent, SpanTermQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(SpanNotQueryBuilder::new, SpanNotQueryBuilder::fromXContent, SpanNotQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(SpanWithinQueryBuilder::new, SpanWithinQueryBuilder::fromXContent, SpanWithinQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(SpanContainingQueryBuilder::new, SpanContainingQueryBuilder::fromXContent,
                 SpanContainingQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(FieldMaskingSpanQueryBuilder.PROTOTYPE::readFrom, FieldMaskingSpanQueryBuilder::fromXContent,
+        registerQuery(FieldMaskingSpanQueryBuilder::new, FieldMaskingSpanQueryBuilder::fromXContent,
                 FieldMaskingSpanQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(SpanFirstQueryBuilder.PROTOTYPE::readFrom, SpanFirstQueryBuilder::fromXContent,
-                SpanFirstQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(SpanNearQueryBuilder.PROTOTYPE::readFrom, SpanNearQueryBuilder::fromXContent, SpanNearQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(SpanOrQueryBuilder.PROTOTYPE::readFrom, SpanOrQueryBuilder::fromXContent, SpanOrQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(MoreLikeThisQueryBuilder.PROTOTYPE::readFrom, MoreLikeThisQueryBuilder::fromXContent,
-                MoreLikeThisQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(WrapperQueryBuilder.PROTOTYPE::readFrom, WrapperQueryBuilder::fromXContent, WrapperQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(IndicesQueryBuilder.PROTOTYPE::readFrom, IndicesQueryBuilder::fromXContent, IndicesQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(CommonTermsQueryBuilder.PROTOTYPE::readFrom, CommonTermsQueryBuilder::fromXContent,
-                CommonTermsQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(SpanMultiTermQueryBuilder.PROTOTYPE::readFrom, SpanMultiTermQueryBuilder::fromXContent,
-                SpanMultiTermQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(FunctionScoreQueryBuilder.PROTOTYPE::readFrom, c -> FunctionScoreQueryBuilder.fromXContent(scoreFunctionsRegistry, c),
+        registerQuery(SpanFirstQueryBuilder::new, SpanFirstQueryBuilder::fromXContent, SpanFirstQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(SpanNearQueryBuilder::new, SpanNearQueryBuilder::fromXContent, SpanNearQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(SpanOrQueryBuilder::new, SpanOrQueryBuilder::fromXContent, SpanOrQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(MoreLikeThisQueryBuilder::new, MoreLikeThisQueryBuilder::fromXContent, MoreLikeThisQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(WrapperQueryBuilder::new, WrapperQueryBuilder::fromXContent, WrapperQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(IndicesQueryBuilder::new, IndicesQueryBuilder::fromXContent, IndicesQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(CommonTermsQueryBuilder::new, CommonTermsQueryBuilder::fromXContent, CommonTermsQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(SpanMultiTermQueryBuilder::new, SpanMultiTermQueryBuilder::fromXContent, SpanMultiTermQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(FunctionScoreQueryBuilder::new, c -> FunctionScoreQueryBuilder.fromXContent(scoreFunctionsRegistry, c),
                 FunctionScoreQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(SimpleQueryStringBuilder.PROTOTYPE::readFrom, SimpleQueryStringBuilder::fromXContent,
-                SimpleQueryStringBuilder.QUERY_NAME_FIELD);
-        registerQuery(TemplateQueryBuilder.PROTOTYPE::readFrom, TemplateQueryBuilder::fromXContent, TemplateQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(TypeQueryBuilder.PROTOTYPE::readFrom, TypeQueryBuilder::fromXContent, TypeQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(ScriptQueryBuilder.PROTOTYPE::readFrom, ScriptQueryBuilder::fromXContent, ScriptQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(GeoDistanceQueryBuilder.PROTOTYPE::readFrom, GeoDistanceQueryBuilder::fromXContent,
-                GeoDistanceQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(GeoDistanceRangeQueryBuilder.PROTOTYPE::readFrom, GeoDistanceRangeQueryBuilder::fromXContent,
+        registerQuery(SimpleQueryStringBuilder::new, SimpleQueryStringBuilder::fromXContent, SimpleQueryStringBuilder.QUERY_NAME_FIELD);
+        registerQuery(TemplateQueryBuilder::new, TemplateQueryBuilder::fromXContent, TemplateQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(TypeQueryBuilder::new, TypeQueryBuilder::fromXContent, TypeQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(ScriptQueryBuilder::new, ScriptQueryBuilder::fromXContent, ScriptQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(GeoDistanceQueryBuilder::new, GeoDistanceQueryBuilder::fromXContent, GeoDistanceQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(GeoDistanceRangeQueryBuilder::new, GeoDistanceRangeQueryBuilder::fromXContent,
                 GeoDistanceRangeQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(GeoBoundingBoxQueryBuilder.PROTOTYPE::readFrom, GeoBoundingBoxQueryBuilder::fromXContent,
+        registerQuery(GeoBoundingBoxQueryBuilder::new, GeoBoundingBoxQueryBuilder::fromXContent,
                 GeoBoundingBoxQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(GeohashCellQuery.Builder.PROTOTYPE::readFrom, GeohashCellQuery.Builder::fromXContent,
-                GeohashCellQuery.QUERY_NAME_FIELD);
-        registerQuery(GeoPolygonQueryBuilder.PROTOTYPE::readFrom, GeoPolygonQueryBuilder::fromXContent,
-                GeoPolygonQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(ExistsQueryBuilder.PROTOTYPE::readFrom, ExistsQueryBuilder::fromXContent, ExistsQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(MatchNoneQueryBuilder.PROTOTYPE::readFrom, MatchNoneQueryBuilder::fromXContent,
-                MatchNoneQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(ParentIdQueryBuilder.PROTO::readFrom, ParentIdQueryBuilder::fromXContent, ParentIdQueryBuilder.QUERY_NAME_FIELD);
-        registerQuery(PercolatorQueryBuilder.PROTO::readFrom, PercolatorQueryBuilder::fromXContent,
-                PercolatorQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(GeohashCellQuery.Builder::new, GeohashCellQuery.Builder::fromXContent, GeohashCellQuery.QUERY_NAME_FIELD);
+        registerQuery(GeoPolygonQueryBuilder::new, GeoPolygonQueryBuilder::fromXContent, GeoPolygonQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(ExistsQueryBuilder::new, ExistsQueryBuilder::fromXContent, ExistsQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(MatchNoneQueryBuilder::new, MatchNoneQueryBuilder::fromXContent, MatchNoneQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(ParentIdQueryBuilder::new, ParentIdQueryBuilder::fromXContent, ParentIdQueryBuilder.QUERY_NAME_FIELD);
+        registerQuery(PercolatorQueryBuilder::new, PercolatorQueryBuilder::fromXContent, PercolatorQueryBuilder.QUERY_NAME_FIELD);
         if (ShapesAvailability.JTS_AVAILABLE && ShapesAvailability.SPATIAL4J_AVAILABLE) {
-            registerQuery(GeoShapeQueryBuilder.PROTOTYPE::readFrom, GeoShapeQueryBuilder::fromXContent,
-                    GeoShapeQueryBuilder.QUERY_NAME_FIELD);
+            registerQuery(GeoShapeQueryBuilder::new, GeoShapeQueryBuilder::fromXContent, GeoShapeQueryBuilder.QUERY_NAME_FIELD);
         }
         // EmptyQueryBuilder is not registered as query parser but used internally.
         // We need to register it with the NamedWriteableRegistry in order to serialize it
-        namedWriteableRegistry.registerPrototype(QueryBuilder.class, EmptyQueryBuilder.PROTOTYPE);
+        namedWriteableRegistry.register(QueryBuilder.class, EmptyQueryBuilder.NAME, EmptyQueryBuilder::new);
     }
 
     static {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceAggregatorBuilder.java
@@ -210,7 +210,7 @@ public class GeoDistanceAggregatorBuilder extends ValuesSourceAggregatorBuilder<
             factory.addRange(Range.PROTOTYPE.readFrom(in));
         }
         factory.keyed = in.readBoolean();
-        factory.distanceType = GeoDistance.readGeoDistanceFrom(in);
+        factory.distanceType = GeoDistance.readFromStream(in);
         factory.unit = DistanceUnit.readFromStream(in);
         return factory;
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregatorBuilder.java
@@ -522,7 +522,7 @@ public class TopHitsAggregatorBuilder extends AggregatorBuilder<TopHitsAggregato
     protected TopHitsAggregatorBuilder doReadFrom(String name, StreamInput in) throws IOException {
         TopHitsAggregatorBuilder factory = new TopHitsAggregatorBuilder(name);
         factory.explain = in.readBoolean();
-        factory.fetchSourceContext = FetchSourceContext.optionalReadFromStream(in);
+        factory.fetchSourceContext = in.readOptionalStreamable(FetchSourceContext::new);
         if (in.readBoolean()) {
             int size = in.readVInt();
             List<String> fieldDataFields = new ArrayList<>(size);
@@ -566,7 +566,7 @@ public class TopHitsAggregatorBuilder extends AggregatorBuilder<TopHitsAggregato
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeBoolean(explain);
-        FetchSourceContext.optionalWriteToStream(fetchSourceContext, out);
+        out.writeOptionalStreamable(fetchSourceContext);
         boolean hasFieldDataFields = fieldDataFields != null;
         out.writeBoolean(hasFieldDataFields);
         if (hasFieldDataFields) {

--- a/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -1196,7 +1196,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
             builder.aggregations = AggregatorFactories.Builder.PROTOTYPE.readFrom(in);
             }
         builder.explain = in.readOptionalBoolean();
-        builder.fetchSourceContext = FetchSourceContext.optionalReadFromStream(in);
+        builder.fetchSourceContext = in.readOptionalStreamable(FetchSourceContext::new);
         boolean hasFieldDataFields = in.readBoolean();
         if (hasFieldDataFields) {
             int size = in.readVInt();
@@ -1300,7 +1300,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
             aggregations.writeTo(out);
         }
         out.writeOptionalBoolean(explain);
-        FetchSourceContext.optionalWriteToStream(fetchSourceContext, out);
+        out.writeOptionalStreamable(fetchSourceContext);
         boolean hasFieldDataFields = fieldDataFields != null;
         out.writeBoolean(hasFieldDataFields);
         if (hasFieldDataFields) {

--- a/core/src/main/java/org/elasticsearch/search/fetch/source/FetchSourceContext.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/source/FetchSourceContext.java
@@ -56,8 +56,7 @@ public class FetchSourceContext implements Streamable, ToXContent {
         return fetchSourceContext;
     }
 
-    FetchSourceContext() {
-
+    public FetchSourceContext() {
     }
 
     public FetchSourceContext(boolean fetchSource) {
@@ -113,24 +112,6 @@ public class FetchSourceContext implements Streamable, ToXContent {
     public FetchSourceContext excludes(String[] excludes) {
         this.excludes = excludes;
         return this;
-    }
-
-    public static FetchSourceContext optionalReadFromStream(StreamInput in) throws IOException {
-        if (!in.readBoolean()) {
-            return null;
-        }
-        FetchSourceContext context = new FetchSourceContext();
-        context.readFrom(in);
-        return context;
-    }
-
-    public static void optionalWriteToStream(FetchSourceContext context, StreamOutput out) throws IOException {
-        if (context == null) {
-            out.writeBoolean(false);
-            return;
-        }
-        out.writeBoolean(true);
-        context.writeTo(out);
     }
 
     public static FetchSourceContext parseFromRestRequest(RestRequest request) {

--- a/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -155,7 +155,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
     public GeoDistanceSortBuilder(StreamInput in) throws IOException {
         fieldName = in.readString();
         points.addAll((List<GeoPoint>) in.readGenericValue());
-        geoDistance = GeoDistance.readGeoDistanceFrom(in);
+        geoDistance = GeoDistance.readFromStream(in);
         unit = DistanceUnit.readFromStream(in);
         order = SortOrder.readFromStream(in);
         sortMode = in.readOptionalWriteable(SortMode::readFromStream);

--- a/core/src/test/java/org/elasticsearch/common/geo/GeoDistanceTests.java
+++ b/core/src/test/java/org/elasticsearch/common/geo/GeoDistanceTests.java
@@ -47,7 +47,7 @@ public class GeoDistanceTests extends ESTestCase {
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             geoDistance.writeTo(out);
             try (StreamInput in = StreamInput.wrap(out.bytes())) {;
-                GeoDistance copy = GeoDistance.readGeoDistanceFrom(in);
+                GeoDistance copy = GeoDistance.readFromStream(in);
                 assertEquals(copy.toString() + " vs. " + geoDistance.toString(), copy, geoDistance);
             }
         }
@@ -61,7 +61,7 @@ public class GeoDistanceTests extends ESTestCase {
                 out.writeVInt(randomIntBetween(Integer.MIN_VALUE, -1));
             }
             try (StreamInput in = StreamInput.wrap(out.bytes())) {
-                GeoDistance.readGeoDistanceFrom(in);
+                GeoDistance.readFromStream(in);
             } catch (IOException e) {
                 assertThat(e.getMessage(), containsString("Unknown GeoDistance ordinal ["));
             }

--- a/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -285,6 +285,9 @@ public class BytesStreamsTests extends ESTestCase {
         out.writeOptionalBytesReference(new BytesArray("test"));
         out.writeOptionalDouble(null);
         out.writeOptionalDouble(1.2);
+        out.writeTimeZone(DateTimeZone.forID("CET"));
+        out.writeOptionalTimeZone(DateTimeZone.getDefault());
+        out.writeOptionalTimeZone(null);
         final byte[] bytes = out.bytes().toBytes();
         StreamInput in = StreamInput.wrap(out.bytes().toBytes());
         assertEquals(in.available(), bytes.length);
@@ -311,6 +314,9 @@ public class BytesStreamsTests extends ESTestCase {
         assertThat(in.readOptionalBytesReference(), equalTo(new BytesArray("test")));
         assertNull(in.readOptionalDouble());
         assertThat(in.readOptionalDouble(), closeTo(1.2, 0.0001));
+        assertEquals(DateTimeZone.forID("CET"), in.readTimeZone());
+        assertEquals(DateTimeZone.getDefault(), in.readOptionalTimeZone());
+        assertNull(in.readOptionalTimeZone());
         assertEquals(0, in.available());
         in.close();
         out.close();
@@ -543,5 +549,4 @@ public class BytesStreamsTests extends ESTestCase {
             assertEquals(point, geoPoint);
         }
     }
-
 }

--- a/core/src/test/java/org/elasticsearch/common/unit/FuzzinessTests.java
+++ b/core/src/test/java/org/elasticsearch/common/unit/FuzzinessTests.java
@@ -179,6 +179,6 @@ public class FuzzinessTests extends ESTestCase {
         BytesStreamOutput output = new BytesStreamOutput();
         in.writeTo(output);
         StreamInput streamInput = StreamInput.wrap(output.bytes());
-        return Fuzziness.readFuzzinessFrom(streamInput);
+        return new Fuzziness(streamInput);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
@@ -656,9 +656,9 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
             output.writeQuery(testQuery);
             try (StreamInput in = new NamedWriteableAwareStreamInput(StreamInput.wrap(output.bytes()), namedWriteableRegistry)) {
                 QueryBuilder<?> deserializedQuery = in.readQuery();
-                assertEquals(deserializedQuery, testQuery);
-                assertEquals(deserializedQuery.hashCode(), testQuery.hashCode());
-                assertNotSame(deserializedQuery, testQuery);
+                assertEquals(testQuery, deserializedQuery);
+                assertEquals(testQuery.hashCode(), deserializedQuery.hashCode());
+                assertNotSame(testQuery, deserializedQuery);
                 return (QB) deserializedQuery;
             }
         }

--- a/core/src/test/java/org/elasticsearch/index/query/CombineFunctionTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/CombineFunctionTests.java
@@ -84,37 +84,37 @@ public class CombineFunctionTests extends ESTestCase {
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeVInt(0);
             try (StreamInput in = StreamInput.wrap(out.bytes())) {
-                assertThat(CombineFunction.readCombineFunctionFrom(in), equalTo(CombineFunction.MULTIPLY));
+                assertThat(CombineFunction.readFromStream(in), equalTo(CombineFunction.MULTIPLY));
             }
         }
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeVInt(1);
             try (StreamInput in = StreamInput.wrap(out.bytes())) {
-                assertThat(CombineFunction.readCombineFunctionFrom(in), equalTo(CombineFunction.REPLACE));
+                assertThat(CombineFunction.readFromStream(in), equalTo(CombineFunction.REPLACE));
             }
         }
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeVInt(2);
             try (StreamInput in = StreamInput.wrap(out.bytes())) {
-                assertThat(CombineFunction.readCombineFunctionFrom(in), equalTo(CombineFunction.SUM));
+                assertThat(CombineFunction.readFromStream(in), equalTo(CombineFunction.SUM));
             }
         }
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeVInt(3);
             try (StreamInput in = StreamInput.wrap(out.bytes())) {
-                assertThat(CombineFunction.readCombineFunctionFrom(in), equalTo(CombineFunction.AVG));
+                assertThat(CombineFunction.readFromStream(in), equalTo(CombineFunction.AVG));
             }
         }
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeVInt(4);
             try (StreamInput in = StreamInput.wrap(out.bytes())) {
-                assertThat(CombineFunction.readCombineFunctionFrom(in), equalTo(CombineFunction.MIN));
+                assertThat(CombineFunction.readFromStream(in), equalTo(CombineFunction.MIN));
             }
         }
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeVInt(5);
             try (StreamInput in = StreamInput.wrap(out.bytes())) {
-                assertThat(CombineFunction.readCombineFunctionFrom(in), equalTo(CombineFunction.MAX));
+                assertThat(CombineFunction.readFromStream(in), equalTo(CombineFunction.MAX));
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
@@ -96,12 +96,7 @@ public class ConstantScoreQueryBuilderTests extends AbstractQueryTestCase<Consta
     }
 
     public void testIllegalArguments() {
-        try {
-            new ConstantScoreQueryBuilder(null);
-            fail("must not be null");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
+        expectThrows(IllegalArgumentException.class, () -> new ConstantScoreQueryBuilder((QueryBuilder<?>) null));
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
@@ -73,16 +73,8 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
     }
 
     public void testIllegalArguments() {
-        try {
-            if (randomBoolean()) {
-                new ExistsQueryBuilder(null);
-            } else {
-                new ExistsQueryBuilder("");
-            }
-            fail("must not be null or empty");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
+        expectThrows(IllegalArgumentException.class, () -> new ExistsQueryBuilder((String) null));
+        expectThrows(IllegalArgumentException.class, () -> new ExistsQueryBuilder(""));
     }
 
     public void testFromJson() throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
@@ -19,9 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.elasticsearch.common.ParseFieldMatcher;
-import org.locationtech.spatial4j.io.GeohashUtils;
-import org.locationtech.spatial4j.shape.Rectangle;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
@@ -29,10 +26,13 @@ import org.apache.lucene.search.LegacyNumericRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.spatial.geopoint.search.GeoPointInBBoxQuery;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.index.search.geo.InMemoryGeoBoundingBoxQuery;
 import org.elasticsearch.test.geo.RandomShapeGenerator;
+import org.locationtech.spatial4j.io.GeohashUtils;
+import org.locationtech.spatial4j.shape.Rectangle;
 
 import java.io.IOException;
 
@@ -89,12 +89,8 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
     }
 
     public void testValidationNullFieldname() {
-        try {
-            new GeoBoundingBoxQueryBuilder(null);
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is("Field name must not be empty."));
-        }
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new GeoBoundingBoxQueryBuilder((String) null));
+        assertEquals("Field name must not be empty.", e.getMessage());
     }
 
     public void testValidationNullType() {

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -81,7 +81,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
             if (randomBoolean()) {
                 new GeoDistanceQueryBuilder("");
             } else {
-                new GeoDistanceQueryBuilder(null);
+                new GeoDistanceQueryBuilder((String) null);
             }
             fail("must not be null or empty");
         } catch (IllegalArgumentException ex) {

--- a/core/src/test/java/org/elasticsearch/index/query/OperatorTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/OperatorTests.java
@@ -54,13 +54,13 @@ public class OperatorTests extends ESTestCase {
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeVInt(0);
             try (StreamInput in = StreamInput.wrap(out.bytes())) {
-                assertThat(Operator.readOperatorFrom(in), equalTo(Operator.OR));
+                assertThat(Operator.readFromStream(in), equalTo(Operator.OR));
             }
         }
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeVInt(1);
             try (StreamInput in = StreamInput.wrap(out.bytes())) {
-                assertThat(Operator.readOperatorFrom(in), equalTo(Operator.AND));
+                assertThat(Operator.readFromStream(in), equalTo(Operator.AND));
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/index/query/ParentIdQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ParentIdQueryBuilderTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
-import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.TestSearchContext;
 import org.hamcrest.Matchers;

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -155,12 +155,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     }
 
     public void testIllegalArguments() {
-        try {
-            new QueryStringQueryBuilder(null);
-            fail("null is not allowed");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
+        expectThrows(IllegalArgumentException.class, () -> new QueryStringQueryBuilder((String) null));
     }
 
     public void testToQueryMatchAllQuery() throws Exception {

--- a/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -135,16 +135,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
     }
 
     public void testIllegalArguments() {
-        try {
-            if (randomBoolean()) {
-                new RangeQueryBuilder(null);
-            } else {
-                new RangeQueryBuilder("");
-            }
-            fail("cannot be null or empty");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
+        expectThrows(IllegalArgumentException.class, () -> new RangeQueryBuilder((String) null));
+        expectThrows(IllegalArgumentException.class, () -> new RangeQueryBuilder(""));
 
         RangeQueryBuilder rangeQueryBuilder = new RangeQueryBuilder("test");
         try {

--- a/core/src/test/java/org/elasticsearch/index/query/ScoreModeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ScoreModeTests.java
@@ -84,37 +84,37 @@ public class ScoreModeTests extends ESTestCase {
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeVInt(0);
             try (StreamInput in = StreamInput.wrap(out.bytes())) {
-                assertThat(FiltersFunctionScoreQuery.ScoreMode.readScoreModeFrom(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.FIRST));
+                assertThat(FiltersFunctionScoreQuery.ScoreMode.readFromStream(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.FIRST));
             }
         }
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeVInt(1);
             try (StreamInput in = StreamInput.wrap(out.bytes())) {
-                assertThat(FiltersFunctionScoreQuery.ScoreMode.readScoreModeFrom(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.AVG));
+                assertThat(FiltersFunctionScoreQuery.ScoreMode.readFromStream(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.AVG));
             }
         }
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeVInt(2);
             try (StreamInput in = StreamInput.wrap(out.bytes())) {
-                assertThat(FiltersFunctionScoreQuery.ScoreMode.readScoreModeFrom(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.MAX));
+                assertThat(FiltersFunctionScoreQuery.ScoreMode.readFromStream(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.MAX));
             }
         }
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeVInt(3);
             try (StreamInput in = StreamInput.wrap(out.bytes())) {
-                assertThat(FiltersFunctionScoreQuery.ScoreMode.readScoreModeFrom(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.SUM));
+                assertThat(FiltersFunctionScoreQuery.ScoreMode.readFromStream(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.SUM));
             }
         }
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeVInt(4);
             try (StreamInput in = StreamInput.wrap(out.bytes())) {
-                assertThat(FiltersFunctionScoreQuery.ScoreMode.readScoreModeFrom(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.MIN));
+                assertThat(FiltersFunctionScoreQuery.ScoreMode.readFromStream(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.MIN));
             }
         }
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeVInt(5);
             try (StreamInput in = StreamInput.wrap(out.bytes())) {
-                assertThat(FiltersFunctionScoreQuery.ScoreMode.readScoreModeFrom(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.MULTIPLY));
+                assertThat(FiltersFunctionScoreQuery.ScoreMode.readFromStream(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.MULTIPLY));
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
@@ -44,12 +44,7 @@ public class ScriptQueryBuilderTests extends AbstractQueryTestCase<ScriptQueryBu
     }
 
     public void testIllegalConstructorArg() {
-        try {
-            new ScriptQueryBuilder(null);
-            fail("cannot be null");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
+        expectThrows(IllegalArgumentException.class, () -> new ScriptQueryBuilder((Script) null));
     }
 
     public void testFromJson() throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -173,12 +173,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
     }
 
     public void testIllegalConstructorArg() {
-        try {
-            new SimpleQueryStringBuilder(null);
-            fail("cannot be null");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
+        expectThrows(IllegalArgumentException.class, () -> new SimpleQueryStringBuilder((String) null));
     }
 
     public void testFieldCannotBeNull() {

--- a/core/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTests.java
@@ -59,12 +59,7 @@ public class SpanMultiTermQueryBuilderTests extends AbstractQueryTestCase<SpanMu
     }
 
     public void testIllegalArgument() {
-        try {
-            new SpanMultiTermQueryBuilder(null);
-            fail("cannot be null");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
+        expectThrows(IllegalArgumentException.class, () -> new SpanMultiTermQueryBuilder((MultiTermQueryBuilder<?>) null));
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTests.java
@@ -52,12 +52,7 @@ public class SpanOrQueryBuilderTests extends AbstractQueryTestCase<SpanOrQueryBu
     }
 
     public void testIllegalArguments() {
-        try {
-            new SpanOrQueryBuilder(null);
-            fail("cannot be null");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
+        expectThrows(IllegalArgumentException.class, () -> new SpanOrQueryBuilder((SpanQueryBuilder<?>) null));
 
         try {
             SpanOrQueryBuilder spanOrBuilder = new SpanOrQueryBuilder(SpanTermQueryBuilder.PROTOTYPE);

--- a/core/src/test/java/org/elasticsearch/index/query/TemplateQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TemplateQueryBuilderTests.java
@@ -64,12 +64,7 @@ public class TemplateQueryBuilderTests extends AbstractQueryTestCase<TemplateQue
     }
 
     public void testIllegalArgument() {
-        try {
-            new TemplateQueryBuilder(null);
-            fail("cannot be null");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
+        expectThrows(IllegalArgumentException.class, () -> new TemplateQueryBuilder((Template) null));
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/index/query/plugin/DummyQueryParserPlugin.java
+++ b/core/src/test/java/org/elasticsearch/index/query/plugin/DummyQueryParserPlugin.java
@@ -49,12 +49,27 @@ public class DummyQueryParserPlugin extends Plugin {
     }
 
     public void onModule(SearchModule module) {
-        module.registerQuery(new DummyQueryBuilder()::readFrom, DummyQueryBuilder::fromXContent, DummyQueryBuilder.QUERY_NAME_FIELD);
+        module.registerQuery(DummyQueryBuilder::new, DummyQueryBuilder::fromXContent, DummyQueryBuilder.QUERY_NAME_FIELD);
     }
 
     public static class DummyQueryBuilder extends AbstractQueryBuilder<DummyQueryBuilder> {
         private static final String NAME = "dummy";
         private static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
+
+        public DummyQueryBuilder() {
+        }
+
+        /**
+         * Read from a stream.
+         */
+        public DummyQueryBuilder(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        protected void doWriteTo(StreamOutput out) throws IOException {
+            // only the superclass has state
+        }
 
         @Override
         protected void doXContent(XContentBuilder builder, Params params) throws IOException {
@@ -70,16 +85,6 @@ public class DummyQueryParserPlugin extends Plugin {
         @Override
         protected Query doToQuery(QueryShardContext context) throws IOException {
             return new DummyQuery(context.isFilter());
-        }
-
-        @Override
-        protected DummyQueryBuilder doReadFrom(StreamInput in) throws IOException {
-            return new DummyQueryBuilder();
-        }
-
-        @Override
-        protected void doWriteTo(StreamOutput out) throws IOException {
-            // Do Nothing
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/indices/TermsLookupTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/TermsLookupTests.java
@@ -71,7 +71,7 @@ public class TermsLookupTests extends ESTestCase {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             termsLookup.writeTo(output);
             try (StreamInput in = StreamInput.wrap(output.bytes())) {
-                TermsLookup deserializedLookup = TermsLookup.readTermsLookupFrom(in);
+                TermsLookup deserializedLookup = new TermsLookup(in);
                 assertEquals(deserializedLookup, termsLookup);
                 assertEquals(deserializedLookup.hashCode(), termsLookup.hashCode());
                 assertNotSame(deserializedLookup, termsLookup);

--- a/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -81,7 +81,7 @@ public class SearchModuleTests extends ModuleTestCase {
     public void testRegisterQueryParserDuplicate() {
         SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry());
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> module
-                .registerQuery(TermQueryBuilder.PROTOTYPE::readFrom, TermQueryBuilder::fromXContent, TermQueryBuilder.QUERY_NAME_FIELD));
+                .registerQuery(TermQueryBuilder::new, TermQueryBuilder::fromXContent, TermQueryBuilder.QUERY_NAME_FIELD));
         assertThat(e.getMessage(), containsString("already registered for name [term] while trying to register [org.elasticsearch."));
     }
 


### PR DESCRIPTION
Now that we've changed queries to be registered by their parsers and readers instead of PROTOTYPEs we can remove the PROTOTYPEs entirely. This does that.

Relates to #17085
