### PR TITLE
Fail queries on not indexed fields.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -319,6 +319,7 @@ public class DateFieldMapper extends FieldMapper implements AllFieldMapper.Inclu
 
         @Override
         public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions, boolean transpositions) {
+            failIfNotIndexed();
             long baseLo = parseToMilliseconds(value, false, null, dateMathParser);
             long baseHi = parseToMilliseconds(value, true, null, dateMathParser);
             long delta;
@@ -333,16 +334,19 @@ public class DateFieldMapper extends FieldMapper implements AllFieldMapper.Inclu
 
         @Override
         public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper) {
+            failIfNotIndexed();
             return rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, null, null);
         }
 
         public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper,
                 @Nullable DateTimeZone timeZone, @Nullable DateMathParser forcedDateParser) {
+            failIfNotIndexed();
             return new LateParsingQuery(lowerTerm, upperTerm, includeLower, includeUpper, timeZone, forcedDateParser);
         }
 
         Query innerRangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper,
                 @Nullable DateTimeZone timeZone, @Nullable DateMathParser forcedDateParser) {
+            failIfNotIndexed();
             DateMathParser parser = forcedDateParser == null
                     ? dateMathParser
                     : forcedDateParser;

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/KeywordFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/KeywordFieldMapper.java
@@ -177,6 +177,7 @@ public final class KeywordFieldMapper extends FieldMapper implements AllFieldMap
         @Override
         public Query regexpQuery(String value, int flags, int maxDeterminizedStates,
                 @Nullable MultiTermQuery.RewriteMethod method, @Nullable QueryShardContext context) {
+            failIfNotIndexed();
             RegexpQuery query = new RegexpQuery(new Term(name(), indexedValueForSearch(value)), flags, maxDeterminizedStates);
             if (method != null) {
                 query.setRewriteMethod(method);

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
@@ -735,6 +735,7 @@ public class NumberFieldMapper extends FieldMapper implements AllFieldMapper.Inc
 
         @Override
         public Query termQuery(Object value, QueryShardContext context) {
+            failIfNotIndexed();
             Query query = type.termQuery(name(), value);
             if (boost() != 1f) {
                 query = new BoostQuery(query, boost());
@@ -744,6 +745,7 @@ public class NumberFieldMapper extends FieldMapper implements AllFieldMapper.Inc
 
         @Override
         public Query termsQuery(List values, QueryShardContext context) {
+            failIfNotIndexed();
             Query query = type.termsQuery(name(), values);
             if (boost() != 1f) {
                 query = new BoostQuery(query, boost());
@@ -753,6 +755,7 @@ public class NumberFieldMapper extends FieldMapper implements AllFieldMapper.Inc
 
         @Override
         public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper) {
+            failIfNotIndexed();
             Query query = type.rangeQuery(name(), lowerTerm, upperTerm, includeLower, includeUpper);
             if (boost() != 1f) {
                 query = new BoostQuery(query, boost());
@@ -763,6 +766,7 @@ public class NumberFieldMapper extends FieldMapper implements AllFieldMapper.Inc
         @Override
         public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength,
                                 int maxExpansions, boolean transpositions) {
+            failIfNotIndexed();
             return type.fuzzyQuery(name(), value, fuzziness);
         }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/TextFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/TextFieldMapper.java
@@ -304,6 +304,7 @@ public class TextFieldMapper extends FieldMapper implements AllFieldMapper.Inclu
         @Override
         public Query regexpQuery(String value, int flags, int maxDeterminizedStates,
                 @Nullable MultiTermQuery.RewriteMethod method, @Nullable QueryShardContext context) {
+            failIfNotIndexed();
             RegexpQuery query = new RegexpQuery(new Term(name(), indexedValueForSearch(value)), flags, maxDeterminizedStates);
             if (method != null) {
                 query.setRewriteMethod(method);

--- a/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
@@ -164,6 +164,7 @@ public class IpFieldMapper extends FieldMapper implements AllFieldMapper.Include
 
         @Override
         public Query termQuery(Object value, @Nullable QueryShardContext context) {
+            failIfNotIndexed();
             if (value instanceof InetAddress) {
                 return InetAddressPoint.newExactQuery(name(), (InetAddress) value);
             } else {
@@ -188,6 +189,7 @@ public class IpFieldMapper extends FieldMapper implements AllFieldMapper.Include
 
         @Override
         public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper) {
+            failIfNotIndexed();
             InetAddress lower;
             if (lowerTerm == null) {
                 lower = XInetAddressPoint.MIN_VALUE;
@@ -219,6 +221,7 @@ public class IpFieldMapper extends FieldMapper implements AllFieldMapper.Include
 
         @Override
         public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions, boolean transpositions) {
+            failIfNotIndexed();
             InetAddress base = parse(value);
             int mask = fuzziness.asInt();
             return XInetAddressPoint.newPrefixQuery(name(), base, mask);

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/BooleanFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/BooleanFieldTypeTests.java
@@ -18,6 +18,9 @@
  */
 package org.elasticsearch.index.mapper.core;
 
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.junit.Before;
@@ -46,5 +49,18 @@ public class BooleanFieldTypeTests extends FieldTypeTestCase {
         expectThrows(IllegalArgumentException.class, () -> ft.valueForSearch(0));
         expectThrows(IllegalArgumentException.class, () -> ft.valueForSearch("true"));
         expectThrows(IllegalArgumentException.class, () -> ft.valueForSearch("G"));
+    }
+
+    public void testTermQuery() {
+        MappedFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+        ft.setIndexOptions(IndexOptions.DOCS);
+        assertEquals(new TermQuery(new Term("field", "T")), ft.termQuery("true", null));
+        assertEquals(new TermQuery(new Term("field", "F")), ft.termQuery("false", null));
+
+        ft.setIndexOptions(IndexOptions.NONE);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> ft.termQuery("true", null));
+        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/DateFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/DateFieldTypeTests.java
@@ -23,10 +23,13 @@ import java.util.Locale;
 
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.MultiReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.joda.DateMathParser;
@@ -143,5 +146,36 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         String date = "2015-10-12T12:09:55.000Z";
         long instant = LegacyDateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime(date).getMillis();
         assertEquals(date, ft.valueForSearch(instant));
+    }
+
+    public void testTermQuery() {
+        MappedFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+        String date = "2015-10-12T14:10:55";
+        long instant = LegacyDateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime(date).getMillis();
+        ft.setIndexOptions(IndexOptions.DOCS);
+        assertEquals(LongPoint.newExactQuery("field", instant), ft.termQuery(date, null));
+
+        ft.setIndexOptions(IndexOptions.NONE);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> ft.termQuery(date, null));
+        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
+    }
+
+    public void testRangeQuery() throws IOException {
+        MappedFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+        String date1 = "2015-10-12T14:10:55";
+        String date2 = "2016-04-28T11:33:52";
+        long instant1 = LegacyDateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime(date1).getMillis();
+        long instant2 = LegacyDateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime(date2).getMillis();
+        ft.setIndexOptions(IndexOptions.DOCS);
+        assertEquals(LongPoint.newRangeQuery("field", instant1, instant2),
+                ft.rangeQuery(date1, date2, true, true).rewrite(new MultiReader()));
+
+        ft.setIndexOptions(IndexOptions.NONE);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> ft.rangeQuery(date1, date2, true, true));
+        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/KeywordFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/KeywordFieldTypeTests.java
@@ -20,12 +20,20 @@ package org.elasticsearch.index.mapper.core;
 
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.TermsQuery;
+import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.search.RegexpQuery;
+import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType.Relation;
 import org.elasticsearch.index.mapper.core.KeywordFieldMapper.KeywordFieldType;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 public class KeywordFieldTypeTests extends FieldTypeTestCase {
     @Override
@@ -40,5 +48,56 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
                 RandomStrings.randomAsciiOfLengthBetween(random(), 0, 5),
                 RandomStrings.randomAsciiOfLengthBetween(random(), 0, 5),
                 randomBoolean(), randomBoolean(), null, null));
+    }
+
+    public void testTermQuery() {
+        MappedFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+        ft.setIndexOptions(IndexOptions.DOCS);
+        assertEquals(new TermQuery(new Term("field", "foo")), ft.termQuery("foo", null));
+
+        ft.setIndexOptions(IndexOptions.NONE);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> ft.termQuery("bar", null));
+        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
+    }
+
+    public void testTermsQuery() {
+        MappedFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+        ft.setIndexOptions(IndexOptions.DOCS);
+        assertEquals(new TermsQuery(new Term("field", "foo"), new Term("field", "bar")),
+                ft.termsQuery(Arrays.asList("foo", "bar"), null));
+
+        ft.setIndexOptions(IndexOptions.NONE);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> ft.termsQuery(Arrays.asList("foo", "bar"), null));
+        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
+    }
+
+    public void testRegexpQuery() {
+        MappedFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+        ft.setIndexOptions(IndexOptions.DOCS);
+        assertEquals(new RegexpQuery(new Term("field","foo.*")),
+                ft.regexpQuery("foo.*", 0, 10, null, null));
+
+        ft.setIndexOptions(IndexOptions.NONE);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> ft.regexpQuery("foo.*", 0, 10, null, null));
+        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
+    }
+
+    public void testFuzzyQuery() {
+        MappedFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+        ft.setIndexOptions(IndexOptions.DOCS);
+        assertEquals(new FuzzyQuery(new Term("field","foo"), 2, 1, 50, true),
+                ft.fuzzyQuery("foo", Fuzziness.fromEdits(2), 1, 50, true));
+
+        ft.setIndexOptions(IndexOptions.NONE);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> ft.fuzzyQuery("foo", Fuzziness.fromEdits(2), 1, 50, true));
+        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/NumberFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/NumberFieldTypeTests.java
@@ -21,6 +21,8 @@ package org.elasticsearch.index.mapper.core;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.index.IndexOptions;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType.Relation;
@@ -48,5 +50,29 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         // current impl ignores args and should always return INTERSECTS
         assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(null, randomDouble(), randomDouble(),
                 randomBoolean(), randomBoolean(), null, null));
+    }
+
+    public void testTermQuery() {
+        MappedFieldType ft = new NumberFieldMapper.NumberFieldType(NumberFieldMapper.NumberType.LONG);
+        ft.setName("field");
+        ft.setIndexOptions(IndexOptions.DOCS);
+        assertEquals(LongPoint.newExactQuery("field", 42), ft.termQuery("42", null));
+
+        ft.setIndexOptions(IndexOptions.NONE);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> ft.termQuery("42", null));
+        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
+    }
+
+    public void testRangeQuery() {
+        MappedFieldType ft = new NumberFieldMapper.NumberFieldType(NumberFieldMapper.NumberType.LONG);
+        ft.setName("field");
+        ft.setIndexOptions(IndexOptions.DOCS);
+        assertEquals(LongPoint.newRangeQuery("field", 1, 3), ft.rangeQuery("1", "3", true, true));
+
+        ft.setIndexOptions(IndexOptions.NONE);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> ft.rangeQuery("1", "3", true, true));
+        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/ip/IpFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ip/IpFieldTypeTests.java
@@ -22,6 +22,7 @@ import java.net.InetAddress;
 
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.document.XInetAddressPoint;
+import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.network.InetAddresses;
@@ -73,6 +74,11 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
         ip = "192.168.1.7";
         prefix = ip + "/16";
         assertEquals(XInetAddressPoint.newPrefixQuery("field", InetAddresses.forString(ip), 16), ft.termQuery(prefix, null));
+
+        ft.setIndexOptions(IndexOptions.NONE);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> ft.termQuery("::1", null));
+        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
     }
 
     public void testRangeQuery() {
@@ -156,5 +162,10 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
                         InetAddresses.forString("192.168.1.7"),
                         InetAddresses.forString("2001:db8::")),
                 ft.rangeQuery("::ffff:c0a8:107", "2001:db8::", true, true));
+
+        ft.setIndexOptions(IndexOptions.NONE);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> ft.rangeQuery("::1", "2001::", true, true));
+        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
     }
 }


### PR DESCRIPTION
While returning no hits on fields that are not mapped may be fine, it is not
for fields that are mapped but not indexed (`index:false`). We should fail the
query in that case rather than returning no hits.
