### PR TITLE
CONSOLE is the new AUTOSENSE

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/SnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/SnippetsTask.groovy
@@ -110,7 +110,8 @@ public class SnippetsTask extends DefaultTask {
                     lastLanguageLine = lineNumber
                     return
                 }
-                if (line ==~ /\/\/ AUTOSENSE\s*/) {
+                if (line ==~ /\/\/ AUTOSENSE\s*/
+                        || line ==~ /\/\/ CONSOLE\s*/) {
                     if (snippet == null) {
                         throw new InvalidUserDataException("AUTOSENSE not " +
                             "paired with a snippet at $file:$lineNumber")

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -14,7 +14,7 @@ PUT twitter/tweet/1
     "message" : "trying out Elasticsearch"
 }
 --------------------------------------------------
-// AUTOSENSE
+// CONSOLE
 
 The result of the above index operation is:
 


### PR DESCRIPTION
This makes the test generation support both while we move from
`// AUTOSENSE` to `// CONSOLE`.

Will bother #18160
