### PR TITLE
Pass test JVM arguments to test nodes

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -129,11 +129,11 @@ class NodeInfo {
             args.add("${esScript}")
         }
 
-        env = [
-            'JAVA_HOME' : project.javaHome
-        ]
+        env = [ 'JAVA_HOME' : project.javaHome ]
         args.addAll("-E", "es.node.portsfile=true")
-        env.put('ES_JAVA_OPTS', config.systemProperties.collect { key, value -> "-D${key}=${value}" }.join(" "))
+        String collectedSystemProperties = config.systemProperties.collect { key, value -> "-D${key}=${value}" }.join(" ")
+        String esJavaOpts = config.jvmArgs.isEmpty() ? collectedSystemProperties : collectedSystemProperties + " " + config.jvmArgs
+        env.put('ES_JAVA_OPTS', esJavaOpts)
         for (Map.Entry<String, String> property : System.properties.entrySet()) {
             if (property.getKey().startsWith('es.')) {
                 args.add("-E")

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -19,7 +19,6 @@
 package org.elasticsearch.gradle.test
 
 import org.apache.tools.ant.taskdefs.condition.Os
-import org.elasticsearch.gradle.VersionProperties
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.Task

--- a/core/src/main/java/org/elasticsearch/bootstrap/JavaVersion.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/JavaVersion.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-class JavaVersion implements Comparable<JavaVersion> {
+public class JavaVersion implements Comparable<JavaVersion> {
     private final List<Integer> version;
 
     public List<Integer> getVersion() {

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardStateIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardStateIT.java
@@ -50,8 +50,8 @@ public class ShardStateIT extends ESIntegTestCase {
         logger.info("--> waiting for a yellow index");
         // JDK 9 type inference gets confused, so we have to help the
         // type inference
-        assertBusy(() -> assertThat(client().admin().cluster().prepareHealth().get().getStatus(),
-            equalTo(ClusterHealthStatus.YELLOW)));
+        assertBusy(((Runnable) () -> assertThat(client().admin().cluster().prepareHealth().get().getStatus(),
+                equalTo(ClusterHealthStatus.YELLOW))));
 
         final long term0 = shard == 0 ? 2 : 1;
         final long term1 = shard == 1 ? 2 : 1;

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardStateIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardStateIT.java
@@ -48,6 +48,8 @@ public class ShardStateIT extends ESIntegTestCase {
         indicesService.indexService(resolveIndex("test")).getShard(shard).failShard("simulated test failure", null);
 
         logger.info("--> waiting for a yellow index");
+        // JDK 9 type inference gets confused, so we have to help the
+        // type inference
         assertBusy(() -> assertThat(client().admin().cluster().prepareHealth().get().getStatus(),
             equalTo(ClusterHealthStatus.YELLOW)));
 

--- a/core/src/test/java/org/elasticsearch/monitor/jvm/JvmInfoTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/jvm/JvmInfoTests.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.monitor.jvm;
+
+import org.apache.lucene.util.Constants;
+import org.elasticsearch.bootstrap.JavaVersion;
+import org.elasticsearch.test.ESTestCase;
+
+public class JvmInfoTests extends ESTestCase {
+
+    public void testUseG1GC() {
+        // if we are running on HotSpot, and the test JVM was started
+        // with UseG1GC, then JvmInfo should successfully report that
+        // G1GC is enabled
+        if (Constants.JVM_NAME.contains("HotSpot")) {
+            assertEquals(Boolean.toString(isG1GCEnabled()), JvmInfo.jvmInfo().useG1GC());
+        } else {
+            assertEquals("unknown", JvmInfo.jvmInfo().useG1GC());
+        }
+    }
+
+    private boolean isG1GCEnabled() {
+        final String argline = System.getProperty("tests.jvm.argline");
+        final boolean g1GCEnabled = flagIsEnabled(argline, "UseG1GC");
+        // for JDK 9 the default collector when no collector is specified is G1 GC
+        final boolean versionIsAtLeastJava9 = JavaVersion.current().compareTo(JavaVersion.parse("9")) >= 0;
+        final boolean noOtherCollectorSpecified =
+                argline == null ||
+                        (!flagIsEnabled(argline, "UseParNewGC") &&
+                                !flagIsEnabled(argline, "UseParallelGC") &&
+                                !flagIsEnabled(argline, "UseParallelOldGC") &&
+                                !flagIsEnabled(argline, "UseSerialGC") &&
+                                !flagIsEnabled(argline, "UseConcMarkSweepGC"));
+        return g1GCEnabled || (versionIsAtLeastJava9 && noOtherCollectorSpecified);
+    }
+
+    private boolean flagIsEnabled(String argline, String flag) {
+        final boolean containsPositiveFlag = argline != null && argline.contains("-XX:+" + flag);
+        if (!containsPositiveFlag) return false;
+        final int index = argline.lastIndexOf(flag);
+        return argline.charAt(index - 1) == '+';
+    }
+
+}


### PR DESCRIPTION
This pull request modifies the integration test node spinup to pass
through the system property `tests.jvm.argline`. The main purpose of
passing through this `tests.jvm.argline` is so that we can continue to
test with G1GC on CI. Thus, also added is a test that if G1GC is
enabled, then `JvmInfo#useG1GC` returns the right thing on HotSpot.
