### PR TITLE
Force attach a fake jar with non "jar" artifacts

### DIFF
--- a/distribution/deb/src/main/resources/FAKE.txt
+++ b/distribution/deb/src/main/resources/FAKE.txt
@@ -1,0 +1,3 @@
+This file is used to generate a FAKE jar which is needed by Sonatype
+to validate the artifact.
+

--- a/distribution/integ-test-zip/src/main/resources/FAKE.txt
+++ b/distribution/integ-test-zip/src/main/resources/FAKE.txt
@@ -1,0 +1,3 @@
+This file is used to generate a FAKE jar which is needed by Sonatype
+to validate the artifact.
+

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -149,12 +149,25 @@
 
     <build>
         <plugins>
+            <!-- Always generate a Javadoc file even if we don't have any java source
+                but only resources
+            -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <configuration>
-                    <includePom>true</includePom>
-                </configuration>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>empty-javadoc-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>javadoc</classifier>
+                            <classesDirectory>${basedir}/src/main/resources</classesDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <!-- We copy libs for deb and rpm -->

--- a/distribution/tar/src/main/resources/FAKE.txt
+++ b/distribution/tar/src/main/resources/FAKE.txt
@@ -1,0 +1,3 @@
+This file is used to generate a FAKE jar which is needed by Sonatype
+to validate the artifact.
+

--- a/distribution/zip/src/main/resources/FAKE.txt
+++ b/distribution/zip/src/main/resources/FAKE.txt
@@ -1,0 +1,3 @@
+This file is used to generate a FAKE jar which is needed by Sonatype
+to validate the artifact.
+

--- a/plugins/site-example/pom.xml
+++ b/plugins/site-example/pom.xml
@@ -29,14 +29,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <configuration>
-                    <includePom>true</includePom>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
             </plugin>
             <!-- disable jar plugin, we have no jar -->
@@ -44,9 +36,19 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
+                    <!-- Always generate a Javadoc file even if we don't have any java source
+                        but only resources
+                    -->
                     <execution>
-                        <id>default-jar</id>
-                        <phase>none</phase>
+                        <id>empty-javadoc-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>javadoc</classifier>
+                            <classesDirectory>${basedir}/src/main/resources</classesDirectory>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/plugins/site-example/src/main/resources/FAKE.txt
+++ b/plugins/site-example/src/main/resources/FAKE.txt
@@ -1,0 +1,3 @@
+This file is used to generate a FAKE jar which is needed by Sonatype
+to validate the artifact.
+


### PR DESCRIPTION
Follow up for #18396: which is reverted with this change

When you upload any `jar` artifact you have to provide the `jar` file, javadocs and sources.

For distribution, we changed from `pom` artifact to `jar` in order to be able to run integration tests.
But we never generate any jar, sources or javadoc because they don't exist.

This PR adds a FAKE file in `src/main/resources`. So Maven is able to generate the JAR file which is uploaded to Sonatype.
Sources are then automatically added.
To generate the javadoc file, we need also to tell maven that javadoc will be based on this `src/main/resources` dir.
As a file exists in it, javadoc is generated as well.

```
[INFO] --- maven-install-plugin:2.5.2:install (default-install) @ elasticsearch ---
[INFO] Installing /Users/dpilato/Documents/Elasticsearch/dev/es-2x/elasticsearch/distribution/zip/target/elasticsearch-2.4.0-SNAPSHOT.jar to /Users/dpilato/.m2/repository/org/elasticsearch/distribution/zip/elasticsearch/2.4.0-SNAPSHOT/elasticsearch-2.4.0-SNAPSHOT.jar
[INFO] Installing /Users/dpilato/Documents/Elasticsearch/dev/es-2x/elasticsearch/distribution/zip/pom.xml to /Users/dpilato/.m2/repository/org/elasticsearch/distribution/zip/elasticsearch/2.4.0-SNAPSHOT/elasticsearch-2.4.0-SNAPSHOT.pom
[INFO] Installing /Users/dpilato/Documents/Elasticsearch/dev/es-2x/elasticsearch/distribution/zip/target/elasticsearch-2.4.0-SNAPSHOT-javadoc.jar to /Users/dpilato/.m2/repository/org/elasticsearch/distribution/zip/elasticsearch/2.4.0-SNAPSHOT/elasticsearch-2.4.0-SNAPSHOT-javadoc.jar
[INFO] Installing /Users/dpilato/Documents/Elasticsearch/dev/es-2x/elasticsearch/distribution/zip/target/elasticsearch-2.4.0-SNAPSHOT-sources.jar to /Users/dpilato/.m2/repository/org/elasticsearch/distribution/zip/elasticsearch/2.4.0-SNAPSHOT/elasticsearch-2.4.0-SNAPSHOT-sources.jar
[INFO] Installing /Users/dpilato/Documents/Elasticsearch/dev/es-2x/elasticsearch/distribution/zip/target/releases/elasticsearch-2.4.0-SNAPSHOT.zip to /Users/dpilato/.m2/repository/org/elasticsearch/distribution/zip/elasticsearch/2.4.0-SNAPSHOT/elasticsearch-2.4.0-SNAPSHOT.zip
```
