### PR TITLE
Allow to disable GPG signing based on env variable

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -406,14 +406,8 @@ installed it'll spin up centos-7 and verify the tar and rpm packages. We
 chose those two distributions as the default because they cover deb and rpm
 packaging and SyvVinit and systemd.
 
-If you need to disable RPM signing (e.g. because the platform does not support it),
-use either `-DskipSign` It is also possible to set the environment variable `OSDISTRO`
-to indicate the operating system is not supported. Currently, the only value recognized
-value is `Fedora release 23 (Twenty Three)`. The value is based on the output of
-the command `facter os.distro.description`. It is recommended to set the environment
-variable in a CI environment as follows:
-
-`export OSDISTRO=$(facter os.distro.description)`
+If you need to disable RPM signing because the platform does not support it,
+use `-DskipSign`.
 
 You can control the boxes that are used for testing like so. Run just
 fedora-22 with:

--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -406,6 +406,15 @@ installed it'll spin up centos-7 and verify the tar and rpm packages. We
 chose those two distributions as the default because they cover deb and rpm
 packaging and SyvVinit and systemd.
 
+If you need to disable RPM signing (e.g. because the platform does not support it),
+use either `-DskipSign` It is also possible to set the environment variable `OSDISTRO`
+to indicate the operating system is not supported. Currently, the only value recognized
+value is `Fedora release 23 (Twenty Three)`. The value is based on the output of
+the command `facter os.distro.description`. It is recommended to set the environment
+variable in a CI environment as follows:
+
+`export OSDISTRO=$(facter os.distro.description)`
+
 You can control the boxes that are used for testing like so. Run just
 fedora-22 with:
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -319,6 +319,38 @@
                 <module>rpm</module>
             </modules>
         </profile>
+        <!--
+            This is a helper profile to automatically deactivate signing on known platforms with gpg-agent 2.1 on which
+            signing just cannot work out of the box with Maven. While it could be possible to support RPM signing
+            on these platforms in a backwards-compatible manner it requires hacks on so many levels that this is just
+            not feasible and we'd rather deactivate signing on those platforms.
+
+            Note that this relies that the build infrastructure sets the environment variable "OSDISTRO" correctly with facter.
+            This means that the build *can* fail if the property is not set. In that case, please check the output of
+            "facter os.distro.description" and create a new profile here.
+
+            For local builds on developer machines that are affected use either the "skipSign" profile or also set
+            the environment variable OSDISTRO to the respective value.
+
+            Ideally, we would just activate the "skipSign" profile or connect the all activation properties for skipSign
+            via a logical condition but this is not possible (see also https://issues.apache.org/jira/browse/MNG-4565).
+        -->
+        <profile>
+            <id>fedora23</id>
+            <activation>
+                <property>
+                    <name>env.OSDISTRO</name>
+                        <value>Fedora release 23 (Twenty Three)</value>
+                </property>
+            </activation>
+            <properties>
+                <!-- Clearing this property prevents the rpm plugin from trying to sign the rpm. -->
+                <gpg.key></gpg.key>
+                <!-- Clearing this property because once we've cleared the above one we can't sign the deb either. -->
+                <deb.sign>false</deb.sign>
+            </properties>
+        </profile>
+
         <profile>
             <!-- Activate me to skip signing the rpm. Signing the rpm requires a few dependencies and might not work
               properly on some distributions. Its known to work on Centos-6, and, ironically, Ubunutu 14.04. -->


### PR DESCRIPTION
With this commit we allow to disable GPG signing based on the value
of the environment variable 'OSDISTRO'. This is needed as there are
compatibility issues with gpg on some platforms which are
complicated to fix (see e.g. mojohaus/rpm-maven-plugin#44 for more details).

We already have the possibility to disable GPG signing based on
the 'skipSign' property but this does not work well with our build 
infrastructure. As all builds are configured uniformly it is not easy 
to define different Maven settings for different build machines. 
Therefore, we will set the environment variable 'OSDISTRO'
on all machines in CI by issuing

`export OSDISTRO=$(facter os.distro.description)`

The Maven build script will then check the value of this variable and
disable GPG signing if it is known not to work on this platform together
with our build infrastructure (currently this is only Fedora 23).
