### PR TITLE
painless: restore accidentally removed test

### DIFF
--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
@@ -175,6 +175,12 @@ public class WhenThingsGoWrongTests extends ScriptTestCase {
         });
     }
 
+    public void testDynamicWrongArgs() {
+        expectThrows(WrongMethodTypeException.class, () -> {
+            exec("def x = new ArrayList(); return x.get('bogus');");
+        });
+    }
+
     public void testDynamicArrayWrongIndex() {
         expectThrows(WrongMethodTypeException.class, () -> {
             exec("def x = new long[1]; x[0]=1; return x['bogus'];");


### PR DESCRIPTION
In my PR #18338 yesterday, I accidentally removed @rmuir's the test. This restores it. Sorry for that.
