### PR TITLE
Add Deduplicating ingest processor

### DIFF
--- a/core/src/main/java/org/elasticsearch/ingest/core/AbstractProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/core/AbstractProcessor.java
@@ -26,7 +26,6 @@ package org.elasticsearch.ingest.core;
  */
 public abstract class AbstractProcessor implements Processor {
     protected final String tag;
-    protected String lastType;
 
     protected AbstractProcessor(String tag) {
         this.tag = tag;
@@ -37,8 +36,4 @@ public abstract class AbstractProcessor implements Processor {
         return tag;
     }
 
-    @Override
-    public void setLastType(String lastType) {
-        this.lastType = lastType;
-    }
 }

--- a/core/src/main/java/org/elasticsearch/ingest/core/AbstractProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/core/AbstractProcessor.java
@@ -26,6 +26,7 @@ package org.elasticsearch.ingest.core;
  */
 public abstract class AbstractProcessor implements Processor {
     protected final String tag;
+    protected String lastType;
 
     protected AbstractProcessor(String tag) {
         this.tag = tag;
@@ -34,5 +35,10 @@ public abstract class AbstractProcessor implements Processor {
     @Override
     public String getTag() {
         return tag;
+    }
+
+    @Override
+    public void setLastType(String lastType) {
+        this.lastType = lastType;
     }
 }

--- a/core/src/main/java/org/elasticsearch/ingest/core/AbstractProcessorFactory.java
+++ b/core/src/main/java/org/elasticsearch/ingest/core/AbstractProcessorFactory.java
@@ -20,6 +20,8 @@
 
 package org.elasticsearch.ingest.core;
 
+
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -30,10 +32,10 @@ public abstract class AbstractProcessorFactory<P extends Processor> implements P
     public static final String TAG_KEY = "tag";
 
     @Override
-    public P create(Map<String, Object> config) throws Exception {
+    public P create(Map<String, Object> config, List<Processor> processors) throws Exception {
         String tag = ConfigurationUtils.readOptionalStringProperty(null, null, config, TAG_KEY);
-        return doCreate(tag, config);
+        return doCreate(tag, config, processors);
     }
 
-    protected abstract P doCreate(String tag, Map<String, Object> config) throws Exception;
+    protected abstract P doCreate(String tag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception;
 }

--- a/core/src/main/java/org/elasticsearch/ingest/core/CompoundProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/core/CompoundProcessor.java
@@ -89,18 +89,15 @@ public class CompoundProcessor implements Processor {
     }
 
     @Override
-    public void setLastType(String lastType) {
-        this.lastType = lastType;
+    public String getField() {
+        return null;
     }
 
     @Override
     public void execute(IngestDocument ingestDocument) throws Exception {
-        String lastType = null;
         for (Processor processor : processors) {
             try {
-                processor.setLastType(lastType);
                 processor.execute(ingestDocument);
-                lastType = processor.getType();
             } catch (Exception e) {
                 if (onFailureProcessors.isEmpty()) {
                     throw e;

--- a/core/src/main/java/org/elasticsearch/ingest/core/CompoundProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/core/CompoundProcessor.java
@@ -20,14 +20,12 @@
 
 package org.elasticsearch.ingest.core;
 
-import org.elasticsearch.common.util.iterable.Iterables;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -38,6 +36,8 @@ public class CompoundProcessor implements Processor {
     public static final String ON_FAILURE_MESSAGE_FIELD = "on_failure_message";
     public static final String ON_FAILURE_PROCESSOR_TYPE_FIELD = "on_failure_processor_type";
     public static final String ON_FAILURE_PROCESSOR_TAG_FIELD = "on_failure_processor_tag";
+
+    protected String lastType;
 
     private final List<Processor> processors;
     private final List<Processor> onFailureProcessors;
@@ -89,10 +89,18 @@ public class CompoundProcessor implements Processor {
     }
 
     @Override
+    public void setLastType(String lastType) {
+        this.lastType = lastType;
+    }
+
+    @Override
     public void execute(IngestDocument ingestDocument) throws Exception {
+        String lastType = null;
         for (Processor processor : processors) {
             try {
+                processor.setLastType(lastType);
                 processor.execute(ingestDocument);
+                lastType = processor.getType();
             } catch (Exception e) {
                 if (onFailureProcessors.isEmpty()) {
                     throw e;

--- a/core/src/main/java/org/elasticsearch/ingest/core/ConfigurationUtils.java
+++ b/core/src/main/java/org/elasticsearch/ingest/core/ConfigurationUtils.java
@@ -238,14 +238,23 @@ public final class ConfigurationUtils {
         if (processorConfigs != null) {
             for (Map<String, Map<String, Object>> processorConfigWithKey : processorConfigs) {
                 for (Map.Entry<String, Map<String, Object>> entry : processorConfigWithKey.entrySet()) {
-                    processors.add(readProcessor(processorRegistry, entry.getKey(), entry.getValue()));
+                    Processor processor = readProcessor(
+                        processorRegistry,
+                        entry.getKey(),
+                        entry.getValue(),
+                        Collections.unmodifiableList(processors)
+                    );
+                    processors.add(processor);
                 }
             }
         }
         return processors;
     }
 
-    private static Processor readProcessor(ProcessorsRegistry processorRegistry, String type, Map<String, Object> config) throws Exception {
+    private static Processor readProcessor(ProcessorsRegistry processorRegistry,
+                                           String type,
+                                           Map<String, Object> config,
+                                           List<Processor> processors) throws Exception {
         Processor.Factory factory = processorRegistry.getProcessorFactory(type);
         if (factory != null) {
             List<Map<String, Map<String, Object>>> onFailureProcessorConfigs =
@@ -253,7 +262,7 @@ public final class ConfigurationUtils {
 
             List<Processor> onFailureProcessors = readProcessorConfigs(onFailureProcessorConfigs, processorRegistry);
             Processor processor;
-            processor = factory.create(config);
+            processor = factory.create(config, processors);
             if (!config.isEmpty()) {
                 throw new ElasticsearchParseException("processor [{}] doesn't support one or more provided configuration parameters {}",
                     type, Arrays.toString(config.keySet().toArray()));

--- a/core/src/main/java/org/elasticsearch/ingest/core/ConfigurationUtils.java
+++ b/core/src/main/java/org/elasticsearch/ingest/core/ConfigurationUtils.java
@@ -104,6 +104,26 @@ public final class ConfigurationUtils {
     }
 
     /**
+     * Returns and removes the specified property from the specified configuration map.
+     *
+     * If the property value isn't of type boolean a {@link ElasticsearchParseException} is thrown.
+     * If the property is missing an {@link ElasticsearchParseException} is thrown
+     */
+    public static boolean readBooleanProperty(String processorType, String processorTag, Map<String, Object> configuration, String propertyName,
+                                      boolean defaultValue) {
+        Object value = configuration.remove(propertyName);
+        if (value == null) {
+            return defaultValue;
+        }
+        try {
+            return Boolean.parseBoolean(value.toString());
+        } catch (Throwable t) {
+            throw newConfigurationException(processorType, processorTag, propertyName,
+                "property cannot be converted to a boolean [" + value.toString() + "]");
+        }
+    }
+
+    /**
      * Returns and removes the specified property of type list from the specified configuration map.
      *
      * If the property value isn't of type list an {@link ElasticsearchParseException} is thrown.

--- a/core/src/main/java/org/elasticsearch/ingest/core/Processor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/core/Processor.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.ingest.core;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -43,9 +44,9 @@ public interface Processor {
     String getTag();
 
     /**
-     * Sets the tag of the processor that ran last
+     * Gets the field the processor operates on
      */
-    void setLastType(String lastType);
+    String getField();
 
     /**
      * A factory that knows how to construct a processor based on a map of maps.
@@ -58,6 +59,6 @@ public interface Processor {
          * Implementations are responsible for removing the used keys, so that after creating a pipeline ingest can
          * verify if all configurations settings have been used.
          */
-        P create(Map<String, Object> config) throws Exception;
+        P create(Map<String, Object> config, List<Processor> processors) throws Exception;
     }
 }

--- a/core/src/main/java/org/elasticsearch/ingest/core/Processor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/core/Processor.java
@@ -43,6 +43,11 @@ public interface Processor {
     String getTag();
 
     /**
+     * Sets the tag of the processor that ran last
+     */
+    void setLastType(String lastType);
+
+    /**
      * A factory that knows how to construct a processor based on a map of maps.
      */
     interface Factory<P extends Processor> {

--- a/core/src/main/java/org/elasticsearch/ingest/processor/AbstractStringProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/processor/AbstractStringProcessor.java
@@ -23,7 +23,9 @@ import org.elasticsearch.ingest.core.AbstractProcessor;
 import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.ingest.core.ConfigurationUtils;
 import org.elasticsearch.ingest.core.IngestDocument;
+import org.elasticsearch.ingest.core.Processor;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -61,7 +63,7 @@ abstract class AbstractStringProcessor extends AbstractProcessor {
         }
 
         @Override
-        public T doCreate(String processorTag, Map<String, Object> config) throws Exception {
+        public T doCreate(String processorTag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception {
             String field = ConfigurationUtils.readStringProperty(processorType, processorTag, config, "field");
             return newProcessor(processorTag, field);
         }

--- a/core/src/main/java/org/elasticsearch/ingest/processor/AppendProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/processor/AppendProcessor.java
@@ -22,10 +22,12 @@ package org.elasticsearch.ingest.processor;
 import org.elasticsearch.ingest.core.AbstractProcessor;
 import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.ingest.core.IngestDocument;
+import org.elasticsearch.ingest.core.Processor;
 import org.elasticsearch.ingest.core.TemplateService;
 import org.elasticsearch.ingest.core.ValueSource;
 import org.elasticsearch.ingest.core.ConfigurationUtils;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -73,7 +75,7 @@ public final class AppendProcessor extends AbstractProcessor {
         }
 
         @Override
-        public AppendProcessor doCreate(String processorTag, Map<String, Object> config) throws Exception {
+        public AppendProcessor doCreate(String processorTag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception {
             String field = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "field");
             Object value = ConfigurationUtils.readObject(TYPE, processorTag, config, "value");
             return new AppendProcessor(processorTag, templateService.compile(field), ValueSource.wrap(value, templateService));

--- a/core/src/main/java/org/elasticsearch/ingest/processor/ConvertProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/processor/ConvertProcessor.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ingest.core.AbstractProcessor;
 import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.ingest.core.IngestDocument;
 import org.elasticsearch.ingest.core.ConfigurationUtils;
+import org.elasticsearch.ingest.core.Processor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -121,7 +122,8 @@ public final class ConvertProcessor extends AbstractProcessor {
         this.convertType = convertType;
     }
 
-    String getField() {
+    @Override
+    public String getField() {
         return field;
     }
 
@@ -161,7 +163,7 @@ public final class ConvertProcessor extends AbstractProcessor {
 
     public static final class Factory extends AbstractProcessorFactory<ConvertProcessor> {
         @Override
-        public ConvertProcessor doCreate(String processorTag, Map<String, Object> config) throws Exception {
+        public ConvertProcessor doCreate(String processorTag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception {
             String field = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "field");
             String typeProperty = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "type");
             String targetField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "target_field", field);

--- a/core/src/main/java/org/elasticsearch/ingest/processor/DateProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/processor/DateProcessor.java
@@ -24,6 +24,7 @@ import org.elasticsearch.ingest.core.AbstractProcessor;
 import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.ingest.core.ConfigurationUtils;
 import org.elasticsearch.ingest.core.IngestDocument;
+import org.elasticsearch.ingest.core.Processor;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.ISODateTimeFormat;
@@ -96,7 +97,8 @@ public final class DateProcessor extends AbstractProcessor {
         return locale;
     }
 
-    String getField() {
+    @Override
+    public String getField() {
         return field;
     }
 
@@ -111,7 +113,7 @@ public final class DateProcessor extends AbstractProcessor {
     public static final class Factory extends AbstractProcessorFactory<DateProcessor> {
 
         @SuppressWarnings("unchecked")
-        public DateProcessor doCreate(String processorTag, Map<String, Object> config) throws Exception {
+        public DateProcessor doCreate(String processorTag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception {
             String field = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "field");
             String targetField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "target_field", DEFAULT_TARGET_FIELD);
             String timezoneString = ConfigurationUtils.readOptionalStringProperty(TYPE, processorTag, config, "timezone");

--- a/core/src/main/java/org/elasticsearch/ingest/processor/DeduplicateProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/processor/DeduplicateProcessor.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.ingest.processor;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.ingest.core.AbstractProcessor;
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
+import org.elasticsearch.ingest.core.IngestDocument;
+import org.elasticsearch.ingest.core.ConfigurationUtils;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
+
+
+/**
+ * Processor that removes duplicate entries from an array.
+ * Throws exception is the specified field is not an array.
+ */
+public final class DeduplicateProcessor extends AbstractProcessor {
+
+    public static final String TYPE = "dedupe";
+    public static final ParseField FIELD = new ParseField("field");
+    public static final ParseField ORDERED = new ParseField("ordered");
+    public static final boolean DEFAULT_ORDERED = true;
+
+    private final String field;
+    private final boolean ordered;
+
+    DeduplicateProcessor(String tag, String field, boolean ordered) {
+        super(tag);
+        this.field = field;
+        this.ordered = ordered;
+    }
+
+    String getField() {
+        return field;
+    }
+
+    @Override
+    public void execute(IngestDocument document) {
+        List<?> list = document.getFieldValue(field, List.class);
+        if (list == null) {
+            throw new IllegalArgumentException("field [" + field + "] is null, cannot deduplicate.");
+        }
+
+        if (list.size() <= 1) {
+            return;
+        }
+
+        if (lastType != null && lastType.equals("sort")) {
+            list = dedupeSorted(list);
+        } else {
+            list = dedupeUnsorted(list, ordered);
+        }
+
+        document.setFieldValue(field, list);
+    }
+
+    private <T> List<T> dedupeSorted(List<T> list) {
+        T last = null;
+        ListIterator<T> iterator = list.listIterator();
+        while (iterator.hasNext()) {
+            T value = iterator.next();
+            if (value.equals(last)) {
+                iterator.remove();
+            } else {
+                last = value;
+            }
+        }
+
+        return list;
+    }
+
+    private <T> List<T> dedupeUnsorted(List<T> list, boolean ordered) {
+        Set<T> dedupeSet;
+        if (ordered) {
+            dedupeSet = new LinkedHashSet<>(list);
+        } else {
+            dedupeSet = new HashSet<>(list);
+        }
+
+        list.clear();
+        list.addAll(dedupeSet);
+        return list;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    public final static class Factory extends AbstractProcessorFactory<DeduplicateProcessor> {
+        @Override
+        public DeduplicateProcessor doCreate(String processorTag, Map<String, Object> config) throws Exception {
+            String field = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, FIELD.getPreferredName());
+            boolean ordered = ConfigurationUtils.readBooleanProperty(TYPE,
+                processorTag,
+                config,
+                ORDERED.getPreferredName(),
+                DEFAULT_ORDERED);
+            return new DeduplicateProcessor(processorTag, field, ordered);
+        }
+    }
+}
+

--- a/core/src/main/java/org/elasticsearch/ingest/processor/FailProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/processor/FailProcessor.java
@@ -23,8 +23,10 @@ import org.elasticsearch.ingest.core.AbstractProcessor;
 import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.ingest.core.ConfigurationUtils;
 import org.elasticsearch.ingest.core.IngestDocument;
+import org.elasticsearch.ingest.core.Processor;
 import org.elasticsearch.ingest.core.TemplateService;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -56,6 +58,11 @@ public final class FailProcessor extends AbstractProcessor {
         return TYPE;
     }
 
+    @Override
+    public String getField() {
+        return null;
+    }
+
     public static final class Factory extends AbstractProcessorFactory<FailProcessor> {
 
         private final TemplateService templateService;
@@ -65,7 +72,7 @@ public final class FailProcessor extends AbstractProcessor {
         }
 
         @Override
-        public FailProcessor doCreate(String processorTag, Map<String, Object> config) throws Exception {
+        public FailProcessor doCreate(String processorTag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception {
             String message = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "message");
             return new FailProcessor(processorTag, templateService.compile(message));
         }

--- a/core/src/main/java/org/elasticsearch/ingest/processor/ForEachProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/processor/ForEachProcessor.java
@@ -75,7 +75,8 @@ public final class ForEachProcessor extends AbstractProcessor {
         return TYPE;
     }
 
-    String getField() {
+    @Override
+    public String getField() {
         return field;
     }
 
@@ -92,7 +93,7 @@ public final class ForEachProcessor extends AbstractProcessor {
         }
 
         @Override
-        protected ForEachProcessor doCreate(String tag, Map<String, Object> config) throws Exception {
+        protected ForEachProcessor doCreate(String tag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception {
             String field = readStringProperty(TYPE, tag, config, "field");
             List<Map<String, Map<String, Object>>> processorConfigs = readList(TYPE, tag, config, "processors");
             List<Processor> processors = ConfigurationUtils.readProcessorConfigs(processorConfigs, processorRegistry);

--- a/core/src/main/java/org/elasticsearch/ingest/processor/GsubProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/processor/GsubProcessor.java
@@ -24,7 +24,9 @@ import org.elasticsearch.ingest.core.AbstractProcessor;
 import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.ingest.core.IngestDocument;
 import org.elasticsearch.ingest.core.ConfigurationUtils;
+import org.elasticsearch.ingest.core.Processor;
 
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -51,7 +53,8 @@ public final class GsubProcessor extends AbstractProcessor {
         this.replacement = replacement;
     }
 
-    String getField() {
+    @Override
+    public String getField() {
         return field;
     }
 
@@ -82,7 +85,7 @@ public final class GsubProcessor extends AbstractProcessor {
 
     public static final class Factory extends AbstractProcessorFactory<GsubProcessor> {
         @Override
-        public GsubProcessor doCreate(String processorTag, Map<String, Object> config) throws Exception {
+        public GsubProcessor doCreate(String processorTag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception {
             String field = readStringProperty(TYPE, processorTag, config, "field");
             String pattern = readStringProperty(TYPE, processorTag, config, "pattern");
             String replacement = readStringProperty(TYPE, processorTag, config, "replacement");

--- a/core/src/main/java/org/elasticsearch/ingest/processor/JoinProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/processor/JoinProcessor.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ingest.core.AbstractProcessor;
 import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.ingest.core.IngestDocument;
 import org.elasticsearch.ingest.core.ConfigurationUtils;
+import org.elasticsearch.ingest.core.Processor;
 
 import java.util.List;
 import java.util.Map;
@@ -45,7 +46,8 @@ public final class JoinProcessor extends AbstractProcessor {
         this.separator = separator;
     }
 
-    String getField() {
+    @Override
+    public String getField() {
         return field;
     }
 
@@ -72,7 +74,7 @@ public final class JoinProcessor extends AbstractProcessor {
 
     public final static class Factory extends AbstractProcessorFactory<JoinProcessor> {
         @Override
-        public JoinProcessor doCreate(String processorTag, Map<String, Object> config) throws Exception {
+        public JoinProcessor doCreate(String processorTag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception {
             String field = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "field");
             String separator = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "separator");
             return new JoinProcessor(processorTag, field, separator);

--- a/core/src/main/java/org/elasticsearch/ingest/processor/RemoveProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/processor/RemoveProcessor.java
@@ -22,9 +22,11 @@ package org.elasticsearch.ingest.processor;
 import org.elasticsearch.ingest.core.AbstractProcessor;
 import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.ingest.core.IngestDocument;
+import org.elasticsearch.ingest.core.Processor;
 import org.elasticsearch.ingest.core.TemplateService;
 import org.elasticsearch.ingest.core.ConfigurationUtils;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -64,7 +66,7 @@ public final class RemoveProcessor extends AbstractProcessor {
         }
 
         @Override
-        public RemoveProcessor doCreate(String processorTag, Map<String, Object> config) throws Exception {
+        public RemoveProcessor doCreate(String processorTag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception {
             String field = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "field");
             return new RemoveProcessor(processorTag, templateService.compile(field));
         }

--- a/core/src/main/java/org/elasticsearch/ingest/processor/RenameProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/processor/RenameProcessor.java
@@ -23,7 +23,9 @@ import org.elasticsearch.ingest.core.AbstractProcessor;
 import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.ingest.core.IngestDocument;
 import org.elasticsearch.ingest.core.ConfigurationUtils;
+import org.elasticsearch.ingest.core.Processor;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -42,7 +44,8 @@ public final class RenameProcessor extends AbstractProcessor {
         this.targetField = targetField;
     }
 
-    String getField() {
+    @Override
+    public String getField() {
         return field;
     }
 
@@ -77,7 +80,7 @@ public final class RenameProcessor extends AbstractProcessor {
 
     public static final class Factory extends AbstractProcessorFactory<RenameProcessor> {
         @Override
-        public RenameProcessor doCreate(String processorTag, Map<String, Object> config) throws Exception {
+        public RenameProcessor doCreate(String processorTag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception {
             String field = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "field");
             String targetField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "target_field");
             return new RenameProcessor(processorTag, field, targetField);

--- a/core/src/main/java/org/elasticsearch/ingest/processor/SetProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/processor/SetProcessor.java
@@ -22,10 +22,12 @@ package org.elasticsearch.ingest.processor;
 import org.elasticsearch.ingest.core.AbstractProcessor;
 import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.ingest.core.IngestDocument;
+import org.elasticsearch.ingest.core.Processor;
 import org.elasticsearch.ingest.core.TemplateService;
 import org.elasticsearch.ingest.core.ValueSource;
 import org.elasticsearch.ingest.core.ConfigurationUtils;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -72,7 +74,7 @@ public final class SetProcessor extends AbstractProcessor {
         }
 
         @Override
-        public SetProcessor doCreate(String processorTag, Map<String, Object> config) throws Exception {
+        public SetProcessor doCreate(String processorTag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception {
             String field = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "field");
             Object value = ConfigurationUtils.readObject(TYPE, processorTag, config, "value");
             return new SetProcessor(processorTag, templateService.compile(field), ValueSource.wrap(value, templateService));

--- a/core/src/main/java/org/elasticsearch/ingest/processor/SplitProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/processor/SplitProcessor.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ingest.core.AbstractProcessor;
 import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.ingest.core.ConfigurationUtils;
 import org.elasticsearch.ingest.core.IngestDocument;
+import org.elasticsearch.ingest.core.Processor;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -47,7 +48,8 @@ public final class SplitProcessor extends AbstractProcessor {
         this.separator = separator;
     }
 
-    String getField() {
+    @Override
+    public String getField() {
         return field;
     }
 
@@ -74,7 +76,7 @@ public final class SplitProcessor extends AbstractProcessor {
 
     public static class Factory extends AbstractProcessorFactory<SplitProcessor> {
         @Override
-        public SplitProcessor doCreate(String processorTag, Map<String, Object> config) throws Exception {
+        public SplitProcessor doCreate(String processorTag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception {
             String field = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "field");
             return new SplitProcessor(processorTag, field, ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "separator"));
         }

--- a/core/src/main/java/org/elasticsearch/ingest/processor/TrackingResultProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/processor/TrackingResultProcessor.java
@@ -67,8 +67,8 @@ public final class TrackingResultProcessor implements Processor {
     }
 
     @Override
-    public void setLastType(String lastType) {
-        actualProcessor.setLastType(lastType);
+    public String getField() {
+        return null;
     }
 
     public static CompoundProcessor decorate(CompoundProcessor compoundProcessor, List<SimulateProcessorResult> processorResultList) {

--- a/core/src/main/java/org/elasticsearch/ingest/processor/TrackingResultProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/processor/TrackingResultProcessor.java
@@ -66,6 +66,11 @@ public final class TrackingResultProcessor implements Processor {
         return actualProcessor.getTag();
     }
 
+    @Override
+    public void setLastType(String lastType) {
+        actualProcessor.setLastType(lastType);
+    }
+
     public static CompoundProcessor decorate(CompoundProcessor compoundProcessor, List<SimulateProcessorResult> processorResultList) {
         List<Processor> processors = new ArrayList<>(compoundProcessor.getProcessors().size());
         for (Processor processor : compoundProcessor.getProcessors()) {

--- a/core/src/main/java/org/elasticsearch/node/NodeModule.java
+++ b/core/src/main/java/org/elasticsearch/node/NodeModule.java
@@ -28,6 +28,7 @@ import org.elasticsearch.ingest.core.TemplateService;
 import org.elasticsearch.ingest.processor.AppendProcessor;
 import org.elasticsearch.ingest.processor.ConvertProcessor;
 import org.elasticsearch.ingest.processor.DateProcessor;
+import org.elasticsearch.ingest.processor.DeduplicateProcessor;
 import org.elasticsearch.ingest.processor.FailProcessor;
 import org.elasticsearch.ingest.processor.ForEachProcessor;
 import org.elasticsearch.ingest.processor.GsubProcessor;
@@ -76,6 +77,7 @@ public class NodeModule extends AbstractModule {
         registerProcessor(GsubProcessor.TYPE, (templateService, registry) -> new GsubProcessor.Factory());
         registerProcessor(FailProcessor.TYPE, (templateService, registry) -> new FailProcessor.Factory(templateService));
         registerProcessor(ForEachProcessor.TYPE, (templateService, registry) -> new ForEachProcessor.Factory(registry));
+        registerProcessor(DeduplicateProcessor.TYPE, (templateService, registry) -> new DeduplicateProcessor.Factory());
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/ingest/processor/DeduplicateProcessorTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/DeduplicateProcessorTests.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.ingest.processor;
+
+import org.elasticsearch.ingest.core.IngestDocument;
+import org.elasticsearch.ingest.RandomDocumentPicks;
+import org.elasticsearch.ingest.core.Processor;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class DeduplicateProcessorTests extends ESTestCase {
+
+    public void testPriorSortAndSortedInput() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        int numItems = randomIntBetween(1, 10);
+
+        List<Integer> fieldValue = new ArrayList<>(numItems * 3);
+        for (int j = 0; j < numItems; j++) {
+            int value = randomIntBetween(0,100);
+            fieldValue.add(value);
+            fieldValue.add(value);
+            fieldValue.add(value);
+        }
+        Collections.sort(fieldValue);
+        Set<Integer> expectedResultSet = new LinkedHashSet<>(fieldValue);
+        List<Integer> expectedResult = new ArrayList<>(expectedResultSet);
+        String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
+
+        // Randomize `ordered` because it shouldn't matter...always ordered due to sort
+        Processor processor = new DeduplicateProcessor(randomAsciiOfLength(10), fieldName, randomBoolean());
+        processor.setLastType("sort");
+
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue(fieldName, List.class), equalTo(expectedResult));
+    }
+
+    public void testNoPriorSortAndUnsortedOrdered() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        int numItems = randomIntBetween(1, 10);
+
+        List<Integer> fieldValue = new ArrayList<>(numItems * 3);
+        for (int j = 0; j < numItems; j++) {
+            int value = randomIntBetween(0,100);
+            fieldValue.add(value);
+            fieldValue.add(value);
+            fieldValue.add(value);
+        }
+        Set<Integer> expectedResultSet = new LinkedHashSet<>(fieldValue);
+        List<Integer> expectedResult = new ArrayList<>(expectedResultSet);
+
+        String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
+        Processor processor = new DeduplicateProcessor(randomAsciiOfLength(10), fieldName, true);
+        processor.execute(ingestDocument);
+        assertEquals(ingestDocument.getFieldValue(fieldName, List.class), expectedResult);
+    }
+
+    public void testNoPriorSortAndUnsortedUnordered() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        int numItems = randomIntBetween(1, 10);
+
+        List<Integer> fieldValue = new ArrayList<>(numItems * 3);
+        for (int j = 0; j < numItems; j++) {
+            int value = randomIntBetween(0,100);
+            fieldValue.add(value);
+            fieldValue.add(value);
+            fieldValue.add(value);
+        }
+        Set<Integer> expectedResultSet = new LinkedHashSet<>(fieldValue);  // keep using Linked here so we can tests non-ordering
+        List<Integer> expectedResult = new ArrayList<>(expectedResultSet);
+
+        String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
+        Processor processor = new DeduplicateProcessor(randomAsciiOfLength(10), fieldName, false);
+        processor.execute(ingestDocument);
+
+        List dedupedList = ingestDocument.getFieldValue(fieldName, List.class);
+        int counter = 0;
+        for (Object value : dedupedList) {
+            assertEquals(expectedResult.contains(value), true);
+            counter++;
+        }
+        assertEquals(dedupedList.size(), counter);  // Make sure there are no extra elements
+    }
+
+    public void testListsOfNull() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        int numItems = randomIntBetween(1, 10);
+
+        List<Integer> fieldValue = new ArrayList<>(numItems * 3);
+        List<Integer> expectedResult = new ArrayList<>(numItems);
+        for (int j = 0; j < numItems; j++) {
+            fieldValue.add(null);
+            fieldValue.add(null);
+            fieldValue.add(null);
+
+        }
+        expectedResult.add(null);
+
+        String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
+        Processor processor = new DeduplicateProcessor(randomAsciiOfLength(10), fieldName, true);
+        processor.execute(ingestDocument);
+        assertEquals(ingestDocument.getFieldValue(fieldName, List.class), expectedResult);
+    }
+
+    public void testDedupeNonListField() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
+        String fieldName = RandomDocumentPicks.randomFieldName(random());
+        ingestDocument.setFieldValue(fieldName, randomAsciiOfLengthBetween(1, 10));
+        Processor processor = new DeduplicateProcessor(randomAsciiOfLength(10), fieldName, true);
+        try {
+            processor.execute(ingestDocument);
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("field [" + fieldName + "] of type [java.lang.String] cannot be cast to [java.util.List]"));
+        }
+    }
+
+    public void testDedupeNonExistingField() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
+        String fieldName = RandomDocumentPicks.randomFieldName(random());
+        Processor processor = new DeduplicateProcessor(randomAsciiOfLength(10), fieldName, true);
+        try {
+            processor.execute(ingestDocument);
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("not present as part of path [" + fieldName + "]"));
+        }
+    }
+
+    public void testDedupeNullValue() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.singletonMap("field", null));
+        Processor processor = new DeduplicateProcessor(randomAsciiOfLength(10), "field", true);
+        try {
+            processor.execute(ingestDocument);
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("field [field] is null, cannot deduplicate."));
+        }
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/ingest/processor/ForEachProcessorTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/ForEachProcessorTests.java
@@ -179,6 +179,11 @@ public class ForEachProcessorTests extends ESTestCase {
                 public String getTag() {
                     return null;
                 }
+
+                @Override
+                public void setLastType(String lastType) {
+
+                }
             });
         }
         int numValues = randomIntBetween(1, 32);

--- a/core/src/test/java/org/elasticsearch/ingest/processor/ForEachProcessorTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/ForEachProcessorTests.java
@@ -181,9 +181,10 @@ public class ForEachProcessorTests extends ESTestCase {
                 }
 
                 @Override
-                public void setLastType(String lastType) {
-
+                public String getField() {
+                    return null;
                 }
+
             });
         }
         int numValues = randomIntBetween(1, 32);

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -739,6 +739,48 @@ Here is an example that adds the parsed date to the `timestamp` field based on t
 }
 --------------------------------------------------
 
+[[deduplicate-processor]]
+=== Deduplicate Processor
+
+Removes duplicate elements from an array.  If the `dedupe` processor is immediately
+preceded by a `sort` processor, deduplication can be done in `O(n)` time and require no
+temporary data structures in memory.
+
+If the input is not sorted, the `dedupe` processor must use a temporary Set datastructure
+to remove duplicates.  This will introduce a small memory and computation overhead.
+
+Raises an exception if the input is not an array.
+
+[[date-options]]
+.Date options
+[options="header"]
+|======
+| Name       | Required  | Default    | Description
+| `field`    | yes       | -          | The field to get the date from.
+| `ordered`  | no        | `true`     | True if the processor should maintain the input's order, false otherwise
+|======
+
+Note: setting `ordered: false` will allow the processor to use an unordered Set internally, which will require
+slightly less memory than an ordered Set.  If you do not need to maintain the order of the elements, consider
+setting `ordered: false`.
+
+Here is an example deduplication processor:
+
+[source,js]
+--------------------------------------------------
+{
+  "description" : "...",
+  "processors" : [
+    {
+      "dedupe" : {
+        "field" : "prices",
+        "ordered" : false
+      }
+    }
+  ]
+}
+--------------------------------------------------
+
 [[fail-processor]]
 === Fail Processor
 Raises an exception. This is useful for when

--- a/modules/ingest-grok/src/main/java/org/elasticsearch/ingest/grok/GrokProcessor.java
+++ b/modules/ingest-grok/src/main/java/org/elasticsearch/ingest/grok/GrokProcessor.java
@@ -23,8 +23,10 @@ import org.elasticsearch.ingest.core.AbstractProcessor;
 import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.ingest.core.ConfigurationUtils;
 import org.elasticsearch.ingest.core.IngestDocument;
+import org.elasticsearch.ingest.core.Processor;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.ingest.core.ConfigurationUtils.newConfigurationException;
@@ -75,7 +77,7 @@ public final class GrokProcessor extends AbstractProcessor {
         }
 
         @Override
-        public GrokProcessor doCreate(String processorTag, Map<String, Object> config) throws Exception {
+        public GrokProcessor doCreate(String processorTag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception {
             String matchField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "field");
             String matchPattern = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "pattern");
             Map<String, String> customPatternBank = ConfigurationUtils.readOptionalMap(TYPE, processorTag, config, "pattern_definitions");

--- a/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/AttachmentProcessor.java
+++ b/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/AttachmentProcessor.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.ingest.core.AbstractProcessor;
 import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.ingest.core.IngestDocument;
+import org.elasticsearch.ingest.core.Processor;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -155,7 +156,7 @@ public final class AttachmentProcessor extends AbstractProcessor {
         static final Set<Property> DEFAULT_PROPERTIES = EnumSet.allOf(Property.class);
 
         @Override
-        public AttachmentProcessor doCreate(String processorTag, Map<String, Object> config) throws Exception {
+        public AttachmentProcessor doCreate(String processorTag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception {
             String field = readStringProperty(TYPE, processorTag, config, "field");
             String targetField = readStringProperty(TYPE, processorTag, config, "target_field", "attachment");
             List<String> properyNames = readOptionalList(TYPE, processorTag, config, "properties");

--- a/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.ingest.core.AbstractProcessor;
 import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.ingest.core.IngestDocument;
+import org.elasticsearch.ingest.core.Processor;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -227,7 +228,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         }
 
         @Override
-        public GeoIpProcessor doCreate(String processorTag, Map<String, Object> config) throws Exception {
+        public GeoIpProcessor doCreate(String processorTag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception {
             String ipField = readStringProperty(TYPE, processorTag, config, "field");
             String targetField = readStringProperty(TYPE, processorTag, config, "target_field", "geoip");
             String databaseFile = readStringProperty(TYPE, processorTag, config, "database_file", "GeoLite2-City.mmdb");

--- a/test/framework/src/main/java/org/elasticsearch/ingest/TestProcessor.java
+++ b/test/framework/src/main/java/org/elasticsearch/ingest/TestProcessor.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.ingest.core.IngestDocument;
 import org.elasticsearch.ingest.core.Processor;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -37,7 +38,6 @@ public class TestProcessor implements Processor {
     private final String tag;
     private final Consumer<IngestDocument> ingestDocumentConsumer;
     private final AtomicInteger invokedCounter = new AtomicInteger();
-    private String lastType;
 
     public TestProcessor(Consumer<IngestDocument> ingestDocumentConsumer) {
         this(null, "test-processor", ingestDocumentConsumer);
@@ -65,18 +65,13 @@ public class TestProcessor implements Processor {
         return tag;
     }
 
-    @Override
-    public void setLastType(String lastType) {
-        this.lastType = lastType;
-    }
-
     public int getInvokedCounter() {
         return invokedCounter.get();
     }
 
     public static final class Factory extends AbstractProcessorFactory<TestProcessor> {
         @Override
-        public TestProcessor doCreate(String processorTag, Map<String, Object> config) throws Exception {
+        public TestProcessor doCreate(String processorTag, Map<String, Object> config, List<Processor> otherProcessors) throws Exception {
             return new TestProcessor(processorTag, "test-processor", ingestDocument -> {});
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/ingest/TestProcessor.java
+++ b/test/framework/src/main/java/org/elasticsearch/ingest/TestProcessor.java
@@ -37,6 +37,7 @@ public class TestProcessor implements Processor {
     private final String tag;
     private final Consumer<IngestDocument> ingestDocumentConsumer;
     private final AtomicInteger invokedCounter = new AtomicInteger();
+    private String lastType;
 
     public TestProcessor(Consumer<IngestDocument> ingestDocumentConsumer) {
         this(null, "test-processor", ingestDocumentConsumer);
@@ -62,6 +63,11 @@ public class TestProcessor implements Processor {
     @Override
     public String getTag() {
         return tag;
+    }
+
+    @Override
+    public void setLastType(String lastType) {
+        this.lastType = lastType;
     }
 
     public int getInvokedCounter() {


### PR DESCRIPTION
Adds a processor that deduplicates an array of elements.

Deduplication is aided if the input is sorted, however that means the processor needs to know if the last processor to run was a `sort` processor.  

I've tweaked the Processor interface to include a `setLastType()` method which is invoked by CompoundProcessor.  This allows processors to know what the previous processor was, to help with potential optimization.

We can remove this optimization if we don't want processors to know state about the pipeline.

This is part 2 of the fingerprinting ingest components (the other being #17999).  Part three would be a "meta-processor" that chains split + lowercase + sort + dedupe + join together.  Same concerns in #17999 about a single unified processor vs multiple individual components apply here too.
