### PR TITLE
Update settings.asciidoc

### DIFF
--- a/docs/reference/migration/migrate_5_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_5_0/settings.asciidoc
@@ -210,12 +210,12 @@ Two cache concurrency level settings
 `indices.fielddata.cache.concurrency_level` because they no longer apply to
 the cache implementation used for the request cache and the field data cache.
 
-==== Using system properties to configure Elasticsearch
+==== Removed using system properties to configure Elasticsearch
 
 Elasticsearch can be configured by setting system properties on the
-command line via `-Des.name.of.property=value.of.property`. This will be
-removed in a future version of Elasticsearch. Instead, use
-`-E es.name.of.setting=value.of.setting`. Note that in all cases the
+command line via `-Des.name.of.property=value.of.property`. This feature
+has been removed. Instead, use
+`-Ees.name.of.setting=value.of.setting`. Note that in all cases the
 name of the setting must be prefixed with `es.`.
 
 ==== Removed using double-dashes to configure Elasticsearch


### PR DESCRIPTION
Looks like this has already been removed from 5.0 Alpha 1.  Change heading of this section to "Removed using ..." and note the feature removal in the description?

```
./elasticsearch -Des.node.name=test
starts elasticsearch

Option             Description                           
------             -----------                           
-E <KeyValuePair>  Configure an Elasticsearch setting    
-V, --version      Prints elasticsearch version          
                     information and exits               
-d, --daemonize    Starts Elasticsearch in the background
-h, --help         show help                             
-p, --pidfile      Creates a pid file in the specified   
                     path on start                       
-s, --silent       show minimal output                   
-v, --verbose      show verbose output                   
ERROR: D is not a recognized option
```
