### PR TITLE
Rename autoSense to console in the docs tests generation code

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
@@ -42,13 +42,13 @@ public class DocsTestPlugin extends RestTestPlugin {
                 'List snippets that probably should be marked // CONSOLE'
         listConsoleCandidates.perSnippet {
             if (
-                       it.autoSense    // Already marked, nothing to do
+                       it.console      // Already marked, nothing to do
                     || it.testResponse // It is a response
                 ) {
                 return
             }
             List<String> languages = [
-                // These languages should almost always be marked autosense
+                // These languages should almost always be marked console
                 'js', 'json',
                 // These are often curl commands that should be converted but
                 // are probably false positives

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
@@ -95,7 +95,7 @@ public class RestTestsFromSnippetsTask extends SnippetsTask {
                 response(snippet)
                 return
             }
-            if (snippet.test || snippet.autoSense) {
+            if (snippet.test || snippet.console) {
                 test(snippet)
                 return
             }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/SnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/SnippetsTask.groovy
@@ -115,10 +115,10 @@ public class SnippetsTask extends DefaultTask {
                 if (line ==~ /\/\/\s*AUTOSENSE\s*/
                         || line ==~ /\/\/\s*CONSOLE\s*/) {
                     if (snippet == null) {
-                        throw new InvalidUserDataException("AUTOSENSE not " +
+                        throw new InvalidUserDataException("CONSOLE not " +
                             "paired with a snippet at $file:$lineNumber")
                     }
-                    snippet.autoSense = true
+                    snippet.console = true
                     return
                 }
                 matcher = line =~ /\/\/\s*TEST(\[(.+)\])?\s*/
@@ -217,7 +217,7 @@ public class SnippetsTask extends DefaultTask {
         int end = NOT_FINISHED
         String contents
 
-        boolean autoSense = false
+        boolean console = false
         boolean test = false
         boolean testResponse = false
         boolean testSetup = false
@@ -233,8 +233,8 @@ public class SnippetsTask extends DefaultTask {
             if (language != null) {
                 result += "($language)"
             }
-            if (autoSense) {
-                result += '// AUTOSENSE'
+            if (console) {
+                result += '// CONSOLE'
             }
             if (test) {
                 result += '// TEST'


### PR DESCRIPTION
Since `// AUTOSENSE` has been replaced by `// CONSOLE` we should use
the new name for the variable name.
