### PR TITLE
Clean up serialization on some stats

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -224,7 +224,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
             threadPool = ThreadPoolStats.readThreadPoolStats(in);
         }
         if (in.readBoolean()) {
-            fs = FsInfo.readFsInfo(in);
+            fs = new FsInfo(in);
         }
         if (in.readBoolean()) {
             transport = TransportStats.readTransportStats(in);

--- a/core/src/main/java/org/elasticsearch/monitor/fs/FsService.java
+++ b/core/src/main/java/org/elasticsearch/monitor/fs/FsService.java
@@ -64,7 +64,7 @@ public class FsService extends AbstractComponent {
                 return probe.stats();
             } catch (IOException ex) {
                 logger.warn("Failed to fetch fs stats - returning empty instance");
-                return new FsInfo();
+                return new FsInfo(0, null);
             }
         }
     }


### PR DESCRIPTION
Removes readFrom which is no longer required/actively discouraged and
replaces some instances of `Streamable` with `Writeable`.

Relates to #17085
