### PR TITLE
Fix response format of /customer/external/1?pretty

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -321,7 +321,8 @@ curl -XGET 'localhost:9200/customer/external/1?pretty'
   "_type" : "external",
   "_id" : "1",
   "_version" : 1,
-  "found" : true, "_source" : { "name": "John Doe" }
+  "found" : true,
+  "_source" : { "name": "John Doe" }
 }
 --------------------------------------------------
 


### PR DESCRIPTION
The response format is displaying elements "found" and "source" in the same lines and they should appear on their own separate lines.
