### PR TITLE
Moves reduce to the AggregatorBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/SearchDfsQueryAndFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchDfsQueryAndFetchAsyncAction.java
@@ -120,7 +120,7 @@ class SearchDfsQueryAndFetchAsyncAction extends AbstractSearchAsyncAction<DfsSea
             public void doRun() throws IOException {
                 sortedShardList = searchPhaseController.sortDocs(true, queryFetchResults);
                 final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryFetchResults,
-                    queryFetchResults);
+                        queryFetchResults, request);
                 String scrollId = null;
                 if (request.scroll() != null) {
                     scrollId = TransportSearchHelper.buildScrollId(request.searchType(), firstResults, null);

--- a/core/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
@@ -197,7 +197,7 @@ class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<DfsSe
             @Override
             public void doRun() throws IOException {
                 final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryResults,
-                    fetchResults);
+                        fetchResults, request);
                 String scrollId = null;
                 if (request.scroll() != null) {
                     scrollId = TransportSearchHelper.buildScrollId(request.searchType(), firstResults, null);

--- a/core/src/main/java/org/elasticsearch/action/search/SearchQueryAndFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchQueryAndFetchAsyncAction.java
@@ -63,7 +63,7 @@ class SearchQueryAndFetchAsyncAction extends AbstractSearchAsyncAction<QueryFetc
                 boolean useScroll = request.scroll() != null;
                 sortedShardList = searchPhaseController.sortDocs(useScroll, firstResults);
                 final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, firstResults,
-                    firstResults);
+                        firstResults, request);
                 String scrollId = null;
                 if (request.scroll() != null) {
                     scrollId = TransportSearchHelper.buildScrollId(request.searchType(), firstResults, null);

--- a/core/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -130,7 +130,7 @@ class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<QuerySea
             @Override
             public void doRun() throws IOException {
                 final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, firstResults,
-                    fetchResults);
+                        fetchResults, request);
                 String scrollId = null;
                 if (request.scroll() != null) {
                     scrollId = TransportSearchHelper.buildScrollId(request.searchType(), firstResults, null);

--- a/core/src/main/java/org/elasticsearch/action/search/SearchScrollQueryAndFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchScrollQueryAndFetchAsyncAction.java
@@ -89,6 +89,7 @@ class SearchScrollQueryAndFetchAsyncAction extends AbstractAsyncAction {
         shardFailures.set(shardIndex, failure);
     }
 
+    @Override
     public void start() {
         if (scrollId.getContext().length == 0) {
             listener.onFailure(new SearchPhaseExecutionException("query", "no nodes to search on", ShardSearchFailure.EMPTY_ARRAY));
@@ -170,7 +171,7 @@ class SearchScrollQueryAndFetchAsyncAction extends AbstractAsyncAction {
     private void innerFinishHim() throws Exception {
         ScoreDoc[] sortedShardList = searchPhaseController.sortDocs(true, queryFetchResults);
         final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryFetchResults,
-            queryFetchResults);
+                queryFetchResults, null);
         String scrollId = null;
         if (request.scroll() != null) {
             scrollId = request.scrollId();

--- a/core/src/main/java/org/elasticsearch/action/search/SearchScrollQueryThenFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchScrollQueryThenFetchAsyncAction.java
@@ -36,6 +36,7 @@ import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.search.query.ScrollQuerySearchResult;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -92,6 +93,7 @@ class SearchScrollQueryThenFetchAsyncAction extends AbstractAsyncAction {
         shardFailures.set(shardIndex, failure);
     }
 
+    @Override
     public void start() {
         if (scrollId.getContext().length == 0) {
             listener.onFailure(new SearchPhaseExecutionException("query", "no nodes to search on", ShardSearchFailure.EMPTY_ARRAY));
@@ -214,8 +216,8 @@ class SearchScrollQueryThenFetchAsyncAction extends AbstractAsyncAction {
         }
     }
 
-    private void innerFinishHim() {
-        InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryResults, fetchResults);
+    private void innerFinishHim() throws IOException {
+        InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryResults, fetchResults, null);
         String scrollId = null;
         if (request.scroll() != null) {
             scrollId = request.scrollId();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -186,6 +186,19 @@ public class AggregatorFactories {
             return this;
         }
 
+        /**
+         * Gets the copy of this object that will be sent to the shard. This
+         * should be a exact copy of the Builder but without the pipeline
+         * aggregator builders which are not needed on the shard
+         */
+        final Builder getShardCopy() {
+            Builder copy = new Builder();
+            for (AggregatorBuilder<?> aggBuilder : aggregatorBuilders) {
+                copy.addAggregator(aggBuilder.getShardCopy());
+            }
+            return copy;
+        }
+
         public AggregatorFactories build(AggregationContext context, AggregatorFactory<?> parent) throws IOException {
             if (aggregatorBuilders.isEmpty() && pipelineAggregatorBuilders.isEmpty()) {
                 return EMPTY;


### PR DESCRIPTION
This adds the reduce method to AggregatorBuilder so that reduce only fields such as Pipeline Aggregators and Aggregation Metadata do not need to be serialised to the shards and back again, simplifying the aggregation framework.
