### PR TITLE
Add missing builder.endObject() in FsInfo

### DIFF
--- a/core/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
+++ b/core/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
@@ -396,12 +396,14 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContent {
                     builder.endObject();
                 }
                 builder.endArray();
+
                 builder.startObject("total");
                 builder.field(OPERATIONS, totalOperations);
                 builder.field(READ_OPERATIONS, totalReadOperations);
                 builder.field(WRITE_OPERATIONS, totalWriteOperations);
                 builder.field(READ_KILOBYTES, totalReadKilobytes);
                 builder.field(WRITE_KILOBYTES, totalWriteKilobytes);
+                builder.endObject();
             }
             return builder;
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/30_discovery.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/30_discovery.yaml
@@ -1,9 +1,5 @@
 ---
 "Discovery stats":
-  - skip:
-      version:     "5.0.0 - "
-      reason:      Tracked in issue 18433 
-
   - do:
       cluster.state: {}
 


### PR DESCRIPTION
This pull request fix a small regression introduced by #15915

Closes #18433 

@ywelsch Can you have a look please? Thanks
