### PR TITLE
CORS should permit same origin requests

### DIFF
--- a/core/src/main/java/org/elasticsearch/http/netty/cors/CorsHandler.java
+++ b/core/src/main/java/org/elasticsearch/http/netty/cors/CorsHandler.java
@@ -32,7 +32,6 @@ import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS;
@@ -40,6 +39,7 @@ import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTRO
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_ALLOW_METHODS;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_MAX_AGE;
+import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.HOST;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ORIGIN;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.USER_AGENT;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.VARY;
@@ -98,7 +98,7 @@ public class CorsHandler extends SimpleChannelUpstreamHandler {
             final String originHeaderVal;
             if (config.isAnyOriginSupported()) {
                 originHeaderVal = ANY_ORIGIN;
-            } else if (config.isOriginAllowed(originHeader)) {
+            } else if (config.isOriginAllowed(originHeader) || isSameOrigin(originHeader, request.headers().get(HOST))) {
                 originHeaderVal = originHeader;
             } else {
                 originHeaderVal = null;
@@ -129,6 +129,17 @@ public class CorsHandler extends SimpleChannelUpstreamHandler {
     private static void forbidden(final ChannelHandlerContext ctx, final HttpRequest request) {
         ctx.getChannel().write(new DefaultHttpResponse(request.getProtocolVersion(), FORBIDDEN))
             .addListener(ChannelFutureListener.CLOSE);
+    }
+
+    private static boolean isSameOrigin(final String origin, final String host) {
+        if (Strings.isNullOrEmpty(host) == false) {
+            // strip protocol from origin
+            final String originDomain = origin.replaceFirst("(http|https)://", "");
+            if (host.equals(originDomain)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -178,6 +189,11 @@ public class CorsHandler extends SimpleChannelUpstreamHandler {
         }
 
         if ("null".equals(origin) && config.isNullOriginAllowed()) {
+            return true;
+        }
+
+        // if the origin is the same as the host of the request, then allow
+        if (isSameOrigin(origin, request.headers().get(HOST))) {
             return true;
         }
 

--- a/core/src/main/java/org/elasticsearch/http/netty/cors/CorsHandler.java
+++ b/core/src/main/java/org/elasticsearch/http/netty/cors/CorsHandler.java
@@ -33,6 +33,7 @@ import org.jboss.netty.handler.codec.http.HttpResponse;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS;
@@ -57,6 +58,7 @@ import static org.jboss.netty.handler.codec.http.HttpResponseStatus.OK;
 public class CorsHandler extends SimpleChannelUpstreamHandler {
 
     public static final String ANY_ORIGIN = "*";
+    private static Pattern PATTERN = Pattern.compile("^https?://");
     private final CorsConfig config;
 
     private HttpRequest request;
@@ -134,7 +136,7 @@ public class CorsHandler extends SimpleChannelUpstreamHandler {
     private static boolean isSameOrigin(final String origin, final String host) {
         if (Strings.isNullOrEmpty(host) == false) {
             // strip protocol from origin
-            final String originDomain = origin.replaceFirst("(http|https)://", "");
+            final String originDomain = PATTERN.matcher(origin).replaceFirst("");
             if (host.equals(originDomain)) {
                 return true;
             }

--- a/core/src/test/java/org/elasticsearch/http/netty/NettyHttpChannelTests.java
+++ b/core/src/test/java/org/elasticsearch/http/netty/NettyHttpChannelTests.java
@@ -55,8 +55,6 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class NettyHttpChannelTests extends ESTestCase {
 
-    private static final String ORIGIN = "remote-host";
-
     private NetworkService networkService;
     private ThreadPool threadPool;
     private MockBigArrays bigArrays;
@@ -86,34 +84,70 @@ public class NettyHttpChannelTests extends ESTestCase {
         Settings settings = Settings.builder()
                 .put(NettyHttpServerTransport.SETTING_CORS_ENABLED, true)
                 .build();
-        HttpResponse response = execRequestWithCors(settings, ORIGIN);
+        HttpResponse response = execRequestWithCors(settings, "remote-host", "request-host");
         // inspect response and validate
         assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN), nullValue());
     }
 
+    @Test
     public void testCorsEnabledWithAllowOrigins() {
-        final String originValue = ORIGIN;
+        final String originValue = "remote-host";
         // create a http transport with CORS enabled and allow origin configured
         Settings settings = Settings.builder()
                 .put(SETTING_CORS_ENABLED, true)
                 .put(SETTING_CORS_ALLOW_ORIGIN, originValue)
                 .build();
-        HttpResponse response = execRequestWithCors(settings, originValue);
+        HttpResponse response = execRequestWithCors(settings, originValue, "request-host");
         // inspect response and validate
         assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN), notNullValue());
         String allowedOrigins = response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN);
         assertThat(allowedOrigins, is(originValue));
     }
 
+    @Test
+    public void testCorsAllowOriginWithSameHost() {
+        String originValue = "remote-host";
+        String host = "remote-host";
+        // create a http transport with CORS enabled
+        Settings settings = Settings.builder()
+                                .put(NettyHttpServerTransport.SETTING_CORS_ENABLED, true)
+                                .build();
+        HttpResponse response = execRequestWithCors(settings, originValue, host);
+        // inspect response and validate
+        assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN), notNullValue());
+        String allowedOrigins = response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN);
+        assertThat(allowedOrigins, is(originValue));
+
+        originValue = "http://" + originValue;
+        response = execRequestWithCors(settings, originValue, host);
+        assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN), notNullValue());
+        allowedOrigins = response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN);
+        assertThat(allowedOrigins, is(originValue));
+
+        originValue = originValue + ":5555";
+        host = host + ":5555";
+        response = execRequestWithCors(settings, originValue, host);
+        assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN), notNullValue());
+        allowedOrigins = response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN);
+        assertThat(allowedOrigins, is(originValue));
+
+        originValue = originValue.replace("http", "https");
+        response = execRequestWithCors(settings, originValue, host);
+        assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN), notNullValue());
+        allowedOrigins = response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN);
+        assertThat(allowedOrigins, is(originValue));
+    }
+
+    @Test
     public void testThatStringLiteralWorksOnMatch() {
-        final String originValue = ORIGIN;
+        final String originValue = "remote-host";
         Settings settings = Settings.builder()
                                 .put(SETTING_CORS_ENABLED, true)
                                 .put(SETTING_CORS_ALLOW_ORIGIN, originValue)
                                 .put(SETTING_CORS_ALLOW_METHODS, "get, options, post")
                                 .put(SETTING_CORS_ALLOW_CREDENTIALS, true)
                                 .build();
-        HttpResponse response = execRequestWithCors(settings, originValue);
+        HttpResponse response = execRequestWithCors(settings, originValue, "request-host");
         // inspect response and validate
         assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN), notNullValue());
         String allowedOrigins = response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN);
@@ -121,13 +155,14 @@ public class NettyHttpChannelTests extends ESTestCase {
         assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS), equalTo("true"));
     }
 
+    @Test
     public void testThatAnyOriginWorks() {
         final String originValue = CorsHandler.ANY_ORIGIN;
         Settings settings = Settings.builder()
                                 .put(SETTING_CORS_ENABLED, true)
                                 .put(SETTING_CORS_ALLOW_ORIGIN, originValue)
                                 .build();
-        HttpResponse response = execRequestWithCors(settings, originValue);
+        HttpResponse response = execRequestWithCors(settings, originValue, "request-host");
         // inspect response and validate
         assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN), notNullValue());
         String allowedOrigins = response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN);
@@ -135,6 +170,7 @@ public class NettyHttpChannelTests extends ESTestCase {
         assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS), nullValue());
     }
 
+    @Test
     public void testHeadersSet() {
         Settings settings = Settings.builder().build();
         httpServerTransport = new NettyHttpServerTransport(settings, networkService, bigArrays);
@@ -162,12 +198,13 @@ public class NettyHttpChannelTests extends ESTestCase {
         assertThat(response.headers().get(HttpHeaders.Names.CONTENT_TYPE), equalTo(resp.contentType()));
     }
 
-    private HttpResponse execRequestWithCors(final Settings settings, final String originValue) {
+    private HttpResponse execRequestWithCors(final Settings settings, final String originValue, final String host) {
         // construct request and send it over the transport layer
         httpServerTransport = new NettyHttpServerTransport(settings, networkService, bigArrays);
         HttpRequest httpRequest = new TestHttpRequest();
-        httpRequest.headers().add(HttpHeaders.Names.ORIGIN, ORIGIN);
+        httpRequest.headers().add(HttpHeaders.Names.ORIGIN, originValue);
         httpRequest.headers().add(HttpHeaders.Names.USER_AGENT, "Mozilla fake");
+        httpRequest.headers().add(HttpHeaders.Names.HOST, host);
         WriteCapturingChannel writeCapturingChannel = new WriteCapturingChannel();
         NettyHttpRequest request = new NettyHttpRequest(httpRequest, writeCapturingChannel);
 


### PR DESCRIPTION
When CORS is enabled, permit requests from the same origin as the request host, as the request is not a cross origin.

Closes #18256 
