### PR TITLE
[TEST] append test class name to node name of external nodes

### DIFF
--- a/qa/backwards/shared/src/test/java/org/elasticsearch/test/CompositeTestCluster.java
+++ b/qa/backwards/shared/src/test/java/org/elasticsearch/test/CompositeTestCluster.java
@@ -51,13 +51,16 @@ import static org.junit.Assert.assertThat;
  */
 public class CompositeTestCluster extends TestCluster {
     private final InternalTestCluster cluster;
+    private String testClassName;
     private final ExternalNode[] externalNodes;
     private ExternalClient client;
     private static final String NODE_PREFIX = "external_";
 
-    public CompositeTestCluster(InternalTestCluster cluster, int numExternalNodes, ExternalNode externalNode) throws IOException {
+    public CompositeTestCluster(InternalTestCluster cluster, int numExternalNodes, ExternalNode externalNode, String testClassName) throws
+        IOException {
         super(cluster.seed());
         this.cluster = cluster;
+        this.testClassName = testClassName;
         this.externalNodes = new ExternalNode[numExternalNodes];
         for (int i = 0; i < externalNodes.length; i++) {
             externalNodes[i] = externalNode;
@@ -77,7 +80,8 @@ public class CompositeTestCluster extends TestCluster {
         final Client client = cluster.size() > 0 ? cluster.client() : cluster.clientNodeClient();
         for (int i = 0; i < externalNodes.length; i++) {
             if (!externalNodes[i].running()) {
-                externalNodes[i] = externalNodes[i].start(client, defaultSettings, NODE_PREFIX + i, cluster.getClusterName(), i);
+                externalNodes[i] = externalNodes[i].start(client, defaultSettings, NODE_PREFIX + testClassName + "_" + i, cluster
+                    .getClusterName(), i);
             }
             externalNodes[i].reset(random.nextLong());
         }

--- a/qa/backwards/shared/src/test/java/org/elasticsearch/test/ESBackcompatTestCase.java
+++ b/qa/backwards/shared/src/test/java/org/elasticsearch/test/ESBackcompatTestCase.java
@@ -202,7 +202,8 @@ public abstract class ESBackcompatTestCase extends ESIntegTestCase {
                 throw new UnsupportedOperationException();
             }
         });
-        return new CompositeTestCluster((InternalTestCluster) cluster, between(minExternalNodes(), maxExternalNodes()), externalNode);
+        return new CompositeTestCluster((InternalTestCluster) cluster, between(minExternalNodes(), maxExternalNodes()), externalNode,
+            getTestClass().getSimpleName());
     }
 
     private Settings addLoggerSettings(Settings externalNodesSettings) {


### PR DESCRIPTION
External node logs do not appear together with the "regular" node
logs but are instead printed before or after the test logs.
This makes debugging rather tricky as several test suites
can spin up external nodes with the same name and we cannot tell from the
logs which is used for which test.
Appending the class name of the test at least allows us to know
which suite the node is used in.
