### PR TITLE
Implement response_format=short on _bulk

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
@@ -135,14 +135,20 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
         builder.field("errors", hasFailures());
         int successes = 0;
         builder.startArray("items"); {
+            int ordinal = 0;
             for (BulkItemResponse itemResponse : this) {
                 if (false == itemResponse.isFailed()) {
                     successes += 1;
                     if (skipSuccesses) continue;
                 }
                 builder.startObject();
+                if (skipSuccesses) {
+                    // The ordinal is implied by the position in the array if we aren't skipping successes.
+                    builder.field("ordinal", ordinal);
+                }
                 itemResponse.toXContent(builder, params);
                 builder.endObject();
+                ordinal++;
             }
         }
         builder.endArray();

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -287,9 +287,9 @@ The order is preserved *and* the objects contain `_index`, `_type`, and
 bulk response item.
 
 If you add `response_format=short` to the request then it'll drop the
-successful items. In that case you'll need to use the `_index`, _type`,
-and `_id` to pair up any returned failures with the bulk request item.
-For example, this bulk request:
+successful items and include an `ordinal` field on each failure that
+is the (0 based) index of the request that caused the failure. For
+example, this bulk request:
 
 [source,js]
 --------------------------------------------------
@@ -313,6 +313,7 @@ Returns this response:
   "took" : 111,
   "errors" : true,
   "items" : [ {
+    "ordinal": 2,
     "update" : {
       "_index" : "test",
       "_type" : "type1",

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -91,10 +91,6 @@ Client libraries using this protocol should try and strive to do
 something similar on the client side, and reduce buffering as much as
 possible.
 
-The response to a bulk action is a large JSON structure with the
-individual results of each action that was performed. The failure of a
-single action does not affect the remaining actions.
-
 There is no "correct" number of actions to perform in a single bulk
 call. You should experiment with different settings to find the optimum
 size for your particular workload.
@@ -206,3 +202,133 @@ the options. Curl example with update actions:
 === Security
 
 See <<url-access-control>>
+
+[float]
+[[bulk-response]]
+=== Response
+
+The response to a bulk action is a large JSON structure with the
+individual results of each action that was performed. The failure of a
+single action does not affect the remaining actions.
+
+This bulk request:
+
+[source,js]
+--------------------------------------------------
+curl -XDELETE localhost:9200/test
+cat << REQUESTS > requests
+{ "index" : { "_index" : "test", "_type" : "type1", "_id" : "1" } }
+{ "foo": "bar" }
+{ "index" : { "_index" : "test", "_type" : "type1", "_id" : "2" } }
+{ "foo": "bar" }
+{ "update" : { "_index" : "test", "_type" : "type1", "_id" : "doesn't exist" } }
+{ "doc": { "foo": "bar" } }
+REQUESTS
+curl -s -XPOST 'localhost:9200/_bulk?pretty' --data-binary "@requests"
+--------------------------------------------------
+
+Will return this response:
+
+[source,js]
+--------------------------------------------------
+{
+  "took" : 116,
+  "errors" : true,
+  "items" : [ {
+    "index" : {
+      "_index" : "test",
+      "_type" : "type1",
+      "_id" : "1",
+      "_version" : 1,
+      "_shards" : {
+        "total" : 2,
+        "successful" : 1,
+        "failed" : 0
+      },
+      "created" : true,
+      "status" : 201
+    }
+  }, {
+    "index" : {
+      "_index" : "test",
+      "_type" : "type1",
+      "_id" : "2",
+      "_version" : 1,
+      "_shards" : {
+        "total" : 2,
+        "successful" : 1,
+        "failed" : 0
+      },
+      "created" : true,
+      "status" : 201
+    }
+  }, {
+    "update" : {
+      "_index" : "test",
+      "_type" : "type1",
+      "_id" : "doesn't exist",
+      "status" : 404,
+      "error" : {
+        "type" : "document_missing_exception",
+        "reason" : "[type1][doesn't exist]: document missing",
+        "index_uuid" : "JcT7yX2CRai8pirh_q_6yQ",
+        "shard" : "4",
+        "index" : "test"
+      }
+    }
+  } ],
+  "successes" : 2
+}
+--------------------------------------------------
+
+Notice that every action comes back as an object in the `items` array.
+The order is preserved *and* the objects contain `_index`, `_type`, and
+`_id`, both of which let you line up each bulk request item with the
+bulk response item.
+
+If you add `response_format=short` to the request then it'll drop the
+successful items. In that case you'll need to use the `_index`, _type`,
+and `_id` to pair up any returned failures with the bulk request item.
+For example, this bulk request:
+
+[source,js]
+--------------------------------------------------
+curl -XDELETE localhost:9200/test
+cat << REQUESTS > requests
+{ "index" : { "_index" : "test", "_type" : "type1", "_id" : "1" } }
+{ "foo": "bar" }
+{ "index" : { "_index" : "test", "_type" : "type1", "_id" : "2" } }
+{ "foo": "bar" }
+{ "update" : { "_index" : "test", "_type" : "type1", "_id" : "doesn't exist" } }
+{ "doc": { "foo": "bar" } }
+REQUESTS
+curl -s -XPOST 'localhost:9200/_bulk?pretty' --data-binary "@requests"
+--------------------------------------------------
+
+Returns this response:
+
+[source,js]
+--------------------------------------------------
+{
+  "took" : 111,
+  "errors" : true,
+  "items" : [ {
+    "update" : {
+      "_index" : "test",
+      "_type" : "type1",
+      "_id" : "doesn't exist",
+      "status" : 404,
+      "error" : {
+        "type" : "document_missing_exception",
+        "reason" : "[type1][doesn't exist]: document missing",
+        "index_uuid" : "TKcle9ylREOqiCUwEWFrOg",
+        "shard" : "4",
+        "index" : "test"
+      }
+    }
+  } ],
+  "successes" : 2
+}
+--------------------------------------------------
+
+Note that either way the number of successes is counted.

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
@@ -44,6 +44,11 @@
         "pipeline" : {
           "type" : "string",
           "description" : "The pipeline id to preprocess incoming documents with"
+        },
+        "response_format": {
+          "type": "string",
+          "default": "long",
+          "description": "Controls what is included in the response. \"long\" will the result of all operations. \"short\" will only return errors."
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/50_response_format.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/50_response_format.yaml
@@ -63,6 +63,7 @@
   - length: { items: 1 }
   - match: { items.0.update._index: idx }  # this one is an error so it'll come back regardless of response_format
   - match: { items.0.update._id: "doesn't exist" }
+  - match: { items.0.update.ordinal: 2 }
   - match: { items.0.update.status: 404 }
   - match: { items.0.update.error.type: "document_missing_exception" }
   - match: { items.0.update.error.reason: "[test][doesn't exist]: document missing" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/50_response_format.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/50_response_format.yaml
@@ -1,0 +1,68 @@
+---
+"response_format=long is default":
+  - do:
+      bulk:
+        body: |
+          { "index": { "_index": "idx", "_type": "test", "_id": "1" } }
+          { "foo": "bar" }
+          { "index": { "_index": "idx", "_type": "test", "_id": "2" } }
+          { "foo": "baz" }
+          { "update": { "_index": "idx", "_type": "test", "_id": "doesn't exist" } }
+          { "doc": { "foo": "this should be an error" } }
+  # This is the same list as the test below
+  - match: { successes: 2 }
+  - length: { items: 3 }
+  - match: { items.0.index._index: idx }  # lots of stuff comes back but for brevity we just check a few things
+  - match: { items.0.index._id: "1" }
+  - match: { items.1.index._index: idx }
+  - match: { items.1.index._id: "2" }
+  - match: { items.2.update._index: idx }  # this one is an error so it'll come back regardless of response_format
+  - match: { items.2.update._id: "doesn't exist" }
+  - match: { items.2.update.status: 404 }
+  - match: { items.2.update.error.type: "document_missing_exception" }
+  - match: { items.2.update.error.reason: "[test][doesn't exist]: document missing" }
+
+---
+"response_format=long":
+  - do:
+      bulk:
+        response_format: long
+        body: |
+          { "index": { "_index": "idx", "_type": "test", "_id": "1" } }
+          { "foo": "bar" }
+          { "index": { "_index": "idx", "_type": "test", "_id": "2" } }
+          { "foo": "baz" }
+          { "update": { "_index": "idx", "_type": "test", "_id": "doesn't exist" } }
+          { "doc": { "foo": "this should be an error" } }
+  # This is the same list as the test above
+  - match: { successes: 2 }
+  - length: { items: 3 }
+  - match: { items.0.index._index: idx }  # lots of stuff comes back but for brevity we just check a few things
+  - match: { items.0.index._id: "1" }
+  - match: { items.1.index._index: idx }
+  - match: { items.1.index._id: "2" }
+  - match: { items.2.update._index: idx }  # this one is an error so it'll come back regardless of response_format
+  - match: { items.2.update._id: "doesn't exist" }
+  - match: { items.2.update.status: 404 }
+  - match: { items.2.update.error.type: "document_missing_exception" }
+  - match: { items.2.update.error.reason: "[test][doesn't exist]: document missing" }
+
+---
+"response_format=short":
+  - do:
+      bulk:
+        response_format: short
+        body: |
+          { "index": { "_index": "idx", "_type": "test", "_id": "1" } }
+          { "foo": "bar" }
+          { "index": { "_index": "idx", "_type": "test", "_id": "2" } }
+          { "foo": "baz" }
+          { "update": { "_index": "idx", "_type": "test", "_id": "doesn't exist" } }
+          { "doc": { "foo": "this should be an error" } }
+  - match: { successes: 2 }
+  - length: { items: 1 }
+  - match: { items.0.update._index: idx }  # this one is an error so it'll come back regardless of response_format
+  - match: { items.0.update._id: "doesn't exist" }
+  - match: { items.0.update.status: 404 }
+  - match: { items.0.update.error.type: "document_missing_exception" }
+  - match: { items.0.update.error.reason: "[test][doesn't exist]: document missing" }


### PR DESCRIPTION
Now we'll always count the number of successes and, if the request
contains `?response_format=short`, we'll omit the successes from
the items list.

When `response_format` isn't set to `short` the items that come back
always line up with the request. They won't do that with `short`.
Instead clients have to use the _index/_type/_id triple to identify
the item that failed. If they happen to use the same triple they are
just out of luck. That is a silly thing to do anyway.

Closes #2661
