### PR TITLE
Kill thread local leak

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/inject/InjectorImpl.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/InjectorImpl.java
@@ -84,12 +84,7 @@ class InjectorImpl implements Injector, Lookups {
         if (parent != null) {
             localContext = parent.localContext;
         } else {
-            localContext = new ThreadLocal<Object[]>() {
-                @Override
-                protected Object[] initialValue() {
-                    return new Object[1];
-                }
-            };
+            localContext = new ThreadLocal<>();
         }
     }
 
@@ -867,13 +862,17 @@ class InjectorImpl implements Injector, Lookups {
         return getProvider(type).get();
     }
 
-    final ThreadLocal<Object[]> localContext;
+    private final ThreadLocal<Object[]> localContext;
 
     /**
      * Looks up thread local context. Creates (and removes) a new context if necessary.
      */
     <T> T callInContext(ContextualCallable<T> callable) throws ErrorsException {
         Object[] reference = localContext.get();
+        if (reference == null) {
+            reference = new Object[1];
+            localContext.set(reference);
+        }
         if (reference[0] == null) {
             reference[0] = new InternalContext();
             try {


### PR DESCRIPTION
This commit modifies InjectorImpl to prevent a thread local leak in
certain web containers. This leak can arise when starting a node client
inside such a web container. The underlying issue is that the
ThreadLocal instance was created via an anonymous class. Such an
anonymous class has an implicit reference back to the InjectorImpl in
which it was created. The solution here is to not use an anonymous class
but instead just create the reference locally and set it on the thread
local.

Closes #283, relates google/guice#630
