### PR TITLE
Update misc.asciidoc

### DIFF
--- a/docs/reference/modules/cluster/misc.asciidoc
+++ b/docs/reference/modules/cluster/misc.asciidoc
@@ -21,19 +21,18 @@ API can make the cluster read-write again.
 ==== Index Tombstones
 
 The cluster state maintains index tombstones to explicitly denote indices that 
-have been deleted.  The tombstones are maintained to prevent indices that were 
-deleted when a node was offline from being reimported as dangling indices when 
-the node comes back online.  The number of tombstones maintained in the cluster 
-state is controlled by the following property, which cannot be updated dynamically:
+have been deleted.  The number of tombstones maintained in the cluster state is 
+controlled by the following property, which cannot be updated dynamically:
 
 `cluster.indices.tombstones.size`::
 
-The maximum number of tombstones that can be in the cluster state before tombstones 
-are purged.  The current default is 500.  Index tombstones remain in the cluster state, 
-until the maximum is exceeded, at which point tombstones are purged to stay within the 
-maximum allowed.  If you change this setting, set the value to the maximum number 
-of index deletions that are expected during the average node downtime in a cluster.
-Otherwise, you may occasionally see deleted indices re-imported as dangling indices.
+Index tombstones prevent nodes that are not part of the cluster when a delete 
+occurs from joining the cluster and reimporting the index as though the delete 
+was never issued. To keep the cluster state from growing huge we only keep the 
+last `cluster.indices.tombstones.size` deletes, which defaults to 500. You can 
+increase it if you expect nodes to be absent from the cluster and miss more 
+than 500 deletes. We think that is rare, thus the default. Tombstones don't take 
+up much space, but we also think that a number like 50,000 is probably too big.
 
 [[cluster-logger]]
 ==== Logger

--- a/docs/reference/modules/cluster/misc.asciidoc
+++ b/docs/reference/modules/cluster/misc.asciidoc
@@ -20,24 +20,20 @@ API can make the cluster read-write again.
 [[cluster-max-tombstones]]
 ==== Index Tombstones
 
-The cluster state maintains index tombstones to explicitely denote indices that 
+The cluster state maintains index tombstones to explicitly denote indices that 
 have been deleted.  The tombstones are maintained to prevent indices that were 
 deleted when a node was offline from being reimported as dangling indices when 
 the node comes back online.  The number of tombstones maintained in the cluster 
-state is controlled by the following property:
+state is controlled by the following property, which cannot be updated dynamically:
 
 `cluster.indices.tombstones.size`::
 
 The maximum number of tombstones that can be in the cluster state before tombstones 
-are purged.  The current default is 500.  Index tombstones remain in the cluster state 
-forever, until the maximum is exceeded, at which point tombstones are purged to stay 
-within the maximum allowed.  If your use case involves a large amount of regular index 
-deletions (on the order of hundreds per day) and you tend to have cluster instability 
-with nodes leaving and rejoining frequently, you may want to increase this setting to 
-something higher (even potentially much higher, depending on how many index deletions 
-you have).  Otherwise, you may occasionally see deleted indices re-imported as dangling
-indices.
-
+are purged.  The current default is 500.  Index tombstones remain in the cluster state, 
+until the maximum is exceeded, at which point tombstones are purged to stay within the 
+maximum allowed.  If you change this setting, set the value to the maximum number 
+of index deletions that are expected during the average node downtime in a cluster.
+Otherwise, you may occasionally see deleted indices re-imported as dangling indices.
 
 [[cluster-logger]]
 ==== Logger

--- a/docs/reference/modules/cluster/misc.asciidoc
+++ b/docs/reference/modules/cluster/misc.asciidoc
@@ -35,7 +35,7 @@ within the maximum allowed.  If your use case involves a large amount of regular
 deletions (on the order of hundreds per day) and you tend to have cluster instability 
 with nodes leaving and rejoining frequently, you may want to increase this setting to 
 something higher (even potentially much higher, depending on how many index deletions 
-you have).  Otherwise, you may see occasional deleted indices re-imported as dangling
+you have).  Otherwise, you may occasionally see deleted indices re-imported as dangling
 indices.
 
 

--- a/docs/reference/modules/cluster/misc.asciidoc
+++ b/docs/reference/modules/cluster/misc.asciidoc
@@ -17,6 +17,28 @@ user with access to the <<cluster-update-settings,cluster-update-settings>>
 API can make the cluster read-write again.
 
 
+[[cluster-max-tombstones]]
+==== Index Tombstones
+
+The cluster state maintains index tombstones to explicitely denote indices that 
+have been deleted.  The tombstones are maintained to prevent indices that were 
+deleted when a node was offline from being reimported as dangling indices when 
+the node comes back online.  The number of tombstones maintained in the cluster 
+state is controlled by the following property:
+
+`cluster.indices.tombstones.size`::
+
+The maximum number of tombstones that can be in the cluster state before tombstones 
+are purged.  The current default is 500.  Index tombstones remain in the cluster state 
+forever, until the maximum is exceeded, at which point tombstones are purged to stay 
+within the maximum allowed.  If your use case involves a large amount of regular index 
+deletions (on the order of hundreds per day) and you tend to have cluster instability 
+with nodes leaving and rejoining frequently, you may want to increase this setting to 
+something higher (even potentially much higher, depending on how many index deletions 
+you have).  Otherwise, you may see occasional deleted indices re-imported as dangling
+indices.
+
+
 [[cluster-logger]]
 ==== Logger
 


### PR DESCRIPTION
Added documentation for the cluster.indices.tombstones.size property for maximum tombstones in the cluster state.
