### PR TITLE
Build: Add fake project to include buildSrc as normal project

### DIFF
--- a/buildSrc/.gitignore
+++ b/buildSrc/.gitignore
@@ -1,0 +1,1 @@
+build-bootstrap/

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -91,14 +91,10 @@ dependencies {
 
 
 /*****************************************************************************
- *                    Bootstrap repositories and IDE setup                   *
+ *                         Bootstrap repositories                            *
  *****************************************************************************/
 // this will only happen when buildSrc is built on its own during build init
 if (project == rootProject) {
-
-  // TODO: move common IDE configuration to a common file to include
-  apply plugin: 'idea'
-  apply plugin: 'eclipse'
 
   repositories {
     mavenCentral()
@@ -107,30 +103,6 @@ if (project == rootProject) {
       url "https://oss.sonatype.org/content/repositories/snapshots/"
     }
   }
-
-  idea {
-    module {
-      inheritOutputDirs = false
-      outputDir = file('build-idea/classes/main')
-      testOutputDir = file('build-idea/classes/test')
-    }
-  }
-
-  eclipse {
-    classpath {
-      defaultOutputDir = file('build-eclipse')
-    }
-  }
-
-  task copyEclipseSettings(type: Copy) {
-    from project.file('src/main/resources/eclipse.settings')
-    into '.settings'
-  }
-  // otherwise .settings is not nuked entirely
-  tasks.cleanEclipse {
-    delete '.settings'
-  }
-  tasks.eclipse.dependsOn(cleanEclipse, copyEclipseSettings)
 }
 
 /*****************************************************************************

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,3 @@
-import java.nio.file.Files
-
 /*
  * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with
@@ -19,25 +17,21 @@ import java.nio.file.Files
  * under the License.
  */
 
-// we must use buildscript + apply so that an external plugin
-// can apply this file, since the plugins directive is not
-// supported through file includes
-buildscript {
-  repositories {
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
-  }
-}
+import java.nio.file.Files
+
 apply plugin: 'groovy'
-apply plugin: 'com.bmuschko.nexus'
-// TODO: move common IDE configuration to a common file to include
-apply plugin: 'idea'
-apply plugin: 'eclipse'
 
 group = 'org.elasticsearch.gradle'
-archivesBaseName = 'build-tools'
+
+if (project == rootProject) {
+  // change the build dir used during build init, so that doing a clean
+  // won't wipe out the buildscript jar
+  buildDir = 'build-bootstrap'
+}
+
+/*****************************************************************************
+ *         Propagating version.properties to the rest of the build           *
+ *****************************************************************************/
 
 Properties props = new Properties()
 props.load(project.file('version.properties').newDataInputStream())
@@ -49,33 +43,6 @@ if (snapshot) {
   // to indicate this being a snapshot build or a release build.
   version += "-SNAPSHOT"
   props.put("elasticsearch", version);
-}
-
-
-repositories {
-  mavenCentral()
-  maven {
-    name 'sonatype-snapshots'
-    url "https://oss.sonatype.org/content/repositories/snapshots/"
-  }
-  jcenter()
-}
-
-dependencies {
-  compile gradleApi()
-  compile localGroovy()
-  compile "com.carrotsearch.randomizedtesting:junit4-ant:${props.getProperty('randomizedrunner')}"
-  compile("junit:junit:${props.getProperty('junit')}") {
-    transitive = false
-  }
-  compile 'com.netflix.nebula:gradle-extra-configurations-plugin:3.0.3'
-  compile 'com.netflix.nebula:nebula-publishing-plugin:4.4.4'
-  compile 'com.netflix.nebula:gradle-info-plugin:3.0.3'
-  compile 'org.eclipse.jgit:org.eclipse.jgit:3.2.0.201312181205-r'
-  compile 'com.perforce:p4java:2012.3.551082' // THIS IS SUPPOSED TO BE OPTIONAL IN THE FUTURE....
-  compile 'de.thetaphi:forbiddenapis:2.0'
-  compile 'com.bmuschko:gradle-nexus-plugin:2.3.1'
-  compile 'org.apache.rat:apache-rat:0.11'
 }
 
 File tempPropertiesFile = new File(project.buildDir, "version.properties")
@@ -97,31 +64,105 @@ processResources {
   from tempPropertiesFile
 }
 
-extraArchive {
-  javadoc = false
-  tests = false
+/*****************************************************************************
+ *                    Dependencies used by the entire build                  *
+ *****************************************************************************/
+
+repositories {
+  jcenter()
 }
 
-idea {
-  module {
-    inheritOutputDirs = false
-    outputDir = file('build-idea/classes/main')
-    testOutputDir = file('build-idea/classes/test')
+dependencies {
+  compile gradleApi()
+  compile localGroovy()
+  compile "com.carrotsearch.randomizedtesting:junit4-ant:${props.getProperty('randomizedrunner')}"
+  compile("junit:junit:${props.getProperty('junit')}") {
+    transitive = false
+  }
+  compile 'com.netflix.nebula:gradle-extra-configurations-plugin:3.0.3'
+  compile 'com.netflix.nebula:nebula-publishing-plugin:4.4.4'
+  compile 'com.netflix.nebula:gradle-info-plugin:3.0.3'
+  compile 'org.eclipse.jgit:org.eclipse.jgit:3.2.0.201312181205-r'
+  compile 'com.perforce:p4java:2012.3.551082' // THIS IS SUPPOSED TO BE OPTIONAL IN THE FUTURE....
+  compile 'de.thetaphi:forbiddenapis:2.0'
+  compile 'com.bmuschko:gradle-nexus-plugin:2.3.1'
+  compile 'org.apache.rat:apache-rat:0.11'
+}
+
+
+/*****************************************************************************
+ *                    Bootstrap repositories and IDE setup                   *
+ *****************************************************************************/
+// this will only happen when buildSrc is built on its own during build init
+if (project == rootProject) {
+
+  // TODO: move common IDE configuration to a common file to include
+  apply plugin: 'idea'
+  apply plugin: 'eclipse'
+
+  repositories {
+    mavenCentral()
+    maven {
+      name 'sonatype-snapshots'
+      url "https://oss.sonatype.org/content/repositories/snapshots/"
+    }
+  }
+
+  idea {
+    module {
+      inheritOutputDirs = false
+      outputDir = file('build-idea/classes/main')
+      testOutputDir = file('build-idea/classes/test')
+    }
+  }
+
+  eclipse {
+    classpath {
+      defaultOutputDir = file('build-eclipse')
+    }
+  }
+
+  task copyEclipseSettings(type: Copy) {
+    from project.file('src/main/resources/eclipse.settings')
+    into '.settings'
+  }
+  // otherwise .settings is not nuked entirely
+  tasks.cleanEclipse {
+    delete '.settings'
+  }
+  tasks.eclipse.dependsOn(cleanEclipse, copyEclipseSettings)
+}
+
+/*****************************************************************************
+ *                           Normal project checks                           *
+ *****************************************************************************/
+
+// this happens when included as a normal project in the build, which we do
+// to enforce precommit checks like forbidden apis, as well as setup publishing
+if (project != rootProject) {
+  apply plugin: 'elasticsearch.build'
+  apply plugin: 'nebula.maven-base-publish'
+  apply plugin: 'nebula.maven-scm'
+
+  // groovydoc succeeds, but has some weird internal exception...
+  groovydoc.enabled = false
+
+  // build-tools is not ready for primetime with these...
+  dependencyLicenses.enabled = false
+  forbiddenApisMain.enabled = false
+  jarHell.enabled = false
+  loggerUsageCheck.enabled = false
+  thirdPartyAudit.enabled = false
+
+  // test for elasticsearch.build tries to run with ES...
+  test.enabled = false
+
+  // TODO: re-enable once randomizedtesting gradle code is published and removed from here
+  licenseHeaders.enabled = false
+
+  forbiddenPatterns {
+    exclude '**/*.wav'
+    // the file that actually defines nocommit
+    exclude '**/ForbiddenPatternsTask.groovy'
   }
 }
-
-eclipse {
-  classpath {
-    defaultOutputDir = file('build-eclipse')
-  }
-}
-
-task copyEclipseSettings(type: Copy) {
-  from project.file('src/main/resources/eclipse.settings')
-  into '.settings'
-}
-// otherwise .settings is not nuked entirely
-tasks.cleanEclipse {
-  delete '.settings'
-}
-tasks.eclipse.dependsOn(cleanEclipse, copyEclipseSettings)

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -232,7 +232,7 @@ class BuildPlugin implements Plugin<Project> {
      */
     static void configureConfigurations(Project project) {
         // we are not shipping these jars, we act like dumb consumers of these things
-        if (project.path.startsWith(':test:fixtures')) {
+        if (project.path.startsWith(':test:fixtures') || project.path == ':build-tools') {
             return
         }
         // fail on any conflicting dependency versions

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name = 'elasticsearch'
 
 List projects = [
+  'build-tools',
   'rest-api-spec',
   'core',
   'docs',
@@ -59,6 +60,8 @@ if (isEclipse) {
 }
 
 include projects.toArray(new String[0])
+
+project(':build-tools').projectDir = new File(rootProject.projectDir, 'buildSrc')
 
 if (isEclipse) {
   project(":core").projectDir = new File(rootProject.projectDir, 'core/src/main')


### PR DESCRIPTION
This is a follow up to #18173 and includes adding pom generation to the
fake build-tools project, which is really just buildSrc, but builds
during normal builds.
