### PR TITLE
add check for non-existent pipelines provided to simulate requests

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
@@ -132,6 +132,9 @@ public class SimulatePipelineRequest extends ActionRequest<SimulatePipelineReque
             throw new IllegalArgumentException("param [pipeline] is null");
         }
         Pipeline pipeline = pipelineStore.get(pipelineId);
+        if (pipeline == null) {
+            throw new IllegalArgumentException("pipeline [" + pipelineId + "] does not exist");
+        }
         List<IngestDocument> ingestDocumentList = parseDocs(config);
         return new Parsed(pipeline, ingestDocumentList, verbose);
     }


### PR DESCRIPTION
Instead of receiving a

```
{
"type" : "null_pointer_exception",
"reason" : null
}
```

you now receive a more detailed error:

```
{
"type" : "illegal_argument_exception",
"reason" : "pipeline [<PIPELINE_ID>] does not exist"
}
```

fixes #18139
