### PR TITLE
Remove deprecated registration methods

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableRegistry.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableRegistry.java
@@ -49,17 +49,6 @@ public class NamedWriteableRegistry {
     }
 
     /**
-     * Registers a {@link NamedWriteable} prototype given its category.
-     * @deprecated Prefer {@link #register(Class, String, org.elasticsearch.common.io.stream.Writeable.Reader)}
-     */
-    @Deprecated
-    @SuppressWarnings("rawtypes") // TODO remove this method entirely before 5.0.0 GA
-    public synchronized <T extends NamedWriteable> void registerPrototype(Class<T> categoryClass,
-            NamedWriteable<? extends T> namedWriteable) {
-        register(categoryClass, namedWriteable.getWriteableName(), namedWriteable::readFrom);
-    }
-
-    /**
      * Returns a prototype of the {@link NamedWriteable} object identified by the name provided as argument and its category
      */
     public synchronized <T> Writeable.Reader<? extends T> getReader(Class<T> categoryClass, String name) {

--- a/core/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -382,18 +382,6 @@ public class SearchModule extends AbstractModule {
     }
 
     /**
-     * Register an aggregation.
-     *
-     * @deprecated prefer {@link #registerPipelineAggregation(Writeable.Reader, PipelineAggregator.Parser, ParseField)}. Will be removed
-     *             before 5.0.0GA.
-     */
-    @Deprecated // NORELEASE remove this before 5.0.0GA
-    public void registerAggregatorParser(Aggregator.Parser parser) {
-        aggregationParserRegistry.register(parser, new ParseField(parser.type()));
-        namedWriteableRegistry.registerPrototype(AggregatorBuilder.class, parser.getFactoryPrototypes());
-    }
-
-    /**
      * Register a pipeline aggregation.
      *
      * @param reader reads the aggregation builder from a stream
@@ -405,18 +393,6 @@ public class SearchModule extends AbstractModule {
             PipelineAggregator.Parser aggregationParser, ParseField aggregationName) {
         pipelineAggregationParserRegistry.register(aggregationParser, aggregationName);
         namedWriteableRegistry.register(PipelineAggregatorBuilder.class, aggregationName.getPreferredName(), reader);
-    }
-
-    /**
-     * Register a pipeline aggregation.
-     *
-     * @deprecated prefer {@link #registerPipelineAggregation(Writeable.Reader, PipelineAggregator.Parser, ParseField)}. Will be removed
-     *             before 5.0.0GA.
-     */
-    @Deprecated // NORELEASE remove this before 5.0.0GA
-    public void registerPipelineParser(PipelineAggregator.Parser parser) {
-        pipelineAggregationParserRegistry.register(parser, new ParseField(parser.type()));
-        namedWriteableRegistry.registerPrototype(PipelineAggregatorBuilder.class, parser.getFactoryPrototype());
     }
 
     public AggregatorParsers getAggregatorParsers() {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
@@ -46,14 +46,6 @@ public abstract class Aggregator extends BucketCollector implements Releasable {
      */
     @FunctionalInterface
     public interface Parser {
-
-        /**
-         * @return The aggregation type this parser is associated with.
-         */
-        default String type() {
-            throw new UnsupportedOperationException(); // NORELEASE remove before 5.0.0GA
-        }
-
         /**
          * Returns the aggregator factory with which this parser is associated, may return {@code null} indicating the
          * aggregation should be skipped (e.g. when trying to aggregate on unmapped fields).
@@ -64,14 +56,6 @@ public abstract class Aggregator extends BucketCollector implements Releasable {
          * @throws java.io.IOException      When parsing fails
          */
         AggregatorBuilder<?> parse(String aggregationName, QueryParseContext context) throws IOException;
-
-        /**
-         * @return an empty {@link AggregatorBuilder} instance for this parser
-         *         that can be used for deserialization
-         */
-        default AggregatorBuilder<?> getFactoryPrototypes() {
-            throw new UnsupportedOperationException(); // NORELEASE remove before 5.0.0GA
-        }
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/search/aggregations/AggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/AggregatorBuilder.java
@@ -71,38 +71,15 @@ public abstract class AggregatorBuilder<AB extends AggregatorBuilder<AB>> extend
         metaData = in.readMap();
     }
 
-    protected boolean usesNewStyleSerialization() { // NORELEASE remove this before 5.0.0GA, when all the aggregations have been migrated
-        return false;
-    }
-
     @Override
     public final void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
-        if (false == usesNewStyleSerialization()) {
-            doWriteTo(out);
-        }
         factoriesBuilder.writeTo(out);
         out.writeMap(metaData);
-        if (usesNewStyleSerialization()) {
-            doWriteTo(out);
-        }
+        doWriteTo(out);
     }
 
     protected abstract void doWriteTo(StreamOutput out) throws IOException;
-
-    @Override
-    public final AB readFrom(StreamInput in) throws IOException {
-        // NORELEASE remove when all aggregations have StreamInput constructor
-        String name = in.readString();
-        AB factory = doReadFrom(name, in);
-        factory.factoriesBuilder = AggregatorFactories.Builder.PROTOTYPE.readFrom(in);
-        factory.metaData = in.readMap();
-        return factory;
-    }
-
-    protected AB doReadFrom(String name, StreamInput in) throws IOException {
-        throw new UnsupportedOperationException(); // NORELEASE remove before 5.0.0GA
-    }
 
     /**
      * Add a sub aggregation to this aggregation.
@@ -187,13 +164,6 @@ public abstract class AggregatorBuilder<AB extends AggregatorBuilder<AB>> extend
     }
 
     protected abstract XContentBuilder internalXContent(XContentBuilder builder, Params params) throws IOException;
-
-    @Override
-    public String getWriteableName() {
-        // NORELEASE remove this before 5.0.0GA - all builders will implement this method on their own.
-        assert usesNewStyleSerialization() == false: "migrated aggregations should just return their NAME";
-        return type.stream().toUtf8();
-    }
 
     @Override
     public int hashCode() {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -69,7 +69,8 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, St
         }
 
         /**
-         * @return The name of the type (mainly used for registering the parser for the aggregator (see {@link org.elasticsearch.search.aggregations.Aggregator.Parser#type()}).
+         * @return The name of the type of aggregation.  This is the key for parsing the aggregation from XContent and is the name of the
+         * aggregation's builder when serialized.
          */
         public String name() {
             return name;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ChildrenAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ChildrenAggregatorBuilder.java
@@ -81,11 +81,6 @@ public class ChildrenAggregatorBuilder extends ValuesSourceAggregatorBuilder<Par
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected ValuesSourceAggregatorFactory<ParentChild, ?> innerBuild(AggregationContext context,
             ValuesSourceConfig<ParentChild> config, AggregatorFactory<?> parent, Builder subFactoriesBuilder) throws IOException {
         return new ChildrenAggregatorFactory(name, type, config, parentType, childFilter, parentFilter, context, parent,

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregatorBuilder.java
@@ -77,11 +77,6 @@ public class FilterAggregatorBuilder extends AggregatorBuilder<FilterAggregatorB
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected AggregatorFactory<?> doBuild(AggregationContext context, AggregatorFactory<?> parent,
             AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
         return new FilterAggregatorFactory(name, type, filter, context, parent, subFactoriesBuilder, metaData);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersAggregatorBuilder.java
@@ -128,11 +128,6 @@ public class FiltersAggregatorBuilder extends AggregatorBuilder<FiltersAggregato
         out.writeString(otherBucketKey);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     /**
      * Set whether to include a bucket for documents not matching any filter
      */

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregatorBuilder.java
@@ -74,11 +74,6 @@ public class GeoGridAggregatorBuilder extends ValuesSourceAggregatorBuilder<Valu
         out.writeVInt(shardSize);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     public GeoGridAggregatorBuilder precision(int precision) {
         this.precision = GeoHashGridParams.checkPrecision(precision);
         return this;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregatorBuilder.java
@@ -52,11 +52,6 @@ public class GlobalAggregatorBuilder extends AggregatorBuilder<GlobalAggregatorB
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected AggregatorFactory<?> doBuild(AggregationContext context, AggregatorFactory<?> parent, Builder subFactoriesBuilder)
             throws IOException {
         return new GlobalAggregatorFactory(name, type, context, parent, subFactoriesBuilder, metaData);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AbstractHistogramBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AbstractHistogramBuilder.java
@@ -79,11 +79,6 @@ public abstract class AbstractHistogramBuilder<AB extends AbstractHistogramBuild
         }
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     public long interval() {
         return interval;
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregatorBuilder.java
@@ -56,11 +56,6 @@ public class MissingAggregatorBuilder extends ValuesSourceAggregatorBuilder<Valu
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected boolean serializeTargetValueType() {
         return true;
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorBuilder.java
@@ -68,11 +68,6 @@ public class NestedAggregatorBuilder extends AggregatorBuilder<NestedAggregatorB
         out.writeString(path);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     /**
      * Get the path to use for this nested aggregation.
      */

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorBuilder.java
@@ -57,11 +57,6 @@ public class ReverseNestedAggregatorBuilder extends AggregatorBuilder<ReverseNes
         out.writeOptionalString(path);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     /**
      * Set the path to use for this nested aggregation. The path must match
      * the path to a nested object in the mappings. If it is not specified

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/AbstractRangeBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/AbstractRangeBuilder.java
@@ -64,11 +64,6 @@ public abstract class AbstractRangeBuilder<AB extends AbstractRangeBuilder<AB, R
         out.writeBoolean(keyed);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     public AB addRange(R range) {
         if (range == null) {
             throw new IllegalArgumentException("[range] must not be null: [" + name + "]");

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceAggregatorBuilder.java
@@ -95,11 +95,6 @@ public class GeoDistanceAggregatorBuilder extends ValuesSourceAggregatorBuilder<
         unit.writeTo(out);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     public GeoDistanceAggregatorBuilder addRange(Range range) {
         if (range == null) {
             throw new IllegalArgumentException("[range] must not be null: [" + name + "]");

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedAggregatorBuilder.java
@@ -68,11 +68,6 @@ public class DiversifiedAggregatorBuilder extends ValuesSourceAggregatorBuilder<
         out.writeOptionalString(executionHint);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     /**
      * Set the max num docs to be returned from each shard.
      */

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregatorBuilder.java
@@ -59,11 +59,6 @@ public class SamplerAggregatorBuilder extends AggregatorBuilder<SamplerAggregato
         out.writeVInt(shardSize);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     /**
      * Set the max num docs to be returned from each shard.
      */

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorBuilder.java
@@ -100,11 +100,6 @@ public class SignificantTermsAggregatorBuilder extends ValuesSourceAggregatorBui
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected boolean serializeTargetValueType() {
         return true;
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorBuilder.java
@@ -99,11 +99,6 @@ public class TermsAggregatorBuilder extends ValuesSourceAggregatorBuilder<Values
         out.writeBoolean(showTermDocCountError);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     public TermsAggregator.BucketCountThresholds bucketCountThresholds() {
         return bucketCountThresholds;
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregatorBuilder.java
@@ -56,11 +56,6 @@ public class AvgAggregatorBuilder extends ValuesSourceAggregatorBuilder.LeafOnly
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected AvgAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig<Numeric> config,
             AggregatorFactory<?> parent, Builder subFactoriesBuilder) throws IOException {
         return new AvgAggregatorFactory(name, type, config, context, parent, subFactoriesBuilder, metaData);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregatorBuilder.java
@@ -67,11 +67,6 @@ public final class CardinalityAggregatorBuilder extends ValuesSourceAggregatorBu
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected boolean serializeTargetValueType() {
         return true;
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsAggregatorBuilder.java
@@ -58,11 +58,6 @@ public class GeoBoundsAggregatorBuilder extends ValuesSourceAggregatorBuilder<Va
         out.writeBoolean(wrapLongitude);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     /**
      * Set whether to wrap longitudes. Defaults to true.
      */

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geocentroid/GeoCentroidAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geocentroid/GeoCentroidAggregatorBuilder.java
@@ -56,11 +56,6 @@ public class GeoCentroidAggregatorBuilder
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected GeoCentroidAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig<ValuesSource.GeoPoint> config,
             AggregatorFactory<?> parent, Builder subFactoriesBuilder) throws IOException {
         return new GeoCentroidAggregatorFactory(name, type, config, context, parent, subFactoriesBuilder, metaData);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregatorBuilder.java
@@ -56,11 +56,6 @@ public class MaxAggregatorBuilder extends ValuesSourceAggregatorBuilder.LeafOnly
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected MaxAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig<Numeric> config,
             AggregatorFactory<?> parent, Builder subFactoriesBuilder) throws IOException {
         return new MaxAggregatorFactory(name, type, config, context, parent, subFactoriesBuilder, metaData);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregatorBuilder.java
@@ -56,11 +56,6 @@ public class MinAggregatorBuilder extends ValuesSourceAggregatorBuilder.LeafOnly
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected MinAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig<Numeric> config,
             AggregatorFactory<?> parent, Builder subFactoriesBuilder) throws IOException {
         return new MinAggregatorFactory(name, type, config, context, parent, subFactoriesBuilder, metaData);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentileRanksAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentileRanksAggregatorBuilder.java
@@ -76,11 +76,6 @@ public class PercentileRanksAggregatorBuilder extends LeafOnly<ValuesSource.Nume
         method.writeTo(out);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     /**
      * Set the values to compute percentiles from.
      */

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregatorBuilder.java
@@ -76,11 +76,6 @@ public class PercentilesAggregatorBuilder extends LeafOnly<ValuesSource.Numeric,
         method.writeTo(out);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     /**
      * Set the values to compute percentiles from.
      */

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregatorBuilder.java
@@ -89,11 +89,6 @@ public class ScriptedMetricAggregatorBuilder extends AggregatorBuilder<ScriptedM
         }
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     /**
      * Set the <tt>init</tt> script.
      */

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggregatorBuilder.java
@@ -62,11 +62,6 @@ public class StatsAggregatorBuilder extends ValuesSourceAggregatorBuilder.LeafOn
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         return builder;
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregatorBuilder.java
@@ -60,11 +60,6 @@ public class ExtendedStatsAggregatorBuilder
         out.writeDouble(sigma);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     public ExtendedStatsAggregatorBuilder sigma(double sigma) {
         if (sigma < 0.0) {
             throw new IllegalArgumentException("[sigma] must be greater than or equal to 0. Found [" + sigma + "] in [" + name + "]");

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregatorBuilder.java
@@ -56,11 +56,6 @@ public class SumAggregatorBuilder extends ValuesSourceAggregatorBuilder.LeafOnly
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected SumAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig<Numeric> config,
             AggregatorFactory<?> parent, Builder subFactoriesBuilder) throws IOException {
         return new SumAggregatorFactory(name, type, config, context, parent, subFactoriesBuilder, metaData);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregatorBuilder.java
@@ -156,11 +156,6 @@ public class TopHitsAggregatorBuilder extends AggregatorBuilder<TopHitsAggregato
         out.writeBoolean(version);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     /**
      * From index to start the search from. Defaults to <tt>0</tt>.
      */

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregatorBuilder.java
@@ -55,11 +55,6 @@ public class ValueCountAggregatorBuilder extends ValuesSourceAggregatorBuilder.L
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected boolean serializeTargetValueType() {
         return true;
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/PipelineAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/PipelineAggregator.java
@@ -39,18 +39,9 @@ public abstract class PipelineAggregator implements Streamable {
      */
     @FunctionalInterface
     public static interface Parser {
-
         public static final ParseField BUCKETS_PATH = new ParseField("buckets_path");
-
         public static final ParseField FORMAT = new ParseField("format");
         public static final ParseField GAP_POLICY = new ParseField("gap_policy");
-
-        /**
-         * @return The aggregation type this parser is associated with.
-         */
-        default String type() {
-            throw new UnsupportedOperationException(); // NORELEASE remove before 5.0.0GA
-        }
 
         /**
          * Returns the pipeline aggregator factory with which this parser is
@@ -66,15 +57,6 @@ public abstract class PipelineAggregator implements Streamable {
          */
         PipelineAggregatorBuilder<?> parse(String pipelineAggregatorName, QueryParseContext context)
                 throws IOException;
-
-        /**
-         * @return an empty {@link PipelineAggregatorBuilder} instance for this
-         *         parser that can be used for deserialization
-         */
-        default PipelineAggregatorBuilder<?> getFactoryPrototype() {
-            throw new UnsupportedOperationException(); // NORELEASE remove before 5.0.0GA
-        }
-
     }
 
     private String name;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/PipelineAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/PipelineAggregatorBuilder.java
@@ -86,33 +86,11 @@ public abstract class PipelineAggregatorBuilder<PAB extends PipelineAggregatorBu
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
         out.writeStringArray(bucketsPaths);
-        if (usesNewStyleSerialization()) {
-            out.writeMap(metaData);
-            doWriteTo(out);
-        } else {
-            doWriteTo(out);
-            out.writeMap(metaData);
-        }
+        out.writeMap(metaData);
+        doWriteTo(out);
     }
 
     protected abstract void doWriteTo(StreamOutput out) throws IOException;
-
-    protected boolean usesNewStyleSerialization() {
-        return false; // NORELEASE remove this before 5.0.0GA, when all the aggregations have been migrated
-    }
-
-    @Override
-    public PipelineAggregatorBuilder<PAB> readFrom(StreamInput in) throws IOException {
-        String name = in.readString();
-        String[] bucketsPaths = in.readStringArray();
-        PipelineAggregatorBuilder<PAB> factory = doReadFrom(name, bucketsPaths, in);
-        factory.metaData = in.readMap();
-        return factory;
-    }
-
-    protected PipelineAggregatorBuilder<PAB> doReadFrom(String name, String[] bucketsPaths, StreamInput in) throws IOException {
-        throw new UnsupportedOperationException(); // NORELEASE remove this before 5.0.0GA, when all the aggregations have been migrated
-    }
 
     public String name() {
         return name;
@@ -159,12 +137,6 @@ public abstract class PipelineAggregatorBuilder<PAB extends PipelineAggregatorBu
 
     public String[] getBucketsPaths() {
         return bucketsPaths;
-    }
-
-    @Override
-    public String getWriteableName() {
-        assert false == usesNewStyleSerialization() : "Migrated aggregations should just return NAME";
-        return type;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/BucketMetricsPipelineAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/BucketMetricsPipelineAggregatorBuilder.java
@@ -54,31 +54,12 @@ public abstract class BucketMetricsPipelineAggregatorBuilder<AF extends BucketMe
 
     @Override
     protected final void doWriteTo(StreamOutput out) throws IOException {
-        if (false == usesNewStyleSerialization()) {
-            innerWriteTo(out);
-        }
         out.writeOptionalString(format);
         gapPolicy.writeTo(out);
-        if (usesNewStyleSerialization()) {
-            innerWriteTo(out);
-        }
+        innerWriteTo(out);
     }
 
     protected abstract void innerWriteTo(StreamOutput out) throws IOException;
-
-    @Override
-    protected final PipelineAggregatorBuilder<AF> doReadFrom(String name, String[] bucketsPaths, StreamInput in) throws IOException {
-        BucketMetricsPipelineAggregatorBuilder<AF> factory = innerReadFrom(name, bucketsPaths, in);
-        factory.format = in.readOptionalString();
-        factory.gapPolicy = GapPolicy.readFrom(in);
-        return factory;
-    }
-
-    protected BucketMetricsPipelineAggregatorBuilder<AF> innerReadFrom(String name, String[] bucketsPaths, StreamInput in)
-            throws IOException {
-        throw new UnsupportedOperationException(); // NORELEASE remove before 5.0.0 GA
-    }
-
 
     /**
      * Sets the format to use on the output of this aggregation.

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/avg/AvgBucketPipelineAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/avg/AvgBucketPipelineAggregatorBuilder.java
@@ -54,11 +54,6 @@ public class AvgBucketPipelineAggregatorBuilder extends BucketMetricsPipelineAgg
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected PipelineAggregator createInternal(Map<String, Object> metaData) throws IOException {
         return new AvgBucketPipelineAggregator(name, bucketsPaths, gapPolicy(), formatter(), metaData);
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/max/MaxBucketPipelineAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/max/MaxBucketPipelineAggregatorBuilder.java
@@ -54,11 +54,6 @@ public class MaxBucketPipelineAggregatorBuilder extends BucketMetricsPipelineAgg
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected PipelineAggregator createInternal(Map<String, Object> metaData) throws IOException {
         return new MaxBucketPipelineAggregator(name, bucketsPaths, gapPolicy(), formatter(), metaData);
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/min/MinBucketPipelineAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/min/MinBucketPipelineAggregatorBuilder.java
@@ -54,11 +54,6 @@ public class MinBucketPipelineAggregatorBuilder extends BucketMetricsPipelineAgg
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected PipelineAggregator createInternal(Map<String, Object> metaData) throws IOException {
         return new MinBucketPipelineAggregator(name, bucketsPaths, gapPolicy(), formatter(), metaData);
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/percentile/PercentilesBucketPipelineAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/percentile/PercentilesBucketPipelineAggregatorBuilder.java
@@ -63,11 +63,6 @@ public class PercentilesBucketPipelineAggregatorBuilder
         out.writeDoubleArray(percents);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     /**
      * Get the percentages to calculate percentiles for in this aggregation
      */

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/stats/StatsBucketPipelineAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/stats/StatsBucketPipelineAggregatorBuilder.java
@@ -56,11 +56,6 @@ public class StatsBucketPipelineAggregatorBuilder extends BucketMetricsPipelineA
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected PipelineAggregator createInternal(Map<String, Object> metaData) throws IOException {
         return new StatsBucketPipelineAggregator(name, bucketsPaths, gapPolicy(), formatter(), metaData);
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/stats/extended/ExtendedStatsBucketPipelineAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/stats/extended/ExtendedStatsBucketPipelineAggregatorBuilder.java
@@ -58,11 +58,6 @@ public class ExtendedStatsBucketPipelineAggregatorBuilder
         out.writeDouble(sigma);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     /**
      * Set the value of sigma to use when calculating the standard deviation
      * bounds

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/sum/SumBucketPipelineAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/sum/SumBucketPipelineAggregatorBuilder.java
@@ -54,11 +54,6 @@ public class SumBucketPipelineAggregatorBuilder extends BucketMetricsPipelineAgg
     }
 
     @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
-    @Override
     protected PipelineAggregator createInternal(Map<String, Object> metaData) throws IOException {
         return new SumBucketPipelineAggregator(name, bucketsPaths, gapPolicy(), formatter(), metaData);
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketscript/BucketScriptPipelineAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketscript/BucketScriptPipelineAggregatorBuilder.java
@@ -93,11 +93,6 @@ public class BucketScriptPipelineAggregatorBuilder extends PipelineAggregatorBui
         gapPolicy.writeTo(out);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     private static Map<String, String> convertToBucketsPathMap(String[] bucketsPaths) {
         Map<String, String> bucketsPathsMap = new HashMap<>();
         for (int i = 0; i < bucketsPaths.length; i++) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketselector/BucketSelectorPipelineAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketselector/BucketSelectorPipelineAggregatorBuilder.java
@@ -88,11 +88,6 @@ public class BucketSelectorPipelineAggregatorBuilder extends PipelineAggregatorB
         gapPolicy.writeTo(out);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     private static Map<String, String> convertToBucketsPathMap(String[] bucketsPaths) {
         Map<String, String> bucketsPathsMap = new HashMap<>();
         for (int i = 0; i < bucketsPaths.length; i++) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/cumulativesum/CumulativeSumPipelineAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/cumulativesum/CumulativeSumPipelineAggregatorBuilder.java
@@ -65,11 +65,6 @@ public class CumulativeSumPipelineAggregatorBuilder extends PipelineAggregatorBu
         out.writeOptionalString(format);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     /**
      * Sets the format to use on the output of this aggregation.
      */

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/DerivativePipelineAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/DerivativePipelineAggregatorBuilder.java
@@ -86,11 +86,6 @@ public class DerivativePipelineAggregatorBuilder extends PipelineAggregatorBuild
         out.writeOptionalString(units);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     public DerivativePipelineAggregatorBuilder format(String format) {
         if (format == null) {
             throw new IllegalArgumentException("[format] must not be null: [" + name + "]");

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/MovAvgPipelineAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/MovAvgPipelineAggregatorBuilder.java
@@ -93,11 +93,6 @@ public class MovAvgPipelineAggregatorBuilder extends PipelineAggregatorBuilder<M
         out.writeOptionalBoolean(minimize);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     /**
      * Sets the format to use on the output of this aggregation.
      */

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/serialdiff/SerialDiffPipelineAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/serialdiff/SerialDiffPipelineAggregatorBuilder.java
@@ -72,11 +72,6 @@ public class SerialDiffPipelineAggregatorBuilder extends PipelineAggregatorBuild
         out.writeVInt(lag);
     }
 
-    @Override
-    protected boolean usesNewStyleSerialization() {
-        return true;
-    }
-
     /**
      * Sets the lag to use when calculating the serial difference.
      */

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/AbstractValuesSourceParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/AbstractValuesSourceParser.java
@@ -122,8 +122,8 @@ public abstract class AbstractValuesSourceParser<VS extends ValuesSource>
                         valueType = ValueType.resolveForScript(parser.text());
                         if (targetValueType != null && valueType.isNotA(targetValueType)) {
                             throw new ParsingException(parser.getTokenLocation(),
-                                    type() + " aggregation [" + aggregationName + "] was configured with an incompatible value type ["
-                                            + valueType + "]. [" + type() + "] aggregation can only work on value of type ["
+                                    "Aggregation [" + aggregationName + "] was configured with an incompatible value type ["
+                                            + valueType + "]. It can only work on value of type ["
                                             + targetValueType + "]");
                         }
                     } else if (!token(aggregationName, currentFieldName, token, parser, context.getParseFieldMatcher(), otherOptions)) {


### PR DESCRIPTION
Removes deprecated registration methods from SearchModule and
NamedWriteableRegistry and removes the "shims" used to migrate
aggregations to the new registration methods.

Relates to #17085
