### PR TITLE
Avoid sliced locked contention in internal engine

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/KeyedLock.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/KeyedLock.java
@@ -50,7 +50,7 @@ public class KeyedLock<T> {
         this(false);
     }
 
-    private final ConcurrentMap<T, KeyLock> map = ConcurrentCollections.newConcurrentMap();
+    private final ConcurrentMap<T, KeyLock> map = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
 
     public Releasable acquire(T key) {
         assert isHeldByCurrentThread(key) == false : "lock for " + key + " is already heald by this thread";

--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/ReleasableLock.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/ReleasableLock.java
@@ -50,7 +50,6 @@ public class ReleasableLock implements Releasable {
         assert removeCurrentThread();
     }
 
-
     public ReleasableLock acquire() throws EngineException {
         lock.lock();
         assert addCurrentThread();

--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/ReleasableLock.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/ReleasableLock.java
@@ -50,6 +50,7 @@ public class ReleasableLock implements Releasable {
         assert removeCurrentThread();
     }
 
+
     public ReleasableLock acquire() throws EngineException {
         lock.lock();
         assert addCurrentThread();

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -42,7 +42,6 @@ import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.InfoStream;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.lucene.LoggerInfoStream;
@@ -50,8 +49,8 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.KeyedLock;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.Uid;
@@ -71,16 +70,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.LinkedTransferQueue;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 
 /**
@@ -107,8 +100,7 @@ public class InternalEngine extends Engine {
     // we use the hashed variant since we iterate over it and check removal and additions on existing keys
     private final LiveVersionMap versionMap;
 
-    private final ConcurrentHashMap<BytesRef, Tuple<ReleasableLock, AbstractRefCounted>> lockMap = new ConcurrentHashMap<>(2 * Runtime.getRuntime().availableProcessors(), 0.75f, 2 * Runtime.getRuntime().availableProcessors());
-    private final ConcurrentLinkedQueue<ReleasableLock> locks = new ConcurrentLinkedQueue<>();
+    private final KeyedLock<BytesRef> keyedLock = new KeyedLock<>();
 
     private final AtomicBoolean versionMapRefreshPending = new AtomicBoolean();
 
@@ -136,9 +128,6 @@ public class InternalEngine extends Engine {
         try {
             this.lastDeleteVersionPruneTimeMSec = engineConfig.getThreadPool().estimatedTimeInMillis();
             mergeScheduler = scheduler = new EngineMergeScheduler(engineConfig.getShardId(), engineConfig.getIndexSettings());
-            for (int i = 0; i < 2 * Runtime.getRuntime().availableProcessors(); i++) {
-                locks.add(new ReleasableLock(new ReentrantLock()));
-            }
             throttle = new IndexThrottle();
             this.searcherFactory = new SearchFactory(logger, isClosed, engineConfig);
             try {
@@ -363,7 +352,7 @@ public class InternalEngine extends Engine {
     }
 
     private boolean innerIndex(Index index) throws IOException {
-        try (ReleasableLock ignored = dirtyLock(index.uid()).acquire()) {
+        try (Releasable ignored = dirtyLock(index.uid())) {
             lastWriteNanos = index.startTime();
             final long currentVersion;
             final boolean deleted;
@@ -405,8 +394,6 @@ public class InternalEngine extends Engine {
             versionMap.putUnderLock(index.uid().bytes(), new VersionValue(updatedVersion, translogLocation));
             index.setTranslogLocation(translogLocation);
             return created;
-        } finally {
-            remove(index.uid());
         }
     }
 
@@ -460,7 +447,7 @@ public class InternalEngine extends Engine {
     }
 
     private void innerDelete(Delete delete) throws IOException {
-        try (ReleasableLock ignored = dirtyLock(delete.uid()).acquire()) {
+        try (Releasable ignored = dirtyLock(delete.uid())) {
             lastWriteNanos = delete.startTime();
             final long currentVersion;
             final boolean deleted;
@@ -505,8 +492,6 @@ public class InternalEngine extends Engine {
             Translog.Location translogLocation = translog.add(new Translog.Delete(delete));
             versionMap.putUnderLock(delete.uid().bytes(), new DeleteVersionValue(updatedVersion, engineConfig.getThreadPool().estimatedTimeInMillis(), translogLocation));
             delete.setTranslogLocation(translogLocation);
-        } finally {
-            remove(delete.uid());
         }
     }
 
@@ -719,7 +704,7 @@ public class InternalEngine extends Engine {
         // we only need to prune the deletes map; the current/old version maps are cleared on refresh:
         for (Map.Entry<BytesRef, VersionValue> entry : versionMap.getAllTombstones()) {
             BytesRef uid = entry.getKey();
-            try (ReleasableLock ignored = dirtyLock(uid).acquire()) { // can we do it without this lock on each value? maybe batch to a set and get the lock once per set?
+            try (Releasable ignored = dirtyLock(uid)) { // can we do it without this lock on each value? maybe batch to a set and get the lock once per set?
 
                 // Must re-get it here, vs using entry.getValue(), in case the uid was indexed/deleted since we pulled the iterator:
                 VersionValue versionValue = versionMap.getTombstoneUnderLock(uid);
@@ -728,8 +713,6 @@ public class InternalEngine extends Engine {
                         versionMap.removeTombstoneUnderLock(uid);
                     }
                 }
-            } finally {
-                remove(uid);
             }
         }
 
@@ -921,35 +904,12 @@ public class InternalEngine extends Engine {
         return searcherManager;
     }
 
-    private ReleasableLock dirtyLock(BytesRef uid) {
-        final Tuple<ReleasableLock, AbstractRefCounted> tuple = lockMap.compute(uid, (k, v) -> {
-            if (v == null || !v.v2().tryIncRef()) {
-                final ReleasableLock lock = locks.poll();
-                final AbstractRefCounted ref = new AbstractRefCounted(null) {
-                    @Override
-                    protected void closeInternal() {
-                        locks.offer(lock);
-                        lockMap.remove(k);
-                    }
-                };
-                return Tuple.tuple(lock, ref);
-            } else {
-                return v;
-            }
-        });
-        return tuple.v1();
+    private Releasable dirtyLock(BytesRef uid) {
+        return keyedLock.acquire(uid);
     }
 
-    private ReleasableLock dirtyLock(Term uid) {
+    private Releasable dirtyLock(Term uid) {
         return dirtyLock(uid.bytes());
-    }
-
-    private void remove(BytesRef uid) {
-        lockMap.get(uid).v2().decRef();
-    }
-
-    private void remove(Term uid) {
-        remove(uid.bytes());
     }
 
     private long loadCurrentVersionFromIndex(Term uid) throws IOException {


### PR DESCRIPTION
Today we use a sliced lock strategy for acquiring locks to prevent concurrent updates to the same document. The number of sliced locks is computed as a linear function of the number of logical processors. Unfortunately, the probability of a collision against a sliced lock is prone to the birthday problem and grows faster than expected. In fact, the mathematics works out such that for a fixed target probability of collision, the number of lock slices should grow like the square of the number of logical processors. This is less-than-ideal, and we can do better anyway. This commit introduces a strategy for avoiding lock contention within the internal engine. Ideally, we would only have lock contention if there were concurrent updates to the same document. So the ideal solution here is to switch to using a keyed lock per document.

Closes #18053