### PR TITLE
add ability to disable ability to override values of existing fields in set processor

### DIFF
--- a/core/src/main/java/org/elasticsearch/ingest/core/ConfigurationUtils.java
+++ b/core/src/main/java/org/elasticsearch/ingest/core/ConfigurationUtils.java
@@ -83,6 +83,28 @@ public final class ConfigurationUtils {
             value.getClass().getName() + "]");
     }
 
+    public static Boolean readBooleanProperty(String processorType, String processorTag, Map<String, Object> configuration,
+                                             String propertyName, boolean defaultValue) {
+        Object value = configuration.remove(propertyName);
+        if (value == null) {
+            return defaultValue;
+        } else {
+            return readBoolean(processorType, processorTag, propertyName, value).booleanValue();
+        }
+    }
+
+    private static Boolean readBoolean(String processorType, String processorTag, String propertyName, Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        throw newConfigurationException(processorType, processorTag, propertyName, "property isn't a boolean, but of type [" +
+            value.getClass().getName() + "]");
+    }
+
+
     /**
      * Returns and removes the specified property from the specified configuration map.
      *

--- a/core/src/main/java/org/elasticsearch/ingest/core/IngestDocument.java
+++ b/core/src/main/java/org/elasticsearch/ingest/core/IngestDocument.java
@@ -117,6 +117,18 @@ public final class IngestDocument {
     }
 
     /**
+     * Returns the value contained in the document with the provided templated path
+     * @param pathTemplate The path within the document in dot-notation
+     * @param clazz The expected class fo the field value
+     * @return the value fro the provided path if existing, null otherwise
+     * @throws IllegalArgumentException if the pathTemplate is null, empty, invalid, if the field doesn't exist,
+     * or if the field that is found at the provided path is not of the expected type.
+     */
+    public <T> T getFieldValue(TemplateService.Template pathTemplate, Class<T> clazz) {
+        return getFieldValue(renderTemplate(pathTemplate), clazz);
+    }
+
+    /**
      * Returns the value contained in the document for the provided path as a byte array.
      * If the path value is a string, a base64 decode operation will happen.
      * If the path value is a byte array, it is just returned
@@ -139,6 +151,16 @@ public final class IngestDocument {
             throw new IllegalArgumentException("Content field [" + path + "] of unknown type [" + object.getClass().getName() +
                 "], must be string or byte array");
         }
+    }
+
+    /**
+     * Checks whether the document contains a value for the provided templated path
+     * @param fieldPathTemplate the template for the path within the document in dot-notation
+     * @return true if the document contains a value for the field, false otherwise
+     * @throws IllegalArgumentException if the path is null, empty or invalid
+     */
+    public boolean hasField(TemplateService.Template fieldPathTemplate) {
+        return hasField(renderTemplate(fieldPathTemplate));
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/ingest/core/ConfigurationUtilsTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/core/ConfigurationUtilsTests.java
@@ -34,7 +34,6 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 
 
@@ -45,6 +44,8 @@ public class ConfigurationUtilsTests extends ESTestCase {
     public void setConfig() {
         config = new HashMap<>();
         config.put("foo", "bar");
+        config.put("boolVal", true);
+        config.put("null", null);
         config.put("arr", Arrays.asList("1", "2", "3"));
         List<Integer> list = new ArrayList<>();
         list.add(2);
@@ -65,6 +66,24 @@ public class ConfigurationUtilsTests extends ESTestCase {
             ConfigurationUtils.readStringProperty(null, null, config, "arr");
         } catch (ElasticsearchParseException e) {
             assertThat(e.getMessage(), equalTo("[arr] property isn't a string, but of type [java.util.Arrays$ArrayList]"));
+        }
+    }
+
+    public void testReadBooleanProperty() {
+        Boolean val = ConfigurationUtils.readBooleanProperty(null, null, config, "boolVal", false);
+        assertThat(val, equalTo(true));
+    }
+
+    public void testReadNullBooleanProperty() {
+        Boolean val = ConfigurationUtils.readBooleanProperty(null, null, config, "null", false);
+        assertThat(val, equalTo(false));
+    }
+
+    public void testReadBooleanPropertyInvalidType() {
+        try {
+            ConfigurationUtils.readBooleanProperty(null, null, config, "arr", true);
+        } catch (ElasticsearchParseException e) {
+            assertThat(e.getMessage(), equalTo("[arr] property isn't a boolean, but of type [java.util.Arrays$ArrayList]"));
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/ingest/core/IngestDocumentTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/core/IngestDocumentTests.java
@@ -199,7 +199,7 @@ public class IngestDocumentTests extends ESTestCase {
 
     public void testGetFieldValueNull() {
         try {
-            ingestDocument.getFieldValue(null, String.class);
+            ingestDocument.getFieldValue((String) null, String.class);
             fail("get field value should have failed");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), equalTo("path cannot be null nor empty"));
@@ -263,7 +263,7 @@ public class IngestDocumentTests extends ESTestCase {
 
     public void testHasFieldNull() {
         try {
-            ingestDocument.hasField(null);
+            ingestDocument.hasField((String) null);
             fail("has field should have failed");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), equalTo("path cannot be null nor empty"));

--- a/core/src/test/java/org/elasticsearch/ingest/processor/SetProcessorFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/SetProcessorFactoryTests.java
@@ -22,7 +22,6 @@ package org.elasticsearch.ingest.processor;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ingest.TestTemplateService;
 import org.elasticsearch.ingest.core.AbstractProcessorFactory;
-import org.elasticsearch.ingest.core.Processor;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
@@ -51,6 +50,22 @@ public class SetProcessorFactoryTests extends ESTestCase {
         assertThat(setProcessor.getTag(), equalTo(processorTag));
         assertThat(setProcessor.getField().execute(Collections.emptyMap()), equalTo("field1"));
         assertThat(setProcessor.getValue().copyAndResolve(Collections.emptyMap()), equalTo("value1"));
+        assertThat(setProcessor.isOverrideEnabled(), equalTo(true));
+    }
+
+    public void testCreateWithOverride() throws Exception {
+        boolean overrideEnabled = randomBoolean();
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "field1");
+        config.put("value", "value1");
+        config.put("override", overrideEnabled);
+        String processorTag = randomAsciiOfLength(10);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
+        SetProcessor setProcessor = factory.create(config);
+        assertThat(setProcessor.getTag(), equalTo(processorTag));
+        assertThat(setProcessor.getField().execute(Collections.emptyMap()), equalTo("field1"));
+        assertThat(setProcessor.getValue().copyAndResolve(Collections.emptyMap()), equalTo("value1"));
+        assertThat(setProcessor.isOverrideEnabled(), equalTo(overrideEnabled));
     }
 
     public void testCreateNoFieldPresent() throws Exception {

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -1179,6 +1179,7 @@ its value will be replaced with the provided one.
 | Name      | Required  | Default  | Description
 | `field`   | yes       | -        | The field to insert, upsert, or update
 | `value`   | yes       | -        | The value to be set for the field
+| `override`| no        | true     | If processor will update fields with pre-existing non-null-valued field. When set to `false`, such fields will not be touched.
 |======
 
 [source,js]


### PR DESCRIPTION
Fixes #17659

adds `override` option for the `set` processor. When set to `false`, the processor will not update 
the value of an existing non-null-valued field in the ingest document

```
{
  "set" : {
    "field" : ...,
    "value" : ...,
    "override" : (true|false)
  }
}
```

This field is optional, and defaults to `true`.
