### PR TITLE
Fix path to assembled packages in contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ cd elasticsearch/
 gradle assemble
 ```
 
-You will find the newly built packages under: `./distribution/build/distributions/`.
+You will find the newly built packages under: `./distribution/(deb|rpm|tar|zip)/build/distributions/`.
 
 Before submitting your changes, run the test suite to make sure that nothing is broken, with:
 


### PR DESCRIPTION
This commit fixes the specification of the path to assembled packages in
the contributing doc.
