### PR TITLE
Remove FieldStats.Float.

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
@@ -315,71 +315,6 @@ public abstract class FieldStats<T extends Comparable<T>> implements Streamable,
 
     }
 
-    public static final class Float extends FieldStats<java.lang.Float> {
-
-        public Float() {
-        }
-
-        public Float(long maxDoc, long docCount, long sumDocFreq, long sumTotalTermFreq, float minValue, float maxValue) {
-            super(1, maxDoc, docCount, sumDocFreq, sumTotalTermFreq);
-            this.minValue = minValue;
-            this.maxValue = maxValue;
-        }
-
-        @Override
-        public String getMinValueAsString() {
-            return String.valueOf(minValue.floatValue());
-        }
-
-        @Override
-        public String getMaxValueAsString() {
-            return String.valueOf(maxValue.floatValue());
-        }
-
-        @Override
-        public void append(FieldStats stats) {
-            super.append(stats);
-            Float other = (Float) stats;
-            this.minValue = Math.min(other.minValue, minValue);
-            this.maxValue = Math.max(other.maxValue, maxValue);
-        }
-
-        @Override
-        protected java.lang.Float valueOf(String value, String optionalFormat) {
-            if (optionalFormat != null) {
-                throw new UnsupportedOperationException("custom format isn't supported");
-            }
-            return java.lang.Float.valueOf(value);
-        }
-
-        @Override
-        public String stringValueOf(Object value, String optionalFormat) {
-            if (optionalFormat != null) {
-                throw new UnsupportedOperationException("custom format isn't supported");
-            }
-            if (value instanceof Number) {
-                return java.lang.Float.toString(((Number) value).floatValue());
-            } else {
-                throw new IllegalArgumentException("value must be a Float: " + value);
-            }
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            minValue = in.readFloat();
-            maxValue = in.readFloat();
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            super.writeTo(out);
-            out.writeFloat(minValue);
-            out.writeFloat(maxValue);
-        }
-
-    }
-
     public static final class Double extends FieldStats<java.lang.Double> {
 
         public Double() {
@@ -528,7 +463,7 @@ public abstract class FieldStats<T extends Comparable<T>> implements Streamable,
         }
 
         public Date(long maxDoc, long docCount, long sumDocFreq, long sumTotalTermFreq, long minValue, long maxValue, FormatDateTimeFormatter dateFormatter) {
-            super(4, maxDoc, docCount, sumDocFreq, sumTotalTermFreq, minValue, maxValue);
+            super(1, maxDoc, docCount, sumDocFreq, sumTotalTermFreq, minValue, maxValue);
             this.dateFormatter = dateFormatter;
         }
 
@@ -614,16 +549,13 @@ public abstract class FieldStats<T extends Comparable<T>> implements Streamable,
                 stats = new Long();
                 break;
             case 1:
-                stats = new Float();
+                stats = new Date();
                 break;
             case 2:
                 stats = new Double();
                 break;
             case 3:
                 stats = new Text();
-                break;
-            case 4:
-                stats = new Date();
                 break;
             default:
                 throw new IllegalArgumentException("Illegal type [" + type + "]");

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
@@ -34,13 +34,11 @@ import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.fieldstats.FieldStats;
 import org.elasticsearch.common.Explicit;
-import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
@@ -174,7 +172,7 @@ public class FloatFieldMapper extends NumberFieldMapper {
             }
             float minValue = NumericUtils.sortableIntToFloat(LegacyNumericUtils.getMinInt(terms));
             float maxValue = NumericUtils.sortableIntToFloat(LegacyNumericUtils.getMaxInt(terms));
-            return new FieldStats.Float(
+            return new FieldStats.Double(
                 maxDoc, terms.getDocCount(), terms.getSumDocFreq(), terms.getSumTotalTermFreq(), minValue, maxValue
             );
         }

--- a/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsIntegrationIT.java
@@ -60,8 +60,8 @@ public class FieldStatsIntegrationIT extends ESIntegTestCase {
         long maxInt = Integer.MIN_VALUE;
         long minLong = Long.MAX_VALUE;
         long maxLong = Long.MIN_VALUE;
-        float minFloat = Float.MAX_VALUE;
-        float maxFloat = Float.MIN_VALUE;
+        double minFloat = Float.MAX_VALUE;
+        double maxFloat = Float.MIN_VALUE;
         double minDouble = Double.MAX_VALUE;
         double maxDouble = Double.MIN_VALUE;
         String minString = new String(Character.toChars(1114111));

--- a/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
@@ -117,8 +117,8 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
         assertThat(result.getAllFieldStats().get(fieldName).getMaxDoc(), equalTo(11L));
         assertThat(result.getAllFieldStats().get(fieldName).getDocCount(), equalTo(11L));
         assertThat(result.getAllFieldStats().get(fieldName).getDensity(), equalTo(100));
-        assertThat(result.getAllFieldStats().get(fieldName).getMinValue(), equalTo(-1f));
-        assertThat(result.getAllFieldStats().get(fieldName).getMaxValue(), equalTo(9f));
+        assertThat(result.getAllFieldStats().get(fieldName).getMinValue(), equalTo(-1d));
+        assertThat(result.getAllFieldStats().get(fieldName).getMaxValue(), equalTo(9d));
         assertThat(result.getAllFieldStats().get(fieldName).getMinValueAsString(), equalTo(Float.toString(-1)));
         assertThat(result.getAllFieldStats().get(fieldName).getMaxValueAsString(), equalTo(Float.toString(9)));
     }


### PR DESCRIPTION
Since doubles can represent all floats accurately, we can just use
FieldStats.Double instead.
