### PR TITLE
Removing the superfluous 's'

### DIFF
--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -39,7 +39,7 @@ example of changing the path of the data and logs directories:
 --------------------------------------------------
 path:
     data: /var/lib/elasticsearch
-    logs: /var/logs/elasticsearch
+    logs: /var/log/elasticsearch
 --------------------------------------------------
 
 Settings can also be flattened as follows:
@@ -47,7 +47,7 @@ Settings can also be flattened as follows:
 [source,yaml]
 --------------------------------------------------
 path.data: /var/lib/elasticsearch
-path.logs: /var/logs/elasticsearch
+path.logs: /var/log/elasticsearch
 --------------------------------------------------
 
 [float]

--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -168,7 +168,7 @@ locations for a Debian-based system:
 
 | logs
   | Log files location.
-  | /var/logs/elasticsearch
+  | /var/log/elasticsearch
   | path.logs
 
 | plugins

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -154,7 +154,7 @@ locations for an RPM-based system:
 
 | logs
   | Log files location.
-  | /var/logs/elasticsearch
+  | /var/log/elasticsearch
   | path.logs
 
 | plugins


### PR DESCRIPTION
Pretty sure we're not making a brand new `/var/logs` directory when everything else goes into `/var/log`
