### PR TITLE
Build: Fix plugin properties generation when version changes

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
@@ -57,11 +57,13 @@ class PluginPropertiesTask extends Copy {
             // configure property substitution
             from(templateFile)
             into(generatedResourcesDir)
-            expand(generateSubstitutions())
+            Map<String, String> properties = generateSubstitutions()
+            expand(properties)
+            inputs.properties(properties)
         }
     }
 
-    Map generateSubstitutions() {
+    Map<String, String> generateSubstitutions() {
         def stringSnap = { version ->
             if (version.endsWith("-SNAPSHOT")) {
                return version.substring(0, version.length() - 9)


### PR DESCRIPTION
This change fixes the generation of plugin properties files when the
version changes. Before, it would not regenerate, and running integTest
would fail with an incompatibile version error.
