### PR TITLE
Change BlobPath.buildAsString() method

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
@@ -30,6 +30,8 @@ import java.util.List;
  */
 public class BlobPath implements Iterable<String> {
 
+    private static final String SEPARATOR = "/";
+
     private final List<String> paths;
 
     public BlobPath() {
@@ -60,15 +62,12 @@ public class BlobPath implements Iterable<String> {
         return new BlobPath(Collections.unmodifiableList(paths));
     }
 
-    public String buildAsString(String separator) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < paths.size(); i++) {
-            sb.append(paths.get(i));
-            if (i < (paths.size() - 1)) {
-                sb.append(separator);
-            }
+    public String buildAsString() {
+        String p = String.join(SEPARATOR, paths);
+        if (p.isEmpty()) {
+            return p;
         }
-        return sb.toString();
+        return p + SEPARATOR;
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/common/blobstore/BlobPathTests.java
+++ b/core/src/test/java/org/elasticsearch/common/blobstore/BlobPathTests.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.blobstore;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.is;
+
+public class BlobPathTests extends ESTestCase {
+
+    public void testBuildAsString() {
+        BlobPath path = new BlobPath();
+        assertThat(path.buildAsString(), is(""));
+
+        path = path.add("a");
+        assertThat(path.buildAsString(), is("a/"));
+
+        path = path.add("b").add("c");
+        assertThat(path.buildAsString(), is("a/b/c/"));
+
+    }
+}

--- a/core/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -231,7 +231,7 @@ public class MockRepository extends FsRepository {
 
             private boolean shouldFail(String blobName, double probability) {
                 if (probability > 0.0) {
-                    String path = path().add(blobName).buildAsString("/") + "/" + randomPrefix;
+                    String path = path().add(blobName).buildAsString() + randomPrefix;
                     path += "/" + incrementAndGet(path);
                     logger.info("checking [{}] [{}]", path, Math.abs(hashCode(path)) < Integer.MAX_VALUE * probability);
                     return Math.abs(hashCode(path)) < Integer.MAX_VALUE * probability;

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
@@ -52,11 +52,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     public AzureBlobContainer(String repositoryName, BlobPath path, AzureBlobStore blobStore) {
         super(path);
         this.blobStore = blobStore;
-        String keyPath = path.buildAsString("/");
-        if (!keyPath.isEmpty()) {
-            keyPath = keyPath + "/";
-        }
-        this.keyPath = keyPath;
+        this.keyPath = path.buildAsString();
         this.repositoryName = repositoryName;
     }
 

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobStore.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobStore.java
@@ -85,11 +85,7 @@ public class AzureBlobStore extends AbstractComponent implements BlobStore {
 
     @Override
     public void delete(BlobPath path) {
-        String keyPath = path.buildAsString("/");
-        if (!keyPath.isEmpty()) {
-            keyPath = keyPath + "/";
-        }
-
+        String keyPath = path.buildAsString();
         try {
             this.client.deleteFiles(this.accountName, this.locMode, container, keyPath);
         } catch (URISyntaxException | StorageException e) {

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/common/blobstore/gcs/GoogleCloudStorageBlobContainer.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/common/blobstore/gcs/GoogleCloudStorageBlobContainer.java
@@ -42,13 +42,7 @@ public class GoogleCloudStorageBlobContainer extends AbstractBlobContainer {
     GoogleCloudStorageBlobContainer(BlobPath path, GoogleCloudStorageBlobStore blobStore) {
         super(path);
         this.blobStore = blobStore;
-
-        String keyPath = path.buildAsString("/");
-        // TODO Move this keyPath logic to the buildAsString() method
-        if (!keyPath.isEmpty()) {
-            keyPath = keyPath + "/";
-        }
-        this.path = keyPath;
+        this.path = path.buildAsString();
     }
 
     @Override

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/common/blobstore/gcs/GoogleCloudStorageBlobStore.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/common/blobstore/gcs/GoogleCloudStorageBlobStore.java
@@ -88,12 +88,7 @@ public class GoogleCloudStorageBlobStore extends AbstractComponent implements Bl
 
     @Override
     public void delete(BlobPath path) throws IOException {
-        String keyPath = path.buildAsString("/");
-        // TODO Move this keyPath logic to the buildAsString() method
-        if (!keyPath.isEmpty()) {
-            keyPath = keyPath + "/";
-        }
-        deleteBlobsByPrefix(keyPath);
+        deleteBlobsByPrefix(path.buildAsString());
     }
 
     @Override

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobContainer.java
@@ -54,11 +54,7 @@ public class S3BlobContainer extends AbstractBlobContainer {
     public S3BlobContainer(BlobPath path, S3BlobStore blobStore) {
         super(path);
         this.blobStore = blobStore;
-        String keyPath = path.buildAsString("/");
-        if (!keyPath.isEmpty()) {
-            keyPath = keyPath + "/";
-        }
-        this.keyPath = keyPath;
+        this.keyPath = path.buildAsString();
     }
 
     @Override

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobStore.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobStore.java
@@ -145,11 +145,7 @@ public class S3BlobStore extends AbstractComponent implements BlobStore {
             if (prevListing != null) {
                 list = client.listNextBatchOfObjects(prevListing);
             } else {
-                String keyPath = path.buildAsString("/");
-                if (!keyPath.isEmpty()) {
-                    keyPath = keyPath + "/";
-                }
-                list = client.listObjects(bucket, keyPath);
+                list = client.listObjects(bucket, path.buildAsString());
                 multiObjectDeleteRequest = new DeleteObjectsRequest(list.getBucketName());
             }
             for (S3ObjectSummary summary : list.getObjectSummaries()) {


### PR DESCRIPTION
This pull request changes the `BlobPath.buildAsString()` behavior so that extra checks in calling methods are not needed anymore.

This a follow up from https://github.com/elastic/elasticsearch/pull/13578#discussion_r59062851
