### PR TITLE
Build: Create javadoc for all projects

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -361,23 +361,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <quiet>true</quiet>
-                            <additionalparam>${doclint.all}</additionalparam>
-                            <additionalparam>${doclint.missing}</additionalparam>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
       <pluginManagement>
         <plugins>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -45,23 +45,6 @@
                    </execution>
                </executions>
            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <quiet>true</quiet>
-                            <additionalparam>${doclint.all}</additionalparam>
-                            <additionalparam>${doclint.missing}</additionalparam>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -519,6 +519,24 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.10.3</version>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                            <configuration>
+                                <quiet>true</quiet>
+                                <additionalparam>${doclint.all}</additionalparam>
+                                <additionalparam>${doclint.missing}</additionalparam>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         <pluginManagement>
             <plugins>
@@ -1299,12 +1317,6 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-invoker-plugin</artifactId>
                     <version>2.0.0</version>
-                </plugin>
-                <plugin>
-                    <!-- We just declare which plugin version to use. Each project can have then its own settings -->
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.3</version>
                 </plugin>
                 <plugin>
                     <!-- We just declare which plugin version to use. Each project can have then its own settings -->


### PR DESCRIPTION
This ensures that javadocs are created for any projects by configuring
on the root pom.xml
