### PR TITLE
Increase default heap size to 2g

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -442,7 +442,7 @@ task run(type: RunTask) {}
  * </dl>
  */
 Map<String, String> expansionsForDistribution(distributionType) {
-  String heapSize = '512m'
+  String heapSize = '2g'
   String footer = "# Built for ${project.name}-${project.version} " +
       "(${distributionType})"
   Map<String, Object> expansions = [

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -442,7 +442,6 @@ task run(type: RunTask) {}
  * </dl>
  */
 Map<String, String> expansionsForDistribution(distributionType) {
-  String heapSize = '2g'
   String footer = "# Built for ${project.name}-${project.version} " +
       "(${distributionType})"
   Map<String, Object> expansions = [
@@ -462,8 +461,8 @@ Map<String, String> expansionsForDistribution(distributionType) {
       'def': '',
     ],
 
-    'heap.min': "${heapSize}",
-    'heap.max': "${heapSize}",
+    'heap.min': "256m",
+    'heap.max': "2g",
 
     'stopping.timeout': [
       'rpm': 86400,


### PR DESCRIPTION
Benchmarking with the geonames data set shows that Elasticsearch truly
needs 2g of heap or the heap is a bottleneck for indexing rates. If our
goal is to satisfy the out-of-the-box-experience, we should prioritize
the out-of-the-box performance experience. Thus, the default heap should
be 2g until smaller heaps are not the bottleneck for indexing small data
sets.

Relates #16334, relates #17686, relates #18309 
