### PR TITLE
Add kotlin query DSL to community clients

### DIFF
--- a/docs/community-clients/index.asciidoc
+++ b/docs/community-clients/index.asciidoc
@@ -13,6 +13,7 @@ a number of clients that have been contributed by the community for various lang
 * <<haskell>>
 * <<java>>
 * <<javascript>>
+* <<kotlin>>
 * <<dotnet>>
 * <<ocaml>>
 * <<perl>>
@@ -104,6 +105,11 @@ The following project appears to be abandoned:
 * https://github.com/ramv/node-elastical[node-elastical]:
   Node.js client for the Elasticsearch REST API
 
+[[kotlin]]
+== kotlin
+
+* https://github.com/mbuhot/eskotlin[ES Kotlin]:
+  Elasticsearch Query DSL for kotlin based on the {client}/java-api/current/index.html[official Elasticsearch Java client].
 
 [[dotnet]]
 == .NET


### PR DESCRIPTION
Hi, 

I've created a query builder DSL for Kotlin language that mimics the JSON query DSL.
This makes it easier to translate the documentation targeting the JSON api onto kotlin code.
Please consider adding it to the list of community clients.

Thanks,

Mike Buhot
