### PR TITLE
Use better typing for dynamic method calls

### DIFF
--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless;
 
+import java.lang.invoke.WrongMethodTypeException;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -140,7 +141,7 @@ public class WhenThingsGoWrongTests extends ScriptTestCase {
     }
     
     public void testDynamicWrongArgs() {
-        expectThrows(ClassCastException.class, () -> {
+        expectThrows(WrongMethodTypeException.class, () -> {
             exec("def x = new ArrayList(); return x.get('bogus');");
         });
     }


### PR DESCRIPTION
Today painless boxes/casts all the parameters as Object. But I think instead we should pass the parameter types we have and let asType take care? It may be able to e.g. avoid boxing or other conversions in some situations.

FYI: I thought about this a lot, I like doing it here in the bytecode emitter, even though it looks strange, because its an implementation detail of how we make the call work.

@uschindler @jdconrad 
