### PR TITLE
Add new IPv6 types to docs where it's supported

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -413,9 +413,9 @@ using the `fuzziness` parameter. The `fuzziness` parameter is context
 sensitive which means that it depends on the type of the field being queried:
 
 [float]
-==== Numeric, date and IPv4 fields
+==== Numeric, date and IP fields
 
-When querying numeric, date and IPv4 fields, `fuzziness` is interpreted as a
+When querying numeric, date, IPv4, and IPv6 fields, `fuzziness` is interpreted as a
 `+/-` margin. It behaves like a <<query-dsl-range-query>> where:
 
     -fuzziness <= field value <= +fuzziness

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -413,9 +413,9 @@ using the `fuzziness` parameter. The `fuzziness` parameter is context
 sensitive which means that it depends on the type of the field being queried:
 
 [float]
-==== Numeric, date and IP fields
+==== Numeric, date and IPv4 fields
 
-When querying numeric, date, IPv4, and IPv6 fields, `fuzziness` is interpreted as a
+When querying numeric, date and IPv4 fields, `fuzziness` is interpreted as a
 `+/-` margin. It behaves like a <<query-dsl-range-query>> where:
 
     -fuzziness <= field value <= +fuzziness

--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -29,7 +29,7 @@ string::        <<text,`text`>> and <<keyword,`keyword`>>
 [float]
 === Specialised datatypes
 
-<<ip>>::            `ip` for IPv4 addresses
+<<ip>>::            `ip` for IPv4 and IPv6 addresses
 <<search-suggesters-completion,Completion datatype>>::
                     `completion` to provide auto-complete suggestions
 <<token-count>>::   `token_count` to count the number of tokens in a string


### PR DESCRIPTION
Feature was completed in https://github.com/elastic/elasticsearch/pull/17746
This should close https://github.com/elastic/elasticsearch/issues/17993
