### PR TITLE
Remove readFrom from ingest

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ingest/SimulateProcessorResult.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/SimulateProcessorResult.java
@@ -34,17 +34,6 @@ public class SimulateProcessorResult implements Writeable<SimulateProcessorResul
     private final WriteableIngestDocument ingestDocument;
     private final Exception failure;
 
-    public SimulateProcessorResult(StreamInput in) throws IOException {
-        this.processorTag = in.readString();
-        if (in.readBoolean()) {
-            this.failure = in.readThrowable();
-            this.ingestDocument = null;
-        } else {
-            this.ingestDocument =  new WriteableIngestDocument(in);
-            this.failure = null;
-        }
-    }
-
     public SimulateProcessorResult(String processorTag, IngestDocument ingestDocument) {
         this.processorTag = processorTag;
         this.ingestDocument = new WriteableIngestDocument(ingestDocument);
@@ -55,6 +44,32 @@ public class SimulateProcessorResult implements Writeable<SimulateProcessorResul
         this.processorTag = processorTag;
         this.failure = failure;
         this.ingestDocument = null;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public SimulateProcessorResult(StreamInput in) throws IOException {
+        this.processorTag = in.readString();
+        if (in.readBoolean()) {
+            this.failure = in.readThrowable();
+            this.ingestDocument = null;
+        } else {
+            this.ingestDocument = new WriteableIngestDocument(in);
+            this.failure = null;
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(processorTag);
+        if (failure == null) {
+            out.writeBoolean(false);
+            ingestDocument.writeTo(out);
+        } else {
+            out.writeBoolean(true);
+            out.writeThrowable(failure);
+        }
     }
 
     public IngestDocument getIngestDocument() {
@@ -70,23 +85,6 @@ public class SimulateProcessorResult implements Writeable<SimulateProcessorResul
 
     public Exception getFailure() {
         return failure;
-    }
-
-    @Override
-    public SimulateProcessorResult readFrom(StreamInput in) throws IOException {
-        return new SimulateProcessorResult(in);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(processorTag);
-        if (failure == null) {
-            out.writeBoolean(false);
-            ingestDocument.writeTo(out);
-        } else {
-            out.writeBoolean(true);
-            out.writeThrowable(failure);
-        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/ingest/IngestStats.java
+++ b/core/src/main/java/org/elasticsearch/ingest/IngestStats.java
@@ -34,6 +34,14 @@ public class IngestStats implements Writeable<IngestStats>, ToXContent {
     private final Stats totalStats;
     private final Map<String, Stats> statsPerPipeline;
 
+    public IngestStats(Stats totalStats, Map<String, Stats> statsPerPipeline) {
+        this.totalStats = totalStats;
+        this.statsPerPipeline = statsPerPipeline;
+    }
+
+    /**
+     * Read from a stream.
+     */
     public IngestStats(StreamInput in) throws IOException {
         this.totalStats = new Stats(in);
         int size = in.readVInt();
@@ -43,10 +51,16 @@ public class IngestStats implements Writeable<IngestStats>, ToXContent {
         }
     }
 
-    public IngestStats(Stats totalStats, Map<String, Stats> statsPerPipeline) {
-        this.totalStats = totalStats;
-        this.statsPerPipeline = statsPerPipeline;
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        totalStats.writeTo(out);
+        out.writeVLong(statsPerPipeline.size());
+        for (Map.Entry<String, Stats> entry : statsPerPipeline.entrySet()) {
+            out.writeString(entry.getKey());
+            entry.getValue().writeTo(out);
+        }
     }
+
 
     /**
      * @return The accumulated stats for all pipelines
@@ -60,21 +74,6 @@ public class IngestStats implements Writeable<IngestStats>, ToXContent {
      */
     public Map<String, Stats> getStatsPerPipeline() {
         return statsPerPipeline;
-    }
-
-    @Override
-    public IngestStats readFrom(StreamInput in) throws IOException {
-        return new IngestStats(in);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        totalStats.writeTo(out);
-        out.writeVLong(statsPerPipeline.size());
-        for (Map.Entry<String, Stats> entry : statsPerPipeline.entrySet()) {
-            out.writeString(entry.getKey());
-            entry.getValue().writeTo(out);
-        }
     }
 
     @Override
@@ -101,6 +100,16 @@ public class IngestStats implements Writeable<IngestStats>, ToXContent {
         private final long ingestCurrent;
         private final long ingestFailedCount;
 
+        public Stats(long ingestCount, long ingestTimeInMillis, long ingestCurrent, long ingestFailedCount) {
+            this.ingestCount = ingestCount;
+            this.ingestTimeInMillis = ingestTimeInMillis;
+            this.ingestCurrent = ingestCurrent;
+            this.ingestFailedCount = ingestFailedCount;
+        }
+
+        /**
+         * Read from a stream.
+         */
         public Stats(StreamInput in) throws IOException {
             ingestCount = in.readVLong();
             ingestTimeInMillis = in.readVLong();
@@ -108,11 +117,12 @@ public class IngestStats implements Writeable<IngestStats>, ToXContent {
             ingestFailedCount = in.readVLong();
         }
 
-        public Stats(long ingestCount, long ingestTimeInMillis, long ingestCurrent, long ingestFailedCount) {
-            this.ingestCount = ingestCount;
-            this.ingestTimeInMillis = ingestTimeInMillis;
-            this.ingestCurrent = ingestCurrent;
-            this.ingestFailedCount = ingestFailedCount;
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(ingestCount);
+            out.writeVLong(ingestTimeInMillis);
+            out.writeVLong(ingestCurrent);
+            out.writeVLong(ingestFailedCount);
         }
 
         /**
@@ -142,19 +152,6 @@ public class IngestStats implements Writeable<IngestStats>, ToXContent {
          */
         public long getIngestFailedCount() {
             return ingestFailedCount;
-        }
-
-        @Override
-        public Stats readFrom(StreamInput in) throws IOException {
-            return new Stats(in);
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeVLong(ingestCount);
-            out.writeVLong(ingestTimeInMillis);
-            out.writeVLong(ingestCurrent);
-            out.writeVLong(ingestFailedCount);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/core/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.ParseFieldMatcherSupplier;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -39,8 +38,7 @@ import java.util.function.BiFunction;
 /**
  * Encapsulates a pipeline's id and configuration as a blob
  */
-public final class PipelineConfiguration extends AbstractDiffable<PipelineConfiguration>
-        implements Writeable<PipelineConfiguration>, ToXContent {
+public final class PipelineConfiguration extends AbstractDiffable<PipelineConfiguration> implements ToXContent {
 
     final static PipelineConfiguration PROTOTYPE = new PipelineConfiguration(null, null);
 

--- a/core/src/main/java/org/elasticsearch/ingest/core/IngestInfo.java
+++ b/core/src/main/java/org/elasticsearch/ingest/core/IngestInfo.java
@@ -21,15 +21,11 @@ package org.elasticsearch.ingest.core;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -39,29 +35,19 @@ public class IngestInfo implements Writeable<IngestInfo>, ToXContent {
 
     private final Set<ProcessorInfo> processors;
 
-    public IngestInfo(StreamInput in) throws IOException {
-        this(Collections.emptyList());
-        final int size = in.readVInt();
-        for (int i = 0; i < size; i++) {
-            processors.add(new ProcessorInfo(in));
-        }
-    }
-
     public IngestInfo(List<ProcessorInfo> processors) {
         this.processors = new TreeSet<>(processors);  // we use a treeset here to have a test-able / predictable order
     }
 
-    public Iterable<ProcessorInfo> getProcessors() {
-        return processors;
-    }
-
-    public boolean containsProcessor(String type) {
-        return processors.contains(new ProcessorInfo(type));
-    }
-
-    @Override
-    public IngestInfo readFrom(StreamInput in) throws IOException {
-        return new IngestInfo(in);
+    /**
+     * Read from a stream.
+     */
+    public IngestInfo(StreamInput in) throws IOException {
+        processors = new TreeSet<>();
+        final int size = in.readVInt();
+        for (int i = 0; i < size; i++) {
+            processors.add(new ProcessorInfo(in));
+        }
     }
 
     @Override
@@ -70,6 +56,14 @@ public class IngestInfo implements Writeable<IngestInfo>, ToXContent {
         for (ProcessorInfo info : processors) {
             info.writeTo(out);
         }
+    }
+
+    public Iterable<ProcessorInfo> getProcessors() {
+        return processors;
+    }
+
+    public boolean containsProcessor(String type) {
+        return processors.contains(new ProcessorInfo(type));
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/ingest/core/ProcessorInfo.java
+++ b/core/src/main/java/org/elasticsearch/ingest/core/ProcessorInfo.java
@@ -21,7 +21,6 @@ package org.elasticsearch.ingest.core;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -32,12 +31,20 @@ public class ProcessorInfo implements Writeable<ProcessorInfo>, ToXContent, Comp
 
     private final String type;
 
+    public ProcessorInfo(String type) {
+        this.type = type;
+    }
+
+    /**
+     * Read from a stream.
+     */
     public ProcessorInfo(StreamInput input) throws IOException {
         type = input.readString();
     }
 
-    public ProcessorInfo(String type) {
-        this.type = type;
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(this.type);
     }
 
     /**
@@ -45,16 +52,6 @@ public class ProcessorInfo implements Writeable<ProcessorInfo>, ToXContent, Comp
      */
     public String getType() {
         return type;
-    }
-
-    @Override
-    public ProcessorInfo readFrom(StreamInput in) throws IOException {
-        return new ProcessorInfo(in);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(this.type);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/ingest/IngestStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/IngestStatsTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.ingest;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -60,10 +59,10 @@ public class IngestStatsTests extends ESTestCase {
         assertEquals(leftStats.getIngestCurrent(), rightStats.getIngestCurrent());
     }
 
-    private <T> T serialize(Writeable<T> writeable) throws IOException {
+    private IngestStats serialize(IngestStats stats) throws IOException {
         BytesStreamOutput out = new BytesStreamOutput();
-        writeable.writeTo(out);
+        stats.writeTo(out);
         StreamInput in = StreamInput.wrap(out.bytes());
-        return writeable.readFrom(in);
+        return new IngestStats(in);
     }
 }


### PR DESCRIPTION
It isn't needed and will be removed from the interface declaring it.

Relates to #17085
