### PR TITLE
Add not-null precondition check in BulkRequest

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -43,6 +43,7 @@ import org.elasticsearch.index.VersionType;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -125,6 +126,7 @@ public class BulkRequest extends ActionRequest<BulkRequest> implements Composite
     }
 
     BulkRequest internalAdd(IndexRequest request, @Nullable Object payload) {
+        Objects.requireNonNull(request, "'request' must not be null");
         requests.add(request);
         addPayload(payload);
         // lack of source is validated in validate() method
@@ -144,6 +146,7 @@ public class BulkRequest extends ActionRequest<BulkRequest> implements Composite
     }
 
     BulkRequest internalAdd(UpdateRequest request, @Nullable Object payload) {
+        Objects.requireNonNull(request, "'request' must not be null");
         requests.add(request);
         addPayload(payload);
         if (request.doc() != null) {


### PR DESCRIPTION
With this commit we add a precondition check to BulkRequest so
we fail early if users pass `null` for the request object.

For a more detailed discussion, see #12038.
This supersedes #12038.

Relates #12038.
