### PR TITLE
CORS handling triggered whether User-Agent is a browser or not

### DIFF
--- a/core/src/main/java/org/elasticsearch/http/netty/cors/CorsHandler.java
+++ b/core/src/main/java/org/elasticsearch/http/netty/cors/CorsHandler.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.http.netty.cors;
 
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.rest.support.RestUtils;
 import org.jboss.netty.channel.ChannelFutureListener;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.MessageEvent;
@@ -41,7 +40,6 @@ import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTRO
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_MAX_AGE;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.HOST;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ORIGIN;
-import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.USER_AGENT;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.VARY;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.OK;
@@ -76,15 +74,13 @@ public class CorsHandler extends SimpleChannelUpstreamHandler {
     public void messageReceived(final ChannelHandlerContext ctx, final MessageEvent e) throws Exception {
         if (config.isCorsSupportEnabled() && e.getMessage() instanceof HttpRequest) {
             request = (HttpRequest) e.getMessage();
-            if (RestUtils.isBrowser(request.headers().get(USER_AGENT))) {
-                if (isPreflightRequest(request)) {
-                    handlePreflight(ctx, request);
-                    return;
-                }
-                if (config.isShortCircuit() && !validateOrigin()) {
-                    forbidden(ctx, request);
-                    return;
-                }
+            if (isPreflightRequest(request)) {
+                handlePreflight(ctx, request);
+                return;
+            }
+            if (config.isShortCircuit() && !validateOrigin()) {
+                forbidden(ctx, request);
+                return;
             }
         }
         super.messageReceived(ctx, e);

--- a/core/src/main/java/org/elasticsearch/rest/support/RestUtils.java
+++ b/core/src/main/java/org/elasticsearch/rest/support/RestUtils.java
@@ -41,17 +41,6 @@ public class RestUtils {
         }
     };
 
-    public static boolean isBrowser(@Nullable String userAgent) {
-        if (userAgent == null) {
-            return false;
-        }
-        // chrome, safari, firefox, ie
-        if (userAgent.startsWith("Mozilla")) {
-            return true;
-        }
-        return false;
-    }
-
     public static void decodeQueryString(String s, int fromIndex, Map<String, String> params) {
         if (fromIndex < 0) {
             return;

--- a/core/src/test/java/org/elasticsearch/http/netty/NettyHttpChannelTests.java
+++ b/core/src/test/java/org/elasticsearch/http/netty/NettyHttpChannelTests.java
@@ -178,7 +178,6 @@ public class NettyHttpChannelTests extends ESTestCase {
         httpServerTransport = new NettyHttpServerTransport(settings, networkService, bigArrays, threadPool);
         HttpRequest httpRequest = new TestHttpRequest();
         httpRequest.headers().add(HttpHeaders.Names.ORIGIN, "remote");
-        httpRequest.headers().add(HttpHeaders.Names.USER_AGENT, "Mozilla fake");
         WriteCapturingChannel writeCapturingChannel = new WriteCapturingChannel();
         NettyHttpRequest request = new NettyHttpRequest(httpRequest, writeCapturingChannel);
 
@@ -205,7 +204,6 @@ public class NettyHttpChannelTests extends ESTestCase {
         httpServerTransport = new NettyHttpServerTransport(settings, networkService, bigArrays, threadPool);
         HttpRequest httpRequest = new TestHttpRequest();
         httpRequest.headers().add(HttpHeaders.Names.ORIGIN, originValue);
-        httpRequest.headers().add(HttpHeaders.Names.USER_AGENT, "Mozilla fake");
         httpRequest.headers().add(HttpHeaders.Names.HOST, host);
         WriteCapturingChannel writeCapturingChannel = new WriteCapturingChannel();
         NettyHttpRequest request = new NettyHttpRequest(httpRequest, writeCapturingChannel);


### PR DESCRIPTION
This commit ensures that if CORS is enabled, then Origin headers are
checked regardless of whether the request came from a browser or not.
In the past, we only proceeded with CORS checks if the User-Agent was a
browser.
