### PR TITLE
Handle indices=["_all"] when restoring a snapshot

### DIFF
--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotUtils.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotUtils.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.snapshots;
 
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.index.IndexNotFoundException;
 
@@ -43,7 +44,7 @@ public class SnapshotUtils {
      * @return filtered out indices
      */
     public static List<String> filterIndices(List<String> availableIndices, String[] selectedIndices, IndicesOptions indicesOptions) {
-        if (selectedIndices == null || selectedIndices.length == 0) {
+        if (IndexNameExpressionResolver.isAllIndices(Arrays.asList(selectedIndices))) {
             return availableIndices;
         }
         Set<String> result = null;

--- a/core/src/test/java/org/elasticsearch/snapshots/SnapshotUtilsTests.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SnapshotUtilsTests.java
@@ -32,6 +32,7 @@ public class SnapshotUtilsTests extends ESTestCase {
     public void testIndexNameFiltering() {
         assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{}, new String[]{"foo", "bar", "baz"});
         assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"*"}, new String[]{"foo", "bar", "baz"});
+        assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"_all"}, new String[]{"foo", "bar", "baz"});
         assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"foo", "bar", "baz"}, new String[]{"foo", "bar", "baz"});
         assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"foo"}, new String[]{"foo"});
         assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"baz", "not_available"}, new String[]{"baz"});


### PR DESCRIPTION
It is documented that setting indices on the RestoreSnapshotRestore to
["_all"] restores all indices, but that was not case. Instead a
IndexNotFoundException was raised.

This fixes/replaces https://github.com/elastic/elasticsearch/pull/16927
