### PR TITLE
Reformat DirectCandidateGenerator's equals method

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGenerator.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGenerator.java
@@ -254,18 +254,15 @@ final class DirectCandidateGenerator extends CandidateGenerator {
 
         @Override
         public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
+            if (this == obj) return true;
+            if (obj == null) return false;
+            if (getClass() != obj.getClass()) return false;
             Candidate other = (Candidate) obj;
             if (term == null) {
-                if (other.term != null)
-                    return false;
-            } else if (!term.equals(other.term))
-                return false;
+                if (other.term != null) return false;
+            } else {
+                if (!term.equals(other.term)) return false;
+            }
             return true;
         }
 


### PR DESCRIPTION
We'd like to have checkstyle complain about if statements without braces
for all non-single-line if statements.
