### PR TITLE
Removing another superfluous 's'

### DIFF
--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -168,7 +168,7 @@ locations for a Debian-based system:
 
 | logs
   | Log files location.
-  | /var/logs/elasticsearch
+  | /var/log/elasticsearch
   | path.logs
 
 | plugins


### PR DESCRIPTION
Pretty sure we're not making a brand new `/var/logs` directory when everything else goes into `/var/log`
