### PR TITLE
Add a `minhash` token filter

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
@@ -259,6 +259,7 @@ public final class AnalysisRegistry implements Closeable {
         tokenFilters.put("classic", ClassicFilterFactory::new);
         tokenFilters.put("decimal_digit", DecimalDigitFilterFactory::new);
         tokenFilters.put("fingerprint", FingerprintTokenFilterFactory::new);
+        tokenFilters.put("minhash", MinHashTokenFilterFactory::new);
     }
 
     private void registerBuiltInAnalyzer(Map<String, AnalysisModule.AnalysisProvider<AnalyzerProvider>> analyzers) {

--- a/core/src/main/java/org/elasticsearch/index/analysis/MinHashTokenFilter.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/MinHashTokenFilter.java
@@ -1,0 +1,121 @@
+package org.elasticsearch.index.analysis;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.lucene.analysis.TokenFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionLengthAttribute;
+import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
+import org.elasticsearch.cluster.routing.Murmur3HashFunction;
+
+/**
+ * Consumes all tokens and emits a set of "minimum hashes", which can be used
+ * for similarity comparisons or clustering.
+ */
+public class MinHashTokenFilter extends TokenFilter {
+
+    private final CharTermAttribute termAttribute = addAttribute(CharTermAttribute.class);
+    private final PositionLengthAttribute posLenAtt = addAttribute(PositionLengthAttribute.class);
+    private final TypeAttribute typeAtt = addAttribute(TypeAttribute.class);
+    private final PositionIncrementAttribute posIncrAtt = addAttribute(PositionIncrementAttribute.class);
+    private int currentPosition;
+    private int[] minHashes;
+
+    private static final int[] xorList = {1776307437,1362611959,578040592,444677783,-1468350538,1065497345,476516387,-1150432725,-32553513,202985346,-520256914,-1021791600,1398563721,-632703196,2067011261,260307261,668345640,-301234798,595776579,-560005079,419781730,935472260,-828211474,-456241981,1976420839,-314396499,-1950548137,511222864,-886766967,1241363781,644154611,-454189829,1618568518,-1166467447,-2141665627,84681584,-818755544,-1808672001,610545784,-1920097362,-1630385755,-1366485383,1618298371,1141859413,-938524288,-232256595,-1368579955,-1961625121,-841673731,1523195865,-1530547177,-430431047,-1379363961,1472130856,168110893,-1632899023,814400923,-67643081,-662281233,1117177417,-562077426,1032837633,-649080591,1642897463,-387073035,22893223,70226167,1558424254,-1750881559,-1144535182,1891627172,1788202751,676458057,-1746448170,-1648027094,-1604054212,-1911850598,1772495029,1282957449,1692623317,-301405368,-759670346,-1884095397,-855853986,-1790079248,-1416886022,-1671659898,77310248,-320075646,1133086524,-1936847922,-1265513383,113485981,548483603,315024764,1178055833,-2104204527,1161488314,439706329,-377850679};
+
+    /**
+     *
+     * @param input     The source of tokens to generate a minhash for
+     * @param numHashes The number of independent hashes to use.  More hashes will
+     *                  generate more tokens, which allows better similarity/clustering
+     *                  accuracy (at the expense of more hashing and larger storage)
+     */
+    public MinHashTokenFilter(TokenStream input, int numHashes) {
+        super(input);
+        if (numHashes < 1) {
+            throw new IllegalArgumentException("Must use one or more hashes for MinHash Token Filter");
+        }
+        if (numHashes > 100) {
+            throw new IllegalArgumentException("Cannot use more than 100 hashes for MinHash Token Filter");
+        }
+        this.minHashes = new int[numHashes];
+        Arrays.fill(this.minHashes, Integer.MAX_VALUE);
+        this.currentPosition = -1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final boolean incrementToken() throws IOException {
+        if (currentPosition == -1) {
+            buildMinHash();
+            currentPosition = 0;
+        }
+
+        if (currentPosition < minHashes.length) {
+            String token = currentPosition + "_" + Integer.toHexString(minHashes[currentPosition]);
+            input.clearAttributes();
+            termAttribute.setEmpty().append(token);
+            posLenAtt.setPositionLength(token.length());
+            posIncrAtt.setPositionIncrement(currentPosition);
+            typeAtt.setType("fingerprint");
+            //TODO offset?
+
+            currentPosition += 1;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Generates the set of minimum hashes for the token stream
+     * @throws IOException
+     */
+    private void buildMinHash() throws IOException {
+        while (input.incrementToken()) {
+
+            int hash = Murmur3HashFunction.hash(termAttribute.toString());
+            minHashes[0] = Math.min(minHashes[0], hash);
+            // Start at 1 because we can use the original hash for 0
+            for (int i = 1; i < this.minHashes.length; i++) {
+                int rotatedHash = Integer.rotateRight(hash, i * 2);
+                rotatedHash ^= xorList[i - 1];
+                minHashes[i] = Math.min(minHashes[i], rotatedHash);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void reset() throws IOException {
+        super.reset();
+        minHashes = new int[minHashes.length];
+        Arrays.fill(this.minHashes, Integer.MAX_VALUE);
+        this.currentPosition = -1;
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/index/analysis/MinHashTokenFilterFactory.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/MinHashTokenFilterFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.miscellaneous.FingerprintFilter;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.IndexSettings;
+
+
+/**
+ *
+ */
+public class MinHashTokenFilterFactory extends AbstractTokenFilterFactory {
+
+    private final int numHashes;
+
+    public static ParseField NUM_HASHES = new ParseField("num_hashes");
+
+    public static final int DEFAULT_NUM_HASHES = 50;
+
+    public MinHashTokenFilterFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
+        super(indexSettings, name, settings);
+        this.numHashes = settings.getAsInt(NUM_HASHES.getPreferredName(),
+            MinHashTokenFilterFactory.DEFAULT_NUM_HASHES);
+    }
+
+    @Override
+    public TokenStream create(TokenStream tokenStream) {
+        return new MinHashTokenFilter(tokenStream, numHashes);
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/index/analysis/MinHashTokenFilterTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/MinHashTokenFilterTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
+import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.test.ESTokenStreamTestCase;
@@ -63,13 +64,8 @@ public class MinHashTokenFilterTests extends ESTokenStreamTestCase {
         String source = "Hello 123 world";
         Tokenizer tokenizer = new StandardTokenizer();
         tokenizer.setReader(new StringReader(source));
-        try {
-            tokenFilter.create(tokenizer);
-            fail("Should throw exception when [num_hashes] is zero");
-        } catch (IllegalArgumentException e) {
-            // all good
-            assertThat(e.getMessage(), equalTo("Must use one or more hashes for MinHash Token Filter"));
-        }
+        Exception e = LuceneTestCase.expectThrows(IllegalArgumentException.class, () -> tokenFilter.create(tokenizer));
+        assertEquals(e.getMessage(), "Must use one or more hashes for MinHash Token Filter");
     }
 
     public void testBadSettingsTooManyHashes() throws IOException {
@@ -85,12 +81,7 @@ public class MinHashTokenFilterTests extends ESTokenStreamTestCase {
         String source = "Hello 123 world";
         Tokenizer tokenizer = new StandardTokenizer();
         tokenizer.setReader(new StringReader(source));
-        try {
-            tokenFilter.create(tokenizer);
-            fail("Should throw exception when [num_hashes] is greater than 100");
-        } catch (IllegalArgumentException e) {
-            // all good
-            assertThat(e.getMessage(), equalTo("Cannot use more than 100 hashes for MinHash Token Filter"));
-        }
+        Exception e = LuceneTestCase.expectThrows(IllegalArgumentException.class, () -> tokenFilter.create(tokenizer));
+        assertEquals(e.getMessage(), "Cannot use more than 100 hashes for MinHash Token Filter");
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/analysis/MinHashTokenFilterTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/MinHashTokenFilterTests.java
@@ -1,0 +1,96 @@
+package org.elasticsearch.index.analysis;
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.standard.StandardTokenizer;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.test.ESTokenStreamTestCase;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class MinHashTokenFilterTests extends ESTokenStreamTestCase {
+
+    public void testMinHash() throws IOException {
+        Settings.Builder builder = Settings.builder()
+            .put("index.analysis.filter.my_minhash.type", "minhash")
+            .put("index.analysis.filter.my_minhash.num_hashes", 5);
+
+        builder.put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString());
+        AnalysisService analysisService = AnalysisTestsHelper.createAnalysisServiceFromSettings(builder.build());
+        TokenFilterFactory tokenFilter = analysisService.tokenFilter("my_minhash");
+        assertThat(tokenFilter, instanceOf(MinHashTokenFilterFactory.class));
+
+        String source = "Hello 123 world";
+        String[] expected = new String[]{"0_915bcf01", "1_db6bf2d", "2_88e874da", "3_24315c2c", "4_8b60acfe"};
+        Tokenizer tokenizer = new StandardTokenizer();
+        tokenizer.setReader(new StringReader(source));
+        assertTokenStreamContents(tokenFilter.create(tokenizer), expected);
+    }
+
+    public void testBadSettingsZeroHashes() throws IOException {
+        Settings.Builder builder = Settings.builder()
+            .put("index.analysis.filter.my_minhash.type", "minhash")
+            .put("index.analysis.filter.my_minhash.num_hashes", 0);
+
+        builder.put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString());
+        AnalysisService analysisService = AnalysisTestsHelper.createAnalysisServiceFromSettings(builder.build());
+        TokenFilterFactory tokenFilter = analysisService.tokenFilter("my_minhash");
+        assertThat(tokenFilter, instanceOf(MinHashTokenFilterFactory.class));
+
+        String source = "Hello 123 world";
+        Tokenizer tokenizer = new StandardTokenizer();
+        tokenizer.setReader(new StringReader(source));
+        try {
+            tokenFilter.create(tokenizer);
+            fail("Should throw exception when [num_hashes] is zero");
+        } catch (IllegalArgumentException e) {
+            // all good
+            assertThat(e.getMessage(), equalTo("Must use one or more hashes for MinHash Token Filter"));
+        }
+    }
+
+    public void testBadSettingsTooManyHashes() throws IOException {
+        Settings.Builder builder = Settings.builder()
+            .put("index.analysis.filter.my_minhash.type", "minhash")
+            .put("index.analysis.filter.my_minhash.num_hashes", 1000);
+
+        builder.put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString());
+        AnalysisService analysisService = AnalysisTestsHelper.createAnalysisServiceFromSettings(builder.build());
+        TokenFilterFactory tokenFilter = analysisService.tokenFilter("my_minhash");
+        assertThat(tokenFilter, instanceOf(MinHashTokenFilterFactory.class));
+
+        String source = "Hello 123 world";
+        Tokenizer tokenizer = new StandardTokenizer();
+        tokenizer.setReader(new StringReader(source));
+        try {
+            tokenFilter.create(tokenizer);
+            fail("Should throw exception when [num_hashes] is greater than 100");
+        } catch (IllegalArgumentException e) {
+            // all good
+            assertThat(e.getMessage(), equalTo("Cannot use more than 100 hashes for MinHash Token Filter"));
+        }
+    }
+}


### PR DESCRIPTION
Adds a `minhash` token filter, which computes the "minimum hashes" for a body of text.  The minhash can be used to estimate the Jaccard similarity coefficient between two documents, since documents with similar tokens will share similar minhashes.  In practice, this provides coarse/fast clustering and similarity comparison.

A user can select the number of hashes to use in the filter.  More hashes gives a finer-grained resolution (since it provides more random projections to divide the sets), at the cost of more computation and storage.

The filter consumes all the original tokens and emits `n` tokens which follow the format `<minhash index>_<minhash>`.  E.g. 

```
["0_915bcf01", "1_db6bf2d", "2_88e874da", "3_24315c2c", "4_8b60acfe"]
```

@jimferenczi pointed me towards this open patch in Lucene, which provides a similar MinHash (and other LSH functionality):  https://issues.apache.org/jira/browse/LUCENE-6968

Since my version was close to done anyway, I figured I'd put it up and see if we should defer to the Lucene implementation, continue with this, move it to Lucene, etc.
- Docs are missing
- Murmur3 is used to provide the initial hash, then rotated/xor'd to provide the rest of the "independent" hashes.  I didn't use the string's hashcode since that biases certain bits in practice, since character encodings and language are not randomly dispersed
- I embedded a list of integers to xor against, rather than generating them at runtime.  Seemed relatively negligible (400 bytes)
