### PR TITLE
Document missing shard version in routing table of cluster state

### DIFF
--- a/docs/reference/migration/migrate_5_0/rest.asciidoc
+++ b/docs/reference/migration/migrate_5_0/rest.asciidoc
@@ -29,6 +29,11 @@ node can contribute to multiple counts as it can have multiple roles. Every
 node is implicitly a coordinating node, so whenever a node has no explicit
 roles, it will be counted as coordinating only.
 
+==== Removed shard `version` information from `/_cluster/state` routing table
+
+We now store allocation id's of shards in the cluster state and use that to 
+select primary shards instead of the version information. 
+
 ==== Node roles are not part of node attributes anymore
 
 Node roles are now returned in a specific section, called `roles`, as part of


### PR DESCRIPTION
as breaking change

removed as per: https://github.com/elastic/elasticsearch/pull/16243

because of: https://github.com/elastic/elasticsearch/issues/14739
