### PR TITLE
Enable installing the rest-api-spec artifact

### DIFF
--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -1,1 +1,8 @@
 apply plugin: 'java'
+apply plugin: 'com.bmuschko.nexus'
+
+extraArchive {
+  sources = false
+  javadoc = false
+  tests = false
+}


### PR DESCRIPTION
Running `gradle install` on the rest-api-spec fails because there is no available install
task. This change applies the nexus plugin so that we can install and should also enable
publishing as part of the uploadArchives task.
