### PR TITLE
Remove getQueryPrototype from QueryParser

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/QueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryParser.java
@@ -22,12 +22,10 @@ package org.elasticsearch.index.query;
 import java.io.IOException;
 
 /**
- * Defines a query parser that is able to read and parse a query object in {@link org.elasticsearch.common.xcontent.XContent}
- * format and create an internal object representing the query, implementing {@link QueryBuilder}, which can be streamed to other nodes.
+ * Defines a query parser that is able to parse {@link QueryBuilder}s from {@link org.elasticsearch.common.xcontent.XContent}.
  */
 @FunctionalInterface
 public interface QueryParser<QB extends QueryBuilder<QB>> {
-
     /**
      * Creates a new {@link QueryBuilder} from the query held by the {@link QueryParseContext}
      * in {@link org.elasticsearch.common.xcontent.XContent} format
@@ -39,11 +37,4 @@ public interface QueryParser<QB extends QueryBuilder<QB>> {
      * @return the new QueryBuilder
      */
     QB fromXContent(QueryParseContext parseContext) throws IOException;
-
-    /**
-     * @return an empty {@link QueryBuilder} instance for this parser that can be used for deserialization
-     */
-    default QB getBuilderPrototype() { // TODO remove this when nothing implements it
-        throw new UnsupportedOperationException();
-    }
 }


### PR DESCRIPTION
It isn't used any more.
