### PR TITLE
Deprecate camelCase usages

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/ParseField.java
+++ b/core/src/main/java/org/elasticsearch/common/ParseField.java
@@ -30,24 +30,19 @@ public class ParseField {
 
     private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(ParseField.class));
 
-    private final String camelCaseName;
     private final String underscoreName;
     private final String[] deprecatedNames;
     private String allReplacedWith = null;
 
     public ParseField(String value, String... deprecatedNames) {
-        camelCaseName = Strings.toCamelCase(value);
         underscoreName = Strings.toUnderscoreCase(value);
-        if (deprecatedNames == null || deprecatedNames.length == 0) {
-            this.deprecatedNames = Strings.EMPTY_ARRAY;
-        } else {
-            final HashSet<String> set = new HashSet<>();
-            for (String depName : deprecatedNames) {
-                set.add(Strings.toCamelCase(depName));
-                set.add(Strings.toUnderscoreCase(depName));
-            }
-            this.deprecatedNames = set.toArray(new String[set.size()]);
+        final HashSet<String> set = new HashSet<>();
+        set.add(Strings.toCamelCase(value));
+        for (String depName : deprecatedNames) {
+            set.add(Strings.toCamelCase(depName));
+            set.add(Strings.toUnderscoreCase(depName));
         }
+        this.deprecatedNames = set.toArray(new String[set.size()]);
     }
 
     public String getPreferredName(){
@@ -55,11 +50,10 @@ public class ParseField {
     }
 
     public String[] getAllNamesIncludedDeprecated() {
-        String[] allNames = new String[2 + deprecatedNames.length];
-        allNames[0] = camelCaseName;
-        allNames[1] = underscoreName;
+        String[] allNames = new String[1 + deprecatedNames.length];
+        allNames[0] = underscoreName;
         for (int i = 0; i < deprecatedNames.length; i++) {
-            allNames[i + 2] = deprecatedNames[i];
+            allNames[i + 1] = deprecatedNames[i];
         }
         return allNames;
     }
@@ -78,7 +72,7 @@ public class ParseField {
     }
 
     boolean match(String currentFieldName, boolean strict) {
-        if (allReplacedWith == null && (currentFieldName.equals(camelCaseName) || currentFieldName.equals(underscoreName))) {
+        if (allReplacedWith == null && currentFieldName.equals(underscoreName)) {
             return true;
         }
         String msg;

--- a/core/src/main/java/org/elasticsearch/common/ParseField.java
+++ b/core/src/main/java/org/elasticsearch/common/ParseField.java
@@ -37,7 +37,10 @@ public class ParseField {
     public ParseField(String value, String... deprecatedNames) {
         underscoreName = Strings.toUnderscoreCase(value);
         final HashSet<String> set = new HashSet<>();
-        set.add(Strings.toCamelCase(value));
+        String camelCaseName = Strings.toCamelCase(value);
+        if (camelCaseName.equals(value) == false) {
+            set.add(camelCaseName);
+        }
         for (String depName : deprecatedNames) {
             set.add(Strings.toCamelCase(depName));
             set.add(Strings.toUnderscoreCase(depName));

--- a/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
@@ -42,7 +42,7 @@ public class ConstantScoreQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
@@ -42,7 +42,7 @@ public class DisMaxQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
@@ -43,7 +43,7 @@ public class FieldMaskingSpanQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
@@ -52,7 +52,7 @@ public class GeoShapeQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
@@ -177,7 +177,7 @@ public class GeohashCellQuery {
 
         @Override
         public String[] names() {
-            return new String[]{NAME, Strings.toCamelCase(NAME)};
+            return new String[]{NAME};
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
@@ -67,7 +67,7 @@ public class HasChildQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[] { NAME, Strings.toCamelCase(NAME) };
+        return new String[] { NAME };
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
@@ -59,7 +59,7 @@ public class HasParentQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
@@ -41,7 +41,7 @@ public class MatchAllQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
@@ -50,7 +50,7 @@ public class NestedQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -62,7 +62,7 @@ public class QueryStringQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -78,7 +78,7 @@ public class SimpleQueryStringParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryParser.java
@@ -41,7 +41,7 @@ public class SpanContainingQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override
@@ -81,8 +81,8 @@ public class SpanContainingQueryParser implements QueryParser {
             } else {
                 throw new QueryParsingException(parseContext, "[span_containing] query does not support [" + currentFieldName + "]");
             }
-        }        
-        
+        }
+
         if (big == null) {
             throw new QueryParsingException(parseContext, "span_containing must include [big]");
         }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
@@ -41,7 +41,7 @@ public class SpanFirstQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
@@ -42,7 +42,7 @@ public class SpanMultiTermQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
@@ -43,7 +43,7 @@ public class SpanNearQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
@@ -41,7 +41,7 @@ public class SpanNotQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
@@ -43,7 +43,7 @@ public class SpanOrQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
@@ -43,7 +43,7 @@ public class SpanTermQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryParser.java
@@ -41,7 +41,7 @@ public class SpanWithinQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NAME};
     }
 
     @Override
@@ -81,8 +81,8 @@ public class SpanWithinQueryParser implements QueryParser {
             } else {
                 throw new QueryParsingException(parseContext, "[span_within] query does not support [" + currentFieldName + "]");
             }
-        }        
-        
+        }
+
         if (big == null) {
             throw new QueryParsingException(parseContext, "span_within must include [big]");
         }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
@@ -69,7 +69,7 @@ public class FunctionScoreQueryParser implements QueryParser {
 
     @Override
     public String[] names() {
-        return new String[] { NAME, Strings.toCamelCase(NAME) };
+        return new String[] { NAME };
     }
 
     private static final ImmutableMap<String, CombineFunction> combineFunctionsMap;

--- a/core/src/main/java/org/elasticsearch/rest/AbstractRestChannel.java
+++ b/core/src/main/java/org/elasticsearch/rest/AbstractRestChannel.java
@@ -21,6 +21,8 @@ package org.elasticsearch.rest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -28,6 +30,8 @@ import org.elasticsearch.common.xcontent.XContentType;
 import java.io.IOException;
 
 public abstract class AbstractRestChannel implements RestChannel {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(AbstractRestChannel.class));
 
     protected final RestRequest request;
     protected final boolean detailedErrorsEnabled;
@@ -70,6 +74,10 @@ public abstract class AbstractRestChannel implements RestChannel {
         builder.humanReadable(request.paramAsBoolean("human", builder.humanReadable()));
 
         String casing = request.param("case");
+        if (casing != null) {
+            String msg = "Parameter 'case' has been deprecated, all responses will use underscore casing in the future";
+            DEPRECATION_LOGGER.deprecated(msg);
+        }
         if (casing != null && "camelCase".equals(casing)) {
             builder.fieldCaseConversion(XContentBuilder.FieldCaseConversion.CAMELCASE);
         } else {

--- a/core/src/test/java/org/elasticsearch/common/ParseFieldTests.java
+++ b/core/src/test/java/org/elasticsearch/common/ParseFieldTests.java
@@ -27,28 +27,31 @@ public class ParseFieldTests extends ESTestCase {
 
     @Test
     public void testParse() {
-        String[] values = new String[]{"foo_bar", "fooBar"};
-        ParseField field = new ParseField(randomFrom(values));
+        String name = "foo_bar";
+        String camelCase = "fooBar";
+        ParseField field = new ParseField(name);
         String[] deprecated = new String[]{"barFoo", "bar_foo"};
         ParseField withDeprecations = field.withDeprecation("Foobar", randomFrom(deprecated));
         assertThat(field, not(sameInstance(withDeprecations)));
-        assertThat(field.match(randomFrom(values), false), is(true));
+        assertThat(field.match(name, false), is(true));
+        assertThat(field.match(camelCase, false), is(true));
         assertThat(field.match("foo bar", false), is(false));
         assertThat(field.match(randomFrom(deprecated), false), is(false));
         assertThat(field.match("barFoo", false), is(false));
 
-        assertThat(withDeprecations.match(randomFrom(values), false), is(true));
+        assertThat(withDeprecations.match(name, false), is(true));
+        assertThat(withDeprecations.match(camelCase, false), is(true));
         assertThat(withDeprecations.match("foo bar", false), is(false));
         assertThat(withDeprecations.match(randomFrom(deprecated), false), is(true));
         assertThat(withDeprecations.match("barFoo", false), is(true));
 
         // now with strict mode
-        assertThat(field.match(randomFrom(values), true), is(true));
+        assertThat(field.match(name, true), is(true));
         assertThat(field.match("foo bar", true), is(false));
         assertThat(field.match(randomFrom(deprecated), true), is(false));
         assertThat(field.match("barFoo", true), is(false));
 
-        assertThat(withDeprecations.match(randomFrom(values), true), is(true));
+        assertThat(withDeprecations.match(name, true), is(true));
         assertThat(withDeprecations.match("foo bar", true), is(false));
         try {
             withDeprecations.match(randomFrom(deprecated), true);
@@ -59,6 +62,13 @@ public class ParseFieldTests extends ESTestCase {
 
         try {
             withDeprecations.match("barFoo", true);
+            fail();
+        } catch (IllegalArgumentException ex) {
+
+        }
+
+        try {
+            withDeprecations.match(camelCase, true);
             fail();
         } catch (IllegalArgumentException ex) {
 

--- a/core/src/test/java/org/elasticsearch/script/ScriptParameterParserTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptParameterParserTests.java
@@ -79,7 +79,7 @@ public class ScriptParameterParserTests extends ESTestCase {
             token = parser.nextToken();
         }
         paramParser = new ScriptParameterParser();
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.EMPTY), equalTo(true));
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.FILE);
         assertThat(paramParser.lang(), nullValue());
     }
@@ -102,7 +102,7 @@ public class ScriptParameterParserTests extends ESTestCase {
             token = parser.nextToken();
         }
         paramParser = new ScriptParameterParser();
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.EMPTY), equalTo(true));
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INDEXED);
         assertThat(paramParser.lang(), nullValue());
     }
@@ -547,7 +547,7 @@ public class ScriptParameterParserTests extends ESTestCase {
         config = new HashMap<>();
         config.put("scriptFile", "scriptValue");
         paramParser = new ScriptParameterParser();
-        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.EMPTY);
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.FILE);
         assertThat(paramParser.lang(), nullValue());
         assertThat(config.isEmpty(), equalTo(true));
@@ -566,7 +566,7 @@ public class ScriptParameterParserTests extends ESTestCase {
         config = new HashMap<>();
         config.put("scriptId", "scriptValue");
         paramParser = new ScriptParameterParser();
-        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.EMPTY);
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INDEXED);
         assertThat(paramParser.lang(), nullValue());
         assertThat(config.isEmpty(), equalTo(true));
@@ -586,7 +586,7 @@ public class ScriptParameterParserTests extends ESTestCase {
         config = new HashMap<>();
         config.put("scriptId", "scriptValue");
         paramParser = new ScriptParameterParser();
-        paramParser.parseConfig(config, false, ParseFieldMatcher.STRICT);
+        paramParser.parseConfig(config, false, ParseFieldMatcher.EMPTY);
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INDEXED);
         assertThat(paramParser.lang(), nullValue());
         assertThat(config.size(), equalTo(1));
@@ -950,7 +950,7 @@ public class ScriptParameterParserTests extends ESTestCase {
         paramParser.parseParams(params);
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INLINE);
         assertThat(paramParser.lang(), nullValue());
-        
+
         paramParser = new ScriptParameterParser(null);
         paramParser.parseParams(params);
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INLINE);


### PR DESCRIPTION
There are a few places where parameters and output are duplicated in camelCase. This change adds deprecation logging for those cases, so that support for providing magical camelCase can be removed in 5.0.

see #8988
