### PR TITLE
Build: Exclude gradle and eclipse build dirs from intellij

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,10 @@ allprojects {
       outputDir = file('build-idea/classes/main')
       testOutputDir = file('build-idea/classes/test')
 
+      // also ignore other possible build dirs
+      excludeDirs += file('build')
+      excludeDirs += file('build-eclipse')
+
       iml {
         // fix so that Gradle idea plugin properly generates support for resource folders
         // see also https://issues.gradle.org/browse/GRADLE-2975


### PR DESCRIPTION
Intellij has a model of "everything is a source dir unless you say
otherwise". This change fixes the intellij configuration to not think
the gradle or eclipse build dirs are source dirs.
