### PR TITLE
Default to server VM and add client VM check

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -246,12 +246,6 @@ final class Bootstrap {
             PidFile.create(environment.pidFile(), true);
         }
 
-        // warn if running using the client VM
-        if (JvmInfo.jvmInfo().getVmName().toLowerCase(Locale.ROOT).contains("client")) {
-            ESLogger logger = Loggers.getLogger(Bootstrap.class);
-            logger.warn("jvm uses the client vm, make sure to run `java` with the server vm for best performance by adding `-server` to the command line");
-        }
-
         try {
             if (!foreground) {
                 Loggers.disableConsoleLogging();

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
@@ -163,6 +163,7 @@ final class BootstrapCheck {
         if (Constants.LINUX) {
             checks.add(new MaxMapCountCheck());
         }
+        checks.add(new ClientJvmCheck());
         return Collections.unmodifiableList(checks);
     }
 
@@ -472,6 +473,33 @@ final class BootstrapCheck {
         @Override
         public final boolean isSystemCheck() {
             return true;
+        }
+
+    }
+
+    static class ClientJvmCheck implements BootstrapCheck.Check {
+
+        @Override
+        public boolean check() {
+            return getVmName().toLowerCase(Locale.ROOT).contains("client");
+        }
+
+        // visible for testing
+        String getVmName() {
+            return JvmInfo.jvmInfo().getVmName();
+        }
+
+        @Override
+        public String errorMessage() {
+            return String.format(
+                    Locale.ROOT,
+                    "JVM is using the client VM [%s] but should be using a server VM for the best performance",
+                    getVmName());
+        }
+
+        @Override
+        public final boolean isSystemCheck() {
+            return false;
         }
 
     }

--- a/distribution/src/main/resources/config/jvm.options
+++ b/distribution/src/main/resources/config/jvm.options
@@ -48,6 +48,9 @@
 
 ## basic
 
+# force the server VM
+-server
+
 # set to headless, just in case
 -Djava.awt.headless=true
 


### PR DESCRIPTION
Today we softly warn about running with the client VM. However, we
should really refuse to start in production mode if running with the
client VM as the performance of the client VM is too devastating for a
server application. This commit adds an option to jvm.options to ensure
that we are starting with the server VM (on all 32-bit non-Windows
platforms on server-class machines (2+ CPUs, 2+ GB physical RAM) this is
the default and on all 64-bit platforms this is the only option) and
adds a bootstrap check for the client VM.
