### PR TITLE
Add tests/doc for boolean fields with expressions

### DIFF
--- a/docs/reference/modules/scripting/scripting.asciidoc
+++ b/docs/reference/modules/scripting/scripting.asciidoc
@@ -492,6 +492,9 @@ You can choose a different value instead, e.g. `doc['myfield'].sum()`.
 
 When a document is missing the field completely, by default the value will be treated as `0`.
 
+Boolean fields are exposed as numerics, with `true` mapped to `1` and `false` mapped to `0`. 
+For example: `doc['on_sale'] ? doc['price'] * 0.5 : doc['price']`
+
 [float]
 === Additional methods for date fields
 Date fields are treated as the number of milliseconds since January 1, 1970 and 
@@ -542,7 +545,7 @@ e.g. based on geolocation of the user.
 
 There are a few limitations relative to other script languages:
 
-* Only numeric, date, and geo_point fields may be accessed
+* Only numeric, boolean, date, and geo_point fields may be accessed
 * Stored fields are not available
 
 [float]


### PR DESCRIPTION
boolean fields happen to already work with expressions (e.g. ternary operator) but we don't document they work or test them.

This just adds doc and a test (and fixes 2-space indent of previous test caused by our gradle build destroying my ide on every `gradle clean`)
