### PR TITLE
Make (read|write)NamedWriteable public

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/geo/builders/GeometryCollectionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/GeometryCollectionBuilder.java
@@ -53,7 +53,7 @@ public class GeometryCollectionBuilder extends ShapeBuilder {
     public GeometryCollectionBuilder(StreamInput in) throws IOException {
         int shapes = in.readVInt();
         for (int i = 0; i < shapes; i++) {
-            shape(in.readShape());
+            shape(in.readNamedWriteable(ShapeBuilder.class));
         }
     }
 
@@ -61,7 +61,7 @@ public class GeometryCollectionBuilder extends ShapeBuilder {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVInt(shapes.size());
         for (ShapeBuilder shape : shapes) {
-            out.writeShape(shape);
+            out.writeNamedWriteable(shape);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableAwareStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableAwareStreamInput.java
@@ -34,7 +34,7 @@ public class NamedWriteableAwareStreamInput extends FilterStreamInput {
     }
 
     @Override
-    <C extends NamedWriteable<?>> C readNamedWriteable(Class<C> categoryClass) throws IOException {
+    public <C extends NamedWriteable<?>> C readNamedWriteable(Class<C> categoryClass) throws IOException {
         String name = readString();
         Writeable.Reader<? extends C> reader = namedWriteableRegistry.getReader(categoryClass, name);
         C c = reader.read(this);

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -725,7 +725,7 @@ public abstract class StreamInput extends InputStream {
      * Default implementation throws {@link UnsupportedOperationException} as StreamInput doesn't hold a registry.
      * Use {@link FilterInputStream} instead which wraps a stream and supports a {@link NamedWriteableRegistry} too.
      */
-    <C extends NamedWriteable<?>> C readNamedWriteable(@SuppressWarnings("unused") Class<C> categoryClass) throws IOException {
+    public <C extends NamedWriteable<?>> C readNamedWriteable(@SuppressWarnings("unused") Class<C> categoryClass) throws IOException {
         throw new UnsupportedOperationException("can't read named writeable from StreamInput");
     }
 

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -34,14 +34,10 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.AggregatorBuilder;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorBuilder;
-import org.elasticsearch.search.rescore.RescoreBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.suggest.SuggestionBuilder;
 import org.elasticsearch.search.suggest.phrase.SmoothingModel;
@@ -744,13 +740,6 @@ public abstract class StreamInput extends InputStream {
      */
     public QueryBuilder<?> readQuery() throws IOException {
         return readNamedWriteable(QueryBuilder.class);
-    }
-
-    /**
-     * Reads a {@link RescoreBuilder} from the current stream
-     */
-    public RescoreBuilder<?> readRescorer() throws IOException {
-        return readNamedWriteable(RescoreBuilder.class);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -721,6 +721,7 @@ public abstract class StreamInput extends InputStream {
      * Default implementation throws {@link UnsupportedOperationException} as StreamInput doesn't hold a registry.
      * Use {@link FilterInputStream} instead which wraps a stream and supports a {@link NamedWriteableRegistry} too.
      */
+    @Nullable
     public <C extends NamedWriteable<?>> C readNamedWriteable(@SuppressWarnings("unused") Class<C> categoryClass) throws IOException {
         throw new UnsupportedOperationException("can't read named writeable from StreamInput");
     }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -740,13 +740,6 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
-     * Reads a {@link PipelineAggregatorBuilder} from the current stream
-     */
-    public PipelineAggregatorBuilder<?> readPipelineAggregatorBuilder() throws IOException {
-        return readNamedWriteable(PipelineAggregatorBuilder.class);
-    }
-
-    /**
      * Reads a {@link QueryBuilder} from the current stream
      */
     public QueryBuilder<?> readQuery() throws IOException {

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -730,6 +730,16 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
+     * Reads an optional {@link QueryBuilder}.
+     */
+    public <C extends NamedWriteable<?>> C readOptionalNamedWriteable(Class<C> categoryClass) throws IOException {
+        if (readBoolean()) {
+            return readNamedWriteable(categoryClass);
+        }
+        return null;
+    }
+
+    /**
      * Reads a {@link AggregatorBuilder} from the current stream
      */
     public AggregatorBuilder<?> readAggregatorBuilder() throws IOException {
@@ -748,16 +758,6 @@ public abstract class StreamInput extends InputStream {
      */
     public QueryBuilder<?> readQuery() throws IOException {
         return readNamedWriteable(QueryBuilder.class);
-    }
-
-    /**
-     * Reads an optional {@link QueryBuilder}.
-     */
-    public QueryBuilder<?> readOptionalQuery() throws IOException {
-        if (readBoolean()) {
-            return readNamedWriteable(QueryBuilder.class);
-        }
-        return null;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -730,7 +730,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
-     * Reads an optional {@link QueryBuilder}.
+     * Reads an optional {@link NamedWriteable}.
      */
     public <C extends NamedWriteable<?>> C readOptionalNamedWriteable(Class<C> categoryClass) throws IOException {
         if (readBoolean()) {

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -747,13 +747,6 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
-     * Reads a {@link ShapeBuilder} from the current stream
-     */
-    public ShapeBuilder readShape() throws IOException {
-        return readNamedWriteable(ShapeBuilder.class);
-    }
-
-    /**
      * Reads a {@link RescoreBuilder} from the current stream
      */
     public RescoreBuilder<?> readRescorer() throws IOException {

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -740,13 +740,6 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
-     * Reads a {@link AggregatorBuilder} from the current stream
-     */
-    public AggregatorBuilder<?> readAggregatorBuilder() throws IOException {
-        return readNamedWriteable(AggregatorBuilder.class);
-    }
-
-    /**
      * Reads a {@link PipelineAggregatorBuilder} from the current stream
      */
     public PipelineAggregatorBuilder<?> readPipelineAggregatorBuilder() throws IOException {

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -737,56 +737,72 @@ public abstract class StreamInput extends InputStream {
 
     /**
      * Reads a {@link QueryBuilder} from the current stream
+     * @deprecated prefer {@link #readNamedWriteable(Class)} passing {@link QueryBuilder}.
      */
+    @Deprecated
     public QueryBuilder<?> readQuery() throws IOException {
         return readNamedWriteable(QueryBuilder.class);
     }
 
     /**
      * Reads a {@link SuggestionBuilder} from the current stream
+     * @deprecated prefer {@link #readNamedWriteable(Class)} passing {@link SuggestionBuilder}.
      */
+    @Deprecated
     public SuggestionBuilder<?> readSuggestion() throws IOException {
         return readNamedWriteable(SuggestionBuilder.class);
     }
 
     /**
      * Reads a {@link SortBuilder} from the current stream
+     * @deprecated prefer {@link #readNamedWriteable(Class)} passing {@link SortBuilder}.
      */
+    @Deprecated
     public SortBuilder<?> readSortBuilder() throws IOException {
         return readNamedWriteable(SortBuilder.class);
     }
 
     /**
      * Reads a {@link org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder} from the current stream
+     * @deprecated prefer {@link #readNamedWriteable(Class)} passing {@link ScoreFunctionBuilder}.
      */
+    @Deprecated
     public ScoreFunctionBuilder<?> readScoreFunction() throws IOException {
         return readNamedWriteable(ScoreFunctionBuilder.class);
     }
 
     /**
      * Reads a {@link SmoothingModel} from the current stream
+     * @deprecated prefer {@link #readNamedWriteable(Class)} passing {@link SmoothingModel}.
      */
+    @Deprecated
     public SmoothingModel readPhraseSuggestionSmoothingModel() throws IOException {
         return readNamedWriteable(SmoothingModel.class);
     }
 
     /**
      * Reads a {@link Task.Status} from the current stream.
+     * @deprecated prefer {@link #readNamedWriteable(Class)} passing {@link Task.Status}.
      */
+    @Deprecated
     public Task.Status readTaskStatus() throws IOException {
         return readNamedWriteable(Task.Status.class);
     }
 
     /**
      * Reads a {@link DocValueFormat} from the current stream.
+     * @deprecated prefer {@link #readNamedWriteable(Class)} passing {@link DocValueFormat}.
      */
+    @Deprecated
     public DocValueFormat readValueFormat() throws IOException {
         return readNamedWriteable(DocValueFormat.class);
     }
 
     /**
      * Reads an {@link AllocationCommand} from the stream.
+     * @deprecated prefer {@link #readNamedWriteable(Class)} passing {@link AllocationCommand}.
      */
+    @Deprecated
     public AllocationCommand readAllocationCommand() throws IOException {
         return readNamedWriteable(AllocationCommand.class);
     }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -693,6 +693,18 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
+     * Write an optional {@link QueryBuilder} to the stream.
+     */
+    public void writeOptionalNamedWriteable(@Nullable NamedWriteable<?> namedWriteable) throws IOException {
+        if (namedWriteable == null) {
+            writeBoolean(false);
+        } else {
+            writeBoolean(true);
+            writeNamedWriteable(namedWriteable);
+        }
+    }
+
+    /**
      * Writes a {@link AggregatorBuilder} to the current stream
      */
     public void writeAggregatorBuilder(AggregatorBuilder<?> builder) throws IOException {
@@ -711,18 +723,6 @@ public abstract class StreamOutput extends OutputStream {
      */
     public void writeQuery(QueryBuilder<?> queryBuilder) throws IOException {
         writeNamedWriteable(queryBuilder);
-    }
-
-    /**
-     * Write an optional {@link QueryBuilder} to the stream.
-     */
-    public void writeOptionalQuery(@Nullable QueryBuilder<?> queryBuilder) throws IOException {
-        if (queryBuilder == null) {
-            writeBoolean(false);
-        } else {
-            writeBoolean(true);
-            writeQuery(queryBuilder);
-        }
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -33,14 +33,10 @@ import org.elasticsearch.cluster.routing.allocation.command.AllocationCommand;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.AggregatorBuilder;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorBuilder;
-import org.elasticsearch.search.rescore.RescoreBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.suggest.SuggestionBuilder;
 import org.elasticsearch.search.suggest.phrase.SmoothingModel;
@@ -768,13 +764,6 @@ public abstract class StreamOutput extends OutputStream {
             obj.writeTo(this);
         }
      }
-
-     /**
-     * Writes a {@link RescoreBuilder} to the current stream
-     */
-    public void writeRescorer(RescoreBuilder<?> rescorer) throws IOException {
-        writeNamedWriteable(rescorer);
-    }
 
     /**
      * Writes a {@link SuggestionBuilder} to the current stream

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -687,7 +687,7 @@ public abstract class StreamOutput extends OutputStream {
     /**
      * Writes a {@link NamedWriteable} to the current stream, by first writing its name and then the object itself
      */
-    void writeNamedWriteable(NamedWriteable<?> namedWriteable) throws IOException {
+    public void writeNamedWriteable(NamedWriteable<?> namedWriteable) throws IOException {
         writeString(namedWriteable.getWriteableName());
         namedWriteable.writeTo(this);
     }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -702,28 +702,36 @@ public abstract class StreamOutput extends OutputStream {
 
     /**
      * Writes a {@link QueryBuilder} to the current stream
+     * @deprecated prefer {@link #writeNamedWriteable(NamedWriteable)}
      */
+    @Deprecated
     public void writeQuery(QueryBuilder<?> queryBuilder) throws IOException {
         writeNamedWriteable(queryBuilder);
     }
 
     /**
      * Writes a {@link ScoreFunctionBuilder} to the current stream
+     * @deprecated prefer {@link #writeNamedWriteable(NamedWriteable)}
      */
+    @Deprecated
     public void writeScoreFunction(ScoreFunctionBuilder<?> scoreFunctionBuilder) throws IOException {
         writeNamedWriteable(scoreFunctionBuilder);
     }
 
     /**
      * Writes the given {@link SmoothingModel} to the stream
+     * @deprecated prefer {@link #writeNamedWriteable(NamedWriteable)}
      */
+    @Deprecated
     public void writePhraseSuggestionSmoothingModel(SmoothingModel smoothinModel) throws IOException {
         writeNamedWriteable(smoothinModel);
     }
 
     /**
      * Writes a {@link Task.Status} to the current stream.
+     * @deprecated prefer {@link #writeNamedWriteable(NamedWriteable)}
      */
+    @Deprecated
     public void writeTaskStatus(Task.Status status) throws IOException {
         writeNamedWriteable(status);
     }
@@ -767,26 +775,36 @@ public abstract class StreamOutput extends OutputStream {
 
     /**
      * Writes a {@link SuggestionBuilder} to the current stream
+     * @deprecated prefer {@link #writeNamedWriteable(NamedWriteable)}
      */
+    @Deprecated
     public void writeSuggestion(SuggestionBuilder<?> suggestion) throws IOException {
         writeNamedWriteable(suggestion);
     }
 
     /**
      * Writes a {@link SortBuilder} to the current stream
+     * @deprecated prefer {@link #writeNamedWriteable(NamedWriteable)}
      */
+    @Deprecated
     public void writeSortBuilder(SortBuilder<?> sort) throws IOException {
         writeNamedWriteable(sort);
     }
 
-    /** Writes a {@link DocValueFormat}. */
+    /**
+     * Writes a {@link DocValueFormat}.
+     * @deprecated prefer {@link #writeNamedWriteable(NamedWriteable)}
+     */
+    @Deprecated
     public void writeValueFormat(DocValueFormat format) throws IOException {
         writeNamedWriteable(format);
     }
 
     /**
      * Writes an {@link AllocationCommand} to the stream.
+     * @deprecated prefer {@link #writeNamedWriteable(NamedWriteable)}
      */
+    @Deprecated
     public void writeAllocationCommand(AllocationCommand command) throws IOException {
         writeNamedWriteable(command);
     }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -705,13 +705,6 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
-     * Writes a {@link AggregatorBuilder} to the current stream
-     */
-    public void writeAggregatorBuilder(AggregatorBuilder<?> builder) throws IOException {
-        writeNamedWriteable(builder);
-    }
-
-    /**
      * Writes a {@link PipelineAggregatorBuilder} to the current stream
      */
     public void writePipelineAggregatorBuilder(PipelineAggregatorBuilder<?> builder) throws IOException {

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -705,13 +705,6 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
-     * Writes a {@link PipelineAggregatorBuilder} to the current stream
-     */
-    public void writePipelineAggregatorBuilder(PipelineAggregatorBuilder<?> builder) throws IOException {
-        writeNamedWriteable(builder);
-    }
-
-    /**
      * Writes a {@link QueryBuilder} to the current stream
      */
     public void writeQuery(QueryBuilder<?> queryBuilder) throws IOException {

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -689,7 +689,7 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
-     * Write an optional {@link QueryBuilder} to the stream.
+     * Write an optional {@link NamedWriteable} to the stream.
      */
     public void writeOptionalNamedWriteable(@Nullable NamedWriteable<?> namedWriteable) throws IOException {
         if (namedWriteable == null) {

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -712,13 +712,6 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
-     * Writes a {@link ShapeBuilder} to the current stream
-     */
-    public void writeShape(ShapeBuilder shapeBuilder) throws IOException {
-        writeNamedWriteable(shapeBuilder);
-    }
-
-    /**
      * Writes a {@link ScoreFunctionBuilder} to the current stream
      */
     public void writeScoreFunction(ScoreFunctionBuilder<?> scoreFunctionBuilder) throws IOException {

--- a/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -144,7 +144,7 @@ public class GeoShapeQueryBuilder extends AbstractQueryBuilder<GeoShapeQueryBuil
         super(in);
         fieldName = in.readString();
         if (in.readBoolean()) {
-            shape = in.readShape();
+            shape = in.readNamedWriteable(ShapeBuilder.class);
             indexedShapeId = null;
             indexedShapeType = null;
         } else {
@@ -165,7 +165,7 @@ public class GeoShapeQueryBuilder extends AbstractQueryBuilder<GeoShapeQueryBuil
         boolean hasShape = shape != null;
         out.writeBoolean(hasShape);
         if (hasShape) {
-            out.writeShape(shape);
+            out.writeNamedWriteable(shape);
         } else {
             out.writeOptionalString(indexedShapeId);
             out.writeOptionalString(indexedShapeType);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -277,13 +277,11 @@ public class AggregatorFactories {
             Builder builder = new Builder();
             int factoriesSize = in.readVInt();
             for (int i = 0; i < factoriesSize; i++) {
-                AggregatorBuilder<?> factory = in.readAggregatorBuilder();
-                builder.addAggregator(factory);
+                builder.addAggregator(in.readNamedWriteable(AggregatorBuilder.class));
             }
             int pipelineFactoriesSize = in.readVInt();
             for (int i = 0; i < pipelineFactoriesSize; i++) {
-                PipelineAggregatorBuilder<?> factory = in.readPipelineAggregatorBuilder();
-                builder.addPipelineAggregator(factory);
+                builder.addPipelineAggregator(in.readNamedWriteable(PipelineAggregatorBuilder.class));
             }
             return builder;
         }
@@ -291,12 +289,12 @@ public class AggregatorFactories {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeVInt(this.aggregatorBuilders.size());
-            for (AggregatorBuilder<?> factory : aggregatorBuilders) {
-                out.writeAggregatorBuilder(factory);
+            for (AggregatorBuilder<?> builder : aggregatorBuilders) {
+                out.writeNamedWriteable(builder);
             }
             out.writeVInt(this.pipelineAggregatorBuilders.size());
-            for (PipelineAggregatorBuilder<?> factory : pipelineAggregatorBuilders) {
-                out.writePipelineAggregatorBuilder(factory);
+            for (PipelineAggregatorBuilder<?> builder : pipelineAggregatorBuilders) {
+                out.writeNamedWriteable(builder);
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -226,7 +226,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
             int size = in.readVInt();
             rescoreBuilders = new ArrayList<>();
             for (int i = 0; i < size; i++) {
-                rescoreBuilders.add(in.readRescorer());
+                rescoreBuilders.add(in.readNamedWriteable(RescoreBuilder.class));
             }
         }
         if (in.readBoolean()) {
@@ -328,7 +328,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
         if (hasRescoreBuilders) {
             out.writeVInt(rescoreBuilders.size());
             for (RescoreBuilder<?> rescoreBuilder : rescoreBuilders) {
-                out.writeRescorer(rescoreBuilder);
+                out.writeNamedWriteable(rescoreBuilder);
             }
         }
         boolean hasScriptFields = scriptFields != null;

--- a/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -101,7 +101,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
      */
     public FieldSortBuilder(StreamInput in) throws IOException {
         fieldName = in.readString();
-        nestedFilter = in.readOptionalQuery();
+        nestedFilter = in.readOptionalNamedWriteable(QueryBuilder.class);
         nestedPath = in.readOptionalString();
         missing = in.readGenericValue();
         order = in.readOptionalWriteable(SortOrder::readFromStream);

--- a/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -112,7 +112,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(fieldName);
-        out.writeOptionalQuery(nestedFilter);
+        out.writeOptionalNamedWriteable(nestedFilter);
         out.writeOptionalString(nestedPath);
         out.writeGenericValue(missing);
         out.writeOptionalWriteable(order);

--- a/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -173,7 +173,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
         unit.writeTo(out);
         order.writeTo(out);
         out.writeOptionalWriteable(sortMode);
-        out.writeOptionalQuery(nestedFilter);
+        out.writeOptionalNamedWriteable(nestedFilter);
         out.writeOptionalString(nestedPath);
         out.writeBoolean(coerce);
         out.writeBoolean(ignoreMalformed);

--- a/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -159,7 +159,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
         unit = DistanceUnit.readFromStream(in);
         order = SortOrder.readFromStream(in);
         sortMode = in.readOptionalWriteable(SortMode::readFromStream);
-        nestedFilter = in.readOptionalQuery();
+        nestedFilter = in.readOptionalNamedWriteable(QueryBuilder.class);
         nestedPath = in.readOptionalString();
         coerce = in.readBoolean();
         ignoreMalformed =in.readBoolean();

--- a/core/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
@@ -128,7 +128,7 @@ public class ScriptSortBuilder extends SortBuilder<ScriptSortBuilder> {
         order.writeTo(out);
         out.writeOptionalWriteable(sortMode);
         out.writeOptionalString(nestedPath);
-        out.writeOptionalQuery(nestedFilter);
+        out.writeOptionalNamedWriteable(nestedFilter);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
@@ -118,7 +118,7 @@ public class ScriptSortBuilder extends SortBuilder<ScriptSortBuilder> {
         order = SortOrder.readFromStream(in);
         sortMode = in.readOptionalWriteable(SortMode::readFromStream);
         nestedPath = in.readOptionalString();
-        nestedFilter = in.readOptionalQuery();
+        nestedFilter = in.readOptionalNamedWriteable(QueryBuilder.class);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
@@ -251,9 +251,9 @@ public abstract class BaseAggregationTestCase<AB extends AggregatorBuilder<AB>> 
     public void testSerialization() throws IOException {
         AB testAgg = createTestAggregatorBuilder();
         try (BytesStreamOutput output = new BytesStreamOutput()) {
-            output.writeAggregatorBuilder(testAgg);
+            output.writeNamedWriteable(testAgg);
             try (StreamInput in = new NamedWriteableAwareStreamInput(StreamInput.wrap(output.bytes()), namedWriteableRegistry)) {
-                AggregatorBuilder deserialized = in.readAggregatorBuilder();
+                AggregatorBuilder<?> deserialized = in.readNamedWriteable(AggregatorBuilder.class);
                 assertEquals(testAgg, deserialized);
                 assertEquals(testAgg.hashCode(), deserialized.hashCode());
                 assertNotSame(testAgg, deserialized);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/BasePipelineAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/BasePipelineAggregationTestCase.java
@@ -256,9 +256,9 @@ public abstract class BasePipelineAggregationTestCase<AF extends PipelineAggrega
     public void testSerialization() throws IOException {
         AF testAgg = createTestAggregatorFactory();
         try (BytesStreamOutput output = new BytesStreamOutput()) {
-            output.writePipelineAggregatorBuilder(testAgg);
+            output.writeNamedWriteable(testAgg);
             try (StreamInput in = new NamedWriteableAwareStreamInput(StreamInput.wrap(output.bytes()), namedWriteableRegistry)) {
-                PipelineAggregatorBuilder deserializedQuery = in.readPipelineAggregatorBuilder();
+                PipelineAggregatorBuilder<?> deserializedQuery = in.readNamedWriteable(PipelineAggregatorBuilder.class);
                 assertEquals(deserializedQuery, testAgg);
                 assertEquals(deserializedQuery.hashCode(), testAgg.hashCode());
                 assertNotSame(deserializedQuery, testAgg);
@@ -296,10 +296,10 @@ public abstract class BasePipelineAggregationTestCase<AF extends PipelineAggrega
     // argument
     private AF copyAggregation(AF agg) throws IOException {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
-            output.writePipelineAggregatorBuilder(agg);
+            output.writeNamedWriteable(agg);
             try (StreamInput in = new NamedWriteableAwareStreamInput(StreamInput.wrap(output.bytes()), namedWriteableRegistry)) {
                 @SuppressWarnings("unchecked")
-                AF secondAgg = (AF) in.readPipelineAggregatorBuilder();
+                AF secondAgg = (AF) in.readNamedWriteable(PipelineAggregatorBuilder.class);
                 return secondAgg;
             }
         }

--- a/core/src/test/java/org/elasticsearch/search/rescore/QueryRescoreBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/rescore/QueryRescoreBuilderTests.java
@@ -335,9 +335,9 @@ public class QueryRescoreBuilderTests extends ESTestCase {
 
     private static RescoreBuilder<?> serializedCopy(RescoreBuilder<?> original) throws IOException {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
-            output.writeRescorer(original);
+            output.writeNamedWriteable(original);
             try (StreamInput in = new NamedWriteableAwareStreamInput(StreamInput.wrap(output.bytes()), namedWriteableRegistry)) {
-                return in.readRescorer();
+                return in.readNamedWriteable(RescoreBuilder.class);
             }
         }
     }

--- a/plugins/delete-by-query/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryRequest.java
+++ b/plugins/delete-by-query/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryRequest.java
@@ -208,7 +208,7 @@ public class DeleteByQueryRequest extends ActionRequest<DeleteByQueryRequest> im
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
         types = in.readStringArray();
-        query = in.readQuery();
+        query = in.readNamedWriteable(QueryBuilder.class);
         routing = in.readOptionalString();
         size = in.readVInt();
         if (in.readBoolean()) {
@@ -225,7 +225,7 @@ public class DeleteByQueryRequest extends ActionRequest<DeleteByQueryRequest> im
         out.writeStringArray(indices);
         indicesOptions.writeIndicesOptions(out);
         out.writeStringArray(types);
-        out.writeQuery(query);
+        out.writeNamedWriteable(query);
         out.writeOptionalString(routing);
         out.writeVInt(size);
         out.writeOptionalStreamable(scroll);


### PR DESCRIPTION
- Make (read|write)NamedWriteable public
- Remove some of the lesser used readXYZ/writeXYZ methods
- Deprecate all remaining readXYZ/writeXYZ methods

I believe it is safe to remove all of the remaining readXYZ/writeXYZ method because the only release that contained them was 5.0.0-alpha1 but that'd make the PR too large. readQuery/writeQuery is very common. The others are rare, but there are too many of them.

Closes #17682
