### PR TITLE
Remove last vestiges of /bin/sh shebangs

### DIFF
--- a/buildSrc/src/main/resources/deb/postinst.ftl
+++ b/buildSrc/src/main/resources/deb/postinst.ftl
@@ -1,2 +1,2 @@
-#!/bin/sh -e
+#!/bin/bash -e
 <% commands.each {command -> %><%= command %><% } %>

--- a/buildSrc/src/main/resources/deb/preinst.ftl
+++ b/buildSrc/src/main/resources/deb/preinst.ftl
@@ -1,2 +1,2 @@
-#!/bin/sh -e
+#!/bin/bash -e
 <% commands.each {command -> %><%= command %><% } %>

--- a/distribution/src/main/resources/bin/elasticsearch-systemd-pre-exec
+++ b/distribution/src/main/resources/bin/elasticsearch-systemd-pre-exec
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # CONF_FILE setting was removed
 if [ ! -z "$CONF_FILE" ]; then

--- a/distribution/src/main/resources/bin/elasticsearch.in.sh
+++ b/distribution/src/main/resources/bin/elasticsearch.in.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # check in case a user was using this mechanism
 if [ "x$ES_CLASSPATH" != "x" ]; then

--- a/plugins/jvm-example/src/main/bin/test
+++ b/plugins/jvm-example/src/main/bin/test
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 
 echo test

--- a/qa/vagrant/src/test/resources/packaging/scripts/modules.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/modules.bash
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This file contains some utilities to test the elasticsearch scripts,
 # the .deb/.rpm packages and the SysV/Systemd scripts.

--- a/qa/vagrant/src/test/resources/packaging/scripts/os_package.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/os_package.bash
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This file contains some utilities to test the elasticsearch scripts with
 # the .deb/.rpm packages.

--- a/qa/vagrant/src/test/resources/packaging/scripts/packaging_test_utils.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/packaging_test_utils.bash
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This file contains some utilities to test the elasticsearch scripts,
 # the .deb/.rpm packages and the SysV/Systemd scripts.

--- a/qa/vagrant/src/test/resources/packaging/scripts/plugins.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/plugins.bash
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This file contains some utilities to test the elasticsearch scripts,
 # the .deb/.rpm packages and the SysV/Systemd scripts.

--- a/qa/vagrant/src/test/resources/packaging/scripts/tar.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/tar.bash
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This file contains some utilities to test the elasticsearch scripts,
 # the .deb/.rpm packages and the SysV/Systemd scripts.


### PR DESCRIPTION
This commit removes the remaining /bin/sh shebangs in favor of
/bin/bash.
