### PR TITLE
Cut range aggregations to registerAggregation

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -123,11 +123,14 @@ import org.elasticsearch.search.aggregations.bucket.nested.InternalReverseNested
 import org.elasticsearch.search.aggregations.bucket.nested.NestedParser;
 import org.elasticsearch.search.aggregations.bucket.nested.ReverseNestedParser;
 import org.elasticsearch.search.aggregations.bucket.range.InternalRange;
+import org.elasticsearch.search.aggregations.bucket.range.RangeAggregatorBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.RangeParser;
+import org.elasticsearch.search.aggregations.bucket.range.date.DateRangeAggregatorBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.date.DateRangeParser;
 import org.elasticsearch.search.aggregations.bucket.range.date.InternalDateRange;
 import org.elasticsearch.search.aggregations.bucket.range.geodistance.GeoDistanceParser;
 import org.elasticsearch.search.aggregations.bucket.range.geodistance.InternalGeoDistance;
+import org.elasticsearch.search.aggregations.bucket.range.ipv4.IPv4RangeAggregatorBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.ipv4.InternalIPv4Range;
 import org.elasticsearch.search.aggregations.bucket.range.ipv4.IpRangeParser;
 import org.elasticsearch.search.aggregations.bucket.sampler.DiversifiedSamplerParser;
@@ -457,9 +460,9 @@ public class SearchModule extends AbstractModule {
         registerAggregatorParser(new DiversifiedSamplerParser());
         registerAggregatorParser(new TermsParser());
         registerAggregatorParser(new SignificantTermsParser(significanceHeuristicParserMapper, queryParserRegistry));
-        registerAggregatorParser(new RangeParser());
-        registerAggregatorParser(new DateRangeParser());
-        registerAggregatorParser(new IpRangeParser());
+        registerAggregation(RangeAggregatorBuilder::new, new RangeParser(), RangeAggregatorBuilder.AGGREGATION_NAME_FIELD);
+        registerAggregation(DateRangeAggregatorBuilder::new, new DateRangeParser(), DateRangeAggregatorBuilder.AGGREGATION_NAME_FIELD);
+        registerAggregation(IPv4RangeAggregatorBuilder::new, new IpRangeParser(), IPv4RangeAggregatorBuilder.AGGREGATION_NAME_FIELD);
         registerAggregation(HistogramAggregatorBuilder::new, new HistogramParser(), HistogramAggregatorBuilder.AGGREGATION_NAME_FIELD);
         registerAggregation(DateHistogramAggregatorBuilder::new, new DateHistogramParser(),
                 DateHistogramAggregatorBuilder.AGGREGATION_NAME_FIELD);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/AbstractRangeBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/AbstractRangeBuilder.java
@@ -20,13 +20,13 @@
 package org.elasticsearch.search.aggregations.bucket.range;
 
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamInputReader;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Range;
-import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorBuilder;
-import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +42,31 @@ public abstract class AbstractRangeBuilder<AB extends AbstractRangeBuilder<AB, R
     protected AbstractRangeBuilder(String name, InternalRange.Factory<?, ?> rangeFactory) {
         super(name, rangeFactory.type(), rangeFactory.getValueSourceType(), rangeFactory.getValueType());
         this.rangeFactory = rangeFactory;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    protected AbstractRangeBuilder(StreamInput in, InternalRange.Factory<?, ?> rangeFactory, StreamInputReader<R> rangeReader)
+            throws IOException {
+        super(in, rangeFactory.type(), rangeFactory.getValueSourceType(), rangeFactory.getValueType());
+        this.rangeFactory = rangeFactory;
+        ranges = in.readList(rangeReader);
+        keyed = in.readBoolean();
+    }
+
+    @Override
+    protected void innerWriteTo(StreamOutput out) throws IOException {
+        out.writeVInt(ranges.size());
+        for (Range range : ranges) {
+            range.writeTo(out);
+        }
+        out.writeBoolean(keyed);
+    }
+
+    @Override
+    protected boolean usesNewStyleSerialization() {
+        return true;
     }
 
     public AB addRange(R range) {
@@ -70,25 +95,6 @@ public abstract class AbstractRangeBuilder<AB extends AbstractRangeBuilder<AB, R
         builder.field(RangeAggregator.RANGES_FIELD.getPreferredName(), ranges);
         builder.field(RangeAggregator.KEYED_FIELD.getPreferredName(), keyed);
         return builder;
-    }
-
-    @Override
-    protected AB innerReadFrom(String name, ValuesSourceType valuesSourceType,
-            ValueType targetValueType, StreamInput in) throws IOException {
-        AbstractRangeBuilder<AB, R> factory = createFactoryFromStream(name, in);
-        factory.keyed = in.readBoolean();
-        return (AB) factory;
-    }
-
-    protected abstract AbstractRangeBuilder<AB, R> createFactoryFromStream(String name, StreamInput in) throws IOException;
-
-    @Override
-    protected void innerWriteTo(StreamOutput out) throws IOException {
-        out.writeVInt(ranges.size());
-        for (Range range : ranges) {
-            range.writeTo(out);
-        }
-        out.writeBoolean(keyed);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorBuilder.java
@@ -19,22 +19,30 @@
 
 package org.elasticsearch.search.aggregations.bucket.range;
 
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Range;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 
 public class RangeAggregatorBuilder extends AbstractRangeBuilder<RangeAggregatorBuilder, Range> {
-
-    static final RangeAggregatorBuilder PROTOTYPE = new RangeAggregatorBuilder("");
+    public static final String NAME = InternalRange.TYPE.name();
+    public static final ParseField AGGREGATION_NAME_FIELD = new ParseField(NAME);
 
     public RangeAggregatorBuilder(String name) {
         super(name, InternalRange.FACTORY);
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public RangeAggregatorBuilder(StreamInput in) throws IOException {
+        super(in, InternalRange.FACTORY, Range.PROTOTYPE::readFrom);
     }
 
     /**
@@ -111,12 +119,7 @@ public class RangeAggregatorBuilder extends AbstractRangeBuilder<RangeAggregator
     }
 
     @Override
-    protected RangeAggregatorBuilder createFactoryFromStream(String name, StreamInput in) throws IOException {
-        int size = in.readVInt();
-        RangeAggregatorBuilder factory = new RangeAggregatorBuilder(name);
-        for (int i = 0; i < size; i++) {
-            factory.addRange(Range.PROTOTYPE.readFrom(in));
-        }
-        return factory;
+    public String getWriteableName() {
+        return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeParser.java
@@ -41,13 +41,11 @@ public class RangeParser extends NumericValuesSourceParser {
         this(true, true, false);
     }
 
+    /**
+     * Used by subclasses that parse slightly different kinds of ranges.
+     */
     protected RangeParser(boolean scriptable, boolean formattable, boolean timezoneAware) {
         super(scriptable, formattable, timezoneAware);
-    }
-
-    @Override
-    public String type() {
-        return InternalRange.TYPE.name();
     }
 
     @Override
@@ -91,10 +89,5 @@ public class RangeParser extends NumericValuesSourceParser {
 
     protected Range parseRange(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException {
         return Range.PROTOTYPE.fromXContent(parser, parseFieldMatcher);
-    }
-
-    @Override
-    public AbstractRangeBuilder<?, ?> getFactoryPrototypes() {
-        return RangeAggregatorBuilder.PROTOTYPE;
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/DateRangeAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/DateRangeAggregatorBuilder.java
@@ -19,30 +19,38 @@
 
 package org.elasticsearch.search.aggregations.bucket.range.date;
 
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.range.AbstractRangeBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Range;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.joda.time.DateTime;
 
 import java.io.IOException;
 
 public class DateRangeAggregatorBuilder extends AbstractRangeBuilder<DateRangeAggregatorBuilder, RangeAggregator.Range> {
-
-    static final DateRangeAggregatorBuilder PROTOTYPE = new DateRangeAggregatorBuilder("");
+    public static final String NAME = InternalDateRange.TYPE.name();
+    public static final ParseField AGGREGATION_NAME_FIELD = new ParseField(NAME);
 
     public DateRangeAggregatorBuilder(String name) {
         super(name, InternalDateRange.FACTORY);
     }
 
+    /**
+     * Read from a stream.
+     */
+    public DateRangeAggregatorBuilder(StreamInput in) throws IOException {
+        super(in, InternalDateRange.FACTORY, Range.PROTOTYPE::readFrom);
+    }
+
     @Override
     public String getWriteableName() {
-        return InternalDateRange.TYPE.name();
+        return NAME;
     }
 
     /**
@@ -254,15 +262,4 @@ public class DateRangeAggregatorBuilder extends AbstractRangeBuilder<DateRangeAg
         return new DateRangeAggregatorFactory(name, type, config, ranges, keyed, rangeFactory, context, parent, subFactoriesBuilder,
                 metaData);
     }
-
-    @Override
-    protected DateRangeAggregatorBuilder createFactoryFromStream(String name, StreamInput in) throws IOException {
-        int size = in.readVInt();
-        DateRangeAggregatorBuilder factory = new DateRangeAggregatorBuilder(name);
-        for (int i = 0; i < size; i++) {
-            factory.addRange(Range.PROTOTYPE.readFrom(in));
-        }
-        return factory;
-    }
-
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/DateRangeParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/DateRangeParser.java
@@ -38,11 +38,6 @@ public class DateRangeParser extends RangeParser {
     }
 
     @Override
-    public String type() {
-        return InternalDateRange.TYPE.name();
-    }
-
-    @Override
     protected DateRangeAggregatorBuilder createFactory(String aggregationName, ValuesSourceType valuesSourceType,
             ValueType targetValueType, Map<ParseField, Object> otherOptions) {
         DateRangeAggregatorBuilder factory = new DateRangeAggregatorBuilder(aggregationName);
@@ -56,10 +51,5 @@ public class DateRangeParser extends RangeParser {
             factory.keyed(keyed);
         }
         return factory;
-    }
-
-    @Override
-    public DateRangeAggregatorBuilder getFactoryPrototypes() {
-        return DateRangeAggregatorBuilder.PROTOTYPE;
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IPv4RangeAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IPv4RangeAggregatorBuilder.java
@@ -40,16 +40,23 @@ import java.io.IOException;
 import java.util.Objects;
 
 public class IPv4RangeAggregatorBuilder extends AbstractRangeBuilder<IPv4RangeAggregatorBuilder, IPv4RangeAggregatorBuilder.Range> {
-
-    static final IPv4RangeAggregatorBuilder PROTOTYPE = new IPv4RangeAggregatorBuilder("");
+    public static final String NAME = InternalIPv4Range.TYPE.name();
+    public static final ParseField AGGREGATION_NAME_FIELD = new ParseField(NAME);
 
     public IPv4RangeAggregatorBuilder(String name) {
         super(name, InternalIPv4Range.FACTORY);
     }
 
+    /**
+     * Read from a stream.
+     */
+    public IPv4RangeAggregatorBuilder(StreamInput in) throws IOException {
+        super(in, InternalIPv4Range.FACTORY, Range.PROTOTYPE::readFrom);
+    }
+
     @Override
     public String getWriteableName() {
-        return InternalIPv4Range.TYPE.name();
+        return NAME;
     }
 
     /**
@@ -130,16 +137,6 @@ public class IPv4RangeAggregatorBuilder extends AbstractRangeBuilder<IPv4RangeAg
             AggregatorFactory<?> parent, Builder subFactoriesBuilder) throws IOException {
         return new Ipv4RangeAggregatorFactory(name, type, config, ranges, keyed, rangeFactory, context, parent, subFactoriesBuilder,
                 metaData);
-    }
-
-    @Override
-    protected IPv4RangeAggregatorBuilder createFactoryFromStream(String name, StreamInput in) throws IOException {
-        int size = in.readVInt();
-        IPv4RangeAggregatorBuilder factory = new IPv4RangeAggregatorBuilder(name);
-        for (int i = 0; i < size; i++) {
-            factory.addRange(Range.PROTOTYPE.readFrom(in));
-        }
-        return factory;
     }
 
     public static class Range extends RangeAggregator.Range {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IpRangeParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IpRangeParser.java
@@ -41,14 +41,9 @@ public class IpRangeParser extends RangeParser {
     }
 
     @Override
-    public String type() {
-        return InternalIPv4Range.TYPE.name();
-    }
-
-    @Override
     protected Range parseRange(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException {
         return IPv4RangeAggregatorBuilder.Range.PROTOTYPE.fromXContent(parser, parseFieldMatcher);
-            }
+    }
 
     @Override
     protected IPv4RangeAggregatorBuilder createFactory(String aggregationName, ValuesSourceType valuesSourceType,
@@ -65,11 +60,5 @@ public class IpRangeParser extends RangeParser {
             factory.keyed(keyed);
         }
         return factory;
-        }
-
-    @Override
-    public IPv4RangeAggregatorBuilder getFactoryPrototypes() {
-        return IPv4RangeAggregatorBuilder.PROTOTYPE;
     }
-
 }


### PR DESCRIPTION
and remove their PROTOTYPES. Does not remove the PROTOTYPEs from their
Range implementations which will have to wait for another commit.

Relates to #17085
