### PR TITLE
Preserve config files from RPM install

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -322,12 +322,13 @@ configure(subprojects.findAll { ['deb', 'rpm'].contains(it.name) }) {
     configurationFile '/etc/elasticsearch/elasticsearch.yml'
     configurationFile '/etc/elasticsearch/jvm.options'
     configurationFile '/etc/elasticsearch/logging.yml'
-    into('/etc') {
-      from "${packagingFiles}/etc"
+    into('/etc/elasticsearch') {
       fileMode 0750
       permissionGroup 'elasticsearch'
       includeEmptyDirs true
       createDirectoryEntry true
+      fileType CONFIG | NOREPLACE
+      from "${packagingFiles}/etc/elasticsearch"
     }
 
     into('/usr/lib/tmpfiles.d') {
@@ -335,21 +336,25 @@ configure(subprojects.findAll { ['deb', 'rpm'].contains(it.name) }) {
     }
     configurationFile '/usr/lib/systemd/system/elasticsearch.service'
     into('/usr/lib/systemd/system') {
+      fileType CONFIG | NOREPLACE
       from "${packagingFiles}/systemd/elasticsearch.service"
     }
     into('/usr/lib/sysctl.d') {
+      fileType CONFIG | NOREPLACE
       from "${packagingFiles}/systemd/sysctl/elasticsearch.conf"
     }
     configurationFile '/etc/init.d/elasticsearch'
     into('/etc/init.d') {
-      from "${packagingFiles}/init.d/elasticsearch"
       fileMode 0755
+      fileType CONFIG | NOREPLACE
+      from "${packagingFiles}/init.d/elasticsearch"
     }
     configurationFile project.expansions['path.env']
     into(new File(project.expansions['path.env']).getParent()) {
-      from "${project.packagingFiles}/env/elasticsearch"
       fileMode 0644
       dirMode 0755
+      fileType CONFIG | NOREPLACE
+      from "${project.packagingFiles}/env/elasticsearch"
     }
 
     /**

--- a/distribution/src/main/packaging/scripts/postrm
+++ b/distribution/src/main/packaging/scripts/postrm
@@ -55,6 +55,7 @@ LOG_DIR="/var/log/elasticsearch"
 PLUGINS_DIR="/usr/share/elasticsearch/plugins"
 PID_DIR="/var/run/elasticsearch"
 DATA_DIR="/var/lib/elasticsearch"
+CONF_DIR="/etc/elasticsearch"
 
 # Source the default env file
 if [ "$SOURCE_ENV_FILE" = "true" ]; then
@@ -102,6 +103,12 @@ if [ "$REMOVE_DIRS" = "true" ]; then
     if [ -d "$DATA_DIR" ]; then
         rmdir --ignore-fail-on-non-empty "$DATA_DIR"
     fi
+
+    # delete the conf directory if and only if empty
+    if [ -d "$CONF_DIR" ]; then
+        rmdir --ignore-fail-on-non-empty "$CONF_DIR"
+    fi
+
 fi
 
 if [ "$REMOVE_USER_AND_GROUP" = "true" ]; then

--- a/distribution/src/main/packaging/scripts/prerm
+++ b/distribution/src/main/packaging/scripts/prerm
@@ -64,4 +64,10 @@ if [ "$STOP_REQUIRED" = "true" ]; then
     echo " OK"
 fi
 
+SCRIPTS_DIR="/etc/elasticsearch/scripts"
+# delete the scripts directory if and only if empty
+if [ -d "$SCRIPTS_DIR" ]; then
+    rmdir --ignore-fail-on-non-empty "$SCRIPTS_DIR"
+fi
+
 ${scripts.footer}

--- a/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
@@ -116,7 +116,7 @@ setup() {
 
     assert_file_not_exist "/etc/elasticsearch"
     assert_file_not_exist "/etc/elasticsearch/elasticsearch.yml"
-    assert_file_not_exist  "/etc/elasticsearch/jvm.options"
+    assert_file_not_exist "/etc/elasticsearch/jvm.options"
     assert_file_not_exist "/etc/elasticsearch/logging.yml"
 
     assert_file_not_exist "/etc/init.d/elasticsearch"
@@ -124,7 +124,6 @@ setup() {
 
     assert_file_not_exist "/etc/sysconfig/elasticsearch"
 }
-
 
 @test "[RPM] reinstall package" {
     rpm -i elasticsearch-$(cat version).rpm
@@ -134,12 +133,46 @@ setup() {
     rpm -qe 'elasticsearch'
 }
 
-@test "[RPM] verify package reinstallation" {
-    verify_package_installation
+@test "[RPM] reremove package" {
+    echo "# ping" >> "/etc/elasticsearch/elasticsearch.yml"
+    echo "# ping" >> "/etc/elasticsearch/jvm.options"
+    echo "# ping" >> "/etc/elasticsearch/logging.yml"
+    echo "# ping" >> "/etc/elasticsearch/scripts/script"
+    rpm -e 'elasticsearch'
 }
 
-@test "[RPM] reremove package" {
-    rpm -e 'elasticsearch'
+@test "[RPM] verify preservation" {
+    # The removal must disable the service
+    # see prerm file
+    if is_systemd; then
+        run systemctl is-enabled elasticsearch.service
+        [ "$status" -eq 1 ]
+    fi
+
+    # Those directories are deleted when removing the package
+    # see postrm file
+    assert_file_not_exist "/var/log/elasticsearch"
+    assert_file_not_exist "/usr/share/elasticsearch/plugins"
+    assert_file_not_exist "/var/run/elasticsearch"
+
+    assert_file_not_exist "/etc/elasticsearch/elasticsearch.yml"
+    assert_file_exist "/etc/elasticsearch/elasticsearch.yml.rpmsave"
+    assert_file_not_exist "/etc/elasticsearch/jvm.options"
+    assert_file_exist "/etc/elasticsearch/jvm.options.rpmsave"
+    assert_file_not_exist "/etc/elasticsearch/logging.yml"
+    assert_file_exist "/etc/elasticsearch/logging.yml.rpmsave"
+    assert_file_exist "/etc/elasticsearch/scripts.rpmsave"
+    assert_file_exist "/etc/elasticsearch/scripts.rpmsave/script"
+
+    assert_file_not_exist "/etc/init.d/elasticsearch"
+    assert_file_not_exist "/usr/lib/systemd/system/elasticsearch.service"
+
+    assert_file_not_exist "/etc/sysconfig/elasticsearch"
+}
+
+@test "[RPM] finalize package removal" {
+    # cleanup
+    rm -rf /etc/elasticsearch
 }
 
 @test "[RPM] package has been removed again" {


### PR DESCRIPTION
This commit modifies the packaging for the RPM package so that edits to
config files will not get lost during removal and upgrade.

Closes #18158
