### PR TITLE
Remove StringBuilder reuse for uid creation.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -327,11 +327,6 @@ public abstract class ParseContext {
         }
 
         @Override
-        public StringBuilder stringBuilder() {
-            return in.stringBuilder();
-        }
-
-        @Override
         public void addDynamicMapper(Mapper update) {
             in.addDynamicMapper(update);
         }
@@ -365,8 +360,6 @@ public abstract class ParseContext {
         private String id;
 
         private Field uid, version;
-
-        private StringBuilder stringBuilder = new StringBuilder();
 
         private AllEntries allEntries = new AllEntries();
 
@@ -524,16 +517,6 @@ public abstract class ParseContext {
         @Override
         public AllEntries allEntries() {
             return this.allEntries;
-        }
-
-        /**
-         * A string builder that can be used to construct complex names for example.
-         * Its better to reuse the.
-         */
-        @Override
-        public StringBuilder stringBuilder() {
-            stringBuilder.setLength(0);
-            return this.stringBuilder;
         }
 
         @Override
@@ -735,12 +718,6 @@ public abstract class ParseContext {
         }
         return clazz.cast(externalValue());
     }
-
-    /**
-     * A string builder that can be used to construct complex names for example.
-     * Its better to reuse the.
-     */
-    public abstract StringBuilder stringBuilder();
 
     /**
      * Add a new mapper dynamically created while parsing.

--- a/core/src/main/java/org/elasticsearch/index/mapper/Uid.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/Uid.java
@@ -123,13 +123,6 @@ public final class Uid {
         return ref;
     }
 
-    public static BytesRef createUidAsBytes(BytesRef type, BytesRef id, BytesRefBuilder spare) {
-        spare.copyBytes(type);
-        spare.append(DELIMITER_BYTES);
-        spare.append(id);
-        return spare.get();
-    }
-
     public static BytesRef[] createUidsForTypesAndId(Collection<String> types, Object id) {
         return createUidsForTypesAndIds(types, Collections.singletonList(id));
     }
@@ -149,11 +142,7 @@ public final class Uid {
     }
 
     public static String createUid(String type, String id) {
-        return createUid(new StringBuilder(), type, id);
-    }
-
-    public static String createUid(StringBuilder sb, String type, String id) {
-        return sb.append(type).append(DELIMITER).append(id).toString();
+        return type + DELIMITER + id;
     }
 
     public static boolean hasDelimiter(BytesRef uid) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
@@ -31,7 +31,6 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.loader.SettingsLoader;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -264,7 +263,7 @@ public class ParentFieldMapper extends MetadataFieldMapper {
                     }
                     // we did not add it in the parsing phase, add it now
                     fields.add(new SortedDocValuesField(fieldType.name(), new BytesRef(parentId)));
-                } else if (parentId != null && !parsedParentId.equals(Uid.createUid(context.stringBuilder(), parentType, parentId))) {
+                } else if (parentId != null && !parsedParentId.equals(Uid.createUid(parentType, parentId))) {
                     throw new MapperParsingException("Parent id mismatch, document value is [" + Uid.createUid(parsedParentId).id() + "], while external value is [" + parentId + "]");
                 }
             }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
@@ -23,7 +23,6 @@ import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.index.Term;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
@@ -177,7 +176,7 @@ public class UidFieldMapper extends MetadataFieldMapper {
 
     @Override
     protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
-        Field uid = new Field(NAME, Uid.createUid(context.stringBuilder(), context.type(), context.id()), Defaults.FIELD_TYPE);
+        Field uid = new Field(NAME, Uid.createUid(context.type(), context.id()), Defaults.FIELD_TYPE);
         context.uid(uid);
         fields.add(uid);
         if (fieldType().hasDocValues()) {


### PR DESCRIPTION
This would be better handled by escape analysis.
