### PR TITLE
painless: optimize/simplify dynamic field and method access

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
@@ -241,7 +241,8 @@ public class Def {
         }
     }
 
-    public static Method getMethod(final Object owner, final String name, final Definition definition) {
+    /** Method lookup for owner.name(), returns null if no matching method was found */ 
+    private static Method getMethod(final Object owner, final String name, final Definition definition) {
         Class<?> clazz = owner.getClass();
 
         while (clazz != null) {
@@ -273,7 +274,8 @@ public class Def {
         return null;
     }
 
-    public static Field getField(final Object owner, final String name, final Definition definition) {
+    /** Field lookup for owner.name, returns null if no matching field was found */ 
+    private static Field getField(final Object owner, final String name, final Definition definition) {
         Class<?> clazz = owner.getClass();
 
         while (clazz != null) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
@@ -242,18 +242,16 @@ public class Def {
     }
 
     public static Method getMethod(final Object owner, final String name, final Definition definition) {
-        Struct struct = null;
         Class<?> clazz = owner.getClass();
-        Method method = null;
 
         while (clazz != null) {
-            struct = definition.classes.get(clazz);
+            Struct struct = definition.classes.get(clazz);
 
             if (struct != null) {
-                method = struct.methods.get(name);
+                Method method = struct.methods.get(name);
 
                 if (method != null) {
-                    break;
+                    return method;
                 }
             }
 
@@ -261,45 +259,31 @@ public class Def {
                 struct = definition.classes.get(iface);
 
                 if (struct != null) {
-                    method = struct.methods.get(name);
+                    Method method = struct.methods.get(name);
 
                     if (method != null) {
-                        break;
+                        return method;
                     }
-                }
-            }
-
-            if (struct != null) {
-                method = struct.methods.get(name);
-
-                if (method != null) {
-                    break;
                 }
             }
 
             clazz = clazz.getSuperclass();
         }
 
-        if (struct == null) {
-            throw new IllegalArgumentException("Unable to find a dynamic struct for class [" + owner.getClass() + "].");
-        }
-
-        return method;
+        return null;
     }
 
     public static Field getField(final Object owner, final String name, final Definition definition) {
-        Struct struct = null;
         Class<?> clazz = owner.getClass();
-        Field field = null;
 
         while (clazz != null) {
-            struct = definition.classes.get(clazz);
+            Struct struct = definition.classes.get(clazz);
 
             if (struct != null) {
-                field = struct.members.get(name);
+                Field field = struct.members.get(name);
 
                 if (field != null) {
-                    break;
+                    return field;
                 }
             }
 
@@ -307,30 +291,18 @@ public class Def {
                 struct = definition.classes.get(iface);
 
                 if (struct != null) {
-                    field = struct.members.get(name);
+                    Field field = struct.members.get(name);
 
                     if (field != null) {
-                        break;
+                        return field;
                     }
-                }
-            }
-
-            if (struct != null) {
-                field = struct.members.get(name);
-
-                if (field != null) {
-                    break;
                 }
             }
 
             clazz = clazz.getSuperclass();
         }
 
-        if (struct == null) {
-            throw new IllegalArgumentException("Unable to find a dynamic struct for class [" + owner.getClass() + "].");
-        }
-
-        return field;
+        return null;
     }
 
     public static Transform getTransform(Class<?> fromClass, Class<?> toClass, final Definition definition) {


### PR DESCRIPTION
The current code checks each classes hash twice. This results in more hash lookups than we really need. Also I think using 'return' instead of 'break' here just makes the code easier to read.

for dynamic access speedup is as high as 20%. this codepath will always be the worst case, even if we add fancy stuff to avoid it later.

@jdconrad can you look?
