### PR TITLE
Retrieve _score directly from Scorer

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Analyzer.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Analyzer.java
@@ -94,6 +94,7 @@ class Analyzer extends PainlessParserBaseVisitor<Void> {
         utility.incrementScope();
         utility.addVariable(null, "#this", definition.execType);
         metadata.inputValueSlot = utility.addVariable(null, "input", definition.smapType).slot;
+        metadata.scorerValueSlot = utility.addVariable(null, "#scorer", definition.objectType).slot;
         metadata.loopCounterSlot = utility.addVariable(null, "#loop", definition.intType).slot;
         metadata.scoreValueSlot = utility.addVariable(null, "_score", definition.floatType).slot;
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Executable.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Executable.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.painless;
 
+import org.apache.lucene.search.Scorer;
+
 import java.util.Map;
 
 public abstract class Executable {
@@ -46,5 +48,5 @@ public abstract class Executable {
         return definition;
     }
 
-    public abstract Object execute(Map<String, Object> input);
+    public abstract Object execute(Map<String, Object> input, Scorer scorer);
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Metadata.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Metadata.java
@@ -411,6 +411,12 @@ class Metadata {
     int inputValueSlot = -1;
 
     /**
+     * Used to determine what slot the Scorer variable is stored in.  This is used in the {@link Writer} to load
+     * _score from it, if _score will be accessed by the script.
+     */
+    int scorerValueSlot = -1;
+
+    /**
      * Used to determine what slot the loopCounter variable is stored in.  This is used n the {@link Writer} whenever
      * the loop variable is accessed.
      */

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/ScriptImpl.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/ScriptImpl.java
@@ -22,7 +22,6 @@ package org.elasticsearch.painless;
 import org.apache.lucene.search.Scorer;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.LeafSearchScript;
-import org.elasticsearch.script.ScoreAccessor;
 import org.elasticsearch.search.lookup.LeafSearchLookup;
 
 import java.util.HashMap;
@@ -47,6 +46,12 @@ final class ScriptImpl implements ExecutableScript, LeafSearchScript {
      * The lookup is used to access search field values at run-time.
      */
     private final LeafSearchLookup lookup;
+
+    /**
+     * Current scorer being used
+     * @see #setScorer(Scorer)
+     */
+    private Scorer scorer;
 
     /**
      * Creates a ScriptImpl for the a previously compiled Painless script.
@@ -84,7 +89,7 @@ final class ScriptImpl implements ExecutableScript, LeafSearchScript {
      */
     @Override
     public Object run() {
-        return executable.execute(variables);
+        return executable.execute(variables, scorer);
     }
 
     /**
@@ -120,7 +125,7 @@ final class ScriptImpl implements ExecutableScript, LeafSearchScript {
      */
     @Override
     public void setScorer(final Scorer scorer) {
-        variables.put("#score", new ScoreAccessor(scorer));
+        this.scorer = scorer;
     }
 
     /**

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/WriterConstants.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/WriterConstants.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.painless;
 
-import org.elasticsearch.script.ScoreAccessor;
+import org.apache.lucene.search.Scorer;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -37,7 +37,7 @@ class WriterConstants {
     final static Type CLASS_TYPE        = Type.getType("L" + CLASS_NAME.replace(".", "/") + ";");
 
     final static Method CONSTRUCTOR = getAsmMethod(void.class, "<init>", Definition.class, String.class, String.class);
-    final static Method EXECUTE     = getAsmMethod(Object.class, "execute", Map.class);
+    final static Method EXECUTE     = getAsmMethod(Object.class, "execute", Map.class, Scorer.class);
 
     final static Type PAINLESS_ERROR_TYPE = Type.getType(PainlessError.class);
 
@@ -47,11 +47,11 @@ class WriterConstants {
 
     final static Type OBJECT_TYPE = Type.getType(Object.class);
 
+    final static Type SCORER_TYPE = Type.getType(Scorer.class);
+    final static Method SCORER_SCORE = getAsmMethod(float.class, "score");
+
     final static Type MAP_TYPE  = Type.getType(Map.class);
     final static Method MAP_GET = getAsmMethod(Object.class, "get", Object.class);
-
-    final static Type SCORE_ACCESSOR_TYPE    = Type.getType(ScoreAccessor.class);
-    final static Method SCORE_ACCESSOR_FLOAT = getAsmMethod(float.class, "floatValue");
 
     /** dynamic callsite bootstrap signature */
     final static MethodType DEF_BOOTSTRAP_TYPE = MethodType.methodType(CallSite.class, MethodHandles.Lookup.class, 


### PR DESCRIPTION
Currently, painless takes the lucene Scorer, wraps it in a ScoreAccessor, and stuffs it into a hashmap.

This means for each document, we have to do a hashmap get, which is unnecessary overhead. This hashing is part of what is responsible for the large difference performance gap between expressions and painless (https://benchmarks.elastic.co/index.html#search_qps_scripts).

We should just pass the Scorer as a parameter instead and avoid the hashing. I think we should also followup with passing the document's fields as ScriptDocValues[] and accessing those by array index, also just like expressions does. That is a trickier change as we can only optimize away the hash lookup when the field index is a string constant (syntax such as `doc['field']/doc.field/doc.get('field')`), but that should be a very common case.

These changes allow us to bypass the waste of the scripting API behind the scenes and get closer to the performance of expressions.
