### PR TITLE
Force attach sources with non "jar" artifacts

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -149,6 +149,14 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <includePom>true</includePom>
+                </configuration>
+            </plugin>
+
             <!-- We copy libs for deb and rpm -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/plugins/site-example/pom.xml
+++ b/plugins/site-example/pom.xml
@@ -29,6 +29,14 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <includePom>true</includePom>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
             </plugin>
             <!-- disable jar plugin, we have no jar -->


### PR DESCRIPTION
Sonatype rule `sources-staging` force to provide a `*-sources.jar` artifact.

This PR generates the source jar even if there is no related java code by considering the `pom.xml` file as a source file.

We could set this globally on the project but I prefer being cautious here and just add this to the projects which are not generating source files archive for now.

When you run it on distribution packages or site-example plugin, you now get:

```
[INFO] --- maven-source-plugin:2.4:jar (attach-sources) @ site-example ---
[INFO] Building jar: /Users/dpilato/Documents/Elasticsearch/dev/es-2x/elasticsearch/plugins/site-example/target/site-example-2.4.0-SNAPSHOT-sources.jar
```

Was previously:

```
[INFO] --- maven-source-plugin:2.4:jar (attach-sources) @ site-example ---
[INFO] No sources in project. Archive not created.
```
