### PR TITLE
Docs: Update example aggs to use dynamic keyword field

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -904,7 +904,7 @@ curl -XPOST 'localhost:9200/bank/_search?pretty' -d '
   "aggs": {
     "group_by_state": {
       "terms": {
-        "field": "state"
+        "field": "state.keyword"
       }
     }
   }
@@ -979,7 +979,7 @@ curl -XPOST 'localhost:9200/bank/_search?pretty' -d '
   "aggs": {
     "group_by_state": {
       "terms": {
-        "field": "state"
+        "field": "state.keyword"
       },
       "aggs": {
         "average_balance": {
@@ -1005,7 +1005,7 @@ curl -XPOST 'localhost:9200/bank/_search?pretty' -d '
   "aggs": {
     "group_by_state": {
       "terms": {
-        "field": "state",
+        "field": "state.keyword",
         "order": {
           "average_balance": "desc"
         }


### PR DESCRIPTION
The getting started docs use dynamic mappings. With the recent change to
string split into text and keyword, text lost the default ability to do
aggs. This was added back in #17188. This change updates the getting
started examples to use the keyword multi field added to dynamically
mapped text fields.

closes #17941
