### PR TITLE
Make registerScoreFunction look like registerQuery

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -65,7 +65,7 @@ import java.util.function.BiFunction;
  * To write a new decay scoring function, create a new class that extends
  * {@link DecayFunctionBuilder}, setup a PARSER field with this class, and
  * register them both using
- * {@link org.elasticsearch.search.SearchModule#registerScoreFunction(ScoreFunctionParser, Writeable.Reader, ParseField)}.
+ * {@link org.elasticsearch.search.SearchModule#registerScoreFunction(Writeable.Reader, ScoreFunctionParser, ParseField)}.
  * See {@link GaussDecayFunctionBuilder#PARSER} for an example.
  */
 public final class DecayFunctionParser<DFB extends DecayFunctionBuilder<DFB>> implements ScoreFunctionParser<DFB> {

--- a/core/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -295,8 +295,8 @@ public class SearchModule extends AbstractModule {
      * {@linkplain ParseField#getPreferredName()}.</li>
      * </ul>
      */
-    public <T extends ScoreFunctionBuilder<T>> void registerScoreFunction(ScoreFunctionParser<T> parser,
-            Writeable.Reader<T> reader, ParseField functionName) {
+    public <T extends ScoreFunctionBuilder<T>> void registerScoreFunction(Writeable.Reader<T> reader, ScoreFunctionParser<T> parser,
+            ParseField functionName) {
         for (String name: functionName.getAllNamesIncludedDeprecated()) {
             Tuple<ParseField, ScoreFunctionParser<?>> oldValue = scoreFunctionParsers.putIfAbsent(name, new Tuple<>(functionName, parser));
             if (oldValue != null) {
@@ -507,17 +507,17 @@ public class SearchModule extends AbstractModule {
     }
 
     private void registerBuiltinScoreFunctionParsers() {
-        registerScoreFunction(ScriptScoreFunctionBuilder::fromXContent, ScriptScoreFunctionBuilder::new,
+        registerScoreFunction(ScriptScoreFunctionBuilder::new, ScriptScoreFunctionBuilder::fromXContent,
                 ScriptScoreFunctionBuilder.FUNCTION_NAME_FIELD);
-        registerScoreFunction(GaussDecayFunctionBuilder.PARSER, GaussDecayFunctionBuilder::new,
+        registerScoreFunction(GaussDecayFunctionBuilder::new, GaussDecayFunctionBuilder.PARSER,
                 GaussDecayFunctionBuilder.FUNCTION_NAME_FIELD);
-        registerScoreFunction(LinearDecayFunctionBuilder.PARSER, LinearDecayFunctionBuilder::new,
+        registerScoreFunction(LinearDecayFunctionBuilder::new, LinearDecayFunctionBuilder.PARSER,
                 LinearDecayFunctionBuilder.FUNCTION_NAME_FIELD);
-        registerScoreFunction(ExponentialDecayFunctionBuilder.PARSER, ExponentialDecayFunctionBuilder::new,
+        registerScoreFunction(ExponentialDecayFunctionBuilder::new, ExponentialDecayFunctionBuilder.PARSER,
                 ExponentialDecayFunctionBuilder.FUNCTION_NAME_FIELD);
-        registerScoreFunction(RandomScoreFunctionBuilder::fromXContent, RandomScoreFunctionBuilder::new,
+        registerScoreFunction(RandomScoreFunctionBuilder::new, RandomScoreFunctionBuilder::fromXContent,
                 RandomScoreFunctionBuilder.FUNCTION_NAME_FIELD);
-        registerScoreFunction(FieldValueFactorFunctionBuilder::fromXContent, FieldValueFactorFunctionBuilder::new,
+        registerScoreFunction(FieldValueFactorFunctionBuilder::new, FieldValueFactorFunctionBuilder::fromXContent,
                 FieldValueFactorFunctionBuilder.FUNCTION_NAME_FIELD);
 
         //weight doesn't have its own parser, so every function supports it out of the box.

--- a/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
@@ -78,8 +78,8 @@ import static org.hamcrest.Matchers.nullValue;
 public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<FunctionScoreQueryBuilder> {
     @BeforeClass
     public static void registerTestRandomScoreFunction() {
-        getSearchModule().registerScoreFunction(RandomScoreFunctionBuilderWithFixedSeed::fromXContent,
-                RandomScoreFunctionBuilderWithFixedSeed::new, RandomScoreFunctionBuilderWithFixedSeed.FUNCTION_NAME_FIELD);
+        getSearchModule().registerScoreFunction(RandomScoreFunctionBuilderWithFixedSeed::new,
+                RandomScoreFunctionBuilderWithFixedSeed::fromXContent, RandomScoreFunctionBuilderWithFixedSeed.FUNCTION_NAME_FIELD);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScorePluginIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScorePluginIT.java
@@ -107,8 +107,8 @@ public class FunctionScorePluginIT extends ESIntegTestCase {
         }
 
         public void onModule(SearchModule scoreModule) {
-            scoreModule.registerScoreFunction(CustomDistanceScoreBuilder.PARSER,
-                    CustomDistanceScoreBuilder::new, CustomDistanceScoreBuilder.FUNCTION_NAME_FIELD);
+            scoreModule.registerScoreFunction(CustomDistanceScoreBuilder::new, CustomDistanceScoreBuilder.PARSER,
+                    CustomDistanceScoreBuilder.FUNCTION_NAME_FIELD);
         }
     }
 


### PR DESCRIPTION
The order of the first two arguments was different on the two register
functions. This makes them consistent.

Relates to #17085
