### PR TITLE
Remove plugin script parsing of system properties

### DIFF
--- a/dev-tools/prepare_release_candidate.py
+++ b/dev-tools/prepare_release_candidate.py
@@ -60,10 +60,10 @@ Plugins can be installed as follows:
 
 The same goes for the x-plugins:
 
-    bin/elasticsearch-plugin -Des.plugins.staging=true install license
-    bin/elasticsearch-plugin -Des.plugins.staging=true install marvel-agent
-    bin/elasticsearch-plugin -Des.plugins.staging=true install shield
-    bin/elasticsearch-plugin -Des.plugins.staging=true install watcher
+    ES_JAVA_OPTS="-Des.plugins.staging=true" bin/elasticsearch-plugin install license
+    ES_JAVA_OPTS="-Des.plugins.staging=true" bin/elasticsearch-plugin install marvel-agent
+    ES_JAVA_OPTS="-Des.plugins.staging=true" bin/elasticsearch-plugin install shield
+    ES_JAVA_OPTS="-Des.plugins.staging=true" bin/elasticsearch-plugin install watcher
 
 To install the deb from an APT repo:
 

--- a/distribution/src/main/resources/bin/elasticsearch-plugin
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin
@@ -77,23 +77,6 @@ if [ ! -x "$JAVA" ]; then
     exit 1
 fi
 
-# real getopt cannot be used because we need to hand options over to the PluginManager
-while [ $# -gt 0 ]; do
-  case $1 in
-    -D*=*)
-      properties="$properties \"$1\""
-      ;;
-    -D*)
-      var=$1
-      shift
-      properties="$properties \"$var\"=\"$1\""
-      ;;
-    *)
-      args="$args \"$1\""
-  esac
-  shift
-done
-
 # check if properties already has a config file or config dir
 if [ -e "$CONF_DIR" ]; then
   case "$properties" in
@@ -110,4 +93,4 @@ fi
 HOSTNAME=`hostname | cut -d. -f1`
 export HOSTNAME
 
-eval "\"$JAVA\"" "$ES_JAVA_OPTS" -Delasticsearch -Des.path.home="\"$ES_HOME\"" $properties -cp "\"$ES_HOME/lib/*\"" org.elasticsearch.plugins.PluginCli $args
+eval "\"$JAVA\"" "$ES_JAVA_OPTS" -Delasticsearch -Des.path.home="\"$ES_HOME\"" $properties -cp "\"$ES_HOME/lib/*\"" org.elasticsearch.plugins.PluginCli "$@"

--- a/docs/plugins/plugin-script.asciidoc
+++ b/docs/plugins/plugin-script.asciidoc
@@ -77,7 +77,7 @@ to a local Java truststore and pass the location to the script as follows:
 
 [source,shell]
 -----------------------------------
-sudo bin/elasticsearch-plugin -Djavax.net.ssl.trustStore=/path/to/trustStore.jks install https://....
+sudo ES_JAVA_OPTS="-Djavax.net.ssl.trustStore=/path/to/trustStore.jks" bin/elasticsearch-plugin install https://....
 -----------------------------------
 
 [[listing-removing]]
@@ -169,7 +169,7 @@ options can be set on the command line:
 
 [source,shell]
 -----------------------------------
-sudo bin/elasticsearch-plugin install mobz/elasticsearch-head -DproxyHost=host_name -DproxyPort=port_number
+sudo ES_JAVA_OPTS="-DproxyHost=host_name -DproxyPort=port_number" bin/elasticsearch-plugin install mobz/elasticsearch-head
 -----------------------------------
 
 On Windows, they need to be added to the `ES_JAVA_OPTS` environment variable:

--- a/docs/reference/migration/migrate_5_0/plugins.asciidoc
+++ b/docs/reference/migration/migrate_5_0/plugins.asciidoc
@@ -101,3 +101,9 @@ Cloud GCE plugin has been renamed to {plugins}/discovery-gce.html[Discovery GCE 
 Mapper attachments has been deprecated. Users should use now the {plugins}/ingest-attachment.html[`ingest-attachment`]
 plugin.
 
+==== Passing of Java System Properties
+
+Previously, Java system properties could be passed to the plugin
+command by passing `-D` style arguments directly to the plugin script.
+This is no longer permitted and such system properties must be passed
+via ES_JAVA_OPTS.

--- a/qa/vagrant/src/test/resources/packaging/scripts/module_and_plugin_test_cases.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/module_and_plugin_test_cases.bash
@@ -438,7 +438,7 @@ fi
     remove_jvm_example
 
     local relativePath=${1:-$(readlink -m jvm-example-*.zip)}
-    sudo -E -u $ESPLUGIN_COMMAND_USER "$ESHOME/bin/elasticsearch-plugin" install "file://$relativePath" -Des.logger.level=DEBUG > /tmp/plugin-cli-output
+    sudo -E -u $ESPLUGIN_COMMAND_USER ES_JAVA_OPTS="-Des.logger.level=DEBUG" "$ESHOME/bin/elasticsearch-plugin" install "file://$relativePath" > /tmp/plugin-cli-output
     local loglines=$(cat /tmp/plugin-cli-output | wc -l)
     if [ "$GROUP" == "TAR PLUGINS" ]; then
         [ "$loglines" -gt "3" ] || {


### PR DESCRIPTION
The plugin script parses command-line options looking for Java system
properties and extracts these arguments to pass to the java command when
starting the JVM. Since elasticsearch-plugin allows arbitrary user
arguments to the JVM via ES_JAVA_OPTS, this parsing is unnecessary. This
commit removes this unnecessary translation.

Relates #18140
