### PR TITLE
Fix the semantics for the BlobContainer interface

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
@@ -27,60 +27,127 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- *
+ * An interface for managing a repository of blob entries, where each blob entry is just a named group of bytes.
  */
 public interface BlobContainer {
 
+    /**
+     * Gets the {@link BlobPath} that defines the implementation specific paths to where the blobs are contained.
+     *
+     * @return  the BlobPath where the blobs are contained
+     */
     BlobPath path();
 
+    /**
+     * Tests whether a blob with the given blob name exists in the container.
+     *
+     * @param   blobName
+     *          The name of the blob whose existence is to be determined.
+     * @return  {@code true} if a blob exists in the {@link BlobContainer} with the given name, and {@code false} otherwise.
+     */
     boolean blobExists(String blobName);
 
     /**
-     * Creates a new InputStream for the given blob name
+     * Creates a new {@link InputStream} for the given blob name.
+     *
+     * @param   blobName
+     *          The name of the blob to get an {@link InputStream} for.
+     * @return  The {@code InputStream} to read the blob.
+     * @throws  IOException if the blob does not exist or can not be read.
      */
     InputStream readBlob(String blobName) throws IOException;
 
     /**
-     * Reads blob content from the input stream and writes it to the blob store
+     * Reads blob content from the input stream and writes it to the container in a new blob with the given name.
+     * This method assumes the container does not already contain a blob of the same blobName.  If a blob by the
+     * same name already exists, the operation will fail and an {@link IOException} will be thrown.
+     *
+     * @param   blobName
+     *          The name of the blob to write the contents of the input stream to.
+     * @param   inputStream
+     *          The input stream from which to retrieve the bytes to write to the blob.
+     * @throws  IOException if the input stream could not be read, a blob by the same name already exists,
+     *          or the target blob could not be written to.
      */
-    void writeBlob(String blobName, InputStream inputStream, long blobSize) throws IOException;
+    void writeBlob(String blobName, InputStream inputStream) throws IOException;
 
     /**
-     * Writes bytes to the blob
+     * Writes the input bytes to a new blob in the container with the given name.  This method assumes the
+     * container does not already contain a blob of the same blobName.  If a blob by the same name already
+     * exists, the operation will fail and an {@link IOException} will be thrown.
+     *
+     * @param   blobName
+     *          The name of the blob to write the contents of the input stream to.
+     * @param   bytes
+     *          The bytes to write to the blob.
+     * @throws  IOException if a blob by the same name already exists, or the target blob could not be written to.
      */
     void writeBlob(String blobName, BytesReference bytes) throws IOException;
 
     /**
-     * Deletes a blob with giving name.
+     * Deletes a blob with giving name, if the blob exists.  If the blob does not exist, this method has no affect.
      *
-     * If a blob exists but cannot be deleted an exception has to be thrown.
+     * @param   blobName
+     *          The name of the blob to delete.
+     * @throws  IOException if the blob exists but could not be deleted.
      */
     void deleteBlob(String blobName) throws IOException;
 
     /**
-     * Deletes blobs with giving names.
+     * Deletes blobs with the given names.  If any subset of the names do not exist in the container, this method has no
+     * affect for those names, and will delete the blobs for those names that do exist.  If any of the blobs failed
+     * to delete, those blobs that were processed before it and successfully deleted will remain deleted.  An exception
+     * is thrown at the first blob entry that fails to delete (TODO: is this the right behavior?  Should we collect
+     * all the failed deletes into a single IOException instead?)
      *
-     * If a blob exists but cannot be deleted an exception has to be thrown.
+     * @param   blobNames
+     *          The collection of blob names to delete from the container.
+     * @throws  IOException if any of the blobs in the collection exists but could not be deleted.
      */
     void deleteBlobs(Collection<String> blobNames) throws IOException;
 
     /**
-     * Deletes all blobs in the container that match the specified prefix.
+     * Deletes all blobs in the container that match the specified prefix.  If any of the blobs failed to delete,
+     * those blobs that were processed before it and successfully deleted will remain deleted.  An exception is
+     * thrown at the first blob entry that fails to delete (TODO: is this the right behavior?  Should we collect
+     * all the failed deletes into a single IOException instead?)
+     *
+     * @param   blobNamePrefix
+     *          The prefix to match against blob names in the container.  Any blob whose name has the prefix will be deleted.
+     * @throws  IOException if any of the matching blobs failed to delete.
      */
     void deleteBlobsByPrefix(String blobNamePrefix) throws IOException;
 
     /**
-     * Lists all blobs in the container
+     * Lists all blobs in the container.
+     *
+     * @return  A map of all the blobs in the container.  The keys in the map are the names of the blobs and
+     *          the values are {@link BlobMetaData}, containing basic information about each blob.
+     * @throws  IOException if there were any failures in reading from the blob container.
      */
     Map<String, BlobMetaData> listBlobs() throws IOException;
 
     /**
-     * Lists all blobs in the container that match specified prefix
+     * Lists all blobs in the container that match the specified prefix.
+     *
+     * @param   blobNamePrefix
+     *          The prefix to match against blob names in the container.
+     * @return  A map of the matching blobs in the container.  The keys in the map are the names of the blobs
+     *          and the values are {@link BlobMetaData}, containing basic information about each blob.
+     * @throws  IOException if there were any failures in reading from the blob container.
      */
     Map<String, BlobMetaData> listBlobsByPrefix(String blobNamePrefix) throws IOException;
 
     /**
-     * Atomically renames source blob into target blob
+     * Atomically renames the source blob into the target blob.  If the source blob does not exist or the
+     * target blob already exists, an exception is thrown.
+     *
+     * @param   sourceBlobName
+     *          The blob to rename.
+     * @param   targetBlobName
+     *          The name of the blob after the renaming.
+     * @throws  IOException if the source blob does not exist, the target blob already exists,
+     *          or there were any failures in reading from the blob container.
      */
     void move(String sourceBlobName, String targetBlobName) throws IOException;
 }

--- a/core/src/main/java/org/elasticsearch/common/blobstore/BlobMetaData.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/BlobMetaData.java
@@ -20,11 +20,17 @@
 package org.elasticsearch.common.blobstore;
 
 /**
- *
+ * An interface for providing basic metadata about a blob.
  */
 public interface BlobMetaData {
 
+    /**
+     * Gets the name of the blob.
+     */
     String name();
 
+    /**
+     * Gets the size of the blob in bytes.
+     */
     long length();
 }

--- a/core/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
@@ -19,14 +19,13 @@
 
 package org.elasticsearch.common.blobstore;
 
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
 /**
- *
+ * The list of paths where a blob can reside.  The contents of the paths are dependent upon the implementation of {@link BlobContainer}.
  */
 public class BlobPath implements Iterable<String> {
 

--- a/core/src/main/java/org/elasticsearch/common/blobstore/BlobStore.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/BlobStore.java
@@ -22,12 +22,18 @@ import java.io.Closeable;
 import java.io.IOException;
 
 /**
- *
+ * An interface for storing blobs.
  */
 public interface BlobStore extends Closeable {
 
+    /**
+     * Get a blob container instance for storing blobs at the given {@link BlobPath}.
+     */
     BlobContainer blobContainer(BlobPath path);
 
+    /**
+     * Delete the blob store at the given {@link BlobPath}.
+     */
     void delete(BlobPath path) throws IOException;
 
 }

--- a/core/src/main/java/org/elasticsearch/common/blobstore/support/AbstractBlobContainer.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/support/AbstractBlobContainer.java
@@ -30,7 +30,7 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- *
+ * A base abstract blob container that implements higher level container methods.
  */
 public abstract class AbstractBlobContainer implements BlobContainer {
 
@@ -55,15 +55,15 @@ public abstract class AbstractBlobContainer implements BlobContainer {
 
     @Override
     public void deleteBlobs(Collection<String> blobNames) throws IOException {
-        for(String blob: blobNames) {
+        for (String blob: blobNames) {
             deleteBlob(blob);
         }
     }
-    
+
     @Override
     public void writeBlob(String blobName, BytesReference bytes) throws IOException {
         try (InputStream stream = bytes.streamInput()) {
-            writeBlob(blobName, stream, bytes.length());
+            writeBlob(blobName, stream);
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
@@ -104,7 +104,7 @@ public class URLBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
-    public void writeBlob(String blobName, InputStream inputStream, long blobSize) throws IOException {
+    public void writeBlob(String blobName, InputStream inputStream) throws IOException {
         throw new UnsupportedOperationException("URL repository doesn't support this operation");
     }
 

--- a/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
@@ -649,7 +649,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
                     final InputStreamIndexInput inputStreamIndexInput = new InputStreamIndexInput(indexInput, partBytes);
                     InputStream inputStream = snapshotRateLimiter == null ? inputStreamIndexInput : new RateLimitingInputStream(inputStreamIndexInput, snapshotRateLimiter, snapshotThrottleListener);
                     inputStream = new AbortableInputStream(inputStream, fileInfo.physicalName());
-                    blobContainer.writeBlob(fileInfo.partName(i), inputStream, partBytes);
+                    blobContainer.writeBlob(fileInfo.partName(i), inputStream);
                 }
                 Store.verify(indexInput);
                 snapshotStatus.addProcessedFile(fileInfo.length());

--- a/core/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatIT.java
@@ -283,6 +283,7 @@ public class BlobStoreFormatIT extends AbstractSnapshotIntegTestCase {
             int location = randomIntBetween(0, buffer.length - 1);
             buffer[location] = (byte) (buffer[location] ^ 42);
         } while (originalChecksum == checksum(buffer));
+        blobContainer.deleteBlob(blobName); // delete original before writing new blob
         blobContainer.writeBlob(blobName, new BytesArray(buffer));
     }
 

--- a/core/src/test/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
@@ -54,8 +54,8 @@ public class BlobContainerWrapper implements BlobContainer {
     }
 
     @Override
-    public void writeBlob(String blobName, InputStream inputStream, long blobSize) throws IOException {
-        delegate.writeBlob(blobName, inputStream, blobSize);
+    public void writeBlob(String blobName, InputStream inputStream) throws IOException {
+        delegate.writeBlob(blobName, inputStream);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -341,9 +341,9 @@ public class MockRepository extends FsRepository {
             }
 
             @Override
-            public void writeBlob(String blobName, InputStream inputStream, long blobSize) throws IOException {
+            public void writeBlob(String blobName, InputStream inputStream) throws IOException {
                 maybeIOExceptionOrBlock(blobName);
-                super.writeBlob(blobName, inputStream, blobSize);
+                super.writeBlob(blobName, inputStream);
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/test/ESBlobStoreContainerTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESBlobStoreContainerTestCase.java
@@ -111,5 +111,24 @@ public abstract class ESBlobStoreContainerTestCase extends ESTestCase {
         }
     }
 
+    public void testOverwriteFails() throws IOException {
+        try (final BlobStore store = newBlobStore()) {
+            final String blobName = "foobar";
+            final BlobContainer container = store.blobContainer(new BlobPath());
+            byte[] data = randomBytes(randomIntBetween(10, scaledRandomIntBetween(1024, 1 << 16)));
+            final BytesArray bytesArray = new BytesArray(data);
+            container.writeBlob(blobName, bytesArray);
+            // should not be able to write to the same blob again
+            try {
+                container.writeBlob(blobName, bytesArray);
+                fail("Cannot overwrite existing blob");
+            } catch (AssertionError e) {
+                // we want to come here
+            }
+            container.deleteBlob(blobName);
+            container.writeBlob(blobName, bytesArray); // deleted it, so should be able to write it again
+        }
+    }
+
     protected abstract BlobStore newBlobStore() throws IOException;
 }

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
@@ -85,7 +85,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
-    public void writeBlob(String blobName, InputStream inputStream, long blobSize) throws IOException {
+    public void writeBlob(String blobName, InputStream inputStream) throws IOException {
         try (OutputStream stream = createOutput(blobName)) {
             Streams.copy(inputStream, stream);
         }

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
@@ -103,7 +103,7 @@ final class HdfsBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
-    public void writeBlob(String blobName, InputStream inputStream, long blobSize) throws IOException {
+    public void writeBlob(String blobName, InputStream inputStream) throws IOException {
         store.execute(new Operation<Void>() {
             @Override
             public Void run(FileContext fileContext) throws IOException {

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobContainer.java
@@ -97,7 +97,7 @@ public class S3BlobContainer extends AbstractBlobContainer {
     }
 
     @Override
-    public void writeBlob(String blobName, InputStream inputStream, long blobSize) throws IOException {
+    public void writeBlob(String blobName, InputStream inputStream) throws IOException {
         try (OutputStream stream = createOutput(blobName)) {
             Streams.copy(inputStream, stream);
         }


### PR DESCRIPTION
This commit contains the following:
1. Clarifies the behavior that must be adhered to by any implementors
   of the BlobContainer interface.  This is done through expanded Javadocs.
2. BlobContainer#writeBlob cannot overwrite an already existing blob.
   It will now throw an exception if trying to write to a pre-existing
   file.

Closes #15579
Closes #15580
