### PR TITLE
Let ingest intercept bulk requests at the bulk shard transport level.

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
@@ -19,7 +19,10 @@
 
 package org.elasticsearch.action.bulk;
 
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
@@ -40,18 +43,35 @@ public class BulkShardRequest extends ReplicationRequest<BulkShardRequest> {
     public BulkShardRequest() {
     }
 
-    BulkShardRequest(BulkRequest bulkRequest, ShardId shardId, boolean refresh, BulkItemRequest[] items) {
+    public BulkShardRequest(ShardId shardId, boolean refresh, BulkItemRequest[] items) {
         super(shardId);
         this.items = items;
         this.refresh = refresh;
     }
 
-    boolean refresh() {
+    public boolean refresh() {
         return this.refresh;
     }
 
-    BulkItemRequest[] items() {
+    public BulkItemRequest[] items() {
         return items;
+    }
+
+    /**
+     * @return Whether this bulk shard request contains index request with an ingest pipeline enabled.
+     */
+    public boolean hasIndexRequestsWithPipelines() {
+        for (BulkItemRequest item : items()) {
+            ActionRequest<?> actionRequest = item.request();
+            if (actionRequest instanceof IndexRequest) {
+                IndexRequest indexRequest = (IndexRequest) actionRequest;
+                if (Strings.hasText(indexRequest.getPipeline())) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkShardResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkShardResponse.java
@@ -33,13 +33,22 @@ public class BulkShardResponse extends ReplicationResponse {
 
     private ShardId shardId;
     private BulkItemResponse[] responses;
+    private long ingestTookInMillis;
 
-    BulkShardResponse() {
+    public BulkShardResponse() {
     }
 
-    BulkShardResponse(ShardId shardId, BulkItemResponse[] responses) {
+    public BulkShardResponse(ShardId shardId, BulkItemResponse[] responses) {
         this.shardId = shardId;
         this.responses = responses;
+        this.ingestTookInMillis = BulkResponse.NO_INGEST_TOOK;
+    }
+
+    public BulkShardResponse(BulkShardResponse source, BulkItemResponse[] responses, long ingestTookInMillis) {
+        this.shardId = source.getShardId();
+        this.responses = responses;
+        this.ingestTookInMillis = ingestTookInMillis;
+        setShardInfo(source.getShardInfo());
     }
 
     public ShardId getShardId() {
@@ -50,6 +59,10 @@ public class BulkShardResponse extends ReplicationResponse {
         return responses;
     }
 
+    public long getIngestTookInMillis() {
+        return ingestTookInMillis;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -58,6 +71,7 @@ public class BulkShardResponse extends ReplicationResponse {
         for (int i = 0; i < responses.length; i++) {
             responses[i] = BulkItemResponse.readBulkItem(in);
         }
+        ingestTookInMillis = in.readZLong();
     }
 
     @Override
@@ -68,5 +82,6 @@ public class BulkShardResponse extends ReplicationResponse {
         for (BulkItemResponse response : responses) {
             response.writeTo(out);
         }
+        out.writeZLong(ingestTookInMillis);
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -336,7 +336,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         for (Map.Entry<ShardId, List<BulkItemRequest>> entry : requestsByShard.entrySet()) {
             final ShardId shardId = entry.getKey();
             final List<BulkItemRequest> requests = entry.getValue();
-            BulkShardRequest bulkShardRequest = new BulkShardRequest(bulkRequest, shardId, bulkRequest.refresh(), requests.toArray(new BulkItemRequest[requests.size()]));
+            BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId, bulkRequest.refresh(), requests.toArray(new BulkItemRequest[requests.size()]));
             bulkShardRequest.consistencyLevel(bulkRequest.consistencyLevel());
             bulkShardRequest.timeout(bulkRequest.timeout());
             shardBulkAction.execute(bulkShardRequest, new ActionListener<BulkShardResponse>() {

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkShardRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkShardRequestTests.java
@@ -28,9 +28,9 @@ public class BulkShardRequestTests extends ESTestCase {
     public void testToString() {
         String index = randomSimpleString(random(), 10);
         int count = between(1, 100);
-        BulkShardRequest r = new BulkShardRequest(null, new ShardId(index, "ignored", 0), false, new BulkItemRequest[count]);
+        BulkShardRequest r = new BulkShardRequest(new ShardId(index, "ignored", 0), false, new BulkItemRequest[count]);
         assertEquals("BulkShardRequest to [" + index + "] containing [" + count + "] requests", r.toString());
-        r = new BulkShardRequest(null, new ShardId(index, "ignored", 0), true, new BulkItemRequest[count]);
+        r = new BulkShardRequest(new ShardId(index, "ignored", 0), true, new BulkItemRequest[count]);
         assertEquals("BulkShardRequest to [" + index + "] containing [" + count + "] requests and a refresh", r.toString());
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/ingest/BulkRequestModifierTests.java
+++ b/core/src/test/java/org/elasticsearch/action/ingest/BulkRequestModifierTests.java
@@ -21,9 +21,11 @@ package org.elasticsearch.action.ingest;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.bulk.BulkItemRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
-import org.elasticsearch.action.bulk.BulkRequest;
-import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.bulk.BulkShardRequest;
+import org.elasticsearch.action.bulk.BulkShardResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.index.shard.ShardId;
@@ -39,57 +41,67 @@ import java.util.Set;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Mockito.mock;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class BulkRequestModifierTests extends ESTestCase {
 
+    private final static ShardId SHARD_ID = new ShardId("_index", "_indexUUID", 0);
+
     public void testBulkRequestModifier() {
         int numRequests = scaledRandomIntBetween(8, 64);
-        BulkRequest bulkRequest = new BulkRequest();
+        List<BulkItemRequest> items = new ArrayList<>();
         for (int i = 0; i < numRequests; i++) {
-            bulkRequest.add(new IndexRequest("_index", "_type", String.valueOf(i)).source("{}"));
+            items.add(new BulkItemRequest(i, new IndexRequest("_index", "_type", String.valueOf(i)).source("{}")));
         }
+        BulkShardRequest bulkRequest = new BulkShardRequest(SHARD_ID, false, items.toArray(new BulkItemRequest[0]));
         CaptureActionListener actionListener = new CaptureActionListener();
         IngestActionFilter.BulkRequestModifier bulkRequestModifier = new IngestActionFilter.BulkRequestModifier(bulkRequest);
 
-        int i = 0;
         Set<Integer> failedSlots = new HashSet<>();
         while (bulkRequestModifier.hasNext()) {
             bulkRequestModifier.next();
             if (randomBoolean()) {
                 bulkRequestModifier.markCurrentItemAsFailed(new RuntimeException());
-                failedSlots.add(i);
+                failedSlots.add(bulkRequestModifier.current.id());
             }
-            i++;
         }
 
-        assertThat(bulkRequestModifier.getBulkRequest().requests().size(), equalTo(numRequests - failedSlots.size()));
+        assertThat(bulkRequestModifier.getBulkShardRequest().items().length, equalTo(numRequests - failedSlots.size()));
         // simulate that we actually executed the modified bulk request:
         long ingestTook = randomLong();
-        ActionListener<BulkResponse> result = bulkRequestModifier.wrapActionListenerIfNeeded(ingestTook, actionListener);
-        result.onResponse(new BulkResponse(new BulkItemResponse[numRequests - failedSlots.size()], 0));
 
-        BulkResponse bulkResponse = actionListener.getResponse();
+        ActionListener<BulkShardResponse> result = bulkRequestModifier.wrapActionListenerIfNeeded(ingestTook, actionListener);
+        List<BulkItemResponse> responses = new ArrayList<>(numRequests - failedSlots.size());
+        for (int j = 0; j < items.size(); j++) {
+            int id = items.get(j).id();
+            if (failedSlots.contains(id)) {
+                continue;
+            }
+            responses.add(new BulkItemResponse(id, "nothing", new IndexResponse()));
+        }
+        result.onResponse(new BulkShardResponse(new BulkShardResponse(), responses.toArray(new BulkItemResponse[responses.size()]), 0));
+
+        BulkShardResponse bulkResponse = actionListener.getResponse();
         assertThat(bulkResponse.getIngestTookInMillis(), equalTo(ingestTook));
-        for (int j = 0; j < bulkResponse.getItems().length; j++) {
-            if (failedSlots.contains(j)) {
-                BulkItemResponse item = bulkResponse.getItems()[j];
+        for (BulkItemResponse item : bulkResponse.getResponses()) {
+            if (failedSlots.contains(item.getItemId())) {
                 assertThat(item.isFailed(), is(true));
                 assertThat(item.getFailure().getIndex(), equalTo("_index"));
                 assertThat(item.getFailure().getType(), equalTo("_type"));
-                assertThat(item.getFailure().getId(), equalTo(String.valueOf(j)));
                 assertThat(item.getFailure().getMessage(), equalTo("java.lang.RuntimeException"));
             } else {
-                assertThat(bulkResponse.getItems()[j], nullValue());
+                assertThat(item.getOpType(), sameInstance("nothing"));
             }
         }
     }
 
     public void testPipelineFailures() {
-        BulkRequest originalBulkRequest = new BulkRequest();
+        List<BulkItemRequest> items = new ArrayList<>();
         for (int i = 0; i < 32; i++) {
-            originalBulkRequest.add(new IndexRequest("index", "type", String.valueOf(i)));
+            items.add(new BulkItemRequest(i, new IndexRequest("index", "type", String.valueOf(i))));
         }
+        BulkShardRequest originalBulkRequest =
+                new BulkShardRequest(SHARD_ID, false, items.toArray(new BulkItemRequest[0]));
 
         IngestActionFilter.BulkRequestModifier modifier = new IngestActionFilter.BulkRequestModifier(originalBulkRequest);
         for (int i = 0; modifier.hasNext(); i++) {
@@ -100,14 +112,14 @@ public class BulkRequestModifierTests extends ESTestCase {
         }
 
         // So half of the requests have "failed", so only the successful requests are left:
-        BulkRequest bulkRequest = modifier.getBulkRequest();
-        assertThat(bulkRequest.requests().size(), Matchers.equalTo(16));
+        BulkShardRequest bulkRequest = modifier.getBulkShardRequest();
+        assertThat(bulkRequest.items().length, Matchers.equalTo(16));
 
         List<BulkItemResponse> responses = new ArrayList<>();
-        ActionListener<BulkResponse> bulkResponseListener = modifier.wrapActionListenerIfNeeded(1L, new ActionListener<BulkResponse>() {
+        ActionListener<BulkShardResponse> bulkResponseListener = modifier.wrapActionListenerIfNeeded(1L, new ActionListener<BulkShardResponse>() {
             @Override
-            public void onResponse(BulkResponse bulkItemResponses) {
-                responses.addAll(Arrays.asList(bulkItemResponses.getItems()));
+            public void onResponse(BulkShardResponse bulkItemResponses) {
+                responses.addAll(Arrays.asList(bulkItemResponses.getResponses()));
             }
 
             @Override
@@ -116,12 +128,16 @@ public class BulkRequestModifierTests extends ESTestCase {
         });
 
         List<BulkItemResponse> originalResponses = new ArrayList<>();
-        for (ActionRequest actionRequest : bulkRequest.requests()) {
+        for (BulkItemRequest item : bulkRequest.items()) {
+            ActionRequest actionRequest = item.request();
             IndexRequest indexRequest = (IndexRequest) actionRequest;
             IndexResponse indexResponse = new IndexResponse(new ShardId("index", "_na_", 0), indexRequest.type(), indexRequest.id(), 1, true);
             originalResponses.add(new BulkItemResponse(Integer.parseInt(indexRequest.id()), indexRequest.opType().lowercase(), indexResponse));
         }
-        bulkResponseListener.onResponse(new BulkResponse(originalResponses.toArray(new BulkItemResponse[originalResponses.size()]), 0));
+        bulkResponseListener.onResponse(
+                new BulkShardResponse(new BulkShardResponse(),
+                        originalResponses.toArray(new BulkItemResponse[originalResponses.size()]), 0)
+        );
 
         assertThat(responses.size(), Matchers.equalTo(32));
         for (int i = 0; i < 32; i++) {
@@ -130,29 +146,27 @@ public class BulkRequestModifierTests extends ESTestCase {
     }
 
     public void testNoFailures() {
-        BulkRequest originalBulkRequest = new BulkRequest();
-        for (int i = 0; i < 32; i++) {
-            originalBulkRequest.add(new IndexRequest("index", "type", String.valueOf(i)));
+        BulkItemRequest[] items = new BulkItemRequest[32];
+        for (int i = 0; i < items.length; i++) {
+            items[i] = new BulkItemRequest(i, new IndexRequest("index", "type", String.valueOf(i)));
         }
+        BulkShardRequest originalBulkRequest = new BulkShardRequest(SHARD_ID, false, items);
 
         IngestActionFilter.BulkRequestModifier modifier = new IngestActionFilter.BulkRequestModifier(originalBulkRequest);
         while (modifier.hasNext()) {
             modifier.next();
         }
 
-        BulkRequest bulkRequest = modifier.getBulkRequest();
-        assertThat(bulkRequest, Matchers.sameInstance(originalBulkRequest));
-        @SuppressWarnings("unchecked")
-        ActionListener<BulkResponse> actionListener = mock(ActionListener.class);
-        assertThat(modifier.wrapActionListenerIfNeeded(1L, actionListener).getClass().isAnonymousClass(), is(true));
+        BulkShardRequest bulkRequest = modifier.getBulkShardRequest();
+        assertThat(bulkRequest.items(), Matchers.equalTo(originalBulkRequest.items()));
     }
 
-    private static class CaptureActionListener implements ActionListener<BulkResponse> {
+    private static class CaptureActionListener implements ActionListener<BulkShardResponse> {
 
-        private BulkResponse response;
+        private BulkShardResponse response;
 
         @Override
-        public void onResponse(BulkResponse bulkItemResponses) {
+        public void onResponse(BulkShardResponse bulkItemResponses) {
             this.response = bulkItemResponses;
         }
 
@@ -160,7 +174,7 @@ public class BulkRequestModifierTests extends ESTestCase {
         public void onFailure(Throwable e) {
         }
 
-        public BulkResponse getResponse() {
+        public BulkShardResponse getResponse() {
             return response;
         }
     }


### PR DESCRIPTION
Today ingest intercepts bulk requests at the bulk transport level. All the bulk items get preprocessed one by one at the coordinating node and there is no parallelism. After that the bulk api splits the requests up in shard bulk requests and then bulk indexing happens in parallel. It would be nice if ingest also preprocesses bulk requests in parallel.

I have been playing around with this idea and come up with this PR for discussion.
Without this change the amount of time spent on ingestion is pretty high chuck on time comparing it to the total time spent (when indexing into indices with a few shards and higher). With this change the relative ingest time compare to the total time spent drops significantly. The change does look sane to me, but perhaps I overlooked something.
