### PR TITLE
Update Jackson 2.6.2 -> 2.6.6 (latest and final 2.6 patch)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <securemock.version>1.1</securemock.version>
         <securesm.version>1.0</securesm.version>
 
-        <jackson.version>2.6.2</jackson.version>
+        <jackson.version>2.6.6</jackson.version>
         <slf4j.version>1.6.2</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
         <jacoco.version>0.7.5.201505241946</jacoco.version>


### PR DESCRIPTION
There are a few important fixes to Jackson between 2.6.2 and 2.6.6; latter is also likely to be the last update for 2.6 branch. Submitting this PR against 2.3 since I was not 100% what is the right way (instructions suggest master but...). In any case, whether via this PR or not, change is one-liner, easy to make wherever.

I also ran `mvn clean test` and did not observe any test failures, so I do not see obvious regressions.
