### PR TITLE
Increase default max open files to 65536

### DIFF
--- a/distribution/deb/src/main/packaging/init.d/elasticsearch
+++ b/distribution/deb/src/main/packaging/init.d/elasticsearch
@@ -60,7 +60,7 @@ ES_HOME=/usr/share/$NAME
 #ES_JAVA_OPTS=
 
 # Maximum number of open files
-MAX_OPEN_FILES=65535
+MAX_OPEN_FILES=${packaging.os.max.open.files}
 
 # Maximum amount of locked memory
 #MAX_LOCKED_MEMORY=

--- a/distribution/src/main/packaging/packaging.properties
+++ b/distribution/src/main/packaging/packaging.properties
@@ -14,7 +14,7 @@ packaging.elasticsearch.heap.min=256m
 packaging.elasticsearch.heap.max=1g
 
 # Specifies the maximum file descriptor number
-packaging.os.max.open.files=65535
+packaging.os.max.open.files=65536
 
 # Maximum number of VMA (Virtual Memory Areas) a process can own
 packaging.os.max.map.count=262144

--- a/docs/reference/setup/as-a-service.asciidoc
+++ b/docs/reference/setup/as-a-service.asciidoc
@@ -16,7 +16,7 @@ Each package features a configuration file, which allows you to set the followin
 `ES_HEAP_SIZE`::          The heap size to start with
 `ES_HEAP_NEWSIZE`::       The size of the new generation heap
 `ES_DIRECT_SIZE`::        The maximum size of the direct memory
-`MAX_OPEN_FILES`::        Maximum number of open files, defaults to `65535`
+`MAX_OPEN_FILES`::        Maximum number of open files, defaults to `65536`
 `MAX_LOCKED_MEMORY`::     Maximum locked memory size. Set to "unlimited" if you use the bootstrap.mlockall option in elasticsearch.yml. You must also set ES_HEAP_SIZE.
 `MAX_MAP_COUNT`::         Maximum number of memory map areas a process may have. If you use `mmapfs` as index store type, make sure this is set to a high value. For more information, check the https://github.com/torvalds/linux/blob/master/Documentation/sysctl/vm.txt[linux kernel documentation] about `max_map_count`. This is set via `sysctl` before starting elasticsearch. Defaults to `65535`
 `LOG_DIR`::               Log directory, defaults to `/var/log/elasticsearch`


### PR DESCRIPTION
This commit increases the default number of max open files from 65535 to
65536 to be consistent with the bootstrap file descriptor warning.

Closes #18040 
