### PR TITLE
Require /bin/bash in packaging

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -317,6 +317,8 @@ configure(subprojects.findAll { ['deb', 'rpm'].contains(it.name) }) {
     preUninstall file("${scripts}/prerm")
     postUninstall file("${scripts}/postrm")
 
+    requires('/bin/bash')
+
     into '/usr/share/elasticsearch'
     fileMode 0644
     dirMode 0755

--- a/docs/reference/migration/migrate_5_0/packaging.asciidoc
+++ b/docs/reference/migration/migrate_5_0/packaging.asciidoc
@@ -37,4 +37,9 @@ from the tar or zip distributions, and /etc/elasticsearch/jvm.options if install
 from the Debian or RPM packages. You can specify an alternative location by setting
 the environment variable `ES_JVM_OPTIONS` to the path to the file.
 
+==== /bin/bash is now required
 
+Previously, the scripts used to start Elasticsearch and run plugin
+commands only required a Bourne-compatible shell. Starting in
+Elasticsearch 5.0.0, the bash shell is now required and `/bin/bash` is a
+hard-dependency for the RPM and Debian packages.


### PR DESCRIPTION
This commit adds a hard requirement to the RPM and Debian packages for
/bin/bash to be present, and adds a note regarding this to the migration
docs.

Relates #18251
