### PR TITLE
Passthrough test logger level to nodes

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -130,6 +130,10 @@ class NodeInfo {
 
         env = [ 'JAVA_HOME' : project.javaHome ]
         args.addAll("-E", "node.portsfile=true")
+        String loggerLevel = System.getProperty("tests.logger.level")
+        if (loggerLevel != null) {
+            args.addAll("-E", "logger.level=${loggerLevel}")
+        }
         String collectedSystemProperties = config.systemProperties.collect { key, value -> "-D${key}=${value}" }.join(" ")
         String esJavaOpts = config.jvmArgs.isEmpty() ? collectedSystemProperties : collectedSystemProperties + " " + config.jvmArgs
         env.put('ES_JAVA_OPTS', esJavaOpts)


### PR DESCRIPTION
This commit passes the system property tests.logger.level down to the
external nodes launched in integration tests. Specific tests that want
to override the default logging level should push down a setting to
the nodes using cluster configuration instead of pushing down a system
property to the nodes using cluster configuration.
