### PR TITLE
Allow CORS requests to work with HTTP compression enabled

### DIFF
--- a/core/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
+++ b/core/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
@@ -512,12 +512,12 @@ public class NettyHttpServerTransport extends AbstractLifecycleComponent<HttpSer
                 httpChunkAggregator.setMaxCumulationBufferComponents(transport.maxCompositeBufferComponents);
             }
             pipeline.addLast("aggregator", httpChunkAggregator);
-            if (transport.settings().getAsBoolean(SETTING_CORS_ENABLED, false)) {
-                pipeline.addLast("cors", new CorsHandler(transport.getCorsConfig()));
-            }
             pipeline.addLast("encoder", new ESHttpResponseEncoder());
             if (transport.compression) {
                 pipeline.addLast("encoder_compress", new HttpContentCompressor(transport.compressionLevel));
+            }
+            if (transport.settings().getAsBoolean(SETTING_CORS_ENABLED, false)) {
+                pipeline.addLast("cors", new CorsHandler(transport.getCorsConfig()));
             }
             if (transport.pipelining) {
                 pipeline.addLast("pipelining", new HttpPipeliningHandler(transport.pipeliningMaxEvents));

--- a/core/src/test/java/org/elasticsearch/rest/CorsRegexIT.java
+++ b/core/src/test/java/org/elasticsearch/rest/CorsRegexIT.java
@@ -30,6 +30,7 @@ import static org.elasticsearch.http.netty.NettyHttpServerTransport.SETTING_CORS
 import static org.elasticsearch.http.netty.NettyHttpServerTransport.SETTING_CORS_ALLOW_CREDENTIALS;
 import static org.elasticsearch.http.netty.NettyHttpServerTransport.SETTING_CORS_ALLOW_METHODS;
 import static org.elasticsearch.http.netty.NettyHttpServerTransport.SETTING_CORS_ENABLED;
+import static org.elasticsearch.http.netty.NettyHttpServerTransport.SETTING_HTTP_COMPRESSION;
 import static org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import static org.elasticsearch.test.ESIntegTestCase.Scope;
 import static org.hamcrest.Matchers.*;
@@ -52,6 +53,7 @@ public class CorsRegexIT extends ESIntegTestCase {
                 .put(SETTING_CORS_ALLOW_METHODS, "get, options, post")
                 .put(SETTING_CORS_ENABLED, true)
                 .put(Node.HTTP_ENABLED, true)
+                .put(SETTING_HTTP_COMPRESSION, randomBoolean())
                 .build();
     }
 


### PR DESCRIPTION
With this commit we fix an issue that prevented to turn on
HTTP compression when using CORS. The problem boiled down
to a problematic order of the respective handlers in
Netty's pipeline.

Note that the same problem is already fixed in ES 5.0 by #18066.

Relates #18066
Fixes #18089
