### PR TITLE
Array load/store and length with invokedynamic

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/DynamicCallSite.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/DynamicCallSite.java
@@ -48,6 +48,10 @@ public final class DynamicCallSite {
     static final int LOAD = 1;
     /** static bootstrap parameter indicating a dynamic store (setter), e.g. foo.bar = baz */
     static final int STORE = 2;
+    /** static bootstrap parameter indicating a dynamic array load, e.g. baz = foo[bar] */
+    static final int ARRAY_LOAD = 3;
+    /** static bootstrap parameter indicating a dynamic array store, e.g. foo[bar] = baz */
+    static final int ARRAY_STORE = 4;
     
     static class InliningCacheCallSite extends MutableCallSite {
         /** maximum number of types before we go megamorphic */
@@ -104,6 +108,10 @@ public final class DynamicCallSite {
                 return Def.lookupGetter(clazz, name, Definition.INSTANCE);
             case STORE:
                 return Def.lookupSetter(clazz, name, Definition.INSTANCE);
+            case ARRAY_LOAD: 
+                return Def.lookupArrayLoad(clazz);
+            case ARRAY_STORE:
+                return Def.lookupArrayStore(clazz);
             default: throw new AssertionError();
         }
     }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/WriterConstants.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/WriterConstants.java
@@ -58,10 +58,14 @@ class WriterConstants {
     final static Handle DEF_BOOTSTRAP_HANDLE = new Handle(Opcodes.H_INVOKESTATIC, Type.getInternalName(DynamicCallSite.class),
                                                           "bootstrap", WriterConstants.DEF_BOOTSTRAP_TYPE.toMethodDescriptorString());
 
-    final static Method DEF_ARRAY_STORE = getAsmMethod(
-        void.class, "arrayStore", Object.class, Object.class, Object.class);
-    final static Method DEF_ARRAY_LOAD = getAsmMethod(
-        Object.class, "arrayLoad", Object.class, Object.class);
+    final static String DEF_DYNAMIC_LOAD_FIELD_DESC = MethodType.methodType(Object.class, Object.class)
+        .toMethodDescriptorString();
+    final static String DEF_DYNAMIC_STORE_FIELD_DESC = MethodType.methodType(void.class, Object.class, Object.class)
+        .toMethodDescriptorString();
+    final static String DEF_DYNAMIC_ARRAY_LOAD_DESC = MethodType.methodType(Object.class, Object.class, Object.class)
+        .toMethodDescriptorString();
+    final static String DEF_DYNAMIC_ARRAY_STORE_DESC = MethodType.methodType(void.class, Object.class, Object.class, Object.class)
+        .toMethodDescriptorString();
 
     final static Method DEF_NOT_CALL = getAsmMethod(Object.class, "not", Object.class);
     final static Method DEF_NEG_CALL = getAsmMethod(Object.class, "neg", Object.class);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/WriterExternal.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/WriterExternal.java
@@ -49,8 +49,6 @@ import static org.elasticsearch.painless.PainlessParser.DIV;
 import static org.elasticsearch.painless.PainlessParser.MUL;
 import static org.elasticsearch.painless.PainlessParser.REM;
 import static org.elasticsearch.painless.PainlessParser.SUB;
-import static org.elasticsearch.painless.WriterConstants.DEF_ARRAY_LOAD;
-import static org.elasticsearch.painless.WriterConstants.DEF_ARRAY_STORE;
 import static org.elasticsearch.painless.WriterConstants.TOBYTEEXACT_INT;
 import static org.elasticsearch.painless.WriterConstants.TOBYTEEXACT_LONG;
 import static org.elasticsearch.painless.WriterConstants.TOBYTEWOOVERFLOW_DOUBLE;
@@ -468,10 +466,10 @@ class WriterExternal {
 
     private void writeLoadStoreField(final ParserRuleContext source, final boolean store, final String name) {
         if (store) {
-            execute.visitInvokeDynamicInsn(name, "(Ljava/lang/Object;Ljava/lang/Object;)V", 
+            execute.visitInvokeDynamicInsn(name, WriterConstants.DEF_DYNAMIC_STORE_FIELD_DESC, 
                                            WriterConstants.DEF_BOOTSTRAP_HANDLE, new Object[] { DynamicCallSite.STORE });
         } else {
-            execute.visitInvokeDynamicInsn(name, "(Ljava/lang/Object;)Ljava/lang/Object;", 
+            execute.visitInvokeDynamicInsn(name, WriterConstants.DEF_DYNAMIC_LOAD_FIELD_DESC, 
                                            WriterConstants.DEF_BOOTSTRAP_HANDLE, new Object[] { DynamicCallSite.LOAD });
         }
     }
@@ -483,9 +481,11 @@ class WriterExternal {
 
         if (type.sort == Sort.DEF) {
             if (store) {
-                execute.invokeStatic(definition.defobjType.type, DEF_ARRAY_STORE);
+                execute.visitInvokeDynamicInsn("arrayStore", WriterConstants.DEF_DYNAMIC_ARRAY_STORE_DESC, 
+                                           WriterConstants.DEF_BOOTSTRAP_HANDLE, new Object[] { DynamicCallSite.ARRAY_STORE });
             } else {
-                execute.invokeStatic(definition.defobjType.type, DEF_ARRAY_LOAD);
+                execute.visitInvokeDynamicInsn("arrayLoad", WriterConstants.DEF_DYNAMIC_ARRAY_LOAD_DESC, 
+                                           WriterConstants.DEF_BOOTSTRAP_HANDLE, new Object[] { DynamicCallSite.ARRAY_LOAD });
             }
         } else {
             if (store) {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ArrayTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ArrayTests.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.painless;
+
+/** Tests for or operator across all types */
+public class ArrayTests extends ScriptTestCase {
+
+    public void testArrayLengthHelper() throws Throwable {
+        assertArrayLength(2, new int[2]);
+        assertArrayLength(3, new long[3]);
+        assertArrayLength(4, new byte[4]);
+        assertArrayLength(5, new float[5]);
+        assertArrayLength(6, new double[6]);
+        assertArrayLength(7, new char[7]);
+        assertArrayLength(8, new short[8]);
+        assertArrayLength(9, new Object[9]);
+        assertArrayLength(10, new Integer[10]);
+        assertArrayLength(11, new String[11][2]);
+    }
+    
+    private void assertArrayLength(int length, Object array) throws Throwable {
+        assertEquals(length, (int) Def.arrayLengthGetter(array.getClass()).invoke(array));
+    }
+
+    public void testArrayLoadStoreInt() {
+        assertEquals(5, exec("def x = new int[5]; return x.length"));
+        assertEquals(5, exec("def x = new int[4]; x[0] = 5; return x[0];"));
+    }
+    
+    public void testArrayLoadStoreString() {
+        assertEquals(5, exec("def x = new String[5]; return x.length"));
+        assertEquals("foobar", exec("def x = new String[4]; x[0] = 'foobar'; return x[0];"));
+    }
+    
+    public void testArrayLoadStoreDef() {
+        assertEquals(5, exec("def x = new def[5]; return x.length"));
+        assertEquals(5, exec("def x = new def[4]; x[0] = 5; return x[0];"));
+    }
+    
+    public void testForLoop() {
+        assertEquals(999*1000/2, exec("def a = new int[1000]; for (int x = 0; x < a.length; x++) { a[x] = x; } "+
+            "int total = 0; for (int x = 0; x < a.length; x++) { total += a[x]; } return total;"));
+    }
+    
+}

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
@@ -62,12 +62,6 @@ public class BasicAPITests extends ScriptTestCase {
         assertEquals(5, exec("def x = new ArrayList(); x.add(3); x[0] = 5; return x[0];"));
     }
     
-    /** Test loads and stores with a list */
-    public void testArrayLoadStore() {
-        assertEquals(5, exec("def x = new int[5]; return x.length"));
-        assertEquals(5, exec("def x = new int[4]; x[0] = 5; return x[0];"));
-    }
-    
     /** Test shortcut for getters with isXXXX */
     public void testListEmpty() {
         assertEquals(true, exec("def x = new ArrayList(); return x.empty;"));


### PR DESCRIPTION
After @rmuir's improvements for using invokedynamic (#18201) with dynamic method calls and field load/stores, this extends the whole thing to array loads and stores.

It also optimizes access to `array.length` by using a specialization for every array type. This works around a missing method in Java's MethodHandles class (e.g., `MethodHandles.arrayLengthGetter(Class<?> arrayType)`).

I did not do performance checks for now, because @rmuir knows better how to do that in ES - I just coded it :-)
