### PR TITLE
Packaging: Make rpm not include parent dirs

### DIFF
--- a/distribution/rpm/build.gradle
+++ b/distribution/rpm/build.gradle
@@ -40,6 +40,7 @@ task buildRpm(type: Rpm) {
   vendor 'Elasticsearch'
   dirMode 0755
   fileMode 0644
+  addParentDirs false
   // TODO ospackage doesn't support icon but we used to have one
 }
 


### PR DESCRIPTION
With this change, the contents of the rpm are now this:

```
/etc/elasticsearch
/etc/elasticsearch/elasticsearch.yml
/etc/elasticsearch/jvm.options
/etc/elasticsearch/logging.yml
/etc/elasticsearch/scripts
/etc/init.d/elasticsearch
/etc/sysconfig/elasticsearch
/usr/lib/sysctl.d/elasticsearch.conf
/usr/lib/systemd/system/elasticsearch.service
/usr/lib/tmpfiles.d/elasticsearch.conf
/usr/share/elasticsearch/LICENSE.txt
/usr/share/elasticsearch/NOTICE.txt
/usr/share/elasticsearch/README.textile
/usr/share/elasticsearch/bin/elasticsearch
/usr/share/elasticsearch/bin/elasticsearch-plugin
/usr/share/elasticsearch/bin/elasticsearch-systemd-pre-exec
/usr/share/elasticsearch/bin/elasticsearch.in.sh
/usr/share/elasticsearch/lib/HdrHistogram-2.1.6.jar
/usr/share/elasticsearch/lib/apache-log4j-extras-1.2.17.jar
/usr/share/elasticsearch/lib/elasticsearch-5.0.0-alpha2-SNAPSHOT.jar
/usr/share/elasticsearch/lib/hppc-0.7.1.jar
/usr/share/elasticsearch/lib/jackson-core-2.7.1.jar
/usr/share/elasticsearch/lib/jackson-dataformat-cbor-2.7.1.jar
/usr/share/elasticsearch/lib/jackson-dataformat-smile-2.7.1.jar
/usr/share/elasticsearch/lib/jackson-dataformat-yaml-2.7.1.jar
/usr/share/elasticsearch/lib/jna-4.1.0.jar
/usr/share/elasticsearch/lib/joda-convert-1.2.jar
/usr/share/elasticsearch/lib/joda-time-2.8.2.jar
/usr/share/elasticsearch/lib/jopt-simple-4.9.jar
/usr/share/elasticsearch/lib/jts-1.13.jar
/usr/share/elasticsearch/lib/log4j-1.2.17.jar
/usr/share/elasticsearch/lib/lucene-analyzers-common-6.0.0.jar
/usr/share/elasticsearch/lib/lucene-backward-codecs-6.0.0.jar
/usr/share/elasticsearch/lib/lucene-core-6.0.0.jar
/usr/share/elasticsearch/lib/lucene-grouping-6.0.0.jar
/usr/share/elasticsearch/lib/lucene-highlighter-6.0.0.jar
/usr/share/elasticsearch/lib/lucene-join-6.0.0.jar
/usr/share/elasticsearch/lib/lucene-memory-6.0.0.jar
/usr/share/elasticsearch/lib/lucene-misc-6.0.0.jar
/usr/share/elasticsearch/lib/lucene-queries-6.0.0.jar
/usr/share/elasticsearch/lib/lucene-queryparser-6.0.0.jar
/usr/share/elasticsearch/lib/lucene-sandbox-6.0.0.jar
/usr/share/elasticsearch/lib/lucene-spatial-6.0.0.jar
/usr/share/elasticsearch/lib/lucene-spatial-extras-6.0.0.jar
/usr/share/elasticsearch/lib/lucene-spatial3d-6.0.0.jar
/usr/share/elasticsearch/lib/lucene-suggest-6.0.0.jar
/usr/share/elasticsearch/lib/netty-3.10.5.Final.jar
/usr/share/elasticsearch/lib/securesm-1.0.jar
/usr/share/elasticsearch/lib/spatial4j-0.6.jar
/usr/share/elasticsearch/lib/t-digest-3.0.jar
/usr/share/elasticsearch/modules/ingest-grok/ingest-grok-5.0.0-alpha2-SNAPSHOT.jar
/usr/share/elasticsearch/modules/ingest-grok/jcodings-1.0.12.jar
/usr/share/elasticsearch/modules/ingest-grok/joni-2.1.6.jar
/usr/share/elasticsearch/modules/ingest-grok/plugin-descriptor.properties
/usr/share/elasticsearch/modules/lang-expression/antlr4-runtime-4.5.1-1.jar
/usr/share/elasticsearch/modules/lang-expression/asm-5.0.4.jar
/usr/share/elasticsearch/modules/lang-expression/asm-commons-5.0.4.jar
/usr/share/elasticsearch/modules/lang-expression/asm-tree-5.0.4.jar
/usr/share/elasticsearch/modules/lang-expression/lang-expression-5.0.0-alpha2-SNAPSHOT.jar
/usr/share/elasticsearch/modules/lang-expression/lucene-expressions-6.0.0.jar
/usr/share/elasticsearch/modules/lang-expression/plugin-descriptor.properties
/usr/share/elasticsearch/modules/lang-expression/plugin-security.policy
/usr/share/elasticsearch/modules/lang-groovy/groovy-2.4.6-indy.jar
/usr/share/elasticsearch/modules/lang-groovy/lang-groovy-5.0.0-alpha2-SNAPSHOT.jar
/usr/share/elasticsearch/modules/lang-groovy/plugin-descriptor.properties
/usr/share/elasticsearch/modules/lang-groovy/plugin-security.policy
/usr/share/elasticsearch/modules/lang-mustache/compiler-0.9.1.jar
/usr/share/elasticsearch/modules/lang-mustache/lang-mustache-5.0.0-alpha2-SNAPSHOT.jar
/usr/share/elasticsearch/modules/lang-mustache/plugin-descriptor.properties
/usr/share/elasticsearch/modules/lang-mustache/plugin-security.policy
/usr/share/elasticsearch/modules/lang-painless/antlr4-runtime-4.5.1-1.jar
/usr/share/elasticsearch/modules/lang-painless/asm-5.0.4.jar
/usr/share/elasticsearch/modules/lang-painless/asm-commons-5.0.4.jar
/usr/share/elasticsearch/modules/lang-painless/asm-tree-5.0.4.jar
/usr/share/elasticsearch/modules/lang-painless/lang-painless-5.0.0-alpha2-SNAPSHOT.jar
/usr/share/elasticsearch/modules/lang-painless/plugin-descriptor.properties
/usr/share/elasticsearch/modules/lang-painless/plugin-security.policy
/usr/share/elasticsearch/modules/reindex/plugin-descriptor.properties
/usr/share/elasticsearch/modules/reindex/reindex-5.0.0-alpha2-SNAPSHOT.jar
/usr/share/elasticsearch/plugins
/var/lib/elasticsearch
/var/log/elasticsearch
/var/run/elasticsearch
```

closes #18162
