### PR TITLE
New Matrix Stats Aggregation module

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/ParseField.java
+++ b/core/src/main/java/org/elasticsearch/common/ParseField.java
@@ -107,4 +107,12 @@ public class ParseField {
     public String[] getDeprecatedNames() {
         return deprecatedNames;
     }
+
+    public static class CommonFields {
+        public static final ParseField FIELD = new ParseField("field");
+        public static final ParseField FIELDS = new ParseField("fields");
+        public static final ParseField FORMAT = new ParseField("format");
+        public static final ParseField MISSING = new ParseField("missing");
+        public static final ParseField TIME_ZONE = new ParseField("time_zone");
+    }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -20,6 +20,7 @@ package org.elasticsearch.search.aggregations;
 
 
 import org.elasticsearch.action.support.ToXContentToBytes;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.search.aggregations.InternalAggregation.Type;
@@ -84,4 +85,8 @@ public abstract class AggregationBuilder
      */
     protected abstract AggregationBuilder subAggregations(AggregatorFactories.Builder subFactories);
 
+    /** Common xcontent fields shared among aggregator builders */
+    public static final class CommonFields extends ParseField.CommonFields {
+        public static final ParseField VALUE_TYPE = new ParseField("value_type");
+    }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -20,6 +20,7 @@ package org.elasticsearch.search.aggregations;
 
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -250,7 +251,8 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, St
     /**
      * Common xcontent fields that are shared among addAggregation
      */
-    public static final class CommonFields {
+    public static final class CommonFields extends ParseField.CommonFields {
+        // todo convert these to ParseField
         public static final String META = "meta";
         public static final String BUCKETS = "buckets";
         public static final String VALUE = "value";

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
@@ -61,29 +61,30 @@ public class AggregationContext {
         assert config.valid() : "value source config is invalid - must have either a field context or a script or marked as unmapped";
 
         final VS vs;
-        if (config.unmapped) {
-            if (config.missing == null) {
+        if (config.unmapped()) {
+            if (config.missing() == null) {
                 // otherwise we will have values because of the missing value
                 vs = null;
-            } else if (config.valueSourceType == ValuesSourceType.NUMERIC) {
+            } else if (config.valueSourceType() == ValuesSourceType.NUMERIC) {
                 vs = (VS) ValuesSource.Numeric.EMPTY;
-            } else if (config.valueSourceType == ValuesSourceType.GEOPOINT) {
+            } else if (config.valueSourceType() == ValuesSourceType.GEOPOINT) {
                 vs = (VS) ValuesSource.GeoPoint.EMPTY;
-            } else if (config.valueSourceType == ValuesSourceType.ANY || config.valueSourceType == ValuesSourceType.BYTES) {
+            } else if (config.valueSourceType() == ValuesSourceType.ANY || config.valueSourceType() == ValuesSourceType.BYTES) {
                 vs = (VS) ValuesSource.Bytes.EMPTY;
             } else {
-                throw new SearchParseException(searchContext, "Can't deal with unmapped ValuesSource type " + config.valueSourceType, null);
+                throw new SearchParseException(searchContext, "Can't deal with unmapped ValuesSource type "
+                    + config.valueSourceType(), null);
             }
         } else {
             vs = originalValuesSource(config);
         }
 
-        if (config.missing == null) {
+        if (config.missing() == null) {
             return vs;
         }
 
         if (vs instanceof ValuesSource.Bytes) {
-            final BytesRef missing = new BytesRef(config.missing.toString());
+            final BytesRef missing = new BytesRef(config.missing().toString());
             if (vs instanceof ValuesSource.Bytes.WithOrdinals) {
                 return (VS) MissingValues.replaceMissing((ValuesSource.Bytes.WithOrdinals) vs, missing);
             } else {
@@ -91,20 +92,20 @@ public class AggregationContext {
             }
         } else if (vs instanceof ValuesSource.Numeric) {
             Number missing = null;
-            if (config.missing instanceof Number) {
-                missing = (Number) config.missing;
+            if (config.missing() instanceof Number) {
+                missing = (Number) config.missing();
             } else {
-                if (config.fieldContext != null && config.fieldContext.fieldType() != null) {
-                    missing = config.fieldContext.fieldType().docValueFormat(null, DateTimeZone.UTC)
-                            .parseDouble(config.missing.toString(), false, context.nowCallable());
+                if (config.fieldContext() != null && config.fieldContext().fieldType() != null) {
+                    missing = config.fieldContext().fieldType().docValueFormat(null, DateTimeZone.UTC)
+                            .parseDouble(config.missing().toString(), false, context.nowCallable());
                 } else {
-                    missing = Double.parseDouble(config.missing.toString());
+                    missing = Double.parseDouble(config.missing().toString());
                 }
             }
             return (VS) MissingValues.replaceMissing((ValuesSource.Numeric) vs, missing);
         } else if (vs instanceof ValuesSource.GeoPoint) {
             // TODO: also support the structured formats of geo points
-            final GeoPoint missing = GeoUtils.parseGeoPoint(config.missing.toString(), new GeoPoint());
+            final GeoPoint missing = GeoUtils.parseGeoPoint(config.missing().toString(), new GeoPoint());
             return (VS) MissingValues.replaceMissing((ValuesSource.GeoPoint) vs, missing);
         } else {
             // Should not happen
@@ -116,21 +117,21 @@ public class AggregationContext {
      * Return the original values source, before we apply `missing`.
      */
     private <VS extends ValuesSource> VS originalValuesSource(ValuesSourceConfig<VS> config) throws IOException {
-        if (config.fieldContext == null) {
-            if (config.valueSourceType == ValuesSourceType.NUMERIC) {
+        if (config.fieldContext() == null) {
+            if (config.valueSourceType() == ValuesSourceType.NUMERIC) {
                 return (VS) numericScript(config);
             }
-            if (config.valueSourceType == ValuesSourceType.BYTES) {
+            if (config.valueSourceType() == ValuesSourceType.BYTES) {
                 return (VS) bytesScript(config);
             }
-            throw new AggregationExecutionException("value source of type [" + config.valueSourceType.name()
+            throw new AggregationExecutionException("value source of type [" + config.valueSourceType().name()
                     + "] is not supported by scripts");
         }
 
-        if (config.valueSourceType == ValuesSourceType.NUMERIC) {
+        if (config.valueSourceType() == ValuesSourceType.NUMERIC) {
             return (VS) numericField(config);
         }
-        if (config.valueSourceType == ValuesSourceType.GEOPOINT) {
+        if (config.valueSourceType() == ValuesSourceType.GEOPOINT) {
             return (VS) geoPointField(config);
         }
         // falling back to bytes values
@@ -138,25 +139,25 @@ public class AggregationContext {
     }
 
     private ValuesSource.Numeric numericScript(ValuesSourceConfig<?> config) throws IOException {
-        return new ValuesSource.Numeric.Script(config.script, config.scriptValueType);
+        return new ValuesSource.Numeric.Script(config.script(), config.scriptValueType());
     }
 
     private ValuesSource.Numeric numericField(ValuesSourceConfig<?> config) throws IOException {
 
-        if (!(config.fieldContext.indexFieldData() instanceof IndexNumericFieldData)) {
-            throw new IllegalArgumentException("Expected numeric type on field [" + config.fieldContext.field() +
-                    "], but got [" + config.fieldContext.fieldType().typeName() + "]");
+        if (!(config.fieldContext().indexFieldData() instanceof IndexNumericFieldData)) {
+            throw new IllegalArgumentException("Expected numeric type on field [" + config.fieldContext().field() +
+                    "], but got [" + config.fieldContext().fieldType().typeName() + "]");
         }
 
-        ValuesSource.Numeric dataSource = new ValuesSource.Numeric.FieldData((IndexNumericFieldData) config.fieldContext.indexFieldData());
-        if (config.script != null) {
-            dataSource = new ValuesSource.Numeric.WithScript(dataSource, config.script);
+        ValuesSource.Numeric dataSource = new ValuesSource.Numeric.FieldData((IndexNumericFieldData)config.fieldContext().indexFieldData());
+        if (config.script() != null) {
+            dataSource = new ValuesSource.Numeric.WithScript(dataSource, config.script());
         }
         return dataSource;
     }
 
     private ValuesSource bytesField(ValuesSourceConfig<?> config) throws IOException {
-        final IndexFieldData<?> indexFieldData = config.fieldContext.indexFieldData();
+        final IndexFieldData<?> indexFieldData = config.fieldContext().indexFieldData();
         ValuesSource dataSource;
         if (indexFieldData instanceof ParentChildIndexFieldData) {
             dataSource = new ValuesSource.Bytes.WithOrdinals.ParentChild((ParentChildIndexFieldData) indexFieldData);
@@ -165,24 +166,24 @@ public class AggregationContext {
         } else {
             dataSource = new ValuesSource.Bytes.FieldData(indexFieldData);
         }
-        if (config.script != null) {
-            dataSource = new ValuesSource.WithScript(dataSource, config.script);
+        if (config.script() != null) {
+            dataSource = new ValuesSource.WithScript(dataSource, config.script());
         }
         return dataSource;
     }
 
     private ValuesSource.Bytes bytesScript(ValuesSourceConfig<?> config) throws IOException {
-        return new ValuesSource.Bytes.Script(config.script);
+        return new ValuesSource.Bytes.Script(config.script());
     }
 
     private ValuesSource.GeoPoint geoPointField(ValuesSourceConfig<?> config) throws IOException {
 
-        if (!(config.fieldContext.indexFieldData() instanceof IndexGeoPointFieldData)) {
-            throw new IllegalArgumentException("Expected geo_point type on field [" + config.fieldContext.field() +
-                    "], but got [" + config.fieldContext.fieldType().typeName() + "]");
+        if (!(config.fieldContext().indexFieldData() instanceof IndexGeoPointFieldData)) {
+            throw new IllegalArgumentException("Expected geo_point type on field [" + config.fieldContext().field() +
+                    "], but got [" + config.fieldContext().fieldType().typeName() + "]");
         }
 
-        return new ValuesSource.GeoPoint.Fielddata((IndexGeoPointFieldData) config.fieldContext.indexFieldData());
+        return new ValuesSource.GeoPoint.Fielddata((IndexGeoPointFieldData) config.fieldContext().indexFieldData());
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
@@ -317,7 +317,7 @@ public abstract class ValuesSourceAggregationBuilder<VS extends ValuesSource, AB
             if (script == null) {
                 @SuppressWarnings("unchecked")
                 ValuesSourceConfig<VS> config = new ValuesSourceConfig(ValuesSourceType.ANY);
-                config.format = resolveFormat(null, valueType);
+                config.format(resolveFormat(null, valueType));
                 return config;
             }
             ValuesSourceType valuesSourceType = valueType != null ? valueType.getValuesSourceType() : this.valuesSourceType;
@@ -329,11 +329,11 @@ public abstract class ValuesSourceAggregationBuilder<VS extends ValuesSource, AB
                 valuesSourceType = ValuesSourceType.BYTES;
             }
             ValuesSourceConfig<VS> config = new ValuesSourceConfig<VS>(valuesSourceType);
-            config.missing = missing;
-            config.timeZone = timeZone;
-            config.format = resolveFormat(format, valueType);
-            config.script = createScript(script, context.searchContext());
-            config.scriptValueType = valueType;
+            config.missing(missing);
+            config.timezone(timeZone);
+            config.format(resolveFormat(format, valueType));
+            config.script(createScript(script, context.searchContext()));
+            config.scriptValueType(valueType);
             return config;
         }
 
@@ -341,13 +341,13 @@ public abstract class ValuesSourceAggregationBuilder<VS extends ValuesSource, AB
         if (fieldType == null) {
             ValuesSourceType valuesSourceType = valueType != null ? valueType.getValuesSourceType() : this.valuesSourceType;
             ValuesSourceConfig<VS> config = new ValuesSourceConfig<>(valuesSourceType);
-            config.missing = missing;
-            config.timeZone = timeZone;
-            config.format = resolveFormat(format, valueType);
-            config.unmapped = true;
+            config.missing(missing);
+            config.timezone(timeZone);
+            config.format(resolveFormat(format, valueType));
+            config.unmapped(true);
             if (valueType != null) {
                 // todo do we really need this for unmapped?
-                config.scriptValueType = valueType;
+                config.scriptValueType(valueType);
             }
             return config;
         }
@@ -367,11 +367,11 @@ public abstract class ValuesSourceAggregationBuilder<VS extends ValuesSource, AB
             config = new ValuesSourceConfig(valuesSourceType);
         }
 
-        config.fieldContext = new FieldContext(field, indexFieldData, fieldType);
-        config.missing = missing;
-        config.timeZone = timeZone;
-        config.script = createScript(script, context.searchContext());
-        config.format = fieldType.docValueFormat(format, timeZone);
+        config.fieldContext(new FieldContext(field, indexFieldData, fieldType));
+        config.missing(missing);
+        config.timezone(timeZone);
+        config.script(createScript(script, context.searchContext()));
+        config.format(fieldType.docValueFormat(format, timeZone));
         return config;
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregatorFactory.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregatorFactory.java
@@ -42,7 +42,7 @@ public abstract class ValuesSourceAggregatorFactory<VS extends ValuesSource, AF 
     }
 
     public DateTimeZone timeZone() {
-        return config.timeZone;
+        return config.timezone();
         }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
@@ -27,15 +27,15 @@ import org.joda.time.DateTimeZone;
  */
 public class ValuesSourceConfig<VS extends ValuesSource> {
 
-    final ValuesSourceType valueSourceType;
-    FieldContext fieldContext;
-    SearchScript script;
-    ValueType scriptValueType;
-    boolean unmapped = false;
-    String formatPattern;
-    DocValueFormat format = DocValueFormat.RAW;
-    Object missing;
-    DateTimeZone timeZone;
+    private final ValuesSourceType valueSourceType;
+    private FieldContext fieldContext;
+    private SearchScript script;
+    private ValueType scriptValueType;
+    private boolean unmapped = false;
+    private String formatPattern;
+    private DocValueFormat format = DocValueFormat.RAW;
+    private Object missing;
+    private DateTimeZone timeZone;
 
     public ValuesSourceConfig(ValuesSourceType valueSourceType) {
         this.valueSourceType = valueSourceType;
@@ -71,6 +71,15 @@ public class ValuesSourceConfig<VS extends ValuesSource> {
         return this;
     }
 
+    public ValuesSourceConfig<VS> scriptValueType(ValueType scriptValueType) {
+        this.scriptValueType = scriptValueType;
+        return this;
+    }
+
+    public ValueType scriptValueType() {
+        return this.scriptValueType;
+    }
+
     public ValuesSourceConfig<VS> unmapped(boolean unmapped) {
         this.unmapped = unmapped;
         return this;
@@ -86,9 +95,17 @@ public class ValuesSourceConfig<VS extends ValuesSource> {
         return this;
     }
 
+    public Object missing() {
+        return this.missing;
+    }
+
     public ValuesSourceConfig<VS> timezone(final DateTimeZone timeZone) {
         this.timeZone= timeZone;
         return this;
+    }
+
+    public DateTimeZone timezone() {
+        return this.timeZone;
     }
 
     public DocValueFormat format() {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
@@ -76,6 +76,21 @@ public class ValuesSourceConfig<VS extends ValuesSource> {
         return this;
     }
 
+    public ValuesSourceConfig<VS> format(final DocValueFormat format) {
+        this.format = format;
+        return this;
+    }
+
+    public ValuesSourceConfig<VS> missing(final Object missing) {
+        this.missing = missing;
+        return this;
+    }
+
+    public ValuesSourceConfig<VS> timezone(final DateTimeZone timeZone) {
+        this.timeZone= timeZone;
+        return this;
+    }
+
     public DocValueFormat format() {
         return format;
     }

--- a/docs/reference/modules.asciidoc
+++ b/docs/reference/modules.asciidoc
@@ -18,6 +18,10 @@ These settings can be dynamically updated on a live cluster with the
 
 The modules in this section are:
 
+<<modules-aggregations-matrix,Matrix Aggregations>>::
+
+    A family of aggregations that operate on multiple document fields and produce a matrix as output.
+
 <<modules-cluster,Cluster-level routing and shard allocation>>::
 
     Settings to control where, when, and how shards are allocated to nodes.
@@ -79,6 +83,8 @@ The modules in this section are:
     client across them.
 --
 
+
+include::modules/aggregations-matrix.asciidoc[]
 
 include::modules/cluster.asciidoc[]
 

--- a/docs/reference/modules/aggregations-matrix.asciidoc
+++ b/docs/reference/modules/aggregations-matrix.asciidoc
@@ -1,0 +1,9 @@
+[[modules-aggregations-matrix]]
+== Matrix Aggregations
+
+experimental[]
+
+The aggregations in this family operate on multiple fields and produce a matrix result based on the values extracted from
+the requested document fields. Unlike metric and bucket aggregations, this aggregation family does not yet support scripting.
+
+include::aggregations/matrix/stats.asciidoc[]

--- a/docs/reference/modules/aggregations/matrix/stats.asciidoc
+++ b/docs/reference/modules/aggregations/matrix/stats.asciidoc
@@ -1,0 +1,112 @@
+[[modules-matrix-aggregations-stats]]
+=== Matrix Stats
+
+The `matrix_stats` aggregation is a numeric aggregation that computes the following statistics over a set of document fields:
+
+[horizontal]
+`count`:: Number of per field samples included in the calculation.
+`mean`:: The average value for each field.
+`variance`:: Per field Measurement for how spread out the samples are from the mean.
+`skewness`:: Per field measurement quantifying the asymmetric distribution around the mean.
+`kurtosis`:: Per field measurement quantifying the shape of the distribution.
+`covariance`:: A matrix that quantitatively describes how changes in one field are associated with another.
+`correlation`:: The covariance matrix scaled to a range of -1 to 1, inclusive. Describes the relationship between field
+            distributions.
+
+The following example demonstrates the use of matrix stats to describe the relationship between income and poverty.
+
+[source,js]
+--------------------------------------------------
+{
+    "aggs": {
+        "matrixstats": {
+            "matrix_stats": {
+                "fields": ["poverty", "income"]
+            }
+        }
+    }
+}
+--------------------------------------------------
+
+The aggregation type is `matrix_stats` and the `fields` setting defines the set of fields (as an array) for computing
+the statistics. The above request returns the following response:
+
+[source,js]
+--------------------------------------------------
+{
+    ...
+    "aggregations": {
+        "matrixstats": {
+            "fields": [{
+                "name": "income",
+                "count": 50,
+                "mean": 51985.1,
+                "variance": 7.383377037755103E7,
+                "skewness": 0.5595114003506483,
+                "kurtosis": 2.5692365287787124,
+                "covariance": {
+                    "income": 7.383377037755103E7,
+                    "poverty": -21093.65836734694
+                },
+                "correlation": {
+                    "income": 1.0,
+                    "poverty": -0.8352655256272504
+                }
+            }, {
+                "name": "poverty",
+                "count": 50,
+                "mean": 12.732000000000001,
+                "variance": 8.637730612244896,
+                "skewness": 0.4516049811903419,
+                "kurtosis": 2.8615929677997767,
+                "covariance": {
+                    "income": -21093.65836734694,
+                    "poverty": 8.637730612244896
+                },
+                "correlation": {
+                    "income": -0.8352655256272504,
+                    "poverty": 1.0
+                }
+            }]
+        }
+    }
+}
+--------------------------------------------------
+
+==== Multi Value Fields
+
+The `matrix_stats` aggregation treats each document field as an independent sample. The `mode` parameter controls what
+array value the aggregation will use for array or multi-valued fields. This parameter can take one of the following:
+
+[horizontal]
+`avg`:: (default) Use the average of all values.
+`min`:: Pick the lowest value.
+`max`:: Pick the highest value.
+`sum`:: Use the sum of all values.
+`median`:: Use the median of all values.
+
+==== Missing Values
+
+The `missing` parameter defines how documents that are missing a value should be treated.
+By default they will be ignored but it is also possible to treat them as if they had a value.
+This is done by adding a set of fieldname : value mappings to specify default values per field.
+
+[source,js]
+--------------------------------------------------
+{
+    "aggs": {
+        "matrixstats": {
+            "matrix_stats": {
+                "fields": ["poverty", "income"],
+                "missing": {"income" : 50000} <1>
+            }
+        }
+    }
+}
+--------------------------------------------------
+
+<1> Documents without a value in the `income` field will have the default value `50000`.
+
+==== Script
+
+This aggregation family does not yet support scripting.

--- a/modules/aggs-matrix-stats/build.gradle
+++ b/modules/aggs-matrix-stats/build.gradle
@@ -21,15 +21,3 @@ esplugin {
     description 'Adds aggregations whose input are a list of numeric fields and output includes a matrix.'
     classname 'org.elasticsearch.search.aggregations.matrix.MatrixAggregationPlugin'
 }
-
-dependencies {
-    testCompile project(path: ':plugins:lang-javascript', configuration: 'runtime')
-}
-
-integTest {
-    cluster {
-        plugin 'lang-javascript', project(':plugins:lang-javascript')
-        setting 'script.inline', 'true'
-        setting 'script.stored', 'true'
-    }
-}

--- a/modules/aggs-matrix-stats/build.gradle
+++ b/modules/aggs-matrix-stats/build.gradle
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+esplugin {
+    description 'Adds aggregations whose input are a list of numeric fields and output includes a matrix.'
+    classname 'org.elasticsearch.search.aggregations.matrix.MatrixAggregationPlugin'
+}
+
+dependencies {
+    testCompile project(path: ':plugins:lang-javascript', configuration: 'runtime')
+}
+
+integTest {
+    cluster {
+        plugin 'lang-javascript', project(':plugins:lang-javascript')
+        setting 'script.inline', 'true'
+        setting 'script.stored', 'true'
+    }
+}

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/MatrixStatsAggregationBuilders.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/MatrixStatsAggregationBuilders.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations;
+
+import org.elasticsearch.search.aggregations.matrix.stats.MatrixStats;
+import org.elasticsearch.search.aggregations.matrix.stats.MatrixStatsAggregatorBuilder;
+
+/**
+ */
+public class MatrixStatsAggregationBuilders {
+    /**
+     * Create a new {@link MatrixStats} aggregation with the given name.
+     */
+    public static MatrixStatsAggregatorBuilder matrixStats(String name) {
+        return new MatrixStatsAggregatorBuilder(name);
+    }
+}

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/MatrixStatsAggregationBuilders.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/MatrixStatsAggregationBuilders.java
@@ -19,7 +19,7 @@
 package org.elasticsearch.search.aggregations;
 
 import org.elasticsearch.search.aggregations.matrix.stats.MatrixStats;
-import org.elasticsearch.search.aggregations.matrix.stats.MatrixStatsAggregatorBuilder;
+import org.elasticsearch.search.aggregations.matrix.stats.MatrixStatsAggregationBuilder;
 
 /**
  */
@@ -27,7 +27,7 @@ public class MatrixStatsAggregationBuilders {
     /**
      * Create a new {@link MatrixStats} aggregation with the given name.
      */
-    public static MatrixStatsAggregatorBuilder matrixStats(String name) {
-        return new MatrixStatsAggregatorBuilder(name);
+    public static MatrixStatsAggregationBuilder matrixStats(String name) {
+        return new MatrixStatsAggregationBuilder(name);
     }
 }

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/MatrixAggregationPlugin.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/MatrixAggregationPlugin.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.matrix;
+
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.search.aggregations.matrix.stats.InternalMatrixStats;
+import org.elasticsearch.search.aggregations.matrix.stats.MatrixStatsAggregatorBuilder;
+import org.elasticsearch.search.aggregations.matrix.stats.MatrixStatsParser;
+
+import java.io.IOException;
+
+public class MatrixAggregationPlugin extends Plugin {
+    static {
+        InternalMatrixStats.registerStreams();
+    }
+
+    public MatrixAggregationPlugin() throws IOException {
+    }
+
+    @Override
+    public String name() {
+        return "aggs-matrix-stats";
+    }
+
+    @Override
+    public String description() {
+        return "Adds aggregations whose input are a list of numeric fields and output includes a matrix.";
+    }
+
+    public void onModule(SearchModule searchModule) {
+        searchModule.registerAggregation(MatrixStatsAggregatorBuilder::new, new MatrixStatsParser(),
+            MatrixStatsAggregatorBuilder.AGGREGATION_NAME_FIELD);
+    }
+}

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/MatrixAggregationPlugin.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/MatrixAggregationPlugin.java
@@ -22,15 +22,12 @@ package org.elasticsearch.search.aggregations.matrix;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.matrix.stats.InternalMatrixStats;
-import org.elasticsearch.search.aggregations.matrix.stats.MatrixStatsAggregatorBuilder;
+import org.elasticsearch.search.aggregations.matrix.stats.MatrixStatsAggregationBuilder;
 import org.elasticsearch.search.aggregations.matrix.stats.MatrixStatsParser;
 
 import java.io.IOException;
 
 public class MatrixAggregationPlugin extends Plugin {
-    static {
-        InternalMatrixStats.registerStreams();
-    }
 
     public MatrixAggregationPlugin() throws IOException {
     }
@@ -46,7 +43,8 @@ public class MatrixAggregationPlugin extends Plugin {
     }
 
     public void onModule(SearchModule searchModule) {
-        searchModule.registerAggregation(MatrixStatsAggregatorBuilder::new, new MatrixStatsParser(),
-            MatrixStatsAggregatorBuilder.AGGREGATION_NAME_FIELD);
+        InternalMatrixStats.registerStreams();
+        searchModule.registerAggregation(MatrixStatsAggregationBuilder::new, new MatrixStatsParser(),
+            MatrixStatsAggregationBuilder.AGGREGATION_NAME_FIELD);
     }
 }

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/InternalMatrixStats.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/InternalMatrixStats.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.matrix.stats;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.aggregations.AggregationStreams;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalMetricsAggregation;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Computes distribution statistics over multiple fields
+ */
+public class InternalMatrixStats extends InternalMetricsAggregation implements MatrixStats {
+
+    public final static Type TYPE = new Type("matrix_stats");
+    public final static AggregationStreams.Stream STREAM = new AggregationStreams.Stream() {
+        @Override
+        public InternalMatrixStats readResult(StreamInput in) throws IOException {
+            InternalMatrixStats result = new InternalMatrixStats();
+            result.readFrom(in);
+            return result;
+        }
+    };
+
+    public static void registerStreams() {
+        AggregationStreams.registerStream(STREAM, TYPE.stream());
+    }
+
+    /** per shard stats needed to compute stats */
+    protected RunningStats stats;
+    /** final result */
+    protected MatrixStatsResults results;
+
+    protected InternalMatrixStats() {
+    }
+
+    /** per shard ctor */
+    protected InternalMatrixStats(String name, long count, RunningStats multiFieldStatsResults, MatrixStatsResults results,
+                                  List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+        super(name, pipelineAggregators, metaData);
+        assert count >= 0;
+        this.stats = multiFieldStatsResults;
+        this.results = results;
+    }
+
+    @Override
+    public Type type() {
+        return TYPE;
+    }
+
+    @Override
+    public long getDocCount() {
+        return stats.docCount;
+    }
+
+    @Override
+    public long getFieldCount(String field) {
+        if (results == null) {
+            return 0;
+        }
+        return results.getFieldCount(field);
+    }
+
+    @Override
+    public Double getMean(String field) {
+        if (results == null) {
+            return null;
+        }
+        return results.getMean(field);
+    }
+
+    @Override
+    public Double getVariance(String field) {
+        if (results == null) {
+            return null;
+        }
+        return results.getVariance(field);
+    }
+
+    @Override
+    public Double getSkewness(String field) {
+        if (results == null) {
+            return null;
+        }
+        return results.getSkewness(field);
+    }
+
+    @Override
+    public Double getKurtosis(String field) {
+        if (results == null) {
+            return null;
+        }
+        return results.getKurtosis(field);
+    }
+
+    @Override
+    public Double getCovariance(String fieldX, String fieldY) {
+        if (results == null) {
+            return null;
+        }
+        return results.getCovariance(fieldX, fieldY);
+    }
+
+    @Override
+    public Map<String, HashMap<String, Double>> getCovariance() {
+        return results.getCovariances();
+    }
+
+    @Override
+    public Double getCorrelation(String fieldX, String fieldY) {
+        if (results == null) {
+            return null;
+        }
+        return results.getCorrelation(fieldX, fieldY);
+    }
+
+    @Override
+    public Map<String, HashMap<String, Double>> getCorrelation() {
+        return results.getCorrelations();
+    }
+
+    static class Fields {
+        public static final String COUNT = "count";
+        public static final String MEAN = "mean";
+        public static final String VARIANCE = "variance";
+        public static final String SKEWNESS = "skewness";
+        public static final String KURTOSIS = "kurtosis";
+        public static final String COVARIANCE = "covariance";
+        public static final String CORRELATION = "correlation";
+    }
+
+    @Override
+    public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        if (results != null) {
+            Set<String> fieldNames = results.getFieldCounts().keySet();
+            builder.field("field", fieldNames);
+            builder.field(Fields.COUNT, results.getFieldCounts().values());
+            builder.field(Fields.MEAN, results.getMeans().values());
+            builder.field(Fields.VARIANCE, results.getVariances().values());
+            builder.field(Fields.SKEWNESS, results.getSkewness().values());
+            builder.field(Fields.KURTOSIS, results.getKurtosis().values());
+            ArrayList<ArrayList<Double>> cov = new ArrayList<>(fieldNames.size());
+            ArrayList<ArrayList<Double>> cor = new ArrayList<>(fieldNames.size());
+            for (String y : fieldNames) {
+                ArrayList<Double> covRow = new ArrayList<>(fieldNames.size());
+                ArrayList<Double> corRow = new ArrayList<>(fieldNames.size());
+                for (String x : fieldNames) {
+                    covRow.add(results.getCovariance(x, y));
+                    corRow.add(results.getCorrelation(x, y));
+                }
+                cov.add(covRow);
+                cor.add(corRow);
+            }
+            builder.field(Fields.COVARIANCE, cov);
+            builder.field(Fields.CORRELATION, cor);
+        }
+
+        return builder;
+    }
+
+    @Override
+    public Object getProperty(List<String> path) {
+        if (path.isEmpty()) {
+            return this;
+        } else if (path.size() == 1) {
+            String coordinate = path.get(0);
+            if (results == null) {
+                results = MatrixStatsResults.EMPTY();
+            }
+            switch (coordinate) {
+                case "counts":
+                    return results.getFieldCounts();
+                case "means":
+                    return results.getMeans();
+                case "variances":
+                    return results.getVariances();
+                case "skewness":
+                    return results.getSkewness();
+                case "kurtosis":
+                    return results.getKurtosis();
+                case "covariance":
+                    return results.getCovariances();
+                case "correlation":
+                    return results.getCorrelations();
+                default:
+                    throw new IllegalArgumentException("Found unknown path element [" + coordinate + "] in [" + getName() + "]");
+            }
+        } else {
+            throw new IllegalArgumentException("path not supported for [" + getName() + "]: " + path);
+        }
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        // write running stats
+        if (stats == null || stats.docCount == 0) {
+            out.writeVLong(0);
+        } else {
+            out.writeVLong(stats.docCount);
+            stats.writeTo(out);
+        }
+
+        // write results
+        if (results == null || results.getDocCount() == 0) {
+            out.writeVLong(0);
+        } else {
+            out.writeVLong(results.getDocCount());
+            results.writeTo(out);
+        }
+    }
+
+    @Override
+    protected void doReadFrom(StreamInput in) throws IOException {
+        // read stats count
+        final long statsCount = in.readVLong();
+        if (statsCount > 0) {
+            stats = new RunningStats(in);
+            stats.docCount = statsCount;
+        }
+
+        // read count
+        final long count = in.readVLong();
+        if (count > 0) {
+            results = new MatrixStatsResults(in);
+        }
+    }
+
+    @Override
+    public InternalAggregation doReduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
+        // merge stats across all shards
+        aggregations.removeIf(p -> ((InternalMatrixStats)p).stats == null);
+
+        // return empty result iff all stats are null
+        if (aggregations.isEmpty()) {
+            return new InternalMatrixStats(name, 0, null, MatrixStatsResults.EMPTY(), pipelineAggregators(), getMetaData());
+        }
+
+        RunningStats runningStats = ((InternalMatrixStats) aggregations.get(0)).stats;
+        for (int i=1; i < aggregations.size(); ++i) {
+            runningStats.merge(((InternalMatrixStats) aggregations.get(i)).stats);
+        }
+        MatrixStatsResults results = new MatrixStatsResults(stats);
+
+        return new InternalMatrixStats(name, results.getDocCount(), runningStats, results, pipelineAggregators(), getMetaData());
+    }
+}

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStats.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStats.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.matrix.stats;
+
+import org.elasticsearch.search.aggregations.Aggregation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Interface for MatrixStats Metric Aggregation
+ */
+public interface MatrixStats extends Aggregation {
+    /** return the total document count */
+    long getDocCount();
+    /** return total field count (differs from docCount if there are missing values) */
+    long getFieldCount(String field);
+    /** return the field mean */
+    Double getMean(String field);
+    /** return the field variance */
+    Double getVariance(String field);
+    /** return the skewness of the distribution */
+    Double getSkewness(String field);
+    /** return the kurtosis of the distribution */
+    Double getKurtosis(String field);
+    /** return the upper triangle of the covariance matrix */
+    Map<String, HashMap<String, Double>> getCovariance();
+    /** return the covariance between field x and field y */
+    Double getCovariance(String fieldX, String fieldY);
+    /** return the upper triangle of the pearson product-moment correlation matrix */
+    Map<String, HashMap<String, Double>> getCorrelation();
+    /** return the correlation coefficient of field x and field y */
+    Double getCorrelation(String fieldX, String fieldY);
+}

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStats.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStats.java
@@ -20,9 +20,6 @@ package org.elasticsearch.search.aggregations.matrix.stats;
 
 import org.elasticsearch.search.aggregations.Aggregation;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Interface for MatrixStats Metric Aggregation
  */
@@ -32,19 +29,15 @@ public interface MatrixStats extends Aggregation {
     /** return total field count (differs from docCount if there are missing values) */
     long getFieldCount(String field);
     /** return the field mean */
-    Double getMean(String field);
+    double getMean(String field);
     /** return the field variance */
-    Double getVariance(String field);
+    double getVariance(String field);
     /** return the skewness of the distribution */
-    Double getSkewness(String field);
+    double getSkewness(String field);
     /** return the kurtosis of the distribution */
-    Double getKurtosis(String field);
-    /** return the upper triangle of the covariance matrix */
-    Map<String, HashMap<String, Double>> getCovariance();
+    double getKurtosis(String field);
     /** return the covariance between field x and field y */
-    Double getCovariance(String fieldX, String fieldY);
-    /** return the upper triangle of the pearson product-moment correlation matrix */
-    Map<String, HashMap<String, Double>> getCorrelation();
+    double getCovariance(String fieldX, String fieldY);
     /** return the correlation coefficient of field x and field y */
-    Double getCorrelation(String fieldX, String fieldY);
+    double getCorrelation(String fieldX, String fieldY);
 }

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregationBuilder.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregationBuilder.java
@@ -23,10 +23,11 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.MultiValuesSourceAggregatorBuilder;
+import org.elasticsearch.search.aggregations.support.MultiValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
@@ -38,19 +39,21 @@ import java.util.Map;
 
 /**
  */
-public class MatrixStatsAggregatorBuilder
-    extends MultiValuesSourceAggregatorBuilder.LeafOnly<ValuesSource.Numeric, MatrixStatsAggregatorBuilder> {
+public class MatrixStatsAggregationBuilder
+    extends MultiValuesSourceAggregationBuilder.LeafOnly<ValuesSource.Numeric, MatrixStatsAggregationBuilder> {
     public static final String NAME = InternalMatrixStats.TYPE.name();
     public static final ParseField AGGREGATION_NAME_FIELD = new ParseField(NAME);
 
-    public MatrixStatsAggregatorBuilder(String name) {
+    private MultiValueMode multiValueMode = MultiValueMode.AVG;
+
+    public MatrixStatsAggregationBuilder(String name) {
         super(name, InternalMatrixStats.TYPE, ValuesSourceType.NUMERIC, ValueType.NUMERIC);
     }
 
     /**
      * Read from a stream.
      */
-    public MatrixStatsAggregatorBuilder(StreamInput in) throws IOException {
+    public MatrixStatsAggregationBuilder(StreamInput in) throws IOException {
         super(in, InternalMatrixStats.TYPE, ValuesSourceType.NUMERIC, ValueType.NUMERIC);
     }
 
@@ -59,14 +62,24 @@ public class MatrixStatsAggregatorBuilder
         // Do nothing, no extra state to write to stream
     }
 
+    public MatrixStatsAggregationBuilder multiValueMode(MultiValueMode multiValueMode) {
+        this.multiValueMode = multiValueMode;
+        return this;
+    }
+
+    public MultiValueMode multiValueMode() {
+        return this.multiValueMode;
+    }
+
     @Override
     protected MatrixStatsAggregatorFactory innerBuild(AggregationContext context, Map<String, ValuesSourceConfig<Numeric>> configs,
-                                                      AggregatorFactory<?> parent, AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new MatrixStatsAggregatorFactory(name, type, configs, context, parent, subFactoriesBuilder, metaData);
+            AggregatorFactory<?> parent, AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
+        return new MatrixStatsAggregatorFactory(name, type, configs, multiValueMode, context, parent, subFactoriesBuilder, metaData);
     }
 
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.field(MULTIVALUE_MODE_FIELD.getPreferredName(), multiValueMode);
         return builder;
     }
 

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregator.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregator.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.matrix.stats;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.LeafBucketCollector;
+import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
+import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.ValuesSource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Metric Aggregation for computing the pearson product correlation coefficient between multiple fields
+ **/
+public class MatrixStatsAggregator extends MetricsAggregator {
+    /** Multiple ValuesSource with field names */
+    final Map<String, ValuesSource.Numeric> valuesSources;
+
+    /** array of descriptive stats, per shard, needed to compute the correlation */
+    ObjectArray<RunningStats> stats;
+
+    public MatrixStatsAggregator(String name, Map<String, ValuesSource.Numeric> valuesSources, AggregationContext context,
+                                 Aggregator parent, List<PipelineAggregator> pipelineAggregators,
+                                 Map<String,Object> metaData) throws IOException {
+        super(name, context, parent, pipelineAggregators, metaData);
+        this.valuesSources = valuesSources;
+        if (valuesSources != null && !valuesSources.isEmpty()) {
+            stats = context.bigArrays().newObjectArray(1);
+        }
+    }
+
+    @Override
+    public boolean needsScores() {
+        boolean needsScores = false;
+        if (valuesSources != null) {
+            for (Map.Entry<String, ValuesSource.Numeric> valueSource : valuesSources.entrySet()) {
+                needsScores |= valueSource.getValue().needsScores();
+            }
+        }
+        return needsScores;
+    }
+
+    @Override
+    public LeafBucketCollector getLeafCollector(LeafReaderContext ctx,
+                                                final LeafBucketCollector sub) throws IOException {
+        if (valuesSources == null || valuesSources.isEmpty()) {
+            return LeafBucketCollector.NO_OP_COLLECTOR;
+        }
+        final BigArrays bigArrays = context.bigArrays();
+        final HashMap<String, SortedNumericDoubleValues> values = new HashMap<>(valuesSources.size());
+        for (Map.Entry<String, ValuesSource.Numeric> valuesSource : valuesSources.entrySet()) {
+            values.put(valuesSource.getKey(), valuesSource.getValue().doubleValues(ctx));
+        }
+
+        return new LeafBucketCollectorBase(sub, values) {
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                // get fields
+                Map<String, Double> fields = getFields(doc);
+                if (fields != null) {
+                    stats = bigArrays.grow(stats, bucket + 1);
+                    RunningStats stat = stats.get(bucket);
+                    // add document fields to correlation stats
+                    if (stat == null) {
+                        stat = new RunningStats(fields);
+                    } else {
+                        stat.add(fields);
+                    }
+                    stats.set(bucket, stat);
+                }
+            }
+
+            /**
+             * return a map of field names and data
+             */
+            private Map<String, Double> getFields(int doc) {
+                // get fieldNames to use as hash keys
+                ArrayList<String> fieldNames = new ArrayList<>(values.keySet());
+                HashMap<String, Double> fields = new HashMap<>(fieldNames.size());
+
+                // loop over fields
+                for (String fieldName : fieldNames) {
+                    final SortedNumericDoubleValues doubleValues = values.get(fieldName);
+                    doubleValues.setDocument(doc);
+                    final int valuesCount = doubleValues.count();
+                    // if document contains an empty field we omit the doc from the correlation
+                    if (valuesCount <= 0) {
+                        return null;
+                    }
+                    // get the field value (multi-value is the average of all the values)
+                    double fieldValue = 0;
+                    for (int i = 0; i < valuesCount; ++i) {
+                        if (Double.isNaN(doubleValues.valueAt(i)) == false) {
+                            fieldValue += doubleValues.valueAt(i);
+                        }
+                    }
+                    fields.put(fieldName, fieldValue / valuesCount);
+                }
+                return fields;
+            }
+        };
+    }
+
+    @Override
+    public InternalAggregation buildAggregation(long bucket) {
+        if (valuesSources == null || bucket >= stats.size()) {
+            return buildEmptyAggregation();
+        }
+        return new InternalMatrixStats(name, stats.size(), stats.get(bucket), null, pipelineAggregators(), metaData());
+    }
+
+    @Override
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalMatrixStats(name, 0, null, null, pipelineAggregators(), metaData());
+    }
+
+    @Override
+    public void doClose() {
+        Releasables.close(stats);
+    }
+}

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregatorBuilder.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregatorBuilder.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.matrix.stats;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.MultiValuesSourceAggregatorBuilder;
+import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValueType;
+import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ */
+public class MatrixStatsAggregatorBuilder
+    extends MultiValuesSourceAggregatorBuilder.LeafOnly<ValuesSource.Numeric, MatrixStatsAggregatorBuilder> {
+    public static final String NAME = InternalMatrixStats.TYPE.name();
+    public static final ParseField AGGREGATION_NAME_FIELD = new ParseField(NAME);
+
+    public MatrixStatsAggregatorBuilder(String name) {
+        super(name, InternalMatrixStats.TYPE, ValuesSourceType.NUMERIC, ValueType.NUMERIC);
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public MatrixStatsAggregatorBuilder(StreamInput in) throws IOException {
+        super(in, InternalMatrixStats.TYPE, ValuesSourceType.NUMERIC, ValueType.NUMERIC);
+    }
+
+    @Override
+    protected void innerWriteTo(StreamOutput out) {
+        // Do nothing, no extra state to write to stream
+    }
+
+    @Override
+    protected MatrixStatsAggregatorFactory innerBuild(AggregationContext context, Map<String, ValuesSourceConfig<Numeric>> configs,
+                                                      AggregatorFactory<?> parent, AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
+        return new MatrixStatsAggregatorFactory(name, type, configs, context, parent, subFactoriesBuilder, metaData);
+    }
+
+    @Override
+    public XContentBuilder doXContentBody(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        return builder;
+    }
+
+    @Override
+    protected int innerHashCode() {
+        return 0;
+    }
+
+    @Override
+    protected boolean innerEquals(Object obj) {
+        return true;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+}

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregatorFactory.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregatorFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.matrix.stats;
+
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.MultiValuesSourceAggregatorFactory;
+import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ */
+public class MatrixStatsAggregatorFactory
+    extends MultiValuesSourceAggregatorFactory<ValuesSource.Numeric, MatrixStatsAggregatorFactory> {
+
+    public MatrixStatsAggregatorFactory(String name, InternalAggregation.Type type,
+                                        Map<String, ValuesSourceConfig<ValuesSource.Numeric>> configs, AggregationContext context,
+                                        AggregatorFactory<?> parent, AggregatorFactories.Builder subFactoriesBuilder,
+                                        Map<String, Object> metaData) throws IOException {
+        super(name, type, configs, context, parent, subFactoriesBuilder, metaData);
+    }
+
+    @Override
+    protected Aggregator createUnmapped(Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData)
+        throws IOException {
+        return new MatrixStatsAggregator(name, null, context, parent, pipelineAggregators, metaData);
+    }
+
+    @Override
+    protected Aggregator doCreateInternal(Map<String, ValuesSource.Numeric> valuesSources, Aggregator parent,
+                                          boolean collectsFromSingleBucket, List<PipelineAggregator> pipelineAggregators,
+                                          Map<String, Object> metaData) throws IOException {
+        return new MatrixStatsAggregator(name, valuesSources, context, parent, pipelineAggregators, metaData);
+    }
+}

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregatorFactory.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregatorFactory.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.matrix.stats;
 
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
@@ -37,23 +38,26 @@ import java.util.Map;
 public class MatrixStatsAggregatorFactory
     extends MultiValuesSourceAggregatorFactory<ValuesSource.Numeric, MatrixStatsAggregatorFactory> {
 
+    private final MultiValueMode multiValueMode;
+
     public MatrixStatsAggregatorFactory(String name, InternalAggregation.Type type,
-                                        Map<String, ValuesSourceConfig<ValuesSource.Numeric>> configs, AggregationContext context,
-                                        AggregatorFactory<?> parent, AggregatorFactories.Builder subFactoriesBuilder,
-                                        Map<String, Object> metaData) throws IOException {
+            Map<String, ValuesSourceConfig<ValuesSource.Numeric>> configs, MultiValueMode multiValueMode,
+            AggregationContext context, AggregatorFactory<?> parent, AggregatorFactories.Builder subFactoriesBuilder,
+            Map<String, Object> metaData) throws IOException {
         super(name, type, configs, context, parent, subFactoriesBuilder, metaData);
+        this.multiValueMode = multiValueMode;
     }
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData)
         throws IOException {
-        return new MatrixStatsAggregator(name, null, context, parent, pipelineAggregators, metaData);
+        return new MatrixStatsAggregator(name, null, context, parent, multiValueMode, pipelineAggregators, metaData);
     }
 
     @Override
     protected Aggregator doCreateInternal(Map<String, ValuesSource.Numeric> valuesSources, Aggregator parent,
                                           boolean collectsFromSingleBucket, List<PipelineAggregator> pipelineAggregators,
                                           Map<String, Object> metaData) throws IOException {
-        return new MatrixStatsAggregator(name, valuesSources, context, parent, pipelineAggregators, metaData);
+        return new MatrixStatsAggregator(name, valuesSources, context, parent, multiValueMode, pipelineAggregators, metaData);
     }
 }

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsParser.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsParser.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.matrix.stats;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.aggregations.support.MultiValuesSourceParser.NumericValuesSourceParser;
+import org.elasticsearch.search.aggregations.support.ValueType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ */
+public class MatrixStatsParser extends NumericValuesSourceParser {
+
+    public MatrixStatsParser() {
+        super(true, true, false);
+    }
+
+    @Override
+    protected boolean token(String aggregationName, String currentFieldName, XContentParser.Token token, XContentParser parser,
+                            ParseFieldMatcher parseFieldMatcher, Map<ParseField, Object> otherOptions) throws IOException {
+        return false;
+    }
+
+    @Override
+    protected MatrixStatsAggregatorBuilder createFactory(String aggregationName, ValuesSourceType valuesSourceType,
+                                                         ValueType targetValueType, Map<ParseField, Object> otherOptions) {
+        return new MatrixStatsAggregatorBuilder(aggregationName);
+    }
+}

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsResults.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsResults.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.matrix.stats;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Descriptive stats gathered per shard. Coordinating node computes final pearson product coefficient
+ * based on these descriptive stats
+ *
+ * @internal
+ */
+class MatrixStatsResults implements Streamable {
+    /** object holding results - computes results in place */
+    final RunningStats results;
+    /** pearson product correlation coefficients */
+    protected HashMap<String, HashMap<String, Double>> correlation;
+
+    /** Base ctor */
+    private MatrixStatsResults() {
+        results = RunningStats.EMPTY();
+        this.correlation = new HashMap<>();
+    }
+
+    /** creates and computes result from provided stats */
+    public MatrixStatsResults(RunningStats stats) {
+        try {
+            this.results = stats.clone();
+            this.correlation = new HashMap<>();
+        } catch (CloneNotSupportedException e) {
+            throw new ElasticsearchException("Error trying to create multifield_stats results", e);
+        }
+        this.compute();
+    }
+
+    /** creates a results object from the given stream */
+    protected MatrixStatsResults(StreamInput in) {
+        try {
+            results = new RunningStats(in);
+            this.readFrom(in);
+        } catch (IOException e) {
+            throw new ElasticsearchException("Error trying to create multifield_stats results from stream input", e);
+        }
+    }
+
+    /** create an empty results object **/
+    protected static MatrixStatsResults EMPTY() {
+        return new MatrixStatsResults();
+    }
+
+    /** return document count */
+    public final long getDocCount() {
+        return results.docCount;
+    }
+
+    /** return the field counts */
+    public Map<String, Long> getFieldCounts() {
+        return Collections.unmodifiableMap(results.counts);
+    }
+
+    /** return the fied count for the requested field */
+    public long getFieldCount(String field) {
+        if (results.counts.containsKey(field) == false) {
+            return 0;
+        }
+        return results.counts.get(field);
+    }
+
+    /** return the means */
+    public Map<String, Double> getMeans() {
+        return Collections.unmodifiableMap(results.means);
+    }
+
+    /** return the mean for the requested field */
+    public Double getMean(String field) {
+        return results.means.get(field);
+    }
+
+    /** return the variances */
+    public Map<String, Double> getVariances() {
+        return Collections.unmodifiableMap(results.variances);
+    }
+
+    /** return the variance for the requested field */
+    public Double getVariance(String field) {
+        return results.variances.get(field);
+    }
+
+    /** return the skewness */
+    public Map<String, Double> getSkewness() {
+        return Collections.unmodifiableMap(results.skewness);
+    }
+
+    /** return the skewness for the requested field */
+    public Double getSkewness(String field) {
+        return results.skewness.get(field);
+    }
+
+    /** return the kurtosis */
+    public Map<String, Double> getKurtosis() {
+        return Collections.unmodifiableMap(results.kurtosis);
+    }
+
+    /** return the kurtosis for the requested field */
+    public Double getKurtosis(String field) {
+        return results.kurtosis.get(field);
+    }
+
+    /** return the covariances */
+    public Map<String, HashMap<String, Double>> getCovariances() {
+        return Collections.unmodifiableMap(results.covariances);
+    }
+
+    /** return the covariance between two fields */
+    public Double getCovariance(String fieldX, String fieldY) {
+        if (fieldX.equals(fieldY)) {
+            return results.variances.get(fieldX);
+        }
+        return getValFromUpperTriangularMatrix(results.covariances, fieldX, fieldY);
+    }
+
+    public Map<String, HashMap<String, Double>> getCorrelations() {
+        return Collections.unmodifiableMap(correlation);
+    }
+
+    /** return the correlation coefficient between two fields */
+    public Double getCorrelation(String fieldX, String fieldY) {
+        if (fieldX.equals(fieldY)) {
+            return 1.0;
+        }
+        return getValFromUpperTriangularMatrix(correlation, fieldX, fieldY);
+    }
+
+    /** return the value for two fields in an upper triangular matrix, regardless of row col location. */
+    private Double getValFromUpperTriangularMatrix(HashMap<String, HashMap<String, Double>> map, String fieldX, String fieldY) {
+        // for the co-value to exist, one of the two (or both) fields has to be a row key
+        if (map.containsKey(fieldX) == false && map.containsKey(fieldY) == false) {
+            return null;
+        } else if (map.containsKey(fieldX)) {
+            // fieldX exists as a row key
+            if (map.get(fieldX).containsKey(fieldY)) {
+                // fieldY exists as a col key to fieldX
+                return map.get(fieldX).get(fieldY);
+            } else {
+                // otherwise fieldX is the col key to fieldY
+                return map.get(fieldY).get(fieldX);
+            }
+        } else if (map.containsKey(fieldY)) {
+            // fieldX did not exist as a row key, it must be a col key
+            return map.get(fieldY).get(fieldX);
+        }
+        throw new IllegalArgumentException("Coefficient not computed between fields: " + fieldX + " and " + fieldY);
+    }
+
+    /** Computes final covariance, variance, and correlation */
+    private void compute() {
+        final double nM1 = results.docCount - 1D;
+        // compute final skewness and kurtosis
+        for (String fieldName : results.means.keySet()) {
+            final double var = results.variances.get(fieldName);
+            // update skewness
+            results.skewness.put(fieldName, Math.sqrt(results.docCount) * results.skewness.get(fieldName) / Math.pow(var, 1.5D));
+            // update kurtosis
+            results.kurtosis.put(fieldName, (double)results.docCount * results.kurtosis.get(fieldName) / (var * var));
+            // update variances
+            results.variances.put(fieldName, results.variances.get(fieldName) / nM1);
+        }
+
+        // compute final covariances and correlation
+        double cor;
+        for (Map.Entry<String, HashMap<String, Double>> row : results.covariances.entrySet()) {
+            final String rowName = row.getKey();
+            final HashMap<String, Double> covRow = row.getValue();
+            final HashMap<String, Double> corRow = new HashMap<>();
+            for (Map.Entry<String, Double> col : covRow.entrySet()) {
+                final String colName = col.getKey();
+                // update covariance
+                covRow.put(colName, covRow.get(colName) / nM1);
+                // update correlation
+                // if there is no variance in the data then correlation is NaN
+                if (results.variances.get(rowName) == 0d || results.variances.get(colName) == 0d) {
+                    cor = Double.NaN;
+                } else {
+                    final double corDen = Math.sqrt(results.variances.get(rowName)) * Math.sqrt(results.variances.get(colName));
+                    cor = covRow.get(colName) / corDen;
+                }
+                corRow.put(colName, cor);
+            }
+            results.covariances.put(rowName, covRow);
+            correlation.put(rowName, corRow);
+        }
+    }
+
+    /** Unmarshalls MatrixStatsResults */
+    @Override
+    @SuppressWarnings("unchecked")
+    public void readFrom(StreamInput in) throws IOException {
+        if (in.readBoolean()) {
+            correlation = (HashMap<String, HashMap<String, Double>>) (in.readGenericValue());
+        } else {
+            correlation = null;
+        }
+    }
+
+    /** Marshalls MatrixStatsResults */
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        // marshall results
+        results.writeTo(out);
+        // marshall correlation
+        if (correlation != null) {
+            out.writeBoolean(true);
+            out.writeGenericValue(correlation);
+        } else {
+            out.writeBoolean(false);
+        }
+    }
+}

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/RunningStats.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/RunningStats.java
@@ -1,0 +1,358 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.matrix.stats;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Descriptive stats gathered per shard. Coordinating node computes final correlation and covariance stats
+ * based on these descriptive stats. This single pass, parallel approach is based on:
+ *
+ * http://prod.sandia.gov/techlib/access-control.cgi/2008/086212.pdf
+ *
+ * @internal
+ */
+public class RunningStats implements Streamable, Cloneable {
+    /** count of observations (same number of observations per field) */
+    protected long docCount = 0;
+    /** per field sum of observations */
+    protected HashMap<String, Double> fieldSum;
+    /** counts */
+    protected HashMap<String, Long> counts;
+    /** mean values (first moment) */
+    protected HashMap<String, Double> means;
+    /** variance values (second moment) */
+    protected HashMap<String, Double> variances;
+    /** skewness values (third moment) */
+    protected HashMap<String, Double> skewness;
+    /** kurtosis values (fourth moment) */
+    protected HashMap<String, Double> kurtosis;
+    /** covariance values */
+    protected HashMap<String, HashMap<String, Double>> covariances;
+
+    private RunningStats() {
+        init();
+    }
+
+    /** Ctor to create an instance of running statistics */
+    public RunningStats(StreamInput in) throws IOException {
+        this();
+        this.readFrom(in);
+    }
+
+    public RunningStats(Map<String, Double> doc) {
+        if (doc != null && doc.isEmpty() == false) {
+            init();
+            this.add(doc);
+        }
+    }
+
+    private void init() {
+        counts = new HashMap<>();
+        fieldSum = new HashMap<>();
+        means = new HashMap<>();
+        skewness = new HashMap<>();
+        kurtosis = new HashMap<>();
+        covariances = new HashMap<>();
+        variances = new HashMap<>();
+    }
+
+    /** create an empty instance */
+    protected static RunningStats EMPTY() {
+        return new RunningStats();
+    }
+
+    /** updates running statistics with a documents field values **/
+    public void add(Map<String, Double> doc) {
+        if (doc == null || doc.isEmpty()) {
+            return;
+        }
+
+        // update total, mean, and variance
+        ++docCount;
+        String fieldName;
+        double fieldValue;
+        double m1, m2, m3, m4;  // moments
+        double d, dn, dn2, t1;
+        final HashMap<String, Double> deltas = new HashMap<>();
+        for (Map.Entry<String, Double> field : doc.entrySet()) {
+            fieldName = field.getKey();
+            fieldValue = field.getValue();
+
+            // update counts
+            counts.put(fieldName, 1 + (counts.containsKey(fieldName) ? counts.get(fieldName) : 0));
+            // update running sum
+            fieldSum.put(fieldName, fieldValue + (fieldSum.containsKey(fieldName) ? fieldSum.get(fieldName) : 0));
+            // update running deltas
+            deltas.put(fieldName, fieldValue * docCount - fieldSum.get(fieldName));
+
+            // update running mean, variance, skewness, kurtosis
+            if (means.containsKey(fieldName) == true) {
+                // update running means
+                m1 = means.get(fieldName);
+                d = fieldValue - m1;
+                means.put(fieldName, m1 + d / docCount);
+                // update running variances
+                dn = d / docCount;
+                t1 = d * dn * (docCount - 1);
+                m2 = variances.get(fieldName);
+                variances.put(fieldName, m2 + t1);
+                m3 = skewness.get(fieldName);
+                skewness.put(fieldName, m3 + (t1 * dn * (docCount - 2D) - 3D * dn * m2));
+                dn2 = dn * dn;
+                m4 = t1 * dn2 * (docCount * docCount - 3D * docCount + 3D) + 6D * dn2 * m2 - 4D * dn * m3;
+                kurtosis.put(fieldName, kurtosis.get(fieldName) + m4);
+            } else {
+                means.put(fieldName, fieldValue);
+                variances.put(fieldName, 0.0);
+                skewness.put(fieldName, 0.0);
+                kurtosis.put(fieldName, 0.0);
+            }
+        }
+
+        this.updateCovariance(doc, deltas);
+    }
+
+    /** Update covariance matrix */
+    private void updateCovariance(final Map<String, Double> doc, final Map<String, Double> deltas) {
+        // deep copy of hash keys (field names)
+        ArrayList<String> cFieldNames = new ArrayList<>(doc.keySet());
+        String fieldName;
+        double dR, newVal;
+        for (Map.Entry<String, Double> field : doc.entrySet()) {
+            fieldName = field.getKey();
+            cFieldNames.remove(fieldName);
+            // update running covariances
+            dR = deltas.get(fieldName);
+            HashMap<String, Double> cFieldVals = (covariances.get(fieldName) != null) ? covariances.get(fieldName) : new HashMap<>();
+            for (String cFieldName : cFieldNames) {
+                if (cFieldVals.containsKey(cFieldName) == true) {
+                    newVal = cFieldVals.get(cFieldName) + 1.0 / (docCount * (docCount - 1.0)) * dR * deltas.get(cFieldName);
+                    cFieldVals.put(cFieldName, newVal);
+                } else {
+                    cFieldVals.put(cFieldName, 0.0);
+                }
+            }
+            if (cFieldVals.size() > 0) {
+                covariances.put(fieldName, cFieldVals);
+            }
+        }
+    }
+
+    /**
+     * Merges the descriptive statistics of a second data set (e.g., per shard)
+     *
+     * running computations taken from: http://prod.sandia.gov/techlib/access-control.cgi/2008/086212.pdf
+     **/
+    public void merge(final RunningStats other) {
+        if (other == null) {
+            return;
+        }
+        final double nA = docCount;
+        final double nB = other.docCount;
+        // merge count
+        docCount += other.docCount;
+
+        final HashMap<String, Double> deltas = new HashMap<>();
+        double meanA, varA, skewA, kurtA, meanB, varB, skewB, kurtB;
+        double d, d2, d3, d4, n2, nA2, nB2;
+        double newSkew, nk;
+        // across fields
+        for (Map.Entry<String, Double> fs : other.means.entrySet()) {
+            final String fieldName = fs.getKey();
+            meanA = means.get(fieldName);
+            varA = variances.get(fieldName);
+            skewA = skewness.get(fieldName);
+            kurtA = kurtosis.get(fieldName);
+            meanB = other.means.get(fieldName);
+            varB = other.variances.get(fieldName);
+            skewB = other.skewness.get(fieldName);
+            kurtB = other.kurtosis.get(fieldName);
+
+            // merge counts of two sets
+            counts.put(fieldName, counts.get(fieldName) + other.counts.get(fieldName));
+
+            // merge means of two sets
+            means.put(fieldName, (nA * means.get(fieldName) + nB * other.means.get(fieldName)) / (nA + nB));
+
+            // merge deltas
+            deltas.put(fieldName, other.fieldSum.get(fieldName) / nB - fieldSum.get(fieldName) / nA);
+
+            // merge totals
+            fieldSum.put(fieldName, fieldSum.get(fieldName) + other.fieldSum.get(fieldName));
+
+            // merge variances, skewness, and kurtosis of two sets
+            d = meanB - meanA;          // delta mean
+            d2 = d * d;                 // delta mean squared
+            d3 = d * d2;                // delta mean cubed
+            d4 = d2 * d2;               // delta mean 4th power
+            n2 = docCount * docCount;   // num samples squared
+            nA2 = nA * nA;              // doc A num samples squared
+            nB2 = nB * nB;              // doc B num samples squared
+            // variance
+            variances.put(fieldName, varA + varB + d2 * nA * other.docCount / docCount);
+            // skeewness
+            newSkew = skewA + skewB + d3 * nA * nB * (nA - nB) / n2;
+            skewness.put(fieldName, newSkew + 3D * d * (nA * varB - nB * varA) / docCount);
+            // kurtosis
+            nk = kurtA + kurtB + d4 * nA * nB * (nA2 - nA * nB + nB2) / (n2 * docCount);
+            kurtosis.put(fieldName, nk + 6D * d2 * (nA2 * varB + nB2 * varA) / n2 + 4D * d * (nA * skewB - nB * skewA) / docCount);
+        }
+
+        this.mergeCovariance(other, deltas);
+    }
+
+    /** Merges two covariance matrices */
+    private void mergeCovariance(final RunningStats other, final HashMap<String, Double> deltas) {
+        final double countA = docCount - other.docCount;
+        double f, dR, newVal;
+        for (Map.Entry<String, Double> fs : other.means.entrySet()) {
+            final String fieldName = fs.getKey();
+            // merge covariances of two sets
+            f = countA * other.docCount / this.docCount;
+            dR = deltas.get(fieldName);
+            // merge covariances
+            if (covariances.containsKey(fieldName)) {
+                HashMap<String, Double> cFieldVals = covariances.get(fieldName);
+                for (String cFieldName : cFieldVals.keySet()) {
+                    newVal = cFieldVals.get(cFieldName);
+                    if (other.covariances.containsKey(fieldName) && other.covariances.get(fieldName).containsKey(cFieldName)) {
+                        newVal += other.covariances.get(fieldName).get(cFieldName) + f * dR * deltas.get(cFieldName);
+                    } else {
+                        newVal += other.covariances.get(cFieldName).get(fieldName) + f * dR * deltas.get(cFieldName);
+                    }
+                    cFieldVals.put(cFieldName, newVal);
+                }
+                covariances.put(fieldName, cFieldVals);
+            }
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        // marshall fieldSum
+        if (fieldSum != null) {
+            out.writeBoolean(true);
+            out.writeGenericValue(fieldSum);
+        } else {
+            out.writeBoolean(false);
+        }
+        // counts
+        if (counts != null) {
+            out.writeBoolean(true);
+            out.writeGenericValue(counts);
+        } else {
+            out.writeBoolean(false);
+        }
+        // mean
+        if (means != null) {
+            out.writeBoolean(true);
+            out.writeGenericValue(means);
+        } else {
+            out.writeBoolean(false);
+        }
+        // variances
+        if (variances != null) {
+            out.writeBoolean(true);
+            out.writeGenericValue(variances);
+        } else {
+            out.writeBoolean(false);
+        }
+        // skewness
+        if (skewness != null) {
+            out.writeBoolean(true);
+            out.writeGenericValue(skewness);
+        } else {
+            out.writeBoolean(false);
+        }
+        // kurtosis
+        if (kurtosis != null) {
+            out.writeBoolean(true);
+            out.writeGenericValue(kurtosis);
+        } else {
+            out.writeBoolean(false);
+        }
+        // covariances
+        if (covariances != null) {
+            out.writeBoolean(true);
+            out.writeGenericValue(covariances);
+        } else {
+            out.writeBoolean(false);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void readFrom(StreamInput in) throws IOException {
+        // read fieldSum
+        if (in.readBoolean()) {
+            fieldSum = (HashMap<String, Double>)(in.readGenericValue());
+        } else {
+            fieldSum = null;
+        }
+        // counts
+        if (in.readBoolean()) {
+            counts = (HashMap<String, Long>)(in.readGenericValue());
+        } else {
+            counts = null;
+        }
+        // means
+        if (in.readBoolean()) {
+            means = (HashMap<String, Double>)(in.readGenericValue());
+        } else {
+            means = null;
+        }
+        // variances
+        if (in.readBoolean()) {
+            variances = (HashMap<String, Double>)(in.readGenericValue());
+        } else {
+            variances = null;
+        }
+        // skewness
+        if (in.readBoolean()) {
+            skewness = (HashMap<String, Double>)(in.readGenericValue());
+        } else {
+            skewness = null;
+        }
+        // kurtosis
+        if (in.readBoolean()) {
+            kurtosis = (HashMap<String, Double>)(in.readGenericValue());
+        } else {
+            kurtosis = null;
+        }
+        // read covariances
+        if (in.readBoolean()) {
+            covariances = (HashMap<String, HashMap<String, Double>>) (in.readGenericValue());
+        } else {
+            covariances = null;
+        }
+    }
+
+    @Override
+    public RunningStats clone() throws CloneNotSupportedException {
+        return (RunningStats)super.clone();
+    }
+}

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSource.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSource.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.support;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.index.fielddata.NumericDoubleValues;
+import org.elasticsearch.search.MultiValueMode;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Class to encapsulate a set of ValuesSource objects labeled by field name
+ */
+public abstract class MultiValuesSource <VS extends ValuesSource> {
+    protected MultiValueMode multiValueMode;
+    protected String[] names;
+    protected VS[] values;
+
+    public static class NumericMultiValuesSource extends MultiValuesSource<ValuesSource.Numeric> {
+        public NumericMultiValuesSource(Map<String, ValuesSource.Numeric> valuesSources, MultiValueMode multiValueMode) {
+            super(valuesSources, multiValueMode);
+            if (valuesSources != null) {
+                this.values = valuesSources.values().toArray(new ValuesSource.Numeric[0]);
+            } else {
+                this.values = new ValuesSource.Numeric[0];
+            }
+        }
+
+        public NumericDoubleValues getField(final int ordinal, LeafReaderContext ctx) throws IOException {
+            if (ordinal > names.length) {
+                throw new IndexOutOfBoundsException("ValuesSource array index " + ordinal + " out of bounds");
+            }
+            return multiValueMode.select(values[ordinal].doubleValues(ctx), Double.NEGATIVE_INFINITY);
+        }
+    }
+
+    public static class BytesMultiValuesSource extends MultiValuesSource<ValuesSource.Bytes> {
+        public BytesMultiValuesSource(Map<String, ValuesSource.Bytes> valuesSources, MultiValueMode multiValueMode) {
+            super(valuesSources, multiValueMode);
+            this.values = valuesSources.values().toArray(new ValuesSource.Bytes[0]);
+        }
+
+        public Object getField(final int ordinal, LeafReaderContext ctx) throws IOException {
+            return values[ordinal].bytesValues(ctx);
+        }
+    }
+
+    public static class GeoPointValuesSource extends MultiValuesSource<ValuesSource.GeoPoint> {
+        public GeoPointValuesSource(Map<String, ValuesSource.GeoPoint> valuesSources, MultiValueMode multiValueMode) {
+            super(valuesSources, multiValueMode);
+            this.values = valuesSources.values().toArray(new ValuesSource.GeoPoint[0]);
+        }
+    }
+
+    private MultiValuesSource(Map<String, ?> valuesSources, MultiValueMode multiValueMode) {
+        if (valuesSources != null) {
+            this.names = valuesSources.keySet().toArray(new String[0]);
+        }
+        this.multiValueMode = multiValueMode;
+    }
+
+    public boolean needsScores() {
+        boolean needsScores = false;
+        for (ValuesSource value : values) {
+            needsScores |= value.needsScores();
+        }
+        return needsScores;
+    }
+
+    public String[] fieldNames() {
+        return this.names;
+    }
+}

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
@@ -1,0 +1,366 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.support;
+
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.AggregationInitializationException;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.InternalAggregation.Type;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ *
+ */
+public abstract class MultiValuesSourceAggregationBuilder<VS extends ValuesSource, AB extends MultiValuesSourceAggregationBuilder<VS, AB>>
+        extends AggregationBuilder<AB> {
+
+    public static final ParseField MULTIVALUE_MODE_FIELD = new ParseField("mode");
+
+    public static abstract class LeafOnly<VS extends ValuesSource, AB extends MultiValuesSourceAggregationBuilder<VS, AB>>
+            extends MultiValuesSourceAggregationBuilder<VS, AB> {
+
+        protected LeafOnly(String name, Type type, ValuesSourceType valuesSourceType, ValueType targetValueType) {
+            super(name, type, valuesSourceType, targetValueType);
+        }
+
+        /**
+         * Read from a stream that does not serialize its targetValueType. This should be used by most subclasses.
+         */
+        protected LeafOnly(StreamInput in, Type type, ValuesSourceType valuesSourceType, ValueType targetValueType) throws IOException {
+            super(in, type, valuesSourceType, targetValueType);
+        }
+
+        /**
+         * Read an aggregation from a stream that serializes its targetValueType. This should only be used by subclasses that override
+         * {@link #serializeTargetValueType()} to return true.
+         */
+        protected LeafOnly(StreamInput in, Type type, ValuesSourceType valuesSourceType) throws IOException {
+            super(in, type, valuesSourceType);
+        }
+
+        @Override
+        public AB subAggregations(Builder subFactories) {
+            throw new AggregationInitializationException("Aggregator [" + name + "] of type [" +
+                type + "] cannot accept sub-aggregations");
+        }
+    }
+
+    private final ValuesSourceType valuesSourceType;
+    private final ValueType targetValueType;
+    private List<String> fields = Collections.emptyList();
+    private ValueType valueType = null;
+    private String format = null;
+    private Object missing = null;
+    private Map<String, Object> missingMap = Collections.emptyMap();
+
+    protected MultiValuesSourceAggregationBuilder(String name, Type type, ValuesSourceType valuesSourceType, ValueType targetValueType) {
+        super(name, type);
+        if (valuesSourceType == null) {
+            throw new IllegalArgumentException("[valuesSourceType] must not be null: [" + name + "]");
+        }
+        this.valuesSourceType = valuesSourceType;
+        this.targetValueType = targetValueType;
+    }
+
+    protected MultiValuesSourceAggregationBuilder(StreamInput in, Type type, ValuesSourceType valuesSourceType, ValueType targetValueType)
+        throws IOException {
+        super(in, type);
+        assert false == serializeTargetValueType() : "Wrong read constructor called for subclass that provides its targetValueType";
+        this.valuesSourceType = valuesSourceType;
+        this.targetValueType = targetValueType;
+        read(in);
+    }
+
+    protected MultiValuesSourceAggregationBuilder(StreamInput in, Type type, ValuesSourceType valuesSourceType) throws IOException {
+        super(in, type);
+        assert serializeTargetValueType() : "Wrong read constructor called for subclass that serializes its targetValueType";
+        this.valuesSourceType = valuesSourceType;
+        this.targetValueType = in.readOptionalWriteable(ValueType::readFromStream);
+        read(in);
+    }
+
+    /**
+     * Read from a stream.
+     */
+    @SuppressWarnings("unchecked")
+    private void read(StreamInput in) throws IOException {
+        fields = (ArrayList<String>)in.readGenericValue();
+        valueType = in.readOptionalWriteable(ValueType::readFromStream);
+        format = in.readOptionalString();
+        missingMap = in.readMap();
+    }
+
+    @Override
+    protected final void doWriteTo(StreamOutput out) throws IOException {
+        if (serializeTargetValueType()) {
+            out.writeOptionalWriteable(targetValueType);
+        }
+        out.writeGenericValue(fields);
+        out.writeOptionalWriteable(valueType);
+        out.writeOptionalString(format);
+        out.writeMap(missingMap);
+        innerWriteTo(out);
+    }
+
+    /**
+     * Write subclass' state to the stream
+     */
+    protected abstract void innerWriteTo(StreamOutput out) throws IOException;
+
+    /**
+     * Sets the field to use for this aggregation.
+     */
+    @SuppressWarnings("unchecked")
+    public AB fields(List<String> fields) {
+        if (fields == null) {
+            throw new IllegalArgumentException("[field] must not be null: [" + name + "]");
+        }
+        this.fields = fields;
+        return (AB) this;
+    }
+
+    /**
+     * Gets the field to use for this aggregation.
+     */
+    public List<String> fields() {
+        return fields;
+    }
+
+    /**
+     * Sets the {@link ValueType} for the value produced by this aggregation
+     */
+    @SuppressWarnings("unchecked")
+    public AB valueType(ValueType valueType) {
+        if (valueType == null) {
+            throw new IllegalArgumentException("[valueType] must not be null: [" + name + "]");
+        }
+        this.valueType = valueType;
+        return (AB) this;
+    }
+
+    /**
+     * Gets the {@link ValueType} for the value produced by this aggregation
+     */
+    public ValueType valueType() {
+        return valueType;
+    }
+
+    /**
+     * Sets the format to use for the output of the aggregation.
+     */
+    @SuppressWarnings("unchecked")
+    public AB format(String format) {
+        if (format == null) {
+            throw new IllegalArgumentException("[format] must not be null: [" + name + "]");
+        }
+        this.format = format;
+        return (AB) this;
+    }
+
+    /**
+     * Gets the format to use for the output of the aggregation.
+     */
+    public String format() {
+        return format;
+    }
+
+    /**
+     * Sets the value to use when the aggregation finds a missing value in a
+     * document
+     */
+    @SuppressWarnings("unchecked")
+    public AB missingMap(Map<String, Object> missingMap) {
+        if (missingMap == null) {
+            throw new IllegalArgumentException("[missing] must not be null: [" + name + "]");
+        }
+        this.missingMap = missingMap;
+        return (AB) this;
+    }
+
+    /**
+     * Gets the value to use when the aggregation finds a missing value in a
+     * document
+     */
+    public Map<String, Object> missingMap() {
+        return missingMap;
+    }
+
+    @Override
+    protected final MultiValuesSourceAggregatorFactory<VS, ?> doBuild(AggregationContext context, AggregatorFactory<?> parent,
+            AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
+        Map<String, ValuesSourceConfig<VS>> configs = resolveConfig(context);
+        MultiValuesSourceAggregatorFactory<VS, ?> factory = innerBuild(context, configs, parent, subFactoriesBuilder);
+        return factory;
+    }
+
+    protected Map<String, ValuesSourceConfig<VS>> resolveConfig(AggregationContext context) {
+        HashMap<String, ValuesSourceConfig<VS>> configs = new HashMap<>();
+        for (String field : fields) {
+            ValuesSourceConfig<VS> config = config(context, field, null);
+            configs.put(field, config);
+        }
+        return configs;
+    }
+
+    protected abstract MultiValuesSourceAggregatorFactory<VS, ?> innerBuild(AggregationContext context,
+            Map<String, ValuesSourceConfig<VS>> configs, AggregatorFactory<?> parent,
+            AggregatorFactories.Builder subFactoriesBuilder) throws IOException;
+
+    public ValuesSourceConfig<VS> config(AggregationContext context, String field, Script script) {
+
+        ValueType valueType = this.valueType != null ? this.valueType : targetValueType;
+
+        if (field == null) {
+            if (script == null) {
+                @SuppressWarnings("unchecked")
+                ValuesSourceConfig<VS> config = new ValuesSourceConfig<>(ValuesSourceType.ANY);
+                return config.format(resolveFormat(null, valueType));
+            }
+            ValuesSourceType valuesSourceType = valueType != null ? valueType.getValuesSourceType() : this.valuesSourceType;
+            if (valuesSourceType == null || valuesSourceType == ValuesSourceType.ANY) {
+                // the specific value source type is undefined, but for scripts,
+                // we need to have a specific value source
+                // type to know how to handle the script values, so we fallback
+                // on Bytes
+                valuesSourceType = ValuesSourceType.BYTES;
+            }
+            ValuesSourceConfig<VS> config = new ValuesSourceConfig<>(valuesSourceType);
+            config.missing(missingMap.get(field));
+            return config.format(resolveFormat(format, valueType));
+        }
+
+        MappedFieldType fieldType = context.searchContext().smartNameFieldType(field);
+        if (fieldType == null) {
+            ValuesSourceType valuesSourceType = valueType != null ? valueType.getValuesSourceType() : this.valuesSourceType;
+            ValuesSourceConfig<VS> config = new ValuesSourceConfig<>(valuesSourceType);
+            config.missing(missingMap.get(field));
+            config.format(resolveFormat(format, valueType));
+            return config.unmapped(true);
+        }
+
+        IndexFieldData<?> indexFieldData = context.searchContext().fieldData().getForField(fieldType);
+
+        ValuesSourceConfig<VS> config;
+        if (valuesSourceType == ValuesSourceType.ANY) {
+            if (indexFieldData instanceof IndexNumericFieldData) {
+                config = new ValuesSourceConfig<>(ValuesSourceType.NUMERIC);
+            } else if (indexFieldData instanceof IndexGeoPointFieldData) {
+                config = new ValuesSourceConfig<>(ValuesSourceType.GEOPOINT);
+            } else {
+                config = new ValuesSourceConfig<>(ValuesSourceType.BYTES);
+            }
+        } else {
+            config = new ValuesSourceConfig<>(valuesSourceType);
+        }
+
+        config.fieldContext(new FieldContext(field, indexFieldData, fieldType));
+        config.missing(missingMap.get(field));
+        return config.format(fieldType.docValueFormat(format, null));
+    }
+
+    private static DocValueFormat resolveFormat(@Nullable String format, @Nullable ValueType valueType) {
+        if (valueType == null) {
+            return DocValueFormat.RAW; // we can't figure it out
+        }
+        DocValueFormat valueFormat = valueType.defaultFormat();
+        if (valueFormat instanceof DocValueFormat.Decimal && format != null) {
+            valueFormat = new DocValueFormat.Decimal(format);
+        }
+        return valueFormat;
+    }
+
+    /**
+     * Should this builder serialize its targetValueType? Defaults to false. All subclasses that override this to true
+     * should use the three argument read constructor rather than the four argument version.
+     */
+    protected boolean serializeTargetValueType() {
+        return false;
+    }
+
+    @Override
+    public final XContentBuilder internalXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        // todo add ParseField support to XContentBuilder
+        if (fields != null) {
+            builder.field(CommonFields.FIELDS.getPreferredName(), fields);
+        }
+        if (missing != null) {
+            builder.field(CommonFields.MISSING.getPreferredName(), missing);
+        }
+        if (format != null) {
+            builder.field(CommonFields.FORMAT.getPreferredName(), format);
+        }
+        if (valueType != null) {
+            builder.field(CommonFields.VALUE_TYPE.getPreferredName(), valueType.getPreferredName());
+        }
+        doXContentBody(builder, params);
+        builder.endObject();
+        return builder;
+    }
+
+    protected abstract XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException;
+
+    @Override
+    protected final int doHashCode() {
+        return Objects.hash(fields, format, missing, targetValueType, valueType, valuesSourceType,
+                innerHashCode());
+    }
+
+    protected abstract int innerHashCode();
+
+    @Override
+    protected final boolean doEquals(Object obj) {
+        MultiValuesSourceAggregationBuilder<?, ?> other = (MultiValuesSourceAggregationBuilder<?, ?>) obj;
+        if (!Objects.equals(fields, other.fields))
+            return false;
+        if (!Objects.equals(format, other.format))
+            return false;
+        if (!Objects.equals(missing, other.missing))
+            return false;
+        if (!Objects.equals(targetValueType, other.targetValueType))
+            return false;
+        if (!Objects.equals(valueType, other.valueType))
+            return false;
+        if (!Objects.equals(valuesSourceType, other.valuesSourceType))
+            return false;
+        return innerEquals(obj);
+    }
+
+    protected abstract boolean innerEquals(Object obj);
+}

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
@@ -30,7 +30,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationInitializationException;
-import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
@@ -48,7 +48,7 @@ import java.util.Objects;
  *
  */
 public abstract class MultiValuesSourceAggregationBuilder<VS extends ValuesSource, AB extends MultiValuesSourceAggregationBuilder<VS, AB>>
-        extends AggregationBuilder<AB> {
+        extends AbstractAggregationBuilder<AB> {
 
     public static final ParseField MULTIVALUE_MODE_FIELD = new ParseField("mode");
 

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregatorFactory.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregatorFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.support;
+
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.InternalAggregation.Type;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class MultiValuesSourceAggregatorFactory<VS extends ValuesSource, AF extends MultiValuesSourceAggregatorFactory<VS, AF>>
+        extends AggregatorFactory<AF> {
+
+    protected Map<String, ValuesSourceConfig<VS>> configs;
+
+    public MultiValuesSourceAggregatorFactory(String name, Type type, Map<String, ValuesSourceConfig<VS>> configs,
+        AggregationContext context, AggregatorFactory<?> parent, AggregatorFactories.Builder subFactoriesBuilder,
+        Map<String, Object> metaData) throws IOException {
+        super(name, type, context, parent, subFactoriesBuilder, metaData);
+        this.configs = configs;
+    }
+
+    @Override
+    public Aggregator createInternal(Aggregator parent, boolean collectsFromSingleBucket, List<PipelineAggregator> pipelineAggregators,
+                                     Map<String, Object> metaData) throws IOException {
+        HashMap<String, VS> valuesSources = new HashMap<>();
+
+        for (Map.Entry<String, ValuesSourceConfig<VS>> config : configs.entrySet()) {
+            VS vs = context.valuesSource(config.getValue(), context.searchContext());
+            if (vs != null) {
+                valuesSources.put(config.getKey(), vs);
+            }
+        }
+        if (valuesSources.isEmpty()) {
+            return createUnmapped(parent, pipelineAggregators, metaData);
+        }
+        return doCreateInternal(valuesSources, parent, collectsFromSingleBucket, pipelineAggregators, metaData);
+    }
+
+    protected abstract Aggregator createUnmapped(Aggregator parent, List<PipelineAggregator> pipelineAggregators,
+                                                 Map<String, Object> metaData) throws IOException;
+
+    protected abstract Aggregator doCreateInternal(Map<String, VS> valuesSources, Aggregator parent, boolean collectsFromSingleBucket,
+        List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException;
+
+}

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceParser.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceParser.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.support;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.script.Script.ScriptField;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregationBuilder.CommonFields;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ */
+public abstract class MultiValuesSourceParser<VS extends ValuesSource> implements Aggregator.Parser {
+
+    public abstract static class AnyValuesSourceParser extends MultiValuesSourceParser<ValuesSource> {
+
+        protected AnyValuesSourceParser(boolean formattable) {
+            super(formattable, ValuesSourceType.ANY, null);
+        }
+    }
+
+    public abstract static class NumericValuesSourceParser extends MultiValuesSourceParser<ValuesSource.Numeric> {
+
+        protected NumericValuesSourceParser(boolean formattable) {
+            super(formattable, ValuesSourceType.NUMERIC, ValueType.NUMERIC);
+        }
+    }
+
+    public abstract static class BytesValuesSourceParser extends MultiValuesSourceParser<ValuesSource.Bytes> {
+
+        protected BytesValuesSourceParser(boolean formattable) {
+            super(formattable, ValuesSourceType.BYTES, ValueType.STRING);
+        }
+    }
+
+    public abstract static class GeoPointValuesSourceParser extends MultiValuesSourceParser<ValuesSource.GeoPoint> {
+
+        protected GeoPointValuesSourceParser(boolean formattable) {
+            super(formattable, ValuesSourceType.GEOPOINT, ValueType.GEOPOINT);
+        }
+    }
+
+    private boolean formattable = false;
+    private ValuesSourceType valuesSourceType = null;
+    private ValueType targetValueType = null;
+
+    private MultiValuesSourceParser(boolean formattable, ValuesSourceType valuesSourceType, ValueType targetValueType) {
+        this.valuesSourceType = valuesSourceType;
+        this.targetValueType = targetValueType;
+        this.formattable = formattable;
+    }
+
+    @Override
+    public final MultiValuesSourceAggregationBuilder<VS, ?> parse(String aggregationName, QueryParseContext context)
+            throws IOException {
+
+        XContentParser parser = context.parser();
+        List<String> fields = null;
+        ValueType valueType = null;
+        String format = null;
+        Map<String, Object> missingMap = null;
+        Map<ParseField, Object> otherOptions = new HashMap<>();
+        final ParseFieldMatcher parseFieldMatcher = context.getParseFieldMatcher();
+
+        XContentParser.Token token;
+        String currentFieldName = null;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.VALUE_STRING) {
+                if (parseFieldMatcher.match(currentFieldName, CommonFields.FIELDS)) {
+                    fields = Collections.singletonList(parser.text());
+                } else if (formattable && parseFieldMatcher.match(currentFieldName, CommonFields.FORMAT)) {
+                    format = parser.text();
+                } else if (parseFieldMatcher.match(currentFieldName, CommonFields.VALUE_TYPE)) {
+                    throw new ParsingException(parser.getTokenLocation(),
+                        "Unexpected token " + token + " [" + currentFieldName + "] in [" + aggregationName + "]. " +
+                            "Multi-field aggregations do not support scripts.");
+                } else if (!token(aggregationName, currentFieldName, token, parser, context.getParseFieldMatcher(), otherOptions)) {
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "Unexpected token " + token + " [" + currentFieldName + "] in [" + aggregationName + "].");
+                }
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                if (parseFieldMatcher.match(currentFieldName, CommonFields.MISSING)) {
+                    missingMap = new HashMap<>();
+                    while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                        parseMissingAndAdd(aggregationName, currentFieldName, parser, missingMap);
+                    }
+                } else if (context.getParseFieldMatcher().match(currentFieldName, ScriptField.SCRIPT)) {
+                    throw new ParsingException(parser.getTokenLocation(),
+                        "Unexpected token " + token + " [" + currentFieldName + "] in [" + aggregationName + "]. " +
+                            "Multi-field aggregations do not support scripts.");
+
+                } else if (!token(aggregationName, currentFieldName, token, parser, context.getParseFieldMatcher(), otherOptions)) {
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "Unexpected token " + token + " [" + currentFieldName + "] in [" + aggregationName + "].");
+                }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                if (context.getParseFieldMatcher().match(currentFieldName, ScriptField.SCRIPT)) {
+                    throw new ParsingException(parser.getTokenLocation(),
+                        "Unexpected token " + token + " [" + currentFieldName + "] in [" + aggregationName + "]. " +
+                            "Multi-field aggregations do not support scripts.");
+                } else if (parseFieldMatcher.match(currentFieldName, CommonFields.FIELDS)) {
+                    fields = new ArrayList<>();
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        if (token == XContentParser.Token.VALUE_STRING) {
+                            fields.add(parser.text());
+                        } else {
+                            throw new ParsingException(parser.getTokenLocation(),
+                                    "Unexpected token " + token + " [" + currentFieldName + "] in [" + aggregationName + "].");
+                        }
+                    }
+                } else if (!token(aggregationName, currentFieldName, token, parser, context.getParseFieldMatcher(), otherOptions)) {
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "Unexpected token " + token + " [" + currentFieldName + "] in [" + aggregationName + "].");
+                }
+            } else if (!token(aggregationName, currentFieldName, token, parser, context.getParseFieldMatcher(), otherOptions)) {
+                throw new ParsingException(parser.getTokenLocation(),
+                        "Unexpected token " + token + " [" + currentFieldName + "] in [" + aggregationName + "].");
+            }
+        }
+
+        MultiValuesSourceAggregationBuilder<VS, ?> factory = createFactory(aggregationName, this.valuesSourceType, this.targetValueType,
+                otherOptions);
+        if (fields != null) {
+            factory.fields(fields);
+        }
+        if (valueType != null) {
+            factory.valueType(valueType);
+        }
+        if (format != null) {
+            factory.format(format);
+        }
+        if (missingMap != null) {
+            factory.missingMap(missingMap);
+        }
+        return factory;
+    }
+
+    private final void parseMissingAndAdd(final String aggregationName, final String currentFieldName,
+                                          XContentParser parser, final Map<String, Object> missing) throws IOException {
+        XContentParser.Token token = parser.currentToken();
+        if (token == null) {
+            token = parser.nextToken();
+        }
+
+        if (token == XContentParser.Token.FIELD_NAME) {
+            final String fieldName = parser.currentName();
+            if (missing.containsKey(fieldName)) {
+                throw new ParsingException(parser.getTokenLocation(),
+                    "Missing field [" + fieldName + "] already defined as [" + missing.get(fieldName)
+                        + "] in [" + aggregationName + "].");
+            }
+            parser.nextToken();
+            missing.put(fieldName, parser.objectText());
+        } else {
+            throw new ParsingException(parser.getTokenLocation(),
+                "Unexpected token " + token + " [" + currentFieldName + "] in [" + aggregationName + "]");
+        }
+    }
+
+    /**
+     * Creates a {@link ValuesSourceAggregationBuilder} from the information
+     * gathered by the subclass. Options parsed in
+     * {@link MultiValuesSourceParser} itself will be added to the factory
+     * after it has been returned by this method.
+     *
+     * @param aggregationName
+     *            the name of the aggregation
+     * @param valuesSourceType
+     *            the type of the {@link ValuesSource}
+     * @param targetValueType
+     *            the target type of the final value output by the aggregation
+     * @param otherOptions
+     *            a {@link Map} containing the extra options parsed by the
+     *            {@link #token(String, String, org.elasticsearch.common.xcontent.XContentParser.Token,
+     *             XContentParser, ParseFieldMatcher, Map)}
+     *            method
+     * @return the created factory
+     */
+    protected abstract MultiValuesSourceAggregationBuilder<VS, ?> createFactory(String aggregationName, ValuesSourceType valuesSourceType,
+        ValueType targetValueType, Map<ParseField, Object> otherOptions);
+
+    /**
+     * Allows subclasses of {@link MultiValuesSourceParser} to parse extra
+     * parameters and store them in a {@link Map} which will later be passed to
+     * {@link #createFactory(String, ValuesSourceType, ValueType, Map)}.
+     *
+     * @param aggregationName
+     *            the name of the aggregation
+     * @param currentFieldName
+     *            the name of the current field being parsed
+     * @param token
+     *            the current token for the parser
+     * @param parser
+     *            the parser
+     * @param parseFieldMatcher
+     *            the {@link ParseFieldMatcher} to use to match field names
+     * @param otherOptions
+     *            a {@link Map} of options to be populated by successive calls
+     *            to this method which will then be passed to the
+     *            {@link #createFactory(String, ValuesSourceType, ValueType, Map)}
+     *            method
+     * @return <code>true</code> if the current token was correctly parsed,
+     *         <code>false</code> otherwise
+     * @throws IOException
+     *             if an error occurs whilst parsing
+     */
+    protected abstract boolean token(String aggregationName, String currentFieldName, XContentParser.Token token, XContentParser parser,
+        ParseFieldMatcher parseFieldMatcher, Map<ParseField, Object> otherOptions) throws IOException;
+}

--- a/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/MatrixAggregationRestIT.java
+++ b/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/MatrixAggregationRestIT.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.matrix;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.test.rest.RestTestCandidate;
+import org.elasticsearch.test.rest.parser.RestTestParseException;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public class MatrixAggregationRestIT extends ESRestTestCase {
+    public MatrixAggregationRestIT(@Name("yaml")RestTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws IOException, RestTestParseException {
+        return ESRestTestCase.createParameters(0, 1);
+    }
+}

--- a/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/BaseMatrixStatsTestCase.java
+++ b/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/BaseMatrixStatsTestCase.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  *
  */
-public class MatrixStatsTestCase extends ESTestCase {
+public abstract class BaseMatrixStatsTestCase extends ESTestCase {
     protected final int numObs = atLeast(10000);
     protected final ArrayList<Double> fieldA = new ArrayList<>(numObs);
     protected final ArrayList<Double> fieldB = new ArrayList<>(numObs);

--- a/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsTestCase.java
+++ b/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsTestCase.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.matrix.stats;
+
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ *
+ */
+public class MatrixStatsTestCase extends ESTestCase {
+    protected final int numObs = atLeast(10000);
+    protected final ArrayList<Double> fieldA = new ArrayList<>(numObs);
+    protected final ArrayList<Double> fieldB = new ArrayList<>(numObs);
+    protected final MultiPassStats actualStats = new MultiPassStats();
+    protected final static String fieldAKey = "fieldA";
+    protected final static String fieldBKey = "fieldB";
+
+    @Before
+    public void setup() {
+        createStats();
+    }
+
+    public void createStats() {
+        for (int n = 0; n < numObs; ++n) {
+            fieldA.add(randomDouble());
+            fieldB.add(randomDouble());
+        }
+        actualStats.computeStats(fieldA, fieldB);
+    }
+
+    static class MultiPassStats {
+        long count;
+        HashMap<String, Double> means = new HashMap<>();
+        HashMap<String, Double> variances = new HashMap<>();
+        HashMap<String, Double> skewness = new HashMap<>();
+        HashMap<String, Double> kurtosis = new HashMap<>();
+        HashMap<String, HashMap<String, Double>> covariances = new HashMap<>();
+        HashMap<String, HashMap<String, Double>> correlations = new HashMap<>();
+
+        @SuppressWarnings("unchecked")
+        void computeStats(final ArrayList<Double> fieldA, final ArrayList<Double> fieldB) {
+            // set count
+            count = fieldA.size();
+            double meanA = 0d;
+            double meanB = 0d;
+
+            // compute mean
+            for (int n = 0; n < count; ++n) {
+                // fieldA
+                meanA += fieldA.get(n);
+                meanB += fieldB.get(n);
+            }
+            means.put(fieldAKey, meanA/count);
+            means.put(fieldBKey, meanB/count);
+
+            // compute variance, skewness, and kurtosis
+            double dA;
+            double dB;
+            double skewA = 0d;
+            double skewB = 0d;
+            double kurtA = 0d;
+            double kurtB = 0d;
+            double varA = 0d;
+            double varB = 0d;
+            double cVar = 0d;
+            for (int n = 0; n < count; ++n) {
+                dA = fieldA.get(n) - means.get(fieldAKey);
+                varA += dA * dA;
+                skewA += dA * dA * dA;
+                kurtA += dA * dA * dA * dA;
+                dB = fieldB.get(n) - means.get(fieldBKey);
+                varB += dB * dB;
+                skewB += dB * dB * dB;
+                kurtB += dB * dB * dB * dB;
+                cVar += dA * dB;
+            }
+            variances.put(fieldAKey, varA / (count - 1));
+            final double stdA = Math.sqrt(variances.get(fieldAKey));
+            variances.put(fieldBKey, varB / (count - 1));
+            final double stdB = Math.sqrt(variances.get(fieldBKey));
+            skewness.put(fieldAKey, skewA / ((count - 1) * variances.get(fieldAKey) * stdA));
+            skewness.put(fieldBKey, skewB / ((count - 1) * variances.get(fieldBKey) * stdB));
+            kurtosis.put(fieldAKey, kurtA / ((count - 1) * variances.get(fieldAKey) * variances.get(fieldAKey)));
+            kurtosis.put(fieldBKey, kurtB / ((count - 1) * variances.get(fieldBKey) * variances.get(fieldBKey)));
+
+            // compute covariance
+            final HashMap<String, Double> fieldACovar = new HashMap<>(2);
+            fieldACovar.put(fieldAKey, 1d);
+            cVar /= count - 1;
+            fieldACovar.put(fieldBKey, cVar);
+            covariances.put(fieldAKey, fieldACovar);
+            final HashMap<String, Double> fieldBCovar = new HashMap<>(2);
+            fieldBCovar.put(fieldAKey, cVar);
+            fieldBCovar.put(fieldBKey, 1d);
+            covariances.put(fieldBKey, fieldBCovar);
+
+            // compute correlation
+            final HashMap<String, Double> fieldACorr = new HashMap<>();
+            fieldACorr.put(fieldAKey, 1d);
+            double corr = covariances.get(fieldAKey).get(fieldBKey);
+            corr /= stdA * stdB;
+            fieldACorr.put(fieldBKey, corr);
+            correlations.put(fieldAKey, fieldACorr);
+            final HashMap<String, Double> fieldBCorr = new HashMap<>();
+            fieldBCorr.put(fieldAKey, corr);
+            fieldBCorr.put(fieldBKey, 1d);
+            correlations.put(fieldBKey, fieldBCorr);
+        }
+
+        public void assertNearlyEqual(MatrixStatsResults stats) {
+            assertThat(count, equalTo(stats.getDocCount()));
+            assertThat(count, equalTo(stats.getFieldCount(fieldAKey)));
+            assertThat(count, equalTo(stats.getFieldCount(fieldBKey)));
+            // means
+            assertTrue(nearlyEqual(means.get(fieldAKey), stats.getMean(fieldAKey), 1e-7));
+            assertTrue(nearlyEqual(means.get(fieldBKey), stats.getMean(fieldBKey), 1e-7));
+            // variances
+            assertTrue(nearlyEqual(variances.get(fieldAKey), stats.getVariance(fieldAKey), 1e-7));
+            assertTrue(nearlyEqual(variances.get(fieldBKey), stats.getVariance(fieldBKey), 1e-7));
+            // skewness (multi-pass is more susceptible to round-off error so we need to slightly relax the tolerance)
+            assertTrue(nearlyEqual(skewness.get(fieldAKey), stats.getSkewness(fieldAKey), 1e-4));
+            assertTrue(nearlyEqual(skewness.get(fieldBKey), stats.getSkewness(fieldBKey), 1e-4));
+            // kurtosis (multi-pass is more susceptible to round-off error so we need to slightly relax the tolerance)
+            assertTrue(nearlyEqual(kurtosis.get(fieldAKey), stats.getKurtosis(fieldAKey), 1e-4));
+            assertTrue(nearlyEqual(kurtosis.get(fieldBKey), stats.getKurtosis(fieldBKey), 1e-4));
+            // covariances
+            assertTrue(nearlyEqual(covariances.get(fieldAKey).get(fieldBKey), stats.getCovariance(fieldAKey, fieldBKey), 1e-7));
+            assertTrue(nearlyEqual(covariances.get(fieldBKey).get(fieldAKey), stats.getCovariance(fieldBKey, fieldAKey), 1e-7));
+            // correlation
+            assertTrue(nearlyEqual(correlations.get(fieldAKey).get(fieldBKey), stats.getCorrelation(fieldAKey, fieldBKey), 1e-7));
+            assertTrue(nearlyEqual(correlations.get(fieldBKey).get(fieldAKey), stats.getCorrelation(fieldBKey, fieldAKey), 1e-7));
+        }
+    }
+
+    private static boolean nearlyEqual(double a, double b, double epsilon) {
+        final double absA = Math.abs(a);
+        final double absB = Math.abs(b);
+        final double diff = Math.abs(a - b);
+
+        if (a == b) { // shortcut, handles infinities
+            return true;
+        } else if (a == 0 || b == 0 || diff < Double.MIN_NORMAL) {
+            // a or b is zero or both are extremely close to it
+            // relative error is less meaningful here
+            return diff < (epsilon * Double.MIN_NORMAL);
+        } else { // use relative error
+            return diff / Math.min((absA + absB), Double.MAX_VALUE) < epsilon;
+        }
+    }
+}

--- a/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/RunningStatsTests.java
+++ b/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/RunningStatsTests.java
@@ -18,13 +18,12 @@
  */
 package org.elasticsearch.search.aggregations.matrix.stats;
 
-import java.util.HashMap;
 import java.util.List;
 
 /**
  *
  */
-public class RunningStatsTests extends MatrixStatsTestCase {
+public class RunningStatsTests extends BaseMatrixStatsTestCase {
 
     /** test running stats */
     public void testRunningStats() throws Exception {
@@ -56,15 +55,18 @@ public class RunningStatsTests extends MatrixStatsTestCase {
     }
 
     private RunningStats createRunningStats(List<Double> fieldAObs, List<Double> fieldBObs) {
-        RunningStats stats = RunningStats.EMPTY();
+        RunningStats stats = new RunningStats();
         // create a document with two numeric fields
-        final HashMap<String, Double> doc = new HashMap<>(2);
+        final String[] fieldNames = new String[2];
+        fieldNames[0] = fieldAKey;
+        fieldNames[1] = fieldBKey;
+        final double[] fieldVals = new double[2];
 
         // running stats computation
         for (int n = 0; n < fieldAObs.size(); ++n) {
-            doc.put(fieldAKey, fieldAObs.get(n));
-            doc.put(fieldBKey, fieldBObs.get(n));
-            stats.add(doc);
+            fieldVals[0] = fieldAObs.get(n);
+            fieldVals[1] = fieldBObs.get(n);
+            stats.add(fieldNames, fieldVals);
         }
         return stats;
     }

--- a/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/RunningStatsTests.java
+++ b/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/RunningStatsTests.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.matrix.stats;
+
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ *
+ */
+public class RunningStatsTests extends MatrixStatsTestCase {
+
+    /** test running stats */
+    public void testRunningStats() throws Exception {
+        final MatrixStatsResults results = new MatrixStatsResults(createRunningStats(fieldA, fieldB));
+        actualStats.assertNearlyEqual(results);
+    }
+
+    /** Test merging stats across observation shards */
+    public void testMergedStats() throws Exception {
+        // slice observations into shards
+        int numShards = randomIntBetween(2, 10);
+        double obsPerShard = Math.floor(numObs / numShards);
+        int start = 0;
+        RunningStats stats = null;
+        List<Double> fieldAShard, fieldBShard;
+        for (int s = 0; s < numShards-1; start = ++s * (int)obsPerShard) {
+            fieldAShard = fieldA.subList(start, start + (int)obsPerShard);
+            fieldBShard = fieldB.subList(start, start + (int)obsPerShard);
+            if (stats == null) {
+                stats = createRunningStats(fieldAShard, fieldBShard);
+            } else {
+                stats.merge(createRunningStats(fieldAShard, fieldBShard));
+            }
+        }
+        stats.merge(createRunningStats(fieldA.subList(start, fieldA.size()), fieldB.subList(start, fieldB.size())));
+
+        final MatrixStatsResults results = new MatrixStatsResults(stats);
+        actualStats.assertNearlyEqual(results);
+    }
+
+    private RunningStats createRunningStats(List<Double> fieldAObs, List<Double> fieldBObs) {
+        RunningStats stats = RunningStats.EMPTY();
+        // create a document with two numeric fields
+        final HashMap<String, Double> doc = new HashMap<>(2);
+
+        // running stats computation
+        for (int n = 0; n < fieldAObs.size(); ++n) {
+            doc.put(fieldAKey, fieldAObs.get(n));
+            doc.put(fieldBKey, fieldBObs.get(n));
+            stats.add(doc);
+        }
+        return stats;
+    }
+
+}

--- a/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/10_basic.yaml
+++ b/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/10_basic.yaml
@@ -1,0 +1,13 @@
+# Integration tests for Matrix Aggs Plugin
+#
+"Matrix stats aggs loaded":
+    - do:
+        cluster.state: {}
+
+    # Get master node id
+    - set: { master_node: master }
+
+    - do:
+        nodes.info: {}
+
+    - match:  { nodes.$master.modules.0.name: aggs-matrix-stats }

--- a/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/20_empty_bucket.yaml
+++ b/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/20_empty_bucket.yaml
@@ -1,0 +1,48 @@
+---
+"Empty Bucket Aggregation":
+  - do:
+    indices.create:
+      index: empty_bucket_idx
+      body:
+        settings:
+          number_of_shards: "3"
+        mappings:
+          test:
+            "properties":
+              "value":
+                "type": "integer"
+              "val1":
+                "type": "double"
+
+  - do:
+    index:
+      index:  empty_bucket_idx
+      type:   test
+      id:     1
+      body:   { "value": 0, "val1": 3.1 }
+
+  - do:
+    index:
+      index:  empty_bucket_idx
+      type:   test
+      id:     2
+      body:   { "value": 2, "val1": -3.1 }
+
+  - do:
+    indices.refresh:
+      index: [empty_bucket_idx]
+
+  - do:
+    search:
+      index: empty_bucket_idx
+      type: test
+
+  - match: {hits.total: 2}
+
+  - do:
+      search:
+        index: empty_bucket_idx
+        type:  test
+        body: {"aggs": {"histo": {"histogram": {"field": "val1", "interval": 1, "min_doc_count": 0}, "aggs": { "mfs" : { "matrix_stats": {"field": ["value", "val1"]} } } } } }
+
+  - match: {hits.total: 2}

--- a/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/20_empty_bucket.yaml
+++ b/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/20_empty_bucket.yaml
@@ -43,6 +43,6 @@
       search:
         index: empty_bucket_idx
         type:  test
-        body: {"aggs": {"histo": {"histogram": {"field": "val1", "interval": 1, "min_doc_count": 0}, "aggs": { "mfs" : { "matrix_stats": {"field": ["value", "val1"]} } } } } }
+        body: {"aggs": {"histo": {"histogram": {"field": "val1", "interval": 1, "min_doc_count": 0}, "aggs": { "mfs" : { "matrix_stats": {"fields": ["value", "val1"]} } } } } }
 
   - match: {hits.total: 2}

--- a/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/30_single_value_field.yaml
+++ b/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/30_single_value_field.yaml
@@ -1,0 +1,184 @@
+---
+setup:
+
+  - do:
+    indices.create:
+      index: test
+      body:
+        settings:
+          number_of_shards: 3
+        mappings:
+          test:
+            "properties":
+              "val1":
+                "type": "double"
+              "val2":
+                "type": "double"
+              "val3":
+                "type": "double"
+
+  - do:
+    indices.create:
+      index: unmapped
+      body:
+        settings:
+          number_of_shards: 3
+
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     1
+      body:   { "val1": 1.9, "val2": 3.1, "val3": 2.3 }
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     2
+      body:   { "val1": -5.2, "val2": -3.4, "val3": 2.3}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     3
+      body:   { "val1": -5.2, "val3": 2.3}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     4
+      body:   { "val1": 18.3, "val2": 104.4, "val3": 2.3}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     5
+      body:   { "val1": -53.2, "val2": -322.4, "val3": 2.3}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     6
+      body:   { "val1": -578.9, "val2": 69.9, "val3": 2.3}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     7
+      body:   { "val1": 16.2, "val2": 17.2, "val3": 2.3}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     8
+      body:   { "val1": -4222.63, "val2": 316.44, "val3": 2.3}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     9
+      body:   { "val1": -59999.55, "val2": -3163.4, "val3": 2.3}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     10
+      body:   { "val1": 782.7, "val2": 789.7, "val3": 2.3}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     11
+      body:   { "val1": -1.2, "val2": 6.3, "val3": 2.3}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     12
+      body:   { "val1": 0, "val2": 1.11, "val3": 2.3}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     13
+      body:   { "val1": 0.1, "val2": 0.92, "val3": 2.3}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     14
+      body:   { "val1": 0.12, "val2": -82.4, "val3": 2.3}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     15
+      body:   { "val1": 98.2, "val2": 32.4, "val3": 2.3}
+
+  - do:
+    indices.refresh:
+      index: [test, unmapped]
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+---
+"Unmapped":
+
+  - do:
+      search:
+        index: unmapped
+        type:  test
+        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val2", "val3"]} } } }
+
+  - match: {hits.total: 0}
+
+---
+"Single value field":
+
+  - do:
+      search:
+        index: test
+        type:  test
+        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val3"]} } } }
+
+  - match: {hits.total: 15}
+  - match: {aggregations.mfs.count.0: 15}
+
+---
+"Partially unmapped":
+
+  - do:
+      search:
+        index: [test, unmapped]
+        type:  test
+        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val2", "val3"]} } } }
+
+  - match: {hits.total: 15}
+  - match: {aggregations.mfs.count.0: 14}
+
+---
+"With script":
+
+  - do:
+      search:
+        index: test
+        type:  test
+        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val2"], "script" : { "my_script" : {"inline" : "1 + doc['val1'].value", "lang" : "js"} } } } } }
+
+  - match: {hits.total: 15}
+  - match: {aggregations.mfs.count.0: 14}
+
+---
+"With script params":
+
+  - do:
+      search:
+        index: test
+        type:  test
+        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val2", "val3"], "script" : { "my_script" : {"inline" : "my_var + doc['val1'].value", "params" : { "my_var" : 1 }, "lang" : "js" } } } } } }
+
+  - match: {hits.total: 15}
+  - match: {aggregations.mfs.count.0: 14}
+  - match: {aggregations.mfs.correlation.1.2: 0.9569513137793205}

--- a/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/30_single_value_field.yaml
+++ b/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/30_single_value_field.yaml
@@ -130,7 +130,7 @@ setup:
       search:
         index: unmapped
         type:  test
-        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val2", "val3"]} } } }
+        body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "val3"]} } } }
 
   - match: {hits.total: 0}
 
@@ -141,10 +141,10 @@ setup:
       search:
         index: test
         type:  test
-        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val3"]} } } }
+        body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val3"]} } } }
 
   - match: {hits.total: 15}
-  - match: {aggregations.mfs.count.0: 15}
+  - match: {aggregations.mfs.fields.0.count: 15}
 
 ---
 "Partially unmapped":
@@ -153,32 +153,41 @@ setup:
       search:
         index: [test, unmapped]
         type:  test
-        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val2", "val3"]} } } }
+        body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "val3"]} } } }
 
   - match: {hits.total: 15}
-  - match: {aggregations.mfs.count.0: 14}
+  - match: {aggregations.mfs.fields.0.count: 14}
+  - match: {aggregations.mfs.fields.2.correlation.val2: 0.9569513137793205}
+
+---
+"Partially unmapped with missing default":
+
+  - do:
+      search:
+        index: [test, unmapped]
+        type:  test
+        body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "val3"], "missing" : {"val2" : 10} } } } }
+
+  - match: {hits.total: 15}
+  - match: {aggregations.mfs.fields.0.count: 15}
+  - match: {aggregations.mfs.fields.2.correlation.val2: 0.9567970467908384}
 
 ---
 "With script":
 
   - do:
+      catch: /parsing_exception/
       search:
         index: test
         type:  test
-        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val2"], "script" : { "my_script" : {"inline" : "1 + doc['val1'].value", "lang" : "js"} } } } } }
-
-  - match: {hits.total: 15}
-  - match: {aggregations.mfs.count.0: 14}
+        body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2"], "script" : { "my_script" : {"inline" : "1 + doc['val1'].value", "lang" : "js"} } } } } }
 
 ---
 "With script params":
 
   - do:
+      catch: /parsing_exception/
       search:
         index: test
         type:  test
-        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val2", "val3"], "script" : { "my_script" : {"inline" : "my_var + doc['val1'].value", "params" : { "my_var" : 1 }, "lang" : "js" } } } } } }
-
-  - match: {hits.total: 15}
-  - match: {aggregations.mfs.count.0: 14}
-  - match: {aggregations.mfs.correlation.1.2: 0.9569513137793205}
+        body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "val3"], "script" : { "my_script" : {"inline" : "my_var + doc['val1'].value", "params" : { "my_var" : 1 }, "lang" : "js" } } } } } }

--- a/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/40_multi_value_field.yaml
+++ b/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/40_multi_value_field.yaml
@@ -130,21 +130,35 @@ setup:
       search:
         index: unmapped
         type:  test
-        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val2", "vals"]} } } }
+        body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "vals"]} } } }
 
   - match: {hits.total: 0}
 
 ---
-"Multi value field":
+"Multi value field Max":
 
   - do:
       search:
         index: test
         type:  test
-        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val3"]} } } }
+        body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "vals"], "mode" : "max"} } } }
 
   - match: {hits.total: 15}
-  - match: {aggregations.mfs.count.0: 15}
+  - match: {aggregations.mfs.fields.0.count: 14}
+  - match: {aggregations.mfs.fields.0.correlation.val1: 0.06838646533369998}
+
+---
+"Multi value field Min":
+
+  - do:
+      search:
+        index: test
+        type:  test
+        body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "vals"], "mode" : "min"} } } }
+
+  - match: {hits.total: 15}
+  - match: {aggregations.mfs.fields.0.count: 14}
+  - match: {aggregations.mfs.fields.0.correlation.val1: -0.09777682707831963}
 
 ---
 "Partially unmapped":
@@ -153,32 +167,41 @@ setup:
       search:
         index: [test, unmapped]
         type:  test
-        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val2", "vals"]} } } }
+        body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "vals"]} } } }
 
   - match: {hits.total: 15}
-  - match: {aggregations.mfs.count.0: 13}
+  - match: {aggregations.mfs.fields.0.count: 13}
+  - match: {aggregations.mfs.fields.0.correlation.val1: -0.044997535185684244}
+
+---
+"Partially unmapped with missing defaults":
+
+  - do:
+      search:
+        index: [test, unmapped]
+        type:  test
+        body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "vals"], "missing" : {"val2" : 10, "vals" : 5 } } } } }
+
+  - match: {hits.total: 15}
+  - match: {aggregations.mfs.fields.0.count: 15}
+  - match: {aggregations.mfs.fields.0.correlation.val2: 0.04028024709708195}
 
 ---
 "With script":
 
   - do:
+      catch: /parsing_exception/
       search:
         index: test
         type:  test
-        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["vals", "val3"], "script" : { "my_script" : {"inline" : "1 + doc['val1'].value", "lang" : "js"} } } } } }
-
-  - match: {hits.total: 15}
-  - match: {aggregations.mfs.count.0: 14}
+        body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["vals", "val3"], "script" : { "my_script" : {"inline" : "1 + doc['val1'].value", "lang" : "js"} } } } } }
 
 ---
 "With script params":
 
   - do:
+      catch: /parsing_exception/
       search:
         index: test
         type:  test
-        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val3", "vals"], "script" : { "my_script" : {"inline" : "my_var + doc['val1'].value", "params" : { "my_var" : 1 }, "lang" : "js" } } } } } }
-
-  - match: {hits.total: 15}
-  - match: {aggregations.mfs.count.0: 14}
-  - match: {aggregations.mfs.correlation.1.2: -0.055971032866899535}
+        body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val3", "vals"], "script" : { "my_script" : {"inline" : "my_var + doc['val1'].value", "params" : { "my_var" : 1 }, "lang" : "js" } } } } } }

--- a/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/40_multi_value_field.yaml
+++ b/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/40_multi_value_field.yaml
@@ -1,0 +1,184 @@
+---
+setup:
+
+  - do:
+    indices.create:
+      index: test
+      body:
+        settings:
+          number_of_shards: 3
+        mappings:
+          test:
+            "properties":
+              "val1":
+                "type": "double"
+              "val2":
+                "type": "double"
+              "val3":
+                "type": "double"
+
+  - do:
+    indices.create:
+      index: unmapped
+      body:
+        settings:
+          number_of_shards: 3
+
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     1
+      body:   { "val1": 1.9, "val2": 3.1, "val3": 2.3, "vals" : [1.9, 16.143] }
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     2
+      body:   { "val1": -5.2, "val2": -3.4, "val3": 2.3, "vals" : [155, 16.23]}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     3
+      body:   { "val1": -5.2, "val3": 2.3, "vals" : [-455, -32.32]}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     4
+      body:   { "val1": 18.3, "val2": 104.4, "val3": 2.3, "vals" : [0.14, 92.1]}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     5
+      body:   { "val1": -53.2, "val2": -322.4, "val3": 2.3, "vals" : [16, 16]}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     6
+      body:   { "val1": -578.9, "val2": 69.9, "val3": 2.3}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     7
+      body:   { "val1": 16.2, "val2": 17.2, "val3": 2.3, "vals" : [1234.3, -3433]}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     8
+      body:   { "val1": -4222.63, "val2": 316.44, "val3": 2.3, "vals" : [177.2, -93.333]}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     9
+      body:   { "val1": -59999.55, "val2": -3163.4, "val3": 2.3, "vals" : [-29.9, 163.0]}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     10
+      body:   { "val1": 782.7, "val2": 789.7, "val3": 2.3, "vals" : [-0.2, 1343.3]}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     11
+      body:   { "val1": -1.2, "val2": 6.3, "val3": 2.3, "vals" : [15.3, 16.9]}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     12
+      body:   { "val1": 0, "val2": 1.11, "val3": 2.3, "vals" : [-644.4, -644.4]}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     13
+      body:   { "val1": 0.1, "val2": 0.92, "val3": 2.3, "vals" : [73.2, 0.12]}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     14
+      body:   { "val1": 0.12, "val2": -82.4, "val3": 2.3, "vals" : [-0.001, 1295.3]}
+  - do:
+    index:
+      index:  test
+      type:   test
+      id:     15
+      body:   { "val1": 98.2, "val2": 32.4, "val3": 2.3, "vals" : [15.5, 16.5]}
+
+  - do:
+    indices.refresh:
+      index: [test, unmapped]
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+---
+"Unmapped":
+
+  - do:
+      search:
+        index: unmapped
+        type:  test
+        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val2", "vals"]} } } }
+
+  - match: {hits.total: 0}
+
+---
+"Multi value field":
+
+  - do:
+      search:
+        index: test
+        type:  test
+        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val3"]} } } }
+
+  - match: {hits.total: 15}
+  - match: {aggregations.mfs.count.0: 15}
+
+---
+"Partially unmapped":
+
+  - do:
+      search:
+        index: [test, unmapped]
+        type:  test
+        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val2", "vals"]} } } }
+
+  - match: {hits.total: 15}
+  - match: {aggregations.mfs.count.0: 13}
+
+---
+"With script":
+
+  - do:
+      search:
+        index: test
+        type:  test
+        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["vals", "val3"], "script" : { "my_script" : {"inline" : "1 + doc['val1'].value", "lang" : "js"} } } } } }
+
+  - match: {hits.total: 15}
+  - match: {aggregations.mfs.count.0: 14}
+
+---
+"With script params":
+
+  - do:
+      search:
+        index: test
+        type:  test
+        body: {"aggs": { "mfs" : { "matrix_stats": {"field": ["val1", "val3", "vals"], "script" : { "my_script" : {"inline" : "my_var + doc['val1'].value", "params" : { "my_var" : 1 }, "lang" : "js" } } } } } }
+
+  - match: {hits.total: 15}
+  - match: {aggregations.mfs.count.0: 14}
+  - match: {aggregations.mfs.correlation.1.2: -0.055971032866899535}

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,7 @@ List projects = [
   'test:fixtures:example-fixture',
   'test:fixtures:hdfs-fixture',
   'test:logger-usage',
+  'modules:aggs-matrix-stats',
   'modules:ingest-grok',
   'modules:lang-expression',
   'modules:lang-groovy',


### PR DESCRIPTION
This PR adds a new aggs-matrix-stats module. The module introduces a new class of aggregations called `Matrix Aggregations`. Matrix aggregations work on multiple fields and produce a matrix as output. The matrix aggregation provided by this module is the `matrix_stats` aggregation which computes the following descriptive statistics over a set of fields:
- Covariance
- Correlation

For completeness (and interpretation purposes) the following per-field statistics are also provided:
- sample count
- population mean
- population variance
- population skewness
- population kurtosis

Example request:

``` javascript
"aggs": {
    "matrixstats": {
        "matrix_stats": {
            "field": ["poverty", "income"]
        }
     }
}
```

Example response:

``` javascript
{
    "aggregations": {
        "matrixstats": {
            "fields": [{
                "name": "income",
                "count": 50,
                "mean": 51985.1,
                "variance": 7.383377037755103E7,
                "skewness": 0.5595114003506483,
                "kurtosis": 2.5692365287787124,
                "covariance": {
                    "income": 7.383377037755103E7,
                    "poverty": -21093.65836734694
                },
                "correlation": {
                    "income": 1.0,
                    "poverty": -0.8352655256272504
                }
            }, {
                "name": "poverty",
                "count": 50,
                "mean": 12.732000000000001,
                "variance": 8.637730612244896,
                "skewness": 0.4516049811903419,
                "kurtosis": 2.8615929677997767,
                "covariance": {
                    "income": -21093.65836734694,
                    "poverty": 8.637730612244896
                },
                "correlation": {
                    "income": -0.8352655256272504,
                    "poverty": 1.0
                }
            }]
        }
    }
}
```

This PR replaces #16826. The differences include:
- renames aggregation from `multifield_stats` to `matrix_stats`
- adds aggregation code as a module instead of directly to core
- refactors Integration Tests as REST Tests
