### PR TITLE
Shorten the serialization of the empty TaskId

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/TransportCancelTasksAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/TransportCancelTasksAction.java
@@ -251,7 +251,7 @@ public class TransportCancelTasksAction extends TransportTasksAction<Cancellable
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
-            parentTaskId = new TaskId(in);
+            parentTaskId = TaskId.readFromStream(in);
             ban = in.readBoolean();
             if (ban) {
                 reason = in.readString();

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TaskInfo.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TaskInfo.java
@@ -85,7 +85,7 @@ public class TaskInfo implements Writeable<TaskInfo>, ToXContent {
         startTime = in.readLong();
         runningTimeNanos = in.readLong();
         cancellable = in.readBoolean();
-        parentTaskId = new TaskId(in);
+        parentTaskId = TaskId.readFromStream(in);
     }
 
     public TaskId getTaskId() {

--- a/core/src/main/java/org/elasticsearch/action/support/ChildTaskActionRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/ChildTaskActionRequest.java
@@ -45,7 +45,7 @@ public abstract class ChildTaskActionRequest<Request extends ActionRequest<Reque
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        parentTaskId = new TaskId(in);
+        parentTaskId = TaskId.readFromStream(in);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/support/ChildTaskRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/ChildTaskRequest.java
@@ -44,7 +44,7 @@ public class ChildTaskRequest extends TransportRequest {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        parentTaskId = new TaskId(in);
+        parentTaskId = TaskId.readFromStream(in);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksRequest.java
@@ -140,8 +140,8 @@ public class BaseTasksRequest<Request extends BaseTasksRequest<Request>> extends
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        taskId = new TaskId(in);
-        parentTaskId = new TaskId(in);
+        taskId = TaskId.readFromStream(in);
+        parentTaskId = TaskId.readFromStream(in);
         nodesIds = in.readStringArray();
         actions = in.readStringArray();
         if (in.readBoolean()) {

--- a/core/src/main/java/org/elasticsearch/tasks/TaskId.java
+++ b/core/src/main/java/org/elasticsearch/tasks/TaskId.java
@@ -31,14 +31,25 @@ import java.io.IOException;
  */
 public final class TaskId implements Writeable<TaskId> {
 
-    public final static TaskId EMPTY_TASK_ID = new TaskId("", -1L);
+    public final static TaskId EMPTY_TASK_ID = new TaskId();
 
     private final String nodeId;
     private final long id;
 
     public TaskId(String nodeId, long id) {
+        if (nodeId.isEmpty()) {
+            throw new IllegalArgumentException("0 length nodeIds are reserved for EMPTY_TASK_ID and are otherwise invalid.");
+        }
         this.nodeId = nodeId;
         this.id = id;
+    }
+
+    /**
+     * Builds {@link #EMPTY_TASK_ID}.
+     */
+    private TaskId() {
+        nodeId = "";
+        id = -1;
     }
 
     public TaskId(String taskId) {
@@ -59,9 +70,30 @@ public final class TaskId implements Writeable<TaskId> {
         }
     }
 
-    public TaskId(StreamInput in) throws IOException {
-        nodeId = in.readString();
-        id = in.readLong();
+    /**
+     * Read a {@linkplain TaskId} from a stream. {@linkplain TaskId} has this rather than the usual constructor that takes a
+     * {@linkplain StreamInput} so we can return the {@link #EMPTY_TASK_ID} without allocating.
+     */
+    public static TaskId readFromStream(StreamInput in) throws IOException {
+        String nodeId = in.readString();
+        if (nodeId.isEmpty()) {
+            /*
+             * The only TaskId allowed to have the empty string as its nodeId is the EMPTY_TASK_ID and there is only ever one of it and it
+             * never writes its taskId to save bytes on the wire because it is by far the most common TaskId.
+             */
+            return EMPTY_TASK_ID;
+        }
+        return new TaskId(nodeId, in.readLong());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(nodeId);
+        if (nodeId.isEmpty()) {
+            // Shortcut the EMPTY_TASK_ID, the only TaskId allowed to have the empty string as its nodeId.
+            return;
+        }
+        out.writeLong(id);
     }
 
     public String getNodeId() {
@@ -84,18 +116,6 @@ public final class TaskId implements Writeable<TaskId> {
             return "unset";
         }
     }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(nodeId);
-        out.writeLong(id);
-    }
-
-    @Override
-    public TaskId readFrom(StreamInput in) throws IOException {
-        return new TaskId(in);
-    }
-
 
     @Override
     public boolean equals(Object o) {

--- a/core/src/test/java/org/elasticsearch/tasks/TaskIdTests.java
+++ b/core/src/test/java/org/elasticsearch/tasks/TaskIdTests.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.tasks;
+
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+public class TaskIdTests extends ESTestCase {
+    private static final int ROUNDS = 30;
+
+    public void testSerialization() throws IOException {
+        /*
+         * The size of the serialized representation of the TaskId doesn't really matter that much because most requests don't contain a
+         * full TaskId.
+         */
+        int expectedSize = 31; // 8 for the task number, 1 for the string length of the uuid, 22 for the actual uuid
+        for (int i = 0; i < ROUNDS; i++) {
+            TaskId taskId = new TaskId(UUIDs.randomBase64UUID(random()), randomInt());
+            TaskId roundTripped = roundTrip(taskId, expectedSize);
+            assertNotSame(taskId, roundTripped);
+            assertEquals(taskId, roundTripped);
+            assertEquals(taskId.hashCode(), roundTripped.hashCode());
+        }
+    }
+
+    public void testSerializationOfEmpty() throws IOException {
+        //The size of the serialized representation of the EMPTY_TASK_ID matters a lot because many requests contain it.
+        int expectedSize = 1;
+        TaskId roundTripped = roundTrip(TaskId.EMPTY_TASK_ID, expectedSize);
+        assertSame(TaskId.EMPTY_TASK_ID, roundTripped);
+    }
+
+    private TaskId roundTrip(TaskId taskId, int expectedSize) throws IOException {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            taskId.writeTo(out);
+            BytesReference bytes = out.bytes();
+            assertEquals(expectedSize, bytes.length());
+            try (StreamInput in = StreamInput.wrap(bytes)) {
+                return TaskId.readFromStream(in);
+            }
+        }
+    }
+}


### PR DESCRIPTION
We plan to change every request so that it can support a parentTaskId.
This shrinks EMPTY_TASK_ID, which will be on every request once that change
is made, from 31 bytes to 9 bytes to 1 byte.
