### PR TITLE
Add synthetic length property as alias to Lists, so they can be used like arrays

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
@@ -1061,12 +1061,14 @@ class Definition {
         addMethod("List", "set", null, false, objectType, new Type[] {intType, objectType}, defType, new Type[] {intType, defType});
         addMethod("List", "get", null, false, objectType, new Type[] {intType}, defType, null);
         addMethod("List", "remove", null, false, objectType, new Type[] {intType}, defType, null);
+        addMethod("List", "getLength", "size", false, intType, new Type[] {}, null, null);
 
         addConstructor("ArrayList", "new", new Type[] {}, null);
 
         addMethod("List<Object>", "set", null, false, objectType, new Type[] {intType, objectType}, null, null);
         addMethod("List<Object>", "get", null, false, objectType, new Type[] {intType}, null, null);
         addMethod("List<Object>", "remove", null, false, objectType, new Type[] {intType}, null, null);
+        addMethod("List<Object>", "getLength", "size", false, intType, new Type[] {}, null, null);
 
         addConstructor("ArrayList<Object>", "new", new Type[] {}, null);
 
@@ -1074,6 +1076,7 @@ class Definition {
             new Type[] {intType, stringType});
         addMethod("List<String>", "get", null, false, objectType, new Type[] {intType}, stringType, null);
         addMethod("List<String>", "remove", null, false, objectType, new Type[] {intType}, stringType, null);
+        addMethod("List<String>", "getLength", "size", false, intType, new Type[] {}, null, null);
 
         addConstructor("ArrayList<String>", "new", new Type[] {}, null);
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
@@ -73,4 +73,12 @@ public class BasicAPITests extends ScriptTestCase {
         assertEquals(5, exec("def x = new ArrayList(); x.add(5); return x.get(0);"));
         assertEquals(5, exec("def x = new ArrayList(); x.add(5); def index = 0; return x.get(index);"));
     }
+    
+    public void testListAsArray() {
+        assertEquals(1, exec("def x = new ArrayList(); x.add(5); return x.length"));
+        assertEquals(5, exec("def x = new ArrayList(); x.add(5); return x[0]"));
+        assertEquals(1, exec("List x = new ArrayList(); x.add('Hallo'); return x.length"));
+        assertEquals(1, exec("List<String> x = new ArrayList<String>(); x.add('Hallo'); return x.length"));
+        assertEquals(1, exec("List<Object> x = new ArrayList<Object>(); x.add('Hallo'); return x.length"));
+    }
 }


### PR DESCRIPTION
While writing tests for the array loads and stores I noticed some inconsistency in painless:

Syntax-wise you can exchange Lists and arrays, e.g. access a List like an array (this also works with maps, but that is out of scope for this issue). I failed to transform a simple `for` loop using `array.length` to using a List. The loads/stores worked, but Lists don't have a `length`property. To really allow lists to be used as arrays, we must add the "length" property manually.

The PR is simple: We need no change in the indy bootstrap part, a Definition is enough. The trick is to add an alias "getLength" to `List`, `List<Object>`, and `List<String>`. Then the property works automatically.
