### PR TITLE
Analyze API : Fix/deprecated filters in analyze in 2x

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
@@ -53,8 +53,8 @@ public class RestAnalyzeAction extends BaseRestHandler {
         public static final ParseField TEXT = new ParseField("text");
         public static final ParseField FIELD = new ParseField("field");
         public static final ParseField TOKENIZER = new ParseField("tokenizer");
-        public static final ParseField TOKEN_FILTERS = new ParseField("token_filters", "filters");
-        public static final ParseField CHAR_FILTERS = new ParseField("char_filters");
+        public static final ParseField TOKEN_FILTERS = new ParseField("filter", "token_filter", "token_filters", "filters");
+        public static final ParseField CHAR_FILTERS = new ParseField("char_filter", "char_filters");
         public static final ParseField EXPLAIN = new ParseField("explain");
         public static final ParseField ATTRIBUTES = new ParseField("attributes");
     }
@@ -78,8 +78,9 @@ public class RestAnalyzeAction extends BaseRestHandler {
         analyzeRequest.analyzer(request.param("analyzer"));
         analyzeRequest.field(request.param("field"));
         analyzeRequest.tokenizer(request.param("tokenizer"));
-        analyzeRequest.tokenFilters(request.paramAsStringArray("token_filters", request.paramAsStringArray("filters", analyzeRequest.tokenFilters())));
-        analyzeRequest.charFilters(request.paramAsStringArray("char_filters", analyzeRequest.charFilters()));
+        analyzeRequest.tokenFilters(request.paramAsStringArray("filter", request.paramAsStringArray("token_filter",
+            request.paramAsStringArray("token_filters", request.paramAsStringArray("filters", analyzeRequest.tokenFilters())))));
+        analyzeRequest.charFilters(request.paramAsStringArray("char_filter", request.paramAsStringArray("char_filters", analyzeRequest.charFilters())));
         analyzeRequest.explain(request.paramAsBoolean("explain", false));
         analyzeRequest.attributes(request.paramAsStringArray("attributes", analyzeRequest.attributes()));
 

--- a/core/src/test/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeActionTests.java
@@ -39,7 +39,7 @@ public class RestAnalyzeActionTests extends ESTestCase {
             .startObject()
             .field("text", "THIS IS A TEST")
             .field("tokenizer", "keyword")
-            .array("filters", "lowercase")
+            .array("filter", "lowercase")
             .endObject().bytes();
 
         AnalyzeRequest analyzeRequest = new AnalyzeRequest("for test");
@@ -97,6 +97,58 @@ public class RestAnalyzeActionTests extends ESTestCase {
             assertThat(e, instanceOf(IllegalArgumentException.class));
             assertThat(e.getMessage(), startsWith("explain must be either 'true' or 'false'"));
         }
+    }
+
+    @Test
+    public void testDeprecatedParams() throws Exception {
+        BytesReference content =  XContentFactory.jsonBuilder()
+            .startObject()
+            .field("text", "THIS IS A TEST")
+            .field("tokenizer", "keyword")
+            .array("filters", "lowercase")
+            .endObject().bytes();
+
+        AnalyzeRequest analyzeRequest = new AnalyzeRequest("for test");
+
+        RestAnalyzeAction.buildFromContent(content, analyzeRequest, new ParseFieldMatcher(Settings.EMPTY));
+
+        assertThat(analyzeRequest.text().length, equalTo(1));
+        assertThat(analyzeRequest.text(), equalTo(new String[]{"THIS IS A TEST"}));
+        assertThat(analyzeRequest.tokenizer(), equalTo("keyword"));
+        assertThat(analyzeRequest.tokenFilters(), equalTo(new String[]{"lowercase"}));
+
+
+        content =  XContentFactory.jsonBuilder()
+            .startObject()
+            .field("text", "THIS IS A TEST")
+            .field("tokenizer", "keyword")
+            .array("token_filters", "lowercase")
+            .endObject().bytes();
+
+        analyzeRequest = new AnalyzeRequest("for test");
+
+        RestAnalyzeAction.buildFromContent(content, analyzeRequest, new ParseFieldMatcher(Settings.EMPTY));
+
+        assertThat(analyzeRequest.text().length, equalTo(1));
+        assertThat(analyzeRequest.text(), equalTo(new String[]{"THIS IS A TEST"}));
+        assertThat(analyzeRequest.tokenizer(), equalTo("keyword"));
+        assertThat(analyzeRequest.tokenFilters(), equalTo(new String[]{"lowercase"}));
+
+        content =  XContentFactory.jsonBuilder()
+            .startObject()
+            .field("text", "THIS IS A TEST")
+            .field("tokenizer", "keyword")
+            .array("char_filters", "lowercase")
+            .endObject().bytes();
+
+        analyzeRequest = new AnalyzeRequest("for test");
+
+        RestAnalyzeAction.buildFromContent(content, analyzeRequest, new ParseFieldMatcher(Settings.EMPTY));
+
+        assertThat(analyzeRequest.text().length, equalTo(1));
+        assertThat(analyzeRequest.text(), equalTo(new String[]{"THIS IS A TEST"}));
+        assertThat(analyzeRequest.tokenizer(), equalTo("keyword"));
+        assertThat(analyzeRequest.charFilters(), equalTo(new String[]{"lowercase"}));
     }
 
 

--- a/docs/reference/indices/analyze.asciidoc
+++ b/docs/reference/indices/analyze.asciidoc
@@ -28,7 +28,7 @@ curl -XGET 'localhost:9200/_analyze' -d '
 --------------------------------------------------
 
 Or by building a custom transient analyzer out of tokenizers,
-token filters and char filters. Token filters can use the shorter 'filters'
+token filters and char filters. Token filters can use the shorter 'filter'
 parameter name:
 
 [source,js]
@@ -36,18 +36,20 @@ parameter name:
 curl -XGET 'localhost:9200/_analyze' -d '
 {
   "tokenizer" : "keyword",
-  "filters" : ["lowercase"],
+  "filter" : ["lowercase"],
   "text" : "this is a test"
 }'
 
 curl -XGET 'localhost:9200/_analyze' -d '
 {
   "tokenizer" : "keyword",
-  "token_filters" : ["lowercase"],
-  "char_filters" : ["html_strip"],
+  "token_filter" : ["lowercase"],
+  "char_filter" : ["html_strip"],
   "text" : "this is a <b>test</b>"
 }'
 --------------------------------------------------
+
+deprecated[2.4.0, `filters`/`token_filters`/`char_filters` will be removed in 5.0.0. Use `filter`/`token_filter`/`char_filter`]
 
 It can also run against a specific index:
 
@@ -90,7 +92,7 @@ All parameters can also supplied as request parameters. For example:
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'localhost:9200/_analyze?tokenizer=keyword&filters=lowercase&text=this+is+a+test'
+curl -XGET 'localhost:9200/_analyze?tokenizer=keyword&filter=lowercase&text=this+is+a+test'
 --------------------------------------------------
 
 For backwards compatibility, we also accept the text parameter as the body of the request,
@@ -98,7 +100,7 @@ provided it doesn't start with `{` :
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'localhost:9200/_analyze?tokenizer=keyword&token_filters=lowercase&char_filters=html_strip' -d 'this is a <b>test</b>'
+curl -XGET 'localhost:9200/_analyze?tokenizer=keyword&token_filter=lowercase&char_filter=html_strip' -d 'this is a <b>test</b>'
 --------------------------------------------------
 
 === Explain Analyze
@@ -113,7 +115,7 @@ experimental[The format of the additional detail information is experimental and
 GET test/_analyze
 {
   "tokenizer" : "standard",
-  "token_filters" : ["snowball"],
+  "token_filter" : ["snowball"],
   "text" : "detailed output",
   "explain" : true,
   "attributes" : ["keyword"] <1>

--- a/docs/reference/migration/migrate_2_3.asciidoc
+++ b/docs/reference/migration/migrate_2_3.asciidoc
@@ -43,3 +43,10 @@ Elasticsearch. Aside from the inherent difficulties in managing such a
 large set of dependencies, this also increases the surface area for
 security issues. This dependency has been reduced to the core Groovy
 language `org.codehaus.groovy:groovy` artifact.
+
+[float]
+=== Analyze API changes
+
+The deprecated `filters`/`token_filters`/`char_filters` parameter has been
+renamed `filter`/`token_filter`/`char_filter`.
+And `filters`/`token_filters`/`char_filters` has been removed in 5.0.0

--- a/plugins/analysis-icu/src/test/resources/rest-api-spec/test/analysis_icu/10_basic.yaml
+++ b/plugins/analysis-icu/src/test/resources/rest-api-spec/test/analysis_icu/10_basic.yaml
@@ -12,7 +12,7 @@
 "Normalization filter":
     - do:
         indices.analyze:
-          filters:      icu_normalizer
+          filter:       icu_normalizer
           text:         Foo Bar Ruß
           tokenizer:    keyword
     - length: { tokens: 1 }
@@ -21,7 +21,7 @@
 "Normalization charfilter":
     - do:
         indices.analyze:
-          char_filters: icu_normalizer
+          char_filter:  icu_normalizer
           text:         Foo Bar Ruß
           tokenizer:    keyword
     - length: { tokens: 1 }
@@ -30,7 +30,7 @@
 "Folding filter":
     - do:
         indices.analyze:
-          filters:      icu_folding
+          filter:       icu_folding
           text:         Foo Bar résumé
           tokenizer:    keyword
     - length: { tokens: 1 }

--- a/plugins/analysis-kuromoji/src/test/resources/rest-api-spec/test/analysis_kuromoji/10_basic.yaml
+++ b/plugins/analysis-kuromoji/src/test/resources/rest-api-spec/test/analysis_kuromoji/10_basic.yaml
@@ -31,7 +31,7 @@
         indices.analyze:
           text:         飲み
           tokenizer:    kuromoji_tokenizer
-          filters:      kuromoji_baseform
+          filter:       kuromoji_baseform
     - length: { tokens: 1 }
     - match:  { tokens.0.token: 飲む }
 ---
@@ -40,7 +40,7 @@
         indices.analyze:
           text:         寿司
           tokenizer:    kuromoji_tokenizer
-          filters:      kuromoji_readingform
+          filter:       kuromoji_readingform
     - length: { tokens: 1 }
     - match:  { tokens.0.token: sushi }
 ---
@@ -49,6 +49,6 @@
         indices.analyze:
           text:         サーバー
           tokenizer:    kuromoji_tokenizer
-          filters:      kuromoji_stemmer
+          filter:       kuromoji_stemmer
     - length: { tokens: 1 }
     - match:  { tokens.0.token: サーバ }

--- a/plugins/analysis-stempel/src/test/resources/rest-api-spec/test/analysis_stempel/10_basic.yaml
+++ b/plugins/analysis-stempel/src/test/resources/rest-api-spec/test/analysis_stempel/10_basic.yaml
@@ -5,7 +5,7 @@
         indices.analyze:
           text:         studenci
           tokenizer:    keyword
-          filters:      polish_stem
+          filter:       polish_stem
     - length: { tokens: 1 }
     - match:  { tokens.0.token: student  }
 ---

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.analyze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.analyze.json
@@ -18,6 +18,10 @@
         },
         "char_filters": {
           "type" : "list",
+          "description" : "Deprecated : A comma-separated list of character filters to use for the analysis"
+        },
+        "char_filter": {
+          "type" : "list",
           "description" : "A comma-separated list of character filters to use for the analysis"
         },
         "field": {
@@ -25,6 +29,10 @@
           "description" : "Use the analyzer configured for this field (instead of passing the analyzer name)"
         },
         "filters": {
+          "type" : "list",
+          "description" : "Deprecated : A comma-separated list of filters to use for the analysis"
+        },
+        "filter": {
           "type" : "list",
           "description" : "A comma-separated list of filters to use for the analysis"
         },

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/10_analyze.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/10_analyze.yaml
@@ -17,7 +17,7 @@ setup:
 "Tokenizer and filter":
     - do:
         indices.analyze:
-          filters:      lowercase
+          filter:      lowercase
           text:         Foo Bar
           tokenizer:    keyword
     - length: { tokens: 1 }
@@ -52,7 +52,7 @@ setup:
 "JSON in Body":
     - do:
         indices.analyze:
-          body: { "text": "Foo Bar", "filters": ["lowercase"], "tokenizer": keyword }
+          body: { "text": "Foo Bar", "filter": ["lowercase"], "tokenizer": keyword }
     - length: {tokens: 1 }
     - match:     { tokens.0.token: foo bar }
 ---
@@ -60,14 +60,14 @@ setup:
     - do:
         indices.analyze:
           text: Foo Bar
-          body: { "text": "Bar Foo", "filters": ["lowercase"], "tokenizer": keyword }
+          body: { "text": "Bar Foo", "filter": ["lowercase"], "tokenizer": keyword }
     - length: {tokens: 1 }
     - match:     { tokens.0.token: bar foo }
 ---
 "Array text":
     - do:
         indices.analyze:
-          body: { "text": ["Foo Bar", "Baz"], "filters": ["lowercase"], "tokenizer": keyword }
+          body: { "text": ["Foo Bar", "Baz"], "filter": ["lowercase"], "tokenizer": keyword }
     - length: {tokens: 2 }
     - match:     { tokens.0.token: foo bar }
     - match:     { tokens.1.token: baz }
@@ -85,7 +85,7 @@ setup:
 "Detail output spcified attribute":
     - do:
         indices.analyze:
-          body: {"text": "<text>This is troubled</text>", "char_filters": ["html_strip"], "filters": ["snowball"], "tokenizer": standard, "explain": true, "attributes": ["keyword"]}
+          body: {"text": "<text>This is troubled</text>", "char_filter": ["html_strip"], "filter": ["snowball"], "tokenizer": standard, "explain": true, "attributes": ["keyword"]}
     - length: { detail.charfilters: 1 }
     - length: { detail.tokenizer.tokens: 3 }
     - length: { detail.tokenfilters.0.tokens: 3 }


### PR DESCRIPTION
Accept "filter"/"char_filter" and deprecated  "filters"/"char_filters" in analyze API

This PR is for 2.x branch.

Closes #15189
