### PR TITLE
Disallow fielddata loading on text fields that are not indexed.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/core/TextFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/TextFieldMapper.java
@@ -321,6 +321,9 @@ public class TextFieldMapper extends FieldMapper implements AllFieldMapper.Inclu
         super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
         assert fieldType.tokenized();
         assert fieldType.hasDocValues() == false;
+        if (fieldType().indexOptions() == IndexOptions.NONE && fieldType().fielddata()) {
+            throw new IllegalArgumentException("Cannot enable fielddata on a [text] field that is not indexed: [" + name() + "]");
+        }
         this.positionIncrementGap = positionIncrementGap;
     }
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/TextFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/TextFieldMapperTests.java
@@ -425,6 +425,17 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
 
         assertEquals(mapping, enabledMapper.mappingSource().toString());
         enabledMapper.mappers().getMapper("field").fieldType().fielddataBuilder(); // no exception this time
+
+        String illegalMapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field")
+                    .field("type", "text")
+                    .field("index", false)
+                    .field("fielddata", true)
+                .endObject().endObject()
+                .endObject().endObject().string();
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
+                () -> parser.parse("type", new CompressedXContent(illegalMapping)));
+        assertThat(ex.getMessage(), containsString("Cannot enable fielddata on a [text] field that is not indexed"));
     }
 
     public void testFrequencyFilter() throws IOException {


### PR DESCRIPTION
If a field is not indexed, we cannot load fielddata for it.
