### PR TITLE
Setup jvm opts correctly for deb/rpm tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -140,6 +140,7 @@ class NodeInfo {
                 args.add("${property.getKey()}=${property.getValue()}")
             }
         }
+        env.put('ES_JVM_OPTIONS', new File(confDir, 'jvm.options'))
         args.addAll("-E", "es.path.conf=${confDir}")
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
             args.add('"') // end the entire command, quoted

--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -167,7 +167,7 @@ fi
 
 # JAVA_OPTS is not a built-in JVM mechanism but some people think it is
 # so let us warn them that we are not observing the value of $JAVA_OPTS
-if [ ! -z "JAVA_OPTS" ]; then
+if [ "x$JAVA_OPTS" != "x" ]; then
     echo "Warning: Ignoring JAVA_OPTS=$JAVA_OPTS"
     echo "Please pass JVM parameters via ES_JAVA_OPTS instead"
 fi


### PR DESCRIPTION
Also stops warning about JAVA_OPTS when it is an empty string.
