### PR TITLE
Adds `ignore_unmapped` option to nested and P/C queries

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/ParentIdQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ParentIdQueryBuilder.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.DocValuesTermsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.ParseField;
@@ -43,11 +44,19 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
     public static final String NAME = "parent_id";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
 
+    /**
+     * The default value for ignore_unmapped.
+     */
+    public static final boolean DEFAULT_IGNORE_UNMAPPED = false;
+
     private static final ParseField ID_FIELD = new ParseField("id");
     private static final ParseField TYPE_FIELD = new ParseField("type", "child_type");
+    private static final ParseField IGNORE_UNMAPPED_FIELD = new ParseField("ignore_unmapped");
 
     private final String type;
     private final String id;
+
+    private boolean ignoreUnmapped = false;
 
     public ParentIdQueryBuilder(String type, String id) {
         this.type = type;
@@ -61,12 +70,14 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
         super(in);
         type = in.readString();
         id = in.readString();
+        ignoreUnmapped = in.readBoolean();
     }
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeString(type);
         out.writeString(id);
+        out.writeBoolean(ignoreUnmapped);
     }
 
     public String getType() {
@@ -77,11 +88,31 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
         return id;
     }
 
+    /**
+     * Sets whether the query builder should ignore unmapped types (and run a
+     * {@link MatchNoDocsQuery} in place of this query) or throw an exception if
+     * the type is unmapped.
+     */
+    public ParentIdQueryBuilder ignoreUnmapped(boolean ignoreUnmapped) {
+        this.ignoreUnmapped = ignoreUnmapped;
+        return this;
+    }
+
+    /**
+     * Gets whether the query builder will ignore unmapped types (and run a
+     * {@link MatchNoDocsQuery} in place of this query) or throw an exception if
+     * the type is unmapped.
+     */
+    public boolean ignoreUnmapped() {
+        return ignoreUnmapped;
+    }
+
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(NAME);
         builder.field(TYPE_FIELD.getPreferredName(), type);
         builder.field(ID_FIELD.getPreferredName(), id);
+        builder.field(IGNORE_UNMAPPED_FIELD.getPreferredName(), ignoreUnmapped);
         printBoostAndQueryName(builder);
         builder.endObject();
     }
@@ -93,6 +124,7 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
         String id = null;
         String queryName = null;
         String currentFieldName = null;
+        boolean ignoreUnmapped = DEFAULT_IGNORE_UNMAPPED;
         XContentParser.Token token;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
@@ -102,6 +134,8 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
                     type = parser.text();
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, ID_FIELD)) {
                     id = parser.text();
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, IGNORE_UNMAPPED_FIELD)) {
+                    ignoreUnmapped = parser.booleanValue();
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.BOOST_FIELD)) {
                     boost = parser.floatValue();
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, AbstractQueryBuilder.NAME_FIELD)) {
@@ -116,6 +150,7 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
         ParentIdQueryBuilder queryBuilder = new ParentIdQueryBuilder(type, id);
         queryBuilder.queryName(queryName);
         queryBuilder.boost(boost);
+        queryBuilder.ignoreUnmapped(ignoreUnmapped);
         return queryBuilder;
     }
 
@@ -124,7 +159,11 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
     protected Query doToQuery(QueryShardContext context) throws IOException {
         DocumentMapper childDocMapper = context.getMapperService().documentMapper(type);
         if (childDocMapper == null) {
-            throw new QueryShardException(context, "[" + NAME + "] no mapping found for type [" + type + "]");
+            if (ignoreUnmapped) {
+                return new MatchNoDocsQuery();
+            } else {
+                throw new QueryShardException(context, "[" + NAME + "] no mapping found for type [" + type + "]");
+            }
         }
         ParentFieldMapper parentFieldMapper = childDocMapper.parentFieldMapper();
         if (parentFieldMapper.active() == false) {
@@ -141,12 +180,14 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
 
     @Override
     protected boolean doEquals(ParentIdQueryBuilder that) {
-        return Objects.equals(type, that.type) && Objects.equals(id, that.id);
+        return Objects.equals(type, that.type)
+                && Objects.equals(id, that.id)
+                && Objects.equals(ignoreUnmapped, that.ignoreUnmapped);
     }
 
     @Override
     protected int doHashCode() {
-        return Objects.hash(type, id);
+        return Objects.hash(type, id, ignoreUnmapped);
     }
 
     @Override

--- a/docs/reference/query-dsl/has-child-query.asciidoc
+++ b/docs/reference/query-dsl/has-child-query.asciidoc
@@ -72,3 +72,12 @@ a match:
 
 The  `min_children` and `max_children` parameters can be combined with
 the `score_mode` parameter.
+
+[float]
+==== Ignore Unmapped
+
+When set to `true` the `ignore_unmapped` option will ignore an unmapped `type`
+and will not match any documents for this query. This can be useful when
+querying multiple indexes which might have different mappings. When set to
+`false` (the default value) the query will throw an exception if the `type`
+is not mapped.

--- a/docs/reference/query-dsl/has-parent-query.asciidoc
+++ b/docs/reference/query-dsl/has-parent-query.asciidoc
@@ -46,3 +46,12 @@ matching parent document. The score mode can be specified with the
     }
 }
 --------------------------------------------------
+
+[float]
+==== Ignore Unmapped
+
+When set to `true` the `ignore_unmapped` option will ignore an unmapped `type`
+and will not match any documents for this query. This can be useful when
+querying multiple indexes which might have different mappings. When set to
+`false` (the default value) the query will throw an exception if the `type`
+is not mapped.

--- a/docs/reference/query-dsl/nested-query.asciidoc
+++ b/docs/reference/query-dsl/nested-query.asciidoc
@@ -55,6 +55,12 @@ The `score_mode` allows to set how inner children matching affects
 scoring of parent. It defaults to `avg`, but can be `sum`, `min`,
 `max` and `none`.
 
+There is also an `ignore_unmapped` option which, when set to `true` will
+ignore an unmapped `path` and will not match any documents for this query.
+This can be useful when querying multiple indexes which might have different
+mappings. When set to `false` (the default value) the query will throw an
+exception if the `path` is not mapped.
+
 Multi level nesting is automatically supported, and detected, resulting
 in an inner nested query to automatically match the relevant nesting
 level (and not root) if it exists within another nested query.

--- a/docs/reference/query-dsl/parent-id-query.asciidoc
+++ b/docs/reference/query-dsl/parent-id-query.asciidoc
@@ -8,10 +8,10 @@ The `parent_id` query can be used to find child documents which belong to a part
 [source,js]
 --------------------------------------------------
 {
-  "parent_id" : {
-    "type" : "blog_tag",
-    "id" : "1"
-  }
+    "parent_id" : {
+        "type" : "blog_tag",
+        "id" : "1"
+    }
 }
 --------------------------------------------------
 
@@ -41,3 +41,8 @@ This query has two required parameters:
 `type`::  The **child** type. This must be a type with `_parent` field.
 
 `id`::    The required parent id select documents must referrer to.
+
+`ignore_unmapped`::  When set to `true` this will ignore an unmapped `type` and will not match any 
+documents for this query. This can be useful when querying multiple indexes
+which might have different mappings. When set to `false` (the default value)
+the query will throw an exception if the `type` is not mapped.


### PR DESCRIPTION
The change adds a new option to the `nested`, `has_parent`, `has_children` and `parent_id` queries: `ignore_unmapped`. If this option is set to false, the `toQuery` method on the QueryBuilder will throw an exception if the type/path specified in the query is unmapped. If the option is set to true, the `toQuery` method on the QueryBuilder will return a MatchNoDocsQuery. The default value is `false`so the queries work how they do today (throwing an exception on unmapped paths/types)
