### PR TITLE
Node names cleanup

### DIFF
--- a/core/src/main/resources/config/names.txt
+++ b/core/src/main/resources/config/names.txt
@@ -1047,7 +1047,7 @@ Gosamyr
 Grand Director
 Grandmaster
 Grappler
-Grasshopper 
+Grasshopper
 Grasshopper II
 Graviton
 Gravity
@@ -1483,7 +1483,7 @@ Lightmaster
 Lightspeed
 Lila Cheney
 Lilandra Neramani
-Lilith, the Daughter of Dracula 
+Lilith, the Daughter of Dracula
 Lin Sun
 Link
 Lionheart


### PR DESCRIPTION
Fixes two node names contained trailing spaces that was causing cat.tasks test to fail.

Fixes #17718
