### PR TITLE
Automatically upgrade analyzed strings with an analyzer to `text`.

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/mapper/core/StringMappingUpgradeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/StringMappingUpgradeTests.java
@@ -107,7 +107,8 @@ public class StringMappingUpgradeTests extends ESSingleNodeTestCase {
         IndexService indexService = createIndex("test");
         DocumentMapperParser parser = indexService.mapperService().documentMapperParser();
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
-                .startObject("properties").startObject("field").field("type", "string").field("analyzer", "keyword").endObject().endObject()
+                .startObject("properties").startObject("field").field("type", "string")
+                .field("index", "not_analyzed").field("analyzer", "keyword").endObject().endObject()
                 .endObject().endObject().string();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> parser.parse("type", new CompressedXContent(mapping)));
@@ -164,6 +165,23 @@ public class StringMappingUpgradeTests extends ESSingleNodeTestCase {
         assertEquals(200, ((KeywordFieldMapper) field).ignoreAbove());
     }
 
+    public void testUpgradeAnalyzer() throws IOException {
+        IndexService indexService = createIndex("test");
+        DocumentMapperParser parser = indexService.mapperService().documentMapperParser();
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "string")
+                .field("analyzer", "standard")
+                .field("search_analyzer", "whitespace")
+                .field("search_quote_analyzer", "keyword").endObject().endObject()
+                .endObject().endObject().string();
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+        FieldMapper field = mapper.mappers().getMapper("field");
+        assertThat(field, instanceOf(TextFieldMapper.class));
+        assertEquals("standard", field.fieldType().indexAnalyzer().name());
+        assertEquals("whitespace", field.fieldType().searchAnalyzer().name());
+        assertEquals("keyword", field.fieldType().searchQuoteAnalyzer().name());
+    }
+
     public void testUpgradeRandomMapping() throws IOException {
         final int iters = 20;
         for (int i = 0; i < iters; ++i) {
@@ -199,6 +217,9 @@ public class StringMappingUpgradeTests extends ESSingleNodeTestCase {
         }
         if (keyword && randomBoolean()) {
             mapping.field("doc_values", randomBoolean());
+        }
+        if (keyword == false && randomBoolean()) {
+            mapping.field("analyzer", "keyword");
         }
         if (randomBoolean()) {
             hasNorms = randomBoolean();


### PR DESCRIPTION
I had stayed away from it until now since the `analyzer` property is supported
on analyzed strings but not on analyzed strings. So the list of supported
properties for the upgrade has been splitted so that we would still fail the
upgrade if setting an analyzer on a not-analyzed string field.

Reported by @gquintana at https://discuss.elastic.co/t/es5-0a1-the-string-type-is-removed-in-5-0-you-should-now-use-either-a-text-or-keyword-field-instead-for-field/47305/7
