### PR TITLE
Use the new points API to index numeric fields.

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -471,12 +471,12 @@
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]ParseContext.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]ParsedDocument.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]CompletionFieldMapper.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]DateFieldMapper.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]DoubleFieldMapper.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]FloatFieldMapper.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]NumberFieldMapper.java" checks="LineLength" />
+  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]LegacyDateFieldMapper.java" checks="LineLength" />
+  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]LegacyDoubleFieldMapper.java" checks="LineLength" />
+  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]LegacyFloatFieldMapper.java" checks="LineLength" />
+  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]LegacyNumberFieldMapper.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]StringFieldMapper.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]TokenCountFieldMapper.java" checks="LineLength" />
+  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]LegacyTokenCountFieldMapper.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]TypeParsers.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]geo[/\\]BaseGeoPointFieldMapper.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]geo[/\\]GeoPointFieldMapper.java" checks="LineLength" />
@@ -1070,8 +1070,8 @@
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]BooleanFieldMapperTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]CompletionFieldTypeTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]MultiFieldCopyToMapperTests.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]TokenCountFieldMapperTests.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]date[/\\]SimpleDateMappingTests.java" checks="LineLength" />
+  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]core[/\\]LegacyTokenCountFieldMapperTests.java" checks="LineLength" />
+  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]date[/\\]LegacyDateMappingTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]dynamictemplate[/\\]genericstore[/\\]GenericStoreDynamicTemplateTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]dynamictemplate[/\\]pathmatch[/\\]PathMatchDynamicTemplateTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]dynamictemplate[/\\]simple[/\\]SimpleDynamicTemplatesTests.java" checks="LineLength" />
@@ -1087,12 +1087,12 @@
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]index[/\\]IndexTypeMapperTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]internal[/\\]FieldNamesFieldMapperTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]internal[/\\]TypeFieldMapperTests.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]ip[/\\]SimpleIpMappingTests.java" checks="LineLength" />
+  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]ip[/\\]LegacyIpMappingTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]merge[/\\]TestMergeMapperTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]multifield[/\\]MultiFieldTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]multifield[/\\]merge[/\\]JavaMultiFieldMergeTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]nested[/\\]NestedMappingTests.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]numeric[/\\]SimpleNumericTests.java" checks="LineLength" />
+  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]numeric[/\\]LegacyNumericTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]object[/\\]NullValueObjectMappingTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]object[/\\]SimpleObjectMappingTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]mapper[/\\]parent[/\\]ParentMappingTests.java" checks="LineLength" />

--- a/buildSrc/src/main/resources/forbidden/es-all-signatures.txt
+++ b/buildSrc/src/main/resources/forbidden/es-all-signatures.txt
@@ -28,3 +28,6 @@ java.security.MessageDigest#clone() @ use org.elasticsearch.common.hash.MessageD
 
 @defaultMessage this should not have been added to lucene in the first place
 org.apache.lucene.index.IndexReader#getCombinedCoreAndDeletesKey()
+
+@defaultMessage Soon to be removed
+org.apache.lucene.document.FieldType#numericType()

--- a/core/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
+++ b/core/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
@@ -41,6 +41,7 @@ import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyDateFieldMapper;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.support.QueryParsers;
 
@@ -336,11 +337,12 @@ public class MapperQueryParser extends QueryParser {
 
             try {
                 Query rangeQuery;
-                if (currentFieldType instanceof DateFieldMapper.DateFieldType && settings.timeZone() != null) {
-                    DateFieldMapper.DateFieldType dateFieldType =
-                        (DateFieldMapper.DateFieldType) this.currentFieldType;
-                    rangeQuery = dateFieldType.rangeQuery(part1, part2, startInclusive, endInclusive,
-                        settings.timeZone(), null);
+                if (currentFieldType instanceof LegacyDateFieldMapper.DateFieldType && settings.timeZone() != null) {
+                    LegacyDateFieldMapper.DateFieldType dateFieldType = (LegacyDateFieldMapper.DateFieldType) this.currentFieldType;
+                    rangeQuery = dateFieldType.rangeQuery(part1, part2, startInclusive, endInclusive, settings.timeZone(), null);
+                } else if (currentFieldType instanceof DateFieldMapper.DateFieldType && settings.timeZone() != null) {
+                    DateFieldMapper.DateFieldType dateFieldType = (DateFieldMapper.DateFieldType) this.currentFieldType;
+                    rangeQuery = dateFieldType.rangeQuery(part1, part2, startInclusive, endInclusive, settings.timeZone(), null);
                 } else {
                     rangeQuery = currentFieldType.rangeQuery(part1, part2, startInclusive, endInclusive);
                 }

--- a/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
@@ -19,23 +19,26 @@
 
 package org.elasticsearch.action.fieldstats;
 
+import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.StringHelper;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.joda.FormatDateTimeFormatter;
 import org.elasticsearch.common.joda.Joda;
+import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
-import org.elasticsearch.index.mapper.ip.IpFieldMapper;
-import org.joda.time.DateTime;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
-public abstract class FieldStats<T extends Comparable<T>> implements Streamable, ToXContent {
+public abstract class FieldStats<T> implements Streamable, ToXContent {
 
-    private byte type;
+    private final byte type;
     private long maxDoc;
     private long docCount;
     private long sumDocFreq;
@@ -43,7 +46,8 @@ public abstract class FieldStats<T extends Comparable<T>> implements Streamable,
     protected T minValue;
     protected T maxValue;
 
-    protected FieldStats() {
+    protected FieldStats(int type) {
+        this.type = (byte) type;
     }
 
     protected FieldStats(int type, long maxDoc, long docCount, long sumDocFreq, long sumTotalTermFreq) {
@@ -149,17 +153,6 @@ public abstract class FieldStats<T extends Comparable<T>> implements Streamable,
     protected abstract T valueOf(String value, String optionalFormat);
 
     /**
-     * @param value
-     *            The value to be converted to a String
-     * @param optionalFormat
-     *            A string describing how to print the specified value. Whether
-     *            this parameter is supported depends on the implementation. If
-     *            optionalFormat is specified and the implementation doesn't
-     *            support it an {@link UnsupportedOperationException} is thrown
-     */
-    public abstract String stringValueOf(Object value, String optionalFormat);
-
-    /**
      * Merges the provided stats into this stats instance.
      */
     public void append(FieldStats stats) {
@@ -181,6 +174,8 @@ public abstract class FieldStats<T extends Comparable<T>> implements Streamable,
         }
     }
 
+    protected abstract int compare(T a, T b);
+
     /**
      * @return <code>true</code> if this instance matches with the provided index constraint, otherwise <code>false</code> is returned
      */
@@ -188,9 +183,9 @@ public abstract class FieldStats<T extends Comparable<T>> implements Streamable,
         int cmp;
         T value  = valueOf(constraint.getValue(), constraint.getOptionalFormat());
         if (constraint.getProperty() == IndexConstraint.Property.MIN) {
-            cmp = minValue.compareTo(value);
+            cmp = compare(minValue, value);
         } else if (constraint.getProperty() == IndexConstraint.Property.MAX) {
-            cmp = maxValue.compareTo(value);
+            cmp = compare(maxValue, value);
         } else {
             throw new IllegalArgumentException("Unsupported property [" + constraint.getProperty() + "]");
         }
@@ -246,9 +241,25 @@ public abstract class FieldStats<T extends Comparable<T>> implements Streamable,
         out.writeLong(sumTotalTermFreq);
     }
 
-    public static class Long extends FieldStats<java.lang.Long> {
+    private static abstract class ComparableFieldStats<T extends Comparable<? super T>> extends FieldStats<T> {
+        protected ComparableFieldStats(int type) {
+            super(type);
+        }
+
+        protected ComparableFieldStats(int type, long maxDoc, long docCount, long sumDocFreq, long sumTotalTermFreq) {
+            super(type, maxDoc, docCount, sumDocFreq, sumTotalTermFreq);
+        }
+
+        @Override
+        protected int compare(T a, T b) {
+            return a.compareTo(b);
+        }
+    }
+
+    public static class Long extends ComparableFieldStats<java.lang.Long> {
 
         public Long() {
+            super(0);
         }
 
         public Long(long maxDoc, long docCount, long sumDocFreq, long sumTotalTermFreq, long minValue, long maxValue) {
@@ -288,18 +299,6 @@ public abstract class FieldStats<T extends Comparable<T>> implements Streamable,
         }
 
         @Override
-        public String stringValueOf(Object value, String optionalFormat) {
-            if (optionalFormat != null) {
-                throw new UnsupportedOperationException("custom format isn't supported");
-            }
-            if (value instanceof Number) {
-                return java.lang.Long.toString(((Number) value).longValue());
-            } else {
-                throw new IllegalArgumentException("value must be a Long: " + value);
-            }
-        }
-
-        @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
             minValue = in.readLong();
@@ -315,9 +314,10 @@ public abstract class FieldStats<T extends Comparable<T>> implements Streamable,
 
     }
 
-    public static final class Double extends FieldStats<java.lang.Double> {
+    public static final class Double extends ComparableFieldStats<java.lang.Double> {
 
         public Double() {
+            super(2);
         }
 
         public Double(long maxDoc, long docCount, long sumDocFreq, long sumTotalTermFreq, double minValue, double maxValue) {
@@ -353,18 +353,6 @@ public abstract class FieldStats<T extends Comparable<T>> implements Streamable,
         }
 
         @Override
-        public String stringValueOf(Object value, String optionalFormat) {
-            if (optionalFormat != null) {
-                throw new UnsupportedOperationException("custom format isn't supported");
-            }
-            if (value instanceof Number) {
-                return java.lang.Double.toString(((Number) value).doubleValue());
-            } else {
-                throw new IllegalArgumentException("value must be a Double: " + value);
-            }
-        }
-
-        @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
             minValue = in.readDouble();
@@ -380,9 +368,10 @@ public abstract class FieldStats<T extends Comparable<T>> implements Streamable,
 
     }
 
-    public static final class Text extends FieldStats<BytesRef> {
+    public static final class Text extends ComparableFieldStats<BytesRef> {
 
         public Text() {
+            super(3);
         }
 
         public Text(long maxDoc, long docCount, long sumDocFreq, long sumTotalTermFreq, BytesRef minValue, BytesRef maxValue) {
@@ -419,18 +408,6 @@ public abstract class FieldStats<T extends Comparable<T>> implements Streamable,
                 throw new UnsupportedOperationException("custom format isn't supported");
             }
             return new BytesRef(value);
-        }
-
-        @Override
-        public String stringValueOf(Object value, String optionalFormat) {
-            if (optionalFormat != null) {
-                throw new UnsupportedOperationException("custom format isn't supported");
-            }
-            if (value instanceof BytesRef) {
-                return ((BytesRef) value).utf8ToString();
-            } else {
-                throw new IllegalArgumentException("value must be a BytesRef: " + value);
-            }
         }
 
         @Override
@@ -487,25 +464,6 @@ public abstract class FieldStats<T extends Comparable<T>> implements Streamable,
         }
 
         @Override
-        public String stringValueOf(Object value, String optionalFormat) {
-            FormatDateTimeFormatter dateFormatter = this.dateFormatter;
-            if (optionalFormat != null) {
-                dateFormatter = Joda.forPattern(optionalFormat);
-            }
-            long millis;
-            if (value instanceof java.lang.Long) {
-                millis = ((java.lang.Long) value).longValue();
-            } else if (value instanceof DateTime) {
-                millis = ((DateTime) value).getMillis();
-            } else if (value instanceof BytesRef) {
-                millis = dateFormatter.parser().parseMillis(((BytesRef) value).utf8ToString());
-            } else {
-                throw new IllegalArgumentException("value must be either a DateTime or a long: " + value);
-            }
-            return dateFormatter.printer().print(millis);
-        }
-
-        @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
             dateFormatter =  Joda.forPattern(in.readString());
@@ -519,25 +477,59 @@ public abstract class FieldStats<T extends Comparable<T>> implements Streamable,
 
     }
 
-    public static class Ip extends Long {
+    public static class Ip extends FieldStats<InetAddress> {
 
-        public Ip(int maxDoc, int docCount, long sumDocFreq, long sumTotalTermFreq, long minValue, long maxValue) {
-            super(maxDoc, docCount, sumDocFreq, sumTotalTermFreq, minValue, maxValue);
-        }
+        private InetAddress minValue, maxValue;
 
-        protected Ip(int type, long maxDoc, long docCount, long sumDocFreq, long sumTotalTermFreq, long minValue, long maxValue) {
-            super(type, maxDoc, docCount, sumDocFreq, sumTotalTermFreq, minValue, maxValue);
+        public Ip(int maxDoc, int docCount, long sumDocFreq, long sumTotalTermFreq,
+                InetAddress minValue, InetAddress maxValue) {
+            super(4, maxDoc, docCount, sumDocFreq, sumTotalTermFreq);
+            this.minValue = minValue;
+            this.maxValue = maxValue;
         }
 
         public Ip() {
+            super(4);
         }
 
         @Override
-        public String stringValueOf(Object value, String optionalFormat) {
-            if (value instanceof BytesRef) {
-                return super.stringValueOf(IpFieldMapper.ipToLong(((BytesRef) value).utf8ToString()), optionalFormat);
+        public String getMinValueAsString() {
+            return NetworkAddress.format(minValue);
+        }
+
+        @Override
+        public String getMaxValueAsString() {
+            return NetworkAddress.format(maxValue);
+        }
+
+        @Override
+        protected InetAddress valueOf(String value, String optionalFormat) {
+            try {
+                return InetAddress.getByName(value);
+            } catch (UnknownHostException e) {
+                throw new RuntimeException(e);
             }
-            return super.stringValueOf(value, optionalFormat);
+        }
+
+        @Override
+        protected int compare(InetAddress a, InetAddress b) {
+            byte[] ab = InetAddressPoint.encode(a);
+            byte[] bb = InetAddressPoint.encode(b);
+            return StringHelper.compare(ab.length, ab, 0, bb, 0);
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            minValue = valueOf(in.readString(), null);
+            maxValue = valueOf(in.readString(), null);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(NetworkAddress.format(minValue));
+            out.writeString(NetworkAddress.format(maxValue));
         }
     }
 
@@ -557,10 +549,12 @@ public abstract class FieldStats<T extends Comparable<T>> implements Streamable,
             case 3:
                 stats = new Text();
                 break;
+            case 4:
+                stats = new Ip();
+                break;
             default:
                 throw new IllegalArgumentException("Illegal type [" + type + "]");
         }
-        stats.type = type;
         stats.readFrom(in);
         return stats;
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/CustomDocValuesField.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/CustomDocValuesField.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.IndexableFieldType;
+
+import java.io.Reader;
+
+// used for binary and geo fields
+public abstract class CustomDocValuesField implements IndexableField {
+
+    public static final FieldType TYPE = new FieldType();
+    static {
+      TYPE.setDocValuesType(DocValuesType.BINARY);
+      TYPE.freeze();
+    }
+
+    private final String name;
+
+    public CustomDocValuesField(String  name) {
+        this.name = name;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public IndexableFieldType fieldType() {
+        return TYPE;
+    }
+
+    @Override
+    public float boost() {
+        return 1f;
+    }
+
+    @Override
+    public String stringValue() {
+        return null;
+    }
+
+    @Override
+    public Reader readerValue() {
+        return null;
+    }
+
+    @Override
+    public Number numericValue() {
+        return null;
+    }
+
+    @Override
+    public TokenStream tokenStream(Analyzer analyzer, TokenStream reuse) {
+        return null;
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -31,7 +31,6 @@ import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.search.BoostQuery;
@@ -358,15 +357,7 @@ public abstract class MappedFieldType extends FieldType {
     }
 
     public Query regexpQuery(String value, int flags, int maxDeterminizedStates, @Nullable MultiTermQuery.RewriteMethod method, @Nullable QueryShardContext context) {
-        if (numericType() != null) {
-            throw new QueryShardException(context, "Cannot use regular expression to filter numeric field [" + name + "]");
-        }
-
-        RegexpQuery query = new RegexpQuery(new Term(name(), indexedValueForSearch(value)), flags, maxDeterminizedStates);
-        if (method != null) {
-            query.setRewriteMethod(method);
-        }
-        return query;
+        throw new QueryShardException(context, "Can only use regular expression on keyword and text fields - not on [" + name + "] which is of type [" + typeName() + "]");
     }
 
     public Query nullValueQuery() {

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.BytesBinaryDVIndexFieldData;
+import org.elasticsearch.index.mapper.CustomDocValuesField;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
@@ -178,7 +179,7 @@ public class BinaryFieldMapper extends FieldMapper {
         return CONTENT_TYPE;
     }
 
-    public static class CustomBinaryDocValuesField extends NumberFieldMapper.CustomNumericDocValuesField {
+    public static class CustomBinaryDocValuesField extends CustomDocValuesField {
 
         private final ObjectArrayList<byte[]> bytesList;
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -20,38 +20,38 @@
 package org.elasticsearch.index.mapper.core;
 
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.MultiFields;
-import org.apache.lucene.index.Terms;
-import org.apache.lucene.search.LegacyNumericRangeQuery;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
-import org.apache.lucene.util.LegacyNumericUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.fieldstats.FieldStats;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.Numbers;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.joda.DateMathParser;
 import org.elasticsearch.common.joda.FormatDateTimeFormatter;
 import org.elasticsearch.common.joda.Joda;
+import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.mapper.core.LongFieldMapper.CustomLongNumericField;
+import org.elasticsearch.index.mapper.core.LegacyNumberFieldMapper.Defaults;
+import org.elasticsearch.index.mapper.internal.AllFieldMapper;
+import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.internal.SearchContext;
 import org.joda.time.DateTimeZone;
@@ -63,37 +63,24 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.index.mapper.core.TypeParsers.parseDateTimeFormatter;
-import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
 
-public class DateFieldMapper extends NumberFieldMapper {
+/** A {@link FieldMapper} for ip addresses. */
+public class DateFieldMapper extends FieldMapper implements AllFieldMapper.IncludeInAll {
 
     public static final String CONTENT_TYPE = "date";
+    public static final FormatDateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = Joda.forPattern(
+            "strict_date_optional_time||epoch_millis", Locale.ROOT);
 
-    public static class Defaults extends NumberFieldMapper.Defaults {
-        public static final FormatDateTimeFormatter DATE_TIME_FORMATTER = Joda.forPattern("strict_date_optional_time||epoch_millis", Locale.ROOT);
-        public static final TimeUnit TIME_UNIT = TimeUnit.MILLISECONDS;
-        public static final DateFieldType FIELD_TYPE = new DateFieldType();
+    public static class Builder extends FieldMapper.Builder<Builder, DateFieldMapper> {
 
-        static {
-            FIELD_TYPE.freeze();
-        }
-
-        public static final String NULL_VALUE = null;
-    }
-
-    public static class Builder extends NumberFieldMapper.Builder<Builder, DateFieldMapper> {
-
-        protected String nullValue = Defaults.NULL_VALUE;
-
+        private Boolean ignoreMalformed;
         private Locale locale;
 
         public Builder(String name) {
-            super(name, Defaults.FIELD_TYPE, Defaults.PRECISION_STEP_64_BIT);
+            super(name, new DateFieldType(), new DateFieldType());
             builder = this;
-            // do *NOT* rely on the default locale
             locale = Locale.ROOT;
         }
 
@@ -102,14 +89,19 @@ public class DateFieldMapper extends NumberFieldMapper {
             return (DateFieldType)fieldType;
         }
 
-        public Builder timeUnit(TimeUnit timeUnit) {
-            fieldType().setTimeUnit(timeUnit);
-            return this;
+        public Builder ignoreMalformed(boolean ignoreMalformed) {
+            this.ignoreMalformed = ignoreMalformed;
+            return builder;
         }
 
-        public Builder nullValue(String nullValue) {
-            this.nullValue = nullValue;
-            return this;
+        protected Explicit<Boolean> ignoreMalformed(BuilderContext context) {
+            if (ignoreMalformed != null) {
+                return new Explicit<>(ignoreMalformed, true);
+            }
+            if (context.indexSettings() != null) {
+                return new Explicit<>(IGNORE_MALFORMED_SETTING.get(context.indexSettings()), false);
+            }
+            return Defaults.IGNORE_MALFORMED;
         }
 
         public Builder dateTimeFormatter(FormatDateTimeFormatter dateTimeFormatter) {
@@ -117,71 +109,69 @@ public class DateFieldMapper extends NumberFieldMapper {
             return this;
         }
 
-        @Override
-        public DateFieldMapper build(BuilderContext context) {
-            setupFieldType(context);
-            fieldType.setNullValue(nullValue);
-            DateFieldMapper fieldMapper = new DateFieldMapper(name, fieldType, defaultFieldType, ignoreMalformed(context),
-                coerce(context), context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
-            return (DateFieldMapper) fieldMapper.includeInAll(includeInAll);
+        public void locale(Locale locale) {
+            this.locale = locale;
         }
 
         @Override
         protected void setupFieldType(BuilderContext context) {
+            super.setupFieldType(context);
             FormatDateTimeFormatter dateTimeFormatter = fieldType().dateTimeFormatter;
             if (!locale.equals(dateTimeFormatter.locale())) {
-                fieldType().setDateTimeFormatter(new FormatDateTimeFormatter(dateTimeFormatter.format(), dateTimeFormatter.parser(), dateTimeFormatter.printer(), locale));
+                fieldType().setDateTimeFormatter( new FormatDateTimeFormatter(dateTimeFormatter.format(),
+                        dateTimeFormatter.parser(), dateTimeFormatter.printer(), locale));
             }
-            super.setupFieldType(context);
-        }
-
-        public Builder locale(Locale locale) {
-            this.locale = locale;
-            return this;
         }
 
         @Override
-        protected int maxPrecisionStep() {
-            return 64;
+        public DateFieldMapper build(BuilderContext context) {
+            setupFieldType(context);
+            DateFieldMapper fieldMapper = new DateFieldMapper(name, fieldType, defaultFieldType, ignoreMalformed(context),
+                    context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+            return (DateFieldMapper) fieldMapper.includeInAll(includeInAll);
         }
     }
 
     public static class TypeParser implements Mapper.TypeParser {
+
+        public TypeParser() {
+        }
+
         @Override
-        public Mapper.Builder<?, ?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-            DateFieldMapper.Builder builder = new DateFieldMapper.Builder(name);
-            parseNumberField(builder, name, node, parserContext);
-            boolean configuredFormat = false;
+        public Mapper.Builder<?,?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            if (parserContext.indexVersionCreated().before(Version.V_5_0_0)) {
+                return new LegacyDateFieldMapper.TypeParser().parse(name, node, parserContext);
+            }
+            Builder builder = new Builder(name);
+            TypeParsers.parseField(builder, name, node, parserContext);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();
-                String propName = Strings.toUnderscoreCase(entry.getKey());
+                String propName = entry.getKey();
                 Object propNode = entry.getValue();
                 if (propName.equals("null_value")) {
                     if (propNode == null) {
                         throw new MapperParsingException("Property [null_value] cannot be null.");
                     }
-                    builder.nullValue(propNode.toString());
+                    builder.nullValue(InetAddresses.forString(propNode.toString()));
                     iterator.remove();
-                } else if (propName.equals("format")) {
-                    builder.dateTimeFormatter(parseDateTimeFormatter(propNode));
-                    configuredFormat = true;
-                    iterator.remove();
-                } else if (propName.equals("numeric_resolution")) {
-                    builder.timeUnit(TimeUnit.valueOf(propNode.toString().toUpperCase(Locale.ROOT)));
+                } else if (propName.equals("ignore_malformed")) {
+                    builder.ignoreMalformed(TypeParsers.nodeBooleanValue("ignore_malformed", propNode, parserContext));
                     iterator.remove();
                 } else if (propName.equals("locale")) {
                     builder.locale(LocaleUtils.parse(propNode.toString()));
                     iterator.remove();
+                } else if (propName.equals("format")) {
+                    builder.dateTimeFormatter(parseDateTimeFormatter(propNode));
+                    iterator.remove();
+                } else if (TypeParsers.parseMultiField(builder, name, parserContext, propName, propNode)) {
+                    iterator.remove();
                 }
-            }
-            if (!configuredFormat) {
-                builder.dateTimeFormatter(Defaults.DATE_TIME_FORMATTER);
             }
             return builder;
         }
     }
 
-    public static class DateFieldType extends NumberFieldType {
+    public static final class DateFieldType extends MappedFieldType {
 
         final class LateParsingQuery extends Query {
 
@@ -192,7 +182,8 @@ public class DateFieldMapper extends NumberFieldMapper {
             final DateTimeZone timeZone;
             final DateMathParser forcedDateParser;
 
-            public LateParsingQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, DateTimeZone timeZone, DateMathParser forcedDateParser) {
+            public LateParsingQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper,
+                    DateTimeZone timeZone, DateMathParser forcedDateParser) {
                 this.lowerTerm = lowerTerm;
                 this.upperTerm = upperTerm;
                 this.includeLower = includeLower;
@@ -244,23 +235,24 @@ public class DateFieldMapper extends NumberFieldMapper {
             }
         }
 
-        protected FormatDateTimeFormatter dateTimeFormatter = Defaults.DATE_TIME_FORMATTER;
-        protected TimeUnit timeUnit = Defaults.TIME_UNIT;
-        protected DateMathParser dateMathParser = new DateMathParser(dateTimeFormatter);
+        protected FormatDateTimeFormatter dateTimeFormatter;
+        protected DateMathParser dateMathParser;
 
-        public DateFieldType() {
-            super(LegacyNumericType.LONG);
+        DateFieldType() {
+            super();
+            setTokenized(false);
+            setHasDocValues(true);
+            setOmitNorms(true);
+            setDateTimeFormatter(DEFAULT_DATE_TIME_FORMATTER);
         }
 
-        protected DateFieldType(DateFieldType ref) {
-            super(ref);
-            this.dateTimeFormatter = ref.dateTimeFormatter;
-            this.timeUnit = ref.timeUnit;
-            this.dateMathParser = ref.dateMathParser;
+        DateFieldType(DateFieldType other) {
+            super(other);
+            setDateTimeFormatter(other.dateTimeFormatter);
         }
 
         @Override
-        public DateFieldType clone() {
+        public MappedFieldType clone() {
             return new DateFieldType(this);
         }
 
@@ -269,13 +261,12 @@ public class DateFieldMapper extends NumberFieldMapper {
             if (!super.equals(o)) return false;
             DateFieldType that = (DateFieldType) o;
             return Objects.equals(dateTimeFormatter.format(), that.dateTimeFormatter.format()) &&
-                   Objects.equals(dateTimeFormatter.locale(), that.dateTimeFormatter.locale()) &&
-                   Objects.equals(timeUnit, that.timeUnit);
+                   Objects.equals(dateTimeFormatter.locale(), that.dateTimeFormatter.locale());
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(super.hashCode(), dateTimeFormatter.format(), timeUnit);
+            return Objects.hash(super.hashCode(), dateTimeFormatter.format(), dateTimeFormatter.locale());
         }
 
         @Override
@@ -289,13 +280,12 @@ public class DateFieldMapper extends NumberFieldMapper {
             if (strict) {
                 DateFieldType other = (DateFieldType)fieldType;
                 if (Objects.equals(dateTimeFormatter().format(), other.dateTimeFormatter().format()) == false) {
-                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [format] across all types.");
+                    conflicts.add("mapper [" + name()
+                        + "] is used by multiple types. Set update_all_types to true to update [format] across all types.");
                 }
                 if (Objects.equals(dateTimeFormatter().locale(), other.dateTimeFormatter().locale()) == false) {
-                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [locale] across all types.");
-                }
-                if (Objects.equals(timeUnit(), other.timeUnit()) == false) {
-                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [numeric_resolution] across all types.");
+                    conflicts.add("mapper [" + name()
+                        + "] is used by multiple types. Set update_all_types to true to update [locale] across all types.");
                 }
             }
         }
@@ -310,48 +300,35 @@ public class DateFieldMapper extends NumberFieldMapper {
             this.dateMathParser = new DateMathParser(dateTimeFormatter);
         }
 
-        public TimeUnit timeUnit() {
-            return timeUnit;
-        }
-
-        public void setTimeUnit(TimeUnit timeUnit) {
-            checkIfFrozen();
-            this.timeUnit = timeUnit;
-            this.dateMathParser = new DateMathParser(dateTimeFormatter);
-        }
-
         protected DateMathParser dateMathParser() {
             return dateMathParser;
         }
 
-        private long parseValue(Object value) {
-            if (value instanceof Number) {
-                return ((Number) value).longValue();
-            }
-            if (value instanceof BytesRef) {
-                return dateTimeFormatter().parser().parseMillis(((BytesRef) value).utf8ToString());
-            }
-            return dateTimeFormatter().parser().parseMillis(value.toString());
-        }
-
-        protected long parseStringValue(String value) {
+        long parse(String value) {
             return dateTimeFormatter().parser().parseMillis(value);
         }
 
         @Override
-        public BytesRef indexedValueForSearch(Object value) {
-            BytesRefBuilder bytesRef = new BytesRefBuilder();
-            LegacyNumericUtils.longToPrefixCoded(parseValue(value), 0, bytesRef); // 0 because of exact match
-            return bytesRef.get();
+        public Query termQuery(Object value, @Nullable QueryShardContext context) {
+            Query query = innerRangeQuery(value, value, true, true, null, null);
+            if (boost() != 1f) {
+                query = new BoostQuery(query, boost());
+            }
+            return query;
         }
 
         @Override
-        public Object valueForSearch(Object value) {
-            Long val = (Long) value;
-            if (val == null) {
-                return null;
+        public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions, boolean transpositions) {
+            long baseLo = parseToMilliseconds(value, false, null, dateMathParser);
+            long baseHi = parseToMilliseconds(value, true, null, dateMathParser);
+            long delta;
+            try {
+                delta = fuzziness.asTimeValue().millis();
+            } catch (Exception e) {
+                // not a time format
+                delta = fuzziness.asLong();
             }
-            return dateTimeFormatter().printer().print(val);
+            return LongPoint.newRangeQuery(name(), baseLo - delta, baseHi + delta);
         }
 
         @Override
@@ -359,45 +336,75 @@ public class DateFieldMapper extends NumberFieldMapper {
             return rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, null, null);
         }
 
-        @Override
-        public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions, boolean transpositions) {
-            long iValue = parseValue(value);
-            long iSim;
-            try {
-                iSim = fuzziness.asTimeValue().millis();
-            } catch (Exception e) {
-                // not a time format
-                iSim =  fuzziness.asLong();
-            }
-            return LegacyNumericRangeQuery.newLongRange(name(), numericPrecisionStep(),
-                iValue - iSim,
-                iValue + iSim,
-                true, true);
-        }
-
-        @Override
-        public FieldStats stats(IndexReader reader) throws IOException {
-            int maxDoc = reader.maxDoc();
-            Terms terms = org.apache.lucene.index.MultiFields.getTerms(reader, name());
-            if (terms == null) {
-                return null;
-            }
-            long minValue = LegacyNumericUtils.getMinLong(terms);
-            long maxValue = LegacyNumericUtils.getMaxLong(terms);
-            return new FieldStats.Date(
-                maxDoc, terms.getDocCount(), terms.getSumDocFreq(), terms.getSumTotalTermFreq(), minValue, maxValue, dateTimeFormatter()
-            );
-        }
-
-        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable DateTimeZone timeZone, @Nullable DateMathParser forcedDateParser) {
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper,
+                @Nullable DateTimeZone timeZone, @Nullable DateMathParser forcedDateParser) {
             return new LateParsingQuery(lowerTerm, upperTerm, includeLower, includeUpper, timeZone, forcedDateParser);
         }
 
-        private Query innerRangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable DateTimeZone timeZone, @Nullable DateMathParser forcedDateParser) {
-            return LegacyNumericRangeQuery.newLongRange(name(), numericPrecisionStep(),
-                lowerTerm == null ? null : parseToMilliseconds(lowerTerm, !includeLower, timeZone, forcedDateParser == null ? dateMathParser : forcedDateParser),
-                upperTerm == null ? null : parseToMilliseconds(upperTerm, includeUpper, timeZone, forcedDateParser == null ? dateMathParser : forcedDateParser),
-                includeLower, includeUpper);
+        Query innerRangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper,
+                @Nullable DateTimeZone timeZone, @Nullable DateMathParser forcedDateParser) {
+            DateMathParser parser = forcedDateParser == null
+                    ? dateMathParser
+                    : forcedDateParser;
+            long l, u;
+            if (lowerTerm == null) {
+                l = Long.MIN_VALUE;
+            } else {
+                l = parseToMilliseconds(lowerTerm, !includeLower, timeZone, parser);
+                if (includeLower == false) {
+                    ++l;
+                }
+            }
+            if (upperTerm == null) {
+                u = Long.MAX_VALUE;
+            } else {
+                u = parseToMilliseconds(upperTerm, includeUpper, timeZone, parser);
+                if (includeUpper == false) {
+                    --u;
+                }
+            }
+            return LongPoint.newRangeQuery(name(), l, u);
+        }
+
+        public long parseToMilliseconds(Object value, boolean roundUp,
+                @Nullable DateTimeZone zone, @Nullable DateMathParser forcedDateParser) {
+            DateMathParser dateParser = dateMathParser();
+            if (forcedDateParser != null) {
+                dateParser = forcedDateParser;
+            }
+
+            String strValue;
+            if (value instanceof BytesRef) {
+                strValue = ((BytesRef) value).utf8ToString();
+            } else {
+                strValue = value.toString();
+            }
+            return dateParser.parse(strValue, now(), roundUp, zone);
+        }
+
+        private static Callable<Long> now() {
+            return () -> {
+                final SearchContext context = SearchContext.current();
+                return context != null
+                        ? context.nowInMillis()
+                        : System.currentTimeMillis();
+            };
+        }
+
+        @Override
+        public FieldStats.Date stats(IndexReader reader) throws IOException {
+            String field = name();
+            long size = PointValues.size(reader, field);
+            if (size == 0) {
+                return null;
+            }
+            int docCount = PointValues.getDocCount(reader, field);
+            byte[] min = PointValues.getMinPackedValue(reader, field);
+            byte[] max = PointValues.getMaxPackedValue(reader, field);
+            return new FieldStats.Date(reader.maxDoc(),docCount, -1L, size,
+                    LongPoint.decodeDimension(min, 0),
+                    LongPoint.decodeDimension(max, 0),
+                    dateTimeFormatter());
         }
 
         @Override
@@ -409,14 +416,13 @@ public class DateFieldMapper extends NumberFieldMapper {
                 dateParser = this.dateMathParser;
             }
 
-            Terms terms = org.apache.lucene.index.MultiFields.getTerms(reader, name());
-            if (terms == null) {
-                // no terms, so nothing matches
+            if (PointValues.size(reader, name()) == 0) {
+                // no points, so nothing matches
                 return Relation.DISJOINT;
             }
 
-            long minValue = LegacyNumericUtils.getMinLong(terms);
-            long maxValue = LegacyNumericUtils.getMaxLong(terms);
+            long minValue = LongPoint.decodeDimension(PointValues.getMinPackedValue(reader, name()), 0);
+            long maxValue = LongPoint.decodeDimension(PointValues.getMaxPackedValue(reader, name()), 0);
 
             long fromInclusive = Long.MIN_VALUE;
             if (from != null) {
@@ -449,29 +455,19 @@ public class DateFieldMapper extends NumberFieldMapper {
             }
         }
 
-        public long parseToMilliseconds(Object value, boolean inclusive, @Nullable DateTimeZone zone, @Nullable DateMathParser forcedDateParser) {
-            if (value instanceof Long) {
-                return ((Long) value).longValue();
-            }
-
-            DateMathParser dateParser = dateMathParser();
-            if (forcedDateParser != null) {
-                dateParser = forcedDateParser;
-            }
-
-            String strValue;
-            if (value instanceof BytesRef) {
-                strValue = ((BytesRef) value).utf8ToString();
-            } else {
-                strValue = value.toString();
-            }
-            return dateParser.parse(strValue, now(), inclusive, zone);
-        }
-
         @Override
         public IndexFieldData.Builder fielddataBuilder() {
             failIfNoDocValues();
             return new DocValuesIndexFieldData.Builder().numericType(NumericType.LONG);
+        }
+
+        @Override
+        public Object valueForSearch(Object value) {
+            Long val = (Long) value;
+            if (val == null) {
+                return null;
+            }
+            return dateTimeFormatter().printer().print(val);
         }
 
         @Override
@@ -487,9 +483,20 @@ public class DateFieldMapper extends NumberFieldMapper {
         }
     }
 
-    protected DateFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType, Explicit<Boolean> ignoreMalformed,Explicit<Boolean> coerce,
-                              Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, indexSettings, multiFields, copyTo);
+    private Boolean includeInAll;
+
+    private Explicit<Boolean> ignoreMalformed;
+
+    private DateFieldMapper(
+            String simpleName,
+            MappedFieldType fieldType,
+            MappedFieldType defaultFieldType,
+            Explicit<Boolean> ignoreMalformed,
+            Settings indexSettings,
+            MultiFields multiFields,
+            CopyTo copyTo) {
+        super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        this.ignoreMalformed = ignoreMalformed;
     }
 
     @Override
@@ -497,121 +504,126 @@ public class DateFieldMapper extends NumberFieldMapper {
         return (DateFieldType) super.fieldType();
     }
 
-    private static Callable<Long> now() {
-        return new Callable<Long>() {
-            @Override
-            public Long call() {
-                final SearchContext context = SearchContext.current();
-                return context != null
-                    ? context.nowInMillis()
-                    : System.currentTimeMillis();
-            }
-        };
-    }
-
-    @Override
-    protected boolean customBoost() {
-        return true;
-    }
-
-    @Override
-    protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
-        String dateAsString = null;
-        float boost = fieldType().boost();
-        if (context.externalValueSet()) {
-            Object externalValue = context.externalValue();
-            dateAsString = (String) externalValue;
-            if (dateAsString == null) {
-                dateAsString = fieldType().nullValueAsString();
-            }
-        } else {
-            XContentParser parser = context.parser();
-            XContentParser.Token token = parser.currentToken();
-            if (token == XContentParser.Token.VALUE_NULL) {
-                dateAsString = fieldType().nullValueAsString();
-            } else if (token == XContentParser.Token.VALUE_NUMBER) {
-                dateAsString = parser.text();
-            } else if (token == XContentParser.Token.START_OBJECT
-                    && Version.indexCreated(context.indexSettings()).before(Version.V_5_0_0_alpha1)) {
-                String currentFieldName = null;
-                while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                    if (token == XContentParser.Token.FIELD_NAME) {
-                        currentFieldName = parser.currentName();
-                    } else {
-                        if ("value".equals(currentFieldName) || "_value".equals(currentFieldName)) {
-                            if (token == XContentParser.Token.VALUE_NULL) {
-                                dateAsString = fieldType().nullValueAsString();
-                            } else {
-                                dateAsString = parser.text();
-                            }
-                        } else if ("boost".equals(currentFieldName) || "_boost".equals(currentFieldName)) {
-                            boost = parser.floatValue();
-                        } else {
-                            throw new IllegalArgumentException("unknown property [" + currentFieldName + "]");
-                        }
-                    }
-                }
-            } else {
-                dateAsString = parser.text();
-            }
-        }
-
-        Long value = null;
-        if (dateAsString != null) {
-            if (context.includeInAll(includeInAll, this)) {
-                context.allEntries().addText(fieldType().name(), dateAsString, boost);
-            }
-            value = fieldType().parseStringValue(dateAsString);
-        }
-
-        if (value != null) {
-            if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
-                CustomLongNumericField field = new CustomLongNumericField(value, fieldType());
-                if (boost != 1f && Version.indexCreated(context.indexSettings()).before(Version.V_5_0_0_alpha1)) {
-                    field.setBoost(boost);
-                }
-                fields.add(field);
-            }
-            if (fieldType().hasDocValues()) {
-                addDocValue(context, fields, value);
-            }
-        }
-    }
-
     @Override
     protected String contentType() {
-        return CONTENT_TYPE;
+        return fieldType.typeName();
+    }
+
+    @Override
+    protected DateFieldMapper clone() {
+        return (DateFieldMapper) super.clone();
+    }
+
+    @Override
+    public Mapper includeInAll(Boolean includeInAll) {
+        if (includeInAll != null) {
+            DateFieldMapper clone = clone();
+            clone.includeInAll = includeInAll;
+            return clone;
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public Mapper includeInAllIfNotSet(Boolean includeInAll) {
+        if (includeInAll != null && this.includeInAll == null) {
+            DateFieldMapper clone = clone();
+            clone.includeInAll = includeInAll;
+            return clone;
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public Mapper unsetIncludeInAll() {
+        if (includeInAll != null) {
+            DateFieldMapper clone = clone();
+            clone.includeInAll = null;
+            return clone;
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+        String dateAsString;
+        if (context.externalValueSet()) {
+            Object dateAsObject = context.externalValue();
+            if (dateAsObject == null) {
+                dateAsString = null;
+            } else {
+                dateAsString = dateAsObject.toString();
+            }
+        } else {
+            dateAsString = context.parser().text();
+        }
+
+        if (dateAsString == null) {
+            dateAsString = fieldType().nullValueAsString();
+        }
+
+        if (dateAsString == null) {
+            return;
+        }
+
+        long timestamp;
+        try {
+            timestamp = fieldType().parse(dateAsString);
+        } catch (IllegalArgumentException e) {
+            if (ignoreMalformed.value()) {
+                return;
+            } else {
+                throw e;
+            }
+        }
+
+        if (context.includeInAll(includeInAll, this)) {
+            context.allEntries().addText(fieldType().name(), dateAsString, fieldType().boost());
+        }
+
+        if (fieldType().indexOptions() != IndexOptions.NONE) {
+            fields.add(new LongPoint(fieldType().name(), timestamp));
+        }
+        if (fieldType().hasDocValues()) {
+            fields.add(new SortedNumericDocValuesField(fieldType().name(), timestamp));
+        }
+        if (fieldType().stored()) {
+            fields.add(new StoredField(fieldType().name(), timestamp));
+        }
+    }
+
+    @Override
+    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+        super.doMerge(mergeWith, updateAllTypes);
+        DateFieldMapper other = (DateFieldMapper) mergeWith;
+        this.includeInAll = other.includeInAll;
+        if (other.ignoreMalformed.explicit()) {
+            this.ignoreMalformed = other.ignoreMalformed;
+        }
     }
 
     @Override
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
 
-        if (includeDefaults || fieldType().numericPrecisionStep() != Defaults.PRECISION_STEP_64_BIT) {
-            builder.field("precision_step", fieldType().numericPrecisionStep());
-        }
-        builder.field("format", fieldType().dateTimeFormatter().format());
-        if (includeDefaults || fieldType().nullValueAsString() != null) {
-            builder.field("null_value", fieldType().nullValueAsString());
+        if (includeDefaults || ignoreMalformed.explicit()) {
+            builder.field("ignore_malformed", ignoreMalformed.value());
         }
         if (includeInAll != null) {
             builder.field("include_in_all", includeInAll);
         } else if (includeDefaults) {
             builder.field("include_in_all", false);
         }
-
-        if (includeDefaults || fieldType().timeUnit() != Defaults.TIME_UNIT) {
-            builder.field("numeric_resolution", fieldType().timeUnit().name().toLowerCase(Locale.ROOT));
+        if (includeDefaults
+                || fieldType().dateTimeFormatter().format().equals(DEFAULT_DATE_TIME_FORMATTER.format()) == false) {
+            builder.field("format", fieldType().dateTimeFormatter().format());
         }
-        // only serialize locale if needed, ROOT is the default, so no need to serialize that case as well...
-        if (fieldType().dateTimeFormatter().locale() != null && fieldType().dateTimeFormatter().locale() != Locale.ROOT) {
+        if (includeDefaults
+                || fieldType().dateTimeFormatter().locale() != Locale.ROOT) {
             builder.field("locale", fieldType().dateTimeFormatter().locale());
-        } else if (includeDefaults) {
-            if (fieldType().dateTimeFormatter().locale() == null) {
-                builder.field("locale", Locale.ROOT);
-            } else {
-                builder.field("locale", fieldType().dateTimeFormatter().locale());
-            }
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/LegacyDateFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/LegacyDateFieldMapper.java
@@ -1,0 +1,617 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.core;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.search.LegacyNumericRangeQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.LegacyNumericUtils;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.fieldstats.FieldStats;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.joda.DateMathParser;
+import org.elasticsearch.common.joda.FormatDateTimeFormatter;
+import org.elasticsearch.common.joda.Joda;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.common.util.LocaleUtils;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
+import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.core.LegacyLongFieldMapper.CustomLongNumericField;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.internal.SearchContext;
+import org.joda.time.DateTimeZone;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseDateTimeFormatter;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
+
+public class LegacyDateFieldMapper extends LegacyNumberFieldMapper {
+
+    public static final String CONTENT_TYPE = "date";
+
+    public static class Defaults extends LegacyNumberFieldMapper.Defaults {
+        public static final FormatDateTimeFormatter DATE_TIME_FORMATTER = Joda.forPattern("strict_date_optional_time||epoch_millis", Locale.ROOT);
+        public static final TimeUnit TIME_UNIT = TimeUnit.MILLISECONDS;
+        public static final DateFieldType FIELD_TYPE = new DateFieldType();
+
+        static {
+            FIELD_TYPE.freeze();
+        }
+
+        public static final String NULL_VALUE = null;
+    }
+
+    public static class Builder extends LegacyNumberFieldMapper.Builder<Builder, LegacyDateFieldMapper> {
+
+        protected String nullValue = Defaults.NULL_VALUE;
+
+        private Locale locale;
+
+        public Builder(String name) {
+            super(name, Defaults.FIELD_TYPE, Defaults.PRECISION_STEP_64_BIT);
+            builder = this;
+            // do *NOT* rely on the default locale
+            locale = Locale.ROOT;
+        }
+
+        @Override
+        public DateFieldType fieldType() {
+            return (DateFieldType)fieldType;
+        }
+
+        public Builder timeUnit(TimeUnit timeUnit) {
+            fieldType().setTimeUnit(timeUnit);
+            return this;
+        }
+
+        public Builder nullValue(String nullValue) {
+            this.nullValue = nullValue;
+            return this;
+        }
+
+        public Builder dateTimeFormatter(FormatDateTimeFormatter dateTimeFormatter) {
+            fieldType().setDateTimeFormatter(dateTimeFormatter);
+            return this;
+        }
+
+        @Override
+        public LegacyDateFieldMapper build(BuilderContext context) {
+            if (context.indexCreatedVersion().onOrAfter(Version.V_5_0_0)) {
+                throw new IllegalStateException("Cannot use legacy numeric types after 5.0");
+            }
+            setupFieldType(context);
+            fieldType.setNullValue(nullValue);
+            LegacyDateFieldMapper fieldMapper = new LegacyDateFieldMapper(name, fieldType, defaultFieldType, ignoreMalformed(context),
+                coerce(context), context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+            return (LegacyDateFieldMapper) fieldMapper.includeInAll(includeInAll);
+        }
+
+        @Override
+        protected void setupFieldType(BuilderContext context) {
+            FormatDateTimeFormatter dateTimeFormatter = fieldType().dateTimeFormatter;
+            if (!locale.equals(dateTimeFormatter.locale())) {
+                fieldType().setDateTimeFormatter(new FormatDateTimeFormatter(dateTimeFormatter.format(), dateTimeFormatter.parser(), dateTimeFormatter.printer(), locale));
+            }
+            super.setupFieldType(context);
+        }
+
+        public Builder locale(Locale locale) {
+            this.locale = locale;
+            return this;
+        }
+
+        @Override
+        protected int maxPrecisionStep() {
+            return 64;
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder<?, ?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            LegacyDateFieldMapper.Builder builder = new LegacyDateFieldMapper.Builder(name);
+            parseNumberField(builder, name, node, parserContext);
+            boolean configuredFormat = false;
+            for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
+                Map.Entry<String, Object> entry = iterator.next();
+                String propName = Strings.toUnderscoreCase(entry.getKey());
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(propNode.toString());
+                    iterator.remove();
+                } else if (propName.equals("format")) {
+                    builder.dateTimeFormatter(parseDateTimeFormatter(propNode));
+                    configuredFormat = true;
+                    iterator.remove();
+                } else if (propName.equals("numeric_resolution")) {
+                    builder.timeUnit(TimeUnit.valueOf(propNode.toString().toUpperCase(Locale.ROOT)));
+                    iterator.remove();
+                } else if (propName.equals("locale")) {
+                    builder.locale(LocaleUtils.parse(propNode.toString()));
+                    iterator.remove();
+                }
+            }
+            if (!configuredFormat) {
+                builder.dateTimeFormatter(Defaults.DATE_TIME_FORMATTER);
+            }
+            return builder;
+        }
+    }
+
+    public static class DateFieldType extends NumberFieldType {
+
+        final class LateParsingQuery extends Query {
+
+            final Object lowerTerm;
+            final Object upperTerm;
+            final boolean includeLower;
+            final boolean includeUpper;
+            final DateTimeZone timeZone;
+            final DateMathParser forcedDateParser;
+
+            public LateParsingQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, DateTimeZone timeZone, DateMathParser forcedDateParser) {
+                this.lowerTerm = lowerTerm;
+                this.upperTerm = upperTerm;
+                this.includeLower = includeLower;
+                this.includeUpper = includeUpper;
+                this.timeZone = timeZone;
+                this.forcedDateParser = forcedDateParser;
+            }
+
+            @Override
+            public Query rewrite(IndexReader reader) throws IOException {
+                Query rewritten = super.rewrite(reader);
+                if (rewritten != this) {
+                    return rewritten;
+                }
+                return innerRangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, timeZone, forcedDateParser);
+            }
+
+            // Even though we only cache rewritten queries it is good to let all queries implement hashCode() and equals():
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (!super.equals(o)) return false;
+
+                LateParsingQuery that = (LateParsingQuery) o;
+                if (includeLower != that.includeLower) return false;
+                if (includeUpper != that.includeUpper) return false;
+                if (lowerTerm != null ? !lowerTerm.equals(that.lowerTerm) : that.lowerTerm != null) return false;
+                if (upperTerm != null ? !upperTerm.equals(that.upperTerm) : that.upperTerm != null) return false;
+                if (timeZone != null ? !timeZone.equals(that.timeZone) : that.timeZone != null) return false;
+
+                return true;
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(super.hashCode(), lowerTerm, upperTerm, includeLower, includeUpper, timeZone);
+            }
+
+            @Override
+            public String toString(String s) {
+                final StringBuilder sb = new StringBuilder();
+                return sb.append(name()).append(':')
+                    .append(includeLower ? '[' : '{')
+                    .append((lowerTerm == null) ? "*" : lowerTerm.toString())
+                    .append(" TO ")
+                    .append((upperTerm == null) ? "*" : upperTerm.toString())
+                    .append(includeUpper ? ']' : '}')
+                    .toString();
+            }
+        }
+
+        protected FormatDateTimeFormatter dateTimeFormatter = Defaults.DATE_TIME_FORMATTER;
+        protected TimeUnit timeUnit = Defaults.TIME_UNIT;
+        protected DateMathParser dateMathParser = new DateMathParser(dateTimeFormatter);
+
+        public DateFieldType() {
+            super(LegacyNumericType.LONG);
+        }
+
+        protected DateFieldType(DateFieldType ref) {
+            super(ref);
+            this.dateTimeFormatter = ref.dateTimeFormatter;
+            this.timeUnit = ref.timeUnit;
+            this.dateMathParser = ref.dateMathParser;
+        }
+
+        @Override
+        public DateFieldType clone() {
+            return new DateFieldType(this);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!super.equals(o)) return false;
+            DateFieldType that = (DateFieldType) o;
+            return Objects.equals(dateTimeFormatter.format(), that.dateTimeFormatter.format()) &&
+                   Objects.equals(dateTimeFormatter.locale(), that.dateTimeFormatter.locale()) &&
+                   Objects.equals(timeUnit, that.timeUnit);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), dateTimeFormatter.format(), timeUnit);
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
+        public void checkCompatibility(MappedFieldType fieldType, List<String> conflicts, boolean strict) {
+            super.checkCompatibility(fieldType, conflicts, strict);
+            if (strict) {
+                DateFieldType other = (DateFieldType)fieldType;
+                if (Objects.equals(dateTimeFormatter().format(), other.dateTimeFormatter().format()) == false) {
+                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [format] across all types.");
+                }
+                if (Objects.equals(dateTimeFormatter().locale(), other.dateTimeFormatter().locale()) == false) {
+                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [locale] across all types.");
+                }
+                if (Objects.equals(timeUnit(), other.timeUnit()) == false) {
+                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [numeric_resolution] across all types.");
+                }
+            }
+        }
+
+        public FormatDateTimeFormatter dateTimeFormatter() {
+            return dateTimeFormatter;
+        }
+
+        public void setDateTimeFormatter(FormatDateTimeFormatter dateTimeFormatter) {
+            checkIfFrozen();
+            this.dateTimeFormatter = dateTimeFormatter;
+            this.dateMathParser = new DateMathParser(dateTimeFormatter);
+        }
+
+        public TimeUnit timeUnit() {
+            return timeUnit;
+        }
+
+        public void setTimeUnit(TimeUnit timeUnit) {
+            checkIfFrozen();
+            this.timeUnit = timeUnit;
+            this.dateMathParser = new DateMathParser(dateTimeFormatter);
+        }
+
+        protected DateMathParser dateMathParser() {
+            return dateMathParser;
+        }
+
+        private long parseValue(Object value) {
+            if (value instanceof Number) {
+                return ((Number) value).longValue();
+            }
+            if (value instanceof BytesRef) {
+                return dateTimeFormatter().parser().parseMillis(((BytesRef) value).utf8ToString());
+            }
+            return dateTimeFormatter().parser().parseMillis(value.toString());
+        }
+
+        protected long parseStringValue(String value) {
+            return dateTimeFormatter().parser().parseMillis(value);
+        }
+
+        @Override
+        public BytesRef indexedValueForSearch(Object value) {
+            BytesRefBuilder bytesRef = new BytesRefBuilder();
+            LegacyNumericUtils.longToPrefixCoded(parseValue(value), 0, bytesRef); // 0 because of exact match
+            return bytesRef.get();
+        }
+
+        @Override
+        public Object valueForSearch(Object value) {
+            Long val = (Long) value;
+            if (val == null) {
+                return null;
+            }
+            return dateTimeFormatter().printer().print(val);
+        }
+
+        @Override
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper) {
+            return rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, null, null);
+        }
+
+        @Override
+        public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions, boolean transpositions) {
+            long iValue = parseValue(value);
+            long iSim;
+            try {
+                iSim = fuzziness.asTimeValue().millis();
+            } catch (Exception e) {
+                // not a time format
+                iSim =  fuzziness.asLong();
+            }
+            return LegacyNumericRangeQuery.newLongRange(name(), numericPrecisionStep(),
+                iValue - iSim,
+                iValue + iSim,
+                true, true);
+        }
+
+        @Override
+        public FieldStats stats(IndexReader reader) throws IOException {
+            int maxDoc = reader.maxDoc();
+            Terms terms = org.apache.lucene.index.MultiFields.getTerms(reader, name());
+            if (terms == null) {
+                return null;
+            }
+            long minValue = LegacyNumericUtils.getMinLong(terms);
+            long maxValue = LegacyNumericUtils.getMaxLong(terms);
+            return new FieldStats.Date(
+                maxDoc, terms.getDocCount(), terms.getSumDocFreq(), terms.getSumTotalTermFreq(), minValue, maxValue, dateTimeFormatter()
+            );
+        }
+
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable DateTimeZone timeZone, @Nullable DateMathParser forcedDateParser) {
+            return new LateParsingQuery(lowerTerm, upperTerm, includeLower, includeUpper, timeZone, forcedDateParser);
+        }
+
+        private Query innerRangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable DateTimeZone timeZone, @Nullable DateMathParser forcedDateParser) {
+            return LegacyNumericRangeQuery.newLongRange(name(), numericPrecisionStep(),
+                lowerTerm == null ? null : parseToMilliseconds(lowerTerm, !includeLower, timeZone, forcedDateParser == null ? dateMathParser : forcedDateParser),
+                upperTerm == null ? null : parseToMilliseconds(upperTerm, includeUpper, timeZone, forcedDateParser == null ? dateMathParser : forcedDateParser),
+                includeLower, includeUpper);
+        }
+
+        @Override
+        public Relation isFieldWithinQuery(IndexReader reader,
+                Object from, Object to,
+                boolean includeLower, boolean includeUpper,
+                DateTimeZone timeZone, DateMathParser dateParser) throws IOException {
+            if (dateParser == null) {
+                dateParser = this.dateMathParser;
+            }
+
+            Terms terms = org.apache.lucene.index.MultiFields.getTerms(reader, name());
+            if (terms == null) {
+                // no terms, so nothing matches
+                return Relation.DISJOINT;
+            }
+
+            long minValue = LegacyNumericUtils.getMinLong(terms);
+            long maxValue = LegacyNumericUtils.getMaxLong(terms);
+
+            long fromInclusive = Long.MIN_VALUE;
+            if (from != null) {
+                fromInclusive = parseToMilliseconds(from, !includeLower, timeZone, dateParser);
+                if (includeLower == false) {
+                    if (fromInclusive == Long.MAX_VALUE) {
+                        return Relation.DISJOINT;
+                    }
+                    ++fromInclusive;
+                }
+            }
+
+            long toInclusive = Long.MAX_VALUE;
+            if (to != null) {
+                toInclusive = parseToMilliseconds(to, includeUpper, timeZone, dateParser);
+                if (includeUpper == false) {
+                    if (toInclusive == Long.MIN_VALUE) {
+                        return Relation.DISJOINT;
+                    }
+                    --toInclusive;
+                }
+            }
+
+            if (minValue >= fromInclusive && maxValue <= toInclusive) {
+                return Relation.WITHIN;
+            } else if (maxValue < fromInclusive || minValue > toInclusive) {
+                return Relation.DISJOINT;
+            } else {
+                return Relation.INTERSECTS;
+            }
+        }
+
+        public long parseToMilliseconds(Object value, boolean inclusive, @Nullable DateTimeZone zone, @Nullable DateMathParser forcedDateParser) {
+            if (value instanceof Long) {
+                return ((Long) value).longValue();
+            }
+
+            DateMathParser dateParser = dateMathParser();
+            if (forcedDateParser != null) {
+                dateParser = forcedDateParser;
+            }
+
+            String strValue;
+            if (value instanceof BytesRef) {
+                strValue = ((BytesRef) value).utf8ToString();
+            } else {
+                strValue = value.toString();
+            }
+            return dateParser.parse(strValue, now(), inclusive, zone);
+        }
+
+        @Override
+        public IndexFieldData.Builder fielddataBuilder() {
+            failIfNoDocValues();
+            return new DocValuesIndexFieldData.Builder().numericType(NumericType.LONG);
+        }
+
+        @Override
+        public DocValueFormat docValueFormat(@Nullable String format, DateTimeZone timeZone) {
+            FormatDateTimeFormatter dateTimeFormatter = this.dateTimeFormatter;
+            if (format != null) {
+                dateTimeFormatter = Joda.forPattern(format);
+            }
+            if (timeZone == null) {
+                timeZone = DateTimeZone.UTC;
+            }
+            return new DocValueFormat.DateTime(dateTimeFormatter, timeZone);
+        }
+    }
+
+    protected LegacyDateFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType, Explicit<Boolean> ignoreMalformed,Explicit<Boolean> coerce,
+                              Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
+        super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, indexSettings, multiFields, copyTo);
+    }
+
+    @Override
+    public DateFieldType fieldType() {
+        return (DateFieldType) super.fieldType();
+    }
+
+    private static Callable<Long> now() {
+        return new Callable<Long>() {
+            @Override
+            public Long call() {
+                final SearchContext context = SearchContext.current();
+                return context != null
+                    ? context.nowInMillis()
+                    : System.currentTimeMillis();
+            }
+        };
+    }
+
+    @Override
+    protected boolean customBoost() {
+        return true;
+    }
+
+    @Override
+    protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
+        String dateAsString = null;
+        float boost = fieldType().boost();
+        if (context.externalValueSet()) {
+            Object externalValue = context.externalValue();
+            dateAsString = (String) externalValue;
+            if (dateAsString == null) {
+                dateAsString = fieldType().nullValueAsString();
+            }
+        } else {
+            XContentParser parser = context.parser();
+            XContentParser.Token token = parser.currentToken();
+            if (token == XContentParser.Token.VALUE_NULL) {
+                dateAsString = fieldType().nullValueAsString();
+            } else if (token == XContentParser.Token.VALUE_NUMBER) {
+                dateAsString = parser.text();
+            } else if (token == XContentParser.Token.START_OBJECT
+                    && Version.indexCreated(context.indexSettings()).before(Version.V_5_0_0_alpha1)) {
+                String currentFieldName = null;
+                while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                    if (token == XContentParser.Token.FIELD_NAME) {
+                        currentFieldName = parser.currentName();
+                    } else {
+                        if ("value".equals(currentFieldName) || "_value".equals(currentFieldName)) {
+                            if (token == XContentParser.Token.VALUE_NULL) {
+                                dateAsString = fieldType().nullValueAsString();
+                            } else {
+                                dateAsString = parser.text();
+                            }
+                        } else if ("boost".equals(currentFieldName) || "_boost".equals(currentFieldName)) {
+                            boost = parser.floatValue();
+                        } else {
+                            throw new IllegalArgumentException("unknown property [" + currentFieldName + "]");
+                        }
+                    }
+                }
+            } else {
+                dateAsString = parser.text();
+            }
+        }
+
+        Long value = null;
+        if (dateAsString != null) {
+            if (context.includeInAll(includeInAll, this)) {
+                context.allEntries().addText(fieldType().name(), dateAsString, boost);
+            }
+            value = fieldType().parseStringValue(dateAsString);
+        }
+
+        if (value != null) {
+            if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
+                CustomLongNumericField field = new CustomLongNumericField(value, fieldType());
+                if (boost != 1f && Version.indexCreated(context.indexSettings()).before(Version.V_5_0_0_alpha1)) {
+                    field.setBoost(boost);
+                }
+                fields.add(field);
+            }
+            if (fieldType().hasDocValues()) {
+                addDocValue(context, fields, value);
+            }
+        }
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        super.doXContentBody(builder, includeDefaults, params);
+
+        if (includeDefaults || fieldType().numericPrecisionStep() != Defaults.PRECISION_STEP_64_BIT) {
+            builder.field("precision_step", fieldType().numericPrecisionStep());
+        }
+        builder.field("format", fieldType().dateTimeFormatter().format());
+        if (includeDefaults || fieldType().nullValueAsString() != null) {
+            builder.field("null_value", fieldType().nullValueAsString());
+        }
+        if (includeInAll != null) {
+            builder.field("include_in_all", includeInAll);
+        } else if (includeDefaults) {
+            builder.field("include_in_all", false);
+        }
+
+        if (includeDefaults || fieldType().timeUnit() != Defaults.TIME_UNIT) {
+            builder.field("numeric_resolution", fieldType().timeUnit().name().toLowerCase(Locale.ROOT));
+        }
+        // only serialize locale if needed, ROOT is the default, so no need to serialize that case as well...
+        if (fieldType().dateTimeFormatter().locale() != null && fieldType().dateTimeFormatter().locale() != Locale.ROOT) {
+            builder.field("locale", fieldType().dateTimeFormatter().locale());
+        } else if (includeDefaults) {
+            if (fieldType().dateTimeFormatter().locale() == null) {
+                builder.field("locale", Locale.ROOT);
+            } else {
+                builder.field("locale", fieldType().dateTimeFormatter().locale());
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/LegacyDoubleFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/LegacyDoubleFieldMapper.java
@@ -34,11 +34,12 @@ import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.fieldstats.FieldStats;
 import org.elasticsearch.common.Explicit;
-import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
@@ -52,59 +53,62 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeFloatValue;
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeDoubleValue;
 import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
 
 /**
  *
  */
-public class FloatFieldMapper extends NumberFieldMapper {
+public class LegacyDoubleFieldMapper extends LegacyNumberFieldMapper {
 
-    public static final String CONTENT_TYPE = "float";
+    public static final String CONTENT_TYPE = "double";
 
-    public static class Defaults extends NumberFieldMapper.Defaults {
-        public static final MappedFieldType FIELD_TYPE = new FloatFieldType();
+    public static class Defaults extends LegacyNumberFieldMapper.Defaults {
+        public static final MappedFieldType FIELD_TYPE = new DoubleFieldType();
 
         static {
             FIELD_TYPE.freeze();
         }
     }
 
-    public static class Builder extends NumberFieldMapper.Builder<Builder, FloatFieldMapper> {
+    public static class Builder extends LegacyNumberFieldMapper.Builder<Builder, LegacyDoubleFieldMapper> {
 
         public Builder(String name) {
-            super(name, Defaults.FIELD_TYPE, Defaults.PRECISION_STEP_32_BIT);
+            super(name, Defaults.FIELD_TYPE, Defaults.PRECISION_STEP_64_BIT);
             builder = this;
         }
 
         @Override
-        public FloatFieldMapper build(BuilderContext context) {
+        public LegacyDoubleFieldMapper build(BuilderContext context) {
+            if (context.indexCreatedVersion().onOrAfter(Version.V_5_0_0)) {
+                throw new IllegalStateException("Cannot use legacy numeric types after 5.0");
+            }
             setupFieldType(context);
-            FloatFieldMapper fieldMapper = new FloatFieldMapper(name, fieldType, defaultFieldType, ignoreMalformed(context), coerce(context),
+            LegacyDoubleFieldMapper fieldMapper = new LegacyDoubleFieldMapper(name, fieldType, defaultFieldType, ignoreMalformed(context), coerce(context),
                     context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
-            return (FloatFieldMapper) fieldMapper.includeInAll(includeInAll);
+            return (LegacyDoubleFieldMapper) fieldMapper.includeInAll(includeInAll);
         }
 
         @Override
         protected int maxPrecisionStep() {
-            return 32;
+            return 64;
         }
     }
 
     public static class TypeParser implements Mapper.TypeParser {
         @Override
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-            FloatFieldMapper.Builder builder = new FloatFieldMapper.Builder(name);
+            LegacyDoubleFieldMapper.Builder builder = new LegacyDoubleFieldMapper.Builder(name);
             parseNumberField(builder, name, node, parserContext);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();
-                String propName = Strings.toUnderscoreCase(entry.getKey());
+                String propName = entry.getKey();
                 Object propNode = entry.getValue();
-                if (propName.equals("null_value")) {
+                if (propName.equals("nullValue") || propName.equals("null_value")) {
                     if (propNode == null) {
                         throw new MapperParsingException("Property [null_value] cannot be null.");
                     }
-                    builder.nullValue(nodeFloatValue(propNode));
+                    builder.nullValue(nodeDoubleValue(propNode));
                     iterator.remove();
                 }
             }
@@ -112,19 +116,19 @@ public class FloatFieldMapper extends NumberFieldMapper {
         }
     }
 
-    static final class FloatFieldType extends NumberFieldType {
+    public static final class DoubleFieldType extends NumberFieldType {
 
-        public FloatFieldType() {
-            super(LegacyNumericType.FLOAT);
+        public DoubleFieldType() {
+            super(LegacyNumericType.DOUBLE);
         }
 
-        protected FloatFieldType(FloatFieldType ref) {
+        protected DoubleFieldType(DoubleFieldType ref) {
             super(ref);
         }
 
         @Override
         public NumberFieldType clone() {
-            return new FloatFieldType(this);
+            return new DoubleFieldType(this);
         }
 
         @Override
@@ -133,31 +137,45 @@ public class FloatFieldMapper extends NumberFieldMapper {
         }
 
         @Override
-        public Float nullValue() {
-            return (Float)super.nullValue();
+        public Double nullValue() {
+            return (Double)super.nullValue();
+        }
+
+        @Override
+        public Double valueForSearch(Object value) {
+            if (value == null) {
+                return null;
+            }
+            if (value instanceof Number) {
+                return ((Number) value).doubleValue();
+            }
+            if (value instanceof BytesRef) {
+                return Numbers.bytesToDouble((BytesRef) value);
+            }
+            return Double.parseDouble(value.toString());
         }
 
         @Override
         public BytesRef indexedValueForSearch(Object value) {
-            int intValue = NumericUtils.floatToSortableInt(parseValue(value));
+            long longValue = NumericUtils.doubleToSortableLong(parseDoubleValue(value));
             BytesRefBuilder bytesRef = new BytesRefBuilder();
-            LegacyNumericUtils.intToPrefixCoded(intValue, 0, bytesRef);   // 0 because of exact match
+            LegacyNumericUtils.longToPrefixCoded(longValue, 0, bytesRef);   // 0 because of exact match
             return bytesRef.get();
         }
 
         @Override
         public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper) {
-            return LegacyNumericRangeQuery.newFloatRange(name(), numericPrecisionStep(),
-                lowerTerm == null ? null : parseValue(lowerTerm),
-                upperTerm == null ? null : parseValue(upperTerm),
+            return LegacyNumericRangeQuery.newDoubleRange(name(), numericPrecisionStep(),
+                lowerTerm == null ? null : parseDoubleValue(lowerTerm),
+                upperTerm == null ? null : parseDoubleValue(upperTerm),
                 includeLower, includeUpper);
         }
 
         @Override
         public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions, boolean transpositions) {
-            float iValue = parseValue(value);
-            final float iSim = fuzziness.asFloat();
-            return LegacyNumericRangeQuery.newFloatRange(name(), numericPrecisionStep(),
+            double iValue = parseDoubleValue(value);
+            double iSim = fuzziness.asDouble();
+            return LegacyNumericRangeQuery.newDoubleRange(name(), numericPrecisionStep(),
                 iValue - iSim,
                 iValue + iSim,
                 true, true);
@@ -170,8 +188,8 @@ public class FloatFieldMapper extends NumberFieldMapper {
             if (terms == null) {
                 return null;
             }
-            float minValue = NumericUtils.sortableIntToFloat(LegacyNumericUtils.getMinInt(terms));
-            float maxValue = NumericUtils.sortableIntToFloat(LegacyNumericUtils.getMaxInt(terms));
+            double minValue = NumericUtils.sortableLongToDouble(LegacyNumericUtils.getMinLong(terms));
+            double maxValue = NumericUtils.sortableLongToDouble(LegacyNumericUtils.getMaxLong(terms));
             return new FieldStats.Double(
                 maxDoc, terms.getDocCount(), terms.getSumDocFreq(), terms.getSumTotalTermFreq(), minValue, maxValue
             );
@@ -180,29 +198,18 @@ public class FloatFieldMapper extends NumberFieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder() {
             failIfNoDocValues();
-            return new DocValuesIndexFieldData.Builder().numericType(NumericType.FLOAT);
+            return new DocValuesIndexFieldData.Builder().numericType(NumericType.DOUBLE);
         }
     }
 
-    protected FloatFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
-                               Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
-                               Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
+    protected LegacyDoubleFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType, Explicit<Boolean> ignoreMalformed,
+                                Explicit<Boolean> coerce, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
         super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, indexSettings, multiFields, copyTo);
     }
 
     @Override
-    public FloatFieldType fieldType() {
-        return (FloatFieldType) super.fieldType();
-    }
-
-    private static float parseValue(Object value) {
-        if (value instanceof Number) {
-            return ((Number) value).floatValue();
-        }
-        if (value instanceof BytesRef) {
-            return Float.parseFloat(((BytesRef) value).utf8ToString());
-        }
-        return Float.parseFloat(value.toString());
+    public DoubleFieldType fieldType() {
+        return (DoubleFieldType) super.fieldType();
     }
 
     @Override
@@ -212,7 +219,7 @@ public class FloatFieldMapper extends NumberFieldMapper {
 
     @Override
     protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
-        float value;
+        double value;
         float boost = fieldType().boost();
         if (context.externalValueSet()) {
             Object externalValue = context.externalValue();
@@ -229,13 +236,13 @@ public class FloatFieldMapper extends NumberFieldMapper {
                     }
                     value = fieldType().nullValue();
                 } else {
-                    value = Float.parseFloat(sExternalValue);
+                    value = Double.parseDouble(sExternalValue);
                 }
             } else {
-                value = ((Number) externalValue).floatValue();
+                value = ((Number) externalValue).doubleValue();
             }
             if (context.includeInAll(includeInAll, this)) {
-                context.allEntries().addText(fieldType().name(), Float.toString(value), boost);
+                context.allEntries().addText(fieldType().name(), Double.toString(value), boost);
             }
         } else {
             XContentParser parser = context.parser();
@@ -252,14 +259,14 @@ public class FloatFieldMapper extends NumberFieldMapper {
                     && Version.indexCreated(context.indexSettings()).before(Version.V_5_0_0_alpha1)) {
                 XContentParser.Token token;
                 String currentFieldName = null;
-                Float objValue = fieldType().nullValue();
+                Double objValue = fieldType().nullValue();
                 while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                     if (token == XContentParser.Token.FIELD_NAME) {
                         currentFieldName = parser.currentName();
                     } else {
                         if ("value".equals(currentFieldName) || "_value".equals(currentFieldName)) {
                             if (parser.currentToken() != XContentParser.Token.VALUE_NULL) {
-                                objValue = parser.floatValue(coerce.value());
+                                objValue = parser.doubleValue(coerce.value());
                             }
                         } else if ("boost".equals(currentFieldName) || "_boost".equals(currentFieldName)) {
                             boost = parser.floatValue();
@@ -274,7 +281,7 @@ public class FloatFieldMapper extends NumberFieldMapper {
                 }
                 value = objValue;
             } else {
-                value = parser.floatValue(coerce.value());
+                value = parser.doubleValue(coerce.value());
                 if (context.includeInAll(includeInAll, this)) {
                     context.allEntries().addText(fieldType().name(), parser.text(), boost);
                 }
@@ -282,14 +289,14 @@ public class FloatFieldMapper extends NumberFieldMapper {
         }
 
         if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
-            CustomFloatNumericField field = new CustomFloatNumericField(value, fieldType());
+            CustomDoubleNumericField field = new CustomDoubleNumericField(value, fieldType());
             if (boost != 1f && Version.indexCreated(context.indexSettings()).before(Version.V_5_0_0_alpha1)) {
                 field.setBoost(boost);
             }
             fields.add(field);
         }
         if (fieldType().hasDocValues()) {
-            addDocValue(context, fields, NumericUtils.floatToSortableInt(value));
+            addDocValue(context, fields, NumericUtils.doubleToSortableLong(value));
         }
     }
 
@@ -302,7 +309,7 @@ public class FloatFieldMapper extends NumberFieldMapper {
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
 
-        if (includeDefaults || fieldType().numericPrecisionStep() != Defaults.PRECISION_STEP_32_BIT) {
+        if (includeDefaults || fieldType().numericPrecisionStep() != Defaults.PRECISION_STEP_64_BIT) {
             builder.field("precision_step", fieldType().numericPrecisionStep());
         }
         if (includeDefaults || fieldType().nullValue() != null) {
@@ -316,11 +323,11 @@ public class FloatFieldMapper extends NumberFieldMapper {
 
     }
 
-    public static class CustomFloatNumericField extends CustomNumericField {
+    public static class CustomDoubleNumericField extends CustomNumericField {
 
-        private final float number;
+        private final double number;
 
-        public CustomFloatNumericField(float number, NumberFieldType fieldType) {
+        public CustomDoubleNumericField(double number, NumberFieldType fieldType) {
             super(number, fieldType);
             this.number = number;
         }
@@ -328,14 +335,15 @@ public class FloatFieldMapper extends NumberFieldMapper {
         @Override
         public TokenStream tokenStream(Analyzer analyzer, TokenStream previous) {
             if (fieldType().indexOptions() != IndexOptions.NONE) {
-                return getCachedStream().setFloatValue(number);
+                return getCachedStream().setDoubleValue(number);
             }
             return null;
         }
 
         @Override
         public String numericAsString() {
-            return Float.toString(number);
+            return Double.toString(number);
         }
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/LegacyIntegerFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/LegacyIntegerFieldMapper.java
@@ -59,11 +59,11 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
 /**
  *
  */
-public class IntegerFieldMapper extends NumberFieldMapper {
+public class LegacyIntegerFieldMapper extends LegacyNumberFieldMapper {
 
     public static final String CONTENT_TYPE = "integer";
 
-    public static class Defaults extends NumberFieldMapper.Defaults {
+    public static class Defaults extends LegacyNumberFieldMapper.Defaults {
         public static final MappedFieldType FIELD_TYPE = new IntegerFieldType();
 
         static {
@@ -71,7 +71,7 @@ public class IntegerFieldMapper extends NumberFieldMapper {
         }
     }
 
-    public static class Builder extends NumberFieldMapper.Builder<Builder, IntegerFieldMapper> {
+    public static class Builder extends LegacyNumberFieldMapper.Builder<Builder, LegacyIntegerFieldMapper> {
 
         public Builder(String name) {
             super(name, Defaults.FIELD_TYPE, Defaults.PRECISION_STEP_32_BIT);
@@ -84,12 +84,15 @@ public class IntegerFieldMapper extends NumberFieldMapper {
         }
 
         @Override
-        public IntegerFieldMapper build(BuilderContext context) {
+        public LegacyIntegerFieldMapper build(BuilderContext context) {
+            if (context.indexCreatedVersion().onOrAfter(Version.V_5_0_0)) {
+                throw new IllegalStateException("Cannot use legacy numeric types after 5.0");
+            }
             setupFieldType(context);
-            IntegerFieldMapper fieldMapper = new IntegerFieldMapper(name, fieldType, defaultFieldType,
+            LegacyIntegerFieldMapper fieldMapper = new LegacyIntegerFieldMapper(name, fieldType, defaultFieldType,
                     ignoreMalformed(context), coerce(context),
                     context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
-            return (IntegerFieldMapper) fieldMapper.includeInAll(includeInAll);
+            return (LegacyIntegerFieldMapper) fieldMapper.includeInAll(includeInAll);
         }
         @Override
         protected int maxPrecisionStep() {
@@ -100,7 +103,7 @@ public class IntegerFieldMapper extends NumberFieldMapper {
     public static class TypeParser implements Mapper.TypeParser {
         @Override
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-            IntegerFieldMapper.Builder builder = new IntegerFieldMapper.Builder(name);
+            LegacyIntegerFieldMapper.Builder builder = new LegacyIntegerFieldMapper.Builder(name);
             parseNumberField(builder, name, node, parserContext);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();
@@ -190,7 +193,7 @@ public class IntegerFieldMapper extends NumberFieldMapper {
         }
     }
 
-    protected IntegerFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
+    protected LegacyIntegerFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
                                  Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
                                  Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
         super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, indexSettings, multiFields, copyTo);

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/LegacyNumberFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/LegacyNumberFieldMapper.java
@@ -1,0 +1,366 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.core;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.List;
+
+import org.apache.lucene.analysis.LegacyNumericTokenStream;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.internal.AllFieldMapper;
+import org.elasticsearch.search.DocValueFormat;
+import org.joda.time.DateTimeZone;
+
+/**
+ *
+ */
+public abstract class LegacyNumberFieldMapper extends FieldMapper implements AllFieldMapper.IncludeInAll {
+    // this is private since it has a different default
+    private static final Setting<Boolean> COERCE_SETTING =
+        Setting.boolSetting("index.mapping.coerce", true, Property.IndexScope);
+
+    public static class Defaults {
+
+        public static final int PRECISION_STEP_8_BIT  = Integer.MAX_VALUE; // 1tpv: 256 terms at most, not useful
+        public static final int PRECISION_STEP_16_BIT = 8;                 // 2tpv
+        public static final int PRECISION_STEP_32_BIT = 8;                 // 4tpv
+        public static final int PRECISION_STEP_64_BIT = 16;                // 4tpv
+
+        public static final Explicit<Boolean> IGNORE_MALFORMED = new Explicit<>(false, false);
+        public static final Explicit<Boolean> COERCE = new Explicit<>(true, false);
+    }
+
+    public abstract static class Builder<T extends Builder, Y extends LegacyNumberFieldMapper> extends FieldMapper.Builder<T, Y> {
+
+        private Boolean ignoreMalformed;
+
+        private Boolean coerce;
+
+        public Builder(String name, MappedFieldType fieldType, int defaultPrecisionStep) {
+            super(name, fieldType, fieldType);
+            this.fieldType.setNumericPrecisionStep(defaultPrecisionStep);
+        }
+
+        public T precisionStep(int precisionStep) {
+            fieldType.setNumericPrecisionStep(precisionStep);
+            return builder;
+        }
+
+        public T ignoreMalformed(boolean ignoreMalformed) {
+            this.ignoreMalformed = ignoreMalformed;
+            return builder;
+        }
+
+        protected Explicit<Boolean> ignoreMalformed(BuilderContext context) {
+            if (ignoreMalformed != null) {
+                return new Explicit<>(ignoreMalformed, true);
+            }
+            if (context.indexSettings() != null) {
+                return new Explicit<>(IGNORE_MALFORMED_SETTING.get(context.indexSettings()), false);
+            }
+            return Defaults.IGNORE_MALFORMED;
+        }
+
+        public T coerce(boolean coerce) {
+            this.coerce = coerce;
+            return builder;
+        }
+
+        protected Explicit<Boolean> coerce(BuilderContext context) {
+            if (coerce != null) {
+                return new Explicit<>(coerce, true);
+            }
+            if (context.indexSettings() != null) {
+                return new Explicit<>(COERCE_SETTING.get(context.indexSettings()), false);
+            }
+            return Defaults.COERCE;
+        }
+
+        protected void setupFieldType(BuilderContext context) {
+            super.setupFieldType(context);
+            int precisionStep = fieldType.numericPrecisionStep();
+            if (precisionStep <= 0 || precisionStep >= maxPrecisionStep()) {
+                fieldType.setNumericPrecisionStep(Integer.MAX_VALUE);
+            }
+        }
+
+        protected abstract int maxPrecisionStep();
+    }
+
+    public static abstract class NumberFieldType extends MappedFieldType {
+
+        public NumberFieldType(LegacyNumericType numericType) {
+            setTokenized(false);
+            setOmitNorms(true);
+            setIndexOptions(IndexOptions.DOCS);
+            setStoreTermVectors(false);
+            setNumericType(numericType);
+        }
+
+        protected NumberFieldType(NumberFieldType ref) {
+            super(ref);
+        }
+
+        @Override
+        public void checkCompatibility(MappedFieldType other,
+                List<String> conflicts, boolean strict) {
+            super.checkCompatibility(other, conflicts, strict);
+            if (numericPrecisionStep() != other.numericPrecisionStep()) {
+                conflicts.add("mapper [" + name() + "] has different [precision_step] values");
+            }
+        }
+
+        public abstract NumberFieldType clone();
+
+        @Override
+        public abstract Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions, boolean transpositions);
+
+        @Override
+        public DocValueFormat docValueFormat(@Nullable String format, DateTimeZone timeZone) {
+            if (timeZone != null) {
+                throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] does not support custom time zones");
+            }
+            if (format == null) {
+                return DocValueFormat.RAW;
+            } else {
+                return new DocValueFormat.Decimal(format);
+            }
+        }
+    }
+
+    protected Boolean includeInAll;
+
+    protected Explicit<Boolean> ignoreMalformed;
+
+    protected Explicit<Boolean> coerce;
+
+    protected LegacyNumberFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
+                                Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce, Settings indexSettings,
+                                MultiFields multiFields, CopyTo copyTo) {
+        super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        assert fieldType.tokenized() == false;
+        this.ignoreMalformed = ignoreMalformed;
+        this.coerce = coerce;
+    }
+
+    @Override
+    protected LegacyNumberFieldMapper clone() {
+        return (LegacyNumberFieldMapper) super.clone();
+    }
+
+    @Override
+    public Mapper includeInAll(Boolean includeInAll) {
+        if (includeInAll != null) {
+            LegacyNumberFieldMapper clone = clone();
+            clone.includeInAll = includeInAll;
+            return clone;
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public Mapper includeInAllIfNotSet(Boolean includeInAll) {
+        if (includeInAll != null && this.includeInAll == null) {
+            LegacyNumberFieldMapper clone = clone();
+            clone.includeInAll = includeInAll;
+            return clone;
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public Mapper unsetIncludeInAll() {
+        if (includeInAll != null) {
+            LegacyNumberFieldMapper clone = clone();
+            clone.includeInAll = null;
+            return clone;
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+        RuntimeException e = null;
+        try {
+            innerParseCreateField(context, fields);
+        } catch (IllegalArgumentException e1) {
+            e = e1;
+        } catch (MapperParsingException e2) {
+            e = e2;
+        }
+
+        if (e != null && !ignoreMalformed.value()) {
+            throw e;
+        }
+    }
+
+    protected abstract void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException;
+
+    protected final void addDocValue(ParseContext context, List<Field> fields, long value) {
+        fields.add(new SortedNumericDocValuesField(fieldType().name(), value));
+    }
+
+    /**
+     * Converts an object value into a double
+     */
+    public static double parseDoubleValue(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+
+        if (value instanceof BytesRef) {
+            return Double.parseDouble(((BytesRef) value).utf8ToString());
+        }
+
+        return Double.parseDouble(value.toString());
+    }
+
+    /**
+     * Converts an object value into a long
+     */
+    public static long parseLongValue(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+
+        if (value instanceof BytesRef) {
+            return Long.parseLong(((BytesRef) value).utf8ToString());
+        }
+
+        return Long.parseLong(value.toString());
+    }
+
+    @Override
+    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+        super.doMerge(mergeWith, updateAllTypes);
+        LegacyNumberFieldMapper nfmMergeWith = (LegacyNumberFieldMapper) mergeWith;
+
+        this.includeInAll = nfmMergeWith.includeInAll;
+        if (nfmMergeWith.ignoreMalformed.explicit()) {
+            this.ignoreMalformed = nfmMergeWith.ignoreMalformed;
+        }
+        if (nfmMergeWith.coerce.explicit()) {
+            this.coerce = nfmMergeWith.coerce;
+        }
+    }
+
+    // used to we can use a numeric field in a document that is then parsed twice!
+    public abstract static class CustomNumericField extends Field {
+
+        private ThreadLocal<LegacyNumericTokenStream> tokenStream = new ThreadLocal<LegacyNumericTokenStream>() {
+            @Override
+            protected LegacyNumericTokenStream initialValue() {
+                return new LegacyNumericTokenStream(fieldType().numericPrecisionStep());
+            }
+        };
+
+        private static ThreadLocal<LegacyNumericTokenStream> tokenStream4 = new ThreadLocal<LegacyNumericTokenStream>() {
+            @Override
+            protected LegacyNumericTokenStream initialValue() {
+                return new LegacyNumericTokenStream(4);
+            }
+        };
+
+        private static ThreadLocal<LegacyNumericTokenStream> tokenStream8 = new ThreadLocal<LegacyNumericTokenStream>() {
+            @Override
+            protected LegacyNumericTokenStream initialValue() {
+                return new LegacyNumericTokenStream(8);
+            }
+        };
+
+        private static ThreadLocal<LegacyNumericTokenStream> tokenStream16 = new ThreadLocal<LegacyNumericTokenStream>() {
+            @Override
+            protected LegacyNumericTokenStream initialValue() {
+                return new LegacyNumericTokenStream(16);
+            }
+        };
+
+        private static ThreadLocal<LegacyNumericTokenStream> tokenStreamMax = new ThreadLocal<LegacyNumericTokenStream>() {
+            @Override
+            protected LegacyNumericTokenStream initialValue() {
+                return new LegacyNumericTokenStream(Integer.MAX_VALUE);
+            }
+        };
+
+        public CustomNumericField(Number value, MappedFieldType fieldType) {
+            super(fieldType.name(), fieldType);
+            if (value != null) {
+                this.fieldsData = value;
+            }
+        }
+
+        protected LegacyNumericTokenStream getCachedStream() {
+            if (fieldType().numericPrecisionStep() == 4) {
+                return tokenStream4.get();
+            } else if (fieldType().numericPrecisionStep() == 8) {
+                return tokenStream8.get();
+            } else if (fieldType().numericPrecisionStep() == 16) {
+                return tokenStream16.get();
+            } else if (fieldType().numericPrecisionStep() == Integer.MAX_VALUE) {
+                return tokenStreamMax.get();
+            }
+            return tokenStream.get();
+        }
+
+        @Override
+        public String stringValue() {
+            return null;
+        }
+
+        @Override
+        public Reader readerValue() {
+            return null;
+        }
+
+        public abstract String numericAsString();
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        super.doXContentBody(builder, includeDefaults, params);
+
+        if (includeDefaults || ignoreMalformed.explicit()) {
+            builder.field("ignore_malformed", ignoreMalformed.value());
+        }
+        if (includeDefaults || coerce.explicit()) {
+            builder.field("coerce", coerce.value());
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/LegacyTokenCountFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/LegacyTokenCountFieldMapper.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.core;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.document.Field;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.core.StringFieldMapper.ValueAndBoost;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.lucene.index.IndexOptions.NONE;
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeIntegerValue;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
+
+/**
+ * A {@link FieldMapper} that takes a string and writes a count of the tokens in that string
+ * to the index.  In most ways the mapper acts just like an {@link LegacyIntegerFieldMapper}.
+ */
+public class LegacyTokenCountFieldMapper extends LegacyIntegerFieldMapper {
+    public static final String CONTENT_TYPE = "token_count";
+
+    public static class Defaults extends LegacyIntegerFieldMapper.Defaults {
+
+    }
+
+    public static class Builder extends LegacyNumberFieldMapper.Builder<Builder, LegacyTokenCountFieldMapper> {
+        private NamedAnalyzer analyzer;
+
+        public Builder(String name) {
+            super(name, Defaults.FIELD_TYPE, Defaults.PRECISION_STEP_32_BIT);
+            builder = this;
+        }
+
+        public Builder analyzer(NamedAnalyzer analyzer) {
+            this.analyzer = analyzer;
+            return this;
+        }
+
+        public NamedAnalyzer analyzer() {
+            return analyzer;
+        }
+
+        @Override
+        public LegacyTokenCountFieldMapper build(BuilderContext context) {
+            if (context.indexCreatedVersion().onOrAfter(Version.V_5_0_0)) {
+                throw new IllegalStateException("Cannot use legacy numeric types after 5.0");
+            }
+            setupFieldType(context);
+            LegacyTokenCountFieldMapper fieldMapper = new LegacyTokenCountFieldMapper(name, fieldType, defaultFieldType,
+                    ignoreMalformed(context), coerce(context), context.indexSettings(),
+                    analyzer, multiFieldsBuilder.build(this, context), copyTo);
+            return (LegacyTokenCountFieldMapper) fieldMapper.includeInAll(includeInAll);
+        }
+
+        @Override
+        protected int maxPrecisionStep() {
+            return 32;
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        @SuppressWarnings("unchecked")
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            LegacyTokenCountFieldMapper.Builder builder = new LegacyTokenCountFieldMapper.Builder(name);
+            for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
+                Map.Entry<String, Object> entry = iterator.next();
+                String propName = Strings.toUnderscoreCase(entry.getKey());
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    builder.nullValue(nodeIntegerValue(propNode));
+                    iterator.remove();
+                } else if (propName.equals("analyzer")) {
+                    NamedAnalyzer analyzer = parserContext.analysisService().analyzer(propNode.toString());
+                    if (analyzer == null) {
+                        throw new MapperParsingException("Analyzer [" + propNode.toString() + "] not found for field [" + name + "]");
+                    }
+                    builder.analyzer(analyzer);
+                    iterator.remove();
+                }
+            }
+            parseNumberField(builder, name, node, parserContext);
+            if (builder.analyzer() == null) {
+                throw new MapperParsingException("Analyzer must be set for field [" + name + "] but wasn't.");
+            }
+            return builder;
+        }
+    }
+
+    private NamedAnalyzer analyzer;
+
+    protected LegacyTokenCountFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType, Explicit<Boolean> ignoreMalformed,
+                                    Explicit<Boolean> coerce, Settings indexSettings, NamedAnalyzer analyzer, MultiFields multiFields, CopyTo copyTo) {
+        super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, indexSettings, multiFields, copyTo);
+        this.analyzer = analyzer;
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+        ValueAndBoost valueAndBoost = StringFieldMapper.parseCreateFieldForString(context, null /* Out null value is an int so we convert*/, fieldType().boost());
+        if (valueAndBoost.value() == null && fieldType().nullValue() == null) {
+            return;
+        }
+
+        if (fieldType().indexOptions() != NONE || fieldType().stored() || fieldType().hasDocValues()) {
+            int count;
+            if (valueAndBoost.value() == null) {
+                count = fieldType().nullValue();
+            } else {
+                count = countPositions(analyzer, simpleName(), valueAndBoost.value());
+            }
+            addIntegerFields(context, fields, count, valueAndBoost.boost());
+        }
+    }
+
+    /**
+     * Count position increments in a token stream.  Package private for testing.
+     * @param analyzer analyzer to create token stream
+     * @param fieldName field name to pass to analyzer
+     * @param fieldValue field value to pass to analyzer
+     * @return number of position increments in a token stream
+     * @throws IOException if tokenStream throws it
+     */
+    static int countPositions(Analyzer analyzer, String fieldName, String fieldValue) throws IOException {
+        try (TokenStream tokenStream = analyzer.tokenStream(fieldName, fieldValue)) {
+            int count = 0;
+            PositionIncrementAttribute position = tokenStream.addAttribute(PositionIncrementAttribute.class);
+            tokenStream.reset();
+            while (tokenStream.incrementToken()) {
+                count += position.getPositionIncrement();
+            }
+            tokenStream.end();
+            count += position.getPositionIncrement();
+            return count;
+        }
+    }
+
+    /**
+     * Name of analyzer.
+     * @return name of analyzer
+     */
+    public String analyzer() {
+        return analyzer.name();
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+        super.doMerge(mergeWith, updateAllTypes);
+        this.analyzer = ((LegacyTokenCountFieldMapper) mergeWith).analyzer;
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        super.doXContentBody(builder, includeDefaults, params);
+
+        builder.field("analyzer", analyzer());
+    }
+
+    @Override
+    public boolean isGenerated() {
+        return true;
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
@@ -19,79 +19,70 @@
 
 package org.elasticsearch.index.mapper.core;
 
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.LegacyNumericTokenStream;
-import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.FloatPoint;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
-import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
-import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.index.IndexableFieldType;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.fieldstats.FieldStats;
 import org.elasticsearch.common.Explicit;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.fielddata.IndexFieldData;
-import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.core.LegacyNumberFieldMapper.Defaults;
 import org.elasticsearch.index.mapper.internal.AllFieldMapper;
+import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
-import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
-/**
- *
- */
-public abstract class NumberFieldMapper extends FieldMapper implements AllFieldMapper.IncludeInAll {
+/** A {@link FieldMapper} for numeric types: byte, short, int, long, float and double. */
+public class NumberFieldMapper extends FieldMapper implements AllFieldMapper.IncludeInAll {
+
     // this is private since it has a different default
     private static final Setting<Boolean> COERCE_SETTING =
-        Setting.boolSetting("index.mapping.coerce", true, Property.IndexScope);
+            Setting.boolSetting("index.mapping.coerce", true, Property.IndexScope);
 
-    public static class Defaults {
-
-        public static final int PRECISION_STEP_8_BIT  = Integer.MAX_VALUE; // 1tpv: 256 terms at most, not useful
-        public static final int PRECISION_STEP_16_BIT = 8;                 // 2tpv
-        public static final int PRECISION_STEP_32_BIT = 8;                 // 4tpv
-        public static final int PRECISION_STEP_64_BIT = 16;                // 4tpv
-
-        public static final Explicit<Boolean> IGNORE_MALFORMED = new Explicit<>(false, false);
-        public static final Explicit<Boolean> COERCE = new Explicit<>(true, false);
-    }
-
-    public abstract static class Builder<T extends Builder, Y extends NumberFieldMapper> extends FieldMapper.Builder<T, Y> {
+    public static class Builder extends FieldMapper.Builder<Builder, NumberFieldMapper> {
 
         private Boolean ignoreMalformed;
-
         private Boolean coerce;
 
-        public Builder(String name, MappedFieldType fieldType, int defaultPrecisionStep) {
-            super(name, fieldType, fieldType);
-            this.fieldType.setNumericPrecisionStep(defaultPrecisionStep);
+        public Builder(String name, NumberType type) {
+            super(name, new NumberFieldType(type), new NumberFieldType(type));
+            builder = this;
         }
 
-        public T precisionStep(int precisionStep) {
-            fieldType.setNumericPrecisionStep(precisionStep);
-            return builder;
-        }
-
-        public T ignoreMalformed(boolean ignoreMalformed) {
+        public Builder ignoreMalformed(boolean ignoreMalformed) {
             this.ignoreMalformed = ignoreMalformed;
             return builder;
         }
@@ -106,7 +97,7 @@ public abstract class NumberFieldMapper extends FieldMapper implements AllFieldM
             return Defaults.IGNORE_MALFORMED;
         }
 
-        public T coerce(boolean coerce) {
+        public Builder coerce(boolean coerce) {
             this.coerce = coerce;
             return builder;
         }
@@ -121,49 +112,658 @@ public abstract class NumberFieldMapper extends FieldMapper implements AllFieldM
             return Defaults.COERCE;
         }
 
+        @Override
         protected void setupFieldType(BuilderContext context) {
             super.setupFieldType(context);
-            int precisionStep = fieldType.numericPrecisionStep();
-            if (precisionStep <= 0 || precisionStep >= maxPrecisionStep()) {
-                fieldType.setNumericPrecisionStep(Integer.MAX_VALUE);
-            }
         }
 
-        protected abstract int maxPrecisionStep();
+        @Override
+        public NumberFieldMapper build(BuilderContext context) {
+            setupFieldType(context);
+            NumberFieldMapper fieldMapper = new NumberFieldMapper(name, fieldType, defaultFieldType, ignoreMalformed(context),
+                    coerce(context), context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+            return (NumberFieldMapper) fieldMapper.includeInAll(includeInAll);
+        }
     }
 
-    public static abstract class NumberFieldType extends MappedFieldType {
+    public static class TypeParser implements Mapper.TypeParser {
 
-        public NumberFieldType(LegacyNumericType numericType) {
-            setTokenized(false);
-            setOmitNorms(true);
-            setIndexOptions(IndexOptions.DOCS);
-            setStoreTermVectors(false);
-            setNumericType(numericType);
-        }
+        final NumberType type;
 
-        protected NumberFieldType(NumberFieldType ref) {
-            super(ref);
+        public TypeParser(NumberType type) {
+            this.type = type;
         }
 
         @Override
-        public void checkCompatibility(MappedFieldType other,
-                List<String> conflicts, boolean strict) {
-            super.checkCompatibility(other, conflicts, strict);
-            if (numericPrecisionStep() != other.numericPrecisionStep()) {
-                conflicts.add("mapper [" + name() + "] has different [precision_step] values");
+        public Mapper.Builder<?,?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            if (parserContext.indexVersionCreated().before(Version.V_5_0_0)) {
+                switch (type) {
+                case BYTE:
+                    return new LegacyByteFieldMapper.TypeParser().parse(name, node, parserContext);
+                case SHORT:
+                    return new LegacyShortFieldMapper.TypeParser().parse(name, node, parserContext);
+                case INTEGER:
+                    return new LegacyIntegerFieldMapper.TypeParser().parse(name, node, parserContext);
+                case LONG:
+                    return new LegacyLongFieldMapper.TypeParser().parse(name, node, parserContext);
+                case FLOAT:
+                    return new LegacyFloatFieldMapper.TypeParser().parse(name, node, parserContext);
+                case DOUBLE:
+                    return new LegacyDoubleFieldMapper.TypeParser().parse(name, node, parserContext);
+                default:
+                    throw new AssertionError();
+                }
             }
+            Builder builder = new Builder(name, type);
+            TypeParsers.parseField(builder, name, node, parserContext);
+            for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
+                Map.Entry<String, Object> entry = iterator.next();
+                String propName = entry.getKey();
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(type.parse(propNode));
+                    iterator.remove();
+                } else if (propName.equals("ignore_malformed")) {
+                    builder.ignoreMalformed(TypeParsers.nodeBooleanValue("ignore_malformed", propNode, parserContext));
+                    iterator.remove();
+                } else if (propName.equals("coerce")) {
+                    builder.coerce(TypeParsers.nodeBooleanValue("coerce", propNode, parserContext));
+                    iterator.remove();
+                }
+            }
+            return builder;
+        }
+    }
+
+    public enum NumberType {
+        FLOAT("float", NumericType.FLOAT) {
+            @Override
+            Float parse(Object value) {
+                if (value instanceof Number) {
+                    return ((Number) value).floatValue();
+                }
+                if (value instanceof BytesRef) {
+                    value = ((BytesRef) value).utf8ToString();
+                }
+                return Float.parseFloat(value.toString());
+            }
+
+            @Override
+            Float parse(XContentParser parser, boolean coerce) throws IOException {
+                return parser.floatValue(coerce);
+            }
+
+            @Override
+            Query termQuery(String field, Object value) {
+                float v = parse(value);
+                return FloatPoint.newExactQuery(field, v);
+            }
+
+            @Override
+            Query termsQuery(String field, List<Object> values) {
+                float[] v = new float[values.size()];
+                for (int i = 0; i < values.size(); ++i) {
+                    v[i] = parse(values.get(i));
+                }
+                return FloatPoint.newSetQuery(field, v);
+            }
+
+            @Override
+            Query rangeQuery(String field, Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper) {
+                float l = Float.NEGATIVE_INFINITY;
+                float u = Float.POSITIVE_INFINITY;
+                if (lowerTerm != null) {
+                    l = parse(lowerTerm);
+                    if (includeLower == false) {
+                        l = Math.nextUp(l);
+                    }
+                }
+                if (upperTerm != null) {
+                    u = parse(upperTerm);
+                    if (includeUpper == false) {
+                        u = Math.nextDown(u);
+                    }
+                }
+                return FloatPoint.newRangeQuery(field, l, u);
+            }
+
+            @Override
+            Query fuzzyQuery(String field, Object value, Fuzziness fuzziness) {
+                float base = parse(value);
+                float delta = fuzziness.asFloat();
+                return rangeQuery(field, base - delta, base + delta, true, true);
+            }
+
+            @Override
+            public List<Field> createFields(String name, Number value, boolean indexed, boolean docValued, boolean stored) {
+                List<Field> fields = new ArrayList<>();
+                if (indexed) {
+                    fields.add(new FloatPoint(name, value.floatValue()));
+                }
+                if (docValued) {
+                    fields.add(new SortedNumericDocValuesField(name, NumericUtils.floatToSortableInt(value.floatValue())));
+                }
+                if (stored) {
+                    fields.add(new StoredField(name, value.floatValue()));
+                }
+                return fields;
+            }
+
+            @Override
+            FieldStats.Double stats(IndexReader reader, String field) throws IOException {
+                long size = PointValues.size(reader, field);
+                if (size == 0) {
+                    return null;
+                }
+                int docCount = PointValues.getDocCount(reader, field);
+                byte[] min = PointValues.getMinPackedValue(reader, field);
+                byte[] max = PointValues.getMaxPackedValue(reader, field);
+                return new FieldStats.Double(reader.maxDoc(),docCount, -1L, size,
+                        FloatPoint.decodeDimension(min, 0),
+                        FloatPoint.decodeDimension(max, 0));
+            }
+        },
+        DOUBLE("double", NumericType.DOUBLE) {
+            @Override
+            Double parse(Object value) {
+                if (value instanceof Number) {
+                    return ((Number) value).doubleValue();
+                }
+                if (value instanceof BytesRef) {
+                    value = ((BytesRef) value).utf8ToString();
+                }
+                return Double.parseDouble(value.toString());
+            }
+
+            @Override
+            Double parse(XContentParser parser, boolean coerce) throws IOException {
+                return parser.doubleValue(coerce);
+            }
+
+            @Override
+            Query termQuery(String field, Object value) {
+                double v = parse(value);
+                return DoublePoint.newExactQuery(field, v);
+            }
+
+            @Override
+            Query termsQuery(String field, List<Object> values) {
+                double[] v = new double[values.size()];
+                for (int i = 0; i < values.size(); ++i) {
+                    v[i] = parse(values.get(i));
+                }
+                return DoublePoint.newSetQuery(field, v);
+            }
+
+            @Override
+            Query rangeQuery(String field, Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper) {
+                double l = Double.NEGATIVE_INFINITY;
+                double u = Double.POSITIVE_INFINITY;
+                if (lowerTerm != null) {
+                    l = parse(lowerTerm);
+                    if (includeLower == false) {
+                        l = Math.nextUp(l);
+                    }
+                }
+                if (upperTerm != null) {
+                    u = parse(upperTerm);
+                    if (includeUpper == false) {
+                        u = Math.nextDown(u);
+                    }
+                }
+                return DoublePoint.newRangeQuery(field, l, u);
+            }
+
+            @Override
+            Query fuzzyQuery(String field, Object value, Fuzziness fuzziness) {
+                double base = parse(value);
+                double delta = fuzziness.asFloat();
+                return rangeQuery(field, base - delta, base + delta, true, true);
+            }
+
+            @Override
+            public List<Field> createFields(String name, Number value, boolean indexed, boolean docValued, boolean stored) {
+                List<Field> fields = new ArrayList<>();
+                if (indexed) {
+                    fields.add(new DoublePoint(name, value.doubleValue()));
+                }
+                if (docValued) {
+                    fields.add(new SortedNumericDocValuesField(name, NumericUtils.doubleToSortableLong(value.doubleValue())));
+                }
+                if (stored) {
+                    fields.add(new StoredField(name, value.doubleValue()));
+                }
+                return fields;
+            }
+
+            @Override
+            FieldStats.Double stats(IndexReader reader, String field) throws IOException {
+                long size = PointValues.size(reader, field);
+                if (size == 0) {
+                    return null;
+                }
+                int docCount = PointValues.getDocCount(reader, field);
+                byte[] min = PointValues.getMinPackedValue(reader, field);
+                byte[] max = PointValues.getMaxPackedValue(reader, field);
+                return new FieldStats.Double(reader.maxDoc(),docCount, -1L, size,
+                        DoublePoint.decodeDimension(min, 0),
+                        DoublePoint.decodeDimension(max, 0));
+            }
+        },
+        BYTE("byte", NumericType.BYTE) {
+            @Override
+            Byte parse(Object value) {
+                if (value instanceof Byte) {
+                    return (Byte) value;
+                }
+                if (value instanceof BytesRef) {
+                    value = ((BytesRef) value).utf8ToString();
+                }
+                return Byte.parseByte(value.toString());
+            }
+
+            @Override
+            Short parse(XContentParser parser, boolean coerce) throws IOException {
+                int value = parser.intValue(coerce);
+                if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
+                    throw new IllegalArgumentException("Value [" + value + "] is out of range for a byte");
+                }
+                return (short) value;
+            }
+
+            @Override
+            Query termQuery(String field, Object value) {
+                return INTEGER.termQuery(field, value);
+            }
+
+            @Override
+            Query termsQuery(String field, List<Object> values) {
+                return INTEGER.termsQuery(field, values);
+            }
+
+            @Override
+            Query rangeQuery(String field, Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper) {
+                return INTEGER.rangeQuery(field, lowerTerm, upperTerm, includeLower, includeUpper);
+            }
+
+            @Override
+            Query fuzzyQuery(String field, Object value, Fuzziness fuzziness) {
+                return INTEGER.fuzzyQuery(field, value, fuzziness);
+            }
+
+            @Override
+            public List<Field> createFields(String name, Number value, boolean indexed, boolean docValued, boolean stored) {
+                return INTEGER.createFields(name, value, indexed, docValued, stored);
+            }
+
+            @Override
+            FieldStats.Long stats(IndexReader reader, String field) throws IOException {
+                return (FieldStats.Long) INTEGER.stats(reader, field);
+            }
+
+            @Override
+            Number valueForSearch(Number value) {
+                return value.byteValue();
+            }
+        },
+        SHORT("short", NumericType.SHORT) {
+            @Override
+            Short parse(Object value) {
+                if (value instanceof Number) {
+                    return ((Number) value).shortValue();
+                }
+                if (value instanceof BytesRef) {
+                    value = ((BytesRef) value).utf8ToString();
+                }
+                return Short.parseShort(value.toString());
+            }
+
+            @Override
+            Short parse(XContentParser parser, boolean coerce) throws IOException {
+                int value = parser.intValue(coerce);
+                if (value < Short.MIN_VALUE || value > Short.MAX_VALUE) {
+                    throw new IllegalArgumentException("Value [" + value + "] is out of range for a short");
+                }
+                return (short) value;
+            }
+
+            @Override
+            Query termQuery(String field, Object value) {
+                return INTEGER.termQuery(field, value);
+            }
+
+            @Override
+            Query termsQuery(String field, List<Object> values) {
+                return INTEGER.termsQuery(field, values);
+            }
+
+            @Override
+            Query rangeQuery(String field, Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper) {
+                return INTEGER.rangeQuery(field, lowerTerm, upperTerm, includeLower, includeUpper);
+            }
+
+            @Override
+            Query fuzzyQuery(String field, Object value, Fuzziness fuzziness) {
+                return INTEGER.fuzzyQuery(field, value, fuzziness);
+            }
+
+            @Override
+            public List<Field> createFields(String name, Number value, boolean indexed, boolean docValued, boolean stored) {
+                return INTEGER.createFields(name, value, indexed, docValued, stored);
+            }
+
+            @Override
+            FieldStats.Long stats(IndexReader reader, String field) throws IOException {
+                return (FieldStats.Long) INTEGER.stats(reader, field);
+            }
+
+            @Override
+            Number valueForSearch(Number value) {
+                return value.shortValue();
+            }
+        },
+        INTEGER("integer", NumericType.INT) {
+            @Override
+            Integer parse(Object value) {
+                if (value instanceof Number) {
+                    return ((Number) value).intValue();
+                }
+                if (value instanceof BytesRef) {
+                    value = ((BytesRef) value).utf8ToString();
+                }
+                return Integer.parseInt(value.toString());
+            }
+
+            @Override
+            Integer parse(XContentParser parser, boolean coerce) throws IOException {
+                return parser.intValue(coerce);
+            }
+
+            @Override
+            Query termQuery(String field, Object value) {
+                int v = parse(value);
+                return IntPoint.newExactQuery(field, v);
+            }
+
+            @Override
+            Query termsQuery(String field, List<Object> values) {
+                int[] v = new int[values.size()];
+                for (int i = 0; i < values.size(); ++i) {
+                    v[i] = parse(values.get(i));
+                }
+                return IntPoint.newSetQuery(field, v);
+            }
+
+            @Override
+            Query rangeQuery(String field, Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper) {
+                int l = Integer.MIN_VALUE;
+                int u = Integer.MAX_VALUE;
+                if (lowerTerm != null) {
+                    l = parse(lowerTerm);
+                    if (includeLower == false) {
+                        if (l == Integer.MAX_VALUE) {
+                            return new MatchNoDocsQuery();
+                        }
+                        ++l;
+                    }
+                }
+                if (upperTerm != null) {
+                    u = parse(upperTerm);
+                    if (includeUpper == false) {
+                        if (u == Integer.MIN_VALUE) {
+                            return new MatchNoDocsQuery();
+                        }
+                        --u;
+                    }
+                }
+                return IntPoint.newRangeQuery(field, l, u);
+            }
+
+            @Override
+            Query fuzzyQuery(String field, Object value, Fuzziness fuzziness) {
+                int base = parse(value);
+                int delta = fuzziness.asInt();
+                return rangeQuery(field, base - delta, base + delta, true, true);
+            }
+
+            @Override
+            public List<Field> createFields(String name, Number value, boolean indexed, boolean docValued, boolean stored) {
+                List<Field> fields = new ArrayList<>();
+                if (indexed) {
+                    fields.add(new IntPoint(name, value.intValue()));
+                }
+                if (docValued) {
+                    fields.add(new SortedNumericDocValuesField(name, value.intValue()));
+                }
+                if (stored) {
+                    fields.add(new StoredField(name, value.intValue()));
+                }
+                return fields;
+            }
+
+            @Override
+            FieldStats.Long stats(IndexReader reader, String field) throws IOException {
+                long size = PointValues.size(reader, field);
+                if (size == 0) {
+                    return null;
+                }
+                int docCount = PointValues.getDocCount(reader, field);
+                byte[] min = PointValues.getMinPackedValue(reader, field);
+                byte[] max = PointValues.getMaxPackedValue(reader, field);
+                return new FieldStats.Long(reader.maxDoc(),docCount, -1L, size,
+                        IntPoint.decodeDimension(min, 0),
+                        IntPoint.decodeDimension(max, 0));
+            }
+        },
+        LONG("long", NumericType.LONG) {
+            @Override
+            Long parse(Object value) {
+                if (value instanceof Number) {
+                    return ((Number) value).longValue();
+                }
+                if (value instanceof BytesRef) {
+                    value = ((BytesRef) value).utf8ToString();
+                }
+                return Long.parseLong(value.toString());
+            }
+
+            @Override
+            Long parse(XContentParser parser, boolean coerce) throws IOException {
+                return parser.longValue(coerce);
+            }
+
+            @Override
+            Query termQuery(String field, Object value) {
+                long v = parse(value);
+                return LongPoint.newExactQuery(field, v);
+            }
+
+            @Override
+            Query termsQuery(String field, List<Object> values) {
+                long[] v = new long[values.size()];
+                for (int i = 0; i < values.size(); ++i) {
+                    v[i] = parse(values.get(i));
+                }
+                return LongPoint.newSetQuery(field, v);
+            }
+
+            @Override
+            Query rangeQuery(String field, Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper) {
+                long l = Long.MIN_VALUE;
+                long u = Long.MAX_VALUE;
+                if (lowerTerm != null) {
+                    l = parse(lowerTerm);
+                    if (includeLower == false) {
+                        if (l == Long.MAX_VALUE) {
+                            return new MatchNoDocsQuery();
+                        }
+                        ++l;
+                    }
+                }
+                if (upperTerm != null) {
+                    u = parse(upperTerm);
+                    if (includeUpper == false) {
+                        if (u == Long.MIN_VALUE) {
+                            return new MatchNoDocsQuery();
+                        }
+                        --u;
+                    }
+                }
+                return LongPoint.newRangeQuery(field, l, u);
+            }
+
+            @Override
+            Query fuzzyQuery(String field, Object value, Fuzziness fuzziness) {
+                long base = parse(value);
+                long delta = fuzziness.asLong();
+                return rangeQuery(field, base - delta, base + delta, true, true);
+            }
+
+            @Override
+            public List<Field> createFields(String name, Number value, boolean indexed, boolean docValued, boolean stored) {
+                List<Field> fields = new ArrayList<>();
+                if (indexed) {
+                    fields.add(new LongPoint(name, value.longValue()));
+                }
+                if (docValued) {
+                    fields.add(new SortedNumericDocValuesField(name, value.longValue()));
+                }
+                if (stored) {
+                    fields.add(new StoredField(name, value.longValue()));
+                }
+                return fields;
+            }
+
+            @Override
+            FieldStats.Long stats(IndexReader reader, String field) throws IOException {
+                long size = PointValues.size(reader, field);
+                if (size == 0) {
+                    return null;
+                }
+                int docCount = PointValues.getDocCount(reader, field);
+                byte[] min = PointValues.getMinPackedValue(reader, field);
+                byte[] max = PointValues.getMaxPackedValue(reader, field);
+                return new FieldStats.Long(reader.maxDoc(),docCount, -1L, size,
+                        LongPoint.decodeDimension(min, 0),
+                        LongPoint.decodeDimension(max, 0));
+            }
+        };
+
+        private final String name;
+        private final NumericType numericType;
+
+        NumberType(String name, NumericType numericType) {
+            this.name = name;
+            this.numericType = numericType;
         }
 
-        public abstract NumberFieldType clone();
+        /** Get the associated type name. */
+        public final String typeName() {
+            return name;
+        }
+        /** Get the associated numerit type */
+        final NumericType numericType() {
+            return numericType;
+        }
+        abstract Query termQuery(String field, Object value);
+        abstract Query termsQuery(String field, List<Object> values);
+        abstract Query rangeQuery(String field, Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper);
+        abstract Query fuzzyQuery(String field, Object value, Fuzziness fuzziness);
+        abstract Number parse(XContentParser parser, boolean coerce) throws IOException;
+        abstract Number parse(Object value);
+        public abstract List<Field> createFields(String name, Number value, boolean indexed, boolean docValued, boolean stored);
+        abstract FieldStats<? extends Number> stats(IndexReader reader, String field) throws IOException;
+        Number valueForSearch(Number value) {
+            return value;
+        }
+    }
+
+    public static final class NumberFieldType extends MappedFieldType {
+
+        NumberType type;
+
+        public NumberFieldType(NumberType type) {
+            super();
+            this.type = Objects.requireNonNull(type);
+            setTokenized(false);
+            setHasDocValues(true);
+            setOmitNorms(true);
+        }
+
+        NumberFieldType(NumberFieldType other) {
+            super(other);
+            this.type = other.type;
+        }
 
         @Override
-        public abstract Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions, boolean transpositions);
+        public MappedFieldType clone() {
+            return new NumberFieldType(this);
+        }
 
         @Override
-        public DocValueFormat docValueFormat(@Nullable String format, DateTimeZone timeZone) {
+        public String typeName() {
+            return type.name;
+        }
+
+        @Override
+        public Query termQuery(Object value, QueryShardContext context) {
+            Query query = type.termQuery(name(), value);
+            if (boost() != 1f) {
+                query = new BoostQuery(query, boost());
+            }
+            return query;
+        }
+
+        @Override
+        public Query termsQuery(List values, QueryShardContext context) {
+            Query query = type.termsQuery(name(), values);
+            if (boost() != 1f) {
+                query = new BoostQuery(query, boost());
+            }
+            return query;
+        }
+
+        @Override
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper) {
+            Query query = type.rangeQuery(name(), lowerTerm, upperTerm, includeLower, includeUpper);
+            if (boost() != 1f) {
+                query = new BoostQuery(query, boost());
+            }
+            return query;
+        }
+
+        @Override
+        public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions, boolean transpositions) {
+            return type.fuzzyQuery(name(), value, fuzziness);
+        }
+
+        @Override
+        public FieldStats stats(IndexReader reader) throws IOException {
+            return type.stats(reader, name());
+        }
+
+        @Override
+        public IndexFieldData.Builder fielddataBuilder() {
+            failIfNoDocValues();
+            return new DocValuesIndexFieldData.Builder().numericType(type.numericType());
+        }
+
+        @Override
+        public Object valueForSearch(Object value) {
+            if (value == null) {
+                return null;
+            }
+            return type.valueForSearch((Number) value);
+        }
+
+        @Override
+        public DocValueFormat docValueFormat(String format, DateTimeZone timeZone) {
             if (timeZone != null) {
-                throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] does not support custom time zones");
+                throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName()
+                    + "] does not support custom time zones");
             }
             if (format == null) {
                 return DocValueFormat.RAW;
@@ -173,19 +773,34 @@ public abstract class NumberFieldMapper extends FieldMapper implements AllFieldM
         }
     }
 
-    protected Boolean includeInAll;
+    private Boolean includeInAll;
 
-    protected Explicit<Boolean> ignoreMalformed;
+    private Explicit<Boolean> ignoreMalformed;
 
-    protected Explicit<Boolean> coerce;
+    private Explicit<Boolean> coerce;
 
-    protected NumberFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
-                                Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce, Settings indexSettings,
-                                MultiFields multiFields, CopyTo copyTo) {
+    private NumberFieldMapper(
+            String simpleName,
+            MappedFieldType fieldType,
+            MappedFieldType defaultFieldType,
+            Explicit<Boolean> ignoreMalformed,
+            Explicit<Boolean> coerce,
+            Settings indexSettings,
+            MultiFields multiFields,
+            CopyTo copyTo) {
         super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
-        assert fieldType.tokenized() == false;
         this.ignoreMalformed = ignoreMalformed;
         this.coerce = coerce;
+    }
+
+    @Override
+    public NumberFieldType fieldType() {
+        return (NumberFieldType) super.fieldType();
+    }
+
+    @Override
+    protected String contentType() {
+        return fieldType.typeName();
     }
 
     @Override
@@ -228,190 +843,65 @@ public abstract class NumberFieldMapper extends FieldMapper implements AllFieldM
 
     @Override
     protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
-        RuntimeException e = null;
-        try {
-            innerParseCreateField(context, fields);
-        } catch (IllegalArgumentException e1) {
-            e = e1;
-        } catch (MapperParsingException e2) {
-            e = e2;
+        XContentParser parser = context.parser();
+        Object value;
+        Number numericValue = null;
+        if (context.externalValueSet()) {
+            value = context.externalValue();
+        } else if (parser.currentToken() == Token.VALUE_NULL) {
+            value = null;
+        } else if (coerce.value()
+                && parser.currentToken() == Token.VALUE_STRING
+                && parser.textLength() == 0) {
+            value = null;
+        } else {
+            value = parser.textOrNull();
+            if (value != null) {
+                try {
+                    numericValue = fieldType().type.parse(parser, coerce.value());
+                } catch (IllegalArgumentException e) {
+                    if (ignoreMalformed.value()) {
+                        return;
+                    } else {
+                        throw e;
+                    }
+                }
+            }
         }
 
-        if (e != null && !ignoreMalformed.value()) {
-            throw e;
-        }
-    }
-
-    protected abstract void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException;
-
-    protected final void addDocValue(ParseContext context, List<Field> fields, long value) {
-        fields.add(new SortedNumericDocValuesField(fieldType().name(), value));
-    }
-
-    /**
-     * Converts an object value into a double
-     */
-    public static double parseDoubleValue(Object value) {
-        if (value instanceof Number) {
-            return ((Number) value).doubleValue();
+        if (value == null) {
+            value = fieldType().nullValue();
         }
 
-        if (value instanceof BytesRef) {
-            return Double.parseDouble(((BytesRef) value).utf8ToString());
+        if (value == null) {
+            return;
         }
 
-        return Double.parseDouble(value.toString());
-    }
-
-    /**
-     * Converts an object value into a long
-     */
-    public static long parseLongValue(Object value) {
-        if (value instanceof Number) {
-            return ((Number) value).longValue();
+        if (numericValue == null) {
+            numericValue = fieldType().type.parse(value);
         }
 
-        if (value instanceof BytesRef) {
-            return Long.parseLong(((BytesRef) value).utf8ToString());
+        if (context.includeInAll(includeInAll, this)) {
+            context.allEntries().addText(fieldType().name(), value.toString(), fieldType().boost());
         }
 
-        return Long.parseLong(value.toString());
+        boolean indexed = fieldType().indexOptions() != IndexOptions.NONE;
+        boolean docValued = fieldType().hasDocValues();
+        boolean stored = fieldType().stored();
+        fields.addAll(fieldType().type.createFields(fieldType().name(), numericValue, indexed, docValued, stored));
     }
 
     @Override
     protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
         super.doMerge(mergeWith, updateAllTypes);
-        NumberFieldMapper nfmMergeWith = (NumberFieldMapper) mergeWith;
-
-        this.includeInAll = nfmMergeWith.includeInAll;
-        if (nfmMergeWith.ignoreMalformed.explicit()) {
-            this.ignoreMalformed = nfmMergeWith.ignoreMalformed;
+        NumberFieldMapper other = (NumberFieldMapper) mergeWith;
+        this.includeInAll = other.includeInAll;
+        if (other.ignoreMalformed.explicit()) {
+            this.ignoreMalformed = other.ignoreMalformed;
         }
-        if (nfmMergeWith.coerce.explicit()) {
-            this.coerce = nfmMergeWith.coerce;
+        if (other.coerce.explicit()) {
+            this.coerce = other.coerce;
         }
-    }
-
-    // used to we can use a numeric field in a document that is then parsed twice!
-    public abstract static class CustomNumericField extends Field {
-
-        private ThreadLocal<LegacyNumericTokenStream> tokenStream = new ThreadLocal<LegacyNumericTokenStream>() {
-            @Override
-            protected LegacyNumericTokenStream initialValue() {
-                return new LegacyNumericTokenStream(fieldType().numericPrecisionStep());
-            }
-        };
-
-        private static ThreadLocal<LegacyNumericTokenStream> tokenStream4 = new ThreadLocal<LegacyNumericTokenStream>() {
-            @Override
-            protected LegacyNumericTokenStream initialValue() {
-                return new LegacyNumericTokenStream(4);
-            }
-        };
-
-        private static ThreadLocal<LegacyNumericTokenStream> tokenStream8 = new ThreadLocal<LegacyNumericTokenStream>() {
-            @Override
-            protected LegacyNumericTokenStream initialValue() {
-                return new LegacyNumericTokenStream(8);
-            }
-        };
-
-        private static ThreadLocal<LegacyNumericTokenStream> tokenStream16 = new ThreadLocal<LegacyNumericTokenStream>() {
-            @Override
-            protected LegacyNumericTokenStream initialValue() {
-                return new LegacyNumericTokenStream(16);
-            }
-        };
-
-        private static ThreadLocal<LegacyNumericTokenStream> tokenStreamMax = new ThreadLocal<LegacyNumericTokenStream>() {
-            @Override
-            protected LegacyNumericTokenStream initialValue() {
-                return new LegacyNumericTokenStream(Integer.MAX_VALUE);
-            }
-        };
-
-        public CustomNumericField(Number value, MappedFieldType fieldType) {
-            super(fieldType.name(), fieldType);
-            if (value != null) {
-                this.fieldsData = value;
-            }
-        }
-
-        protected LegacyNumericTokenStream getCachedStream() {
-            if (fieldType().numericPrecisionStep() == 4) {
-                return tokenStream4.get();
-            } else if (fieldType().numericPrecisionStep() == 8) {
-                return tokenStream8.get();
-            } else if (fieldType().numericPrecisionStep() == 16) {
-                return tokenStream16.get();
-            } else if (fieldType().numericPrecisionStep() == Integer.MAX_VALUE) {
-                return tokenStreamMax.get();
-            }
-            return tokenStream.get();
-        }
-
-        @Override
-        public String stringValue() {
-            return null;
-        }
-
-        @Override
-        public Reader readerValue() {
-            return null;
-        }
-
-        public abstract String numericAsString();
-    }
-
-    public static abstract class CustomNumericDocValuesField implements IndexableField {
-
-        public static final FieldType TYPE = new FieldType();
-        static {
-          TYPE.setDocValuesType(DocValuesType.BINARY);
-          TYPE.freeze();
-        }
-
-        private final String name;
-
-        public CustomNumericDocValuesField(String  name) {
-            this.name = name;
-        }
-
-        @Override
-        public String name() {
-            return name;
-        }
-
-        @Override
-        public IndexableFieldType fieldType() {
-            return TYPE;
-        }
-
-        @Override
-        public float boost() {
-            return 1f;
-        }
-
-        @Override
-        public String stringValue() {
-            return null;
-        }
-
-        @Override
-        public Reader readerValue() {
-            return null;
-        }
-
-        @Override
-        public Number numericValue() {
-            return null;
-        }
-
-        @Override
-        public TokenStream tokenStream(Analyzer analyzer, TokenStream reuse) {
-            return null;
-        }
-
     }
 
     @Override
@@ -423,6 +913,11 @@ public abstract class NumberFieldMapper extends FieldMapper implements AllFieldM
         }
         if (includeDefaults || coerce.explicit()) {
             builder.field("coerce", coerce.value());
+        }
+        if (includeInAll != null) {
+            builder.field("include_in_all", includeInAll);
+        } else if (includeDefaults) {
+            builder.field("include_in_all", false);
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -22,9 +22,13 @@ package org.elasticsearch.index.mapper.core;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.ESLogger;
@@ -44,6 +48,7 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.internal.AllFieldMapper;
+import org.elasticsearch.index.query.QueryShardContext;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -55,7 +60,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import static org.apache.lucene.index.IndexOptions.NONE;
-import static org.elasticsearch.index.mapper.core.TypeParsers.parseMultiField;
 import static org.elasticsearch.index.mapper.core.TypeParsers.parseTextField;
 
 public class StringFieldMapper extends FieldMapper implements AllFieldMapper.IncludeInAll {
@@ -469,6 +473,15 @@ public class StringFieldMapper extends FieldMapper implements AllFieldMapper.Inc
                         + name() + "] in order to load fielddata in memory by uninverting the inverted index. Note that this can however "
                         + "use significant memory.");
             }
+        }
+
+        @Override
+        public Query regexpQuery(String value, int flags, int maxDeterminizedStates, @Nullable MultiTermQuery.RewriteMethod method, @Nullable QueryShardContext context) {
+            RegexpQuery query = new RegexpQuery(new Term(name(), indexedValueForSearch(value)), flags, maxDeterminizedStates);
+            if (method != null) {
+                query.setRewriteMethod(method);
+            }
+            return query;
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/TextFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/TextFieldMapper.java
@@ -21,7 +21,11 @@ package org.elasticsearch.index.mapper.core;
 
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.RegexpQuery;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -36,6 +40,7 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.internal.AllFieldMapper;
+import org.elasticsearch.index.query.QueryShardContext;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -294,6 +299,16 @@ public class TextFieldMapper extends FieldMapper implements AllFieldMapper.Inclu
                         + "use significant memory.");
             }
             return new PagedBytesIndexFieldData.Builder(fielddataMinFrequency, fielddataMaxFrequency, fielddataMinSegmentSize);
+        }
+
+        @Override
+        public Query regexpQuery(String value, int flags, int maxDeterminizedStates,
+                @Nullable MultiTermQuery.RewriteMethod method, @Nullable QueryShardContext context) {
+            RegexpQuery query = new RegexpQuery(new Term(name(), indexedValueForSearch(value)), flags, maxDeterminizedStates);
+            if (method != null) {
+                query.setRewriteMethod(method);
+            }
+            return query;
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapper.java
@@ -23,7 +23,8 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.document.Field;
-import org.elasticsearch.common.Explicit;
+import org.apache.lucene.index.IndexOptions;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -33,33 +34,31 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.mapper.core.StringFieldMapper.ValueAndBoost;
 
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.lucene.index.IndexOptions.NONE;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeIntegerValue;
-import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
 
 /**
  * A {@link FieldMapper} that takes a string and writes a count of the tokens in that string
- * to the index.  In most ways the mapper acts just like an {@link IntegerFieldMapper}.
+ * to the index.  In most ways the mapper acts just like an {@link LegacyIntegerFieldMapper}.
  */
-public class TokenCountFieldMapper extends IntegerFieldMapper {
+public class TokenCountFieldMapper extends FieldMapper {
     public static final String CONTENT_TYPE = "token_count";
 
-    public static class Defaults extends IntegerFieldMapper.Defaults {
-
+    public static class Defaults {
+        public static final MappedFieldType FIELD_TYPE = new NumberFieldMapper.NumberFieldType(NumberFieldMapper.NumberType.INTEGER);
     }
 
-    public static class Builder extends NumberFieldMapper.Builder<Builder, TokenCountFieldMapper> {
+    public static class Builder extends FieldMapper.Builder<Builder, TokenCountFieldMapper> {
         private NamedAnalyzer analyzer;
 
         public Builder(String name) {
-            super(name, Defaults.FIELD_TYPE, Defaults.PRECISION_STEP_32_BIT);
+            super(name, Defaults.FIELD_TYPE, Defaults.FIELD_TYPE);
             builder = this;
         }
 
@@ -75,15 +74,8 @@ public class TokenCountFieldMapper extends IntegerFieldMapper {
         @Override
         public TokenCountFieldMapper build(BuilderContext context) {
             setupFieldType(context);
-            TokenCountFieldMapper fieldMapper = new TokenCountFieldMapper(name, fieldType, defaultFieldType,
-                    ignoreMalformed(context), coerce(context), context.indexSettings(),
-                    analyzer, multiFieldsBuilder.build(this, context), copyTo);
-            return (TokenCountFieldMapper) fieldMapper.includeInAll(includeInAll);
-        }
-
-        @Override
-        protected int maxPrecisionStep() {
-            return 32;
+            return new TokenCountFieldMapper(name, fieldType, defaultFieldType,
+                    context.indexSettings(), analyzer, multiFieldsBuilder.build(this, context), copyTo);
         }
     }
 
@@ -91,6 +83,9 @@ public class TokenCountFieldMapper extends IntegerFieldMapper {
         @Override
         @SuppressWarnings("unchecked")
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            if (parserContext.indexVersionCreated().before(Version.V_5_0_0)) {
+                return new LegacyTokenCountFieldMapper.TypeParser().parse(name, node, parserContext);
+            }
             TokenCountFieldMapper.Builder builder = new TokenCountFieldMapper.Builder(name);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();
@@ -108,7 +103,7 @@ public class TokenCountFieldMapper extends IntegerFieldMapper {
                     iterator.remove();
                 }
             }
-            parseNumberField(builder, name, node, parserContext);
+            parseField(builder, name, node, parserContext);
             if (builder.analyzer() == null) {
                 throw new MapperParsingException("Analyzer must be set for field [" + name + "] but wasn't.");
             }
@@ -118,28 +113,32 @@ public class TokenCountFieldMapper extends IntegerFieldMapper {
 
     private NamedAnalyzer analyzer;
 
-    protected TokenCountFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType, Explicit<Boolean> ignoreMalformed,
-                                    Explicit<Boolean> coerce, Settings indexSettings, NamedAnalyzer analyzer, MultiFields multiFields, CopyTo copyTo) {
-        super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, indexSettings, multiFields, copyTo);
+    protected TokenCountFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType, 
+            Settings indexSettings, NamedAnalyzer analyzer, MultiFields multiFields, CopyTo copyTo) {
+        super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
         this.analyzer = analyzer;
     }
 
     @Override
     protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
-        ValueAndBoost valueAndBoost = StringFieldMapper.parseCreateFieldForString(context, null /* Out null value is an int so we convert*/, fieldType().boost());
-        if (valueAndBoost.value() == null && fieldType().nullValue() == null) {
-            return;
+        final String value;
+        if (context.externalValueSet()) {
+            value = context.externalValue().toString();
+        } else {
+            value = context.parser().textOrNull();
         }
 
-        if (fieldType().indexOptions() != NONE || fieldType().stored() || fieldType().hasDocValues()) {
-            int count;
-            if (valueAndBoost.value() == null) {
-                count = fieldType().nullValue();
-            } else {
-                count = countPositions(analyzer, simpleName(), valueAndBoost.value());
-            }
-            addIntegerFields(context, fields, count, valueAndBoost.boost());
+        final int tokenCount;
+        if (value == null) {
+            tokenCount = (Integer) fieldType().nullValue();
+        } else {
+            tokenCount = countPositions(analyzer, name(), value);
         }
+
+        boolean indexed = fieldType().indexOptions() != IndexOptions.NONE;
+        boolean docValued = fieldType().hasDocValues();
+        boolean stored = fieldType().stored();
+        fields.addAll(NumberFieldMapper.NumberType.INTEGER.createFields(fieldType().name(), tokenCount, indexed, docValued, stored));
     }
 
     /**
@@ -186,7 +185,6 @@ public class TokenCountFieldMapper extends IntegerFieldMapper {
     @Override
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
-
         builder.field("analyzer", analyzer());
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
@@ -81,7 +81,8 @@ public class TypeParsers {
         }
     }
 
-    public static void parseNumberField(NumberFieldMapper.Builder builder, String name, Map<String, Object> numberNode, Mapper.TypeParser.ParserContext parserContext) {
+    @Deprecated // for legacy ints only
+    public static void parseNumberField(LegacyNumberFieldMapper.Builder builder, String name, Map<String, Object> numberNode, Mapper.TypeParser.ParserContext parserContext) {
         parseField(builder, name, numberNode, parserContext);
         for (Iterator<Map.Entry<String, Object>> iterator = numberNode.entrySet().iterator(); iterator.hasNext();) {
             Map.Entry<String, Object> entry = iterator.next();

--- a/core/src/main/java/org/elasticsearch/index/mapper/geo/BaseGeoPointFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/geo/BaseGeoPointFieldMapper.java
@@ -43,8 +43,9 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyDoubleFieldMapper;
 import org.elasticsearch.index.mapper.core.KeywordFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyNumberFieldMapper;
 import org.elasticsearch.index.mapper.core.NumberFieldMapper;
 import org.elasticsearch.index.mapper.object.ArrayValueMapperParser;
 import org.elasticsearch.search.DocValueFormat;
@@ -145,25 +146,32 @@ public abstract class BaseGeoPointFieldMapper extends FieldMapper implements Arr
         }
 
         public abstract Y build(BuilderContext context, String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
-                                Settings indexSettings, DoubleFieldMapper latMapper, DoubleFieldMapper lonMapper,
+                                Settings indexSettings, FieldMapper latMapper, FieldMapper lonMapper,
                                 KeywordFieldMapper geoHashMapper, MultiFields multiFields, Explicit<Boolean> ignoreMalformed, CopyTo copyTo);
 
         public Y build(Mapper.BuilderContext context) {
             GeoPointFieldType geoPointFieldType = (GeoPointFieldType)fieldType;
 
-            DoubleFieldMapper latMapper = null;
-            DoubleFieldMapper lonMapper = null;
+            FieldMapper latMapper = null;
+            FieldMapper lonMapper = null;
 
             context.path().add(name);
             if (enableLatLon) {
-                NumberFieldMapper.Builder<?, ?> latMapperBuilder = new DoubleFieldMapper.Builder(Names.LAT).includeInAll(false);
-                NumberFieldMapper.Builder<?, ?> lonMapperBuilder = new DoubleFieldMapper.Builder(Names.LON).includeInAll(false);
-                if (precisionStep != null) {
-                    latMapperBuilder.precisionStep(precisionStep);
-                    lonMapperBuilder.precisionStep(precisionStep);
+                if (context.indexCreatedVersion().before(Version.V_5_0_0)) {
+                    LegacyNumberFieldMapper.Builder<?, ?> latMapperBuilder = new LegacyDoubleFieldMapper.Builder(Names.LAT).includeInAll(false);
+                    LegacyNumberFieldMapper.Builder<?, ?> lonMapperBuilder = new LegacyDoubleFieldMapper.Builder(Names.LON).includeInAll(false);
+                    if (precisionStep != null) {
+                        latMapperBuilder.precisionStep(precisionStep);
+                        lonMapperBuilder.precisionStep(precisionStep);
+                    }
+                    latMapper = (LegacyDoubleFieldMapper) latMapperBuilder.includeInAll(false).store(fieldType.stored()).docValues(false).build(context);
+                    lonMapper = (LegacyDoubleFieldMapper) lonMapperBuilder.includeInAll(false).store(fieldType.stored()).docValues(false).build(context);
+                } else {
+                    latMapper = new NumberFieldMapper.Builder(Names.LAT, NumberFieldMapper.NumberType.DOUBLE)
+                            .includeInAll(false).store(fieldType.stored()).docValues(false).build(context);
+                    lonMapper = new NumberFieldMapper.Builder(Names.LON, NumberFieldMapper.NumberType.DOUBLE)
+                            .includeInAll(false).store(fieldType.stored()).docValues(false).build(context);
                 }
-                latMapper = (DoubleFieldMapper) latMapperBuilder.includeInAll(false).store(fieldType.stored()).docValues(false).build(context);
-                lonMapper = (DoubleFieldMapper) lonMapperBuilder.includeInAll(false).store(fieldType.stored()).docValues(false).build(context);
                 geoPointFieldType.setLatLonEnabled(latMapper.fieldType(), lonMapper.fieldType());
             }
             KeywordFieldMapper geoHashMapper = null;
@@ -361,16 +369,16 @@ public abstract class BaseGeoPointFieldMapper extends FieldMapper implements Arr
         }
     }
 
-    protected DoubleFieldMapper latMapper;
+    protected FieldMapper latMapper;
 
-    protected DoubleFieldMapper lonMapper;
+    protected FieldMapper lonMapper;
 
     protected KeywordFieldMapper geoHashMapper;
 
     protected Explicit<Boolean> ignoreMalformed;
 
     protected BaseGeoPointFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType, Settings indexSettings,
-                                      DoubleFieldMapper latMapper, DoubleFieldMapper lonMapper, KeywordFieldMapper geoHashMapper,
+                                      FieldMapper latMapper, FieldMapper lonMapper, KeywordFieldMapper geoHashMapper,
                                       MultiFields multiFields, Explicit<Boolean> ignoreMalformed, CopyTo copyTo) {
         super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
         this.latMapper = latMapper;
@@ -542,8 +550,8 @@ public abstract class BaseGeoPointFieldMapper extends FieldMapper implements Arr
     public FieldMapper updateFieldType(Map<String, MappedFieldType> fullNameToFieldType) {
         BaseGeoPointFieldMapper updated = (BaseGeoPointFieldMapper) super.updateFieldType(fullNameToFieldType);
         KeywordFieldMapper geoUpdated = geoHashMapper == null ? null : (KeywordFieldMapper) geoHashMapper.updateFieldType(fullNameToFieldType);
-        DoubleFieldMapper latUpdated = latMapper == null ? null : (DoubleFieldMapper) latMapper.updateFieldType(fullNameToFieldType);
-        DoubleFieldMapper lonUpdated = lonMapper == null ? null : (DoubleFieldMapper) lonMapper.updateFieldType(fullNameToFieldType);
+        FieldMapper latUpdated = latMapper == null ? null : latMapper.updateFieldType(fullNameToFieldType);
+        FieldMapper lonUpdated = lonMapper == null ? null : lonMapper.updateFieldType(fullNameToFieldType);
         if (updated == this
                 && geoUpdated == geoHashMapper
                 && latUpdated == latMapper

--- a/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -28,11 +28,11 @@ import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
 import org.elasticsearch.index.mapper.core.KeywordFieldMapper;
 
 import java.io.IOException;
@@ -78,8 +78,8 @@ public class GeoPointFieldMapper extends BaseGeoPointFieldMapper  {
 
         @Override
         public GeoPointFieldMapper build(BuilderContext context, String simpleName, MappedFieldType fieldType,
-                                         MappedFieldType defaultFieldType, Settings indexSettings, DoubleFieldMapper latMapper,
-                                         DoubleFieldMapper lonMapper, KeywordFieldMapper geoHashMapper, MultiFields multiFields, Explicit<Boolean> ignoreMalformed,
+                                         MappedFieldType defaultFieldType, Settings indexSettings, FieldMapper latMapper,
+                                         FieldMapper lonMapper, KeywordFieldMapper geoHashMapper, MultiFields multiFields, Explicit<Boolean> ignoreMalformed,
                                          CopyTo copyTo) {
             fieldType.setTokenized(false);
             if (context.indexCreatedVersion().before(Version.V_2_3_0)) {
@@ -109,7 +109,7 @@ public class GeoPointFieldMapper extends BaseGeoPointFieldMapper  {
     }
 
     public GeoPointFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType, Settings indexSettings,
-                               DoubleFieldMapper latMapper, DoubleFieldMapper lonMapper,
+                               FieldMapper latMapper, FieldMapper lonMapper,
                                KeywordFieldMapper geoHashMapper, MultiFields multiFields, Explicit<Boolean> ignoreMalformed, CopyTo copyTo) {
         super(simpleName, fieldType, defaultFieldType, indexSettings, latMapper, lonMapper, geoHashMapper, multiFields,
                 ignoreMalformed, copyTo);

--- a/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapperLegacy.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapperLegacy.java
@@ -38,9 +38,9 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
+import org.elasticsearch.index.mapper.CustomDocValuesField;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.core.KeywordFieldMapper;
-import org.elasticsearch.index.mapper.core.NumberFieldMapper.CustomNumericDocValuesField;
 import org.elasticsearch.index.mapper.object.ArrayValueMapperParser;
 
 import java.io.IOException;
@@ -108,8 +108,8 @@ public class GeoPointFieldMapperLegacy extends BaseGeoPointFieldMapper implement
 
         @Override
         public GeoPointFieldMapperLegacy build(BuilderContext context, String simpleName, MappedFieldType fieldType,
-                                               MappedFieldType defaultFieldType, Settings indexSettings, DoubleFieldMapper latMapper,
-                                               DoubleFieldMapper lonMapper, KeywordFieldMapper geoHashMapper, MultiFields multiFields, Explicit<Boolean> ignoreMalformed,
+                                               MappedFieldType defaultFieldType, Settings indexSettings, FieldMapper latMapper,
+                                               FieldMapper lonMapper, KeywordFieldMapper geoHashMapper, MultiFields multiFields, Explicit<Boolean> ignoreMalformed,
                                                CopyTo copyTo) {
             fieldType.setTokenized(false);
             setupFieldType(context);
@@ -266,7 +266,7 @@ public class GeoPointFieldMapperLegacy extends BaseGeoPointFieldMapper implement
     protected Explicit<Boolean> coerce;
 
     public GeoPointFieldMapperLegacy(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType, Settings indexSettings,
-                                     DoubleFieldMapper latMapper, DoubleFieldMapper lonMapper,
+                                     FieldMapper latMapper, FieldMapper lonMapper,
                                      KeywordFieldMapper geoHashMapper, MultiFields multiFields, Explicit<Boolean> ignoreMalformed,
                                      Explicit<Boolean> coerce, CopyTo copyTo) {
         super(simpleName, fieldType, defaultFieldType, indexSettings, latMapper, lonMapper, geoHashMapper, multiFields,
@@ -335,7 +335,7 @@ public class GeoPointFieldMapperLegacy extends BaseGeoPointFieldMapper implement
         }
     }
 
-    public static class CustomGeoPointDocValuesField extends CustomNumericDocValuesField {
+    public static class CustomGeoPointDocValuesField extends CustomDocValuesField {
 
         private final ObjectHashSet<GeoPoint> points;
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
@@ -34,7 +34,7 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.SourceToParse;
-import org.elasticsearch.index.mapper.core.LongFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyLongFieldMapper;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -51,7 +51,7 @@ public class TTLFieldMapper extends MetadataFieldMapper {
     public static final String NAME = "_ttl";
     public static final String CONTENT_TYPE = "_ttl";
 
-    public static class Defaults extends LongFieldMapper.Defaults {
+    public static class Defaults extends LegacyLongFieldMapper.Defaults {
         public static final String NAME = TTLFieldMapper.CONTENT_TYPE;
 
         public static final TTLFieldType TTL_FIELD_TYPE = new TTLFieldType();
@@ -127,7 +127,7 @@ public class TTLFieldMapper extends MetadataFieldMapper {
         }
     }
 
-    public static final class TTLFieldType extends LongFieldMapper.LongFieldType {
+    public static final class TTLFieldType extends LegacyLongFieldMapper.LongFieldType {
 
         public TTLFieldType() {
         }
@@ -226,7 +226,7 @@ public class TTLFieldMapper extends MetadataFieldMapper {
                     throw new AlreadyExpiredException(context.index(), context.type(), context.id(), timestamp, ttl, now);
                 }
                 // the expiration timestamp (timestamp + ttl) is set as field
-                fields.add(new LongFieldMapper.CustomLongNumericField(expire, fieldType()));
+                fields.add(new LegacyLongFieldMapper.CustomLongNumericField(expire, fieldType()));
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -34,8 +34,8 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.mapper.core.DateFieldMapper;
-import org.elasticsearch.index.mapper.core.LongFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyDateFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyLongFieldMapper;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -52,7 +52,7 @@ public class TimestampFieldMapper extends MetadataFieldMapper {
     public static final String CONTENT_TYPE = "_timestamp";
     public static final String DEFAULT_DATE_TIME_FORMAT = "epoch_millis||strictDateOptionalTime";
 
-    public static class Defaults extends DateFieldMapper.Defaults {
+    public static class Defaults extends LegacyDateFieldMapper.Defaults {
         public static final String NAME = "_timestamp";
 
         // TODO: this should be removed
@@ -86,8 +86,8 @@ public class TimestampFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public DateFieldMapper.DateFieldType fieldType() {
-            return (DateFieldMapper.DateFieldType)fieldType;
+        public LegacyDateFieldMapper.DateFieldType fieldType() {
+            return (LegacyDateFieldMapper.DateFieldType)fieldType;
         }
 
         public Builder enabled(EnabledAttributeMapper enabledState) {
@@ -169,7 +169,7 @@ public class TimestampFieldMapper extends MetadataFieldMapper {
         }
     }
 
-    public static final class TimestampFieldType extends DateFieldMapper.DateFieldType {
+    public static final class TimestampFieldType extends LegacyDateFieldMapper.DateFieldType {
 
         public TimestampFieldType() {}
 
@@ -242,7 +242,7 @@ public class TimestampFieldMapper extends MetadataFieldMapper {
         if (enabledState.enabled) {
             long timestamp = context.sourceToParse().timestamp();
             if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
-                fields.add(new LongFieldMapper.CustomLongNumericField(timestamp, fieldType()));
+                fields.add(new LegacyLongFieldMapper.CustomLongNumericField(timestamp, fieldType()));
             }
             if (fieldType().hasDocValues()) {
                 fields.add(new NumericDocValuesField(fieldType().name(), timestamp));

--- a/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
@@ -19,136 +19,109 @@
 
 package org.elasticsearch.index.mapper.ip;
 
-import org.apache.lucene.analysis.LegacyNumericTokenStream;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.Terms;
-import org.apache.lucene.search.LegacyNumericRangeQuery;
+import org.apache.lucene.index.PointValues;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
-import org.apache.lucene.util.LegacyNumericUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.fieldstats.FieldStats;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.Numbers;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.network.Cidrs;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.IndexFieldData;
-import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.mapper.core.LongFieldMapper;
-import org.elasticsearch.index.mapper.core.LongFieldMapper.CustomLongNumericField;
-import org.elasticsearch.index.mapper.core.NumberFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyNumberFieldMapper.Defaults;
+import org.elasticsearch.index.mapper.core.TypeParsers;
+import org.elasticsearch.index.mapper.internal.AllFieldMapper;
+import org.elasticsearch.index.mapper.ip.LegacyIpFieldMapper;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.bucket.range.ipv4.InternalIPv4Range;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
-import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
-
-/**
- *
- */
-public class IpFieldMapper extends NumberFieldMapper {
+/** A {@link FieldMapper} for ip addresses. */
+public class IpFieldMapper extends FieldMapper implements AllFieldMapper.IncludeInAll {
 
     public static final String CONTENT_TYPE = "ip";
-    public static final long MAX_IP = 4294967296L;
 
-    public static String longToIp(long longIp) {
-        int octet3 = (int) ((longIp >> 24) % 256);
-        int octet2 = (int) ((longIp >> 16) % 256);
-        int octet1 = (int) ((longIp >> 8) % 256);
-        int octet0 = (int) ((longIp) % 256);
-        return octet3 + "." + octet2 + "." + octet1 + "." + octet0;
-    }
+    public static class Builder extends FieldMapper.Builder<Builder, IpFieldMapper> {
 
-    private static final Pattern pattern = Pattern.compile("\\.");
-
-    public static long ipToLong(String ip) {
-        try {
-            if (!InetAddresses.isInetAddress(ip)) {
-                throw new IllegalArgumentException("failed to parse ip [" + ip + "], not a valid ip address");
-            }
-            String[] octets = pattern.split(ip);
-            if (octets.length != 4) {
-                throw new IllegalArgumentException("failed to parse ip [" + ip + "], not a valid ipv4 address (4 dots)");
-            }
-            return (Long.parseLong(octets[0]) << 24) + (Integer.parseInt(octets[1]) << 16) +
-                    (Integer.parseInt(octets[2]) << 8) + Integer.parseInt(octets[3]);
-        } catch (Exception e) {
-            if (e instanceof IllegalArgumentException) {
-                throw (IllegalArgumentException) e;
-            }
-            throw new IllegalArgumentException("failed to parse ip [" + ip + "]", e);
-        }
-    }
-
-    public static class Defaults extends NumberFieldMapper.Defaults {
-        public static final String NULL_VALUE = null;
-
-        public static final MappedFieldType FIELD_TYPE = new IpFieldType();
-
-        static {
-            FIELD_TYPE.freeze();
-        }
-    }
-
-    public static class Builder extends NumberFieldMapper.Builder<Builder, IpFieldMapper> {
-
-        protected String nullValue = Defaults.NULL_VALUE;
+        private Boolean ignoreMalformed;
 
         public Builder(String name) {
-            super(name, Defaults.FIELD_TYPE, Defaults.PRECISION_STEP_64_BIT);
+            super(name, new IpFieldType(), new IpFieldType());
             builder = this;
+        }
+
+        public Builder ignoreMalformed(boolean ignoreMalformed) {
+            this.ignoreMalformed = ignoreMalformed;
+            return builder;
+        }
+
+        protected Explicit<Boolean> ignoreMalformed(BuilderContext context) {
+            if (ignoreMalformed != null) {
+                return new Explicit<>(ignoreMalformed, true);
+            }
+            if (context.indexSettings() != null) {
+                return new Explicit<>(IGNORE_MALFORMED_SETTING.get(context.indexSettings()), false);
+            }
+            return Defaults.IGNORE_MALFORMED;
         }
 
         @Override
         public IpFieldMapper build(BuilderContext context) {
             setupFieldType(context);
-            IpFieldMapper fieldMapper = new IpFieldMapper(name, fieldType, defaultFieldType, ignoreMalformed(context), coerce(context),
+            IpFieldMapper fieldMapper = new IpFieldMapper(name, fieldType, defaultFieldType, ignoreMalformed(context),
                     context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
             return (IpFieldMapper) fieldMapper.includeInAll(includeInAll);
-        }
-
-        @Override
-        protected int maxPrecisionStep() {
-            return 64;
         }
     }
 
     public static class TypeParser implements Mapper.TypeParser {
+
+        public TypeParser() {
+        }
+
         @Override
-        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-            IpFieldMapper.Builder builder = new Builder(name);
-            parseNumberField(builder, name, node, parserContext);
+        public Mapper.Builder<?,?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            if (parserContext.indexVersionCreated().before(Version.V_5_0_0)) {
+                return new LegacyIpFieldMapper.TypeParser().parse(name, node, parserContext);
+            }
+            Builder builder = new Builder(name);
+            TypeParsers.parseField(builder, name, node, parserContext);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();
-                String propName = Strings.toUnderscoreCase(entry.getKey());
+                String propName = entry.getKey();
                 Object propNode = entry.getValue();
                 if (propName.equals("null_value")) {
                     if (propNode == null) {
                         throw new MapperParsingException("Property [null_value] cannot be null.");
                     }
-                    builder.nullValue(propNode.toString());
+                    builder.nullValue(InetAddresses.forString(propNode.toString()));
+                    iterator.remove();
+                } else if (propName.equals("ignore_malformed")) {
+                    builder.ignoreMalformed(TypeParsers.nodeBooleanValue("ignore_malformed", propNode, parserContext));
+                    iterator.remove();
+                } else if (TypeParsers.parseMultiField(builder, name, parserContext, propName, propNode)) {
                     iterator.remove();
                 }
             }
@@ -156,17 +129,20 @@ public class IpFieldMapper extends NumberFieldMapper {
         }
     }
 
-    public static final class IpFieldType extends LongFieldMapper.LongFieldType {
+    public static final class IpFieldType extends MappedFieldType {
 
-        public IpFieldType() {
+        IpFieldType() {
+            super();
+            setTokenized(false);
+            setHasDocValues(true);
         }
 
-        protected IpFieldType(IpFieldType ref) {
-            super(ref);
+        IpFieldType(IpFieldType other) {
+            super(other);
         }
 
         @Override
-        public NumberFieldType clone() {
+        public MappedFieldType clone() {
             return new IpFieldType(this);
         }
 
@@ -175,95 +151,100 @@ public class IpFieldMapper extends NumberFieldMapper {
             return CONTENT_TYPE;
         }
 
-        /**
-         * IPs should return as a string.
-         */
-        @Override
-        public Object valueForSearch(Object value) {
-            Long val = (Long) value;
-            if (val == null) {
-                return null;
+        private InetAddress parse(Object value) {
+            if (value instanceof InetAddress) {
+                return (InetAddress) value;
+            } else {
+                if (value instanceof BytesRef) {
+                    value = ((BytesRef) value).utf8ToString();
+                }
+                return InetAddresses.forString(value.toString());
             }
-            return longToIp(val);
-        }
-
-        @Override
-        public BytesRef indexedValueForSearch(Object value) {
-            BytesRefBuilder bytesRef = new BytesRefBuilder();
-            LegacyNumericUtils.longToPrefixCoded(parseValue(value), 0, bytesRef); // 0 because of exact match
-            return bytesRef.get();
         }
 
         @Override
         public Query termQuery(Object value, @Nullable QueryShardContext context) {
-            if (value != null) {
-                String term;
+            if (value instanceof InetAddress) {
+                return InetAddressPoint.newExactQuery(name(), (InetAddress) value);
+            } else {
                 if (value instanceof BytesRef) {
-                    term = ((BytesRef) value).utf8ToString();
-                } else {
-                    term = value.toString();
+                    value = ((BytesRef) value).utf8ToString();
                 }
-                long[] fromTo;
-                // assume that the term is either a CIDR range or the
-                // term is a single IPv4 address; if either of these
-                // assumptions is wrong, the CIDR parsing will fail
-                // anyway, and that is okay
+                String term = value.toString();
                 if (term.contains("/")) {
-                    // treat the term as if it is in CIDR notation
-                    fromTo = Cidrs.cidrMaskToMinMax(term);
-                } else {
-                    // treat the term as if it is a single IPv4, and
-                    // apply a CIDR mask equivalent to the host route
-                    fromTo = Cidrs.cidrMaskToMinMax(term + "/32");
+                    String[] fields = term.split("/");
+                    if (fields.length == 2) {
+                        InetAddress address = InetAddresses.forString(fields[0]);
+                        int prefixLength = Integer.parseInt(fields[1]);
+                        return InetAddressPoint.newPrefixQuery(name(), address, prefixLength);
+                    } else {
+                        throw new IllegalArgumentException("Expected [ip/prefix] but was [" + term + "]");
+                    }
                 }
-                if (fromTo != null) {
-                    return rangeQuery(fromTo[0] == 0 ? null : fromTo[0],
-                            fromTo[1] == InternalIPv4Range.MAX_IP ? null : fromTo[1], true, false);
-                }
+                InetAddress address = InetAddresses.forString(term);
+                return InetAddressPoint.newExactQuery(name(), address);
             }
-            return super.termQuery(value, context);
         }
 
         @Override
         public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper) {
-            return LegacyNumericRangeQuery.newLongRange(name(), numericPrecisionStep(),
-                lowerTerm == null ? null : parseValue(lowerTerm),
-                upperTerm == null ? null : parseValue(upperTerm),
-                includeLower, includeUpper);
+            if (includeLower == false || includeUpper == false) {
+                // TODO: should we drop range support entirely
+                throw new IllegalArgumentException("range on ip addresses only supports inclusive bounds");
+            }
+            InetAddress lower;
+            if (lowerTerm == null) {
+                lower = InetAddressPoint.decode(new byte[16]);
+            } else {
+                lower = parse(lowerTerm);
+            }
+
+            InetAddress upper;
+            if (upperTerm == null) {
+                byte[] bytes = new byte[16];
+                Arrays.fill(bytes, (byte) 255); 
+                upper = InetAddressPoint.decode(bytes);
+            } else {
+                upper = parse(upperTerm);
+            }
+
+            return InetAddressPoint.newRangeQuery(name(), lower, upper);
         }
 
         @Override
         public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions, boolean transpositions) {
-            long iValue = parseValue(value);
-            long iSim;
-            try {
-                iSim = ipToLong(fuzziness.asString());
-            } catch (IllegalArgumentException e) {
-                iSim = fuzziness.asLong();
-            }
-            return LegacyNumericRangeQuery.newLongRange(name(), numericPrecisionStep(),
-                iValue - iSim,
-                iValue + iSim,
-                true, true);
+            InetAddress base = parse(value);
+            int mask = fuzziness.asInt();
+            return InetAddressPoint.newPrefixQuery(name(), base, mask);
         }
 
         @Override
-        public FieldStats stats(IndexReader reader) throws IOException {
-            int maxDoc = reader.maxDoc();
-            Terms terms = org.apache.lucene.index.MultiFields.getTerms(reader, name());
-            if (terms == null) {
+        public FieldStats.Ip stats(IndexReader reader) throws IOException {
+            String field = name();
+            long size = PointValues.size(reader, field);
+            if (size == 0) {
                 return null;
             }
-            long minValue = LegacyNumericUtils.getMinLong(terms);
-            long maxValue = LegacyNumericUtils.getMaxLong(terms);
-            return new FieldStats.Ip(maxDoc, terms.getDocCount(), terms.getSumDocFreq(),
-                    terms.getSumTotalTermFreq(), minValue, maxValue);
+            int docCount = PointValues.getDocCount(reader, field);
+            byte[] min = PointValues.getMinPackedValue(reader, field);
+            byte[] max = PointValues.getMaxPackedValue(reader, field);
+            return new FieldStats.Ip(reader.maxDoc(),docCount, -1L, size,
+                    InetAddressPoint.decode(min),
+                    InetAddressPoint.decode(max));
         }
 
         @Override
         public IndexFieldData.Builder fielddataBuilder() {
             failIfNoDocValues();
-            return new DocValuesIndexFieldData.Builder().numericType(NumericType.LONG);
+            return new DocValuesIndexFieldData.Builder();
+        }
+
+        @Override
+        public Object valueForSearch(Object value) {
+            if (value == null) {
+                return null;
+            }
+            return DocValueFormat.IP.format((BytesRef) value);
         }
 
         @Override
@@ -279,79 +260,139 @@ public class IpFieldMapper extends NumberFieldMapper {
         }
     }
 
-    protected IpFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
-                            Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
-                            Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, indexSettings, multiFields, copyTo);
-    }
+    private Boolean includeInAll;
 
-    private static long parseValue(Object value) {
-        if (value instanceof Number) {
-            return ((Number) value).longValue();
-        }
-        if (value instanceof BytesRef) {
-            return ipToLong(((BytesRef) value).utf8ToString());
-        }
-        return ipToLong(value.toString());
+    private Explicit<Boolean> ignoreMalformed;
+
+    private IpFieldMapper(
+            String simpleName,
+            MappedFieldType fieldType,
+            MappedFieldType defaultFieldType,
+            Explicit<Boolean> ignoreMalformed,
+            Settings indexSettings,
+            MultiFields multiFields,
+            CopyTo copyTo) {
+        super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        this.ignoreMalformed = ignoreMalformed;
     }
 
     @Override
-    protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
-        String ipAsString;
-        if (context.externalValueSet()) {
-            ipAsString = (String) context.externalValue();
-            if (ipAsString == null) {
-                ipAsString = fieldType().nullValueAsString();
-            }
-        } else {
-            if (context.parser().currentToken() == XContentParser.Token.VALUE_NULL) {
-                ipAsString = fieldType().nullValueAsString();
-            } else {
-                ipAsString = context.parser().text();
-            }
-        }
-
-        if (ipAsString == null) {
-            return;
-        }
-        if (context.includeInAll(includeInAll, this)) {
-            context.allEntries().addText(fieldType().name(), ipAsString, fieldType().boost());
-        }
-
-        final long value = ipToLong(ipAsString);
-        if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
-            CustomLongNumericField field = new CustomLongNumericField(value, fieldType());
-            if (fieldType.boost() != 1f && Version.indexCreated(context.indexSettings()).before(Version.V_5_0_0_alpha1)) {
-                field.setBoost(fieldType().boost());
-            }
-            fields.add(field);
-        }
-        if (fieldType().hasDocValues()) {
-            addDocValue(context, fields, value);
-        }
+    public IpFieldType fieldType() {
+        return (IpFieldType) super.fieldType();
     }
 
     @Override
     protected String contentType() {
-        return CONTENT_TYPE;
+        return fieldType.typeName();
+    }
+
+    @Override
+    protected IpFieldMapper clone() {
+        return (IpFieldMapper) super.clone();
+    }
+
+    @Override
+    public Mapper includeInAll(Boolean includeInAll) {
+        if (includeInAll != null) {
+            IpFieldMapper clone = clone();
+            clone.includeInAll = includeInAll;
+            return clone;
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public Mapper includeInAllIfNotSet(Boolean includeInAll) {
+        if (includeInAll != null && this.includeInAll == null) {
+            IpFieldMapper clone = clone();
+            clone.includeInAll = includeInAll;
+            return clone;
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public Mapper unsetIncludeInAll() {
+        if (includeInAll != null) {
+            IpFieldMapper clone = clone();
+            clone.includeInAll = null;
+            return clone;
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+        Object addressAsObject;
+        if (context.externalValueSet()) {
+            addressAsObject = context.externalValue();
+        } else {
+            addressAsObject = context.parser().text();
+        }
+
+        if (addressAsObject == null) {
+            addressAsObject = fieldType().nullValue();
+        }
+
+        if (addressAsObject == null) {
+            return;
+        }
+
+        String addressAsString = addressAsObject.toString();
+        InetAddress address;
+        if (addressAsObject instanceof InetAddress) {
+            address = (InetAddress) addressAsObject;
+        } else {
+            try {
+                address = InetAddresses.forString(addressAsString);
+            } catch (IllegalArgumentException e) {
+                if (ignoreMalformed.value()) {
+                    return;
+                } else {
+                    throw e;
+                }
+            }
+        }
+
+        if (context.includeInAll(includeInAll, this)) {
+            context.allEntries().addText(fieldType().name(), addressAsString, fieldType().boost());
+        }
+
+        if (fieldType().indexOptions() != IndexOptions.NONE) {
+            fields.add(new InetAddressPoint(fieldType().name(), address));
+        }
+        if (fieldType().hasDocValues()) {
+            fields.add(new SortedSetDocValuesField(fieldType().name(), new BytesRef(InetAddressPoint.encode(address))));
+        }
+        if (fieldType().stored()) {
+            fields.add(new StoredField(fieldType().name(), new BytesRef(InetAddressPoint.encode(address))));
+        }
+    }
+
+    @Override
+    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+        super.doMerge(mergeWith, updateAllTypes);
+        IpFieldMapper other = (IpFieldMapper) mergeWith;
+        this.includeInAll = other.includeInAll;
+        if (other.ignoreMalformed.explicit()) {
+            this.ignoreMalformed = other.ignoreMalformed;
+        }
     }
 
     @Override
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
 
-        if (includeDefaults || fieldType().numericPrecisionStep() != Defaults.PRECISION_STEP_64_BIT) {
-            builder.field("precision_step", fieldType().numericPrecisionStep());
-        }
-        if (includeDefaults || fieldType().nullValueAsString() != null) {
-            builder.field("null_value", fieldType().nullValueAsString());
+        if (includeDefaults || ignoreMalformed.explicit()) {
+            builder.field("ignore_malformed", ignoreMalformed.value());
         }
         if (includeInAll != null) {
             builder.field("include_in_all", includeInAll);
         } else if (includeDefaults) {
             builder.field("include_in_all", false);
         }
-
     }
-
 }

--- a/core/src/main/java/org/elasticsearch/index/mapper/ip/LegacyIpFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ip/LegacyIpFieldMapper.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.ip;
+
+import org.apache.lucene.analysis.LegacyNumericTokenStream;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.search.LegacyNumericRangeQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.LegacyNumericUtils;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.fieldstats.FieldStats;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.network.Cidrs;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
+import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.core.LegacyLongFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyLongFieldMapper.CustomLongNumericField;
+import org.elasticsearch.index.mapper.core.LegacyNumberFieldMapper;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.bucket.range.ipv4.InternalIPv4Range;
+import org.joda.time.DateTimeZone;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
+
+/**
+ *
+ */
+public class LegacyIpFieldMapper extends LegacyNumberFieldMapper {
+
+    public static final String CONTENT_TYPE = "ip";
+    public static final long MAX_IP = 4294967296L;
+
+    public static String longToIp(long longIp) {
+        int octet3 = (int) ((longIp >> 24) % 256);
+        int octet2 = (int) ((longIp >> 16) % 256);
+        int octet1 = (int) ((longIp >> 8) % 256);
+        int octet0 = (int) ((longIp) % 256);
+        return octet3 + "." + octet2 + "." + octet1 + "." + octet0;
+    }
+
+    private static final Pattern pattern = Pattern.compile("\\.");
+
+    public static long ipToLong(String ip) {
+        try {
+            if (!InetAddresses.isInetAddress(ip)) {
+                throw new IllegalArgumentException("failed to parse ip [" + ip + "], not a valid ip address");
+            }
+            String[] octets = pattern.split(ip);
+            if (octets.length != 4) {
+                throw new IllegalArgumentException("failed to parse ip [" + ip + "], not a valid ipv4 address (4 dots)");
+            }
+            return (Long.parseLong(octets[0]) << 24) + (Integer.parseInt(octets[1]) << 16) +
+                    (Integer.parseInt(octets[2]) << 8) + Integer.parseInt(octets[3]);
+        } catch (Exception e) {
+            if (e instanceof IllegalArgumentException) {
+                throw (IllegalArgumentException) e;
+            }
+            throw new IllegalArgumentException("failed to parse ip [" + ip + "]", e);
+        }
+    }
+
+    public static class Defaults extends LegacyNumberFieldMapper.Defaults {
+        public static final String NULL_VALUE = null;
+
+        public static final MappedFieldType FIELD_TYPE = new IpFieldType();
+
+        static {
+            FIELD_TYPE.freeze();
+        }
+    }
+
+    public static class Builder extends LegacyNumberFieldMapper.Builder<Builder, LegacyIpFieldMapper> {
+
+        protected String nullValue = Defaults.NULL_VALUE;
+
+        public Builder(String name) {
+            super(name, Defaults.FIELD_TYPE, Defaults.PRECISION_STEP_64_BIT);
+            builder = this;
+        }
+
+        @Override
+        public LegacyIpFieldMapper build(BuilderContext context) {
+            if (context.indexCreatedVersion().onOrAfter(Version.V_5_0_0)) {
+                throw new IllegalStateException("Cannot use legacy numeric types after 5.0");
+            }
+            setupFieldType(context);
+            LegacyIpFieldMapper fieldMapper = new LegacyIpFieldMapper(name, fieldType, defaultFieldType, ignoreMalformed(context),
+                    coerce(context), context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+            return (LegacyIpFieldMapper) fieldMapper.includeInAll(includeInAll);
+        }
+
+        @Override
+        protected int maxPrecisionStep() {
+            return 64;
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            LegacyIpFieldMapper.Builder builder = new Builder(name);
+            parseNumberField(builder, name, node, parserContext);
+            for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
+                Map.Entry<String, Object> entry = iterator.next();
+                String propName = Strings.toUnderscoreCase(entry.getKey());
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(propNode.toString());
+                    iterator.remove();
+                }
+            }
+            return builder;
+        }
+    }
+
+    public static final class IpFieldType extends LegacyLongFieldMapper.LongFieldType {
+
+        public IpFieldType() {
+        }
+
+        protected IpFieldType(IpFieldType ref) {
+            super(ref);
+        }
+
+        @Override
+        public NumberFieldType clone() {
+            return new IpFieldType(this);
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        /**
+         * IPs should return as a string.
+         */
+        @Override
+        public Object valueForSearch(Object value) {
+            Long val = (Long) value;
+            if (val == null) {
+                return null;
+            }
+            return longToIp(val);
+        }
+
+        @Override
+        public BytesRef indexedValueForSearch(Object value) {
+            BytesRefBuilder bytesRef = new BytesRefBuilder();
+            LegacyNumericUtils.longToPrefixCoded(parseValue(value), 0, bytesRef); // 0 because of exact match
+            return bytesRef.get();
+        }
+
+        @Override
+        public Query termQuery(Object value, @Nullable QueryShardContext context) {
+            if (value != null) {
+                String term;
+                if (value instanceof BytesRef) {
+                    term = ((BytesRef) value).utf8ToString();
+                } else {
+                    term = value.toString();
+                }
+                long[] fromTo;
+                // assume that the term is either a CIDR range or the
+                // term is a single IPv4 address; if either of these
+                // assumptions is wrong, the CIDR parsing will fail
+                // anyway, and that is okay
+                if (term.contains("/")) {
+                    // treat the term as if it is in CIDR notation
+                    fromTo = Cidrs.cidrMaskToMinMax(term);
+                } else {
+                    // treat the term as if it is a single IPv4, and
+                    // apply a CIDR mask equivalent to the host route
+                    fromTo = Cidrs.cidrMaskToMinMax(term + "/32");
+                }
+                if (fromTo != null) {
+                    return rangeQuery(fromTo[0] == 0 ? null : fromTo[0],
+                            fromTo[1] == InternalIPv4Range.MAX_IP ? null : fromTo[1], true, false);
+                }
+            }
+            return super.termQuery(value, context);
+        }
+
+        @Override
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper) {
+            return LegacyNumericRangeQuery.newLongRange(name(), numericPrecisionStep(),
+                lowerTerm == null ? null : parseValue(lowerTerm),
+                upperTerm == null ? null : parseValue(upperTerm),
+                includeLower, includeUpper);
+        }
+
+        @Override
+        public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions, boolean transpositions) {
+            long iValue = parseValue(value);
+            long iSim;
+            try {
+                iSim = ipToLong(fuzziness.asString());
+            } catch (IllegalArgumentException e) {
+                iSim = fuzziness.asLong();
+            }
+            return LegacyNumericRangeQuery.newLongRange(name(), numericPrecisionStep(),
+                iValue - iSim,
+                iValue + iSim,
+                true, true);
+        }
+
+        @Override
+        public FieldStats stats(IndexReader reader) throws IOException {
+            int maxDoc = reader.maxDoc();
+            Terms terms = org.apache.lucene.index.MultiFields.getTerms(reader, name());
+            if (terms == null) {
+                return null;
+            }
+            long minValue = LegacyNumericUtils.getMinLong(terms);
+            long maxValue = LegacyNumericUtils.getMaxLong(terms);
+            return new FieldStats.Ip(maxDoc, terms.getDocCount(), terms.getSumDocFreq(),
+                    terms.getSumTotalTermFreq(),
+                    InetAddress.getByName(longToIp(minValue)),
+                    InetAddress.getByName(longToIp(maxValue)));
+        }
+
+        @Override
+        public IndexFieldData.Builder fielddataBuilder() {
+            failIfNoDocValues();
+            return new DocValuesIndexFieldData.Builder().numericType(NumericType.LONG);
+        }
+
+        @Override
+        public DocValueFormat docValueFormat(@Nullable String format, DateTimeZone timeZone) {
+            if (format != null) {
+                throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] does not support custom formats");
+            }
+            if (timeZone != null) {
+                throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName()
+                    + "] does not support custom time zones");
+            }
+            return DocValueFormat.IP;
+        }
+    }
+
+    protected LegacyIpFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
+                            Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
+                            Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
+        super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, indexSettings, multiFields, copyTo);
+    }
+
+    private static long parseValue(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        if (value instanceof BytesRef) {
+            return ipToLong(((BytesRef) value).utf8ToString());
+        }
+        return ipToLong(value.toString());
+    }
+
+    @Override
+    protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
+        String ipAsString;
+        if (context.externalValueSet()) {
+            ipAsString = (String) context.externalValue();
+            if (ipAsString == null) {
+                ipAsString = fieldType().nullValueAsString();
+            }
+        } else {
+            if (context.parser().currentToken() == XContentParser.Token.VALUE_NULL) {
+                ipAsString = fieldType().nullValueAsString();
+            } else {
+                ipAsString = context.parser().text();
+            }
+        }
+
+        if (ipAsString == null) {
+            return;
+        }
+        if (context.includeInAll(includeInAll, this)) {
+            context.allEntries().addText(fieldType().name(), ipAsString, fieldType().boost());
+        }
+
+        final long value = ipToLong(ipAsString);
+        if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
+            CustomLongNumericField field = new CustomLongNumericField(value, fieldType());
+            if (fieldType.boost() != 1f && Version.indexCreated(context.indexSettings()).before(Version.V_5_0_0_alpha1)) {
+                field.setBoost(fieldType().boost());
+            }
+            fields.add(field);
+        }
+        if (fieldType().hasDocValues()) {
+            addDocValue(context, fields, value);
+        }
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        super.doXContentBody(builder, includeDefaults, params);
+
+        if (includeDefaults || fieldType().numericPrecisionStep() != Defaults.PRECISION_STEP_64_BIT) {
+            builder.field("precision_step", fieldType().numericPrecisionStep());
+        }
+        if (includeDefaults || fieldType().nullValueAsString() != null) {
+            builder.field("null_value", fieldType().nullValueAsString());
+        }
+        if (includeInAll != null) {
+            builder.field("include_in_all", includeInAll);
+        } else if (includeDefaults) {
+            builder.field("include_in_all", false);
+        }
+
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/index/mapper/object/RootObjectMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/object/RootObjectMapper.java
@@ -54,7 +54,7 @@ public class RootObjectMapper extends ObjectMapper {
     public static class Defaults {
         public static final FormatDateTimeFormatter[] DYNAMIC_DATE_TIME_FORMATTERS =
                 new FormatDateTimeFormatter[]{
-                        DateFieldMapper.Defaults.DATE_TIME_FORMATTER,
+                        DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
                         Joda.getStrictStandardDateFormatter()
                 };
         public static final boolean DATE_DETECTION = true;

--- a/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyDateFieldMapper;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
@@ -437,7 +438,14 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
         Query query = null;
         MappedFieldType mapper = context.fieldMapper(this.fieldName);
         if (mapper != null) {
-            if (mapper instanceof DateFieldMapper.DateFieldType) {
+            if (mapper instanceof LegacyDateFieldMapper.DateFieldType) {
+                DateMathParser forcedDateParser = null;
+                if (this.format  != null) {
+                    forcedDateParser = new DateMathParser(this.format);
+                }
+                query = ((LegacyDateFieldMapper.DateFieldType) mapper).rangeQuery(from, to, includeLower, includeUpper,
+                        timeZone, forcedDateParser);
+            } else if (mapper instanceof DateFieldMapper.DateFieldType) {
                 DateMathParser forcedDateParser = null;
                 if (this.format  != null) {
                     forcedDateParser = new DateMathParser(this.format);

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -44,6 +44,8 @@ import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyDateFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyNumberFieldMapper;
 import org.elasticsearch.index.mapper.core.NumberFieldMapper;
 import org.elasticsearch.index.mapper.geo.BaseGeoPointFieldMapper;
 import org.elasticsearch.index.query.QueryShardContext;
@@ -198,12 +200,14 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
 
         // dates and time and geo need special handling
         parser.nextToken();
-        if (fieldType instanceof DateFieldMapper.DateFieldType) {
-            return parseDateVariable(parser, context, (DateFieldMapper.DateFieldType) fieldType, mode);
+        if (fieldType instanceof LegacyDateFieldMapper.DateFieldType
+                || fieldType instanceof DateFieldMapper.DateFieldType) {
+            return parseDateVariable(parser, context, fieldType, mode);
         } else if (fieldType instanceof BaseGeoPointFieldMapper.GeoPointFieldType) {
-            return parseGeoVariable(parser, context, (BaseGeoPointFieldMapper.GeoPointFieldType) fieldType, mode);
-        } else if (fieldType instanceof NumberFieldMapper.NumberFieldType) {
-            return parseNumberVariable(parser, context, (NumberFieldMapper.NumberFieldType) fieldType, mode);
+            return parseGeoVariable(parser, context, fieldType, mode);
+        } else if (fieldType instanceof LegacyNumberFieldMapper.NumberFieldType
+                || fieldType instanceof NumberFieldMapper.NumberFieldType) {
+            return parseNumberVariable(parser, context, fieldType, mode);
         } else {
             throw new ParsingException(parser.getTokenLocation(), "field [{}] is of type [{}], but only numeric types are supported.",
                     fieldName, fieldType);
@@ -211,7 +215,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
     }
 
     private AbstractDistanceScoreFunction parseNumberVariable(XContentParser parser, QueryShardContext context,
-            NumberFieldMapper.NumberFieldType fieldType, MultiValueMode mode) throws IOException {
+            MappedFieldType fieldType, MultiValueMode mode) throws IOException {
         XContentParser.Token token;
         String parameterName = null;
         double scale = 0;
@@ -246,7 +250,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
     }
 
     private AbstractDistanceScoreFunction parseGeoVariable(XContentParser parser, QueryShardContext context,
-            BaseGeoPointFieldMapper.GeoPointFieldType fieldType, MultiValueMode mode) throws IOException {
+            MappedFieldType fieldType, MultiValueMode mode) throws IOException {
         XContentParser.Token token;
         String parameterName = null;
         GeoPoint origin = new GeoPoint();
@@ -280,7 +284,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
     }
 
     private AbstractDistanceScoreFunction parseDateVariable(XContentParser parser, QueryShardContext context,
-            DateFieldMapper.DateFieldType dateFieldType, MultiValueMode mode) throws IOException {
+            MappedFieldType dateFieldType, MultiValueMode mode) throws IOException {
         XContentParser.Token token;
         String parameterName = null;
         String scaleString = null;
@@ -306,7 +310,11 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
         if (originString == null) {
             origin = context.nowInMillis();
         } else {
-            origin = dateFieldType.parseToMilliseconds(originString, false, null, null);
+            if (dateFieldType instanceof LegacyDateFieldMapper.DateFieldType) {
+                origin = ((LegacyDateFieldMapper.DateFieldType) dateFieldType).parseToMilliseconds(originString, false, null, null);
+            } else {
+                origin = ((DateFieldMapper.DateFieldType) dateFieldType).parseToMilliseconds(originString, false, null, null);
+            }
         }
 
         if (scaleString == null) {

--- a/core/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -28,18 +28,14 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.core.BinaryFieldMapper;
 import org.elasticsearch.index.mapper.core.BooleanFieldMapper;
-import org.elasticsearch.index.mapper.core.ByteFieldMapper;
 import org.elasticsearch.index.mapper.core.CompletionFieldMapper;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
-import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
-import org.elasticsearch.index.mapper.core.FloatFieldMapper;
-import org.elasticsearch.index.mapper.core.IntegerFieldMapper;
 import org.elasticsearch.index.mapper.core.KeywordFieldMapper;
-import org.elasticsearch.index.mapper.core.LongFieldMapper;
-import org.elasticsearch.index.mapper.core.ShortFieldMapper;
 import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.elasticsearch.index.mapper.core.TextFieldMapper;
 import org.elasticsearch.index.mapper.core.TokenCountFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyTokenCountFieldMapper;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.internal.AllFieldMapper;
@@ -87,12 +83,9 @@ public class IndicesModule extends AbstractModule {
     }
 
     private void registerBuiltInMappers() {
-        registerMapper(ByteFieldMapper.CONTENT_TYPE, new ByteFieldMapper.TypeParser());
-        registerMapper(ShortFieldMapper.CONTENT_TYPE, new ShortFieldMapper.TypeParser());
-        registerMapper(IntegerFieldMapper.CONTENT_TYPE, new IntegerFieldMapper.TypeParser());
-        registerMapper(LongFieldMapper.CONTENT_TYPE, new LongFieldMapper.TypeParser());
-        registerMapper(FloatFieldMapper.CONTENT_TYPE, new FloatFieldMapper.TypeParser());
-        registerMapper(DoubleFieldMapper.CONTENT_TYPE, new DoubleFieldMapper.TypeParser());
+        for (NumberFieldMapper.NumberType type : NumberFieldMapper.NumberType.values()) {
+            registerMapper(type.typeName(), new NumberFieldMapper.TypeParser(type));
+        }
         registerMapper(BooleanFieldMapper.CONTENT_TYPE, new BooleanFieldMapper.TypeParser());
         registerMapper(BinaryFieldMapper.CONTENT_TYPE, new BinaryFieldMapper.TypeParser());
         registerMapper(DateFieldMapper.CONTENT_TYPE, new DateFieldMapper.TypeParser());

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValueType.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValueType.java
@@ -64,7 +64,7 @@ public enum ValueType implements Writeable<ValueType> {
         }
     },
     DATE((byte) 5, "date", "date", ValuesSourceType.NUMERIC, IndexNumericFieldData.class,
-            new DocValueFormat.DateTime(DateFieldMapper.Defaults.DATE_TIME_FORMATTER, DateTimeZone.UTC)) {
+            new DocValueFormat.DateTime(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER, DateTimeZone.UTC)) {
         @Override
         public boolean isNumeric() {
             return true;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregatorBuilder.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.aggregations.support;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.joda.FormatDateTimeFormatter;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;

--- a/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.fieldstats.FieldStatsResponse;
 import org.elasticsearch.action.fieldstats.IndexConstraint;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyDateFieldMapper;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -305,9 +306,9 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
 
     public void testDateFiltering() {
         DateTime dateTime1 = new DateTime(2014, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC);
-        String dateTime1Str = DateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().print(dateTime1);
+        String dateTime1Str = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().print(dateTime1);
         DateTime dateTime2 = new DateTime(2014, 1, 2, 0, 0, 0, 0, DateTimeZone.UTC);
-        String dateTime2Str = DateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().print(dateTime2);
+        String dateTime2Str = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().print(dateTime2);
 
         createIndex("test1", Settings.EMPTY, "type", "value", "type=date");
         client().prepareIndex("test1", "test").setSource("value", dateTime1Str).get();

--- a/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
@@ -43,12 +43,12 @@ import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper.BuilderContext;
 import org.elasticsearch.index.mapper.core.BinaryFieldMapper;
-import org.elasticsearch.index.mapper.core.ByteFieldMapper;
-import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
-import org.elasticsearch.index.mapper.core.FloatFieldMapper;
-import org.elasticsearch.index.mapper.core.IntegerFieldMapper;
-import org.elasticsearch.index.mapper.core.LongFieldMapper;
-import org.elasticsearch.index.mapper.core.ShortFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyByteFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyDoubleFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyFloatFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyIntegerFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyLongFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyShortFieldMapper;
 import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
@@ -106,17 +106,17 @@ public abstract class AbstractFieldDataTestCase extends ESSingleNodeTestCase {
         if (type.equals("string")) {
             fieldType = new StringFieldMapper.Builder(fieldName).tokenized(false).fielddata(docValues == false).docValues(docValues).build(context).fieldType();
         } else if (type.equals("float")) {
-            fieldType = new FloatFieldMapper.Builder(fieldName).docValues(docValues).build(context).fieldType();
+            fieldType = new LegacyFloatFieldMapper.Builder(fieldName).docValues(docValues).build(context).fieldType();
         } else if (type.equals("double")) {
-            fieldType = new DoubleFieldMapper.Builder(fieldName).docValues(docValues).build(context).fieldType();
+            fieldType = new LegacyDoubleFieldMapper.Builder(fieldName).docValues(docValues).build(context).fieldType();
         } else if (type.equals("long")) {
-            fieldType = new LongFieldMapper.Builder(fieldName).docValues(docValues).build(context).fieldType();
+            fieldType = new LegacyLongFieldMapper.Builder(fieldName).docValues(docValues).build(context).fieldType();
         } else if (type.equals("int")) {
-            fieldType = new IntegerFieldMapper.Builder(fieldName).docValues(docValues).build(context).fieldType();
+            fieldType = new LegacyIntegerFieldMapper.Builder(fieldName).docValues(docValues).build(context).fieldType();
         } else if (type.equals("short")) {
-            fieldType = new ShortFieldMapper.Builder(fieldName).docValues(docValues).build(context).fieldType();
+            fieldType = new LegacyShortFieldMapper.Builder(fieldName).docValues(docValues).build(context).fieldType();
         } else if (type.equals("byte")) {
-            fieldType = new ByteFieldMapper.Builder(fieldName).docValues(docValues).build(context).fieldType();
+            fieldType = new LegacyByteFieldMapper.Builder(fieldName).docValues(docValues).build(context).fieldType();
         } else if (type.equals("geo_point")) {
             if (indexService.getIndexSettings().getIndexVersionCreated().before(Version.V_2_2_0)) {
                 fieldType =  new GeoPointFieldMapperLegacy.Builder(fieldName).docValues(docValues).build(context).fieldType();

--- a/core/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -39,13 +39,14 @@ import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper.BuilderContext;
 import org.elasticsearch.index.mapper.core.BooleanFieldMapper;
-import org.elasticsearch.index.mapper.core.ByteFieldMapper;
-import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
-import org.elasticsearch.index.mapper.core.FloatFieldMapper;
-import org.elasticsearch.index.mapper.core.IntegerFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyByteFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyDoubleFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyFloatFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyIntegerFieldMapper;
 import org.elasticsearch.index.mapper.core.KeywordFieldMapper;
-import org.elasticsearch.index.mapper.core.LongFieldMapper;
-import org.elasticsearch.index.mapper.core.ShortFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyLongFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyShortFieldMapper;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper;
 import org.elasticsearch.index.mapper.core.TextFieldMapper;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
@@ -79,22 +80,24 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
         assertTrue(fd instanceof SortedSetDVOrdinalsIndexFieldData);
 
         for (MappedFieldType mapper : Arrays.asList(
-                new ByteFieldMapper.Builder("int").build(ctx).fieldType(),
-                new ShortFieldMapper.Builder("int").build(ctx).fieldType(),
-                new IntegerFieldMapper.Builder("int").build(ctx).fieldType(),
-                new LongFieldMapper.Builder("long").build(ctx).fieldType()
+                new NumberFieldMapper.Builder("int", NumberFieldMapper.NumberType.BYTE).build(ctx).fieldType(),
+                new NumberFieldMapper.Builder("int", NumberFieldMapper.NumberType.SHORT).build(ctx).fieldType(),
+                new NumberFieldMapper.Builder("int", NumberFieldMapper.NumberType.INTEGER).build(ctx).fieldType(),
+                new NumberFieldMapper.Builder("long", NumberFieldMapper.NumberType.LONG).build(ctx).fieldType()
                 )) {
             ifdService.clear();
             fd = ifdService.getForField(mapper);
             assertTrue(fd instanceof SortedNumericDVIndexFieldData);
         }
 
-        final MappedFieldType floatMapper = new FloatFieldMapper.Builder("float").build(ctx).fieldType();
+        final MappedFieldType floatMapper = new NumberFieldMapper.Builder("float", NumberFieldMapper.NumberType.FLOAT)
+                .build(ctx).fieldType();
         ifdService.clear();
         fd = ifdService.getForField(floatMapper);
         assertTrue(fd instanceof SortedNumericDVIndexFieldData);
 
-        final MappedFieldType doubleMapper = new DoubleFieldMapper.Builder("double").build(ctx).fieldType();
+        final MappedFieldType doubleMapper = new NumberFieldMapper.Builder("double", NumberFieldMapper.NumberType.DOUBLE)
+                .build(ctx).fieldType();
         ifdService.clear();
         fd = ifdService.getForField(doubleMapper);
         assertTrue(fd instanceof SortedNumericDVIndexFieldData);
@@ -194,11 +197,11 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
     }
 
     public void testRequireDocValuesOnLongs() {
-        doTestRequireDocValues(new LongFieldMapper.LongFieldType());
+        doTestRequireDocValues(new LegacyLongFieldMapper.LongFieldType());
     }
 
     public void testRequireDocValuesOnDoubles() {
-        doTestRequireDocValues(new DoubleFieldMapper.DoubleFieldType());
+        doTestRequireDocValues(new LegacyDoubleFieldMapper.DoubleFieldType());
     }
 
     public void testRequireDocValuesOnBools() {

--- a/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -33,11 +33,8 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
 import org.elasticsearch.index.mapper.core.DateFieldMapper.DateFieldType;
-import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
-import org.elasticsearch.index.mapper.core.FloatFieldMapper;
-import org.elasticsearch.index.mapper.core.IntegerFieldMapper;
-import org.elasticsearch.index.mapper.core.LongFieldMapper;
-import org.elasticsearch.index.mapper.core.LongFieldMapper.LongFieldType;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper.NumberFieldType;
 import org.elasticsearch.index.mapper.core.TextFieldMapper;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
@@ -45,6 +42,7 @@ import java.io.IOException;
 
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
@@ -427,10 +425,10 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
     public void testReuseExistingMappings() throws IOException, Exception {
         IndexService indexService = createIndex("test", Settings.EMPTY, "type",
                 "my_field1", "type=text,store=true",
-                "my_field2", "type=integer,precision_step=10",
+                "my_field2", "type=integer,store=false",
                 "my_field3", "type=long,doc_values=false",
-                "my_field4", "type=float,index_options=freqs",
-                "my_field5", "type=double,precision_step=14",
+                "my_field4", "type=float,index=false",
+                "my_field5", "type=double,store=true",
                 "my_field6", "type=date,doc_values=false");
 
         // Even if the dynamic type of our new field is long, we already have a mapping for the same field
@@ -483,21 +481,22 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
         // since we already have a mapping of type integer
         assertNotNull(myField2Mapper);
         // same type
-        assertTrue(myField2Mapper instanceof IntegerFieldMapper);
+        assertEquals("integer", ((FieldMapper) myField2Mapper).fieldType().typeName());
         // and same option
-        assertEquals(10, ((IntegerFieldMapper) myField2Mapper).fieldType().numericPrecisionStep());
+        assertFalse(((FieldMapper) myField2Mapper).fieldType().stored());
 
         assertNotNull(myField3Mapper);
-        assertTrue(myField3Mapper instanceof LongFieldMapper);
-        assertFalse(((LongFieldType) ((LongFieldMapper) myField3Mapper).fieldType()).hasDocValues());
+        assertTrue(myField3Mapper instanceof NumberFieldMapper);
+        assertFalse(((NumberFieldType) ((NumberFieldMapper) myField3Mapper).fieldType()).hasDocValues());
 
         assertNotNull(myField4Mapper);
-        assertTrue(myField4Mapper instanceof FloatFieldMapper);
-        assertEquals(IndexOptions.DOCS_AND_FREQS, ((FieldMapper) myField4Mapper).fieldType().indexOptions());
+        assertTrue(myField4Mapper instanceof NumberFieldMapper);
+        assertEquals(IndexOptions.NONE, ((FieldMapper) myField4Mapper).fieldType().indexOptions());
 
         assertNotNull(myField5Mapper);
-        assertTrue(myField5Mapper instanceof DoubleFieldMapper);
-        assertEquals(14, ((DoubleFieldMapper) myField5Mapper).fieldType().numericPrecisionStep());
+
+        assertTrue(myField5Mapper instanceof NumberFieldMapper);
+        assertTrue(((NumberFieldMapper) myField5Mapper).fieldType().stored());
 
         assertNotNull(myField6Mapper);
         assertTrue(myField6Mapper instanceof DateFieldMapper);
@@ -584,9 +583,60 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
         ParsedDocument parsedDocument = mapper.parse("index", "type", "id", source);
         Mapping update = parsedDocument.dynamicMappingsUpdate();
         assertNotNull(update);
-        assertThat(update.root().getMapper("foo"), instanceOf(FloatFieldMapper.class));
-        assertThat(update.root().getMapper("bar"), instanceOf(FloatFieldMapper.class));
-        assertThat(update.root().getMapper("baz"), instanceOf(FloatFieldMapper.class));
-        assertThat(update.root().getMapper("quux"), instanceOf(FloatFieldMapper.class));
+        assertThat(((FieldMapper) update.root().getMapper("foo")).fieldType().typeName(), equalTo("float"));
+        assertThat(((FieldMapper) update.root().getMapper("bar")).fieldType().typeName(), equalTo("float"));
+        assertThat(((FieldMapper) update.root().getMapper("baz")).fieldType().typeName(), equalTo("float"));
+        assertThat(((FieldMapper) update.root().getMapper("quux")).fieldType().typeName(), equalTo("float"));
+    }
+
+    public void testNumericDetectionEnabled() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .field("numeric_detection", true)
+                .endObject().endObject().string();
+
+        IndexService index = createIndex("test");
+        client().admin().indices().preparePutMapping("test").setType("type").setSource(mapping).get();
+        DocumentMapper defaultMapper = index.mapperService().documentMapper("type");
+
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("s_long", "100")
+                .field("s_double", "100.0")
+                .endObject()
+                .bytes());
+        assertNotNull(doc.dynamicMappingsUpdate());
+        client().admin().indices().preparePutMapping("test").setType("type").setSource(doc.dynamicMappingsUpdate().toString()).get();
+
+        defaultMapper = index.mapperService().documentMapper("type");
+        FieldMapper mapper = defaultMapper.mappers().smartNameFieldMapper("s_long");
+        assertThat(mapper.fieldType().typeName(), equalTo("long"));
+
+        mapper = defaultMapper.mappers().smartNameFieldMapper("s_double");
+        assertThat(mapper.fieldType().typeName(), equalTo("float"));
+    }
+
+    public void testNumericDetectionDefault() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .endObject().endObject().string();
+
+        IndexService index = createIndex("test");
+        client().admin().indices().preparePutMapping("test").setType("type").setSource(mapping).get();
+        DocumentMapper defaultMapper = index.mapperService().documentMapper("type");
+
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("s_long", "100")
+                .field("s_double", "100.0")
+                .endObject()
+                .bytes());
+        assertNotNull(doc.dynamicMappingsUpdate());
+        assertAcked(client().admin().indices().preparePutMapping("test").setType("type").setSource(doc.dynamicMappingsUpdate().toString()).get());
+
+        defaultMapper = index.mapperService().documentMapper("type");
+        FieldMapper mapper = defaultMapper.mappers().smartNameFieldMapper("s_long");
+        assertThat(mapper, instanceOf(TextFieldMapper.class));
+
+        mapper = defaultMapper.mappers().smartNameFieldMapper("s_double");
+        assertThat(mapper, instanceOf(TextFieldMapper.class));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -29,7 +29,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.mapper.core.KeywordFieldMapper.KeywordFieldType;
-import org.elasticsearch.index.mapper.core.LongFieldMapper.LongFieldType;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper.NumberFieldType;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
@@ -188,7 +188,7 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
     public void testUnmappedFieldType() {
         MapperService mapperService = createIndex("index").mapperService();
         assertThat(mapperService.unmappedFieldType("keyword"), instanceOf(KeywordFieldType.class));
-        assertThat(mapperService.unmappedFieldType("long"), instanceOf(LongFieldType.class));
+        assertThat(mapperService.unmappedFieldType("long"), instanceOf(NumberFieldType.class));
         // back compat
         assertThat(mapperService.unmappedFieldType("string"), instanceOf(KeywordFieldType.class));
     }

--- a/core/src/test/java/org/elasticsearch/index/mapper/boost/CustomBoostMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/boost/CustomBoostMappingTests.java
@@ -176,19 +176,12 @@ public class CustomBoostMappingTests extends ESSingleNodeTestCase {
             assertThat(doc.rootDoc().getField("s_field").boost(), equalTo(1f));
             assertThat(doc.rootDoc().getField("s_field").fieldType().omitNorms(), equalTo(true));
             assertThat(doc.rootDoc().getField("l_field").boost(), equalTo(1f));
-            assertThat(doc.rootDoc().getField("l_field").fieldType().omitNorms(), equalTo(true));
             assertThat(doc.rootDoc().getField("i_field").boost(), equalTo(1f));
-            assertThat(doc.rootDoc().getField("i_field").fieldType().omitNorms(), equalTo(true));
             assertThat(doc.rootDoc().getField("sh_field").boost(), equalTo(1f));
-            assertThat(doc.rootDoc().getField("sh_field").fieldType().omitNorms(), equalTo(true));
             assertThat(doc.rootDoc().getField("b_field").boost(), equalTo(1f));
-            assertThat(doc.rootDoc().getField("b_field").fieldType().omitNorms(), equalTo(true));
             assertThat(doc.rootDoc().getField("d_field").boost(), equalTo(1f));
-            assertThat(doc.rootDoc().getField("d_field").fieldType().omitNorms(), equalTo(true));
             assertThat(doc.rootDoc().getField("f_field").boost(), equalTo(1f));
-            assertThat(doc.rootDoc().getField("f_field").fieldType().omitNorms(), equalTo(true));
             assertThat(doc.rootDoc().getField("date_field").boost(), equalTo(1f));
-            assertThat(doc.rootDoc().getField("date_field").fieldType().omitNorms(), equalTo(true));
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/copyto/CopyToMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/copyto/CopyToMapperTests.java
@@ -36,7 +36,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.ParseContext.Document;
 import org.elasticsearch.index.mapper.ParsedDocument;
-import org.elasticsearch.index.mapper.core.LongFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyLongFieldMapper;
 import org.elasticsearch.index.mapper.core.TextFieldMapper;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
@@ -131,7 +131,7 @@ public class CopyToMapperTests extends ESSingleNodeTestCase {
 
         docMapper = index.mapperService().documentMapper("type1");
         fieldMapper = docMapper.mappers().getMapper("new_field");
-        assertThat(fieldMapper, instanceOf(LongFieldMapper.class));
+        assertThat(fieldMapper.fieldType().typeName(), equalTo("long"));
     }
 
     public void testCopyToFieldsInnerObjectParsing() throws Exception {

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/DateFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/DateFieldMapperTests.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.core;
+
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.DocumentMapperParser;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class DateFieldMapperTests extends ESSingleNodeTestCase {
+
+    IndexService indexService;
+    DocumentMapperParser parser;
+
+    @Before
+    public void before() {
+        indexService = createIndex("test");
+        parser = indexService.mapperService().documentMapperParser();
+    }
+
+    public void testDefaults() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "date").endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "2016-03-11")
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1, pointField.fieldType().pointDimensionCount());
+        assertEquals(8, pointField.fieldType().pointNumBytes());
+        assertFalse(pointField.fieldType().stored());
+        assertEquals(1457654400000L, pointField.numericValue().longValue());
+        IndexableField dvField = fields[1];
+        assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
+        assertEquals(1457654400000L, dvField.numericValue().longValue());
+        assertFalse(dvField.fieldType().stored());
+    }
+
+    public void testNotIndexed() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "date").field("index", false).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "2016-03-11")
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.length);
+        IndexableField dvField = fields[0];
+        assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
+    }
+
+    public void testNoDocValues() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "date").field("doc_values", false).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "2016-03-11")
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1, pointField.fieldType().pointDimensionCount());
+    }
+
+    public void testStore() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "date").field("store", true).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "2016-03-11")
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(3, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1, pointField.fieldType().pointDimensionCount());
+        IndexableField dvField = fields[1];
+        assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
+        IndexableField storedField = fields[2];
+        assertTrue(storedField.fieldType().stored());
+        assertEquals(1457654400000L, storedField.numericValue().longValue());
+    }
+
+    public void testIgnoreMalformed() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "date").endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ThrowingRunnable runnable = () -> mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "2016-03-99")
+                .endObject()
+                .bytes());
+        MapperParsingException e = expectThrows(MapperParsingException.class, runnable);
+        assertThat(e.getCause().getMessage(), containsString("Cannot parse \"2016-03-99\""));
+
+        mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "date")
+                .field("ignore_malformed", true).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper2 = parser.parse("type", new CompressedXContent(mapping));
+
+        ParsedDocument doc = mapper2.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", ":1")
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(0, fields.length);
+    }
+
+    public void testIncludeInAll() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "date").endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "2016-03-11")
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("_all");
+        assertEquals(1, fields.length);
+        assertEquals("2016-03-11", fields[0].stringValue());
+
+        mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "date")
+                .field("include_in_all", false).endObject().endObject()
+                .endObject().endObject().string();
+
+        mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "2016-03-11")
+                .endObject()
+                .bytes());
+
+        fields = doc.rootDoc().getFields("_all");
+        assertEquals(0, fields.length);
+    }
+
+    public void testChangeFormat() throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "date")
+                .field("format", "epoch_second").endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", 1457654400)
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1457654400000L, pointField.numericValue().longValue());
+    }
+
+    public void testChangeLocale() throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "date").field("locale", "fr").endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", 1457654400)
+                .endObject()
+                .bytes());
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/LegacyByteFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/LegacyByteFieldTypeTests.java
@@ -20,32 +20,22 @@ package org.elasticsearch.index.mapper.core;
 
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MappedFieldType.Relation;
-import org.elasticsearch.index.mapper.core.DoubleFieldMapper.DoubleFieldType;
 import org.junit.Before;
 
-import java.io.IOException;
-
-public class DoubleFieldTypeTests extends FieldTypeTestCase {
+public class LegacyByteFieldTypeTests extends FieldTypeTestCase {
     @Override
     protected MappedFieldType createDefaultFieldType() {
-        return new DoubleFieldMapper.DoubleFieldType();
+        return new LegacyByteFieldMapper.ByteFieldType();
     }
 
     @Before
     public void setupProperties() {
-        setDummyNullValue(10.0D);
-    }
-
-    public void testIsFieldWithinQuery() throws IOException {
-        DoubleFieldType ft = new DoubleFieldType();
-        // current impl ignores args and shourd always return INTERSECTS
-        assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(null, randomDouble(), randomDouble(),
-                randomBoolean(), randomBoolean(), null, null));
+        setDummyNullValue((byte)10);
     }
 
     public void testValueForSearch() {
         MappedFieldType ft = createDefaultFieldType();
-        assertEquals(Double.valueOf(1.2), ft.valueForSearch(1.2));
+        // bytes are stored as ints
+        assertEquals(Byte.valueOf((byte) 3), ft.valueForSearch(Integer.valueOf(3)));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/LegacyDateFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/LegacyDateFieldTypeTests.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.mapper.core;
+
+import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.LegacyLongField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.MultiReader;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.common.joda.DateMathParser;
+import org.elasticsearch.common.joda.Joda;
+import org.elasticsearch.index.mapper.FieldTypeTestCase;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MappedFieldType.Relation;
+import org.elasticsearch.index.mapper.ParseContext.Document;
+import org.elasticsearch.index.mapper.core.LegacyDateFieldMapper.DateFieldType;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+public class LegacyDateFieldTypeTests extends FieldTypeTestCase {
+    @Override
+    protected MappedFieldType createDefaultFieldType() {
+        return new LegacyDateFieldMapper.DateFieldType();
+    }
+
+    @Before
+    public void setupProperties() {
+        setDummyNullValue(10);
+        addModifier(new Modifier("format", true) {
+            @Override
+            public void modify(MappedFieldType ft) {
+                ((LegacyDateFieldMapper.DateFieldType) ft).setDateTimeFormatter(Joda.forPattern("basic_week_date", Locale.ROOT));
+            }
+        });
+        addModifier(new Modifier("locale", true) {
+            @Override
+            public void modify(MappedFieldType ft) {
+                ((LegacyDateFieldMapper.DateFieldType) ft).setDateTimeFormatter(Joda.forPattern("date_optional_time", Locale.CANADA));
+            }
+        });
+        addModifier(new Modifier("numeric_resolution", true) {
+            @Override
+            public void modify(MappedFieldType ft) {
+                ((LegacyDateFieldMapper.DateFieldType)ft).setTimeUnit(TimeUnit.HOURS);
+            }
+        });
+    }
+
+    public void testIsFieldWithinQueryEmptyReader() throws IOException {
+        IndexReader reader = new MultiReader();
+        DateFieldType ft = new DateFieldType();
+        ft.setName("my_date");
+        assertEquals(Relation.DISJOINT, ft.isFieldWithinQuery(reader, "2015-10-12", "2016-04-03",
+                randomBoolean(), randomBoolean(), null, null));
+    }
+
+    private void doTestIsFieldWithinQuery(DateFieldType ft, DirectoryReader reader,
+            DateTimeZone zone, DateMathParser alternateFormat) throws IOException {
+        assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(reader, "2015-10-09", "2016-01-02",
+                randomBoolean(), randomBoolean(), null, null));
+        assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(reader, "2016-01-02", "2016-06-20",
+                randomBoolean(), randomBoolean(), null, null));
+        assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(reader, "2016-01-02", "2016-02-12",
+                randomBoolean(), randomBoolean(), null, null));
+        assertEquals(Relation.DISJOINT, ft.isFieldWithinQuery(reader, "2014-01-02", "2015-02-12",
+                randomBoolean(), randomBoolean(), null, null));
+        assertEquals(Relation.DISJOINT, ft.isFieldWithinQuery(reader, "2016-05-11", "2016-08-30",
+                randomBoolean(), randomBoolean(), null, null));
+        assertEquals(Relation.WITHIN, ft.isFieldWithinQuery(reader, "2015-09-25", "2016-05-29",
+                randomBoolean(), randomBoolean(), null, null));
+        assertEquals(Relation.WITHIN, ft.isFieldWithinQuery(reader, "2015-10-12", "2016-04-03",
+                true, true, null, null));
+        assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(reader, "2015-10-12", "2016-04-03",
+                false, false, null, null));
+        assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(reader, "2015-10-12", "2016-04-03",
+                false, true, null, null));
+        assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(reader, "2015-10-12", "2016-04-03",
+                true, false, null, null));
+    }
+
+    public void testIsFieldWithinQuery() throws IOException {
+        Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+        long instant1 = LegacyDateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime("2015-10-12").getMillis();
+        long instant2 = LegacyDateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime("2016-04-03").getMillis();
+        Document doc = new Document();
+        LegacyLongField field = new LegacyLongField("my_date", instant1, Store.NO);
+        doc.add(field);
+        w.addDocument(doc);
+        field.setLongValue(instant2);
+        w.addDocument(doc);
+        DirectoryReader reader = DirectoryReader.open(w);
+        DateFieldType ft = new DateFieldType();
+        ft.setName("my_date");
+        DateMathParser alternateFormat = new DateMathParser(LegacyDateFieldMapper.Defaults.DATE_TIME_FORMATTER);
+        doTestIsFieldWithinQuery(ft, reader, null, null);
+        doTestIsFieldWithinQuery(ft, reader, null, alternateFormat);
+        doTestIsFieldWithinQuery(ft, reader, DateTimeZone.UTC, null);
+        doTestIsFieldWithinQuery(ft, reader, DateTimeZone.UTC, alternateFormat);
+        IOUtils.close(reader, w, dir);
+    }
+
+    public void testValueFormat() {
+        MappedFieldType ft = createDefaultFieldType();
+        long instant = LegacyDateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime("2015-10-12T14:10:55").getMillis();
+        assertEquals("2015-10-12T14:10:55.000Z",
+                ft.docValueFormat(null, DateTimeZone.UTC).format(instant));
+        assertEquals("2015-10-12T15:10:55.000+01:00",
+                ft.docValueFormat(null, DateTimeZone.forOffsetHours(1)).format(instant));
+        assertEquals("2015",
+                createDefaultFieldType().docValueFormat("YYYY", DateTimeZone.UTC).format(instant));
+        assertEquals(instant,
+                ft.docValueFormat(null, DateTimeZone.UTC).parseLong("2015-10-12T14:10:55", false, null));
+        assertEquals(instant,
+                ft.docValueFormat(null, DateTimeZone.UTC).parseLong("2015-10-12T14:10:55", true, null));
+        assertEquals(LegacyDateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime("2015-10-13").getMillis() - 1,
+                ft.docValueFormat(null, DateTimeZone.UTC).parseLong("2015-10-12||/d", true, null));
+    }
+
+    public void testValueForSearch() {
+        MappedFieldType ft = createDefaultFieldType();
+        String date = "2015-10-12T12:09:55.000Z";
+        long instant = LegacyDateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime(date).getMillis();
+        assertEquals(date, ft.valueForSearch(instant));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/LegacyDoubleFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/LegacyDoubleFieldTypeTests.java
@@ -20,22 +20,32 @@ package org.elasticsearch.index.mapper.core;
 
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MappedFieldType.Relation;
+import org.elasticsearch.index.mapper.core.LegacyDoubleFieldMapper.DoubleFieldType;
 import org.junit.Before;
 
-public class ShortFieldTypeTests extends FieldTypeTestCase {
+import java.io.IOException;
+
+public class LegacyDoubleFieldTypeTests extends FieldTypeTestCase {
     @Override
     protected MappedFieldType createDefaultFieldType() {
-        return new ShortFieldMapper.ShortFieldType();
+        return new LegacyDoubleFieldMapper.DoubleFieldType();
     }
 
     @Before
     public void setupProperties() {
-        setDummyNullValue((short)10);
+        setDummyNullValue(10.0D);
+    }
+
+    public void testIsFieldWithinQuery() throws IOException {
+        DoubleFieldType ft = new DoubleFieldType();
+        // current impl ignores args and shourd always return INTERSECTS
+        assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(null, randomDouble(), randomDouble(),
+                randomBoolean(), randomBoolean(), null, null));
     }
 
     public void testValueForSearch() {
         MappedFieldType ft = createDefaultFieldType();
-        // shorts are stored as ints
-        assertEquals(Short.valueOf((short) 3), ft.valueForSearch(Integer.valueOf(3)));
+        assertEquals(Double.valueOf(1.2), ft.valueForSearch(1.2));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/LegacyFloatFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/LegacyFloatFieldTypeTests.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.mapper.core;
+
+import org.elasticsearch.index.mapper.FieldTypeTestCase;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MappedFieldType.Relation;
+import org.elasticsearch.index.mapper.core.LegacyFloatFieldMapper.FloatFieldType;
+import org.junit.Before;
+
+import java.io.IOException;
+
+public class LegacyFloatFieldTypeTests extends FieldTypeTestCase {
+    @Override
+    protected MappedFieldType createDefaultFieldType() {
+        return new LegacyFloatFieldMapper.FloatFieldType();
+    }
+
+    @Before
+    public void setupProperties() {
+        setDummyNullValue(10.0f);
+    }
+
+    public void testIsFieldWithinQuery() throws IOException {
+        FloatFieldType ft = new FloatFieldType();
+        // current impl ignores args and shourd always return INTERSECTS
+        assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(null, randomFloat(), randomFloat(),
+                randomBoolean(), randomBoolean(), null, null));
+    }
+
+    public void testValueForSearch() {
+        MappedFieldType ft = createDefaultFieldType();
+        assertEquals(Float.valueOf(1.2f), ft.valueForSearch(1.2f));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/LegacyIntegerFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/LegacyIntegerFieldTypeTests.java
@@ -21,31 +21,31 @@ package org.elasticsearch.index.mapper.core;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType.Relation;
-import org.elasticsearch.index.mapper.core.FloatFieldMapper.FloatFieldType;
+import org.elasticsearch.index.mapper.core.LegacyIntegerFieldMapper.IntegerFieldType;
 import org.junit.Before;
 
 import java.io.IOException;
 
-public class FloatFieldTypeTests extends FieldTypeTestCase {
+public class LegacyIntegerFieldTypeTests extends FieldTypeTestCase {
     @Override
     protected MappedFieldType createDefaultFieldType() {
-        return new FloatFieldMapper.FloatFieldType();
+        return new LegacyIntegerFieldMapper.IntegerFieldType();
     }
 
     @Before
     public void setupProperties() {
-        setDummyNullValue(10.0f);
+        setDummyNullValue(10);
     }
 
     public void testIsFieldWithinQuery() throws IOException {
-        FloatFieldType ft = new FloatFieldType();
+        IntegerFieldType ft = new IntegerFieldType();
         // current impl ignores args and shourd always return INTERSECTS
-        assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(null, randomFloat(), randomFloat(),
+        assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(null, randomInt(), randomInt(),
                 randomBoolean(), randomBoolean(), null, null));
     }
 
     public void testValueForSearch() {
         MappedFieldType ft = createDefaultFieldType();
-        assertEquals(Float.valueOf(1.2f), ft.valueForSearch(1.2f));
+        assertEquals(Integer.valueOf(3), ft.valueForSearch(Integer.valueOf(3)));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/LegacyLongFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/LegacyLongFieldTypeTests.java
@@ -21,31 +21,31 @@ package org.elasticsearch.index.mapper.core;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType.Relation;
-import org.elasticsearch.index.mapper.core.IntegerFieldMapper.IntegerFieldType;
+import org.elasticsearch.index.mapper.core.LegacyLongFieldMapper.LongFieldType;
 import org.junit.Before;
 
 import java.io.IOException;
 
-public class IntegerFieldTypeTests extends FieldTypeTestCase {
+public class LegacyLongFieldTypeTests extends FieldTypeTestCase {
     @Override
     protected MappedFieldType createDefaultFieldType() {
-        return new IntegerFieldMapper.IntegerFieldType();
+        return new LegacyLongFieldMapper.LongFieldType();
     }
 
     @Before
     public void setupProperties() {
-        setDummyNullValue(10);
+        setDummyNullValue((long)10);
     }
 
     public void testIsFieldWithinQuery() throws IOException {
-        IntegerFieldType ft = new IntegerFieldType();
+        LongFieldType ft = new LongFieldType();
         // current impl ignores args and shourd always return INTERSECTS
-        assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(null, randomInt(), randomInt(),
+        assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(null, randomLong(), randomLong(),
                 randomBoolean(), randomBoolean(), null, null));
     }
 
     public void testValueForSearch() {
         MappedFieldType ft = createDefaultFieldType();
-        assertEquals(Integer.valueOf(3), ft.valueForSearch(Integer.valueOf(3)));
+        assertEquals(Long.valueOf(3), ft.valueForSearch(Long.valueOf(3)));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/LegacyShortFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/LegacyShortFieldTypeTests.java
@@ -20,32 +20,22 @@ package org.elasticsearch.index.mapper.core;
 
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MappedFieldType.Relation;
-import org.elasticsearch.index.mapper.core.LongFieldMapper.LongFieldType;
 import org.junit.Before;
 
-import java.io.IOException;
-
-public class LongFieldTypeTests extends FieldTypeTestCase {
+public class LegacyShortFieldTypeTests extends FieldTypeTestCase {
     @Override
     protected MappedFieldType createDefaultFieldType() {
-        return new LongFieldMapper.LongFieldType();
+        return new LegacyShortFieldMapper.ShortFieldType();
     }
 
     @Before
     public void setupProperties() {
-        setDummyNullValue((long)10);
-    }
-
-    public void testIsFieldWithinQuery() throws IOException {
-        LongFieldType ft = new LongFieldType();
-        // current impl ignores args and shourd always return INTERSECTS
-        assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(null, randomLong(), randomLong(),
-                randomBoolean(), randomBoolean(), null, null));
+        setDummyNullValue((short)10);
     }
 
     public void testValueForSearch() {
         MappedFieldType ft = createDefaultFieldType();
-        assertEquals(Long.valueOf(3), ft.valueForSearch(Long.valueOf(3)));
+        // shorts are stored as ints
+        assertEquals(Short.valueOf((short) 3), ft.valueForSearch(Integer.valueOf(3)));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/LegacyTokenCountFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/LegacyTokenCountFieldMapperTests.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.core;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.CannedTokenStream;
+import org.apache.lucene.analysis.MockTokenizer;
+import org.apache.lucene.analysis.Token;
+import org.apache.lucene.analysis.TokenStream;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.DocumentMapperParser;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Test for {@link LegacyTokenCountFieldMapper}.
+ */
+public class LegacyTokenCountFieldMapperTests extends ESSingleNodeTestCase {
+
+    private static final Settings BW_SETTINGS = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_2_3_0).build();
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(InternalSettingsPlugin.class);
+    }
+
+    public void testMerge() throws IOException {
+        String stage1Mapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("person")
+                    .startObject("properties")
+                        .startObject("tc")
+                            .field("type", "token_count")
+                            .field("analyzer", "keyword")
+                        .endObject()
+                    .endObject()
+                .endObject().endObject().string();
+        MapperService mapperService = createIndex("test", BW_SETTINGS).mapperService();
+        DocumentMapper stage1 = mapperService.merge("person", new CompressedXContent(stage1Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+
+        String stage2Mapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("person")
+                    .startObject("properties")
+                        .startObject("tc")
+                            .field("type", "token_count")
+                            .field("analyzer", "standard")
+                        .endObject()
+                    .endObject()
+                .endObject().endObject().string();
+        DocumentMapper stage2 = mapperService.merge("person", new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+
+        // previous mapper has not been modified
+        assertThat(((LegacyTokenCountFieldMapper) stage1.mappers().smartNameFieldMapper("tc")).analyzer(), equalTo("keyword"));
+        // but the new one has the change
+        assertThat(((LegacyTokenCountFieldMapper) stage2.mappers().smartNameFieldMapper("tc")).analyzer(), equalTo("standard"));
+    }
+
+    public void testCountPositions() throws IOException {
+        // We're looking to make sure that we:
+        Token t1 = new Token();      // Don't count tokens without an increment
+        t1.setPositionIncrement(0);
+        Token t2 = new Token();
+        t2.setPositionIncrement(1);  // Count normal tokens with one increment
+        Token t3 = new Token();
+        t2.setPositionIncrement(2);  // Count funny tokens with more than one increment
+        int finalTokenIncrement = 4; // Count the final token increment on the rare token streams that have them
+        Token[] tokens = new Token[] {t1, t2, t3};
+        Collections.shuffle(Arrays.asList(tokens), random());
+        final TokenStream tokenStream = new CannedTokenStream(finalTokenIncrement, 0, tokens);
+        // TODO: we have no CannedAnalyzer?
+        Analyzer analyzer = new Analyzer() {
+                @Override
+                public TokenStreamComponents createComponents(String fieldName) {
+                    return new TokenStreamComponents(new MockTokenizer(), tokenStream);
+                }
+            };
+        assertThat(LegacyTokenCountFieldMapper.countPositions(analyzer, "", ""), equalTo(7));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/NumberFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/NumberFieldMapperTests.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.core;
+
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.DocumentMapperParser;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class NumberFieldMapperTests extends ESSingleNodeTestCase {
+
+    private static final Set<String> TYPES = new HashSet<>(Arrays.asList("byte", "short", "integer", "long", "float", "double"));
+
+    IndexService indexService;
+    DocumentMapperParser parser;
+
+    @Before
+    public void before() {
+        indexService = createIndex("test");
+        parser = indexService.mapperService().documentMapperParser();
+    }
+
+    public void testDefaults() throws Exception {
+        for (String type : TYPES) {
+            doTestDefaults(type);
+        }
+    }
+
+    public void doTestDefaults(String type) throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", type).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", 123)
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1, pointField.fieldType().pointDimensionCount());
+        assertFalse(pointField.fieldType().stored());
+        assertEquals(123, pointField.numericValue().doubleValue(), 0d);
+        IndexableField dvField = fields[1];
+        assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
+        assertFalse(dvField.fieldType().stored());
+    }
+
+    public void testNotIndexed() throws Exception {
+        for (String type : TYPES) {
+            doTestNotIndexed(type);
+        }
+    }
+
+    public void doTestNotIndexed(String type) throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", type).field("index", false).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", 123)
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.length);
+        IndexableField dvField = fields[0];
+        assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
+    }
+
+    public void testNoDocValues() throws Exception {
+        for (String type : TYPES) {
+            doTestNotIndexed(type);
+        }
+    }
+
+    public void doTestNoDocValues(String type) throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", type).field("doc_values", false).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", 123)
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1, pointField.fieldType().pointDimensionCount());
+        assertEquals(123, pointField.numericValue().doubleValue(), 0d);
+    }
+
+    public void testStore() throws Exception {
+        for (String type : TYPES) {
+            doTestStore(type);
+        }
+    }
+
+    public void doTestStore(String type) throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", type).field("store", true).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", 123)
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(3, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1, pointField.fieldType().pointDimensionCount());
+        assertEquals(123, pointField.numericValue().doubleValue(), 0d);
+        IndexableField dvField = fields[1];
+        assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
+        IndexableField storedField = fields[2];
+        assertTrue(storedField.fieldType().stored());
+        assertEquals(123, storedField.numericValue().doubleValue(), 0d);
+    }
+
+    public void testCoerce() throws Exception {
+        for (String type : TYPES) {
+            doTestCoerce(type);
+        }
+    }
+
+    public void doTestCoerce(String type) throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", type).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "123")
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1, pointField.fieldType().pointDimensionCount());
+        assertEquals(123, pointField.numericValue().doubleValue(), 0d);
+        IndexableField dvField = fields[1];
+        assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
+
+        mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", type).field("coerce", false).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper2 = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper2.mappingSource().toString());
+
+        ThrowingRunnable runnable = () -> mapper2.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "123")
+                .endObject()
+                .bytes());
+        MapperParsingException e = expectThrows(MapperParsingException.class, runnable);
+        assertThat(e.getCause().getMessage(), containsString("passed as String"));
+    }
+
+    public void testIgnoreMalformed() throws Exception {
+        for (String type : TYPES) {
+            doTestIgnoreMalformed(type);
+        }
+    }
+
+    public void doTestIgnoreMalformed(String type) throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", type).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ThrowingRunnable runnable = () -> mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "a")
+                .endObject()
+                .bytes());
+        MapperParsingException e = expectThrows(MapperParsingException.class, runnable);
+        assertThat(e.getCause().getMessage(), containsString("For input string: \"a\""));
+
+        mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", type).field("ignore_malformed", true).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper2 = parser.parse("type", new CompressedXContent(mapping));
+
+        ParsedDocument doc = mapper2.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "a")
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(0, fields.length);
+    }
+
+    public void testIncludeInAll() throws Exception {
+        for (String type : TYPES) {
+            doTestIncludeInAll(type);
+        }
+    }
+
+    public void doTestIncludeInAll(String type) throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", type).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", 123)
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("_all");
+        assertEquals(1, fields.length);
+        assertEquals("123", fields[0].stringValue());
+
+        mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", type)
+                .field("include_in_all", false).endObject().endObject()
+                .endObject().endObject().string();
+
+        mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", 123)
+                .endObject()
+                .bytes());
+
+        fields = doc.rootDoc().getFields("_all");
+        assertEquals(0, fields.length);
+    }
+
+    public void testRejectNorms() throws IOException {
+        // not supported as of 5.0
+        for (String type : Arrays.asList("byte", "short", "integer", "long", "float", "double")) {
+            DocumentMapperParser parser = createIndex("index-" + type).mapperService().documentMapperParser();
+            String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties")
+                    .startObject("foo")
+                        .field("type", type)
+                        .field("norms", random().nextBoolean())
+                    .endObject()
+                .endObject().endObject().endObject().string();
+            MapperParsingException e = expectThrows(MapperParsingException.class,
+                    () -> parser.parse("type", new CompressedXContent(mapping)));
+            assertThat(e.getMessage(), containsString("Mapping definition for [foo] has unsupported parameters:  [norms"));
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/NumberFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/NumberFieldTypeTests.java
@@ -16,26 +16,37 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch.index.mapper.core;
+
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MappedFieldType.Relation;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper.NumberType;
 import org.junit.Before;
 
-public class ByteFieldTypeTests extends FieldTypeTestCase {
-    @Override
-    protected MappedFieldType createDefaultFieldType() {
-        return new ByteFieldMapper.ByteFieldType();
-    }
+import java.io.IOException;
+
+public class NumberFieldTypeTests extends FieldTypeTestCase {
+
+    NumberType type;
 
     @Before
-    public void setupProperties() {
-        setDummyNullValue((byte)10);
+    public void pickType() {
+        type = RandomPicks.randomFrom(random(), NumberFieldMapper.NumberType.values());
     }
 
-    public void testValueForSearch() {
+    @Override
+    protected MappedFieldType createDefaultFieldType() {
+        return new NumberFieldMapper.NumberFieldType(type);
+    }
+
+    public void testIsFieldWithinQuery() throws IOException {
         MappedFieldType ft = createDefaultFieldType();
-        // bytes are stored as ints
-        assertEquals(Byte.valueOf((byte) 3), ft.valueForSearch(Integer.valueOf(3)));
+        // current impl ignores args and should always return INTERSECTS
+        assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(null, randomDouble(), randomDouble(),
+                randomBoolean(), randomBoolean(), null, null));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapperTests.java
@@ -27,7 +27,6 @@ import org.apache.lucene.analysis.TokenStream;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.DocumentMapperParser;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
@@ -52,7 +51,8 @@ public class TokenCountFieldMapperTests extends ESSingleNodeTestCase {
                     .endObject()
                 .endObject().endObject().string();
         MapperService mapperService = createIndex("test").mapperService();
-        DocumentMapper stage1 = mapperService.merge("person", new CompressedXContent(stage1Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper stage1 = mapperService.merge("person",
+                new CompressedXContent(stage1Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
 
         String stage2Mapping = XContentFactory.jsonBuilder().startObject()
                 .startObject("person")
@@ -63,7 +63,8 @@ public class TokenCountFieldMapperTests extends ESSingleNodeTestCase {
                         .endObject()
                     .endObject()
                 .endObject().endObject().string();
-        DocumentMapper stage2 = mapperService.merge("person", new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper stage2 = mapperService.merge("person",
+                new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
 
         // previous mapper has not been modified
         assertThat(((TokenCountFieldMapper) stage1.mappers().smartNameFieldMapper("tc")).analyzer(), equalTo("keyword"));

--- a/core/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/genericstore/GenericStoreDynamicTemplateTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/genericstore/GenericStoreDynamicTemplateTests.java
@@ -55,9 +55,11 @@ public class GenericStoreDynamicTemplateTests extends ESSingleNodeTestCase {
         FieldMapper fieldMapper = docMapper.mappers().getMapper("name");
         assertThat(fieldMapper.fieldType().stored(), equalTo(true));
 
-        f = doc.getField("age");
-        assertThat(f.name(), equalTo("age"));
-        assertThat(f.fieldType().stored(), equalTo(true));
+        boolean stored = false;
+        for (IndexableField field : doc.getFields("age")) {
+            stored |=  field.fieldType().stored();
+        }
+        assertTrue(stored);
 
         fieldMapper = docMapper.mappers().getMapper("age");
         assertThat(fieldMapper.fieldType().stored(), equalTo(true));

--- a/core/src/test/java/org/elasticsearch/index/mapper/geo/GeoPointFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/geo/GeoPointFieldTypeTests.java
@@ -20,7 +20,7 @@ package org.elasticsearch.index.mapper.geo;
 
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyDoubleFieldMapper;
 import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.junit.Before;
 
@@ -41,7 +41,7 @@ public class GeoPointFieldTypeTests extends FieldTypeTestCase {
         addModifier(new Modifier("lat_lon", false) {
             @Override
             public void modify(MappedFieldType ft) {
-                ((BaseGeoPointFieldMapper.GeoPointFieldType)ft).setLatLonEnabled(new DoubleFieldMapper.DoubleFieldType(), new DoubleFieldMapper.DoubleFieldType());
+                ((BaseGeoPointFieldMapper.GeoPointFieldType)ft).setLatLonEnabled(new LegacyDoubleFieldMapper.DoubleFieldType(), new LegacyDoubleFieldMapper.DoubleFieldType());
             }
         });
     }

--- a/core/src/test/java/org/elasticsearch/index/mapper/internal/TimestampFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/internal/TimestampFieldTypeTests.java
@@ -20,9 +20,9 @@ package org.elasticsearch.index.mapper.internal;
 
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
-import org.elasticsearch.index.mapper.core.DateFieldTypeTests;
+import org.elasticsearch.index.mapper.core.LegacyDateFieldTypeTests;
 
-public class TimestampFieldTypeTests extends DateFieldTypeTests {
+public class TimestampFieldTypeTests extends LegacyDateFieldTypeTests {
     @Override
     protected MappedFieldType createDefaultFieldType() {
         return new TimestampFieldMapper.TimestampFieldType();
@@ -32,7 +32,7 @@ public class TimestampFieldTypeTests extends DateFieldTypeTests {
     public void testValueForSearch() {
         MappedFieldType ft = createDefaultFieldType();
         String date = "2015-10-12T12:09:55.000Z";
-        long instant = DateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime(date).getMillis();
+        long instant = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(date).getMillis();
         assertEquals(instant, ft.valueForSearch(instant));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/ip/IpFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ip/IpFieldMapperTests.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.ip;
+
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.DocumentMapperParser;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.junit.Before;
+
+import static org.hamcrest.Matchers.containsString;
+
+import java.net.InetAddress;
+
+public class IpFieldMapperTests extends ESSingleNodeTestCase {
+
+    IndexService indexService;
+    DocumentMapperParser parser;
+
+    @Before
+    public void before() {
+        indexService = createIndex("test");
+        parser = indexService.mapperService().documentMapperParser();
+    }
+
+    public void testDefaults() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "ip").endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "::1")
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1, pointField.fieldType().pointDimensionCount());
+        assertEquals(16, pointField.fieldType().pointNumBytes());
+        assertFalse(pointField.fieldType().stored());
+        assertEquals(new BytesRef(InetAddressPoint.encode(InetAddresses.forString("::1"))), pointField.binaryValue());
+        IndexableField dvField = fields[1];
+        assertEquals(DocValuesType.SORTED_SET, dvField.fieldType().docValuesType());
+        assertEquals(new BytesRef(InetAddressPoint.encode(InetAddresses.forString("::1"))), dvField.binaryValue());
+        assertFalse(dvField.fieldType().stored());
+    }
+
+    public void testNotIndexed() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "ip").field("index", false).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "::1")
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.length);
+        IndexableField dvField = fields[0];
+        assertEquals(DocValuesType.SORTED_SET, dvField.fieldType().docValuesType());
+    }
+
+    public void testNoDocValues() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "ip").field("doc_values", false).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "::1")
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1, pointField.fieldType().pointDimensionCount());
+        assertEquals(new BytesRef(InetAddressPoint.encode(InetAddresses.forString("::1"))), pointField.binaryValue());
+    }
+
+    public void testStore() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "ip").field("store", true).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "::1")
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(3, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1, pointField.fieldType().pointDimensionCount());
+        IndexableField dvField = fields[1];
+        assertEquals(DocValuesType.SORTED_SET, dvField.fieldType().docValuesType());
+        IndexableField storedField = fields[2];
+        assertTrue(storedField.fieldType().stored());
+        assertEquals(new BytesRef(InetAddressPoint.encode(InetAddress.getByName("::1"))),
+                storedField.binaryValue());
+    }
+
+    public void testIgnoreMalformed() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "ip").endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ThrowingRunnable runnable = () -> mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", ":1")
+                .endObject()
+                .bytes());
+        MapperParsingException e = expectThrows(MapperParsingException.class, runnable);
+        assertThat(e.getCause().getMessage(), containsString("':1' is not an IP string literal"));
+
+        mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "ip").field("ignore_malformed", true).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper2 = parser.parse("type", new CompressedXContent(mapping));
+
+        ParsedDocument doc = mapper2.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", ":1")
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(0, fields.length);
+    }
+
+    public void testIncludeInAll() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "ip").endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "::1")
+                .endObject()
+                .bytes());
+
+        IndexableField[] fields = doc.rootDoc().getFields("_all");
+        assertEquals(1, fields.length);
+        assertEquals("::1", fields[0].stringValue());
+
+        mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "ip")
+                .field("include_in_all", false).endObject().endObject()
+                .endObject().endObject().string();
+
+        mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "::1")
+                .endObject()
+                .bytes());
+
+        fields = doc.rootDoc().getFields("_all");
+        assertEquals(0, fields.length);
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/mapper/ip/IpFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ip/IpFieldTypeTests.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.mapper.ip;
+
+import java.net.InetAddress;
+
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.index.mapper.FieldTypeTestCase;
+import org.elasticsearch.index.mapper.MappedFieldType;
+
+public class IpFieldTypeTests extends FieldTypeTestCase {
+    @Override
+    protected MappedFieldType createDefaultFieldType() {
+        return new IpFieldMapper.IpFieldType();
+    }
+
+    public void testValueFormat() throws Exception {
+        MappedFieldType ft = createDefaultFieldType();
+        String ip = "2001:db8::2:1";
+        BytesRef asBytes = new BytesRef(InetAddressPoint.encode(InetAddress.getByName(ip)));
+        assertEquals(ip, ft.docValueFormat(null, null).format(asBytes));
+
+        ip = "192.168.1.7";
+        asBytes = new BytesRef(InetAddressPoint.encode(InetAddress.getByName(ip)));
+        assertEquals(ip, ft.docValueFormat(null, null).format(asBytes));
+    }
+
+    public void testValueForSearch() throws Exception {
+        MappedFieldType ft = createDefaultFieldType();
+        String ip = "2001:db8::2:1";
+        BytesRef asBytes = new BytesRef(InetAddressPoint.encode(InetAddresses.forString(ip)));
+        assertEquals(ip, ft.valueForSearch(asBytes));
+
+        ip = "192.168.1.7";
+        asBytes = new BytesRef(InetAddressPoint.encode(InetAddresses.forString(ip)));
+        assertEquals(ip, ft.valueForSearch(asBytes));
+    }
+
+    public void testTermQuery() {
+        MappedFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+
+        String ip = "2001:db8::2:1";
+        assertEquals(InetAddressPoint.newExactQuery("field", InetAddresses.forString(ip)), ft.termQuery(ip, null));
+
+        ip = "192.168.1.7";
+        assertEquals(InetAddressPoint.newExactQuery("field", InetAddresses.forString(ip)), ft.termQuery(ip, null));
+
+        ip = "2001:db8::2:1";
+        String prefix = ip + "/64";
+        assertEquals(InetAddressPoint.newPrefixQuery("field", InetAddresses.forString(ip), 64), ft.termQuery(prefix, null));
+
+        ip = "192.168.1.7";
+        prefix = ip + "/16";
+        assertEquals(InetAddressPoint.newPrefixQuery("field", InetAddresses.forString(ip), 16), ft.termQuery(prefix, null));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/mapper/lucene/StoredNumericValuesTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/lucene/StoredNumericValuesTests.java
@@ -54,8 +54,9 @@ public class StoredNumericValuesTests extends ESSingleNodeTestCase {
                             .startObject("field5").field("type", "long").field("store", true).endObject()
                             .startObject("field6").field("type", "double").field("store", true).endObject()
                             .startObject("field7").field("type", "ip").field("store", true).endObject()
-                            .startObject("field8").field("type", "date").field("store", true).endObject()
-                            .startObject("field9").field("type", "boolean").field("store", true).endObject()
+                            .startObject("field8").field("type", "ip").field("store", true).endObject()
+                            .startObject("field9").field("type", "date").field("store", true).endObject()
+                            .startObject("field10").field("type", "boolean").field("store", true).endObject()
                         .endObject()
                     .endObject()
                 .endObject()
@@ -71,8 +72,9 @@ public class StoredNumericValuesTests extends ESSingleNodeTestCase {
                     .startArray("field5").value(1).value(2).value(3).endArray()
                     .field("field6", 1.1)
                     .field("field7", "192.168.1.1")
-                    .field("field8", "2016-04-05")
-                    .field("field9", true)
+                    .field("field8", "2001:db8::2:1")
+                    .field("field9", "2016-04-05")
+                    .field("field10", true)
                 .endObject()
                 .bytes());
 
@@ -85,7 +87,7 @@ public class StoredNumericValuesTests extends ESSingleNodeTestCase {
                 Collections.emptySet(), Collections.singletonList("field*"), false);
         searcher.doc(0, fieldsVisitor);
         fieldsVisitor.postProcess(mapper);
-        assertThat(fieldsVisitor.fields().size(), equalTo(9));
+        assertThat(fieldsVisitor.fields().size(), equalTo(10));
         assertThat(fieldsVisitor.fields().get("field1").size(), equalTo(1));
         assertThat(fieldsVisitor.fields().get("field1").get(0), equalTo((byte) 1));
 
@@ -110,10 +112,13 @@ public class StoredNumericValuesTests extends ESSingleNodeTestCase {
         assertThat(fieldsVisitor.fields().get("field7").get(0), equalTo("192.168.1.1"));
 
         assertThat(fieldsVisitor.fields().get("field8").size(), equalTo(1));
-        assertThat(fieldsVisitor.fields().get("field8").get(0), equalTo("2016-04-05T00:00:00.000Z"));
+        assertThat(fieldsVisitor.fields().get("field8").get(0), equalTo("2001:db8::2:1"));
 
         assertThat(fieldsVisitor.fields().get("field9").size(), equalTo(1));
-        assertThat(fieldsVisitor.fields().get("field9").get(0), equalTo(true));
+        assertThat(fieldsVisitor.fields().get("field9").get(0), equalTo("2016-04-05T00:00:00.000Z"));
+
+        assertThat(fieldsVisitor.fields().get("field10").size(), equalTo(1));
+        assertThat(fieldsVisitor.fields().get("field10").get(0), equalTo(true));
 
         reader.close();
         writer.close();

--- a/core/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldTests.java
@@ -42,9 +42,7 @@ import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
-import java.util.TreeMap;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.test.StreamsUtils.copyToBytesFromClasspath;

--- a/core/src/test/java/org/elasticsearch/index/mapper/update/UpdateMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/update/UpdateMappingTests.java
@@ -28,9 +28,9 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
-import org.elasticsearch.index.mapper.core.LongFieldMapper;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
@@ -132,17 +132,18 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
             mapperService.merge("type", new CompressedXContent(update.string()), MapperService.MergeReason.MAPPING_UPDATE, false);
             fail();
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("mapper [foo] of different type, current_type [long], merged_type [double]"));
+            assertThat(e.getMessage(), containsString("mapper [foo] cannot be changed from type [long] to [double]"));
         }
 
         try {
             mapperService.merge("type", new CompressedXContent(update.string()), MapperService.MergeReason.MAPPING_UPDATE, false);
             fail();
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("mapper [foo] of different type, current_type [long], merged_type [double]"));
+            assertThat(e.getMessage(), containsString("mapper [foo] cannot be changed from type [long] to [double]"));
         }
 
-        assertTrue(mapperService.documentMapper("type").mapping().root().getMapper("foo") instanceof LongFieldMapper);
+        assertThat(((FieldMapper) mapperService.documentMapper("type").mapping().root().getMapper("foo")).fieldType().typeName(),
+                equalTo("long"));
     }
 
     public void testConflictNewType() throws Exception {
@@ -171,7 +172,8 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
             assertTrue(e.getMessage(), e.getMessage().contains("mapper [foo] cannot be changed from type [long] to [double]"));
         }
 
-        assertTrue(mapperService.documentMapper("type1").mapping().root().getMapper("foo") instanceof LongFieldMapper);
+        assertThat(((FieldMapper) mapperService.documentMapper("type1").mapping().root().getMapper("foo")).fieldType().typeName(),
+                equalTo("long"));
         assertNull(mapperService.documentMapper("type2"));
     }
 
@@ -206,7 +208,8 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
             assertTrue(e.getMessage(), e.getMessage().contains("mapper [foo] cannot be changed from type [long] to [double]"));
         }
 
-        assertTrue(mapperService.documentMapper("type1").mapping().root().getMapper("foo") instanceof LongFieldMapper);
+        assertThat(((FieldMapper) mapperService.documentMapper("type1").mapping().root().getMapper("foo")).fieldType().typeName(),
+                equalTo("long"));
         assertNotNull(mapperService.documentMapper("type2"));
         assertNull(mapperService.documentMapper("type2").mapping().root().getMapper("foo"));
     }

--- a/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
@@ -120,6 +120,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
@@ -172,6 +173,12 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
         return index;
     }
 
+    private static Version indexVersionCreated;
+
+    protected static Version getIndexVersionCreated() {
+        return indexVersionCreated;
+    }
+
     private static String[] currentTypes;
 
     protected static String[] getCurrentTypes() {
@@ -193,14 +200,14 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
     @BeforeClass
     public static void init() throws IOException {
         // we have to prefer CURRENT since with the range of versions we support it's rather unlikely to get the current actually.
-        Version version = randomBoolean() ? Version.CURRENT : VersionUtils.randomVersionBetween(random(), Version.V_2_0_0_beta1, Version.CURRENT);
+        indexVersionCreated = randomBoolean() ? Version.CURRENT : VersionUtils.randomVersionBetween(random(), Version.V_2_0_0_beta1, Version.CURRENT);
         Settings settings = Settings.builder()
                 .put("node.name", AbstractQueryTestCase.class.toString())
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
                 .put(ScriptService.SCRIPT_AUTO_RELOAD_ENABLED_SETTING.getKey(), false)
                 .build();
         Settings indexSettings = Settings.builder()
-                .put(IndexMetaData.SETTING_VERSION_CREATED, version).build();
+                .put(IndexMetaData.SETTING_VERSION_CREATED, indexVersionCreated).build();
         final ThreadPool threadPool = new ThreadPool(settings);
         index = new Index(randomAsciiOfLengthBetween(1, 10), "_na_");
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index, indexSettings);

--- a/core/src/test/java/org/elasticsearch/index/query/AbstractTermQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractTermQueryTestCase.java
@@ -25,50 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public abstract class AbstractTermQueryTestCase<QB extends BaseTermQueryBuilder<QB>> extends AbstractQueryTestCase<QB> {
-    @Override
-    protected final QB doCreateTestQueryBuilder() {
-        String fieldName = null;
-        Object value;
-        switch (randomIntBetween(0, 3)) {
-            case 0:
-                if (randomBoolean()) {
-                    fieldName = BOOLEAN_FIELD_NAME;
-                }
-                value = randomBoolean();
-                break;
-            case 1:
-                if (randomBoolean()) {
-                    fieldName = STRING_FIELD_NAME;
-                }
-                if (frequently()) {
-                    value = randomAsciiOfLengthBetween(1, 10);
-                } else {
-                    // generate unicode string in 10% of cases
-                    JsonStringEncoder encoder = JsonStringEncoder.getInstance();
-                    value = new String(encoder.quoteAsString(randomUnicodeOfLength(10)));
-                }
-                break;
-            case 2:
-                if (randomBoolean()) {
-                    fieldName = INT_FIELD_NAME;
-                }
-                value = randomInt(10000);
-                break;
-            case 3:
-                if (randomBoolean()) {
-                    fieldName = DOUBLE_FIELD_NAME;
-                }
-                value = randomDouble();
-                break;
-            default:
-                throw new UnsupportedOperationException();
-        }
-
-        if (fieldName == null) {
-            fieldName = randomAsciiOfLengthBetween(1, 10);
-        }
-        return createQueryBuilder(fieldName, value);
-    }
 
     protected abstract QB createQueryBuilder(String fieldName, Object value);
 

--- a/core/src/test/java/org/elasticsearch/index/query/FuzzyQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/FuzzyQueryBuilderTests.java
@@ -19,17 +19,21 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.LegacyNumericRangeQuery;
+import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -60,7 +64,7 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
     @Override
     protected void doAssertLuceneQuery(FuzzyQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
         if (isNumericFieldName(queryBuilder.fieldName()) || queryBuilder.fieldName().equals(DATE_FIELD_NAME)) {
-            assertThat(query, instanceOf(LegacyNumericRangeQuery.class));
+            assertThat(query, either(instanceOf(LegacyNumericRangeQuery.class)).or(instanceOf(PointRangeQuery.class)));
         } else {
             assertThat(query, instanceOf(FuzzyQuery.class));
         }
@@ -139,10 +143,13 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
                 "    }\n" +
                 "}\n";
         Query parsedQuery = parseQuery(query).toQuery(createShardContext());
-        assertThat(parsedQuery, instanceOf(LegacyNumericRangeQuery.class));
-        LegacyNumericRangeQuery fuzzyQuery = (LegacyNumericRangeQuery) parsedQuery;
-        assertThat(fuzzyQuery.getMin().longValue(), equalTo(7L));
-        assertThat(fuzzyQuery.getMax().longValue(), equalTo(17L));
+        Query expected;
+        if (getIndexVersionCreated().onOrAfter(Version.V_5_0_0)) {
+            expected = IntPoint.newRangeQuery(INT_FIELD_NAME, 7, 17);
+        } else {
+            expected = LegacyNumericRangeQuery.newIntRange(INT_FIELD_NAME, 7, 17, true, true);
+        }
+        assertEquals(expected, parsedQuery);
     }
 
     public void testFromJson() throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/query/MatchPhrasePrefixQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchPhrasePrefixQueryBuilderTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.lucene.search.MultiPhrasePrefixQuery;
@@ -70,7 +71,8 @@ public class MatchPhrasePrefixQueryBuilderTests extends AbstractQueryTestCase<Ma
             throws IOException {
         assertThat(query, notNullValue());
         assertThat(query,
-                either(instanceOf(BooleanQuery.class)).or(instanceOf(MultiPhrasePrefixQuery.class)).or(instanceOf(TermQuery.class)));
+                either(instanceOf(BooleanQuery.class)).or(instanceOf(MultiPhrasePrefixQuery.class))
+                .or(instanceOf(TermQuery.class)).or(instanceOf(PointRangeQuery.class)));
     }
 
     public void testIllegalValues() {

--- a/core/src/test/java/org/elasticsearch/index/query/MatchPhraseQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchPhraseQueryBuilderTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 
@@ -66,7 +67,8 @@ public class MatchPhraseQueryBuilderTests extends AbstractQueryTestCase<MatchPhr
     @Override
     protected void doAssertLuceneQuery(MatchPhraseQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
         assertThat(query, notNullValue());
-        assertThat(query, either(instanceOf(BooleanQuery.class)).or(instanceOf(PhraseQuery.class)).or(instanceOf(TermQuery.class)));
+        assertThat(query, either(instanceOf(BooleanQuery.class)).or(instanceOf(PhraseQuery.class))
+                .or(instanceOf(TermQuery.class)).or(instanceOf(PointRangeQuery.class)));
     }
 
     public void testIllegalValues() {

--- a/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -26,6 +26,7 @@ import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.LegacyNumericRangeQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.ParseFieldMatcher;
@@ -126,15 +127,18 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
         switch (queryBuilder.type()) {
         case BOOLEAN:
             assertThat(query, either(instanceOf(BooleanQuery.class)).or(instanceOf(ExtendedCommonTermsQuery.class))
-                    .or(instanceOf(TermQuery.class)).or(instanceOf(FuzzyQuery.class)).or(instanceOf(LegacyNumericRangeQuery.class)));
+                    .or(instanceOf(TermQuery.class)).or(instanceOf(FuzzyQuery.class))
+                    .or(instanceOf(LegacyNumericRangeQuery.class)).or(instanceOf(PointRangeQuery.class)));
             break;
         case PHRASE:
             assertThat(query, either(instanceOf(BooleanQuery.class)).or(instanceOf(PhraseQuery.class))
-                    .or(instanceOf(TermQuery.class)).or(instanceOf(FuzzyQuery.class)).or(instanceOf(LegacyNumericRangeQuery.class)));
+                    .or(instanceOf(TermQuery.class)).or(instanceOf(FuzzyQuery.class))
+                    .or(instanceOf(LegacyNumericRangeQuery.class)).or(instanceOf(PointRangeQuery.class)));
             break;
         case PHRASE_PREFIX:
             assertThat(query, either(instanceOf(BooleanQuery.class)).or(instanceOf(MultiPhrasePrefixQuery.class))
-                    .or(instanceOf(TermQuery.class)).or(instanceOf(FuzzyQuery.class)).or(instanceOf(LegacyNumericRangeQuery.class)));
+                    .or(instanceOf(TermQuery.class)).or(instanceOf(FuzzyQuery.class))
+                    .or(instanceOf(LegacyNumericRangeQuery.class)).or(instanceOf(PointRangeQuery.class)));
             break;
         }
 
@@ -213,6 +217,10 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
 
             assertEquals(value - width, numericRangeQuery.getMin().doubleValue(), width * .1);
             assertEquals(value + width, numericRangeQuery.getMax().doubleValue(), width * .1);
+        }
+
+        if (query instanceof PointRangeQuery) {
+            // TODO
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -29,6 +29,7 @@ import org.apache.lucene.search.LegacyNumericRangeQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.lucene.all.AllTermQuery;
@@ -134,7 +135,8 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
                 .or(instanceOf(FuzzyQuery.class)).or(instanceOf(MultiPhrasePrefixQuery.class))
                 .or(instanceOf(MatchAllDocsQuery.class)).or(instanceOf(ExtendedCommonTermsQuery.class))
                 .or(instanceOf(MatchNoDocsQuery.class)).or(instanceOf(PhraseQuery.class))
-                .or(instanceOf(LegacyNumericRangeQuery.class)));
+                .or(instanceOf(LegacyNumericRangeQuery.class))
+                .or(instanceOf(PointRangeQuery.class)));
     }
 
     public void testIllegaArguments() {

--- a/core/src/test/java/org/elasticsearch/index/query/RandomQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomQueryBuilder.java
@@ -62,7 +62,7 @@ public class RandomQueryBuilder {
         // for now, only use String Rangequeries for MultiTerm test, numeric and date makes little sense
         // see issue #12123 for discussion
         MultiTermQueryBuilder<?> multiTermQueryBuilder;
-        switch(RandomInts.randomIntBetween(r, 0, 5)) {
+        switch(RandomInts.randomIntBetween(r, 0, 3)) {
             case 0:
                 RangeQueryBuilder stringRangeQuery = new RangeQueryBuilder(AbstractQueryTestCase.STRING_FIELD_NAME);
                 stringRangeQuery.from("a" + RandomStrings.randomAsciiOfLengthBetween(r, 1, 10));
@@ -70,21 +70,12 @@ public class RandomQueryBuilder {
                 multiTermQueryBuilder = stringRangeQuery;
                 break;
             case 1:
-                RangeQueryBuilder numericRangeQuery = new RangeQueryBuilder(AbstractQueryTestCase.INT_FIELD_NAME);
-                numericRangeQuery.from(RandomInts.randomIntBetween(r, 1, 100));
-                numericRangeQuery.to(RandomInts.randomIntBetween(r, 101, 200));
-                multiTermQueryBuilder = numericRangeQuery;
-                break;
-            case 2:
-                multiTermQueryBuilder = new FuzzyQueryBuilder(AbstractQueryTestCase.INT_FIELD_NAME, RandomInts.randomInt(r, 1000));
-                break;
-            case 3:
                 multiTermQueryBuilder = new FuzzyQueryBuilder(AbstractQueryTestCase.STRING_FIELD_NAME, RandomStrings.randomAsciiOfLengthBetween(r, 1, 10));
                 break;
-            case 4:
+            case 2:
                 multiTermQueryBuilder = new PrefixQueryBuilderTests().createTestQueryBuilder();
                 break;
-            case 5:
+            case 3:
                 multiTermQueryBuilder = new WildcardQueryBuilderTests().createTestQueryBuilder();
                 break;
             default:

--- a/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -19,7 +19,10 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.search.LegacyNumericRangeQuery;
+import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermRangeQuery;
 import org.elasticsearch.ElasticsearchParseException;
@@ -37,6 +40,7 @@ import java.util.Map;
 
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -122,13 +126,40 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         } else if (queryBuilder.fieldName().equals(DATE_FIELD_NAME)) {
             //we can't properly test unmapped dates because LateParsingQuery is package private
         } else if (queryBuilder.fieldName().equals(INT_FIELD_NAME)) {
-            assertThat(query, instanceOf(LegacyNumericRangeQuery.class));
-            LegacyNumericRangeQuery numericRangeQuery = (LegacyNumericRangeQuery) query;
-            assertThat(numericRangeQuery.getField(), equalTo(queryBuilder.fieldName()));
-            assertThat(numericRangeQuery.getMin(), equalTo(queryBuilder.from()));
-            assertThat(numericRangeQuery.getMax(), equalTo(queryBuilder.to()));
-            assertThat(numericRangeQuery.includesMin(), equalTo(queryBuilder.includeLower()));
-            assertThat(numericRangeQuery.includesMax(), equalTo(queryBuilder.includeUpper()));
+            assertThat(query, either(instanceOf(LegacyNumericRangeQuery.class)).or(instanceOf(PointRangeQuery.class)));
+            if (query instanceof LegacyNumericRangeQuery) {
+                LegacyNumericRangeQuery numericRangeQuery = (LegacyNumericRangeQuery) query;
+                assertThat(numericRangeQuery.getField(), equalTo(queryBuilder.fieldName()));
+                assertThat(numericRangeQuery.getMin(), equalTo(queryBuilder.from()));
+                assertThat(numericRangeQuery.getMax(), equalTo(queryBuilder.to()));
+                assertThat(numericRangeQuery.includesMin(), equalTo(queryBuilder.includeLower()));
+                assertThat(numericRangeQuery.includesMax(), equalTo(queryBuilder.includeUpper()));
+            } else {
+                Integer min = (Integer) queryBuilder.from();
+                Integer max = (Integer) queryBuilder.to();
+                int minInt, maxInt;
+                if (min == null) {
+                    minInt = Integer.MIN_VALUE;
+                } else {
+                    minInt = min.intValue();
+                    if (queryBuilder.includeLower() == false && minInt != Integer.MAX_VALUE) {
+                        minInt++;
+                    }
+                }
+                if (max == null) {
+                    maxInt = Integer.MAX_VALUE;
+                } else {
+                    maxInt = max.intValue();
+                    if (queryBuilder.includeUpper() == false && maxInt != Integer.MIN_VALUE) {
+                        maxInt--;
+                    }
+                }
+                try {
+                assertEquals(IntPoint.newRangeQuery(INT_FIELD_NAME, minInt, maxInt), query);
+                }catch(AssertionError e) {
+                    throw e;
+                }
+            }
         } else {
             throw new UnsupportedOperationException();
         }
@@ -194,13 +225,17 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         Query parsedQuery = rangeQuery(INT_FIELD_NAME).from(23).to(54).includeLower(true).includeUpper(false).toQuery(createShardContext());
         // since age is automatically registered in data, we encode it as numeric
-        assertThat(parsedQuery, instanceOf(LegacyNumericRangeQuery.class));
-        LegacyNumericRangeQuery rangeQuery = (LegacyNumericRangeQuery) parsedQuery;
-        assertThat(rangeQuery.getField(), equalTo(INT_FIELD_NAME));
-        assertThat(rangeQuery.getMin().intValue(), equalTo(23));
-        assertThat(rangeQuery.getMax().intValue(), equalTo(54));
-        assertThat(rangeQuery.includesMin(), equalTo(true));
-        assertThat(rangeQuery.includesMax(), equalTo(false));
+        assertThat(parsedQuery, either(instanceOf(LegacyNumericRangeQuery.class)).or(instanceOf(PointRangeQuery.class)));
+        if (parsedQuery instanceof LegacyNumericRangeQuery) {
+            LegacyNumericRangeQuery rangeQuery = (LegacyNumericRangeQuery) parsedQuery;
+            assertThat(rangeQuery.getField(), equalTo(INT_FIELD_NAME));
+            assertThat(rangeQuery.getMin().intValue(), equalTo(23));
+            assertThat(rangeQuery.getMax().intValue(), equalTo(54));
+            assertThat(rangeQuery.includesMin(), equalTo(true));
+            assertThat(rangeQuery.includesMax(), equalTo(false));
+        } else {
+            assertEquals(IntPoint.newRangeQuery(INT_FIELD_NAME, 23, 53), parsedQuery);
+        }
     }
 
     public void testDateRangeQueryFormat() throws IOException {
@@ -216,15 +251,22 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 "    }\n" +
                 "}";
         Query parsedQuery = parseQuery(query).toQuery(createShardContext()).rewrite(null);
-        assertThat(parsedQuery, instanceOf(LegacyNumericRangeQuery.class));
+        assertThat(parsedQuery, either(instanceOf(LegacyNumericRangeQuery.class)).or(instanceOf(PointRangeQuery.class)));
 
-        // Min value was 01/01/2012 (dd/MM/yyyy)
-        DateTime min = DateTime.parse("2012-01-01T00:00:00.000+00");
-        assertThat(((LegacyNumericRangeQuery) parsedQuery).getMin().longValue(), is(min.getMillis()));
-
-        // Max value was 2030 (yyyy)
-        DateTime max = DateTime.parse("2030-01-01T00:00:00.000+00");
-        assertThat(((LegacyNumericRangeQuery) parsedQuery).getMax().longValue(), is(max.getMillis()));
+        if (parsedQuery instanceof LegacyNumericRangeQuery) {
+            // Min value was 01/01/2012 (dd/MM/yyyy)
+            DateTime min = DateTime.parse("2012-01-01T00:00:00.000+00");
+            assertThat(((LegacyNumericRangeQuery) parsedQuery).getMin().longValue(), is(min.getMillis()));
+    
+            // Max value was 2030 (yyyy)
+            DateTime max = DateTime.parse("2030-01-01T00:00:00.000+00");
+            assertThat(((LegacyNumericRangeQuery) parsedQuery).getMax().longValue(), is(max.getMillis()));
+        } else {
+            assertEquals(LongPoint.newRangeQuery(DATE_FIELD_NAME,
+                    DateTime.parse("2012-01-01T00:00:00.000+00").getMillis(),
+                    DateTime.parse("2030-01-01T00:00:00.000+00").getMillis() - 1),
+                    parsedQuery);
+        }
 
         // Test Invalid format
         query = "{\n" +
@@ -255,16 +297,23 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 "    }\n" +
                 "}\n";
         Query parsedQuery = parseQuery(query).toQuery(createShardContext()).rewrite(null);
-        assertThat(parsedQuery, instanceOf(LegacyNumericRangeQuery.class));
-        LegacyNumericRangeQuery rangeQuery = (LegacyNumericRangeQuery) parsedQuery;
-
-        DateTime min = DateTime.parse("2014-11-01T00:00:00.000+00");
-        assertThat(rangeQuery.getMin().longValue(), is(min.getMillis()));
-        assertTrue(rangeQuery.includesMin());
-
-        DateTime max = DateTime.parse("2014-12-08T23:59:59.999+00");
-        assertThat(rangeQuery.getMax().longValue(), is(max.getMillis()));
-        assertTrue(rangeQuery.includesMax());
+        assertThat(parsedQuery, either(instanceOf(LegacyNumericRangeQuery.class)).or(instanceOf(PointRangeQuery.class)));
+        if (parsedQuery instanceof LegacyNumericRangeQuery) {
+            LegacyNumericRangeQuery rangeQuery = (LegacyNumericRangeQuery) parsedQuery;
+    
+            DateTime min = DateTime.parse("2014-11-01T00:00:00.000+00");
+            assertThat(rangeQuery.getMin().longValue(), is(min.getMillis()));
+            assertTrue(rangeQuery.includesMin());
+    
+            DateTime max = DateTime.parse("2014-12-08T23:59:59.999+00");
+            assertThat(rangeQuery.getMax().longValue(), is(max.getMillis()));
+            assertTrue(rangeQuery.includesMax());
+        } else {
+            assertEquals(LongPoint.newRangeQuery(DATE_FIELD_NAME,
+                    DateTime.parse("2014-11-01T00:00:00.000+00").getMillis(),
+                    DateTime.parse("2014-12-08T23:59:59.999+00").getMillis()),
+                    parsedQuery);
+        }
 
         query = "{\n" +
                 "    \"range\" : {\n" +
@@ -275,16 +324,23 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 "    }\n" +
                 "}";
         parsedQuery = parseQuery(query).toQuery(createShardContext()).rewrite(null);
-        assertThat(parsedQuery, instanceOf(LegacyNumericRangeQuery.class));
-        rangeQuery = (LegacyNumericRangeQuery) parsedQuery;
-
-        min = DateTime.parse("2014-11-30T23:59:59.999+00");
-        assertThat(rangeQuery.getMin().longValue(), is(min.getMillis()));
-        assertFalse(rangeQuery.includesMin());
-
-        max = DateTime.parse("2014-12-08T00:00:00.000+00");
-        assertThat(rangeQuery.getMax().longValue(), is(max.getMillis()));
-        assertFalse(rangeQuery.includesMax());
+        assertThat(parsedQuery, either(instanceOf(LegacyNumericRangeQuery.class)).or(instanceOf(PointRangeQuery.class)));
+        if (parsedQuery instanceof LegacyNumericRangeQuery) {
+            LegacyNumericRangeQuery rangeQuery = (LegacyNumericRangeQuery) parsedQuery;
+    
+            DateTime min = DateTime.parse("2014-11-30T23:59:59.999+00");
+            assertThat(rangeQuery.getMin().longValue(), is(min.getMillis()));
+            assertFalse(rangeQuery.includesMin());
+    
+            DateTime max = DateTime.parse("2014-12-08T00:00:00.000+00");
+            assertThat(rangeQuery.getMax().longValue(), is(max.getMillis()));
+            assertFalse(rangeQuery.includesMax());
+        } else {
+            assertEquals(LongPoint.newRangeQuery(DATE_FIELD_NAME,
+                    DateTime.parse("2014-11-30T23:59:59.999+00").getMillis() + 1,
+                    DateTime.parse("2014-12-08T00:00:00.000+00").getMillis() - 1),
+                    parsedQuery);
+        }
     }
 
     public void testDateRangeQueryTimezone() throws IOException {
@@ -300,17 +356,21 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 "    }\n" +
                 "}";
         Query parsedQuery = parseQuery(query).toQuery(createShardContext()).rewrite(null);
-        assertThat(parsedQuery, instanceOf(LegacyNumericRangeQuery.class));
-
-        // Min value was 2012-01-01 (UTC) so we need to remove one hour
-        DateTime min = DateTime.parse("2012-01-01T00:00:00.000+01:00");
-        // Max value is when we started the test. So it should be some ms from now
-        DateTime max = new DateTime(startDate, DateTimeZone.UTC);
-
-        assertThat(((LegacyNumericRangeQuery) parsedQuery).getMin().longValue(), is(min.getMillis()));
-
-        // We should not have a big difference here (should be some ms)
-        assertThat(((LegacyNumericRangeQuery) parsedQuery).getMax().longValue() - max.getMillis(), lessThanOrEqualTo(60000L));
+        if (parsedQuery instanceof PointRangeQuery) {
+            // TODO what can we assert
+        } else {
+            assertThat(parsedQuery, instanceOf(LegacyNumericRangeQuery.class));
+    
+            // Min value was 2012-01-01 (UTC) so we need to remove one hour
+            DateTime min = DateTime.parse("2012-01-01T00:00:00.000+01:00");
+            // Max value is when we started the test. So it should be some ms from now
+            DateTime max = new DateTime(startDate, DateTimeZone.UTC);
+    
+            assertThat(((LegacyNumericRangeQuery) parsedQuery).getMin().longValue(), is(min.getMillis()));
+    
+            // We should not have a big difference here (should be some ms)
+            assertThat(((LegacyNumericRangeQuery) parsedQuery).getMax().longValue() - max.getMillis(), lessThanOrEqualTo(60000L));
+        }
 
         query = "{\n" +
                 "    \"range\" : {\n" +

--- a/core/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTests.java
@@ -26,12 +26,36 @@ import org.apache.lucene.search.spans.SpanTermQuery;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.index.mapper.MappedFieldType;
 
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
+
 import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
 public class SpanTermQueryBuilderTests extends AbstractTermQueryTestCase<SpanTermQueryBuilder> {
+
+    @Override
+    protected SpanTermQueryBuilder doCreateTestQueryBuilder() {
+        String fieldName = null;
+        Object value;
+
+        if (randomBoolean()) {
+            fieldName = STRING_FIELD_NAME;
+        }
+        if (frequently()) {
+            value = randomAsciiOfLengthBetween(1, 10);
+        } else {
+            // generate unicode string in 10% of cases
+            JsonStringEncoder encoder = JsonStringEncoder.getInstance();
+            value = new String(encoder.quoteAsString(randomUnicodeOfLength(10)));
+        }
+
+        if (fieldName == null) {
+            fieldName = randomAsciiOfLengthBetween(1, 10);
+        }
+        return createQueryBuilder(fieldName, value);
+    }
 
     @Override
     protected SpanTermQueryBuilder createQueryBuilder(String fieldName, Object value) {

--- a/core/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
@@ -20,19 +20,69 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.index.mapper.MappedFieldType;
 
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
+
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBuilder> {
+
+    @Override
+    protected TermQueryBuilder doCreateTestQueryBuilder() {
+        String fieldName = null;
+        Object value;
+        switch (randomIntBetween(0, 3)) {
+            case 0:
+                if (randomBoolean()) {
+                    fieldName = BOOLEAN_FIELD_NAME;
+                }
+                value = randomBoolean();
+                break;
+            case 1:
+                if (randomBoolean()) {
+                    fieldName = STRING_FIELD_NAME;
+                }
+                if (frequently()) {
+                    value = randomAsciiOfLengthBetween(1, 10);
+                } else {
+                    // generate unicode string in 10% of cases
+                    JsonStringEncoder encoder = JsonStringEncoder.getInstance();
+                    value = new String(encoder.quoteAsString(randomUnicodeOfLength(10)));
+                }
+                break;
+            case 2:
+                if (randomBoolean()) {
+                    fieldName = INT_FIELD_NAME;
+                }
+                value = randomInt(10000);
+                break;
+            case 3:
+                if (randomBoolean()) {
+                    fieldName = DOUBLE_FIELD_NAME;
+                }
+                value = randomDouble();
+                break;
+            default:
+                throw new UnsupportedOperationException();
+        }
+
+        if (fieldName == null) {
+            fieldName = randomAsciiOfLengthBetween(1, 10);
+        }
+        return createQueryBuilder(fieldName, value);
+    }
+
     /**
      * @return a TermQuery with random field name and value, optional random boost and queryname
      */
@@ -43,15 +93,19 @@ public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBu
 
     @Override
     protected void doAssertLuceneQuery(TermQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
-        assertThat(query, instanceOf(TermQuery.class));
-        TermQuery termQuery = (TermQuery) query;
-        assertThat(termQuery.getTerm().field(), equalTo(queryBuilder.fieldName()));
+        assertThat(query, either(instanceOf(TermQuery.class)).or(instanceOf(PointRangeQuery.class)));
         MappedFieldType mapper = context.fieldMapper(queryBuilder.fieldName());
-        if (mapper != null) {
-            Term term = ((TermQuery) mapper.termQuery(queryBuilder.value(), null)).getTerm();
-            assertThat(termQuery.getTerm(), equalTo(term));
+        if (query instanceof TermQuery) {
+            TermQuery termQuery = (TermQuery) query;
+            assertThat(termQuery.getTerm().field(), equalTo(queryBuilder.fieldName()));
+            if (mapper != null) {
+                Term term = ((TermQuery) mapper.termQuery(queryBuilder.value(), null)).getTerm();
+                assertThat(termQuery.getTerm(), equalTo(term));
+            } else {
+                assertThat(termQuery.getTerm().bytes(), equalTo(BytesRefs.toBytesRef(queryBuilder.value())));
+            }
         } else {
-            assertThat(termQuery.getTerm().bytes(), equalTo(BytesRefs.toBytesRef(queryBuilder.value())));
+            assertEquals(query, mapper.termQuery(queryBuilder.value(), null));
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
@@ -52,8 +52,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.search.suggest.SuggestBuilder;
-import org.elasticsearch.search.suggest.SuggestBuilders;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.util.Collection;

--- a/core/src/test/java/org/elasticsearch/percolator/PercolatorIT.java
+++ b/core/src/test/java/org/elasticsearch/percolator/PercolatorIT.java
@@ -170,7 +170,7 @@ public class PercolatorIT extends ESIntegTestCase {
     }
 
     public void testSimple2() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "field1", "type=long,doc_values=true", "field2", "type=text"));
+        assertAcked(prepareCreate("test").addMapping("type1", "field1", "type=long", "field2", "type=text"));
         ensureGreen();
 
         // introduce the doc

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
@@ -79,7 +79,7 @@ public class DateHistogramIT extends ESIntegTestCase {
     }
 
     private DateTime date(String date) {
-        return DateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime(date);
+        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(date);
     }
 
     private static String format(DateTime date, String pattern) {
@@ -144,7 +144,7 @@ public class DateHistogramIT extends ESIntegTestCase {
     }
 
     private static String getBucketKeyAsString(DateTime key, DateTimeZone tz) {
-        return Joda.forPattern(DateFieldMapper.Defaults.DATE_TIME_FORMATTER.format()).printer().withZone(tz).print(key);
+        return Joda.forPattern(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.format()).printer().withZone(tz).print(key);
     }
 
     public void testSingleValuedField() throws Exception {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramOffsetIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramOffsetIT.java
@@ -18,10 +18,8 @@
  */
 package org.elasticsearch.search.aggregations.bucket;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
@@ -57,7 +55,7 @@ public class DateHistogramOffsetIT extends ESIntegTestCase {
     private static final String DATE_FORMAT = "yyyy-MM-dd:hh-mm-ss";
 
     private DateTime date(String date) {
-        return DateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime(date);
+        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(date);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/IPv4RangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/IPv4RangeTests.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.common.network.Cidrs;
-import org.elasticsearch.index.mapper.ip.IpFieldMapper;
+import org.elasticsearch.index.mapper.ip.LegacyIpFieldMapper;
 import org.elasticsearch.search.aggregations.BaseAggregationTestCase;
 import org.elasticsearch.search.aggregations.bucket.range.ipv4.IPv4RangeAggregatorBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.ipv4.IPv4RangeAggregatorBuilder.Range;
@@ -44,8 +44,8 @@ public class IPv4RangeTests extends BaseAggregationTestCase<IPv4RangeAggregatorB
                 if (randomBoolean()) {
                     factory.addRange(new Range(key, from, to));
                 } else {
-                    String fromAsStr = Double.isInfinite(from) ? null : IpFieldMapper.longToIp((long) from);
-                    String toAsStr = Double.isInfinite(to) ? null : IpFieldMapper.longToIp((long) to);
+                    String fromAsStr = Double.isInfinite(from) ? null : LegacyIpFieldMapper.longToIp((long) from);
+                    String toAsStr = Double.isInfinite(to) ? null : LegacyIpFieldMapper.longToIp((long) to);
                     factory.addRange(new Range(key, fromAsStr, toAsStr));
                 }
             } else {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/IpTermsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/IpTermsIT.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.bucket;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+
+public class IpTermsIT extends AbstractTermsTestCase {
+
+    public void testBasics() throws Exception {
+        assertAcked(prepareCreate("index").addMapping("type", "ip", "type=ip"));
+        indexRandom(true,
+                client().prepareIndex("index", "type", "1").setSource("ip", "192.168.1.7"),
+                client().prepareIndex("index", "type", "2").setSource("ip", "192.168.1.7"),
+                client().prepareIndex("index", "type", "3").setSource("ip", "2001:db8::2:1"));
+
+        SearchResponse response = client().prepareSearch("index").addAggregation(
+                AggregationBuilders.terms("my_terms").field("ip").executionHint(randomExecutionHint())).get();
+        assertSearchResponse(response);
+        Terms terms = response.getAggregations().get("my_terms");
+        assertEquals(2, terms.getBuckets().size());
+
+        Terms.Bucket bucket1 = terms.getBuckets().get(0);
+        assertEquals(2, bucket1.getDocCount());
+        assertEquals("192.168.1.7", bucket1.getKey());
+        assertEquals("192.168.1.7", bucket1.getKeyAsString());
+
+        Terms.Bucket bucket2 = terms.getBuckets().get(1);
+        assertEquals(1, bucket2.getDocCount());
+        assertEquals("2001:db8::2:1", bucket2.getKey());
+        assertEquals("2001:db8::2:1", bucket2.getKeyAsString());
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardReduceIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardReduceIT.java
@@ -235,6 +235,7 @@ public class ShardReduceIT extends ESIntegTestCase {
         assertThat(histo.getBuckets().size(), equalTo(4));
     }
 
+    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/17700")
     public void testIpRange() throws Exception {
         SearchResponse response = client().prepareSearch("idx")
                 .setQuery(QueryBuilders.matchAllQuery())

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsIT.java
@@ -69,15 +69,15 @@ public class SignificantTermsIT extends ESIntegTestCase {
                 .build();
     }
 
-    public static final int MUSIC_CATEGORY=1;
-    public static final int OTHER_CATEGORY=2;
-    public static final int SNOWBOARDING_CATEGORY=3;
+    public static final String MUSIC_CATEGORY="1";
+    public static final String OTHER_CATEGORY="2";
+    public static final String SNOWBOARDING_CATEGORY="3";
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
         assertAcked(prepareCreate("test").setSettings(SETTING_NUMBER_OF_SHARDS, 5, SETTING_NUMBER_OF_REPLICAS, 0).addMapping("fact",
                 "_routing", "required=true", "routing_id", "type=keyword", "fact_category",
-                "type=integer,index=true", "description", "type=text,fielddata=true"));
+                "type=keyword,index=true", "description", "type=text,fielddata=true"));
         createIndex("idx_unmapped");
 
         ensureGreen();
@@ -123,12 +123,12 @@ public class SignificantTermsIT extends ESIntegTestCase {
                 .actionGet();
         assertSearchResponse(response);
         SignificantTerms topTerms = response.getAggregations().get("mySignificantTerms");
-        Number topCategory = (Number) topTerms.getBuckets().iterator().next().getKey();
-        assertTrue(topCategory.equals(new Long(SNOWBOARDING_CATEGORY)));
+        String topCategory = (String) topTerms.getBuckets().iterator().next().getKey();
+        assertTrue(topCategory.equals(SNOWBOARDING_CATEGORY));
     }
 
     public void testStructuredAnalysisWithIncludeExclude() throws Exception {
-        long[] excludeTerms = { MUSIC_CATEGORY };
+        String[] excludeTerms = { MUSIC_CATEGORY };
         SearchResponse response = client().prepareSearch("test")
                 .setSearchType(SearchType.QUERY_AND_FETCH)
                 .setQuery(new TermQueryBuilder("_all", "paul"))
@@ -139,8 +139,8 @@ public class SignificantTermsIT extends ESIntegTestCase {
                 .actionGet();
         assertSearchResponse(response);
         SignificantTerms topTerms = response.getAggregations().get("mySignificantTerms");
-        Number topCategory = (Number) topTerms.getBuckets().iterator().next().getKey();
-        assertTrue(topCategory.equals(new Long(OTHER_CATEGORY)));
+        String topCategory = topTerms.getBuckets().iterator().next().getKeyAsString();
+        assertTrue(topCategory.equals(OTHER_CATEGORY));
     }
 
     public void testIncludeExclude() throws Exception {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
@@ -94,7 +94,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
     }
 
     public void testPlugin() throws Exception {
-        String type = randomBoolean() ? "text" : "long";
+        String type = randomBoolean() ? "text" : "keyword";
         String settings = "{\"index.number_of_shards\": 1, \"index.number_of_replicas\": 0}";
         SharedSignificantTermsTestMethods.index01Docs(type, settings, this);
         SearchResponse response = client().prepareSearch(INDEX_NAME).setTypes(DOC_TYPE)
@@ -257,7 +257,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
     }
 
     public void testXContentResponse() throws Exception {
-        String type = randomBoolean() ? "text" : "long";
+        String type = randomBoolean() ? "text" : "keyword";
         String settings = "{\"index.number_of_shards\": 1, \"index.number_of_replicas\": 0}";
         SharedSignificantTermsTestMethods.index01Docs(type, settings, this);
         SearchResponse response = client().prepareSearch(INDEX_NAME).setTypes(DOC_TYPE)
@@ -279,12 +279,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
 
         XContentBuilder responseBuilder = XContentFactory.jsonBuilder();
         classes.toXContent(responseBuilder, null);
-        String result = null;
-        if (type.equals("long")) {
-            result = "\"class\"{\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0,\"buckets\":[{\"key\":\"0\",\"doc_count\":4,\"sig_terms\":{\"doc_count\":4,\"buckets\":[{\"key\":0,\"doc_count\":4,\"score\":0.39999999999999997,\"bg_count\":5}]}},{\"key\":\"1\",\"doc_count\":3,\"sig_terms\":{\"doc_count\":3,\"buckets\":[{\"key\":1,\"doc_count\":3,\"score\":0.75,\"bg_count\":4}]}}]}";
-        } else {
-            result = "\"class\"{\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0,\"buckets\":[{\"key\":\"0\",\"doc_count\":4,\"sig_terms\":{\"doc_count\":4,\"buckets\":[{\"key\":\"0\",\"doc_count\":4,\"score\":0.39999999999999997,\"bg_count\":5}]}},{\"key\":\"1\",\"doc_count\":3,\"sig_terms\":{\"doc_count\":3,\"buckets\":[{\"key\":\"1\",\"doc_count\":3,\"score\":0.75,\"bg_count\":4}]}}]}";
-        }
+        String result = "\"class\"{\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0,\"buckets\":[{\"key\":\"0\",\"doc_count\":4,\"sig_terms\":{\"doc_count\":4,\"buckets\":[{\"key\":\"0\",\"doc_count\":4,\"score\":0.39999999999999997,\"bg_count\":5}]}},{\"key\":\"1\",\"doc_count\":3,\"sig_terms\":{\"doc_count\":3,\"buckets\":[{\"key\":\"1\",\"doc_count\":3,\"score\":0.75,\"bg_count\":4}]}}]}";
         assertThat(responseBuilder.string(), equalTo(result));
 
     }
@@ -333,7 +328,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
     }
 
     public void testBackgroundVsSeparateSet() throws Exception {
-        String type = randomBoolean() ? "text" : "long";
+        String type = randomBoolean() ? "text" : "keyword";
         String settings = "{\"index.number_of_shards\": 1, \"index.number_of_replicas\": 0}";
         SharedSignificantTermsTestMethods.index01Docs(type, settings, this);
         testBackgroundVsSeparateSet(new MutualInformation(true, true), new MutualInformation(true, false));
@@ -460,7 +455,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
     }
 
     public void testScriptScore() throws ExecutionException, InterruptedException, IOException {
-        indexRandomFrequencies01(randomBoolean() ? "text" : "long");
+        indexRandomFrequencies01(randomBoolean() ? "text" : "keyword");
         ScriptHeuristic scriptHeuristic = getScriptSignificanceHeuristic();
         ensureYellow();
         SearchResponse response = client().prepareSearch(INDEX_NAME)

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsShardMinDocCountIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsShardMinDocCountIT.java
@@ -53,7 +53,7 @@ public class TermsShardMinDocCountIT extends ESIntegTestCase {
     public void testShardMinDocCountSignificantTermsTest() throws Exception {
         String textMappings;
         if (randomBoolean()) {
-            textMappings = "type=long";
+            textMappings = "type=keyword";
         } else {
             textMappings = "type=text,fielddata=true";
         }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/DateDerivativeIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/DateDerivativeIT.java
@@ -59,7 +59,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
     }
 
     private DateTime date(String date) {
-        return DateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime(date);
+        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(date);
     }
 
     private static String format(DateTime date, String pattern) {

--- a/core/src/test/java/org/elasticsearch/search/simple/SimpleSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/simple/SimpleSearchIT.java
@@ -102,7 +102,7 @@ public class SimpleSearchIT extends ESIntegTestCase {
         client().prepareIndex("test", "type1", "1").setSource("from", "192.168.0.5", "to", "192.168.0.10").setRefresh(true).execute().actionGet();
 
         SearchResponse search = client().prepareSearch()
-                .setQuery(boolQuery().must(rangeQuery("from").lt("192.168.0.7")).must(rangeQuery("to").gt("192.168.0.7")))
+                .setQuery(boolQuery().must(rangeQuery("from").lte("192.168.0.7")).must(rangeQuery("to").gte("192.168.0.7")))
                 .execute().actionGet();
 
         assertHitCount(search, 1L);
@@ -122,6 +122,7 @@ public class SimpleSearchIT extends ESIntegTestCase {
         client().prepareIndex("test", "type1", "2").setSource("ip", "192.168.0.2").execute().actionGet();
         client().prepareIndex("test", "type1", "3").setSource("ip", "192.168.0.3").execute().actionGet();
         client().prepareIndex("test", "type1", "4").setSource("ip", "192.168.1.4").execute().actionGet();
+        client().prepareIndex("test", "type1", "5").setSource("ip", "2001:db8::ff00:42:8329").execute().actionGet();
         refresh();
 
         SearchResponse search = client().prepareSearch()
@@ -155,13 +156,28 @@ public class SimpleSearchIT extends ESIntegTestCase {
         assertHitCount(search, 4L);
 
         search = client().prepareSearch()
+                .setQuery(boolQuery().must(QueryBuilders.termQuery("ip", "2001:db8::ff00:42:8329/128")))
+                .execute().actionGet();
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch()
+                .setQuery(boolQuery().must(QueryBuilders.termQuery("ip", "2001:db8::/64")))
+                .execute().actionGet();
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch()
+                .setQuery(boolQuery().must(QueryBuilders.termQuery("ip", "::/0")))
+                .execute().actionGet();
+        assertHitCount(search, 5L);
+
+        search = client().prepareSearch()
                 .setQuery(boolQuery().must(QueryBuilders.termQuery("ip", "192.168.1.5/32")))
                 .execute().actionGet();
         assertHitCount(search, 0L);
 
         assertFailures(client().prepareSearch().setQuery(boolQuery().must(QueryBuilders.termQuery("ip", "0/0/0/0/0"))),
                 RestStatus.BAD_REQUEST,
-                containsString("invalid IPv4/CIDR; expected [a.b.c.d, e] but was [[0, 0, 0, 0, 0]]"));
+                containsString("Expected [ip/prefix] but was [0/0/0/0/0]"));
     }
 
     public void testSimpleId() {
@@ -351,7 +367,7 @@ public class SimpleSearchIT extends ESIntegTestCase {
             client().prepareSearch("idx").setQuery(QueryBuilders.regexpQuery("num", "34")).get();
             fail("SearchPhaseExecutionException should have been thrown");
         } catch (SearchPhaseExecutionException ex) {
-            assertThat(ex.getCause().getCause().getMessage(), equalTo("Cannot use regular expression to filter numeric field [num]"));
+            assertThat(ex.getCause().getCause().getMessage(), containsString("Can only use regular expression on keyword and text fields"));
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
@@ -40,7 +40,7 @@ import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper.BuilderContext;
-import org.elasticsearch.index.mapper.core.DoubleFieldMapper.DoubleFieldType;
+import org.elasticsearch.index.mapper.core.LegacyDoubleFieldMapper.DoubleFieldType;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper.Nested;
 import org.elasticsearch.index.query.QueryParseContext;

--- a/core/src/test/java/org/elasticsearch/test/search/aggregations/bucket/SharedSignificantTermsTestMethods.java
+++ b/core/src/test/java/org/elasticsearch/test/search/aggregations/bucket/SharedSignificantTermsTestMethods.java
@@ -48,7 +48,7 @@ public class SharedSignificantTermsTestMethods {
     public static final String CLASS_FIELD = "class";
 
     public static void aggregateAndCheckFromSeveralShards(ESIntegTestCase testCase) throws ExecutionException, InterruptedException {
-        String type = ESTestCase.randomBoolean() ? "text" : "long";
+        String type = ESTestCase.randomBoolean() ? "text" : "keyword";
         String settings = "{\"index.number_of_shards\": 5, \"index.number_of_replicas\": 0}";
         index01Docs(type, settings, testCase);
         testCase.ensureGreen();

--- a/docs/reference/mapping/types/date.asciidoc
+++ b/docs/reference/mapping/types/date.asciidoc
@@ -129,15 +129,9 @@ The following parameters are accepted by `date` fields:
     which is substituted for any explicit `null` values.  Defaults to `null`,
     which means the field is treated as missing.
 
-<<precision-step,`precision_step`>>::
-
-    Controls the number of extra terms that are indexed to make
-    <<query-dsl-range-query,`range` queries>> faster. Defaults to `16`.
-
 <<mapping-store,`store`>>::
 
     Whether the field value should be stored and retrievable separately from
     the <<mapping-source-field,`_source`>> field. Accepts `true` or `false`
     (default).
-
 

--- a/docs/reference/mapping/types/ip.asciidoc
+++ b/docs/reference/mapping/types/ip.asciidoc
@@ -1,9 +1,8 @@
 [[ip]]
-=== IPv4 datatype
+=== IP datatype
 
-An `ip` field is really a <<number,`long`>> field which accepts
-https://en.wikipedia.org/wiki/IPv4[IPv4] addresses and indexes them as long
-values:
+An `ip` field can index/store either https://en.wikipedia.org/wiki/IPv4[IPv4] or
+https://en.wikipedia.org/wiki/IPv6[IPv6] addresses.
 
 [source,js]
 --------------------------------------------------
@@ -28,11 +27,8 @@ PUT my_index/my_type/1
 GET my_index/_search
 {
   "query": {
-    "range": {
-      "ip_addr": {
-        "gte": "192.168.1.0",
-        "lt":  "192.168.2.0"
-      }
+    "term": {
+      "ip_addr": "192.168.0.0/16"
     }
   }
 }
@@ -75,16 +71,40 @@ The following parameters are accepted by `ip` fields:
     Accepts an IPv4 value which is substituted for any explicit `null` values.
     Defaults to `null`, which means the field is treated as missing.
 
-<<precision-step,`precision_step`>>::
-
-    Controls the number of extra terms that are indexed to make
-    <<query-dsl-range-query,`range` queries>> faster. Defaults to `16`.
-
 <<mapping-store,`store`>>::
 
     Whether the field value should be stored and retrievable separately from
     the <<mapping-source-field,`_source`>> field. Accepts `true` or `false`
     (default).
 
+==== Querying `ip` fields
 
-NOTE: IPv6 addresses are not supported yet.
+The most common way to query ip addresses is to use the
+https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation[CIDR]
+notation: `[ip_address]/[prefix_length]`. For instance:
+
+[source,js]
+--------------------------------------------------
+GET my_index/_search
+{
+  "query": {
+    "term": {
+      "ip_addr": "192.168.0.0/16"
+    }
+  }
+}
+--------------------------------------------------
+
+or
+
+[source,js]
+--------------------------------------------------
+GET my_index/_search
+{
+  "query": {
+    "term": {
+      "ip_addr": "2001:db8::/48"
+    }
+  }
+}
+--------------------------------------------------

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -79,12 +79,6 @@ The following parameters are accepted by numeric types:
     substituted for any explicit `null` values.  Defaults to `null`, which
     means the field is treated as missing.
 
-<<precision-step,`precision_step`>>::
-
-    Controls the number of extra terms that are indexed to make
-    <<query-dsl-range-query,`range` queries>> faster. The default depends on the
-    numeric `type`.
-
 <<mapping-store,`store`>>::
 
     Whether the field value should be stored and retrievable separately from

--- a/docs/reference/migration/migrate_5_0.asciidoc
+++ b/docs/reference/migration/migrate_5_0.asciidoc
@@ -41,6 +41,8 @@ way to do this is to upgrade to Elasticsearch 2.3 or later and to use the
 * <<breaking_50_packaging>>
 * <<breaking_50_plugins>>
 * <<breaking_50_fs>>
+* <<breaking_50_aggregations_changes>>
+
 
 include::migrate_5_0/search.asciidoc[]
 
@@ -65,3 +67,5 @@ include::migrate_5_0/packaging.asciidoc[]
 include::migrate_5_0/plugins.asciidoc[]
 
 include::migrate_5_0/fs.asciidoc[]
+
+include::migrate_5_0/aggregations.asciidoc[]

--- a/docs/reference/migration/migrate_5_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_5_0/aggregations.asciidoc
@@ -1,0 +1,13 @@
+[[breaking_50_aggregations_changes]]
+=== Aggregation changes
+
+==== Significant terms on numeric fields
+
+Numeric fields have been refactored to use a different data structure that
+performs better for range queries. However, since this data structure does
+not record document frequencies, numeric fields can no longer be used for
+significant terms aggregations. It is recommended to use <<keyword,`keyword`>>
+fields instead, either directly or through a <<multi-fields,multi-field>>
+if the numeric representation is still needed for sorting, range queries or
+numeric aggregations like
+<<search-aggregations-metrics-stats-aggregation,`stats` aggregations>>.

--- a/docs/reference/migration/migrate_5_0/mapping.asciidoc
+++ b/docs/reference/migration/migrate_5_0/mapping.asciidoc
@@ -36,6 +36,46 @@ String mappings now have the following default mappings:
 This allows to perform full-text search on the original field name and to sort
 and run aggregations on the sub keyword field.
 
+==== Numeric fields
+
+Numeric fields are now indexed with a completely different data-structure, called
+BKD tree, that is expected to require less disk space and be faster for range
+queries than the previous way that numerics were indexed.
+
+Term queries will return constant scores now, while they used to return higher
+scores for rare terms due to the contribution of the document frequency, which
+this new BKD structure does not record. If scoring is needed, then it is advised
+to map the numeric fields as <<keyword,`keyword`s>> too.
+
+Note that this <<keyword,`keyword`>> mapping do not need to replace the numeric
+mapping. For instance if you need both sorting and scoring on your numeric field,
+you could map it both as a number and a `keyword` using <<multi-fields>>:
+
+[source,js]
+--------------------------------------------------
+PUT /my_index
+{
+  "mappings": {
+    "my_type": {
+      "properties": {
+        "my_number": {
+          "type": "long",
+          "fields": {
+            "keyword": {
+              "type":  "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+// AUTOSENSE
+
+Also the `precision_step` parameter is now irrelevant and will be rejected on
+indices that are created on or after 5.0.
+
 ==== `index` property
 
 On all field datatypes (except for the deprecated `string` field), the `index`

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
@@ -36,6 +36,7 @@ import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
+import org.elasticsearch.index.mapper.core.LegacyDateFieldMapper;
 import org.elasticsearch.script.ClassPermission;
 import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
@@ -246,7 +247,8 @@ public class ExpressionScriptEngineService extends AbstractComponent implements 
     }
 
     protected ValueSource getDateMethodValueSource(MappedFieldType fieldType, IndexFieldData<?> fieldData, String fieldName, String methodName, int calendarType) {
-        if (!(fieldType instanceof DateFieldMapper.DateFieldType)) {
+        if (fieldType instanceof LegacyDateFieldMapper.DateFieldType == false
+                && fieldType instanceof DateFieldMapper.DateFieldType == false) {
             throw new IllegalArgumentException("Member method [" + methodName + "] can only be used with a date field type, not the field [" + fieldName + "].");
         }
 

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/IPv4RangeTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/IPv4RangeTests.java
@@ -18,9 +18,10 @@
  */
 package org.elasticsearch.messy.tests;
 
+import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.index.mapper.ip.IpFieldMapper;
+import org.elasticsearch.index.mapper.ip.LegacyIpFieldMapper;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.groovy.GroovyPlugin;
@@ -51,6 +52,7 @@ import static org.hamcrest.core.IsNull.nullValue;
 /**
  *
  */
+@AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/17700")
 @ESIntegTestCase.SuiteScopeTestCase
 public class IPv4RangeTests extends ESIntegTestCase {
 
@@ -143,23 +145,23 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.100-10.0.0.200"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.200-*"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(55L));
@@ -185,18 +187,18 @@ public class IPv4RangeTests extends ESIntegTestCase {
         Range.Bucket bucket = buckets.get(0);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.0/25"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.0")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.0")));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.0"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.128")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.128")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.128"));
         assertThat(bucket.getDocCount(), equalTo(128L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.128/25"));
-        assertThat((long) ((Number) bucket.getFrom()).doubleValue(), equalTo(IpFieldMapper.ipToLong("10.0.0.128")));
+        assertThat((long) ((Number) bucket.getFrom()).doubleValue(), equalTo(LegacyIpFieldMapper.ipToLong("10.0.0.128")));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.128"));
-        assertThat((long) ((Number) bucket.getTo()).doubleValue(), equalTo(IpFieldMapper.ipToLong("10.0.1.0"))); // range is exclusive on the to side
+        assertThat((long) ((Number) bucket.getTo()).doubleValue(), equalTo(LegacyIpFieldMapper.ipToLong("10.0.1.0"))); // range is exclusive on the to side
         assertThat(bucket.getToAsString(), equalTo("10.0.1.0"));
         assertThat(bucket.getDocCount(), equalTo(127L)); // include 10.0.0.128
     }
@@ -225,23 +227,23 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("r2"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("r3"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(55L));
@@ -275,7 +277,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getDocCount(), equalTo(100L));
         Sum sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -288,9 +290,9 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.100-10.0.0.200"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(bucket.getDocCount(), equalTo(100L));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -303,7 +305,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.200-*"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(55L));
@@ -336,23 +338,23 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.100-10.0.0.200"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.200-*"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(55L));
@@ -399,23 +401,23 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.100-10.0.0.200"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(bucket.getDocCount(), equalTo(101L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.200-*"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(56L));
@@ -443,23 +445,23 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.100-10.0.0.200"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(bucket.getDocCount(), equalTo(101L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.200-*"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(56L));
@@ -487,23 +489,23 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.100-10.0.0.200"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.200-*"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(55L));
@@ -531,23 +533,23 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.100-10.0.0.200"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(bucket.getDocCount(), equalTo(101L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.200-*"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(56L));
@@ -577,23 +579,23 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getDocCount(), equalTo(0L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.100-10.0.0.200"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(bucket.getDocCount(), equalTo(0L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.200-*"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(0L));
@@ -623,23 +625,23 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.100-10.0.0.200"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.100"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat((String) bucket.getKey(), equalTo("10.0.0.200-*"));
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.200"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
+        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) LegacyIpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(55L));

--- a/plugins/mapper-attachments/src/main/java/org/elasticsearch/mapper/attachments/AttachmentMapper.java
+++ b/plugins/mapper-attachments/src/main/java/org/elasticsearch/mapper/attachments/AttachmentMapper.java
@@ -39,7 +39,8 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
-import org.elasticsearch.index.mapper.core.IntegerFieldMapper;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.mapper.core.TextFieldMapper;
 
 import java.io.IOException;
@@ -141,7 +142,7 @@ public class AttachmentMapper extends FieldMapper {
 
         private Mapper.Builder<?, ?> contentTypeBuilder = new TextFieldMapper.Builder(FieldNames.CONTENT_TYPE);
 
-        private Mapper.Builder<?, ?> contentLengthBuilder = new IntegerFieldMapper.Builder(FieldNames.CONTENT_LENGTH);
+        private Mapper.Builder<?, ?> contentLengthBuilder = new NumberFieldMapper.Builder(FieldNames.CONTENT_LENGTH, NumberType.INTEGER);
 
         private Mapper.Builder<?, ?> languageBuilder = new TextFieldMapper.Builder(FieldNames.LANGUAGE);
 

--- a/plugins/mapper-attachments/src/test/java/org/elasticsearch/mapper/attachments/MultifieldAttachmentMapperTests.java
+++ b/plugins/mapper-attachments/src/test/java/org/elasticsearch/mapper/attachments/MultifieldAttachmentMapperTests.java
@@ -29,10 +29,7 @@ import org.elasticsearch.index.mapper.DocumentMapperParser;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
-import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.elasticsearch.index.mapper.core.TextFieldMapper;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.junit.After;
 import org.junit.Before;
 
 import java.nio.charset.StandardCharsets;
@@ -49,17 +46,11 @@ import static org.hamcrest.Matchers.startsWith;
 public class MultifieldAttachmentMapperTests extends AttachmentUnitTestCase {
 
     private DocumentMapperParser mapperParser;
-    private ThreadPool threadPool;
 
     @Before
     public void setupMapperParser() throws Exception {
         mapperParser = MapperTestUtils.newMapperService(createTempDir(), Settings.EMPTY, getIndicesModuleWithRegisteredAttachmentMapper()).documentMapperParser();
 
-    }
-
-    @After
-    public void cleanup() throws InterruptedException {
-        terminate(threadPool);
     }
 
     public void testSimpleMappings() throws Exception {
@@ -94,7 +85,6 @@ public class MultifieldAttachmentMapperTests extends AttachmentUnitTestCase {
         String forcedName = "dummyname.txt";
 
         String bytes = Base64.encodeBytes(originalText.getBytes(StandardCharsets.ISO_8859_1));
-        threadPool = new ThreadPool("testing-only");
 
         MapperService mapperService = MapperTestUtils.newMapperService(createTempDir(), Settings.EMPTY, getIndicesModuleWithRegisteredAttachmentMapper());
 

--- a/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
+++ b/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
@@ -24,46 +24,46 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.Explicit;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.hash.MurmurHash3;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
+import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.mapper.core.LongFieldMapper;
-import org.elasticsearch.index.mapper.core.NumberFieldMapper;
+import org.elasticsearch.index.mapper.core.TypeParsers;
 
-import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
-
-public class Murmur3FieldMapper extends LongFieldMapper {
+public class Murmur3FieldMapper extends FieldMapper {
 
     public static final String CONTENT_TYPE = "murmur3";
 
-    public static class Defaults extends LongFieldMapper.Defaults {
+    public static class Defaults {
         public static final MappedFieldType FIELD_TYPE = new Murmur3FieldType();
         static {
             FIELD_TYPE.freeze();
         }
     }
 
-    public static class Builder extends NumberFieldMapper.Builder<Builder, Murmur3FieldMapper> {
+    public static class Builder extends FieldMapper.Builder<Builder, Murmur3FieldMapper> {
 
         public Builder(String name) {
-            super(name, Defaults.FIELD_TYPE, Integer.MAX_VALUE);
+            super(name, Defaults.FIELD_TYPE, Defaults.FIELD_TYPE);
             builder = this;
-            builder.precisionStep(Integer.MAX_VALUE);
         }
 
         @Override
         public Murmur3FieldMapper build(BuilderContext context) {
             setupFieldType(context);
-            Murmur3FieldMapper fieldMapper = new Murmur3FieldMapper(name, fieldType, defaultFieldType,
-                    ignoreMalformed(context), coerce(context),
+            return new Murmur3FieldMapper(name, fieldType, defaultFieldType,
                     context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
-            return (Murmur3FieldMapper) fieldMapper.includeInAll(includeInAll);
         }
 
         @Override
@@ -73,11 +73,6 @@ public class Murmur3FieldMapper extends LongFieldMapper {
             defaultFieldType.setIndexOptions(IndexOptions.NONE);
             fieldType.setHasDocValues(true);
             defaultFieldType.setHasDocValues(true);
-        }
-
-        @Override
-        protected int maxPrecisionStep() {
-            return 64;
         }
     }
 
@@ -94,18 +89,18 @@ public class Murmur3FieldMapper extends LongFieldMapper {
                 throw new MapperParsingException("Setting [index] cannot be modified for field [" + name + "]");
             }
 
-            parseNumberField(builder, name, node, parserContext);
-            // Because this mapper extends LongFieldMapper the null_value field will be added to the JSON when transferring cluster state
-            // between nodes so we have to remove the entry here so that the validation doesn't fail
-            // TODO should murmur3 support null_value? at the moment if a user sets null_value it has to be silently ignored since we can't
-            // determine whether the JSON is the original JSON from the user or if its the serialised cluster state being passed between nodes.
-//            node.remove("null_value");
+            if (parserContext.indexVersionCreated().before(Version.V_5_0_0)) {
+                node.remove("precision_step");
+            }
+
+            TypeParsers.parseField(builder, name, node, parserContext);
+
             return builder;
         }
     }
 
     // this only exists so a check can be done to match the field type to using murmur3 hashing...
-    public static class Murmur3FieldType extends LongFieldMapper.LongFieldType {
+    public static class Murmur3FieldType extends MappedFieldType {
         public Murmur3FieldType() {
         }
 
@@ -114,15 +109,25 @@ public class Murmur3FieldMapper extends LongFieldMapper {
         }
 
         @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
         public Murmur3FieldType clone() {
             return new Murmur3FieldType(this);
+        }
+
+        @Override
+        public IndexFieldData.Builder fielddataBuilder() {
+            failIfNoDocValues();
+            return new DocValuesIndexFieldData.Builder().numericType(NumericType.LONG);
         }
     }
 
     protected Murmur3FieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
-            Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
             Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, indexSettings, multiFields, copyTo);
+        super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
     }
 
     @Override
@@ -131,7 +136,8 @@ public class Murmur3FieldMapper extends LongFieldMapper {
     }
 
     @Override
-    protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected void parseCreateField(ParseContext context, List<Field> fields)
+            throws IOException {
         final Object value;
         if (context.externalValueSet()) {
             value = context.externalValue();
@@ -141,9 +147,11 @@ public class Murmur3FieldMapper extends LongFieldMapper {
         if (value != null) {
             final BytesRef bytes = new BytesRef(value.toString());
             final long hash = MurmurHash3.hash128(bytes.bytes, bytes.offset, bytes.length, 0, new MurmurHash3.Hash128()).h1;
-            super.innerParseCreateField(context.createExternalValueContext(hash), fields);
+            fields.add(new SortedNumericDocValuesField(fieldType().name(), hash));
+            if (fieldType().stored()) {
+                fields.add(new StoredField(name(), hash));
+            }
         }
-
     }
 
     @Override

--- a/plugins/mapper-size/src/test/java/org/elasticsearch/index/mapper/size/SizeMappingTests.java
+++ b/plugins/mapper-size/src/test/java/org/elasticsearch/index/mapper/size/SizeMappingTests.java
@@ -39,6 +39,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+import org.apache.lucene.index.IndexableField;
+
 public class SizeMappingTests extends ESSingleNodeTestCase {
 
     IndexService indexService;
@@ -67,8 +69,14 @@ public class SizeMappingTests extends ESSingleNodeTestCase {
                 .bytes();
         ParsedDocument doc = docMapper.parse(SourceToParse.source(source).type("type").id("1"));
 
-        assertThat(doc.rootDoc().getField("_size").fieldType().stored(), equalTo(true));
-        assertThat(doc.rootDoc().getField("_size").tokenStream(docMapper.mappers().indexAnalyzer(), null), notNullValue());
+        boolean stored = false;
+        boolean points = false;
+        for (IndexableField field : doc.rootDoc().getFields("_size")) {
+            stored |= field.fieldType().stored();
+            points |= field.fieldType().pointDimensionCount() > 0;
+        }
+        assertTrue(stored);
+        assertTrue(points);
     }
 
     public void testSizeDisabled() throws Exception {


### PR DESCRIPTION
This makes all numeric fields including `date`, `ip` and `token_count` use
points instead of the inverted index as a lookup structure. This is expected
to perform worse for exact queries, but faster for range queries. It also
requires less storage.

Notes about how the change works:
- Numeric mappers have been split into a legacy version that is essentially
  the current mapper, and a new version that uses points, eg.
  LegacyDateFieldMapper and DateFieldMapper.
- Since new and old fields have the same names, the decision about which one
  to use is made based on the index creation version.
- If you try to force using a legacy field on a new index or a field that uses
  points on an old index, you will get an exception.
- IP addresses now support IPv6 via Lucene's InetAddressPoint and store them
  in SORTED_SET doc values using the same encoding (fixed length of 16 bytes
  and sortable).
- The internal MappedFieldType that is stored by the new mappers does not have
  any of the points-related properties set. Instead, it keeps setting the index
  options when parsing the `index` property of mappings and does
  `if (fieldType.indexOptions() != IndexOptions.NONE) { // add point field }`
  when parsing documents.

Known issues that won't fix:
- You can't use numeric fields in significant terms aggregations anymore since
  this requires document frequencies, which points do not record.
- Term queries on numeric fields will now return constant scores instead of
  giving better scores to the rare values.

Known issues that we could work around (in follow-up PRs, this one is too large
already):
- Range queries on `ip` addresses only work if both the lower and upper bounds
  are inclusive (exclusive bounds are not exposed in Lucene). We could either
  decide to implement it, or drop range support entirely and tell users to
  query subnets using the CIDR notation instead.
- Since IP addresses now use a different representation for doc values,
  aggregations will fail when running a terms aggregation on an ip field on a
  list of indices that contains both pre-5.0 and 5.0 indices.
- The ip range aggregation does not work on the new ip field. We need to either
  implement range aggs for SORTED_SET doc values or drop support for ip ranges
  and tell users to use filters instead. #17700

Closes #16751
Closes #17007
Closes #11513
