### PR TITLE
Remove boxing when loading and storing values in "def" fields/arrays, remove boxing onsimple method calls of "def" methods

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ADefLink.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ADefLink.java
@@ -23,6 +23,8 @@ import org.elasticsearch.painless.Definition.Type;
 
 /**
  * The superclass for all LDef* (link) nodes that store or return a DEF. (Internal only.)
+ * For this node it is allowed to change {@link ALink#after} from outside, by default
+ * {@code after} is {@code DEF}.
  */
 abstract class ADefLink extends ALink {
     

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ADefLink.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ADefLink.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.painless.node;
+
+import org.elasticsearch.painless.Definition.Type;
+
+/**
+ * The superclass for all LDef* (link) nodes that store or return a DEF. (Internal only.)
+ */
+abstract class ADefLink extends ALink {
+    
+    /**
+     * The type of the original type that was pushed on stack, set by {@link EChain} during analyze.
+     * This value is only used for writing the 'store' bytecode, otherwise ignored.
+     */
+    Type storeValueType = null;
+
+    ADefLink(final int line, final String location, final int size) {
+        super(line, location, size);
+    }
+
+}

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EChain.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EChain.java
@@ -221,8 +221,8 @@ public final class EChain extends AExpression {
             lastDef.storeValueType = last.after;
         }
 
-        statement = true;
-        actual = read ? last.after : definition.voidType;
+        this.statement = true;
+        this.actual = read ? last.after : definition.voidType;
     }
 
     private void analyzeWrite(final CompilerSettings settings, final Definition definition, final Variables variables) {
@@ -234,16 +234,16 @@ public final class EChain extends AExpression {
             final ADefLink lastDef = (ADefLink) last;
             expression.analyze(settings, definition, variables);
             lastDef.storeValueType = expression.expected = expression.actual;
-            actual = read ? lastDef.storeValueType : definition.voidType;
+            this.actual = read ? lastDef.storeValueType : definition.voidType;
         } else {
             // otherwise we adapt the type of the expression to the store type
             expression.expected = last.after;
             expression.analyze(settings, definition, variables);
-            actual = read ? last.after : definition.voidType;
+            this.actual = read ? last.after : definition.voidType;
         }
+        
         expression = expression.cast(settings, definition, variables);
-
-        statement = true;
+        this.statement = true;
     }
 
     private void analyzeRead() {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EChain.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EChain.java
@@ -242,6 +242,11 @@ public final class EChain extends AExpression {
     private void analyzeRead() {
         final ALink last = links.get(links.size() - 1);
 
+        // If the load node is a DEF node, we adapt its after type to use _this_ expected output type:
+        if (last instanceof ADefLink && this.expected != null) {
+            last.after = this.expected;
+        }
+
         constant = last.string;
         statement = last.statement;
         actual = last.after;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EChain.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EChain.java
@@ -215,6 +215,12 @@ public final class EChain extends AExpression {
         there = AnalyzerCaster.getLegalCast(definition, location, last.after, promote, false);
         back = AnalyzerCaster.getLegalCast(definition, location, promote, last.after, true);
 
+        if (last instanceof ADefLink) {
+            final ADefLink lastDef = (ADefLink) last;
+            // Unfortunately, we don't know the real type because we load from DEF and store to DEF!
+            lastDef.storeValueType = last.after;
+        }
+
         statement = true;
         actual = read ? last.after : definition.voidType;
     }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EChain.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EChain.java
@@ -222,8 +222,17 @@ public final class EChain extends AExpression {
     private void analyzeWrite(final CompilerSettings settings, final Definition definition, final Variables variables) {
         final ALink last = links.get(links.size() - 1);
 
-        expression.expected = last.after;
-        expression.analyze(settings, definition, variables);
+        // If the store node is a DEF node, we remove the cast to DEF from the expression
+        // and promote the real type to it:
+        if (last instanceof ADefLink) {
+            final ADefLink lastDef = (ADefLink) last;
+            expression.analyze(settings, definition, variables);
+            lastDef.storeValueType = expression.expected = expression.actual;
+        } else {
+            // otherwise we adapt the type of the expression to the store type
+            expression.expected = last.after;
+            expression.analyze(settings, definition, variables);
+        }
         expression = expression.cast(settings, definition, variables);
 
         statement = true;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EChain.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EChain.java
@@ -234,15 +234,16 @@ public final class EChain extends AExpression {
             final ADefLink lastDef = (ADefLink) last;
             expression.analyze(settings, definition, variables);
             lastDef.storeValueType = expression.expected = expression.actual;
+            actual = read ? lastDef.storeValueType : definition.voidType;
         } else {
             // otherwise we adapt the type of the expression to the store type
             expression.expected = last.after;
             expression.analyze(settings, definition, variables);
+            actual = read ? last.after : definition.voidType;
         }
         expression = expression.cast(settings, definition, variables);
 
         statement = true;
-        actual = read ? last.after : definition.voidType;
     }
 
     private void analyzeRead() {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LCall.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LCall.java
@@ -59,9 +59,6 @@ public final class LCall extends ALink {
         method = statik ? struct.functions.get(name) : struct.methods.get(name);
 
         if (method != null) {
-            final Definition.Type[] types = new Definition.Type[method.arguments.size()];
-            method.arguments.toArray(types);
-
             if (method.arguments.size() != arguments.size()) {
                 throw new IllegalArgumentException(error("When calling [" + name + "] on type [" + struct.name + "]" +
                     " expected [" + method.arguments.size() + "] arguments, but found [" + arguments.size() + "]."));
@@ -70,7 +67,7 @@ public final class LCall extends ALink {
             for (int argument = 0; argument < arguments.size(); ++argument) {
                 final AExpression expression = arguments.get(argument);
 
-                expression.expected = types[argument];
+                expression.expected = method.arguments.get(argument);
                 expression.analyze(settings, definition, variables);
                 arguments.set(argument, expression.cast(settings, definition, variables));
             }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LDefArray.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LDefArray.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.painless.WriterConstants.DEF_BOOTSTRAP_HANDLE;
 /**
  * Represents an array load/store or shortcut on a def type.  (Internal only.)
  */
-final class LDefArray extends ALink {
+final class LDefArray extends ADefLink {
 
     AExpression index;
 
@@ -61,13 +61,16 @@ final class LDefArray extends ALink {
     @Override
     void load(final CompilerSettings settings, final Definition definition, final GeneratorAdapter adapter) {
         final String desc = Type.getMethodDescriptor(after.type, definition.defType.type, index.actual.type);
-        adapter.visitInvokeDynamicInsn("arrayLoad", desc, DEF_BOOTSTRAP_HANDLE, DefBootstrap.ARRAY_LOAD);
+        adapter.invokeDynamic("arrayLoad", desc, DEF_BOOTSTRAP_HANDLE, DefBootstrap.ARRAY_LOAD);
     }
 
     @Override
     void store(final CompilerSettings settings, final Definition definition, final GeneratorAdapter adapter) {
+        if (storeValueType == null) {
+            throw new IllegalStateException(error("Illegal tree structure."));
+        }
         final String desc = Type.getMethodDescriptor(definition.voidType.type, definition.defType.type,
-            index.actual.type, definition.defType.type);
-        adapter.visitInvokeDynamicInsn("arrayStore", desc, DEF_BOOTSTRAP_HANDLE, DefBootstrap.ARRAY_STORE);
+            index.actual.type, storeValueType.type);
+        adapter.invokeDynamic("arrayStore", desc, DEF_BOOTSTRAP_HANDLE, DefBootstrap.ARRAY_STORE);
     }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LDefArray.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LDefArray.java
@@ -36,7 +36,7 @@ final class LDefArray extends ADefLink {
     AExpression index;
 
     LDefArray(final int line, final String location, final AExpression index) {
-        super(line, location, 0);
+        super(line, location, 2);
 
         this.index = index;
     }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LDefCall.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LDefCall.java
@@ -32,7 +32,7 @@ import static org.elasticsearch.painless.WriterConstants.DEF_BOOTSTRAP_HANDLE;
 /**
  * Represents a method call made on a def type. (Internal only.)
  */
-final class LDefCall extends ALink {
+final class LDefCall extends ADefLink {
 
     final String name;
     final List<AExpression> arguments;
@@ -84,7 +84,7 @@ final class LDefCall extends ALink {
         // return value
         signature.append(after.type.getDescriptor());
 
-        adapter.visitInvokeDynamicInsn(name, signature.toString(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.METHOD_CALL);
+        adapter.invokeDynamic(name, signature.toString(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.METHOD_CALL);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LDefField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LDefField.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.painless.WriterConstants.DEF_BOOTSTRAP_HANDLE;
 /**
  * Represents a field load/store or shortcut on a def type.  (Internal only.)
  */
-final class LDefField extends ALink {
+final class LDefField extends ADefLink {
 
     final String value;
 
@@ -57,12 +57,15 @@ final class LDefField extends ALink {
     @Override
     void load(final CompilerSettings settings, final Definition definition, final GeneratorAdapter adapter) {
         final String desc = Type.getMethodDescriptor(after.type, definition.defType.type);
-        adapter.visitInvokeDynamicInsn(value, desc, DEF_BOOTSTRAP_HANDLE, DefBootstrap.LOAD);
+        adapter.invokeDynamic(value, desc, DEF_BOOTSTRAP_HANDLE, DefBootstrap.LOAD);
     }
 
     @Override
     void store(final CompilerSettings settings, final Definition definition, final GeneratorAdapter adapter) {
-        final String desc = Type.getMethodDescriptor(definition.voidType.type, definition.defType.type, definition.defType.type);
-        adapter.visitInvokeDynamicInsn(value, desc, DEF_BOOTSTRAP_HANDLE, DefBootstrap.STORE);
+        if (storeValueType == null) {
+            throw new IllegalStateException(error("Illegal tree structure."));
+        }
+        final String desc = Type.getMethodDescriptor(definition.voidType.type, definition.defType.type, storeValueType.type);
+        adapter.invokeDynamic(value, desc, DEF_BOOTSTRAP_HANDLE, DefBootstrap.STORE);
     }
 }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ArrayTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ArrayTests.java
@@ -54,6 +54,14 @@ public class ArrayTests extends ScriptTestCase {
         assertEquals(5, exec("def x = new def[4]; x[0] = 5; return x[0];"));
     }
     
+    public void testArrayCompoundInt() {
+        assertEquals(6, exec("int[] x = new int[5]; x[0] = 5; x[0]++; return x[0];"));
+    }
+    
+    public void testArrayCompoundDef() {
+        assertEquals(6, exec("def x = new int[5]; x[0] = 5; x[0]++; return x[0];"));
+    }
+    
     public void testForLoop() {
         assertEquals(999*1000/2, exec("def a = new int[1000]; for (int x = 0; x < a.length; x++) { a[x] = x; } "+
             "int total = 0; for (int x = 0; x < a.length; x++) { total += a[x]; } return total;"));

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ArrayTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ArrayTests.java
@@ -62,6 +62,14 @@ public class ArrayTests extends ScriptTestCase {
         assertEquals(6, exec("def x = new int[5]; x[0] = 5; x[0]++; return x[0];"));
     }
     
+    public void testJacksCrazyExpression1() {
+        assertEquals(1, exec("int x; def[] y = new def[1]; x = y[0] = 1; return x;"));
+    }
+    
+    public void testJacksCrazyExpression2() {
+        assertEquals(1, exec("int x; def y = new def[1]; x = y[0] = 1; return x;"));
+    }
+    
     public void testForLoop() {
         assertEquals(999*1000/2, exec("def a = new int[1000]; for (int x = 0; x < a.length; x++) { a[x] = x; } "+
             "int total = 0; for (int x = 0; x < a.length; x++) { total += a[x]; } return total;"));

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
@@ -81,4 +81,9 @@ public class BasicAPITests extends ScriptTestCase {
         assertEquals(1, exec("List<String> x = new ArrayList<String>(); x.add('Hallo'); return x.length"));
         assertEquals(1, exec("List<Object> x = new ArrayList<Object>(); x.add('Hallo'); return x.length"));
     }
+    
+    public void testDefAssignments() {
+        assertEquals(2, exec("int x; def y = 2.0; x = (int)y;"));
+    }
+    
 }


### PR DESCRIPTION
I finally managed to get the field and array stores to `def` fields or arrays no longer box. The problem to solve was to hack into `EChain.analyzeWrite` and promote the type the other way round:
- If it finds out that last node (the store link) in the chain accepts a `def` type, the code changes the return type of the expression (of which result should be stored) and disables casting the usual way. After that the return type of the expression gets promoted to directly to the store node.
- The code in field store and array store's `write()` was adapted to use the promoted type in the descriptor (this change was missing in my last PR already).

In addition in this PR I made all invokedynamic calls use the `GeneratorAdapter` method name instead on the underlying visitor's method name. This makes all invokes named the same throughout codebase.

Another change is removal of a useless List -> array clone.
