### PR TITLE
Send HTTP Warning Header(s) for any Deprecation Usage from a REST request

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -53,6 +53,7 @@ import java.nio.file.FileSystemLoopException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.NotDirectoryException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -412,6 +413,21 @@ public abstract class StreamInput extends InputStream {
     @SuppressWarnings("unchecked")
     public Map<String, Object> readMap() throws IOException {
         return (Map<String, Object>) readGenericValue();
+    }
+
+    /**
+     * Read a map of strings to string lists.
+     */
+    public Map<String, List<String>> readMapOfLists() throws IOException {
+        int size = readVInt();
+        if (size == 0) {
+            return Collections.emptyMap();
+        }
+        Map<String, List<String>> map = new HashMap<>(size);
+        for (int i = 0; i < size; ++i) {
+            map.put(readString(), readList(StreamInput::readString));
+        }
+        return map;
     }
 
     @SuppressWarnings({"unchecked"})

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -403,6 +403,21 @@ public abstract class StreamOutput extends OutputStream {
         writeGenericValue(map);
     }
 
+    /**
+     * Writes a map of strings to string lists.
+     */
+    public void writeMapOfLists(Map<String, List<String>> map) throws IOException {
+        writeVInt(map.size());
+
+        for (Map.Entry<String, List<String>> entry : map.entrySet()) {
+            writeString(entry.getKey());
+            writeVInt(entry.getValue().size());
+            for (String v : entry.getValue()) {
+                writeString(v);
+            }
+        }
+    }
+
     @FunctionalInterface
     interface Writer {
         void write(StreamOutput o, Object value) throws IOException;

--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
@@ -28,8 +28,10 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -64,8 +66,8 @@ public final class ThreadContext implements Closeable, Writeable {
 
     public static final String PREFIX = "request.headers";
     public static final Setting<Settings> DEFAULT_HEADERS_SETTING = Setting.groupSetting(PREFIX + ".", Property.NodeScope);
+    private static final ThreadContextStruct DEFAULT_CONTEXT = new ThreadContextStruct();
     private final Map<String, String> defaultHeader;
-    private static final ThreadContextStruct DEFAULT_CONTEXT = new ThreadContextStruct(Collections.emptyMap());
     private final ContextThreadLocal threadLocal;
 
     /**
@@ -110,7 +112,7 @@ public final class ThreadContext implements Closeable, Writeable {
     public StoredContext stashAndMergeHeaders(Map<String, String> headers) {
         final ThreadContextStruct context = threadLocal.get();
         Map<String, String> newHeader = new HashMap<>(headers);
-        newHeader.putAll(context.headers);
+        newHeader.putAll(context.requestHeaders);
         threadLocal.set(DEFAULT_CONTEXT.putHeaders(newHeader));
         return () -> {
             threadLocal.set(context);
@@ -143,7 +145,7 @@ public final class ThreadContext implements Closeable, Writeable {
      * Returns the header for the given key or <code>null</code> if not present
      */
     public String getHeader(String key) {
-        String value = threadLocal.get().headers.get(key);
+        String value = threadLocal.get().requestHeaders.get(key);
         if (value == null)  {
             return defaultHeader.get(key);
         }
@@ -151,11 +153,27 @@ public final class ThreadContext implements Closeable, Writeable {
     }
 
     /**
-     * Returns all of the current contexts headers
+     * Returns all of the request contexts headers
      */
     public Map<String, String> getHeaders() {
         HashMap<String, String> map = new HashMap<>(defaultHeader);
-        map.putAll(threadLocal.get().headers);
+        map.putAll(threadLocal.get().requestHeaders);
+        return Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * Get a copy of all <em>response</em> headers.
+     *
+     * @return Never {@code null}.
+     */
+    public Map<String, List<String>> getResponseHeaders() {
+        Map<String, List<String>> responseHeaders = threadLocal.get().responseHeaders;
+        HashMap<String, List<String>> map = new HashMap<>(responseHeaders.size());
+
+        for (Map.Entry<String, List<String>> entry : responseHeaders.entrySet()) {
+            map.put(entry.getKey(), Collections.unmodifiableList(entry.getValue()));
+        }
+
         return Collections.unmodifiableMap(map);
     }
 
@@ -170,7 +188,7 @@ public final class ThreadContext implements Closeable, Writeable {
      * Puts a header into the context
      */
     public void putHeader(String key, String value) {
-        threadLocal.set(threadLocal.get().putPersistent(key, value));
+        threadLocal.set(threadLocal.get().putRequest(key, value));
     }
 
     /**
@@ -190,8 +208,18 @@ public final class ThreadContext implements Closeable, Writeable {
     /**
      * Returns a transient header object or <code>null</code> if there is no header for the given key
      */
+    @SuppressWarnings("unchecked") // (T)object
     public <T> T getTransient(String key) {
         return (T) threadLocal.get().transientHeaders.get(key);
+    }
+
+    /**
+     * Add the <em>unique</em> response {@code value} for the specified {@code key}.
+     * <p>
+     * Any duplicate {@code value} is ignored.
+     */
+    public void addResponseHeader(String key, String value) {
+        threadLocal.set(threadLocal.get().putResponse(key, value));
     }
 
     /**
@@ -234,32 +262,41 @@ public final class ThreadContext implements Closeable, Writeable {
     }
 
     static final class ThreadContextStruct {
-        private final Map<String,String> headers;
+        private final Map<String, String> requestHeaders;
         private final Map<String, Object> transientHeaders;
+        private final Map<String, List<String>> responseHeaders;
 
         private ThreadContextStruct(StreamInput in) throws IOException {
-            int numValues = in.readVInt();
-            Map<String, String> headers = numValues == 0 ? Collections.emptyMap() : new HashMap<>(numValues);
-            for (int i = 0; i < numValues; i++) {
-                headers.put(in.readString(), in.readString());
+            final int numRequest = in.readVInt();
+            Map<String, String> requestHeaders = numRequest == 0 ? Collections.emptyMap() : new HashMap<>(numRequest);
+            for (int i = 0; i < numRequest; i++) {
+                requestHeaders.put(in.readString(), in.readString());
             }
-            this.headers = headers;
+
+            this.requestHeaders = requestHeaders;
+            this.responseHeaders = in.readMapOfLists();
             this.transientHeaders = Collections.emptyMap();
         }
 
-        private ThreadContextStruct(Map<String, String> headers, Map<String, Object> transientHeaders) {
-            this.headers = headers;
+        private ThreadContextStruct(Map<String, String> requestHeaders,
+                                    Map<String, List<String>> responseHeaders,
+                                    Map<String, Object> transientHeaders) {
+            this.requestHeaders = requestHeaders;
+            this.responseHeaders = responseHeaders;
             this.transientHeaders = transientHeaders;
         }
 
-        private ThreadContextStruct(Map<String, String> headers) {
-            this(headers, Collections.emptyMap());
+        /**
+         * This represents the default context and it should only ever be called by {@link #DEFAULT_CONTEXT}.
+         */
+        private ThreadContextStruct() {
+            this(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
         }
 
-        private ThreadContextStruct putPersistent(String key, String value) {
-            Map<String, String> newHeaders = new HashMap<>(this.headers);
-            putSingleHeader(key, value, newHeaders);
-            return new ThreadContextStruct(newHeaders, transientHeaders);
+        private ThreadContextStruct putRequest(String key, String value) {
+            Map<String, String> newRequestHeaders = new HashMap<>(this.requestHeaders);
+            putSingleHeader(key, value, newRequestHeaders);
+            return new ThreadContextStruct(newRequestHeaders, responseHeaders, transientHeaders);
         }
 
         private void putSingleHeader(String key, String value, Map<String, String> newHeaders) {
@@ -276,9 +313,31 @@ public final class ThreadContext implements Closeable, Writeable {
                 for (Map.Entry<String, String> entry : headers.entrySet()) {
                     putSingleHeader(entry.getKey(), entry.getValue(), newHeaders);
                 }
-                newHeaders.putAll(this.headers);
-                return new ThreadContextStruct(newHeaders, transientHeaders);
+                newHeaders.putAll(this.requestHeaders);
+                return new ThreadContextStruct(newHeaders, responseHeaders, transientHeaders);
             }
+        }
+
+        private ThreadContextStruct putResponse(String key, String value) {
+            assert value != null;
+
+            final Map<String, List<String>> newResponseHeaders = new HashMap<>(this.responseHeaders);
+            final List<String> existingValues = newResponseHeaders.get(key);
+
+            if (existingValues != null) {
+                if (existingValues.contains(value)) {
+                    return this;
+                }
+
+                final List<String> newValues = new ArrayList<>(existingValues);
+                newValues.add(value);
+
+                newResponseHeaders.put(key, Collections.unmodifiableList(newValues));
+            } else {
+                newResponseHeaders.put(key, Collections.singletonList(value));
+            }
+
+            return new ThreadContextStruct(requestHeaders, newResponseHeaders, transientHeaders);
         }
 
         private ThreadContextStruct putTransient(String key, Object value) {
@@ -286,13 +345,12 @@ public final class ThreadContext implements Closeable, Writeable {
             if (newTransient.putIfAbsent(key, value) != null) {
                 throw new IllegalArgumentException("value for key [" + key + "] already present");
             }
-            return new ThreadContextStruct(headers, newTransient);
+            return new ThreadContextStruct(requestHeaders, responseHeaders, newTransient);
         }
 
         boolean isEmpty() {
-            return headers.isEmpty() && transientHeaders.isEmpty();
+            return requestHeaders.isEmpty() && responseHeaders.isEmpty() && transientHeaders.isEmpty();
         }
-
 
         private ThreadContextStruct copyHeaders(Iterable<Map.Entry<String, String>> headers) {
             Map<String, String> newHeaders = new HashMap<>();
@@ -303,20 +361,21 @@ public final class ThreadContext implements Closeable, Writeable {
         }
 
         private void writeTo(StreamOutput out, Map<String, String> defaultHeaders) throws IOException {
-            final Map<String, String> headers;
+            final Map<String, String> requestHeaders;
             if (defaultHeaders.isEmpty()) {
-                headers = this.headers;
+                requestHeaders = this.requestHeaders;
             } else {
-                headers = new HashMap<>(defaultHeaders);
-                headers.putAll(this.headers);
+                requestHeaders = new HashMap<>(defaultHeaders);
+                requestHeaders.putAll(this.requestHeaders);
             }
 
-            int keys = headers.size();
-            out.writeVInt(keys);
-            for (Map.Entry<String, String> entry : headers.entrySet()) {
+            out.writeVInt(requestHeaders.size());
+            for (Map.Entry<String, String> entry : requestHeaders.entrySet()) {
                 out.writeString(entry.getKey());
                 out.writeString(entry.getValue());
             }
+
+            out.writeMapOfLists(responseHeaders);
         }
 
     }

--- a/core/src/main/java/org/elasticsearch/http/netty/HttpRequestHandler.java
+++ b/core/src/main/java/org/elasticsearch/http/netty/HttpRequestHandler.java
@@ -61,7 +61,7 @@ public class HttpRequestHandler extends SimpleChannelUpstreamHandler {
         // the netty HTTP handling always copy over the buffer to its own buffer, either in NioWorker internally
         // when reading, or using a cumalation buffer
         NettyHttpRequest httpRequest = new NettyHttpRequest(request, e.getChannel());
-        NettyHttpChannel channel = new NettyHttpChannel(serverTransport, httpRequest, oue, detailedErrorsEnabled);
+        NettyHttpChannel channel = new NettyHttpChannel(serverTransport, httpRequest, oue, detailedErrorsEnabled, threadContext);
         serverTransport.dispatchRequest(httpRequest, channel);
         super.messageReceived(ctx, e);
     }

--- a/core/src/main/java/org/elasticsearch/rest/DeprecationRestHandler.java
+++ b/core/src/main/java/org/elasticsearch/rest/DeprecationRestHandler.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.rest;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.DeprecationLogger;
+
+import java.util.Objects;
+
+/**
+ * {@code DeprecationRestHandler} provides a proxy for any existing {@link RestHandler} so that usage of the handler can be
+ * logged using the {@link DeprecationLogger}.
+ */
+public class DeprecationRestHandler implements RestHandler {
+
+    private final RestHandler handler;
+    private final String deprecationMessage;
+    private final DeprecationLogger deprecationLogger;
+
+    /**
+     * Create a {@link DeprecationRestHandler} that encapsulates the {@code handler} using the {@code deprecationLogger} to log
+     * deprecation {@code warning}.
+     *
+     * @param handler The rest handler to deprecate (it's possible that the handler is reused with a different name!)
+     * @param deprecationMessage The message to warn users with when they use the {@code handler}
+     * @param deprecationLogger The deprecation logger
+     * @throws NullPointerException if any parameter except {@code deprecationMessage} is {@code null}
+     * @throws IllegalArgumentException if {@code deprecationMessage} is not a valid header
+     */
+    public DeprecationRestHandler(RestHandler handler, String deprecationMessage, DeprecationLogger deprecationLogger) {
+        this.handler = Objects.requireNonNull(handler);
+        this.deprecationMessage = requireValidHeader(deprecationMessage);
+        this.deprecationLogger = Objects.requireNonNull(deprecationLogger);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Usage is logged via the {@link DeprecationLogger} so that the actual response can be notified of deprecation as well.
+     */
+    @Override
+    public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) throws Exception {
+        deprecationLogger.deprecated(deprecationMessage);
+
+        handler.handleRequest(request, channel, client);
+    }
+
+    /**
+     * This does a very basic pass at validating that a header's value contains only expected characters according to RFC-5987, and those
+     * that it references.
+     * <p>
+     * https://tools.ietf.org/html/rfc5987
+     * <p>
+     * This is only expected to be used for assertions. The idea is that only readable US-ASCII characters are expected; the rest must be
+     * encoded with percent encoding, which makes checking for a valid character range very simple.
+     *
+     * @param value The header value to check
+     * @return {@code true} if the {@code value} is not obviously wrong.
+     */
+    public static boolean validHeaderValue(String value) {
+        if (Strings.hasText(value) == false) {
+            return false;
+        }
+
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+
+            // 32 = ' ' (31 = unit separator); 126 = '~' (127 = DEL)
+            if (c < 32 || c > 126) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Throw an exception if the {@code value} is not a {@link #validHeaderValue(String) valid header}.
+     *
+     * @param value The header value to check
+     * @return Always {@code value}.
+     * @throws IllegalArgumentException if {@code value} is not a {@link #validHeaderValue(String) valid header}.
+     */
+    public static String requireValidHeader(String value) {
+        if (validHeaderValue(value) == false) {
+            throw new IllegalArgumentException("header value must contain only US ASCII text");
+        }
+
+        return value;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestController.java
@@ -23,6 +23,7 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.path.PathTrie;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -112,7 +113,27 @@ public class RestController extends AbstractLifecycleComponent {
     }
 
     /**
-     * Registers a rest handler to be executed when the provided method and path match the request.
+     * Registers a REST handler to be executed when the provided {@code method} and {@code path} match the request.
+     *
+     * @param method GET, POST, etc.
+     * @param path Path to handle (e.g., "/{index}/{type}/_bulk")
+     * @param handler The handler to actually execute
+     * @param deprecationMessage The message to log and send as a header in the response
+     * @param logger The existing deprecation logger to use
+     */
+    public void registerAsDeprecatedHandler(RestRequest.Method method, String path, RestHandler handler,
+                                            String deprecationMessage, DeprecationLogger logger) {
+        assert (handler instanceof DeprecationRestHandler) == false;
+
+        registerHandler(method, path, new DeprecationRestHandler(handler, deprecationMessage, logger));
+    }
+
+    /**
+     * Registers a REST handler to be executed when the provided method and path match the request.
+     *
+     * @param method GET, POST, etc.
+     * @param path Path to handle (e.g., "/{index}/{type}/_bulk")
+     * @param handler The handler to actually execute
      */
     public void registerHandler(RestRequest.Method method, String path, RestHandler handler) {
         PathTrie<RestHandler> handlers = getHandlersForMethod(method);

--- a/core/src/test/java/org/elasticsearch/common/logging/DeprecationLoggerTests.java
+++ b/core/src/test/java/org/elasticsearch/common/logging/DeprecationLoggerTests.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common.logging;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Tests {@link DeprecationLogger}
+ */
+public class DeprecationLoggerTests extends ESTestCase {
+
+    private final DeprecationLogger logger = new DeprecationLogger(Loggers.getLogger(getClass()));
+
+    public void testAddsHeaderWithThreadContext() throws IOException {
+        String msg = "A simple message [{}]";
+        String param = randomAsciiOfLengthBetween(1, 5);
+        String formatted = LoggerMessageFormat.format(msg, (Object)param);
+
+        try (ThreadContext threadContext = new ThreadContext(Settings.EMPTY)) {
+            Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
+
+            logger.deprecated(threadContexts, msg, param);
+
+            Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
+
+            assertEquals(1, responseHeaders.size());
+            assertEquals(formatted, responseHeaders.get(DeprecationLogger.DEPRECATION_HEADER).get(0));
+        }
+    }
+
+    public void testAddsCombinedHeaderWithThreadContext() throws IOException {
+        String msg = "A simple message [{}]";
+        String param = randomAsciiOfLengthBetween(1, 5);
+        String formatted = LoggerMessageFormat.format(msg, (Object)param);
+        String formatted2 = randomAsciiOfLengthBetween(1, 10);
+
+        try (ThreadContext threadContext = new ThreadContext(Settings.EMPTY)) {
+            Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
+
+            logger.deprecated(threadContexts, msg, param);
+            logger.deprecated(threadContexts, formatted2);
+
+            Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
+
+            assertEquals(1, responseHeaders.size());
+
+            List<String> responses = responseHeaders.get(DeprecationLogger.DEPRECATION_HEADER);
+
+            assertEquals(2, responses.size());
+            assertEquals(formatted, responses.get(0));
+            assertEquals(formatted2, responses.get(1));
+        }
+    }
+
+    public void testCanRemoveThreadContext() throws IOException {
+        final String expected = "testCanRemoveThreadContext";
+        final String unexpected = "testCannotRemoveThreadContext";
+
+        try (ThreadContext threadContext = new ThreadContext(Settings.EMPTY)) {
+            // NOTE: by adding it to the logger, we allow any concurrent test to write to it (from their own threads)
+            DeprecationLogger.setThreadContext(threadContext);
+
+            logger.deprecated(expected);
+
+            Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
+            List<String> responses = responseHeaders.get(DeprecationLogger.DEPRECATION_HEADER);
+
+            // ensure it works (note: concurrent tests may be adding to it, but in different threads, so it should have no impact)
+            assertThat(responses, hasSize(atLeast(1)));
+            assertThat(responses, hasItem(equalTo(expected)));
+
+            DeprecationLogger.removeThreadContext(threadContext);
+
+            logger.deprecated(unexpected);
+
+            responseHeaders = threadContext.getResponseHeaders();
+            responses = responseHeaders.get(DeprecationLogger.DEPRECATION_HEADER);
+
+            assertThat(responses, hasSize(atLeast(1)));
+            assertThat(responses, hasItem(expected));
+            assertThat(responses, not(hasItem(unexpected)));
+        }
+    }
+
+    public void testIgnoresClosedThreadContext() throws IOException {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        Set<ThreadContext> threadContexts = new HashSet<>(1);
+
+        threadContexts.add(threadContext);
+
+        threadContext.close();
+
+        logger.deprecated(threadContexts, "Ignored logger message");
+
+        assertTrue(threadContexts.contains(threadContext));
+    }
+
+    public void testSafeWithoutThreadContext() {
+        logger.deprecated(Collections.emptySet(), "Ignored");
+    }
+
+    public void testFailsWithoutThreadContextSet() {
+        expectThrows(NullPointerException.class, () -> logger.deprecated((Set<ThreadContext>)null, "Does not explode"));
+    }
+
+    public void testFailsWhenDoubleSettingSameThreadContext() throws IOException {
+        try (ThreadContext threadContext = new ThreadContext(Settings.EMPTY)) {
+            DeprecationLogger.setThreadContext(threadContext);
+
+            try {
+                expectThrows(IllegalStateException.class, () -> DeprecationLogger.setThreadContext(threadContext));
+            } finally {
+                // cleanup after ourselves
+                DeprecationLogger.removeThreadContext(threadContext);
+            }
+        }
+    }
+
+    public void testFailsWhenRemovingUnknownThreadContext() throws IOException {
+        try (ThreadContext threadContext = new ThreadContext(Settings.EMPTY)) {
+            expectThrows(IllegalStateException.class, () -> DeprecationLogger.removeThreadContext(threadContext));
+        }
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
@@ -19,14 +19,18 @@
 package org.elasticsearch.common.util.concurrent;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class ThreadContextTests extends ESTestCase {
@@ -35,7 +39,7 @@ public class ThreadContextTests extends ESTestCase {
         Settings build = Settings.builder().put("request.headers.default", "1").build();
         ThreadContext threadContext = new ThreadContext(build);
         threadContext.putHeader("foo", "bar");
-        threadContext.putTransient("ctx.foo", new Integer(1));
+        threadContext.putTransient("ctx.foo", 1);
         assertEquals("bar", threadContext.getHeader("foo"));
         assertEquals(new Integer(1), threadContext.getTransient("ctx.foo"));
         assertEquals("1", threadContext.getHeader("default"));
@@ -46,7 +50,7 @@ public class ThreadContextTests extends ESTestCase {
         }
 
         assertEquals("bar", threadContext.getHeader("foo"));
-        assertEquals(new Integer(1), threadContext.getTransient("ctx.foo"));
+        assertEquals(Integer.valueOf(1), threadContext.getTransient("ctx.foo"));
         assertEquals("1", threadContext.getHeader("default"));
     }
 
@@ -54,7 +58,7 @@ public class ThreadContextTests extends ESTestCase {
         Settings build = Settings.builder().put("request.headers.default", "1").build();
         ThreadContext threadContext = new ThreadContext(build);
         threadContext.putHeader("foo", "bar");
-        threadContext.putTransient("ctx.foo", new Integer(1));
+        threadContext.putTransient("ctx.foo", 1);
         assertEquals("bar", threadContext.getHeader("foo"));
         assertEquals(new Integer(1), threadContext.getTransient("ctx.foo"));
         assertEquals("1", threadContext.getHeader("default"));
@@ -70,7 +74,7 @@ public class ThreadContextTests extends ESTestCase {
 
         assertNull(threadContext.getHeader("simon"));
         assertEquals("bar", threadContext.getHeader("foo"));
-        assertEquals(new Integer(1), threadContext.getTransient("ctx.foo"));
+        assertEquals(Integer.valueOf(1), threadContext.getTransient("ctx.foo"));
         assertEquals("1", threadContext.getHeader("default"));
     }
 
@@ -78,9 +82,9 @@ public class ThreadContextTests extends ESTestCase {
         Settings build = Settings.builder().put("request.headers.default", "1").build();
         ThreadContext threadContext = new ThreadContext(build);
         threadContext.putHeader("foo", "bar");
-        threadContext.putTransient("ctx.foo", new Integer(1));
+        threadContext.putTransient("ctx.foo", 1);
         assertEquals("bar", threadContext.getHeader("foo"));
-        assertEquals(new Integer(1), threadContext.getTransient("ctx.foo"));
+        assertEquals(Integer.valueOf(1), threadContext.getTransient("ctx.foo"));
         assertEquals("1", threadContext.getHeader("default"));
         ThreadContext.StoredContext storedContext = threadContext.newStoredContext();
         threadContext.putHeader("foo.bar", "baz");
@@ -91,7 +95,7 @@ public class ThreadContextTests extends ESTestCase {
         }
 
         assertEquals("bar", threadContext.getHeader("foo"));
-        assertEquals(new Integer(1), threadContext.getTransient("ctx.foo"));
+        assertEquals(Integer.valueOf(1), threadContext.getTransient("ctx.foo"));
         assertEquals("1", threadContext.getHeader("default"));
         assertEquals("baz", threadContext.getHeader("foo.bar"));
         if (randomBoolean()) {
@@ -100,9 +104,42 @@ public class ThreadContextTests extends ESTestCase {
             storedContext.close();
         }
         assertEquals("bar", threadContext.getHeader("foo"));
-        assertEquals(new Integer(1), threadContext.getTransient("ctx.foo"));
+        assertEquals(Integer.valueOf(1), threadContext.getTransient("ctx.foo"));
         assertEquals("1", threadContext.getHeader("default"));
         assertNull(threadContext.getHeader("foo.bar"));
+    }
+
+    public void testResponseHeaders() {
+        final boolean expectThird = randomBoolean();
+
+        final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+
+        threadContext.addResponseHeader("foo", "bar");
+        // pretend that another thread created the same response
+        if (randomBoolean()) {
+            threadContext.addResponseHeader("foo", "bar");
+        }
+
+        threadContext.addResponseHeader("Warning", "One is the loneliest number");
+        threadContext.addResponseHeader("Warning", "Two can be as bad as one");
+        if (expectThird) {
+            threadContext.addResponseHeader("Warning", "No is the saddest experience");
+        }
+
+        final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
+        final List<String> foo = responseHeaders.get("foo");
+        final List<String> warnings = responseHeaders.get("Warning");
+        final int expectedWarnings = expectThird ? 3 : 2;
+
+        assertThat(foo, hasSize(1));
+        assertEquals("bar", foo.get(0));
+        assertThat(warnings, hasSize(expectedWarnings));
+        assertThat(warnings, hasItem(equalTo("One is the loneliest number")));
+        assertThat(warnings, hasItem(equalTo("Two can be as bad as one")));
+
+        if (expectThird) {
+            assertThat(warnings, hasItem(equalTo("No is the saddest experience")));
+        }
     }
 
     public void testCopyHeaders() {
@@ -117,7 +154,7 @@ public class ThreadContextTests extends ESTestCase {
         Settings build = Settings.builder().put("request.headers.default", "1").build();
         ThreadContext threadContext = new ThreadContext(build);
         threadContext.putHeader("foo", "bar");
-        threadContext.putTransient("ctx.foo", new Integer(1));
+        threadContext.putTransient("ctx.foo", 1);
 
         threadContext.close();
         try {
@@ -146,20 +183,35 @@ public class ThreadContextTests extends ESTestCase {
         Settings build = Settings.builder().put("request.headers.default", "1").build();
         ThreadContext threadContext = new ThreadContext(build);
         threadContext.putHeader("foo", "bar");
-        threadContext.putTransient("ctx.foo", new Integer(1));
+        threadContext.putTransient("ctx.foo", 1);
+        threadContext.addResponseHeader("Warning", "123456");
+        if (rarely()) {
+            threadContext.addResponseHeader("Warning", "123456");
+        }
+        threadContext.addResponseHeader("Warning", "234567");
+
         BytesStreamOutput out = new BytesStreamOutput();
         threadContext.writeTo(out);
         try (ThreadContext.StoredContext ctx = threadContext.stashContext()) {
             assertNull(threadContext.getHeader("foo"));
             assertNull(threadContext.getTransient("ctx.foo"));
+            assertTrue(threadContext.getResponseHeaders().isEmpty());
             assertEquals("1", threadContext.getHeader("default"));
 
             threadContext.readHeaders(out.bytes().streamInput());
             assertEquals("bar", threadContext.getHeader("foo"));
             assertNull(threadContext.getTransient("ctx.foo"));
+
+            final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
+            final List<String> warnings = responseHeaders.get("Warning");
+
+            assertThat(responseHeaders.keySet(), hasSize(1));
+            assertThat(warnings, hasSize(2));
+            assertThat(warnings, hasItem(equalTo("123456")));
+            assertThat(warnings, hasItem(equalTo("234567")));
         }
         assertEquals("bar", threadContext.getHeader("foo"));
-        assertEquals(new Integer(1), threadContext.getTransient("ctx.foo"));
+        assertEquals(Integer.valueOf(1), threadContext.getTransient("ctx.foo"));
         assertEquals("1", threadContext.getHeader("default"));
     }
 
@@ -169,21 +221,35 @@ public class ThreadContextTests extends ESTestCase {
             Settings build = Settings.builder().put("request.headers.default", "1").build();
             ThreadContext threadContext = new ThreadContext(build);
             threadContext.putHeader("foo", "bar");
-            threadContext.putTransient("ctx.foo", new Integer(1));
+            threadContext.putTransient("ctx.foo", 1);
+            threadContext.addResponseHeader("Warning", "123456");
+            if (rarely()) {
+                threadContext.addResponseHeader("Warning", "123456");
+            }
+            threadContext.addResponseHeader("Warning", "234567");
 
             assertEquals("bar", threadContext.getHeader("foo"));
             assertNotNull(threadContext.getTransient("ctx.foo"));
             assertEquals("1", threadContext.getHeader("default"));
+            assertThat(threadContext.getResponseHeaders().keySet(), hasSize(1));
             threadContext.writeTo(out);
         }
         {
             Settings otherSettings = Settings.builder().put("request.headers.default", "5").build();
-            ThreadContext otherhreadContext = new ThreadContext(otherSettings);
-            otherhreadContext.readHeaders(out.bytes().streamInput());
+            ThreadContext otherThreadContext = new ThreadContext(otherSettings);
+            otherThreadContext.readHeaders(out.bytes().streamInput());
 
-            assertEquals("bar", otherhreadContext.getHeader("foo"));
-            assertNull(otherhreadContext.getTransient("ctx.foo"));
-            assertEquals("1", otherhreadContext.getHeader("default"));
+            assertEquals("bar", otherThreadContext.getHeader("foo"));
+            assertNull(otherThreadContext.getTransient("ctx.foo"));
+            assertEquals("1", otherThreadContext.getHeader("default"));
+
+            final Map<String, List<String>> responseHeaders = otherThreadContext.getResponseHeaders();
+            final List<String> warnings = responseHeaders.get("Warning");
+
+            assertThat(responseHeaders.keySet(), hasSize(1));
+            assertThat(warnings, hasSize(2));
+            assertThat(warnings, hasItem(equalTo("123456")));
+            assertThat(warnings, hasItem(equalTo("234567")));
         }
     }
 
@@ -192,7 +258,7 @@ public class ThreadContextTests extends ESTestCase {
         {
             ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
             threadContext.putHeader("foo", "bar");
-            threadContext.putTransient("ctx.foo", new Integer(1));
+            threadContext.putTransient("ctx.foo", 1);
 
             assertEquals("bar", threadContext.getHeader("foo"));
             assertNotNull(threadContext.getTransient("ctx.foo"));
@@ -209,7 +275,6 @@ public class ThreadContextTests extends ESTestCase {
             assertEquals("5", otherhreadContext.getHeader("default"));
         }
     }
-
 
     public void testCanResetDefault() {
         Settings build = Settings.builder().put("request.headers.default", "1").build();

--- a/core/src/test/java/org/elasticsearch/http/netty/NettyHttpChannelTests.java
+++ b/core/src/test/java/org/elasticsearch/http/netty/NettyHttpChannelTests.java
@@ -181,7 +181,7 @@ public class NettyHttpChannelTests extends ESTestCase {
         NettyHttpRequest request = new NettyHttpRequest(httpRequest, writeCapturingChannel);
 
         // send a response
-        NettyHttpChannel channel = new NettyHttpChannel(httpServerTransport, request, null, randomBoolean());
+        NettyHttpChannel channel = new NettyHttpChannel(httpServerTransport, request, null, randomBoolean(), threadPool.getThreadContext());
         TestReponse resp = new TestReponse();
         final String customHeader = "custom-header";
         final String customHeaderValue = "xyz";
@@ -207,7 +207,7 @@ public class NettyHttpChannelTests extends ESTestCase {
         WriteCapturingChannel writeCapturingChannel = new WriteCapturingChannel();
         NettyHttpRequest request = new NettyHttpRequest(httpRequest, writeCapturingChannel);
 
-        NettyHttpChannel channel = new NettyHttpChannel(httpServerTransport, request, null, randomBoolean());
+        NettyHttpChannel channel = new NettyHttpChannel(httpServerTransport, request, null, randomBoolean(), threadPool.getThreadContext());
         channel.sendResponse(new TestReponse());
 
         // get the response

--- a/core/src/test/java/org/elasticsearch/rest/DeprecationHttpIT.java
+++ b/core/src/test/java/org/elasticsearch/rest/DeprecationHttpIT.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.rest;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.StringEntity;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.common.logging.LoggerMessageFormat;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.rest.plugins.TestDeprecatedQueryBuilder;
+import org.elasticsearch.rest.plugins.TestDeprecationHeaderRestAction;
+import org.elasticsearch.rest.plugins.TestDeprecationPlugin;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import org.hamcrest.Matcher;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.rest.RestStatus.OK;
+import static org.elasticsearch.rest.plugins.TestDeprecationHeaderRestAction.TEST_DEPRECATED_SETTING_TRUE1;
+import static org.elasticsearch.rest.plugins.TestDeprecationHeaderRestAction.TEST_DEPRECATED_SETTING_TRUE2;
+import static org.elasticsearch.rest.plugins.TestDeprecationHeaderRestAction.TEST_NOT_DEPRECATED_SETTING;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Tests {@code DeprecationLogger} uses the {@code ThreadContext} to add response headers.
+ */
+public class DeprecationHttpIT extends ESIntegTestCase {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+                .put(super.nodeSettings(nodeOrdinal))
+                .put("force.http.enabled", true)
+                // change values of deprecated settings so that accessing them is logged
+                .put(TEST_DEPRECATED_SETTING_TRUE1.getKey(), ! TEST_DEPRECATED_SETTING_TRUE1.getDefault(Settings.EMPTY))
+                .put(TEST_DEPRECATED_SETTING_TRUE2.getKey(), ! TEST_DEPRECATED_SETTING_TRUE2.getDefault(Settings.EMPTY))
+                // non-deprecated setting to ensure not everything is logged
+                .put(TEST_NOT_DEPRECATED_SETTING.getKey(), ! TEST_NOT_DEPRECATED_SETTING.getDefault(Settings.EMPTY))
+                .build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return pluginList(TestDeprecationPlugin.class);
+    }
+
+    /**
+     * Attempts to do a scatter/gather request that expects unique responses per sub-request.
+     */
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/19222")
+    public void testUniqueDeprecationResponsesMergedTogether() throws IOException {
+        final String[] indices = new String[randomIntBetween(2, 5)];
+
+        // add at least one document for each index
+        for (int i = 0; i < indices.length; ++i) {
+            indices[i] = "test" + i;
+
+            // create indices with a single shard to reduce noise; the query only deprecates uniquely by index anyway
+            assertTrue(prepareCreate(indices[i]).setSettings(Settings.builder().put("number_of_shards", 1)).get().isAcknowledged());
+
+            int randomDocCount = randomIntBetween(1, 2);
+
+            for (int j = 0; j < randomDocCount; ++j) {
+                index(indices[i], "type", Integer.toString(j), "{\"field\":" + j + "}");
+            }
+        }
+
+        refresh(indices);
+
+        final String commaSeparatedIndices = Stream.of(indices).collect(Collectors.joining(","));
+
+        final String body =
+            "{\"query\":{\"bool\":{\"filter\":[{\"" + TestDeprecatedQueryBuilder.NAME +  "\":{}}]}}}";
+
+        // trigger all index deprecations
+        try (Response response = getRestClient().performRequest("GET",
+                                                                "/" + commaSeparatedIndices + "/_search",
+                                                                Collections.emptyMap(),
+                                                                new StringEntity(body, RestClient.JSON_CONTENT_TYPE))) {
+            assertThat(response.getStatusLine().getStatusCode(), equalTo(OK.getStatus()));
+
+            final List<String> deprecatedWarnings = getWarningHeaders(response.getHeaders());
+            final List<Matcher<String>> headerMatchers = new ArrayList<>(indices.length);
+
+            for (String index : indices) {
+                headerMatchers.add(containsString(LoggerMessageFormat.format("[{}] index", (Object)index)));
+            }
+
+            assertThat(deprecatedWarnings, hasSize(headerMatchers.size()));
+            for (Matcher<String> headerMatcher : headerMatchers) {
+                assertThat(deprecatedWarnings, hasItem(headerMatcher));
+            }
+        }
+    }
+
+    public void testDeprecationWarningsAppearInHeaders() throws IOException {
+        doTestDeprecationWarningsAppearInHeaders();
+    }
+
+    public void testDeprecationHeadersDoNotGetStuck() throws IOException {
+        doTestDeprecationWarningsAppearInHeaders();
+        doTestDeprecationWarningsAppearInHeaders();
+        if (rarely()) {
+            doTestDeprecationWarningsAppearInHeaders();
+        }
+    }
+
+    /**
+     * Run a request that receives a predictably randomized number of deprecation warnings.
+     * <p>
+     * Re-running this back-to-back helps to ensure that warnings are not being maintained across requests.
+     */
+    private void doTestDeprecationWarningsAppearInHeaders() throws IOException {
+        final boolean useDeprecatedField = randomBoolean();
+        final boolean useNonDeprecatedSetting = randomBoolean();
+
+        // deprecated settings should also trigger a deprecation warning
+        final List<Setting<Boolean>> settings = new ArrayList<>(3);
+        settings.add(TEST_DEPRECATED_SETTING_TRUE1);
+
+        if (randomBoolean()) {
+            settings.add(TEST_DEPRECATED_SETTING_TRUE2);
+        }
+
+        if (useNonDeprecatedSetting) {
+            settings.add(TEST_NOT_DEPRECATED_SETTING);
+        }
+
+        Collections.shuffle(settings, random());
+
+        // trigger all deprecations
+        try (Response response = getRestClient().performRequest("GET",
+                                                                "/_test_cluster/deprecated_settings",
+                                                                Collections.emptyMap(),
+                                                                buildSettingsRequest(settings, useDeprecatedField))) {
+            assertThat(response.getStatusLine().getStatusCode(), equalTo(OK.getStatus()));
+
+            final List<String> deprecatedWarnings = getWarningHeaders(response.getHeaders());
+            final List<Matcher<String>> headerMatchers = new ArrayList<>(4);
+
+            headerMatchers.add(equalTo(TestDeprecationHeaderRestAction.DEPRECATED_ENDPOINT));
+            if (useDeprecatedField) {
+                headerMatchers.add(equalTo(TestDeprecationHeaderRestAction.DEPRECATED_USAGE));
+            }
+            for (Setting<?> setting : settings) {
+                if (setting.isDeprecated()) {
+                    headerMatchers.add(containsString(LoggerMessageFormat.format("[{}] setting was deprecated", (Object)setting.getKey())));
+                }
+            }
+
+            assertThat(deprecatedWarnings, hasSize(headerMatchers.size()));
+            for (Matcher<String> headerMatcher : headerMatchers) {
+                assertThat(deprecatedWarnings, hasItem(headerMatcher));
+            }
+        }
+    }
+
+    private List<String> getWarningHeaders(Header[] headers) {
+        List<String> warnings = new ArrayList<>();
+
+        for (Header header : headers) {
+            if (header.getName().equals("Warning")) {
+                warnings.add(header.getValue());
+            }
+        }
+
+        return warnings;
+    }
+
+    private HttpEntity buildSettingsRequest(List<Setting<Boolean>> settings, boolean useDeprecatedField) throws IOException {
+        XContentBuilder builder = JsonXContent.contentBuilder();
+
+        builder.startObject().startArray(useDeprecatedField ? "deprecated_settings" : "settings");
+
+        for (Setting<Boolean> setting : settings) {
+            builder.value(setting.getKey());
+        }
+
+        builder.endArray().endObject();
+
+        return new StringEntity(builder.string(), RestClient.JSON_CONTENT_TYPE);
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/rest/DeprecationRestHandlerTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/DeprecationRestHandlerTests.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.rest;
+
+import com.carrotsearch.randomizedtesting.generators.CodepointSetGenerator;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.test.ESTestCase;
+
+import org.mockito.InOrder;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests {@link DeprecationRestHandler}.
+ */
+public class DeprecationRestHandlerTests extends ESTestCase {
+
+    private final RestHandler handler = mock(RestHandler.class);
+    /**
+     * Note: Headers should only use US ASCII (and this inevitably becomes one!).
+     */
+    private final String deprecationMessage = randomAsciiOfLengthBetween(1, 30);
+    private final DeprecationLogger deprecationLogger = mock(DeprecationLogger.class);
+
+    public void testNullHandler() {
+        expectThrows(NullPointerException.class, () -> new DeprecationRestHandler(null, deprecationMessage, deprecationLogger));
+    }
+
+    public void testInvalidDeprecationMessageThrowsException() {
+        String invalidDeprecationMessage = randomFrom("", null, "     ");
+
+        expectThrows(IllegalArgumentException.class,
+                     () -> new DeprecationRestHandler(handler, invalidDeprecationMessage, deprecationLogger));
+    }
+
+    public void testNullDeprecationLogger() {
+        expectThrows(NullPointerException.class, () -> new DeprecationRestHandler(handler, deprecationMessage, null));
+    }
+
+    public void testHandleRequestLogsWarningThenForwards() throws Exception {
+        RestRequest request = mock(RestRequest.class);
+        RestChannel channel = mock(RestChannel.class);
+        NodeClient client = mock(NodeClient.class);
+
+        DeprecationRestHandler deprecatedHandler = new DeprecationRestHandler(handler, deprecationMessage, deprecationLogger);
+
+        // test it
+        deprecatedHandler.handleRequest(request, channel, client);
+
+        InOrder inOrder = inOrder(handler, request, channel, deprecationLogger);
+
+        // log, then forward
+        inOrder.verify(deprecationLogger).deprecated(deprecationMessage);
+        inOrder.verify(handler).handleRequest(request, channel, client);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    public void testValidHeaderValue() {
+        ASCIIHeaderGenerator generator = new ASCIIHeaderGenerator();
+        String value = generator.ofCodeUnitsLength(random(), 1, 50);
+
+        assertTrue(DeprecationRestHandler.validHeaderValue(value));
+        assertSame(value, DeprecationRestHandler.requireValidHeader(value));
+    }
+
+    public void testInvalidHeaderValue() {
+        ASCIIHeaderGenerator generator = new ASCIIHeaderGenerator();
+        String value = generator.ofCodeUnitsLength(random(), 0, 25) +
+                       randomFrom('\t', '\0', '\n', (char)27 /* ESC */, (char)31 /* unit separator*/, (char)127 /* DEL */) +
+                       generator.ofCodeUnitsLength(random(), 0, 25);
+
+        assertFalse(DeprecationRestHandler.validHeaderValue(value));
+
+        expectThrows(IllegalArgumentException.class, () -> DeprecationRestHandler.requireValidHeader(value));
+    }
+
+    public void testInvalidHeaderValueNull() {
+        assertFalse(DeprecationRestHandler.validHeaderValue(null));
+
+        expectThrows(IllegalArgumentException.class, () -> DeprecationRestHandler.requireValidHeader(null));
+    }
+
+    public void testInvalidHeaderValueEmpty() {
+        String blank = randomFrom("", "\t", "    ");
+
+        assertFalse(DeprecationRestHandler.validHeaderValue(blank));
+
+        expectThrows(IllegalArgumentException.class, () -> DeprecationRestHandler.requireValidHeader(blank));
+    }
+
+    /**
+     * {@code ASCIIHeaderGenerator} only uses characters expected to be valid in headers (simplified US-ASCII).
+     */
+    private static class ASCIIHeaderGenerator extends CodepointSetGenerator {
+        /**
+         * Create a character array for characters [{@code from}, {@code to}].
+         *
+         * @param from Starting code point (inclusive).
+         * @param to Ending code point (inclusive).
+         * @return Never {@code null}.
+         */
+        static char[] asciiFromTo(int from, int to) {
+            char[] chars = new char[to - from + 1];
+
+            for (int i = from; i <= to; ++i) {
+                chars[i - from] = (char)i;
+            }
+
+            return chars;
+        }
+
+        /**
+         * Create a generator for characters [32, 126].
+         */
+        public ASCIIHeaderGenerator() {
+            super(asciiFromTo(32, 126));
+        }
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/rest/plugins/TestDeprecatedQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/rest/plugins/TestDeprecatedQueryBuilder.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.plugins;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryShardContext;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * A query that performs a <code>match_all</code> query, but with each <em>index</em> touched getting a unique deprecation warning.
+ * <p>
+ * This makes it easy to test multiple unique responses for a single request.
+ */
+public class TestDeprecatedQueryBuilder extends AbstractQueryBuilder<TestDeprecatedQueryBuilder> {
+
+    public static final String NAME = "deprecated_match_all";
+    public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME);
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(TestDeprecatedQueryBuilder.class));
+
+    public TestDeprecatedQueryBuilder() {
+        // nothing to do
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public TestDeprecatedQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        // nothing to do
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME).endObject();
+    }
+
+    public static Optional<TestDeprecatedQueryBuilder> fromXContent(QueryParseContext parseContext) throws IOException, ParsingException {
+        XContentParser parser = parseContext.parser();
+
+        if (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            throw new ParsingException(parser.getTokenLocation(), "[{}] query does not have any fields", NAME);
+        }
+
+        return Optional.of(new TestDeprecatedQueryBuilder());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) throws IOException {
+        DEPRECATION_LOGGER.deprecated("[{}] query is deprecated, but used on [{}] index", NAME, context.index().getName());
+
+        return Queries.newMatchAllQuery();
+    }
+
+    @Override
+    public int doHashCode() {
+        return 0;
+    }
+
+    @Override
+    protected boolean doEquals(TestDeprecatedQueryBuilder other) {
+        return true;
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/rest/plugins/TestDeprecationHeaderRestAction.java
+++ b/core/src/test/java/org/elasticsearch/rest/plugins/TestDeprecationHeaderRestAction.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.rest.plugins;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestStatus;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Enables testing {@code DeprecationRestHandler} via integration tests by guaranteeing a deprecated REST endpoint.
+ * <p>
+ * This adds an endpoint named <code>/_test_cluster/deprecated_settings</code> that touches specified settings given their names
+ * and returns their values.
+ */
+public class TestDeprecationHeaderRestAction extends BaseRestHandler {
+
+    public static final Setting<Boolean> TEST_DEPRECATED_SETTING_TRUE1 =
+        Setting.boolSetting("test.setting.deprecated.true1", true,
+                            Setting.Property.NodeScope, Setting.Property.Deprecated, Setting.Property.Dynamic);
+    public static final Setting<Boolean> TEST_DEPRECATED_SETTING_TRUE2 =
+        Setting.boolSetting("test.setting.deprecated.true2", true,
+                            Setting.Property.NodeScope, Setting.Property.Deprecated, Setting.Property.Dynamic);
+    public static final Setting<Boolean> TEST_NOT_DEPRECATED_SETTING =
+        Setting.boolSetting("test.setting.not_deprecated", false,
+                            Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    private static final Map<String, Setting<?>> SETTINGS;
+
+    static {
+        Map<String, Setting<?>> settingsMap = new HashMap<>(3);
+
+        settingsMap.put(TEST_DEPRECATED_SETTING_TRUE1.getKey(), TEST_DEPRECATED_SETTING_TRUE1);
+        settingsMap.put(TEST_DEPRECATED_SETTING_TRUE2.getKey(), TEST_DEPRECATED_SETTING_TRUE2);
+        settingsMap.put(TEST_NOT_DEPRECATED_SETTING.getKey(), TEST_NOT_DEPRECATED_SETTING);
+
+        SETTINGS = Collections.unmodifiableMap(settingsMap);
+    }
+
+    public static final String DEPRECATED_ENDPOINT = "[/_test_cluster/deprecated_settings] exists for deprecated tests";
+    public static final String DEPRECATED_USAGE = "[deprecated_settings] usage is deprecated. use [settings] instead";
+
+    @Inject
+    public TestDeprecationHeaderRestAction(Settings settings, RestController controller) {
+        super(settings);
+
+        controller.registerAsDeprecatedHandler(RestRequest.Method.GET, "/_test_cluster/deprecated_settings", this,
+                                               DEPRECATED_ENDPOINT, deprecationLogger);
+    }
+
+    @SuppressWarnings("unchecked") // List<String> casts
+    @Override
+    public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) throws Exception {
+        final List<String> settings;
+
+        try (XContentParser parser = XContentFactory.xContent(request.content()).createParser(request.content())) {
+            final Map<String, Object> source = parser.map();
+
+            if (source.containsKey("deprecated_settings")) {
+                deprecationLogger.deprecated(DEPRECATED_USAGE);
+
+                settings = (List<String>)source.get("deprecated_settings");
+            } else {
+                settings = (List<String>)source.get("settings");
+            }
+        }
+
+        final XContentBuilder builder = channel.newBuilder();
+
+        builder.startObject().startArray("settings");
+        for (String setting : settings) {
+            builder.startObject().field(setting, SETTINGS.get(setting).getRaw(this.settings)).endObject();
+        }
+        builder.endArray().endObject();
+
+        channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/rest/plugins/TestDeprecationPlugin.java
+++ b/core/src/test/java/org/elasticsearch/rest/plugins/TestDeprecationPlugin.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.rest.plugins;
+
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.search.SearchModule;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Adds {@link TestDeprecationHeaderRestAction} for testing deprecation requests via HTTP.
+ */
+public class TestDeprecationPlugin extends Plugin implements ActionPlugin {
+
+    @Override
+    public List<Class<? extends RestHandler>> getRestHandlers() {
+        return Collections.singletonList(TestDeprecationHeaderRestAction.class);
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return Arrays.asList(
+            TestDeprecationHeaderRestAction.TEST_DEPRECATED_SETTING_TRUE1,
+            TestDeprecationHeaderRestAction.TEST_DEPRECATED_SETTING_TRUE2,
+            TestDeprecationHeaderRestAction.TEST_NOT_DEPRECATED_SETTING);
+    }
+
+    public void onModule(SearchModule module) {
+        module.registerQuery(TestDeprecatedQueryBuilder::new,
+                             TestDeprecatedQueryBuilder::fromXContent,
+                             TestDeprecatedQueryBuilder.QUERY_NAME_FIELD);
+    }
+
+}


### PR DESCRIPTION
This adds support for `ThreadContext`s to maintain _unique_ Response headers (repeated header values are ignored) in addition to Request headers. In particular, this enables REST requests (e.g., `PUT /test`) that hop across the nodes to properly return headers as part of the overall request. With the response headers `Thread` aware thanks to the `ThreadContext`, we can associate individual requests with deprecation logging and therefore warn developers when they unwittingly use deprecated features:

``` http
PUT /test
{
  "mappings": {
    "type": {
      "properties": {
        "field": {
          "type": "string"
        },
        "field2": {
          "type": "string"
        }
      }
    }
  }
}
```

The headers that would get returned by this would be:

```
HTTP/1.1 200 OK
Warning: The [string] field is deprecated, please use [text] or [keyword] instead on [field]
Warning: The [string] field is deprecated, please use [text] or [keyword] instead on [field2]
Content-Type: application/json; charset=UTF-8
Content-Length: 21
```

Alongside that feature, this adds a `DeprecationRestHandler` that logs a deprecation warning whenever it is used, but it otherwise behaves identically to normal `RestHandler`s. This allows REST APIs to be deprecated in a consistent manner instead of dropped without any non-documentation-level deprecation warnings in advance.

Closes #17687
