### PR TITLE
No map collisions on FiltersTests

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/FiltersTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/FiltersTests.java
@@ -35,8 +35,9 @@ public class FiltersTests extends BaseAggregationTestCase<FiltersAggregatorBuild
         FiltersAggregatorBuilder factory;
         if (randomBoolean()) {
             KeyedFilter[] filters = new KeyedFilter[size];
-            for (int i = 0; i < size; i++) {
-                filters[i] = new KeyedFilter(randomAsciiOfLengthBetween(1, 20),
+            int i = 0;
+            for (String key : randomUnique(() -> randomAsciiOfLengthBetween(1, 20), size)) {
+                filters[i++] = new KeyedFilter(key,
                         QueryBuilders.termQuery(randomAsciiOfLengthBetween(5, 20), randomAsciiOfLengthBetween(5, 20)));
             }
             factory = new FiltersAggregatorBuilder(randomAsciiOfLengthBetween(1, 20), filters);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -76,6 +76,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -596,6 +597,23 @@ public abstract class ESTestCase extends LuceneTestCase {
         List<T> tempList = new ArrayList<>(collection);
         Collections.shuffle(tempList, random());
         return tempList.subList(0, size);
+    }
+
+    /**
+     * Builds a set of unique items. Usually you'll get the requested count but you might get less than that number if the supplier returns
+     * lots of repeats. Make sure that the items properly implement equals and hashcode.
+     */
+    public static <T> Set<T> randomUnique(Supplier<T> supplier, int targetCount) {
+        Set<T> things = new HashSet<>();
+        int maxTries = targetCount * 10;
+        for (int t = 0; t < maxTries; t++) {
+            if (things.size() == targetCount) {
+                return things;
+            }
+            things.add(supplier.get());
+        }
+        // Oh well, we didn't get enough unique things. It'll be ok.
+        return things;
     }
 
     /**

--- a/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
@@ -33,6 +33,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
 
 public class ESTestCaseTests extends ESTestCase {
 
@@ -108,5 +113,18 @@ public class ESTestCaseTests extends ESTestCase {
             result.put(randomAsciiOfLengthBetween(5, 15), randomStringObjectMap(depth - 1));
         }
         return result;
+    }
+
+    public void testRandomUniqueNotUnique() {
+        assertThat(randomUnique(() -> 1, 10), hasSize(1));
+    }
+
+    public void testRandomUniqueTotallyUnique() {
+        AtomicInteger i = new AtomicInteger();
+        assertThat(randomUnique(i::incrementAndGet, 100), hasSize(100));
+    }
+
+    public void testRandomUniqueNormalUsageAlwayMoreThanOne() {
+        assertThat(randomUnique(() -> randomAsciiOfLengthBetween(1, 20), 10), hasSize(greaterThan(0)));
     }
 }


### PR DESCRIPTION
Adds randomUnique to generate unique things and uses it to make unique
keys.

The offending seed was 81AE616FEAD10F17.
