### PR TITLE
Switch scripts to use bash

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # CONTROLLING STARTUP:
 #

--- a/distribution/src/main/resources/bin/elasticsearch-plugin
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin
@@ -1,5 +1,4 @@
-#!/bin/sh
-
+#!/bin/bash
 
 CDPATH=""
 SCRIPT="$0"


### PR DESCRIPTION
This commit switches the command-line scripts to use bash instead of sh
so that we can take advantage of features that bash provides like
arrays.

Closes #14002
