### PR TITLE
Add method overloading based on arity

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefBootstrap.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefBootstrap.java
@@ -91,10 +91,10 @@ public final class DefBootstrap {
         /**
          * Does a slow lookup against the whitelist.
          */
-        private static MethodHandle lookup(int flavor, Class<?> clazz, String name) {
+        private static MethodHandle lookup(int flavor, Class<?> clazz, String name, MethodType type) {
             switch(flavor) {
                 case METHOD_CALL:
-                    return Def.lookupMethod(clazz, name, Definition.INSTANCE);
+                    return Def.lookupMethod(clazz, name, type, Definition.INSTANCE);
                 case LOAD:
                     return Def.lookupGetter(clazz, name, Definition.INSTANCE);
                 case STORE:
@@ -115,7 +115,7 @@ public final class DefBootstrap {
             final MethodType type = type();
             final Object receiver = args[0];
             final Class<?> receiverClass = receiver.getClass();
-            final MethodHandle target = lookup(flavor, receiverClass, name).asType(type);
+            final MethodHandle target = lookup(flavor, receiverClass, name, type).asType(type);
 
             if (depth >= MAX_DEPTH) {
                 // revert to a vtable call

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/FeatureTest.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/FeatureTest.java
@@ -1,0 +1,66 @@
+package org.elasticsearch.painless;
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/** Currently just a dummy class for testing a few features not yet exposed by whitelist! */
+public class FeatureTest {
+    private int x;
+    private int y;
+    
+    /** empty ctor */
+    public FeatureTest() {
+    }
+    
+    /** ctor with params */
+    public FeatureTest(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    /** getter for x */
+    public int getX() {
+        return x;
+    }
+
+    /** setter for x */
+    public void setX(int x) {
+        this.x = x;
+    }
+
+    /** getter for y */
+    public int getY() {
+        return y;
+    }
+
+    /** setter for y */
+    public void setY(int y) {
+        this.y = y;
+    }
+
+    /** static method that returns true */
+    public static boolean overloadedStatic() {
+        return true;
+    }
+    
+    /** static method that returns what you ask it */
+    public static boolean overloadedStatic(boolean whatToReturn) {
+        return whatToReturn;
+    }
+}

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LCall.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LCall.java
@@ -55,15 +55,11 @@ public final class LCall extends ALink {
             throw new IllegalArgumentException(error("Cannot assign a value to a call [" + name + "]."));
         }
 
+        Definition.MethodKey methodKey = new Definition.MethodKey(name, arguments.size());
         final Struct struct = before.struct;
-        method = statik ? struct.functions.get(name) : struct.methods.get(name);
+        method = statik ? struct.staticMethods.get(methodKey) : struct.methods.get(methodKey);
 
         if (method != null) {
-            if (method.arguments.size() != arguments.size()) {
-                throw new IllegalArgumentException(error("When calling [" + name + "] on type [" + struct.name + "]" +
-                    " expected [" + method.arguments.size() + "] arguments, but found [" + arguments.size() + "]."));
-            }
-
             for (int argument = 0; argument < arguments.size(); ++argument) {
                 final AExpression expression = arguments.get(argument);
 
@@ -83,7 +79,8 @@ public final class LCall extends ALink {
             return link.analyze(settings, definition, variables);
         }
 
-        throw new IllegalArgumentException(error("Unknown call [" + name + "] on type [" + struct.name + "]."));
+        throw new IllegalArgumentException(error("Unknown call [" + name + "] with [" + arguments.size() + 
+                                                 "] arguments on type [" + struct.name + "]."));
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LField.java
@@ -60,7 +60,7 @@ public final class LField extends ALink {
         }
 
         final Struct struct = before.struct;
-        field = statik ? struct.statics.get(value) : struct.members.get(value);
+        field = statik ? struct.staticMembers.get(value) : struct.members.get(value);
 
         if (field != null) {
             if (store && java.lang.reflect.Modifier.isFinal(field.reflect.getModifiers())) {
@@ -72,9 +72,12 @@ public final class LField extends ALink {
 
             return this;
         } else {
+            // TODO: improve this: the isXXX case seems missing???
             final boolean shortcut =
-                struct.methods.containsKey("get" + Character.toUpperCase(value.charAt(0)) + value.substring(1)) ||
-                struct.methods.containsKey("set" + Character.toUpperCase(value.charAt(0)) + value.substring(1));
+                struct.methods.containsKey(new Definition.MethodKey("get" + 
+                        Character.toUpperCase(value.charAt(0)) + value.substring(1), 0)) ||
+                struct.methods.containsKey(new Definition.MethodKey("set" + 
+                        Character.toUpperCase(value.charAt(0)) + value.substring(1), 1));
 
             if (shortcut) {
                 return new LShortcut(line, location, value).copy(this).analyze(settings, definition, variables);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LListShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LListShortcut.java
@@ -43,8 +43,8 @@ final class LListShortcut extends ALink {
 
     @Override
     ALink analyze(final CompilerSettings settings, final Definition definition, final Variables variables) {
-        getter = before.struct.methods.get("get");
-        setter = before.struct.methods.get("set");
+        getter = before.struct.methods.get(new Definition.MethodKey("get", 1));
+        setter = before.struct.methods.get(new Definition.MethodKey("set", 2));
 
         if (getter != null && (getter.rtn.sort == Sort.VOID || getter.arguments.size() != 1 ||
             getter.arguments.get(0).sort != Sort.INT)) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LMapShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LMapShortcut.java
@@ -43,8 +43,8 @@ final class LMapShortcut extends ALink {
 
     @Override
     ALink analyze(final CompilerSettings settings, final Definition definition, final Variables variables) {
-        getter = before.struct.methods.get("get");
-        setter = before.struct.methods.get("put");
+        getter = before.struct.methods.get(new Definition.MethodKey("get", 1));
+        setter = before.struct.methods.get(new Definition.MethodKey("put", 2));
 
         if (getter != null && (getter.rtn.sort == Sort.VOID || getter.arguments.size() != 1)) {
             throw new IllegalArgumentException(error("Illegal map get shortcut for type [" + before.name + "]."));

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LNewObj.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LNewObj.java
@@ -63,7 +63,7 @@ public final class LNewObj extends ALink {
         }
 
         final Struct struct = type.struct;
-        constructor = struct.constructors.get("new");
+        constructor = struct.constructors.get(new Definition.MethodKey("new", arguments.size()));
 
         if (constructor != null) {
             final Type[] types = new Type[constructor.arguments.size()];

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/LShortcut.java
@@ -47,8 +47,8 @@ final class LShortcut extends ALink {
     ALink analyze(final CompilerSettings settings, final Definition definition, final Variables variables) {
         final Struct struct = before.struct;
 
-        getter = struct.methods.get("get" + Character.toUpperCase(value.charAt(0)) + value.substring(1));
-        setter = struct.methods.get("set" + Character.toUpperCase(value.charAt(0)) + value.substring(1));
+        getter = struct.methods.get(new Definition.MethodKey("get" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 0));
+        setter = struct.methods.get(new Definition.MethodKey("set" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 1));
 
         if (getter != null && (getter.rtn.sort == Sort.VOID || !getter.arguments.isEmpty())) {
             throw new IllegalArgumentException(error(

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/OverloadTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/OverloadTests.java
@@ -1,0 +1,52 @@
+package org.elasticsearch.painless;
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/** Tests method overloading */
+public class OverloadTests extends ScriptTestCase {
+
+    public void testMethod() {
+        assertEquals(2, exec("return 'abc123abc'.indexOf('c');"));
+        assertEquals(8, exec("return 'abc123abc'.indexOf('c', 3);"));
+        IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+            exec("return 'abc123abc'.indexOf('c', 3, 'bogus');");
+        });
+        assertTrue(expected.getMessage().contains("[indexOf] with [3] arguments"));
+    }
+    
+    public void testMethodDynamic() {
+        assertEquals(2, exec("def x = 'abc123abc'; return x.indexOf('c');"));
+        assertEquals(8, exec("def x = 'abc123abc'; return x.indexOf('c', 3);"));
+        IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+            exec("def x = 'abc123abc'; return x.indexOf('c', 3, 'bogus');");
+        });
+        assertTrue(expected.getMessage().contains("dynamic method [indexOf] with signature [(String,int,String)"));
+    }
+    
+    public void testConstructor() {
+        assertEquals(true, exec("FeatureTest f = new FeatureTest(); return f.x == 0 && f.y == 0;"));
+        assertEquals(true, exec("FeatureTest f = new FeatureTest(1, 2); return f.x == 1 && f.y == 2;"));
+    }
+    
+    public void testStatic() {
+        assertEquals(true, exec("return FeatureTest.overloadedStatic();"));
+        assertEquals(false, exec("return FeatureTest.overloadedStatic(false);"));
+    }
+}


### PR DESCRIPTION
Currently painless only keys methods, constructors, static methods based on `name`. This means we cannot have multiple signatures with the same name, which makes it difficult to expand the whitelist.

For example `new Date()` vs `new Date(long)`. 

Here we just allow to overload based on number of parameters vs signatures: to keep everything still simple (including the user since much typing is dynamic and implicit conversions could get complex), but allow improvements for many cases where this is really needed.

For methods i added variants of `String.indexOf`, but in order to test the ctor and static method case I added a `FeatureTest` to the whitelist. This also contains getter/setters for loads and stores which we need to test but aren't yet exposed to the whitelist. It needs to be possible to divorce these two things, so we don't have to rush the api just to test.

We key methods on MethodKey (name + arity), but this only impacts the slow path for method lookups, the caching still works the same, so it does not have a performance impact.
