### PR TITLE
Creates SearchParseContext class

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
@@ -49,6 +49,7 @@ import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.indices.query.IndicesQueriesRegistry;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.SearchParseContext;
 import org.elasticsearch.search.aggregations.AggregatorParsers;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -222,7 +223,7 @@ public class TransportPercolateAction extends HandledTransportAction<PercolateRe
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(source)) {
             QueryParseContext context = new QueryParseContext(queryRegistry, parser, parseFieldMatcher);
-            searchSourceBuilder.parseXContent(context, aggParsers, null);
+            searchSourceBuilder.parseXContent(new SearchParseContext(context, aggParsers, null));
             searchRequest.source(searchSourceBuilder);
             return searchRequest;
         }

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -50,6 +50,7 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 import org.elasticsearch.script.Template;
+import org.elasticsearch.search.SearchParseContext;
 import org.elasticsearch.search.aggregations.AggregatorParsers;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.suggest.Suggesters;
@@ -195,7 +196,8 @@ public class RestMultiSearchAction extends BaseRestHandler {
                 try (XContentParser requestParser = XContentFactory.xContent(slice).createParser(slice)) {
                     final QueryParseContext queryParseContext = new QueryParseContext(indicesQueriesRegistry, requestParser,
                             parseFieldMatcher);
-                    searchRequest.source(SearchSourceBuilder.fromXContent(queryParseContext, aggParsers, suggesters));
+                    searchRequest
+                            .source(SearchSourceBuilder.fromXContent(new SearchParseContext(queryParseContext, aggParsers, suggesters)));
                 }
             }
             // move pointers

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -42,6 +42,7 @@ import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestStatusToXContentListener;
 import org.elasticsearch.script.Template;
 import org.elasticsearch.search.Scroll;
+import org.elasticsearch.search.SearchParseContext;
 import org.elasticsearch.search.aggregations.AggregatorParsers;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
@@ -128,7 +129,7 @@ public class RestSearchAction extends BaseRestHandler {
                     Template template = TemplateQueryBuilder.parse(parser, context.getParseFieldMatcher(), "params", "template");
                     searchRequest.template(template);
                 } else {
-                    searchRequest.source().parseXContent(context, aggParsers, suggesters);
+                    searchRequest.source().parseXContent(new SearchParseContext(context, aggParsers, suggesters));
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/search/SearchParseContext.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchParseContext.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search;
+
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.search.aggregations.AggregatorParsers;
+import org.elasticsearch.search.suggest.Suggesters;
+
+public class SearchParseContext {
+
+    private final QueryParseContext queryParseContext;
+    private final AggregatorParsers aggParsers;
+    private final Suggesters suggesters;
+
+    public SearchParseContext(QueryParseContext queryParseContext, AggregatorParsers aggParsers, Suggesters suggesters) {
+        this.queryParseContext = queryParseContext;
+        this.aggParsers = aggParsers;
+        this.suggesters = suggesters;
+    }
+
+    public AggregatorParsers getAggregatorParsers() {
+        return aggParsers;
+    }
+
+    public QueryParseContext getQueryParseContext() {
+        return queryParseContext;
+    }
+
+    public Suggesters getSuggesters() {
+        return suggesters;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchService.java
@@ -33,7 +33,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.lucene.search.FieldDoc;
-import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TopDocs;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
@@ -570,7 +569,8 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> imp
                 try (XContentParser parser = XContentFactory.xContent(run).createParser(run)) {
                     QueryParseContext queryParseContext = new QueryParseContext(indicesService.getIndicesQueryRegistry(), parser,
                             parseFieldMatcher);
-                    parseSource(context, SearchSourceBuilder.fromXContent(queryParseContext, aggParsers, suggesters));
+                    parseSource(context,
+                            SearchSourceBuilder.fromXContent(new SearchParseContext(queryParseContext, aggParsers, suggesters)));
                 }
             }
             parseSource(context, request.source());

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestReindexAction.java
@@ -44,6 +44,7 @@ import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.script.Script;
+import org.elasticsearch.search.SearchParseContext;
 import org.elasticsearch.search.aggregations.AggregatorParsers;
 import org.elasticsearch.search.suggest.Suggesters;
 
@@ -78,7 +79,8 @@ public class RestReindexAction extends AbstractBaseReindexRestHandler<ReindexReq
             XContentBuilder builder = XContentFactory.contentBuilder(parser.contentType());
             builder.map(source);
             try (XContentParser innerParser = parser.contentType().xContent().createParser(builder.bytes())) {
-                search.source().parseXContent(context.queryParseContext(innerParser), context.aggParsers, context.suggesters);
+                search.source().parseXContent(new SearchParseContext(context.queryParseContext(innerParser), 
+                        context.aggParsers, context.suggesters));
             }
         };
 


### PR DESCRIPTION
This class can hold all object relating to parsing search requests. This will become useful when we move the parsing of the custom fetch sub phases from the shards to the coordinating node as it will serve as the object to retrieve the parser for the plugins sub fetch phase
