### PR TITLE
Shard level tasks in Bulk Action lose reference to their parent tasks

### DIFF
--- a/core/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
@@ -122,12 +122,13 @@ public class TransportBulkActionTookTests extends ESTestCase {
 
                 @Override
                 void executeBulk(
+                        Task task,
                         BulkRequest bulkRequest,
                         long startTimeNanos,
                         ActionListener<BulkResponse> listener,
                         AtomicArray<BulkItemResponse> responses) {
                     expected.set(1000000);
-                    super.executeBulk(bulkRequest, startTimeNanos, listener, responses);
+                    super.executeBulk(task, bulkRequest, startTimeNanos, listener, responses);
                 }
             };
         } else {
@@ -151,13 +152,14 @@ public class TransportBulkActionTookTests extends ESTestCase {
 
                 @Override
                 void executeBulk(
+                        Task task,
                         BulkRequest bulkRequest,
                         long startTimeNanos,
                         ActionListener<BulkResponse> listener,
                         AtomicArray<BulkItemResponse> responses) {
                     long elapsed = spinForAtLeastOneMillisecond();
                     expected.set(elapsed);
-                    super.executeBulk(bulkRequest, startTimeNanos, listener, responses);
+                    super.executeBulk(task, bulkRequest, startTimeNanos, listener, responses);
                 }
             };
         }
@@ -183,7 +185,7 @@ public class TransportBulkActionTookTests extends ESTestCase {
         bulkRequest.add(bulkAction.getBytes(StandardCharsets.UTF_8), 0, bulkAction.length(), null, null);
         AtomicLong expected = new AtomicLong();
         TransportBulkAction action = createAction(controlled, expected);
-        action.doExecute(bulkRequest, new ActionListener<BulkResponse>() {
+        action.doExecute(null, bulkRequest, new ActionListener<BulkResponse>() {
             @Override
             public void onResponse(BulkResponse bulkItemResponses) {
                 if (controlled) {


### PR DESCRIPTION
During the bulk action a hierachy of tasks is getting created: bulk->bulk[s](coord node) -> bulk[s](primary shard node) -> bulk[s][p] and bulk[s][r]. Due to a bug the first bulk[s] task didn't have bulk's task id is set as a parent id.  This commit fixes this bug.
