### PR TITLE
Make doc_values accessible for _type

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/mapper/internal/TypeFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/internal/TypeFieldMapperTests.java
@@ -24,12 +24,16 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
+import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
 
 import java.util.Collection;
+
+import static org.hamcrest.Matchers.instanceOf;
 
 public class TypeFieldMapperTests extends ESSingleNodeTestCase {
 
@@ -44,6 +48,7 @@ public class TypeFieldMapperTests extends ESSingleNodeTestCase {
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
         TypeFieldMapper typeMapper = docMapper.metadataMapper(TypeFieldMapper.class);
         assertTrue(typeMapper.fieldType().hasDocValues());
+        assertThat(typeMapper.fieldType().fielddataBuilder(), instanceOf(DocValuesIndexFieldData.Builder.class));
     }
 
     public void testDocValuesPre21() throws Exception {
@@ -54,5 +59,6 @@ public class TypeFieldMapperTests extends ESSingleNodeTestCase {
         DocumentMapper docMapper = createIndex("test", bwcSettings).mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
         TypeFieldMapper typeMapper = docMapper.metadataMapper(TypeFieldMapper.class);
         assertFalse(typeMapper.fieldType().hasDocValues());
+        assertThat(typeMapper.fieldType().fielddataBuilder(), instanceOf(PagedBytesIndexFieldData.Builder.class));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/internal/TypeFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/internal/TypeFieldTypeTests.java
@@ -37,11 +37,23 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.junit.Before;
 
 public class TypeFieldTypeTests extends FieldTypeTestCase {
     @Override
     protected MappedFieldType createDefaultFieldType() {
         return new TypeFieldMapper.TypeFieldType();
+    }
+
+    @Before
+    public void setupProperties() {
+        addModifier(new Modifier("fielddata", true) {
+            @Override
+            public void modify(MappedFieldType ft) {
+                TypeFieldMapper.TypeFieldType tft = (TypeFieldMapper.TypeFieldType) ft;
+                tft.setFielddata(tft.fielddata() == false);
+            }
+        });
     }
 
     public void testTermQuery() throws Exception {

--- a/docs/reference/mapping/fields/type-field.asciidoc
+++ b/docs/reference/mapping/fields/type-field.asciidoc
@@ -5,7 +5,8 @@ Each document indexed is associated with a <<mapping-type-field,`_type`>> (see
 <<mapping-type>>) and an <<mapping-id-field,`_id`>>.  The `_type` field is
 indexed in order to make searching by type name fast.
 
-The value of the `_type` field is accessible in queries and scripts:
+The value of the `_type` field is accessible in queries, aggregations,
+scripts, and when sorting:
 
 [source,js]
 --------------------------
@@ -27,9 +28,24 @@ GET my_index/type_*/_search
       "_type": [ "type_1", "type_2" ] <1>
     }
   },
+  "aggs": {
+    "types": {
+      "terms": {
+        "field": "_type", <2>
+        "size": 10
+      }
+    }
+  },
+  "sort": [
+    {
+      "_type": { <3>
+        "order": "desc"
+      }
+    }
+  ],
   "script_fields": {
     "type": {
-      "script": "doc['_type']" <2>
+      "script": "doc['_type']" <4>
     }
   }
 }
@@ -38,4 +54,7 @@ GET my_index/type_*/_search
 // CONSOLE
 
 <1> Querying on the `_type` field
-<2> Accessing the `_type` field in scripts (inline scripts must be <<enable-dynamic-scripting,enabled>> for this example to work)
+<2> Aggregating on the `_type` field
+<3> Sorting on the `_type` field
+<4> Accessing the `_type` field in scripts (inline scripts must be <<enable-dynamic-scripting,enabled>> for this example to work)
+


### PR DESCRIPTION
`doc_values` for _type field are created but any attempt to load them throws an IAE.

This PR re-enables `doc_values` loading for _type, it also enables `fielddata` loading if doc_values are not enabled.

It also restores the old docs that gives example on how to sort or aggregate on _type field.
I am not sure if the removal was intentional or not. It it's the case please ignore this PR.
