### PR TITLE
Fix typo in search api - fields doc. 

### DIFF
--- a/docs/reference/search/request/fields.asciidoc
+++ b/docs/reference/search/request/fields.asciidoc
@@ -27,7 +27,7 @@ For example:
 [source,js]
 --------------------------------------------------
 {
-    "fields": "["xxx*", "*xxx", "*xxx*", "xxx*yyy", "user", "postDate"],
+    "fields": ["xxx*", "*xxx", "*xxx*", "xxx*yyy", "user", "postDate"],
     "query" : {
         "term" : { "user" : "kimchy" }
     }


### PR DESCRIPTION
remove extra `"`  in search api doc.
