### PR TITLE
Build: Explicitly set target and source compatibility for javac

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -355,6 +355,11 @@ class BuildPlugin implements Plugin<Project> {
                 }
                 options.encoding = 'UTF-8'
                 //options.incremental = true
+
+                // gradle ignores target/source compatibility when it is "unnecessary", but since to compile with
+                // java 9, gradle is running in java 8, it incorrectly thinks it is unnecessary
+                assert minimumJava == JavaVersion.VERSION_1_8
+                options.compilerArgs << '-target' << '1.8' << '-source' << '1.8'
             }
         }
     }


### PR DESCRIPTION
Gradle has a "shortcut" which omits the target and source compatibility
we set when it thinks it is not necessary (eg gradle is running on the
same version as the target compat). However, the way we compile against
java 9 is to set javac to use java 9, while gradle still runs on java 8.
This change makes -source and -target explicit for now, until these
"optimizations" can be removed from gradle.

closes #18039
