### PR TITLE
Switch default batch size for reindex to 1000

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -30,7 +30,7 @@ That will return something like this:
   "timed_out": false,
   "created": 120,
   "updated": 0,
-  "batches": 2,
+  "batches": 1,
   "version_conflicts": 0,
   "noops": 0,
   "retries": 0,
@@ -301,7 +301,7 @@ POST _reindex
 // CONSOLE
 // TEST[s/^/PUT source\nGET _cluster\/health?wait_for_status=yellow\n/]
 
-By default `_reindex` uses scroll batches of 100. You can change the
+By default `_reindex` uses scroll batches of 1000. You can change the
 batch size with the `size` field in the `source` element:
 
 [source,js]
@@ -310,7 +310,7 @@ POST _reindex
 {
   "source": {
     "index": "source",
-    "size": 1000
+    "size": 100
   },
   "dest": {
     "index": "dest",
@@ -465,7 +465,7 @@ The responses looks like:
             "updated" : 3500,
             "created" : 0,
             "deleted" : 0,
-            "batches" : 36,
+            "batches" : 4,
             "version_conflicts" : 0,
             "noops" : 0,
             "retries": 0,

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -23,7 +23,7 @@ That will return something like this:
   "took" : 147,
   "timed_out": false,
   "updated": 120,
-  "batches": 2,
+  "batches": 1,
   "version_conflicts": 0,
   "noops": 0,
   "retries": 0,
@@ -146,12 +146,12 @@ POST twitter/_update_by_query?routing=1
 // CONSOLE
 // TEST[setup:twitter]
 
-By default `_update_by_query` uses scroll batches of 100. You can change the
+By default `_update_by_query` uses scroll batches of 1000. You can change the
 batch size with the `scroll_size` URL parameter:
 
 [source,js]
 --------------------------------------------------
-POST twitter/_update_by_query?scroll_size=1000
+POST twitter/_update_by_query?scroll_size=100
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:twitter]
@@ -296,7 +296,7 @@ The responses looks like:
             "updated" : 3500,
             "created" : 0,
             "deleted" : 0,
-            "batches" : 36,
+            "batches" : 4,
             "version_conflicts" : 0,
             "noops" : 0,
             "retries": 0,

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -42,7 +42,7 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
         extends ActionRequest<Self> {
     public static final int SIZE_ALL_MATCHES = -1;
     private static final TimeValue DEFAULT_SCROLL_TIMEOUT = timeValueMinutes(5);
-    private static final int DEFAULT_SCROLL_SIZE = 100;
+    private static final int DEFAULT_SCROLL_SIZE = 1000;
 
     /**
      * The search to be executed.


### PR DESCRIPTION
1000 is likely to perform much better.
