### PR TITLE
Do not decode path when sending error

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
+++ b/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
@@ -123,9 +123,9 @@ public class BytesRestResponse extends RestResponse {
                 params =  new ToXContent.DelegatingMapParams(Collections.singletonMap(ElasticsearchException.REST_EXCEPTION_SKIP_STACK_TRACE, "false"), channel.request());
             } else {
                 if (status.getStatus() < 500) {
-                    SUPPRESSED_ERROR_LOGGER.debug("{} Params: {}", t, channel.request().path(), channel.request().params());
+                    SUPPRESSED_ERROR_LOGGER.debug("{} Params: {}", t, channel.request().rawPath(), channel.request().params());
                 } else {
-                    SUPPRESSED_ERROR_LOGGER.warn("{} Params: {}", t, channel.request().path(), channel.request().params());
+                    SUPPRESSED_ERROR_LOGGER.warn("{} Params: {}", t, channel.request().rawPath(), channel.request().params());
                 }
                 params = channel.request();
             }

--- a/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
+++ b/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
@@ -123,9 +123,9 @@ public class BytesRestResponse extends RestResponse {
                 params =  new ToXContent.DelegatingMapParams(Collections.singletonMap(ElasticsearchException.REST_EXCEPTION_SKIP_STACK_TRACE, "false"), channel.request());
             } else {
                 if (status.getStatus() < 500) {
-                    SUPPRESSED_ERROR_LOGGER.debug("{} Params: {}", t, channel.request().rawPath(), channel.request().params());
+                    SUPPRESSED_ERROR_LOGGER.debug("path: {}, params: {}", t, channel.request().rawPath(), channel.request().params());
                 } else {
-                    SUPPRESSED_ERROR_LOGGER.warn("{} Params: {}", t, channel.request().rawPath(), channel.request().params());
+                    SUPPRESSED_ERROR_LOGGER.warn("path: {}, params: {}", t, channel.request().rawPath(), channel.request().params());
                 }
                 params = channel.request();
             }

--- a/core/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
@@ -161,12 +161,8 @@ public class BytesRestResponseTests extends ESTestCase {
         final BytesRestResponse response = new BytesRestResponse(channel, e);
         assertNotNull(response.content());
         final String content = response.content().toUtf8();
-        assertThat(
-            content,
-            containsString("\"type\":\"illegal_argument_exception\""));
-        assertThat(
-            content,
-            containsString("\"reason\":\"partial escape sequence at end of string: %a\""));
+        assertThat(content, containsString("\"type\":\"illegal_argument_exception\""));
+        assertThat(content, containsString("\"reason\":\"partial escape sequence at end of string: %a\""));
         assertThat(content, containsString("\"status\":" + 400));
     }
 
@@ -176,12 +172,8 @@ public class BytesRestResponseTests extends ESTestCase {
         final BytesRestResponse response = new BytesRestResponse(channel, new ElasticsearchException("simulated"));
         assertNotNull(response.content());
         final String content = response.content().toUtf8();
-        assertThat(
-            content,
-            containsString("\"type\":\"exception\""));
-        assertThat(
-            content,
-            containsString("\"reason\":\"simulated\""));
+        assertThat(content, containsString("\"type\":\"exception\""));
+        assertThat(content, containsString("\"reason\":\"simulated\""));
         assertThat(content, containsString("\"status\":" + 500));
     }
 


### PR DESCRIPTION
Today when sending a REST error to a client, we send the decoded
path. But decoding that path can already be the cause of the error in
which case decoding it again will just throw an exception leading to us
never sending an error back to the client. It would be better to send
the entire raw path to the client and that is what we do in this commit.

Closes #18476
