### PR TITLE
Add index name in IndexAlreadyExistsException default message

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/IndexAlreadyExistsException.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndexAlreadyExistsException.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 public class IndexAlreadyExistsException extends ElasticsearchException {
 
     public IndexAlreadyExistsException(Index index) {
-        this(index, "already exists");
+        this(index, "index " + index.toString() + " already exists");
     }
 
     public IndexAlreadyExistsException(Index index, String message) {


### PR DESCRIPTION
Adding the index name would be nicer to users especially when indices are automatically created
