### PR TITLE
Fix DateFieldType.isFieldWithinQuery:

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -416,7 +416,12 @@ public class DateFieldMapper extends FieldMapper implements AllFieldMapper.Inclu
                 dateParser = this.dateMathParser;
             }
 
-            if (PointValues.size(reader, name()) == 0) {
+            try {
+                if (PointValues.size(reader, name()) == 0) {
+                    // no points, so nothing matches
+                    return Relation.DISJOINT;
+                }
+            } catch (Exception e) {
                 // no points, so nothing matches
                 return Relation.DISJOINT;
             }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/DateFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/DateFieldTypeTests.java
@@ -113,6 +113,12 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         doTestIsFieldWithinQuery(ft, reader, null, alternateFormat);
         doTestIsFieldWithinQuery(ft, reader, DateTimeZone.UTC, null);
         doTestIsFieldWithinQuery(ft, reader, DateTimeZone.UTC, alternateFormat);
+
+        // Fields with no value indexed.
+        DateFieldType ft2 = new DateFieldType();
+        ft2.setName("my_date2");
+        assertEquals(Relation.DISJOINT, ft2.isFieldWithinQuery(reader, "2015-10-09", "2016-01-02",
+            false, false, null, null));
         IOUtils.close(reader, w, dir);
     }
 


### PR DESCRIPTION
- PointValues.size throws an exception if there is no value indexed for the field.
