### PR TITLE
Allow only a single extension for a scripting engine

### DIFF
--- a/core/src/main/java/org/elasticsearch/script/NativeScriptEngineService.java
+++ b/core/src/main/java/org/elasticsearch/script/NativeScriptEngineService.java
@@ -54,8 +54,8 @@ public class NativeScriptEngineService extends AbstractComponent implements Scri
     }
 
     @Override
-    public List<String> getExtensions() {
-        return Collections.emptyList();
+    public String getExtension() {
+        return ""; // Native scripts have no extensions
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/script/ScriptEngineService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptEngineService.java
@@ -33,7 +33,7 @@ public interface ScriptEngineService extends Closeable {
 
     String getType();
 
-    List<String> getExtensions();
+    String getExtension();
 
     Object compile(String script, Map<String, String> params);
 

--- a/core/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -170,9 +170,7 @@ public class ScriptService extends AbstractComponent implements Closeable {
         for (ScriptEngineService scriptEngine : scriptEngines) {
             String language = scriptEngineRegistry.getLanguage(scriptEngine.getClass());
             enginesByLangBuilder.put(language, scriptEngine);
-            for (String ext : scriptEngine.getExtensions()) {
-                enginesByExtBuilder.put(ext, scriptEngine);
-            }
+            enginesByExtBuilder.put(scriptEngine.getExtension(), scriptEngine);
         }
         this.scriptEnginesByLang = unmodifiableMap(enginesByLangBuilder);
         this.scriptEnginesByExt = unmodifiableMap(enginesByExtBuilder);

--- a/core/src/test/java/org/elasticsearch/script/ScriptModesTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptModesTests.java
@@ -241,8 +241,8 @@ public class ScriptModesTests extends ESTestCase {
         }
 
         @Override
-        public List<String> getExtensions() {
-            return Collections.unmodifiableList(Arrays.asList("custom", "test"));
+        public String getExtension() {
+            return NAME;
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -145,7 +145,7 @@ public class ScriptServiceTests extends ESTestCase {
     public void testScriptsWithoutExtensions() throws IOException {
         buildScriptService(Settings.EMPTY);
         Path testFileNoExt = scriptsFilePath.resolve("test_no_ext");
-        Path testFileWithExt = scriptsFilePath.resolve("test_script.tst");
+        Path testFileWithExt = scriptsFilePath.resolve("test_script.test");
         Streams.copy("test_file_no_ext".getBytes("UTF-8"), Files.newOutputStream(testFileNoExt));
         Streams.copy("test_file".getBytes("UTF-8"), Files.newOutputStream(testFileWithExt));
         resourceWatcherService.notifyNow();
@@ -173,7 +173,7 @@ public class ScriptServiceTests extends ESTestCase {
         Path testHiddenFile = scriptsFilePath.resolve(".hidden_file");
         Streams.copy("test_hidden_file".getBytes("UTF-8"), Files.newOutputStream(testHiddenFile));
 
-        Path testFileScript = scriptsFilePath.resolve("file_script.tst");
+        Path testFileScript = scriptsFilePath.resolve("file_script.test");
         Streams.copy("test_file_script".getBytes("UTF-8"), Files.newOutputStream(testFileScript));
         resourceWatcherService.notifyNow();
 
@@ -510,16 +510,14 @@ public class ScriptServiceTests extends ESTestCase {
 
         public static final String NAME = "test";
 
-        public static final List<String> EXTENSIONS = Collections.unmodifiableList(Arrays.asList("test", "tst"));
-
         @Override
         public String getType() {
             return NAME;
         }
 
         @Override
-        public List<String> getExtensions() {
-            return EXTENSIONS;
+        public String getExtension() {
+            return NAME;
         }
 
         @Override
@@ -560,8 +558,8 @@ public class ScriptServiceTests extends ESTestCase {
         }
 
         @Override
-        public List<String> getExtensions() {
-            return EXTENSIONS;
+        public String getExtension() {
+            return NAME;
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/script/ScriptSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptSettingsTests.java
@@ -73,16 +73,14 @@ public class ScriptSettingsTests extends ESTestCase {
 
         public static final String NAME = "custom";
 
-        public static final List<String> TYPES = Collections.unmodifiableList(Arrays.asList("test"));
-
         @Override
         public String getType() {
             return NAME;
         }
 
         @Override
-        public List<String> getExtensions() {
-            return Collections.unmodifiableList(Arrays.asList("test"));
+        public String getExtension() {
+            return NAME;
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgIT.java
@@ -382,8 +382,6 @@ public class AvgIT extends AbstractNumericTestCase {
 
         public static final String NAME = "extract_field";
 
-        public static final List<String> TYPES = Collections.singletonList(NAME);
-
         @Override
         public void close() throws IOException {
         }
@@ -394,8 +392,8 @@ public class AvgIT extends AbstractNumericTestCase {
         }
 
         @Override
-        public List<String> getExtensions() {
-            return TYPES;
+        public String getExtension() {
+            return NAME;
         }
 
         @Override
@@ -509,8 +507,6 @@ public class AvgIT extends AbstractNumericTestCase {
 
         public static final String NAME = "field_value";
 
-        public static final List<String> TYPES = Collections.singletonList(NAME);
-
         @Override
         public void close() throws IOException {
         }
@@ -521,8 +517,8 @@ public class AvgIT extends AbstractNumericTestCase {
         }
 
         @Override
-        public List<String> getExtensions() {
-            return TYPES;
+        public String getExtension() {
+            return NAME;
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
@@ -378,8 +378,6 @@ public class SumIT extends AbstractNumericTestCase {
 
         public static final String NAME = "extract_field";
 
-        public static final List<String> TYPES = Collections.singletonList(NAME);
-
         @Override
         public void close() throws IOException {
         }
@@ -390,8 +388,8 @@ public class SumIT extends AbstractNumericTestCase {
         }
 
         @Override
-        public List<String> getExtensions() {
-            return TYPES;
+        public String getExtension() {
+            return NAME;
         }
 
         @Override
@@ -507,8 +505,6 @@ public class SumIT extends AbstractNumericTestCase {
 
         public static final String NAME = "field_value";
 
-        public static final List<String> TYPES = Collections.singletonList(NAME);
-
         @Override
         public void close() throws IOException {
         }
@@ -519,8 +515,8 @@ public class SumIT extends AbstractNumericTestCase {
         }
 
         @Override
-        public List<String> getExtensions() {
-            return TYPES;
+        public String getExtension() {
+            return NAME;
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
@@ -236,8 +236,6 @@ public class ValueCountIT extends ESIntegTestCase {
 
         public static final String NAME = "field_value";
 
-        public static final List<String> TYPES = Collections.singletonList(NAME);
-
         @Override
         public void close() throws IOException {
         }
@@ -248,8 +246,8 @@ public class ValueCountIT extends ESIntegTestCase {
         }
 
         @Override
-        public List<String> getExtensions() {
-            return TYPES;
+        public String getExtension() {
+            return NAME;
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/update/UpdateIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateIT.java
@@ -103,8 +103,6 @@ public class UpdateIT extends ESIntegTestCase {
 
         public static final String NAME = "put_values";
 
-        public static final List<String> TYPES = Collections.singletonList(NAME);
-
         @Override
         public void close() throws IOException {
         }
@@ -115,8 +113,8 @@ public class UpdateIT extends ESIntegTestCase {
         }
 
         @Override
-        public List<String> getExtensions() {
-            return TYPES;
+        public String getExtension() {
+            return NAME;
         }
 
         @Override
@@ -192,8 +190,6 @@ public class UpdateIT extends ESIntegTestCase {
 
         public static final String NAME = "field_inc";
 
-        public static final List<String> TYPES = Collections.singletonList(NAME);
-
         @Override
         public void close() throws IOException {
         }
@@ -204,8 +200,8 @@ public class UpdateIT extends ESIntegTestCase {
         }
 
         @Override
-        public List<String> getExtensions() {
-            return TYPES;
+        public String getExtension() {
+            return NAME;
         }
 
         @Override
@@ -274,8 +270,6 @@ public class UpdateIT extends ESIntegTestCase {
 
         public static final String NAME = "scripted_upsert";
 
-        public static final List<String> TYPES = Collections.singletonList(NAME);
-
         @Override
         public void close() throws IOException {
         }
@@ -286,8 +280,8 @@ public class UpdateIT extends ESIntegTestCase {
         }
 
         @Override
-        public List<String> getExtensions() {
-            return TYPES;
+        public String getExtension() {
+            return NAME;
         }
 
         @Override
@@ -356,8 +350,6 @@ public class UpdateIT extends ESIntegTestCase {
 
         public static final String NAME = "extract_ctx";
 
-        public static final List<String> TYPES = Collections.singletonList(NAME);
-
         @Override
         public void close() throws IOException {
         }
@@ -368,8 +360,8 @@ public class UpdateIT extends ESIntegTestCase {
         }
 
         @Override
-        public List<String> getExtensions() {
-            return TYPES;
+        public String getExtension() {
+            return NAME;
         }
 
         @Override

--- a/docs/reference/migration/migrate_5_0/scripting.asciidoc
+++ b/docs/reference/migration/migrate_5_0/scripting.asciidoc
@@ -93,3 +93,9 @@ script engine in particular registered both `"lang": "js"` and `"lang":
 "javascript"`. Script engines can now only register a single language. All
 references to `"lang": "js"` should be changed to `"lang": "javascript"` for
 existing users of the lang-javascript plugin.
+
+==== Scripting engines now register only a single extension
+
+Prior to 5.0.0 scripting engines could register multiple extensions. The only
+engine doing this was the Javascript engine, which registered "js" and
+"javascript". It now only registers the "js" file extension for on-disk scripts.

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
@@ -62,8 +62,6 @@ public class ExpressionScriptEngineService extends AbstractComponent implements 
 
     public static final String NAME = "expression";
 
-    public static final List<String> TYPES = Collections.singletonList(NAME);
-
     @Inject
     public ExpressionScriptEngineService(Settings settings) {
         super(settings);
@@ -75,8 +73,8 @@ public class ExpressionScriptEngineService extends AbstractComponent implements 
     }
 
     @Override
-    public List<String> getExtensions() {
-        return TYPES;
+    public String getExtension() {
+        return NAME;
     }
 
     @Override

--- a/modules/lang-groovy/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
+++ b/modules/lang-groovy/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
@@ -76,7 +76,6 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
      */
     public static final String NAME = "groovy";
 
-    public static final List<String> TYPES = Collections.singletonList(NAME);
     /**
      * The name of the Groovy compiler setting to use associated with activating <code>invokedynamic</code> support.
      */
@@ -166,8 +165,8 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
     }
 
     @Override
-    public List<String> getExtensions() {
-        return TYPES;
+    public String getExtension() {
+        return NAME;
     }
 
     @Override

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
@@ -55,8 +55,6 @@ public final class MustacheScriptEngineService extends AbstractComponent impleme
 
     public static final String NAME = "mustache";
 
-    public static final List<String> TYPES = Collections.singletonList(NAME);
-
     static final String CONTENT_TYPE_PARAM = "content_type";
     static final String JSON_CONTENT_TYPE = "application/json";
     static final String PLAIN_TEXT_CONTENT_TYPE = "text/plain";
@@ -117,8 +115,8 @@ public final class MustacheScriptEngineService extends AbstractComponent impleme
     }
 
     @Override
-    public List<String> getExtensions() {
-        return TYPES;
+    public String getExtension() {
+        return NAME;
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngineService.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngineService.java
@@ -54,21 +54,6 @@ public final class PainlessScriptEngineService extends AbstractComponent impleme
     public static final String NAME = "painless";
 
     /**
-     * Standard list of names for the Painless language.  (There is only one.)
-     */
-    public static final List<String> TYPES = Collections.singletonList(NAME);
-
-    /**
-     * Standard extension of the Painless language.
-     */
-    public static final String EXTENSION = "painless";
-
-    /**
-     * Standard list of extensions for the Painless language.  (There is only one.)
-     */
-    public static final List<String> EXTENSIONS = Collections.singletonList(EXTENSION);
-
-    /**
      * Default compiler settings to be used.
      */
     private static final CompilerSettings DEFAULT_COMPILER_SETTINGS = new CompilerSettings();
@@ -112,8 +97,8 @@ public final class PainlessScriptEngineService extends AbstractComponent impleme
      * @return Always contains only the single extension of the language.
      */
     @Override
-    public List<String> getExtensions() {
-        return EXTENSIONS;
+    public String getExtension() {
+        return NAME;
     }
 
     /**

--- a/plugins/lang-javascript/src/main/java/org/elasticsearch/script/javascript/JavaScriptScriptEngineService.java
+++ b/plugins/lang-javascript/src/main/java/org/elasticsearch/script/javascript/JavaScriptScriptEngineService.java
@@ -70,7 +70,7 @@ public class JavaScriptScriptEngineService extends AbstractComponent implements 
 
     public static final String NAME = "javascript";
 
-    public static final List<String> EXTENSIONS = Collections.unmodifiableList(Arrays.asList("js", "javascript"));
+    public static final String EXTENSION = "js";
 
     private final AtomicLong counter = new AtomicLong();
 
@@ -166,8 +166,8 @@ public class JavaScriptScriptEngineService extends AbstractComponent implements 
     }
 
     @Override
-    public List<String> getExtensions() {
-        return EXTENSIONS;
+    public String getExtension() {
+        return EXTENSION;
     }
 
     @Override

--- a/plugins/lang-python/src/main/java/org/elasticsearch/plugin/python/PythonPlugin.java
+++ b/plugins/lang-python/src/main/java/org/elasticsearch/plugin/python/PythonPlugin.java
@@ -40,6 +40,6 @@ public class PythonPlugin extends Plugin {
     }
 
     public void onModule(ScriptModule module) {
-        module.addScriptEngine(new ScriptEngineRegistry.ScriptEngineRegistration(PythonScriptEngineService.class, PythonScriptEngineService.TYPE));
+        module.addScriptEngine(new ScriptEngineRegistry.ScriptEngineRegistration(PythonScriptEngineService.class, PythonScriptEngineService.NAME));
     }
 }

--- a/plugins/lang-python/src/main/java/org/elasticsearch/script/python/PythonScriptEngineService.java
+++ b/plugins/lang-python/src/main/java/org/elasticsearch/script/python/PythonScriptEngineService.java
@@ -58,7 +58,8 @@ import java.util.Map;
 //TODO we can optimize the case for Map<String, Object> similar to PyStringMap
 public class PythonScriptEngineService extends AbstractComponent implements ScriptEngineService {
 
-    public static final String TYPE = "python";
+    public static final String NAME = "python";
+    public static final String EXTENSION = "py";
 
     private final PythonInterpreter interp;
 
@@ -97,12 +98,12 @@ public class PythonScriptEngineService extends AbstractComponent implements Scri
 
     @Override
     public String getType() {
-        return TYPE;
+        return NAME;
     }
 
     @Override
-    public List<String> getExtensions() {
-        return Collections.unmodifiableList(Arrays.asList("py"));
+    public String getExtension() {
+        return EXTENSION;
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -38,8 +38,6 @@ public class MockScriptEngine implements ScriptEngineService {
 
     public static final String NAME = "mockscript";
 
-    public static final List<String> TYPES = Collections.singletonList(NAME);
-
     public static class TestPlugin extends Plugin {
 
         public TestPlugin() {
@@ -68,8 +66,8 @@ public class MockScriptEngine implements ScriptEngineService {
     }
 
     @Override
-    public List<String> getExtensions() {
-        return TYPES;
+    public String getExtension() {
+        return NAME;
     }
 
     @Override


### PR DESCRIPTION
Previously multiple extensions could be provided, however, this can lead
to confusion with on-disk scripts (ie, "foo.js" and "foo.javascript")
having different content. Only a single extension is now supported.

The only language currently supporting multiple extensions was the
Javascript engine ("js" and "javascript"). It now only supports the
`.js` extension.

Relates to #10598
