### PR TITLE
Packaging: Add executable check to RPM init script

### DIFF
--- a/distribution/rpm/src/main/packaging/init.d/elasticsearch
+++ b/distribution/rpm/src/main/packaging/init.d/elasticsearch
@@ -71,6 +71,11 @@ if [ -n $USER ] && [ -z $ES_USER ] ; then
    ES_USER=$USER
 fi
 
+if [ ! -x "$exec" ]; then
+    echo "The elasticsearch startup script does not exists or it is not executable, tried: $exec"
+    exit 1
+fi
+
 checkJava() {
     if [ -x "$JAVA_HOME/bin/java" ]; then
         JAVA="$JAVA_HOME/bin/java"


### PR DESCRIPTION
The RPM init script did not include the check for `bin/elasticsearch` being
executable. This fix adds this checks and makes the tests pass.

This fixes the init script, so the tests pass on centos-6 again.
