### PR TITLE
Add back Version.V_5_0_0.

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,4 +1,4 @@
-elasticsearch     = 5.0.0-alpha2
+elasticsearch     = 5.0.0
 lucene            = 6.0.0
 
 # optional dependencies

--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -73,7 +73,9 @@ public class Version {
     public static final Version V_5_0_0_alpha1 = new Version(V_5_0_0_alpha1_ID, org.apache.lucene.util.Version.LUCENE_6_0_0);
     public static final int V_5_0_0_alpha2_ID = 5000002;
     public static final Version V_5_0_0_alpha2 = new Version(V_5_0_0_alpha2_ID, org.apache.lucene.util.Version.LUCENE_6_0_0);
-    public static final Version CURRENT = V_5_0_0_alpha2;
+    public static final int V_5_0_0_ID = 5000099;
+    public static final Version V_5_0_0 = new Version(V_5_0_0_ID, org.apache.lucene.util.Version.LUCENE_6_0_0);
+    public static final Version CURRENT = V_5_0_0;
 
     static {
         assert CURRENT.luceneVersion.equals(org.apache.lucene.util.Version.LATEST) : "Version must be upgraded to ["
@@ -86,6 +88,8 @@ public class Version {
 
     public static Version fromId(int id) {
         switch (id) {
+            case V_5_0_0_ID:
+                return V_5_0_0;
             case V_5_0_0_alpha2_ID:
                 return V_5_0_0_alpha2;
             case V_5_0_0_alpha1_ID:

--- a/qa/backwards-5.0/build.gradle
+++ b/qa/backwards-5.0/build.gradle
@@ -18,6 +18,6 @@ integTest {
   cluster {
     numNodes = 2
     numBwcNodes = 1
-    bwcVersion = "5.0.0-alpha2-SNAPSHOT" // this is the same as the current version until we released the first RC
+    bwcVersion = "5.0.0-SNAPSHOT" // this is the same as the current version until we released the first RC
   }
 }


### PR DESCRIPTION
This was lost whene releasing alpha2 since the version constant got renamed.
