### PR TITLE
Backports Notify GatewayRecoveryListener on failure

### DIFF
--- a/core/src/main/java/org/elasticsearch/gateway/GatewayService.java
+++ b/core/src/main/java/org/elasticsearch/gateway/GatewayService.java
@@ -38,6 +38,7 @@ import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.discovery.DiscoveryService;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -187,9 +188,17 @@ public class GatewayService extends AbstractLifecycleComponent<GatewayService> i
             }
         } else {
             if (recovered.compareAndSet(false, true)) {
-                threadPool.generic().execute(new Runnable() {
+                threadPool.generic().execute(new AbstractRunnable() {
                     @Override
-                    public void run() {
+                    public void onFailure(Throwable t) {
+                        logger.warn("Recovery failed", t);
+                        // we reset `recovered` in the listener don't reset it here otherwise there might be a race
+                        // that resets it to false while a new recover is already running?
+                        recoveryListener.onFailure("state recovery failed: " + t.getMessage());
+                    }
+
+                    @Override
+                    protected void doRun() throws Exception {
                         gateway.performStateRecovery(recoveryListener);
                     }
                 });


### PR DESCRIPTION
If the recovery throws an exception we fail to notify the recovery
listener and bubble up the uncaught exception.  Commit https://github.com/elastic/elasticsearch/commit/8ca284862dce41968f455b1aa40c0f30ab4e1181 fixed this for master, but the problem remains on 2.x, causing intermittent test failures of `org.elasticsearch.client.transport.TransportClientIT#testNodeVersionIsUpdated`.

This PR backports the aforementioned commit.
