### PR TITLE
Add _score order in the terms aggregation

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
@@ -69,7 +69,7 @@ public class DoubleTermsAggregator extends LongTermsAggregator {
     private static DoubleTerms.Bucket convertToDouble(InternalTerms.Bucket bucket) {
         final long term = ((Number) bucket.getKey()).longValue();
         final double value = NumericUtils.sortableLongToDouble(term);
-        return new DoubleTerms.Bucket(value, bucket.docCount, bucket.aggregations, bucket.showDocCountError, bucket.docCountError, bucket.format);
+        return new DoubleTerms.Bucket(value, bucket.docCount, bucket.maxScore, bucket.aggregations, bucket.showDocCountError, bucket.docCountError, bucket.format);
     }
 
     private static DoubleTerms convertToDouble(LongTerms terms) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalOrder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalOrder.java
@@ -49,6 +49,7 @@ class InternalOrder extends Terms.Order {
     private static final byte COUNT_ASC_ID = 2;
     private static final byte TERM_DESC_ID = 3;
     private static final byte TERM_ASC_ID = 4;
+    private static final byte SCORE_DESC_ID = 5;
 
     /**
      * Order by the (higher) count of each term.
@@ -92,6 +93,27 @@ class InternalOrder extends Terms.Order {
             return o1.compareTerm(o2);
         }
     });
+
+    public static final InternalOrder SCORE_DESC = new InternalOrder(SCORE_DESC_ID, "_score", false, new Comparator<Terms.Bucket> () {
+        @Override
+        public int compare(Terms.Bucket o1, Terms.Bucket o2) {
+            return o2.compareScore(o1);
+        }
+    });
+
+    public static boolean isScoreDesc(Terms.Order order) {
+        if (order == SCORE_DESC) {
+            return true;
+        } else if (order instanceof CompoundOrder) {
+            CompoundOrder compoundOrder = (CompoundOrder) order;
+            for (Order inner : compoundOrder.orderElements()) {
+                if (inner == SCORE_DESC) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 
     public static boolean isCountDesc(Terms.Order order) {
         if (order == COUNT_DESC) {
@@ -351,6 +373,7 @@ class InternalOrder extends Terms.Order {
                 case COUNT_ASC_ID: return absoluteOrder ? new CompoundOrder(Collections.singletonList((Terms.Order) InternalOrder.COUNT_ASC)) : InternalOrder.COUNT_ASC;
                 case TERM_DESC_ID: return InternalOrder.TERM_DESC;
                 case TERM_ASC_ID: return InternalOrder.TERM_ASC;
+                case SCORE_DESC_ID: return InternalOrder.SCORE_DESC;
                 case Aggregation.ID:
                     boolean asc = in.readBoolean();
                     String key = in.readString();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
@@ -82,9 +82,9 @@ public class LongTerms extends InternalTerms<LongTerms, LongTerms.Bucket> {
             super(format, showDocCountError);
         }
 
-        public Bucket(long term, long docCount, InternalAggregations aggregations, boolean showDocCountError, long docCountError,
+        public Bucket(long term, long docCount, float maxScore, InternalAggregations aggregations, boolean showDocCountError, long docCountError,
                 DocValueFormat format) {
-            super(docCount, aggregations, showDocCountError, docCountError, format);
+            super(docCount, maxScore, aggregations, showDocCountError, docCountError, format);
             this.term = term;
         }
 
@@ -109,8 +109,8 @@ public class LongTerms extends InternalTerms<LongTerms, LongTerms.Bucket> {
         }
 
         @Override
-        Bucket newBucket(long docCount, InternalAggregations aggs, long docCountError) {
-            return new Bucket(term, docCount, aggs, showDocCountError, docCountError, format);
+        Bucket newBucket(long docCount, float maxScore, InternalAggregations aggs, long docCountError) {
+            return new Bucket(term, docCount, maxScore, aggs, showDocCountError, docCountError, format);
         }
 
         @Override
@@ -121,6 +121,7 @@ public class LongTerms extends InternalTerms<LongTerms, LongTerms.Bucket> {
             if (showDocCountError) {
                 docCountError = in.readLong();
             }
+            maxScore = in.readFloat();
             aggregations = InternalAggregations.readAggregations(in);
         }
 
@@ -131,6 +132,7 @@ public class LongTerms extends InternalTerms<LongTerms, LongTerms.Bucket> {
             if (showDocCountError) {
                 out.writeLong(docCountError);
             }
+            out.writeFloat(maxScore);
             aggregations.writeTo(out);
         }
 
@@ -144,6 +146,9 @@ public class LongTerms extends InternalTerms<LongTerms, LongTerms.Bucket> {
             builder.field(CommonFields.DOC_COUNT, getDocCount());
             if (showDocCountError) {
                 builder.field(InternalTerms.DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME, getDocCountError());
+            }
+            if (Float.isNaN(maxScore) == false) {
+                builder.field(InternalTerms.MAX_SCORE, maxScore);
             }
             aggregations.toXContentInternal(builder, params);
             builder.endObject();
@@ -173,7 +178,7 @@ public class LongTerms extends InternalTerms<LongTerms, LongTerms.Bucket> {
 
     @Override
     public Bucket createBucket(InternalAggregations aggregations, Bucket prototype) {
-        return new Bucket(prototype.term, prototype.docCount, aggregations, prototype.showDocCountError, prototype.docCountError,
+        return new Bucket(prototype.term, prototype.docCount, prototype.maxScore, aggregations, prototype.showDocCountError, prototype.docCountError,
                 prototype.format);
     }
 
@@ -233,5 +238,4 @@ public class LongTerms extends InternalTerms<LongTerms, LongTerms.Bucket> {
         builder.endArray();
         return builder;
     }
-
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/Terms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/Terms.java
@@ -62,14 +62,25 @@ public interface Terms extends MultiBucketsAggregation {
     /**
      * A bucket that is associated with a single term
      */
-    static abstract class Bucket extends InternalMultiBucketAggregation.InternalBucket {
+    abstract class Bucket extends InternalMultiBucketAggregation.InternalBucket {
+        float maxScore;
+
+        public Bucket() {
+        }
 
         public abstract Number getKeyAsNumber();
 
         abstract int compareTerm(Terms.Bucket other);
 
-        public abstract long getDocCountError();
+        int compareScore(Terms.Bucket other) {
+            return Float.compare(maxScore, other.maxScore);
+        }
 
+        public float getMaxScore() {
+            return maxScore;
+        }
+
+        public abstract long getDocCountError();
     }
 
     /**
@@ -111,6 +122,10 @@ public interface Terms extends MultiBucketsAggregation {
          */
         public static Order term(boolean asc) {
             return asc ? InternalOrder.TERM_ASC : InternalOrder.TERM_DESC;
+        }
+
+        public static Order score() {
+            return InternalOrder.SCORE_DESC;
         }
 
         /**

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregator.java
@@ -203,4 +203,12 @@ public abstract class TermsAggregator extends BucketsAggregator {
                 && !aggsUsedForSorting.contains(aggregator);
     }
 
+
+    @Override
+    public boolean needsScores() {
+        if (InternalOrder.isScoreDesc(order)) {
+            return true;
+        }
+        return super.needsScores();
+    }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsParser.java
@@ -118,6 +118,10 @@ public class TermsParser extends AbstractTermsParser {
                 if ("asc".equalsIgnoreCase(dir)) {
                     orderAsc = true;
                 } else if ("desc".equalsIgnoreCase(dir)) {
+                    if (orderKey.equals("_score")) {
+                        throw new ParsingException(parser.getTokenLocation(),
+                            "Invalid terms order direction [" + dir + "] in terms aggregation [" + aggregationName + "]");
+                    }
                     orderAsc = false;
                 } else {
                     throw new ParsingException(parser.getTokenLocation(),
@@ -167,6 +171,9 @@ public class TermsParser extends AbstractTermsParser {
         }
         if ("_count".equals(key)) {
             return Order.count(asc);
+        }
+        if ("_score".equals(key)) {
+            return Order.score();
         }
         return Order.aggregation(key, asc);
     }

--- a/docs/reference/aggregations/bucket/terms-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/terms-aggregation.asciidoc
@@ -275,6 +275,50 @@ Ordering the buckets alphabetically by their terms in an ascending manner:
 }
 --------------------------------------------------
 
+Ordering the buckets by their best score:
+
+[source,js]
+--------------------------------------------------
+{
+    "aggs" : {
+        "genders" : {
+            "terms" : {
+                "field" : "gender",
+                "order" : { "_score": "asc" }
+            }
+        }
+    }
+}
+--------------------------------------------------
+
+WARNING: Sorting by descending score is not allowed.
+
+Response:
+
+[source,js]
+--------------------------------------------------
+{
+    ...
+
+    "aggregations" : {
+        "genders" : {
+            "doc_count_error_upper_bound": 0, <1>
+            "sum_other_doc_count": 0, <2>
+            "buckets" : [ <3>
+                {
+                    "key" : "male",
+                    "doc_count" : 10,
+                    "max_score": 1.0,
+                },
+                {
+                    "key" : "female",
+                    "doc_count" : 10,
+                    "max_score": 0.75
+                }
+            ]
+        }
+    }
+}
 
 Ordering the buckets by single value metrics sub-aggregation (identified by the aggregation name):
 

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/DoubleTermsTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/DoubleTermsTests.java
@@ -272,6 +272,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(key(bucket), equalTo("" + (double)i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
             assertThat(bucket.getDocCount(), equalTo(1L));
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
         }
     }
 
@@ -298,6 +299,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(key(bucket), equalTo("" + (double) i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
             assertThat(bucket.getDocCount(), equalTo(1L));
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
         }
     }
 
@@ -327,6 +329,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("" + expecteds[i]);
             assertThat(bucket, notNullValue());
             assertThat(bucket.getDocCount(), equalTo(1L));
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
         }
     }
 
@@ -352,6 +355,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(key(bucket), equalTo("" + (double)i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
             assertThat(bucket.getDocCount(), equalTo(1L));
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
             i++;
         }
     }
@@ -378,6 +382,35 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(key(bucket), equalTo("" + (double) i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
             assertThat(bucket.getDocCount(), equalTo(1L));
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
+            i--;
+        }
+    }
+
+    public void testSingleValueFieldOrderedByScore() throws Exception {
+        SearchResponse response = client().prepareSearch("idx").setTypes("type")
+            .setQuery(QueryBuilders.functionScoreQuery(ScoreFunctionBuilders.fieldValueFactorFunction(SINGLE_VALUED_FIELD_NAME)))
+            .addAggregation(terms("terms")
+                .field(SINGLE_VALUED_FIELD_NAME)
+                .collectMode(randomFrom(SubAggCollectionMode.values()))
+                .order(Terms.Order.score()))
+            .execute().actionGet();
+
+        assertSearchResponse(response);
+
+
+        Terms terms = response.getAggregations().get("terms");
+        assertThat(terms, notNullValue());
+        assertThat(terms.getName(), equalTo("terms"));
+        assertThat(terms.getBuckets().size(), equalTo(5));
+
+        int i = 4;
+        for (Terms.Bucket bucket : terms.getBuckets()) {
+            assertThat(bucket, notNullValue());
+            assertThat(key(bucket), equalTo("" + (double) i));
+            assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
+            assertThat(bucket.getDocCount(), equalTo(1L));
+            assertThat(bucket.getMaxScore(), equalTo((float) i));
             i--;
         }
     }
@@ -407,6 +440,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(key(bucket), equalTo("" + (double) i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
             assertThat(bucket.getDocCount(), equalTo(1L));
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
             assertThat((long) sum.getValue(), equalTo(i+i+1L));
@@ -438,6 +472,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(key(bucket), equalTo("" + (i+1d)));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i + 1));
             assertThat(bucket.getDocCount(), equalTo(1L));
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
         }
     }
 
@@ -461,6 +496,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (double) i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
             if (i == 0 || i == 5) {
                 assertThat(bucket.getDocCount(), equalTo(1L));
             } else {
@@ -490,6 +526,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (i+1d)));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i + 1));
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
             if (i == 0 || i == 5) {
                 assertThat(bucket.getDocCount(), equalTo(1L));
             } else {
@@ -519,6 +556,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
         assertThat(key(bucket), equalTo("1.0"));
         assertThat(bucket.getKeyAsNumber().intValue(), equalTo(1));
         assertThat(bucket.getDocCount(), equalTo(5L));
+        assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
     }
 
     /*
@@ -587,6 +625,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             } else {
                 assertThat(bucket.getDocCount(), equalTo(2L));
             }
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
         }
     }
 
@@ -628,6 +667,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(key(bucket), equalTo("" + (double) i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
             assertThat(bucket.getDocCount(), equalTo(1L));
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
         }
     }
 
@@ -676,6 +716,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             Avg avg = bucket.getAggregations().get("avg_i");
             assertThat(avg, notNullValue());
             assertThat(avg.getValue(), equalTo((double) i));
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
         }
     }
 
@@ -719,6 +760,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
                 assertThat(subBucket, notNullValue());
                 assertThat(key(subBucket), equalTo(String.valueOf(j)));
                 assertThat(subBucket.getDocCount(), equalTo(1L));
+                assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
                 j++;
             }
         }
@@ -952,6 +994,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             Stats stats = bucket.getAggregations().get("stats");
             assertThat(stats, notNullValue());
             assertThat(stats.getMax(), equalTo((double) i));
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
         }
     }
 
@@ -981,6 +1024,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             Stats stats = bucket.getAggregations().get("stats");
             assertThat(stats, notNullValue());
             assertThat(stats.getMax(), equalTo((double) i));
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
         }
     }
 
@@ -1010,6 +1054,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             ExtendedStats stats = bucket.getAggregations().get("stats");
             assertThat(stats, notNullValue());
             assertThat(stats.getMax(), equalTo((double) i));
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
         }
 
     }
@@ -1037,6 +1082,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(key(bucket), equalTo("" + (double)i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
             assertThat(bucket.getDocCount(), equalTo(i == 1 ? 3L : 1L));
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
         }
     }
 
@@ -1094,6 +1140,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
         int i = 0;
         for (Terms.Bucket bucket : terms.getBuckets()) {
             assertThat(bucket, notNullValue());
+            assertThat(bucket.getMaxScore(), equalTo(Float.NaN));
             assertThat(key(bucket), equalTo(String.valueOf(expectedKeys[i])));
             assertThat(bucket.getDocCount(), equalTo(expectedMultiSortBuckets.get(expectedKeys[i]).get("_count")));
             Avg avg = bucket.getAggregations().get("avg_l");


### PR DESCRIPTION
- Sort terms by max score in the bucket.

This is already achievable with a max aggregation and the aggregation order but this would be needed if we decide to implement the breadth_first strategy when the score is needed.
Currently the breadth_first strategy is not possible when the score is needed or if the sort is extracted from an inner aggregation.
With this approach we could break the second limitation and focus on the first one.
Relates to #9825
