### PR TITLE
convert settings for ResourceWatcherService to new infrastructure

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -94,6 +94,7 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.TransportSettings;
 import org.elasticsearch.transport.netty.NettyTransport;
 import org.elasticsearch.tribe.TribeService;
+import org.elasticsearch.watcher.ResourceWatcherService;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -411,6 +412,10 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     IndexingMemoryController.MIN_INDEX_BUFFER_SIZE_SETTING,
                     IndexingMemoryController.MAX_INDEX_BUFFER_SIZE_SETTING,
                     IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING,
-                    IndexingMemoryController.SHARD_MEMORY_INTERVAL_TIME_SETTING
+                    IndexingMemoryController.SHARD_MEMORY_INTERVAL_TIME_SETTING,
+                    ResourceWatcherService.ENABLED,
+                    ResourceWatcherService.RELOAD_INTERVAL_HIGH,
+                    ResourceWatcherService.RELOAD_INTERVAL_MEDIUM,
+                    ResourceWatcherService.RELOAD_INTERVAL_LOW
             )));
 }

--- a/core/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
+++ b/core/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
@@ -20,6 +20,8 @@ package org.elasticsearch.watcher;
 
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
@@ -64,6 +66,14 @@ public class ResourceWatcherService extends AbstractLifecycleComponent<ResourceW
         }
     }
 
+    public static final Setting<Boolean> ENABLED = Setting.boolSetting("resource.reload.enabled", true, Property.NodeScope);
+    public static final Setting<TimeValue> RELOAD_INTERVAL_HIGH =
+        Setting.timeSetting("resource.reload.interval.high", Frequency.HIGH.interval, Property.NodeScope);
+    public static final Setting<TimeValue> RELOAD_INTERVAL_MEDIUM = Setting.timeSetting("resource.reload.interval.medium",
+        Setting.timeSetting("resource.reload.interval", Frequency.MEDIUM.interval), Property.NodeScope);
+    public static final Setting<TimeValue> RELOAD_INTERVAL_LOW =
+        Setting.timeSetting("resource.reload.interval.low", Frequency.LOW.interval, Property.NodeScope);
+
     private final boolean enabled;
     private final ThreadPool threadPool;
 
@@ -78,15 +88,14 @@ public class ResourceWatcherService extends AbstractLifecycleComponent<ResourceW
     @Inject
     public ResourceWatcherService(Settings settings, ThreadPool threadPool) {
         super(settings);
-        this.enabled = settings.getAsBoolean("resource.reload.enabled", true);
+        this.enabled = ENABLED.get(settings);
         this.threadPool = threadPool;
 
-        TimeValue interval = settings.getAsTime("resource.reload.interval.low", Frequency.LOW.interval);
+        TimeValue interval = RELOAD_INTERVAL_LOW.get(settings);
         lowMonitor = new ResourceMonitor(interval, Frequency.LOW);
-        interval = settings.getAsTime("resource.reload.interval.medium",
-                settings.getAsTime("resource.reload.interval", Frequency.MEDIUM.interval));
+        interval = RELOAD_INTERVAL_MEDIUM.get(settings);
         mediumMonitor = new ResourceMonitor(interval, Frequency.MEDIUM);
-        interval = settings.getAsTime("resource.reload.interval.high", Frequency.HIGH.interval);
+        interval = RELOAD_INTERVAL_HIGH.get(settings);
         highMonitor = new ResourceMonitor(interval, Frequency.HIGH);
 
         logRemovedSetting("watcher.enabled", "resource.reload.enabled");


### PR DESCRIPTION
This commit converts the settings for the ResourceWatcherService to use the new infrastructure and
registers the settings so that they do not cause errors when used.
