### PR TITLE
Release: Ensure javadocs are released for plugins

### DIFF
--- a/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/AwsModule.java
+++ b/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/AwsModule.java
@@ -41,6 +41,8 @@ public class AwsModule extends AbstractModule {
 
     /**
      * Check if discovery is meant to start
+     * @param settings settings to extract discover type from
+     * @param logger the logger to be used
      * @return true if we can start discovery features
      */
     public static boolean isEc2DiscoveryActive(Settings settings, ESLogger logger) {

--- a/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/blobstore/DefaultS3OutputStream.java
+++ b/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/blobstore/DefaultS3OutputStream.java
@@ -37,20 +37,26 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
+ * <p>
  * DefaultS3OutputStream uploads data to the AWS S3 service using 2 modes: single and multi part.
- * <p/>
+ * </p>
+ * <p>
  * When the length of the chunk is lower than buffer_size, the chunk is uploaded with a single request.
  * Otherwise multiple requests are made, each of buffer_size (except the last one which can be lower than buffer_size).
- * <p/>
+ * </p>
+ * <p>
  * Quick facts about S3:
- * <p/>
- * Maximum object size:                 5 TB
- * Maximum number of parts per upload:  10,000
- * Part numbers:                        1 to 10,000 (inclusive)
- * Part size:                           5 MB to 5 GB, last part can be < 5 MB
- * <p/>
+ * </p>
+ * <ul>
+ * <li>Maximum object size:                 5 TB</li>
+ * <li>Maximum number of parts per upload:  10,000</li>
+ * <li>Part numbers:                        1 to 10,000 (inclusive)</li>
+ * <li>Part size:                           5 MB to 5 GB, last part can be &lt; 5 MB</li>
+ * </ul>
+ * <p>
  * See http://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
  * See http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html
+ * </p>
  */
 public class DefaultS3OutputStream extends S3OutputStream {
 

--- a/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobStore.java
+++ b/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobStore.java
@@ -36,9 +36,6 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import java.util.ArrayList;
 import java.util.Locale;
 
-/**
- *
- */
 public class S3BlobStore extends AbstractComponent implements BlobStore {
 
     public static final ByteSizeValue MIN_BUFFER_SIZE = new ByteSizeValue(5, ByteSizeUnit.MB);
@@ -215,6 +212,8 @@ public class S3BlobStore extends AbstractComponent implements BlobStore {
 
     /**
      * Constructs canned acl from string
+     * @param cannedACL canned access control list
+     * @return the corresponding access control list
      */
     public static CannedAccessControlList initCannedACL(String cannedACL) {
         if (cannedACL == null || cannedACL.equals("")) {

--- a/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/network/Ec2NameResolver.java
+++ b/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/network/Ec2NameResolver.java
@@ -35,9 +35,10 @@ import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 
 /**
+ * <p>
  * Resolves certain ec2 related 'meta' hostnames into an actual hostname
  * obtained from ec2 meta-data.
- * <p/>
+ * </p>
  * Valid config values for {@link Ec2HostnameType}s are -
  * <ul>
  * <li>_ec2_ - maps to privateIpv4</li>
@@ -81,6 +82,7 @@ public class Ec2NameResolver extends AbstractComponent implements CustomNameReso
 
     /**
      * Construct a {@link CustomNameResolver}.
+     * @param settings The global settings
      */
     public Ec2NameResolver(Settings settings) {
         super(settings);

--- a/plugins/cloud-aws/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/cloud-aws/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -39,8 +39,9 @@ import java.io.IOException;
 import java.util.Locale;
 
 /**
+ * <p>
  * Shared file system implementation of the BlobStoreRepository
- * <p/>
+ * </p>
  * Shared file system repository supports the following settings
  * <dl>
  * <dt>{@code bucket}</dt><dd>S3 bucket</dd>
@@ -70,10 +71,9 @@ public class S3Repository extends BlobStoreRepository {
      * @param repositorySettings   repository settings
      * @param indexShardRepository index shard repository
      * @param s3Service            S3 service
-     * @throws IOException
      */
     @Inject
-    public S3Repository(RepositoryName name, RepositorySettings repositorySettings, IndexShardRepository indexShardRepository, AwsS3Service s3Service) throws IOException {
+    public S3Repository(RepositoryName name, RepositorySettings repositorySettings, IndexShardRepository indexShardRepository, AwsS3Service s3Service) {
         super(name.getName(), repositorySettings, indexShardRepository);
 
         String bucket = repositorySettings.settings().get("bucket", settings.get(REPOSITORY_S3.BUCKET));

--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/AzureModule.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/AzureModule.java
@@ -93,6 +93,7 @@ public class AzureModule extends AbstractModule {
 
     /**
      * Check if discovery is meant to start
+     * @param settings settings to extract cloud enabled parameter from
      * @return true if we can start discovery features
      */
     public static boolean isCloudReady(Settings settings) {
@@ -101,6 +102,8 @@ public class AzureModule extends AbstractModule {
 
     /**
      * Check if discovery is meant to start
+     * @param settings settings to extract cloud enabled parameter from
+     * @param logger the logger to be used
      * @return true if we can start discovery features
      */
     public static boolean isDiscoveryReady(Settings settings, ESLogger logger) {
@@ -137,6 +140,8 @@ public class AzureModule extends AbstractModule {
 
     /**
      * Check if we have repository azure settings available
+     * @param settings settings to extract cloud enabled parameter from
+     * @param logger the logger to be used
      * @return true if we can use snapshot and restore
      */
     public static boolean isSnapshotReady(Settings settings, ESLogger logger) {

--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
@@ -44,8 +44,9 @@ import java.util.List;
 import java.util.Locale;
 
 /**
+ * <p>
  * Azure file system implementation of the BlobStoreRepository
- * <p/>
+ * </p>
  * Azure file system repository supports the following settings:
  * <dl>
  * <dt>{@code container}</dt><dd>Azure container name. Defaults to elasticsearch-snapshots</dd>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -23,28 +23,45 @@
     <build>
         <plugins>
            <!-- integration tests: install artifact as plugin -->
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <executions>
-                        <!-- start up external cluster -->
-                        <execution>
-                            <id>integ-setup</id>
-                            <phase>pre-integration-test</phase>
-                            <goals>
-                                <goal>run</goal>
-                            </goals>
-                            <configuration>
-                                <skip>${skip.integ.tests}</skip>
-                                <target>
-                                    <ant antfile="${elasticsearch.integ.antfile}" target="start-external-cluster-with-plugin">
-                                        <property name="tests.jvm.argline" value="${tests.jvm.argline}"/>
-                                    </ant>
-                                </target>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
+           <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-antrun-plugin</artifactId>
+               <executions>
+                   <!-- start up external cluster -->
+                   <execution>
+                       <id>integ-setup</id>
+                       <phase>pre-integration-test</phase>
+                       <goals>
+                           <goal>run</goal>
+                       </goals>
+                       <configuration>
+                           <skip>${skip.integ.tests}</skip>
+                           <target>
+                               <ant antfile="${elasticsearch.integ.antfile}" target="start-external-cluster-with-plugin">
+                                   <property name="tests.jvm.argline" value="${tests.jvm.argline}"/>
+                               </ant>
+                           </target>
+                       </configuration>
+                   </execution>
+               </executions>
+           </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <quiet>true</quiet>
+                            <additionalparam>${doclint.all}</additionalparam>
+                            <additionalparam>${doclint.missing}</additionalparam>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
In order to release javadocs for plugins as well, these need to
be generated and valid.
