### PR TITLE
Don't try to compute completion stats on a reader after we already closed it

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -753,16 +753,10 @@ public class IndexShard extends AbstractIndexShardComponent {
         CompletionStats completionStats = new CompletionStats();
         final Engine.Searcher currentSearcher = acquireSearcher("completion_stats");
         try {
-            PostingsFormat postingsFormat = PostingsFormat.forName(Completion090PostingsFormat.CODEC_NAME);
-            if (postingsFormat instanceof Completion090PostingsFormat) {
-                Completion090PostingsFormat completionPostingsFormat = (Completion090PostingsFormat) postingsFormat;
-                completionStats.add(completionPostingsFormat.completionStats(currentSearcher.reader(), fields));
-            }
+            Completion090PostingsFormat postingsFormat = ((Completion090PostingsFormat) PostingsFormat.forName(Completion090PostingsFormat.CODEC_NAME));
+            completionStats.add(postingsFormat.completionStats(currentSearcher.reader(), fields));
         } finally {
             currentSearcher.close();
-            Completion090PostingsFormat postingsFormat = ((Completion090PostingsFormat) PostingsFormat.forName
-                    (Completion090PostingsFormat.CODEC_NAME));
-            completionStats.add(postingsFormat.completionStats(currentSearcher.reader(), fields));
         }
         return completionStats;
     }


### PR DESCRIPTION
This can cause `AlreadyClosedException` and can also crash your JVM if `mmapfs` is in use and Lucene's best-effort check to catch this illegal usage fails, in 2.3.2.

I'll also fix this in 5.0.0, but there the bug is more harmless (computes stats twice, but without causing ACE/possible JVM crash).
