### PR TITLE
Add plugin information for Verbose mode

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/ListPluginsCommand.java
+++ b/core/src/main/java/org/elasticsearch/plugins/ListPluginsCommand.java
@@ -51,6 +51,18 @@ class ListPluginsCommand extends Command {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(env.pluginsFile())) {
             for (Path plugin : stream) {
                 terminal.println(plugin.getFileName().toString());
+                PluginInfo info = null;
+                try { 
+                    info = PluginInfo.readFromProperties(env.pluginsFile().resolve(plugin.toAbsolutePath()));
+                    terminal.println(Terminal.Verbosity.VERBOSE, info.toString());
+                }
+                catch(IOException ex) {
+                    terminal.println(Terminal.Verbosity.VERBOSE, "Plugin properties file missing for plugin");
+                }
+                catch (Exception ex){
+                    terminal.println(Terminal.Verbosity.VERBOSE, "Unable to retrieve plugin information."
+                            + " Please verify that this plugin is compatible with your current version");
+                }
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/plugins/ListPluginsCommand.java
+++ b/core/src/main/java/org/elasticsearch/plugins/ListPluginsCommand.java
@@ -51,18 +51,8 @@ class ListPluginsCommand extends Command {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(env.pluginsFile())) {
             for (Path plugin : stream) {
                 terminal.println(plugin.getFileName().toString());
-                PluginInfo info = null;
-                try { 
-                    info = PluginInfo.readFromProperties(env.pluginsFile().resolve(plugin.toAbsolutePath()));
-                    terminal.println(Terminal.Verbosity.VERBOSE, info.toString());
-                }
-                catch(IOException ex) {
-                    terminal.println(Terminal.Verbosity.VERBOSE, "Plugin properties file missing for plugin");
-                }
-                catch (Exception ex){
-                    terminal.println(Terminal.Verbosity.VERBOSE, "Unable to retrieve plugin information."
-                            + " Please verify that this plugin is compatible with your current version");
-                }
+                PluginInfo info = PluginInfo.readFromProperties(env.pluginsFile().resolve(plugin.toAbsolutePath()));
+                terminal.println(Terminal.Verbosity.VERBOSE, info.toString());
             }
         }
     }

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
@@ -123,6 +123,10 @@ public class ListPluginsCommandTests extends ESTestCase {
         MockTerminal terminal = listPlugins(env, params);
         String output = terminal.getOutput();
         assertTrue(output, output.contains("Plugin information"));
+        assertTrue(output, output.contains("Classname: org.fake"));
+        assertTrue(output, output.contains("fake_plugin"));
+        assertTrue(output, output.contains("1.0"));
+        assertTrue(output, output.contains("fake desc"));
     }
     
     public void testPluginWithVerboseMultiplePlugins() throws Exception {

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
@@ -132,23 +132,23 @@ public class ListPluginsCommandTests extends ESTestCase {
         assertEquals(output, buildMultiline("fake_plugin1", "fake_plugin2"));
     }
     
-    public void testPluginWithoutDescriptionFile() throws Exception{
+    public void testPluginWithoutDescriptorFile() throws Exception{
         Environment env = createEnv();
         Files.createDirectories(env.pluginsFile().resolve("fake1"));
         NoSuchFileException e = expectThrows(NoSuchFileException.class, () -> {
         	listPlugins(env);
         });
-        assertTrue(e.getMessage(), e.getMessage().contains("fake1\\plugin-descriptor.properties"));
+        assertEquals(e.getFile(), env.pluginsFile().resolve("fake1").resolve(PluginInfo.ES_PLUGIN_PROPERTIES).toString());
     }
     
-    public void testPluginWithWrongDescriptionFile() throws Exception{
+    public void testPluginWithWrongDescriptorFile() throws Exception{
         Environment env = createEnv();        
         PluginTestUtil.writeProperties(env.pluginsFile().resolve("fake1"),
                 "description", "fake desc");
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
         	listPlugins(env);
         });
-        assertTrue(e.getMessage(), e.getMessage().contains("Property [name] is missing in"));
+        assertEquals(e.getMessage(), "Property [name] is missing in [" + env.pluginsFile().resolve("fake1").resolve(PluginInfo.ES_PLUGIN_PROPERTIES).toString() + "]");
     }
     
 }

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
@@ -19,18 +19,17 @@
 
 package org.elasticsearch.plugins;
 
+
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.cli.ExitCodes;
 import org.elasticsearch.cli.MockTerminal;
-import org.elasticsearch.cli.UserError;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.test.ESTestCase;
@@ -58,6 +57,20 @@ public class ListPluginsCommandTests extends ESTestCase {
         assertEquals(ExitCodes.OK, status);
         return terminal;
     }
+    
+    static String buildMultiline(String... args){
+    	return Arrays.asList(args).stream().collect(Collectors.joining("\n", "", "\n"));
+    }
+    
+    static void buildFakePlugin(Environment env, String description, String name, String classname) throws IOException {
+        PluginTestUtil.writeProperties(env.pluginsFile().resolve(name),
+                "description", description,
+                "name", name,
+                "version", "1.0",
+                "elasticsearch.version", Version.CURRENT.toString(),
+                "java.version", System.getProperty("java.specification.version"),
+                "classname", classname);
+    }
 
 
     public void testPluginsDirMissing() throws Exception {
@@ -66,7 +79,7 @@ public class ListPluginsCommandTests extends ESTestCase {
         IOException e = expectThrows(IOException.class, () -> {
            listPlugins(env);
         });
-        assertTrue(e.getMessage(), e.getMessage().contains("Plugins directory missing"));
+        assertEquals(e.getMessage(), "Plugins directory missing: " + env.pluginsFile());
     }
 
     public void testNoPlugins() throws Exception {
@@ -76,132 +89,47 @@ public class ListPluginsCommandTests extends ESTestCase {
 
     public void testOnePlugin() throws Exception {
         Environment env = createEnv();
-        PluginTestUtil.writeProperties(env.pluginsFile().resolve("fake"),
-                "description", "fake desc",
-                "name", "fake_plugin",
-                "version", "1.0",
-                "elasticsearch.version", Version.CURRENT.toString(),
-                "java.version", System.getProperty("java.specification.version"),
-                "classname", "org.fake");
-        
+        buildFakePlugin(env, "fake desc", "fake", "org.fake");
         MockTerminal terminal = listPlugins(env);
-        assertTrue(terminal.getOutput(), terminal.getOutput().contains("fake"));
+        assertEquals(terminal.getOutput(), buildMultiline("fake"));
     }
 
     public void testTwoPlugins() throws Exception {
         Environment env = createEnv();
-        PluginTestUtil.writeProperties(env.pluginsFile().resolve("fake1"),
-                "description", "fake desc",
-                "name", "fake_plugin",
-                "version", "1.0",
-                "elasticsearch.version", Version.CURRENT.toString(),
-                "java.version", System.getProperty("java.specification.version"),
-                "classname", "org.fake");
-        PluginTestUtil.writeProperties(env.pluginsFile().resolve("fake2"),
-                "description", "fake desc",
-                "name", "fake2_plugin",
-                "version", "1.0",
-                "elasticsearch.version", Version.CURRENT.toString(),
-                "java.version", System.getProperty("java.specification.version"),
-                "classname", "org.fake");
+        buildFakePlugin(env, "fake desc", "fake1", "org.fake");
+        buildFakePlugin(env, "fake desc 2", "fake2", "org.fake");
         MockTerminal terminal = listPlugins(env);
-        String output = terminal.getOutput();
-        assertTrue(output, output.contains("fake1"));
-        assertTrue(output, output.contains("fake2"));
+        assertEquals(terminal.getOutput(), buildMultiline("fake1", "fake2"));
     }
     
     public void testPluginWithVerbose() throws Exception {
         Environment env = createEnv();
-        PluginTestUtil.writeProperties(env.pluginsFile().resolve("fake1"),
-                "description", "fake desc",
-                "name", "fake_plugin",
-                "version", "1.0",
-                "elasticsearch.version", Version.CURRENT.toString(),
-                "java.version", System.getProperty("java.specification.version"),
-                "classname", "org.fake");
+        buildFakePlugin(env, "fake desc", "fake_plugin", "org.fake");
         String[] params = { "-v" };
         MockTerminal terminal = listPlugins(env, params);
-        String output = terminal.getOutput();
-        assertTrue(output, output.contains("Plugin information"));
-        assertTrue(output, output.contains("Classname: org.fake"));
-        assertTrue(output, output.contains("fake_plugin"));
-        assertTrue(output, output.contains("1.0"));
-        assertTrue(output, output.contains("fake desc"));
+        assertEquals(terminal.getOutput(), buildMultiline("Plugins directory: " + env.pluginsFile(), "fake_plugin",
+        		"- Plugin information:", "Name: fake_plugin", "Description: fake desc", "Version: 1.0", " * Classname: org.fake"));
     }
     
     public void testPluginWithVerboseMultiplePlugins() throws Exception {
         Environment env = createEnv();
-        
-        PluginTestUtil.writeProperties(env.pluginsFile().resolve("fake1"),
-                "description", "fake desc",
-                "name", "fake_plugin",
-                "version", "1.0",
-                "elasticsearch.version", Version.CURRENT.toString(),
-                "java.version", System.getProperty("java.specification.version"),
-                "classname", "org.fake");
-
-        PluginTestUtil.writeProperties(env.pluginsFile().resolve("fake2"),
-                "description", "fake desc",
-                "name", "fake2_plugin",
-                "version", "1.0",
-                "elasticsearch.version", Version.CURRENT.toString(),
-                "java.version", System.getProperty("java.specification.version"),
-                "classname", "org.fake2");
-        
-        PluginTestUtil.writeProperties(env.pluginsFile().resolve("fake3"),
-                "description", "fake desc",
-                "name", "fake3_plugin",
-                "version", "1.0",
-                "elasticsearch.version", Version.CURRENT.toString(),
-                "java.version", System.getProperty("java.specification.version"),
-                "classname", "org.fake3");
-
+        buildFakePlugin(env, "fake desc 1", "fake_plugin1", "org.fake");
+        buildFakePlugin(env, "fake desc 2", "fake_plugin2", "org.fake2");
         String[] params = { "-v" };
         MockTerminal terminal = listPlugins(env, params);
-        String output = terminal.getOutput();
-        
-        //Should be 3 plugins, so if i split by plugin informations i should get 4 strings
-        assertTrue(output, output.split("Plugin information").length == 4);
-        assertTrue(output, output.contains("Classname: org.fake"));
-        assertTrue(output, output.contains("Classname: org.fake2"));
-        assertTrue(output, output.contains("Classname: org.fake3"));
-        assertTrue(output, output.contains("fake_plugin"));
-        assertTrue(output, output.contains("fake2_plugin"));
-        assertTrue(output, output.contains("fake3_plugin"));
-        assertTrue(output, output.contains("1.0"));
-        assertTrue(output, output.contains("fake desc"));
+        assertEquals(terminal.getOutput(), buildMultiline("Plugins directory: " + env.pluginsFile(),
+        		"fake_plugin1", "- Plugin information:", "Name: fake_plugin1", "Description: fake desc 1", "Version: 1.0",
+        		" * Classname: org.fake", "fake_plugin2", "- Plugin information:", "Name: fake_plugin2",
+        		"Description: fake desc 2", "Version: 1.0", " * Classname: org.fake2"));
     }
         
     public void testPluginWithoutVerboseMultiplePlugins() throws Exception {
         Environment env = createEnv();
-        
-        PluginTestUtil.writeProperties(env.pluginsFile().resolve("fake1"),
-                "description", "fake desc",
-                "name", "fake_plugin",
-                "version", "1.0",
-                "elasticsearch.version", Version.CURRENT.toString(),
-                "java.version", System.getProperty("java.specification.version"),
-                "classname", "org.fake");
-
-        PluginTestUtil.writeProperties(env.pluginsFile().resolve("fake2"),
-                "description", "fake desc",
-                "name", "fake2_plugin",
-                "version", "1.0",
-                "elasticsearch.version", Version.CURRENT.toString(),
-                "java.version", System.getProperty("java.specification.version"),
-                "classname", "org.fake2");
-        
-        PluginTestUtil.writeProperties(env.pluginsFile().resolve("fake3"),
-                "description", "fake desc",
-                "name", "fake3_plugin",
-                "version", "1.0",
-                "elasticsearch.version", Version.CURRENT.toString(),
-                "java.version", System.getProperty("java.specification.version"),
-                "classname", "org.fake3");
-
+        buildFakePlugin(env, "fake desc 1", "fake_plugin1", "org.fake");
+        buildFakePlugin(env, "fake desc 2", "fake_plugin2", "org.fake2");
         MockTerminal terminal = listPlugins(env, new String[0]);
         String output = terminal.getOutput();
-        assertFalse(output, output.contains("Plugin information"));
+        assertEquals(output, buildMultiline("fake_plugin1", "fake_plugin2"));
     }
     
     public void testPluginWithoutDescriptionFile() throws Exception{
@@ -222,4 +150,5 @@ public class ListPluginsCommandTests extends ESTestCase {
         });
         assertTrue(e.getMessage(), e.getMessage().contains("Property [name] is missing in"));
     }
+    
 }

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
@@ -59,7 +59,7 @@ public class ListPluginsCommandTests extends ESTestCase {
     }
     
     static String buildMultiline(String... args){
-    	return Arrays.asList(args).stream().collect(Collectors.joining("\n", "", "\n"));
+        return Arrays.asList(args).stream().collect(Collectors.joining("\n", "", "\n"));
     }
     
     static void buildFakePlugin(Environment env, String description, String name, String classname) throws IOException {
@@ -108,7 +108,7 @@ public class ListPluginsCommandTests extends ESTestCase {
         String[] params = { "-v" };
         MockTerminal terminal = listPlugins(env, params);
         assertEquals(terminal.getOutput(), buildMultiline("Plugins directory: " + env.pluginsFile(), "fake_plugin",
-        		"- Plugin information:", "Name: fake_plugin", "Description: fake desc", "Version: 1.0", " * Classname: org.fake"));
+                "- Plugin information:", "Name: fake_plugin", "Description: fake desc", "Version: 1.0", " * Classname: org.fake"));
     }
     
     public void testPluginWithVerboseMultiplePlugins() throws Exception {
@@ -118,9 +118,9 @@ public class ListPluginsCommandTests extends ESTestCase {
         String[] params = { "-v" };
         MockTerminal terminal = listPlugins(env, params);
         assertEquals(terminal.getOutput(), buildMultiline("Plugins directory: " + env.pluginsFile(),
-        		"fake_plugin1", "- Plugin information:", "Name: fake_plugin1", "Description: fake desc 1", "Version: 1.0",
-        		" * Classname: org.fake", "fake_plugin2", "- Plugin information:", "Name: fake_plugin2",
-        		"Description: fake desc 2", "Version: 1.0", " * Classname: org.fake2"));
+                "fake_plugin1", "- Plugin information:", "Name: fake_plugin1", "Description: fake desc 1", "Version: 1.0",
+                " * Classname: org.fake", "fake_plugin2", "- Plugin information:", "Name: fake_plugin2",
+                "Description: fake desc 2", "Version: 1.0", " * Classname: org.fake2"));
     }
         
     public void testPluginWithoutVerboseMultiplePlugins() throws Exception {

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
@@ -135,9 +135,7 @@ public class ListPluginsCommandTests extends ESTestCase {
     public void testPluginWithoutDescriptorFile() throws Exception{
         Environment env = createEnv();
         Files.createDirectories(env.pluginsFile().resolve("fake1"));
-        NoSuchFileException e = expectThrows(NoSuchFileException.class, () -> {
-        	listPlugins(env);
-        });
+        NoSuchFileException e = expectThrows(NoSuchFileException.class, () -> listPlugins(env));
         assertEquals(e.getFile(), env.pluginsFile().resolve("fake1").resolve(PluginInfo.ES_PLUGIN_PROPERTIES).toString());
     }
     
@@ -145,10 +143,9 @@ public class ListPluginsCommandTests extends ESTestCase {
         Environment env = createEnv();        
         PluginTestUtil.writeProperties(env.pluginsFile().resolve("fake1"),
                 "description", "fake desc");
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
-        	listPlugins(env);
-        });
-        assertEquals(e.getMessage(), "Property [name] is missing in [" + env.pluginsFile().resolve("fake1").resolve(PluginInfo.ES_PLUGIN_PROPERTIES).toString() + "]");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> listPlugins(env));
+        assertEquals(e.getMessage(), "Property [name] is missing in [" +
+                env.pluginsFile().resolve("fake1").resolve(PluginInfo.ES_PLUGIN_PROPERTIES).toString() + "]");
     }
     
 }

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
@@ -112,12 +112,13 @@ public class ListPluginsCommandTests extends ESTestCase {
     
     public void testPluginWithVerbose() throws Exception {
         Environment env = createEnv();
-        Files.createDirectory(env.pluginsFile().resolve("fake1"));
-        Path configFile = Files.createFile(env.pluginsFile().resolve("fake1").resolve(PluginInfo.ES_PLUGIN_PROPERTIES));
-        List<String> config = Arrays.asList("description=fake plugin",
-                "version=" + Version.CURRENT.toString(), "name=fake_plugin", "name=fake_plugin",
-                "elasticsearch.version=" + Version.CURRENT.toString(), "java.version=1.8", "classname=org.fake");
-        Files.write(configFile, config, Charset.forName("UTF-8"));
+        PluginTestUtil.writeProperties(env.pluginsFile().resolve("fake1"),
+                "description", "fake desc",
+                "name", "fake_plugin",
+                "version", "1.0",
+                "elasticsearch.version", Version.CURRENT.toString(),
+                "java.version", System.getProperty("java.specification.version"),
+                "classname", "org.fake");
         String[] params = { "-v" };
         MockTerminal terminal = listPlugins(env, params);
         String output = terminal.getOutput();


### PR DESCRIPTION
Fix for #16375 

With this Pull Request, we will show extra information about plugins running the `bin/elasticsearch-plugin` command under `verbose` mode.
