### PR TITLE
Further simplifications of plugin script

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-plugin
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin
@@ -77,20 +77,10 @@ if [ ! -x "$JAVA" ]; then
     exit 1
 fi
 
-# check if properties already has a config file or config dir
-if [ -e "$CONF_DIR" ]; then
-  case "$properties" in
-    *-Des.default.path.conf=*|*-Des.path.conf=*)
-    ;;
-    *)
-      properties="$properties -Des.default.path.conf=\"$CONF_DIR\""
-    ;;
-  esac
-fi
-
 # full hostname passed through cut for portability on systems that do not support hostname -s
 # export on separate line for shells that do not support combining definition and export
 HOSTNAME=`hostname | cut -d. -f1`
 export HOSTNAME
 
-eval "\"$JAVA\"" "$ES_JAVA_OPTS" -Delasticsearch -Des.path.home="\"$ES_HOME\"" $properties -cp "\"$ES_HOME/lib/*\"" org.elasticsearch.plugins.PluginCli "$@"
+exec "$JAVA" $ES_JAVA_OPTS -Delasticsearch -Des.path.home="$ES_HOME" -Des.default.path.conf="$CONF_DIR" \
+  -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginCli "$@"


### PR DESCRIPTION
In 7d1fd17172f5f8cb7ed381de1ff23dfb9f1856a5 the parsing of command-line
properties in the plugin script was removed. That commit missed
additional parsing of the properties for es.default.path.conf. This
commit removes that parsing and also replaces the use of eval with exec.

Relates #18207
