### PR TITLE
Remove 'case' parameter from rest apis

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -305,7 +305,7 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
         if (outputIndices) {
             builder.startObject(Fields.INDICES);
             for (ClusterIndexHealth indexHealth : clusterStateHealth.getIndices().values()) {
-                builder.startObject(indexHealth.getIndex(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(indexHealth.getIndex());
                 indexHealth.toXContent(builder, params);
                 builder.endObject();
             }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
@@ -64,23 +64,23 @@ public class NodesInfoResponse extends BaseNodesResponse<NodeInfo> implements To
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field("cluster_name", getClusterName().value(), XContentBuilder.FieldCaseConversion.NONE);
+        builder.field("cluster_name", getClusterName().value());
 
         builder.startObject("nodes");
         for (NodeInfo nodeInfo : this) {
-            builder.startObject(nodeInfo.getNode().getId(), XContentBuilder.FieldCaseConversion.NONE);
+            builder.startObject(nodeInfo.getNode().getId());
 
-            builder.field("name", nodeInfo.getNode().getName(), XContentBuilder.FieldCaseConversion.NONE);
+            builder.field("name", nodeInfo.getNode().getName());
             builder.field("transport_address", nodeInfo.getNode().getAddress().toString());
-            builder.field("host", nodeInfo.getNode().getHostName(), XContentBuilder.FieldCaseConversion.NONE);
-            builder.field("ip", nodeInfo.getNode().getHostAddress(), XContentBuilder.FieldCaseConversion.NONE);
+            builder.field("host", nodeInfo.getNode().getHostName());
+            builder.field("ip", nodeInfo.getNode().getHostAddress());
 
             builder.field("version", nodeInfo.getVersion());
             builder.field("build_hash", nodeInfo.getBuild().shortHash());
 
             if (nodeInfo.getServiceAttributes() != null) {
                 for (Map.Entry<String, String> nodeAttribute : nodeInfo.getServiceAttributes().entrySet()) {
-                    builder.field(nodeAttribute.getKey(), nodeAttribute.getValue(), XContentBuilder.FieldCaseConversion.NONE);
+                    builder.field(nodeAttribute.getKey(), nodeAttribute.getValue());
                 }
             }
 
@@ -93,7 +93,7 @@ public class NodesInfoResponse extends BaseNodesResponse<NodeInfo> implements To
             if (!nodeInfo.getNode().getAttributes().isEmpty()) {
                 builder.startObject("attributes");
                 for (Map.Entry<String, String> entry : nodeInfo.getNode().getAttributes().entrySet()) {
-                    builder.field(entry.getKey(), entry.getValue(), XContentBuilder.FieldCaseConversion.NONE);
+                    builder.field(entry.getKey(), entry.getValue());
                 }
                 builder.endObject();
             }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -299,10 +299,10 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         if (!params.param("node_info_format", "default").equals("none")) {
-            builder.field("name", getNode().getName(), XContentBuilder.FieldCaseConversion.NONE);
-            builder.field("transport_address", getNode().getAddress().toString(), XContentBuilder.FieldCaseConversion.NONE);
-            builder.field("host", getNode().getHostName(), XContentBuilder.FieldCaseConversion.NONE);
-            builder.field("ip", getNode().getAddress(), XContentBuilder.FieldCaseConversion.NONE);
+            builder.field("name", getNode().getName());
+            builder.field("transport_address", getNode().getAddress().toString());
+            builder.field("host", getNode().getHostName());
+            builder.field("ip", getNode().getAddress());
 
             builder.startArray("roles");
             for (DiscoveryNode.Role role : getNode().getRoles()) {
@@ -313,7 +313,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
             if (!getNode().getAttributes().isEmpty()) {
                 builder.startObject("attributes");
                 for (Map.Entry<String, String> attrEntry : getNode().getAttributes().entrySet()) {
-                    builder.field(attrEntry.getKey(), attrEntry.getValue(), XContentBuilder.FieldCaseConversion.NONE);
+                    builder.field(attrEntry.getKey(), attrEntry.getValue());
                 }
                 builder.endObject();
             }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
@@ -65,7 +65,7 @@ public class NodesStatsResponse extends BaseNodesResponse<NodeStats> implements 
 
         builder.startObject("nodes");
         for (NodeStats nodeStats : this) {
-            builder.startObject(nodeStats.getNode().getId(), XContentBuilder.FieldCaseConversion.NONE);
+            builder.startObject(nodeStats.getNode().getId());
             builder.field("timestamp", nodeStats.getTimestamp());
             nodeStats.toXContent(builder, params);
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
@@ -163,7 +163,7 @@ public class ListTasksResponse extends BaseTasksResponse implements ToXContent {
             builder.startObject("nodes");
             for (Map.Entry<DiscoveryNode, List<TaskInfo>> entry : getPerNodeTasks().entrySet()) {
                 DiscoveryNode node = entry.getKey();
-                builder.startObject(node.getId(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(node.getId());
                 builder.field("name", node.getName());
                 builder.field("transport_address", node.getAddress().toString());
                 builder.field("host", node.getHostName());
@@ -178,13 +178,13 @@ public class ListTasksResponse extends BaseTasksResponse implements ToXContent {
                 if (!node.getAttributes().isEmpty()) {
                     builder.startObject("attributes");
                     for (Map.Entry<String, String> attrEntry : node.getAttributes().entrySet()) {
-                        builder.field(attrEntry.getKey(), attrEntry.getValue(), XContentBuilder.FieldCaseConversion.NONE);
+                        builder.field(attrEntry.getKey(), attrEntry.getValue());
                     }
                     builder.endObject();
                 }
                 builder.startObject("tasks");
                 for(TaskInfo task : entry.getValue()) {
-                    builder.startObject(task.getTaskId().toString(), XContentBuilder.FieldCaseConversion.NONE);
+                    builder.startObject(task.getTaskId().toString());
                     task.toXContent(builder, params);
                     builder.endObject();
                 }
@@ -194,7 +194,7 @@ public class ListTasksResponse extends BaseTasksResponse implements ToXContent {
         } else if ("parents".equals(groupBy)) {
             builder.startObject("tasks");
             for (TaskGroup group : getTaskGroups()) {
-                builder.startObject(group.getTaskInfo().getTaskId().toString(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(group.getTaskInfo().getTaskId().toString());
                 group.toXContent(builder, params);
                 builder.endObject();
             }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/VerifyRepositoryResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/VerifyRepositoryResponse.java
@@ -86,8 +86,8 @@ public class VerifyRepositoryResponse extends ActionResponse implements ToXConte
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.NODES);
         for (DiscoveryNode node : nodes) {
-            builder.startObject(node.getId(), XContentBuilder.FieldCaseConversion.NONE);
-            builder.field(Fields.NAME, node.getName(), XContentBuilder.FieldCaseConversion.NONE);
+            builder.startObject(node.getId());
+            builder.field(Fields.NAME, node.getName());
             builder.endObject();
         }
         builder.endObject();

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexStatus.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexStatus.java
@@ -96,7 +96,7 @@ public class SnapshotIndexStatus implements Iterable<SnapshotIndexShardStatus>, 
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(getIndex(), XContentBuilder.FieldCaseConversion.NONE);
+        builder.startObject(getIndex());
         shardsStats.toXContent(builder, params);
         stats.toXContent(builder, params);
         builder.startObject(Fields.SHARDS);

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
@@ -74,10 +74,10 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         for (Map.Entry<String, Map<String, Map<String, FieldMappingMetaData>>> indexEntry : mappings.entrySet()) {
-            builder.startObject(indexEntry.getKey(), XContentBuilder.FieldCaseConversion.NONE);
+            builder.startObject(indexEntry.getKey());
             builder.startObject("mappings");
             for (Map.Entry<String, Map<String, FieldMappingMetaData>> typeEntry : indexEntry.getValue().entrySet()) {
-                builder.startObject(typeEntry.getKey(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(typeEntry.getKey());
                 for (Map.Entry<String, FieldMappingMetaData> fieldEntry : typeEntry.getValue().entrySet()) {
                     builder.startObject(fieldEntry.getKey());
                     fieldEntry.getValue().toXContent(builder, params);

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
@@ -102,7 +102,7 @@ public class IndicesSegmentResponse extends BroadcastResponse implements ToXCont
         builder.startObject(Fields.INDICES);
 
         for (IndexSegments indexSegments : getIndices().values()) {
-            builder.startObject(indexSegments.getIndex(), XContentBuilder.FieldCaseConversion.NONE);
+            builder.startObject(indexSegments.getIndex());
 
             builder.startObject(Fields.SHARDS);
             for (IndexShardSegments indexSegment : indexSegments) {
@@ -164,7 +164,7 @@ public class IndicesSegmentResponse extends BroadcastResponse implements ToXCont
         builder.endObject();
         return builder;
     }
-    
+
     static void toXContent(XContentBuilder builder, Accountable tree) throws IOException {
         builder.startObject();
         builder.field(Fields.DESCRIPTION, tree.toString());

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -176,7 +176,7 @@ public class IndicesStatsResponse extends BroadcastResponse implements ToXConten
         if ("indices".equalsIgnoreCase(level) || "shards".equalsIgnoreCase(level)) {
             builder.startObject(Fields.INDICES);
             for (IndexStats indexStats : getIndices().values()) {
-                builder.startObject(indexStats.getIndex(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(indexStats.getIndex());
 
                 builder.startObject("primaries");
                 indexStats.getPrimaries().toXContent(builder, params);

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/UpgradeStatusResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/UpgradeStatusResponse.java
@@ -126,7 +126,7 @@ public class UpgradeStatusResponse extends BroadcastResponse implements ToXConte
         if (outputIndices) {
             builder.startObject(Fields.INDICES);
             for (IndexUpgradeStatus indexUpgradeStatus : getIndices().values()) {
-                builder.startObject(indexUpgradeStatus.getIndex(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(indexUpgradeStatus.getIndex());
 
                 builder.byteSizeField(Fields.SIZE_IN_BYTES, Fields.SIZE, indexUpgradeStatus.getTotalBytes());
                 builder.byteSizeField(Fields.SIZE_TO_UPGRADE_IN_BYTES, Fields.SIZE_TO_UPGRADE, indexUpgradeStatus.getToUpgradeBytes());

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -427,7 +427,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
             builder.startObject("templates");
             for (ObjectCursor<IndexTemplateMetaData> cursor : metaData().templates().values()) {
                 IndexTemplateMetaData templateMetaData = cursor.value;
-                builder.startObject(templateMetaData.name(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(templateMetaData.name());
 
                 builder.field("template", templateMetaData.template());
                 builder.field("order", templateMetaData.order());
@@ -458,7 +458,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
 
             builder.startObject("indices");
             for (IndexMetaData indexMetaData : metaData()) {
-                builder.startObject(indexMetaData.getIndex().getName(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(indexMetaData.getIndex().getName());
 
                 builder.field("state", indexMetaData.getState().toString().toLowerCase(Locale.ENGLISH));
 
@@ -522,7 +522,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
             builder.startObject("routing_table");
             builder.startObject("indices");
             for (IndexRoutingTable indexRoutingTable : routingTable()) {
-                builder.startObject(indexRoutingTable.getIndex().getName(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(indexRoutingTable.getIndex().getName());
                 builder.startObject("shards");
                 for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
                     builder.startArray(Integer.toString(indexShardRoutingTable.shardId().id()));
@@ -549,7 +549,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
 
             builder.startObject("nodes");
             for (RoutingNode routingNode : getRoutingNodes()) {
-                builder.startArray(routingNode.nodeId() == null ? "null" : routingNode.nodeId(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startArray(routingNode.nodeId() == null ? "null" : routingNode.nodeId());
                 for (ShardRouting shardRouting : routingNode) {
                     shardRouting.toXContent(builder, params);
                 }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/AliasMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/AliasMetaData.java
@@ -281,7 +281,7 @@ public class AliasMetaData extends AbstractDiffable<AliasMetaData> {
         }
 
         public static void toXContent(AliasMetaData aliasMetaData, XContentBuilder builder, ToXContent.Params params) throws IOException {
-            builder.startObject(aliasMetaData.alias(), XContentBuilder.FieldCaseConversion.NONE);
+            builder.startObject(aliasMetaData.alias());
 
             boolean binary = params.paramAsBoolean("binary", false);
 

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -908,7 +908,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
         }
 
         public static void toXContent(IndexMetaData indexMetaData, XContentBuilder builder, ToXContent.Params params) throws IOException {
-            builder.startObject(indexMetaData.getIndex().getName(), XContentBuilder.FieldCaseConversion.NONE);
+            builder.startObject(indexMetaData.getIndex().getName());
 
             builder.field(KEY_VERSION, indexMetaData.getVersion());
             builder.field(KEY_STATE, indexMetaData.getState().toString().toLowerCase(Locale.ENGLISH));
@@ -936,7 +936,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
             builder.endArray();
 
             for (ObjectObjectCursor<String, Custom> cursor : indexMetaData.getCustoms()) {
-                builder.startObject(cursor.key, XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(cursor.key);
                 cursor.value.toXContent(builder, params);
                 builder.endObject();
             }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
@@ -316,7 +316,7 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
 
         @SuppressWarnings("unchecked")
         public static void toXContent(IndexTemplateMetaData indexTemplateMetaData, XContentBuilder builder, ToXContent.Params params) throws IOException {
-            builder.startObject(indexTemplateMetaData.name(), XContentBuilder.FieldCaseConversion.NONE);
+            builder.startObject(indexTemplateMetaData.name());
 
             builder.field("order", indexTemplateMetaData.order());
             builder.field("template", indexTemplateMetaData.template());
@@ -352,7 +352,7 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
             }
 
             for (ObjectObjectCursor<String, IndexMetaData.Custom> cursor : indexTemplateMetaData.customs()) {
-                builder.startObject(cursor.key, XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(cursor.key);
                 cursor.value.toXContent(builder, params);
                 builder.endObject();
             }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetaData.java
@@ -197,7 +197,7 @@ public class RepositoriesMetaData extends AbstractDiffable<Custom> implements Me
      * @param params     serialization parameters
      */
     public static void toXContent(RepositoryMetaData repository, XContentBuilder builder, ToXContent.Params params) throws IOException {
-        builder.startObject(repository.name(), XContentBuilder.FieldCaseConversion.NONE);
+        builder.startObject(repository.name());
         builder.field("type", repository.type());
         builder.startObject("settings");
         repository.settings().toXContent(builder, params);

--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -335,7 +335,7 @@ public class DiscoveryNode implements Writeable<DiscoveryNode>, ToXContent {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(getId(), XContentBuilder.FieldCaseConversion.NONE);
+        builder.startObject(getId());
         builder.field("name", getName());
         builder.field("transport_address", getAddress().toString());
 

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -751,7 +751,7 @@ public final class Settings implements ToXContent {
             }
         } else {
             for (Map.Entry<String, String> entry : settings.getAsMap().entrySet()) {
-                builder.field(entry.getKey(), entry.getValue(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.field(entry.getKey(), entry.getValue());
             }
         }
         return builder;

--- a/core/src/main/java/org/elasticsearch/common/unit/Fuzziness.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/Fuzziness.java
@@ -43,7 +43,7 @@ public final class Fuzziness implements ToXContent, Writeable<Fuzziness> {
     public static final Fuzziness ONE = new Fuzziness(1);
     public static final Fuzziness TWO = new Fuzziness(2);
     public static final Fuzziness AUTO = new Fuzziness("AUTO");
-    public static final ParseField FIELD = new ParseField(X_FIELD_NAME.camelCase().getValue());
+    public static final ParseField FIELD = new ParseField(X_FIELD_NAME.value());
 
     private final String fuzziness;
 

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentBuilderString.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentBuilderString.java
@@ -19,27 +19,18 @@
 
 package org.elasticsearch.common.xcontent;
 
-import org.elasticsearch.common.Strings;
-
 /**
- *
+ * TODO: remove this, it is just a wrapper that is no longer needed
  */
 public class XContentBuilderString {
 
-    private final XContentString underscore;
-
-    private final XContentString camelCase;
+    private final String value;
 
     public XContentBuilderString(String value) {
-        underscore = new XContentString(Strings.toUnderscoreCase(value));
-        camelCase = new XContentString(Strings.toCamelCase(value));
+        this.value = value;
     }
 
-    public XContentString underscore() {
-        return underscore;
-    }
-
-    public XContentString camelCase() {
-        return camelCase;
+    public String value() {
+        return value;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
@@ -54,7 +54,7 @@ public class FieldDataStats implements Streamable, ToXContent {
         this.memorySize += stats.memorySize;
         this.evictions += stats.evictions;
         if (stats.fields != null) {
-            if (fields == null) { 
+            if (fields == null) {
                 fields = stats.fields.clone();
             } else {
                 assert !stats.fields.containsKey(null);
@@ -138,7 +138,7 @@ public class FieldDataStats implements Streamable, ToXContent {
             final long[] values = fields.values;
             for (int i = 0; i < keys.length; i++) {
                 if (keys[i] != null) {
-                    builder.startObject((String) keys[i], XContentBuilder.FieldCaseConversion.NONE);
+                    builder.startObject((String) keys[i]);
                     builder.byteSizeField(Fields.MEMORY_SIZE_IN_BYTES, Fields.MEMORY_SIZE, values[i]);
                     builder.endObject();
                 }

--- a/core/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
+++ b/core/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
@@ -309,7 +309,7 @@ public class SearchStats implements Streamable, ToXContent {
         if (groupStats != null && !groupStats.isEmpty()) {
             builder.startObject(Fields.GROUPS);
             for (Map.Entry<String, Stats> entry : groupStats.entrySet()) {
-                builder.startObject(entry.getKey(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(entry.getKey());
                 entry.getValue().toXContent(builder, params);
                 builder.endObject();
             }

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexingStats.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexingStats.java
@@ -258,7 +258,7 @@ public class IndexingStats implements Streamable, ToXContent {
         if (typeStats != null && !typeStats.isEmpty()) {
             builder.startObject(Fields.TYPES);
             for (Map.Entry<String, Stats> entry : typeStats.entrySet()) {
-                builder.startObject(entry.getKey(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(entry.getKey());
                 entry.getValue().toXContent(builder, params);
                 builder.endObject();
             }

--- a/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
@@ -221,7 +221,7 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
         // Then we list all snapshots with list of all blobs that are used by the snapshot
         builder.startObject(Fields.SNAPSHOTS);
         for (SnapshotFiles snapshot : shardSnapshots) {
-            builder.startObject(snapshot.snapshot(), XContentBuilder.FieldCaseConversion.NONE);
+            builder.startObject(snapshot.snapshot());
             builder.startArray(Fields.FILES);
             for (FileInfo fileInfo : snapshot.indexFiles()) {
                 builder.value(fileInfo.name());

--- a/core/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
+++ b/core/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
@@ -166,13 +166,13 @@ public class FsInfo implements Iterable<FsInfo.Path>, Streamable, ToXContent {
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             if (path != null) {
-                builder.field(Fields.PATH, path, XContentBuilder.FieldCaseConversion.NONE);
+                builder.field(Fields.PATH, path);
             }
             if (mount != null) {
-                builder.field(Fields.MOUNT, mount, XContentBuilder.FieldCaseConversion.NONE);
+                builder.field(Fields.MOUNT, mount);
             }
             if (type != null) {
-                builder.field(Fields.TYPE, type, XContentBuilder.FieldCaseConversion.NONE);
+                builder.field(Fields.TYPE, type);
             }
 
             if (total != -1) {

--- a/core/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/core/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -195,7 +195,7 @@ public class JvmStats implements Streamable, ToXContent {
 
             builder.startObject(Fields.POOLS);
             for (MemoryPool pool : mem) {
-                builder.startObject(pool.getName(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(pool.getName());
                 builder.byteSizeField(Fields.USED_IN_BYTES, Fields.USED, pool.used);
                 builder.byteSizeField(Fields.MAX_IN_BYTES, Fields.MAX, pool.max);
 
@@ -219,7 +219,7 @@ public class JvmStats implements Streamable, ToXContent {
 
             builder.startObject(Fields.COLLECTORS);
             for (GarbageCollector collector : gc) {
-                builder.startObject(collector.getName(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(collector.getName());
                 builder.field(Fields.COLLECTION_COUNT, collector.getCollectionCount());
                 builder.timeValueField(Fields.COLLECTION_TIME_IN_MILLIS, Fields.COLLECTION_TIME, collector.collectionTime);
                 builder.endObject();
@@ -232,7 +232,7 @@ public class JvmStats implements Streamable, ToXContent {
         if (bufferPools != null) {
             builder.startObject(Fields.BUFFER_POOLS);
             for (BufferPool bufferPool : bufferPools) {
-                builder.startObject(bufferPool.getName(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(bufferPool.getName());
                 builder.field(Fields.COUNT, bufferPool.getCount());
                 builder.byteSizeField(Fields.USED_IN_BYTES, Fields.USED, bufferPool.used);
                 builder.byteSizeField(Fields.TOTAL_CAPACITY_IN_BYTES, Fields.TOTAL_CAPACITY, bufferPool.totalCapacity);

--- a/core/src/main/java/org/elasticsearch/rest/AbstractRestChannel.java
+++ b/core/src/main/java/org/elasticsearch/rest/AbstractRestChannel.java
@@ -71,15 +71,6 @@ public abstract class AbstractRestChannel implements RestChannel {
         }
 
         builder.humanReadable(request.paramAsBoolean("human", builder.humanReadable()));
-
-        String casing = request.param("case");
-        if (casing != null && "camelCase".equals(casing)) {
-            builder.fieldCaseConversion(XContentBuilder.FieldCaseConversion.CAMELCASE);
-        } else {
-            // we expect all REST interfaces to write results in underscore casing, so
-            // no need for double casing
-            builder.fieldCaseConversion(XContentBuilder.FieldCaseConversion.NONE);
-        }
         return builder;
     }
 

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetAliasesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetAliasesAction.java
@@ -83,7 +83,7 @@ public class RestGetAliasesAction extends BaseRestHandler {
 
                 builder.startObject();
                 for (ObjectObjectCursor<String, List<AliasMetaData>> entry : response.getAliases()) {
-                    builder.startObject(entry.key, XContentBuilder.FieldCaseConversion.NONE);
+                    builder.startObject(entry.key);
                     builder.startObject(Fields.ALIASES);
                     for (AliasMetaData alias : entry.value) {
                         AliasMetaData.Builder.toXContent(alias, builder, ToXContent.EMPTY_PARAMS);

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetMappingAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetMappingAction.java
@@ -88,7 +88,7 @@ public class RestGetMappingAction extends BaseRestHandler {
                     if (indexEntry.value.isEmpty()) {
                         continue;
                     }
-                    builder.startObject(indexEntry.key, XContentBuilder.FieldCaseConversion.NONE);
+                    builder.startObject(indexEntry.key);
                     builder.startObject(Fields.MAPPINGS);
                     for (ObjectObjectCursor<String, MappingMetaData> typeEntry : indexEntry.value) {
                         builder.field(typeEntry.key);

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
@@ -77,7 +77,7 @@ public class RestGetSettingsAction extends BaseRestHandler {
                     if (cursor.value.getAsMap().isEmpty()) {
                         continue;
                     }
-                    builder.startObject(cursor.key, XContentBuilder.FieldCaseConversion.NONE);
+                    builder.startObject(cursor.key);
                     builder.startObject("settings");
                     cursor.value.toXContent(builder, request);
                     builder.endObject();

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/upgrade/RestUpgradeAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/upgrade/RestUpgradeAction.java
@@ -89,7 +89,7 @@ public class RestUpgradeAction extends BaseRestHandler {
                 buildBroadcastShardsHeader(builder, request, response);
                 builder.startObject("upgraded_indices");
                 for (Map.Entry<String, Tuple<Version, String>> entry : response.versions().entrySet()) {
-                    builder.startObject(entry.getKey(), XContentBuilder.FieldCaseConversion.NONE);
+                    builder.startObject(entry.getKey());
                     builder.field("upgrade_version", entry.getValue().v1());
                     builder.field("oldest_lucene_segment_version", entry.getValue().v2());
                     builder.endObject();

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
@@ -102,7 +102,7 @@ public class RestValidateQueryAction extends BaseRestHandler {
                     for (QueryExplanation explanation : response.getQueryExplanation()) {
                         builder.startObject();
                         if (explanation.getIndex() != null) {
-                            builder.field(INDEX_FIELD, explanation.getIndex(), XContentBuilder.FieldCaseConversion.NONE);
+                            builder.field(INDEX_FIELD, explanation.getIndex());
                         }
                         builder.field(VALID_FIELD, explanation.isValid());
                         if (explanation.getError() != null) {

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionStats.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionStats.java
@@ -80,7 +80,7 @@ public class CompletionStats implements Streamable, ToXContent {
         } else {
             out.writeBoolean(true);
             out.writeVInt(fields.size());
-            
+
             assert !fields.containsKey(null);
             final Object[] keys = fields.keys;
             final long[] values = fields.values;
@@ -105,7 +105,7 @@ public class CompletionStats implements Streamable, ToXContent {
             final long[] values = fields.values;
             for (int i = 0; i < keys.length; i++) {
                 if (keys[i] != null) {
-                    builder.startObject((String) keys[i], XContentBuilder.FieldCaseConversion.NONE);
+                    builder.startObject((String) keys[i]);
                     builder.byteSizeField(Fields.SIZE_IN_BYTES, Fields.SIZE, values[i]);
                     builder.endObject();
                 }
@@ -137,7 +137,7 @@ public class CompletionStats implements Streamable, ToXContent {
         sizeInBytes += completion.getSizeInBytes();
 
         if (completion.fields != null) {
-            if (fields == null) { 
+            if (fields == null) {
                 fields = completion.fields.clone();
             } else {
                 assert !completion.fields.containsKey(null);

--- a/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -889,7 +889,7 @@ public class ThreadPool extends AbstractComponent implements Closeable {
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.startObject(name, XContentBuilder.FieldCaseConversion.NONE);
+            builder.startObject(name);
             builder.field(Fields.TYPE, type.getType());
             if (min != -1) {
                 builder.field(Fields.MIN, min);

--- a/core/src/main/java/org/elasticsearch/threadpool/ThreadPoolStats.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ThreadPoolStats.java
@@ -112,7 +112,7 @@ public class ThreadPoolStats implements Streamable, ToXContent, Iterable<ThreadP
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.startObject(name, XContentBuilder.FieldCaseConversion.NONE);
+            builder.startObject(name);
             if (threads != -1) {
                 builder.field(Fields.THREADS, threads);
             }

--- a/core/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
@@ -47,8 +47,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
-import static org.elasticsearch.common.xcontent.XContentBuilder.FieldCaseConversion.CAMELCASE;
-import static org.elasticsearch.common.xcontent.XContentBuilder.FieldCaseConversion.UNDERSCORE;
 import static org.hamcrest.Matchers.equalTo;
 
 public class XContentBuilderTests extends ESTestCase {
@@ -167,16 +165,6 @@ public class XContentBuilderTests extends ESTestCase {
         byte[] data = bos.bytes().toBytes();
         String sData = new String(data, "UTF8");
         assertThat(sData, equalTo("{\"name\":\"something\", source : { test : \"value\" },\"name2\":\"something2\"}"));
-    }
-
-    public void testFieldCaseConversion() throws Exception {
-        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON).fieldCaseConversion(CAMELCASE);
-        builder.startObject().field("test_name", "value").endObject();
-        assertThat(builder.string(), equalTo("{\"testName\":\"value\"}"));
-
-        builder = XContentFactory.contentBuilder(XContentType.JSON).fieldCaseConversion(UNDERSCORE);
-        builder.startObject().field("testName", "value").endObject();
-        assertThat(builder.string(), equalTo("{\"test_name\":\"value\"}"));
     }
 
     public void testByteConversion() throws Exception {


### PR DESCRIPTION
The current api allows for choosing which "case" response json keys are
written in. This has the options of camelCase or underscore. camelCase
is going to be deprecated from the query apis. However, with the case
api, it is not necessary to deprecate, as users who were using it in 2.x
can transition completely on 2.x before upgrading by simply using
the underscore option.

This change removes the 'case' option from rest apis.

see #8988
