### PR TITLE
Remove readFrom from some classes in index

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/Index.java
+++ b/core/src/main/java/org/elasticsearch/index/Index.java
@@ -41,11 +41,19 @@ public class Index implements Writeable<Index> {
         this.uuid = uuid.intern();
     }
 
+    /**
+     * Read from a stream.
+     */
     public Index(StreamInput in) throws IOException {
         this.name = in.readString();
         this.uuid = in.readString();
     }
 
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name);
+        out.writeString(uuid);
+    }
 
     public String getName() {
         return this.name;
@@ -84,16 +92,5 @@ public class Index implements Writeable<Index> {
         int result = name.hashCode();
         result = 31 * result + uuid.hashCode();
         return result;
-    }
-
-    @Override
-    public Index readFrom(StreamInput in) throws IOException {
-        return new Index(in);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(name);
-        out.writeString(uuid);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -1077,24 +1077,22 @@ public abstract class Engine implements Closeable {
             this.id = Arrays.copyOf(id, id.length);
         }
 
+        /**
+         * Read from a stream.
+         */
         public CommitId(StreamInput in) throws IOException {
             assert in != null;
             this.id = in.readByteArray();
         }
 
         @Override
-        public String toString() {
-            return Base64.encodeBytes(id);
-        }
-
-        @Override
-        public CommitId readFrom(StreamInput in) throws IOException {
-            return new CommitId(in);
-        }
-
-        @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeByteArray(id);
+        }
+
+        @Override
+        public String toString() {
+            return Base64.encodeBytes(id);
         }
 
         public boolean idsEqual(byte[] id) {

--- a/core/src/main/java/org/elasticsearch/index/store/StoreFileMetaData.java
+++ b/core/src/main/java/org/elasticsearch/index/store/StoreFileMetaData.java
@@ -49,16 +49,6 @@ public class StoreFileMetaData implements Writeable {
 
     private final BytesRef hash;
 
-    public StoreFileMetaData(StreamInput in) throws IOException {
-        name = in.readString();
-        length = in.readVLong();
-        checksum = in.readString();
-        String versionString = in.readString();
-        assert versionString != null;
-        writtenBy = Lucene.parseVersionLenient(versionString, FIRST_LUCENE_CHECKSUM_VERSION);
-        hash = in.readBytesRef();
-    }
-
     public StoreFileMetaData(String name, long length, String checksum) {
         this(name, length, checksum, FIRST_LUCENE_CHECKSUM_VERSION);
     }
@@ -79,6 +69,26 @@ public class StoreFileMetaData implements Writeable {
         this.hash = hash == null ? new BytesRef() : hash;
     }
 
+    /**
+     * Read from a stream.
+     */
+    public StoreFileMetaData(StreamInput in) throws IOException {
+        name = in.readString();
+        length = in.readVLong();
+        checksum = in.readString();
+        // TODO Why not Version.parse?
+        writtenBy = Lucene.parseVersionLenient(in.readString(), FIRST_LUCENE_CHECKSUM_VERSION);
+        hash = in.readBytesRef();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name);
+        out.writeVLong(length);
+        out.writeString(checksum);
+        out.writeString(writtenBy.toString());
+        out.writeBytesRef(hash);
+    }
 
     /**
      * Returns the name of this file
@@ -116,20 +126,6 @@ public class StoreFileMetaData implements Writeable {
     @Override
     public String toString() {
         return "name [" + name + "], length [" + length + "], checksum [" + checksum + "], writtenBy [" + writtenBy + "]" ;
-    }
-
-    @Override
-    public StoreFileMetaData readFrom(StreamInput in) throws IOException {
-        return new StoreFileMetaData(in);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(name);
-        out.writeVLong(length);
-        out.writeString(checksum);
-        out.writeString(writtenBy.toString());
-        out.writeBytesRef(hash);
     }
 
     /**


### PR DESCRIPTION
These methods aren't used. They were just there to implement an interface
and that interface is losing that method.

Relates to #17085
