### PR TITLE
_score as double, not float

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Analyzer.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Analyzer.java
@@ -108,8 +108,8 @@ class Analyzer extends PainlessParserBaseVisitor<Void> {
         //
         // loop counter to catch runaway scripts. internal use only.
         metadata.loopCounterSlot = utility.addVariable(null, "#loop", definition.intType).slot;
-        // document's score as a read-only float.
-        metadata.scoreValueSlot = utility.addVariable(null, "_score", definition.floatType).slot;
+        // document's score as a read-only double.
+        metadata.scoreValueSlot = utility.addVariable(null, "_score", definition.doubleType).slot;
         // ctx map set by executable scripts as a read-only map.
         metadata.ctxValueSlot = utility.addVariable(null, "ctx", definition.smapType).slot;
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Writer.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Writer.java
@@ -152,15 +152,16 @@ class Writer extends PainlessParserBaseVisitor<Void> {
     private void writeExecute() {
         if (metadata.scoreValueUsed) {
             // if the _score value is used, we do this once:
-            //   float _score = scorer.score();
+            //   final double _score = scorer.score();
             execute.visitVarInsn(Opcodes.ALOAD, metadata.scorerValueSlot);
             execute.invokeVirtual(WriterConstants.SCORER_TYPE, WriterConstants.SCORER_SCORE);
-            execute.visitVarInsn(Opcodes.FSTORE, metadata.scoreValueSlot);
+            execute.visitInsn(Opcodes.F2D);
+            execute.visitVarInsn(Opcodes.DSTORE, metadata.scoreValueSlot);
         }
         
         if (metadata.ctxValueUsed) {
             // if the _ctx value is used, we do this once:
-            //   Map<String,Object> ctx = input.get("ctx");
+            //   final Map<String,Object> ctx = input.get("ctx");
             execute.visitVarInsn(Opcodes.ALOAD, metadata.inputValueSlot);
             execute.push("ctx");
             execute.invokeInterface(WriterConstants.MAP_TYPE, WriterConstants.MAP_GET);


### PR DESCRIPTION
This is a floating point trap to users. Otherwise there are no single-precision floats, unless they explicitly create them. 

`float` document's fields are exposed as `double` via fielddata accessors, so they are effectively instantly promoted to double (regardless of whether the language in question would do that anyway).

`_score` is treated as `double` for one reason or another, by every other scripting language, including expressions. I think it should be here too. I also like the types being more predictable.
