### PR TITLE
Isolate StreamableReader

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/AbstractDiffable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/AbstractDiffable.java
@@ -46,7 +46,7 @@ public abstract class AbstractDiffable<T extends Diffable<T>> implements Diffabl
         return new CompleteDiff<>(this, in);
     }
 
-    public static <T extends Diffable<T>> Diff<T> readDiffFrom(StreamableReader<T> reader, StreamInput in) throws IOException {
+    public static <T extends Diffable<T>> Diff<T> readDiffFrom(T reader, StreamInput in) throws IOException {
         return new CompleteDiff<T>(reader, in);
     }
 
@@ -72,7 +72,7 @@ public abstract class AbstractDiffable<T extends Diffable<T>> implements Diffabl
         /**
          * Read simple diff from the stream
          */
-        public CompleteDiff(StreamableReader<T> reader, StreamInput in) throws IOException {
+        public CompleteDiff(Diffable<T> reader, StreamInput in) throws IOException {
             if (in.readBoolean()) {
                 this.part = reader.readFrom(in);
             } else {

--- a/core/src/main/java/org/elasticsearch/cluster/Diffable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/Diffable.java
@@ -39,4 +39,8 @@ public interface Diffable<T> extends Writeable<T> {
      */
     Diff<T> readDiffFrom(StreamInput in) throws IOException;
 
+    /**
+     * Reads an object of this type from the provided {@linkplain StreamInput}. The receiving instance remains unchanged.
+     */
+    T readFrom(StreamInput in) throws IOException;
 }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/Writeable.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/Writeable.java
@@ -37,13 +37,12 @@ import java.io.IOException;
  * {@link StreamInput}. The reasoning behind this is that most "good" readFrom implementations just delegated to such a constructor anyway
  * and they required an unsightly PROTOTYPE object.
  */
-public interface Writeable<T> extends StreamableReader<T> { // TODO remove extends StreamableReader<T> from this interface, and remove <T>
+public interface Writeable<T> { // TODO remove <T>
     /**
      * Write this into the {@linkplain StreamOutput}.
      */
     void writeTo(StreamOutput out) throws IOException;
 
-    @Override
     default T readFrom(StreamInput in) throws IOException {
         // See class javadoc for reasoning
         throw new UnsupportedOperationException(

--- a/core/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
@@ -399,12 +399,7 @@ public class DiffableTests extends ESTestCase {
 
             @Override
             public Diff<TestDiffable> readDiff(StreamInput in, K key) throws IOException {
-                return AbstractDiffable.readDiffFrom(new StreamableReader<TestDiffable>() {
-                    @Override
-                    public TestDiffable readFrom(StreamInput in) throws IOException {
-                        return new TestDiffable(in.readString());
-                    }
-                }, in);
+                return AbstractDiffable.readDiffFrom(TestDiffable.PROTO, in);
             }
         };
     }


### PR DESCRIPTION
Makes Writeable not depend on StreamableReader. Keeps the default readFrom
implementation for backwards compatibility during the PROTOTYPE removal
but that'll go when those are gone.

Makes Diffable not extend StreamableReader. Instead Diffable has a readFrom
method. The PROTOTYPE removal will not get to cluster state for a long time
so that method will stay.

Now only a few things implement StreamableReader. They will be addressed
individually and then we'll remove StreamableReader.

Relates to #17085
