### PR TITLE
Row-centric output for _cat/fielddata

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestFielddataAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestFielddataAction.java
@@ -19,8 +19,7 @@
 
 package org.elasticsearch.rest.action.cat;
 
-import com.carrotsearch.hppc.ObjectLongHashMap;
-import com.carrotsearch.hppc.ObjectLongMap;
+import com.carrotsearch.hppc.cursors.ObjectLongCursor;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
@@ -35,11 +34,6 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
-
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
@@ -57,7 +51,6 @@ public class RestFielddataAction extends AbstractCatAction {
 
     @Override
     protected void doRequest(final RestRequest request, final RestChannel channel, final Client client) {
-
         final NodesStatsRequest nodesStatsRequest = new NodesStatsRequest("data:true");
         nodesStatsRequest.clear();
         nodesStatsRequest.indices(true);
@@ -86,54 +79,28 @@ public class RestFielddataAction extends AbstractCatAction {
                 .addCell("host", "alias:h;desc:host name")
                 .addCell("ip", "desc:ip address")
                 .addCell("node", "alias:n;desc:node name")
-                .addCell("total", "text-align:right;desc:total field data usage")
+                .addCell("field", "alias:f;desc:field name")
+                .addCell("size", "text-align:right;alias:s;desc:field data usage")
                 .endHeaders();
         return table;
     }
 
     private Table buildTable(final RestRequest request, final NodesStatsResponse nodeStatses) {
-        Set<String> fieldNames = new HashSet<>();
-        Map<NodeStats, ObjectLongMap<String>> nodesFields = new HashMap<>();
+        Table table = getTableWithHeader(request);
 
-        // Collect all the field names so a new table can be built
-        for (NodeStats ns : nodeStatses.getNodes()) {
-            ObjectLongHashMap<String> fields = ns.getIndices().getFieldData().getFields();
-            nodesFields.put(ns, fields);
-            if (fields != null) {
-                for (String key : fields.keys().toArray(String.class)) {
-                    fieldNames.add(key);
+        for (NodeStats nodeStats: nodeStatses.getNodes()) {
+            if (nodeStats.getIndices().getFieldData().getFields() != null) {
+                for (ObjectLongCursor<String> cursor : nodeStats.getIndices().getFieldData().getFields()) {
+                    table.startRow();
+                    table.addCell(nodeStats.getNode().getId());
+                    table.addCell(nodeStats.getNode().getHostName());
+                    table.addCell(nodeStats.getNode().getHostAddress());
+                    table.addCell(nodeStats.getNode().getName());
+                    table.addCell(cursor.key);
+                    table.addCell(new ByteSizeValue(cursor.value));
+                    table.endRow();
                 }
             }
-        }
-
-        // The table must be rebuilt because it has dynamic headers based on the fields
-        Table table = new Table();
-        table.startHeaders()
-                .addCell("id", "desc:node id")
-                .addCell("host", "alias:h;desc:host name")
-                .addCell("ip", "desc:ip address")
-                .addCell("node", "alias:n;desc:node name")
-                .addCell("total", "text-align:right;desc:total field data usage");
-        // The table columns must be built dynamically since the number of fields is unknown
-        for (String fieldName : fieldNames) {
-            table.addCell(fieldName, "text-align:right;desc:" + fieldName + " field");
-        }
-        table.endHeaders();
-
-        for (Map.Entry<NodeStats, ObjectLongMap<String>> statsEntry : nodesFields.entrySet()) {
-            table.startRow();
-            // add the node info and field data total before each individual field
-            NodeStats ns = statsEntry.getKey();
-            table.addCell(ns.getNode().getId());
-            table.addCell(ns.getNode().getHostName());
-            table.addCell(ns.getNode().getHostAddress());
-            table.addCell(ns.getNode().getName());
-            table.addCell(ns.getIndices().getFieldData().getMemorySize());
-            ObjectLongMap<String> fields = statsEntry.getValue();
-            for (String fieldName : fieldNames) {
-                table.addCell(new ByteSizeValue(fields == null ? 0L : fields.getOrDefault(fieldName, 0L)));
-            }
-            table.endRow();
         }
 
         return table;

--- a/docs/reference/cat/fielddata.asciidoc
+++ b/docs/reference/cat/fielddata.asciidoc
@@ -7,10 +7,13 @@ on every data node in the cluster.
 [source,sh]
 --------------------------------------------------
 % curl '192.168.56.10:9200/_cat/fielddata?v'
-id                     host    ip            node          total   body    text
-c223lARiSGeezlbrcugAYQ myhost1 10.20.100.200 Jessica Jones 385.6kb 159.8kb 225.7kb
-waPCbitNQaCL6xC8VxjAwg myhost2 10.20.100.201 Adversary     435.2kb 159.8kb 275.3kb
-yaDkp-G3R0q1AJ-HUEvkSQ myhost3 10.20.100.202 Microchip     284.6kb 109.2kb 175.3kb
+id                     host    ip            node          field   size
+c223lARiSGeezlbrcugAYQ myhost1 10.20.100.200 Jessica Jones body    159.8kb
+c223lARiSGeezlbrcugAYQ myhost1 10.20.100.200 Jessica Jones text    225.7kb
+waPCbitNQaCL6xC8VxjAwg myhost2 10.20.100.201 Adversary     body    159.8kb
+waPCbitNQaCL6xC8VxjAwg myhost2 10.20.100.201 Adversary     text    275.3kb
+yaDkp-G3R0q1AJ-HUEvkSQ myhost3 10.20.100.202 Microchip     body    109.2kb
+yaDkp-G3R0q1AJ-HUEvkSQ myhost3 10.20.100.202 Microchip     text    175.3kb
 --------------------------------------------------
 
 Fields can be specified either as a query parameter, or in the URL path:
@@ -18,17 +21,19 @@ Fields can be specified either as a query parameter, or in the URL path:
 [source,sh]
 --------------------------------------------------
 % curl '192.168.56.10:9200/_cat/fielddata?v&fields=body'
-id                     host    ip            node          total   body
-c223lARiSGeezlbrcugAYQ myhost1 10.20.100.200 Jessica Jones 385.6kb 159.8kb
-waPCbitNQaCL6xC8VxjAwg myhost2 10.20.100.201 Adversary     435.2kb 159.8kb
-yaDkp-G3R0q1AJ-HUEvkSQ myhost3 10.20.100.202 Microchip     284.6kb 109.2kb
+id                     host    ip            node          field   size
+c223lARiSGeezlbrcugAYQ myhost1 10.20.100.200 Jessica Jones body    159.8kb
+waPCbitNQaCL6xC8VxjAwg myhost2 10.20.100.201 Adversary     body    159.8kb
+yaDkp-G3R0q1AJ-HUEvkSQ myhost3 10.20.100.202 Microchip     body    109.2kb
 
 % curl '192.168.56.10:9200/_cat/fielddata/body,text?v'
-id                     host    ip            node          total   body    text
-c223lARiSGeezlbrcugAYQ myhost1 10.20.100.200 Jessica Jones 385.6kb 159.8kb 225.7kb
-waPCbitNQaCL6xC8VxjAwg myhost2 10.20.100.201 Adversary     435.2kb 159.8kb 275.3kb
-yaDkp-G3R0q1AJ-HUEvkSQ myhost3 10.20.100.202 Microchip     284.6kb 109.2kb 175.3kb
+id                     host    ip            node          field   size
+c223lARiSGeezlbrcugAYQ myhost1 10.20.100.200 Jessica Jones body    159.8kb
+c223lARiSGeezlbrcugAYQ myhost1 10.20.100.200 Jessica Jones text    225.7kb
+waPCbitNQaCL6xC8VxjAwg myhost2 10.20.100.201 Adversary     body    159.8kb
+waPCbitNQaCL6xC8VxjAwg myhost2 10.20.100.201 Adversary     text    275.3kb
+yaDkp-G3R0q1AJ-HUEvkSQ myhost3 10.20.100.202 Microchip     body    109.2kb
+yaDkp-G3R0q1AJ-HUEvkSQ myhost3 10.20.100.202 Microchip     text    175.3kb
 --------------------------------------------------
 
-The output shows the total fielddata and then the individual fielddata for the
-`body` and `text` fields.
+The output shows the individual fielddata for the`body` and `text` fields, one row per field per node.

--- a/docs/reference/migration/migrate_5_0/cat.asciidoc
+++ b/docs/reference/migration/migrate_5_0/cat.asciidoc
@@ -38,3 +38,10 @@ and `i` for ingest. A node with no explicit roles will be a coordinating
 only node and marked with `-`. A node can have multiple roles. The
 master column has been adapted to return only whether a node is the
 current master (`*`) or not (`-`).
+
+==== Changes to cat field data API
+
+The cat field data endpoint adds a row per field instead of a column per field.
+
+The `total` field has been removed from the field data API. Total field data usage per node
+can be got by cat nodes API.

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.fielddata/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.fielddata/10_basic.yaml
@@ -10,7 +10,8 @@
                    host .+ \n
                    ip .+ \n
                    node .+ \n
-                   total .+ \n
+                   field .+ \n
+                   size .+ \n
                $/
 
 ---
@@ -38,39 +39,41 @@
         type: type
         body: { foo: bar }
         refresh: true
+
   - do:
       search:
         index: index
         body:
           query: { match_all: {} }
           sort: foo
+
   - do:
       cat.fielddata:
-        h: total
+        h: field,size
         v: true
 
   - match:
       $body: |
-               /^   total               \n
-                    (\s*\d+(\.\d+)?[gmk]?b  \n)+ $/
+               /^ field \s+   size \n
+                  foo     \s+ (\d+(\.\d+)?[gmk]?b  \n)+ $/
 
   - do:
       cat.fielddata:
-        h: total,foo
-        v: true
-
-  - match:
-      $body: |
-               /^   total \s+              foo \n
-                    (\s*\d+(\.\d+)?[gmk]?b \s+ \d+(\.\d+)?[gmk]?b \n)+ $/
-
-  - do:
-      cat.fielddata:
-        h: total,foo
+        h: field,size
         fields: notfoo,foo
         v: true
 
   - match:
       $body: |
-               /^   total \s+              foo \n
-                    (\s*\d+(\.\d+)?[gmk]?b \s+ \d+(\.\d+)?[gmk]?b \n)+ $/
+               /^ field \s+   size \n
+                  foo     \s+ (\d+(\.\d+)?[gmk]?b  \n)+ $/
+
+  - do:
+      cat.fielddata:
+        h: field,size
+        fields: notfoo
+        v: true
+
+  - match:
+      $body: |
+               /^ field \s+   size \n $/


### PR DESCRIPTION
I deleted field `total`, because I think it's bad idea to mix aggregate size with individual field sizes. You can get total field data usage per node by `_cat/nodes` API.

Closes #10249
