### PR TITLE
Improve logging of raw rest actions on failure

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/section/DoSection.java
@@ -129,7 +129,11 @@ public class DoSection implements ExecutableSection {
     }
 
     private String formatStatusCodeMessage(RestResponse restResponse, String expected) {
-        return "expected [" + expected + "] status code but api [" + apiCallSection.getApi() + "] returned ["
+        String api = apiCallSection.getApi();
+        if ("raw".equals(api)) {
+            api += "[method=" + apiCallSection.getParams().get("method") + " path=" + apiCallSection.getParams().get("path") + "]";
+        }
+        return "expected [" + expected + "] status code but api [" + api + "] returned ["
                 + restResponse.getStatusCode() + " " + restResponse.getReasonPhrase() + "] [" + restResponse.getBodyAsString() + "]";
     }
 


### PR DESCRIPTION
Log the method and the path.

This should give me more to go on when debugging integration test failures like
http://build-us-00.elastic.co/job/es_core_master_windows-2012-r2/3039/console

They don't reproduce locally....
