### PR TITLE
Handle case when readThrowable returns null.

### DIFF
--- a/core/src/main/java/org/elasticsearch/transport/netty/MessageChannelHandler.java
+++ b/core/src/main/java/org/elasticsearch/transport/netty/MessageChannelHandler.java
@@ -191,6 +191,9 @@ public class MessageChannelHandler extends SimpleChannelUpstreamHandler {
         } catch (Throwable e) {
             error = new TransportSerializationException("Failed to deserialize exception response from stream", e);
         }
+        if (error == null) {
+            error = new TransportSerializationException("Failed to deserialize exception response from stream", null);
+        }
         handleException(handler, error);
     }
 


### PR DESCRIPTION
If readThrowable returns null, assign the error variable a TransportSerializationException. It is important to assign a value, because null causes the handleException method to throw a NullPointerException and never call the handler.
