### PR TITLE
Add tests that packages depend on bash

### DIFF
--- a/qa/vagrant/src/test/resources/packaging/scripts/30_deb_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/30_deb_package.bats
@@ -40,6 +40,10 @@ setup() {
     export_elasticsearch_paths
 }
 
+@test "[DEB] package depends on bash" {
+    dpkg -I elasticsearch-$(cat version).deb | grep "Depends:.*bash.*"
+}
+
 ##################################
 # Install DEB package
 ##################################

--- a/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
@@ -39,6 +39,10 @@ setup() {
     export_elasticsearch_paths
 }
 
+@test "[RPM] package depends on bash" {
+    rpm -qpR elasticsearch-$(cat version).rpm | grep '/bin/bash'
+}
+
 ##################################
 # Install RPM package
 ##################################


### PR DESCRIPTION
This commit adds bats tests that the RPM and Debian packages depend on
bash.

Relates #18259
