### PR TITLE
Rename the dynamic call site factory to DefBootstrap

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
@@ -43,7 +43,7 @@ import java.util.stream.Stream;
  * or method depending on the receiver's class. For these, we emit an {@code invokedynamic} instruction that,
  * for each new type encountered will query a corresponding {@code lookupXXX} method to retrieve the appropriate
  * method. In most cases, the {@code lookupXXX} methods here will only be called once for a given call site, because
- * caching ({@link DynamicCallSite}) generally works: usually all objects at any call site will be consistently
+ * caching ({@link DefBootstrap}) generally works: usually all objects at any call site will be consistently
  * the same type (or just a few types).  In extreme cases, if there is type explosion, they may be called every
  * single time, but simplicity is still more valuable than performance in this code.
  */

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/WriterConstants.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/WriterConstants.java
@@ -58,7 +58,7 @@ public final class WriterConstants {
     public final static MethodType DEF_BOOTSTRAP_TYPE =
         MethodType.methodType(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, int.class);
     public final static Handle DEF_BOOTSTRAP_HANDLE =
-        new Handle(Opcodes.H_INVOKESTATIC, Type.getInternalName(DynamicCallSite.class),
+        new Handle(Opcodes.H_INVOKESTATIC, Type.getInternalName(DefBootstrap.class),
             "bootstrap", DEF_BOOTSTRAP_TYPE.toMethodDescriptorString());
 
     public final static String DEF_DYNAMIC_LOAD_FIELD_DESC =

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LDefArray.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LDefArray.java
@@ -21,7 +21,7 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.DynamicCallSite;
+import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Variables;
 import org.objectweb.asm.commons.GeneratorAdapter;
 
@@ -62,13 +62,13 @@ final class LDefArray extends ALink {
     @Override
     void load(final CompilerSettings settings, final Definition definition, final GeneratorAdapter adapter) {
         adapter.visitInvokeDynamicInsn(
-            "arrayLoad", DEF_DYNAMIC_ARRAY_LOAD_DESC, DEF_BOOTSTRAP_HANDLE, new Object[] { DynamicCallSite.ARRAY_LOAD });
+            "arrayLoad", DEF_DYNAMIC_ARRAY_LOAD_DESC, DEF_BOOTSTRAP_HANDLE, new Object[] { DefBootstrap.ARRAY_LOAD });
 
     }
 
     @Override
     void store(final CompilerSettings settings, final Definition definition, final GeneratorAdapter adapter) {
         adapter.visitInvokeDynamicInsn(
-            "arrayStore", DEF_DYNAMIC_ARRAY_STORE_DESC, DEF_BOOTSTRAP_HANDLE, new Object[] { DynamicCallSite.ARRAY_STORE });
+            "arrayStore", DEF_DYNAMIC_ARRAY_STORE_DESC, DEF_BOOTSTRAP_HANDLE, new Object[] { DefBootstrap.ARRAY_STORE });
     }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LDefCall.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LDefCall.java
@@ -21,7 +21,7 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.DynamicCallSite;
+import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Variables;
 import org.objectweb.asm.commons.GeneratorAdapter;
 
@@ -84,7 +84,7 @@ final class LDefCall extends ALink {
         // return value
         signature.append(definition.defType.type.getDescriptor());
 
-        adapter.visitInvokeDynamicInsn(name, signature.toString(), DEF_BOOTSTRAP_HANDLE, new Object[] { DynamicCallSite.METHOD_CALL });
+        adapter.visitInvokeDynamicInsn(name, signature.toString(), DEF_BOOTSTRAP_HANDLE, new Object[] { DefBootstrap.METHOD_CALL });
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LDefField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LDefField.java
@@ -21,7 +21,7 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.DynamicCallSite;
+import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Variables;
 import org.objectweb.asm.commons.GeneratorAdapter;
 
@@ -57,11 +57,11 @@ final class LDefField extends ALink {
 
     @Override
     void load(final CompilerSettings settings, final Definition definition, final GeneratorAdapter adapter) {
-        adapter.visitInvokeDynamicInsn(value, DEF_DYNAMIC_LOAD_FIELD_DESC, DEF_BOOTSTRAP_HANDLE, new Object[] { DynamicCallSite.LOAD });
+        adapter.visitInvokeDynamicInsn(value, DEF_DYNAMIC_LOAD_FIELD_DESC, DEF_BOOTSTRAP_HANDLE, new Object[] { DefBootstrap.LOAD });
     }
 
     @Override
     void store(final CompilerSettings settings, final Definition definition, final GeneratorAdapter adapter) {
-        adapter.visitInvokeDynamicInsn(value, DEF_DYNAMIC_STORE_FIELD_DESC, DEF_BOOTSTRAP_HANDLE, new Object[] { DynamicCallSite.STORE });
+        adapter.visitInvokeDynamicInsn(value, DEF_DYNAMIC_STORE_FIELD_DESC, DEF_BOOTSTRAP_HANDLE, new Object[] { DefBootstrap.STORE });
     }
 }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/DefBootstrapTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/DefBootstrapTests.java
@@ -26,14 +26,14 @@ import java.lang.invoke.MethodType;
 
 import org.elasticsearch.test.ESTestCase;
 
-public class DynamicCallSiteTests extends ESTestCase {
+public class DefBootstrapTests extends ESTestCase {
     
     /** calls toString() on integers, twice */
     public void testOneType() throws Throwable {
-        CallSite site = DynamicCallSite.bootstrap(MethodHandles.publicLookup(), 
+        CallSite site = DefBootstrap.bootstrap(MethodHandles.publicLookup(), 
                                                   "toString", 
                                                   MethodType.methodType(String.class, Object.class), 
-                                                  DynamicCallSite.METHOD_CALL);
+                                                  DefBootstrap.METHOD_CALL);
         MethodHandle handle = site.dynamicInvoker();
         assertDepthEquals(site, 0);
 
@@ -47,10 +47,10 @@ public class DynamicCallSiteTests extends ESTestCase {
     }
     
     public void testTwoTypes() throws Throwable {
-        CallSite site = DynamicCallSite.bootstrap(MethodHandles.publicLookup(), 
+        CallSite site = DefBootstrap.bootstrap(MethodHandles.publicLookup(), 
                                                   "toString", 
                                                   MethodType.methodType(String.class, Object.class), 
-                                                  DynamicCallSite.METHOD_CALL);
+                                                  DefBootstrap.METHOD_CALL);
         MethodHandle handle = site.dynamicInvoker();
         assertDepthEquals(site, 0);
 
@@ -68,11 +68,11 @@ public class DynamicCallSiteTests extends ESTestCase {
     
     public void testTooManyTypes() throws Throwable {
         // if this changes, test must be rewritten
-        assertEquals(5, DynamicCallSite.InliningCacheCallSite.MAX_DEPTH);
-        CallSite site = DynamicCallSite.bootstrap(MethodHandles.publicLookup(), 
+        assertEquals(5, DefBootstrap.PIC.MAX_DEPTH);
+        CallSite site = DefBootstrap.bootstrap(MethodHandles.publicLookup(), 
                                                   "toString", 
                                                   MethodType.methodType(String.class, Object.class), 
-                                                  DynamicCallSite.METHOD_CALL);
+                                                  DefBootstrap.METHOD_CALL);
         MethodHandle handle = site.dynamicInvoker();
         assertDepthEquals(site, 0);
 
@@ -91,7 +91,7 @@ public class DynamicCallSiteTests extends ESTestCase {
     }
     
     static void assertDepthEquals(CallSite site, int expected) {
-        DynamicCallSite.InliningCacheCallSite dsite = (DynamicCallSite.InliningCacheCallSite) site;
+        DefBootstrap.PIC dsite = (DefBootstrap.PIC) site;
         assertEquals(expected, dsite.depth);
     }
 }


### PR DESCRIPTION
... and make the inner class name very short (PIC = Polymorphic Inline Cache)

The reason for this change is to make stack traces look nice if the bootstrapping of invokedynamic fails. The current class names were inconsistent and redundant. PIC (Polymorphic Inline Cache) is just an internal impl detail and the name was choosen to be short.
