### PR TITLE
Tests: Delay starting progress loggers for vagrant until test is running

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/TapLoggerOutputStream.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/TapLoggerOutputStream.groovy
@@ -19,9 +19,11 @@
 package org.elasticsearch.gradle.vagrant
 
 import com.carrotsearch.gradle.junit4.LoggingOutputStream
+import groovy.transform.PackageScope
 import org.gradle.api.GradleScriptException
 import org.gradle.api.logging.Logger
 import org.gradle.logging.ProgressLogger
+import org.gradle.logging.ProgressLoggerFactory
 
 import java.util.regex.Matcher
 
@@ -35,73 +37,77 @@ import java.util.regex.Matcher
  * There is a Tap4j project but we can't use it because it wants to parse the
  * entire TAP stream at once and won't parse it stream-wise.
  */
-class TapLoggerOutputStream extends LoggingOutputStream {
-  ProgressLogger progressLogger
-  Logger logger
-  int testsCompleted = 0
-  int testsFailed = 0
-  int testsSkipped = 0
-  Integer testCount
-  String countsFormat
+public class TapLoggerOutputStream extends LoggingOutputStream {
+    private final ProgressLogger progressLogger
+    private boolean isStarted = false
+    private final Logger logger
+    private int testsCompleted = 0
+    private int testsFailed = 0
+    private int testsSkipped = 0
+    private Integer testCount
+    private String countsFormat
 
-  TapLoggerOutputStream(Map args) {
-    logger = args.logger
-    progressLogger = args.factory.newOperation(VagrantLoggerOutputStream)
-    progressLogger.setDescription("TAP output for `$args.command`")
-    progressLogger.started()
-    progressLogger.progress("Starting `$args.command`...")
-  }
-
-  void flush() {
-    if (end == start) return
-    line(new String(buffer, start, end - start))
-    start = end
-  }
-
-  void line(String line) {
-    // System.out.print "===> $line\n"
-    if (testCount == null) {
-      try {
-        testCount = line.split('\\.').last().toInteger()
-        def length = (testCount as String).length()
-        countsFormat = "%0${length}d"
-        countsFormat = "[$countsFormat|$countsFormat|$countsFormat/$countsFormat]"
-        return
-      } catch (Exception e) {
-        throw new GradleScriptException(
-          'Error parsing first line of TAP stream!!', e)
-      }
-    }
-    Matcher m = line =~ /(?<status>ok|not ok) \d+(?<skip> # skip (?<skipReason>\(.+\))?)? \[(?<suite>.+)\] (?<test>.+)/
-    if (!m.matches()) {
-      /* These might be failure report lines or comments or whatever. Its hard
-        to tell and it doesn't matter. */
-      logger.warn(line)
-      return
-    }
-    boolean skipped = m.group('skip') != null
-    boolean success = !skipped && m.group('status') == 'ok'
-    String skipReason = m.group('skipReason')
-    String suiteName = m.group('suite')
-    String testName = m.group('test')
-
-    String status
-    if (skipped) {
-      status = "SKIPPED"
-      testsSkipped++
-    } else if (success) {
-      status = "     OK"
-      testsCompleted++
-    } else {
-      status = " FAILED"
-      testsFailed++
+    TapLoggerOutputStream(Map args) {
+        logger = args.logger
+        progressLogger = args.factory.newOperation(VagrantLoggerOutputStream)
+        progressLogger.setDescription("TAP output for `${args.command}`")
     }
 
-    String counts = sprintf(countsFormat,
-      [testsCompleted, testsFailed, testsSkipped, testCount])
-    progressLogger.progress("Tests $counts, $status [$suiteName] $testName")
-    if (!success) {
-      logger.warn(line)
+    @Override
+    public void flush() {
+        if (isStarted == false) {
+            progressLogger.started()
+            isStarted = true
+        }
+        if (end == start) return
+        line(new String(buffer, start, end - start))
+        start = end
     }
-  }
+
+    void line(String line) {
+        // System.out.print "===> $line\n"
+        if (testCount == null) {
+            try {
+                testCount = line.split('\\.').last().toInteger()
+                def length = (testCount as String).length()
+                countsFormat = "%0${length}d"
+                countsFormat = "[$countsFormat|$countsFormat|$countsFormat/$countsFormat]"
+                return
+            } catch (Exception e) {
+                throw new GradleScriptException(
+                        'Error parsing first line of TAP stream!!', e)
+            }
+        }
+        Matcher m = line =~ /(?<status>ok|not ok) \d+(?<skip> # skip (?<skipReason>\(.+\))?)? \[(?<suite>.+)\] (?<test>.+)/
+        if (!m.matches()) {
+            /* These might be failure report lines or comments or whatever. Its hard
+              to tell and it doesn't matter. */
+            logger.warn(line)
+            return
+        }
+        boolean skipped = m.group('skip') != null
+        boolean success = !skipped && m.group('status') == 'ok'
+        String skipReason = m.group('skipReason')
+        String suiteName = m.group('suite')
+        String testName = m.group('test')
+
+        String status
+        if (skipped) {
+            status = "SKIPPED"
+            testsSkipped++
+        } else if (success) {
+            status = "     OK"
+            testsCompleted++
+        } else {
+            status = " FAILED"
+            testsFailed++
+        }
+
+        String counts = sprintf(countsFormat,
+                [testsCompleted, testsFailed, testsSkipped, testCount])
+        progressLogger.progress("Tests $counts, $status [$suiteName] $testName")
+        if (!success) {
+            logger.warn(line)
+        }
+    }
 }


### PR DESCRIPTION
This was broken recently as part of making the vagrant tasks extend
LoggedExec. This change fixes the progress logger to not be started
until we start seeing output from vagrant.
