### PR TITLE
Account for rpm behavior difference on directories

### DIFF
--- a/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
@@ -161,8 +161,10 @@ setup() {
     assert_file_exist "/etc/elasticsearch/jvm.options.rpmsave"
     assert_file_not_exist "/etc/elasticsearch/logging.yml"
     assert_file_exist "/etc/elasticsearch/logging.yml.rpmsave"
-    assert_file_exist "/etc/elasticsearch/scripts.rpmsave"
-    assert_file_exist "/etc/elasticsearch/scripts.rpmsave/script"
+    # older versions of rpm behave differently and preserve the
+    # directory but do not append the ".rpmsave" suffix
+    test -e "/etc/elasticsearch/scripts" || test -e "/etc/elasticsearch/scripts.rpmsave"
+    test -e "/etc/elasticsearch/scripts/script" || test -e "/etc/elasticsearch/scripts.rpmsave/script"
 
     assert_file_not_exist "/etc/init.d/elasticsearch"
     assert_file_not_exist "/usr/lib/systemd/system/elasticsearch.service"


### PR DESCRIPTION
This commit modifies the packaging tests to account for the fact that
rpm behaves differently with respect to preserving directories marked as
"CONFIG | NOREPLACE" on older versions versus newer versions. Older
versions will leave the directory as-is while newer versions will append
the suffix ".rpmsave" to the directory name.
