### PR TITLE
Fix NullPointerException in SimpleQueryParser when analyzing text produces a null query

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryParser.java
@@ -128,8 +128,10 @@ public class SimpleQueryParser extends org.apache.lucene.queryparser.simple.Simp
             try {
                 if (settings.analyzeWildcard()) {
                     Query analyzedQuery = newPossiblyAnalyzedQuery(entry.getKey(), text);
-                    analyzedQuery.setBoost(entry.getValue());
-                    bq.add(analyzedQuery, BooleanClause.Occur.SHOULD);
+                    if (analyzedQuery != null) {
+                        analyzedQuery.setBoost(entry.getValue());
+                        bq.add(analyzedQuery, BooleanClause.Occur.SHOULD);
+                    }
                 } else {
                     PrefixQuery prefix = new PrefixQuery(new Term(entry.getKey(), text));
                     prefix.setBoost(entry.getValue());

--- a/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
@@ -346,4 +346,31 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         assertSearchHits(searchResponse, "1");
     }
 
+    @Test
+    public void testEmptySimpleQueryStringWithAnalysis() throws Exception {
+        // https://github.com/elastic/elasticsearch/issues/18202
+        String mapping = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("type1")
+                .startObject("properties")
+                .startObject("body")
+                .field("type", "string")
+                .field("analyzer", "stop")
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject().string();
+
+        CreateIndexRequestBuilder mappingRequest = client().admin().indices()
+                .prepareCreate("test1")
+                .addMapping("type1", mapping);
+        mappingRequest.execute().actionGet();
+        indexRandom(true, client().prepareIndex("test1", "type1", "1").setSource("body", "Some Text"));
+        refresh();
+
+        SearchResponse searchResponse = client().prepareSearch()
+                .setQuery(simpleQueryStringQuery("the*").analyzeWildcard(true).field("body")).get();
+        assertNoFailures(searchResponse);
+        assertHitCount(searchResponse, 0l);
+    }
 }


### PR DESCRIPTION
Resolves #18202

This is already fixed on Master/5.x, so this is just for the 2.x branches. I will forward-port the test though, always good to have more tests.
