### PR TITLE
Add support for MatchNoDocsQuery in percolator's query terms extract service

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/percolator/ExtractQueryTermsService.java
+++ b/core/src/main/java/org/elasticsearch/index/percolator/ExtractQueryTermsService.java
@@ -37,19 +37,16 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.search.spans.FieldMaskingSpanQuery;
-import org.apache.lucene.search.spans.SpanContainingQuery;
 import org.apache.lucene.search.spans.SpanFirstQuery;
-import org.apache.lucene.search.spans.SpanMultiTermQueryWrapper;
 import org.apache.lucene.search.spans.SpanNearQuery;
 import org.apache.lucene.search.spans.SpanNotQuery;
 import org.apache.lucene.search.spans.SpanOrQuery;
 import org.apache.lucene.search.spans.SpanQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
-import org.apache.lucene.search.spans.SpanWithinQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
+import org.elasticsearch.common.lucene.search.MatchNoDocsQuery;
 import org.elasticsearch.index.mapper.ParseContext;
 
 import java.io.IOException;
@@ -72,11 +69,11 @@ public final class ExtractQueryTermsService {
 
     /**
      * Extracts all terms from the specified query and adds it to the specified document.
-     *  @param query The query to extract terms from
-     * @param document The document to add the extracted terms to
-     * @param queryTermsFieldField The field in the document holding the extracted terms
-     * @param unknownQueryField The field used to mark a document that not all query terms could be extracted. For example
-     *                          the query contained an unsupported query (e.g. WildcardQuery).
+     * @param query                 The query to extract terms from
+     * @param document              The document to add the extracted terms to
+     * @param queryTermsFieldField  The field in the document holding the extracted terms
+     * @param unknownQueryField     The field used to mark a document that not all query terms could be extracted.
+     *                              For example the query contained an unsupported query (e.g. WildcardQuery).
      * @param fieldType The field type for the query metadata field
      */
     public static void extractQueryTerms(Query query, ParseContext.Document document, String queryTermsFieldField, String unknownQueryField, FieldType fieldType) {
@@ -106,7 +103,10 @@ public final class ExtractQueryTermsService {
      * an UnsupportedQueryException is thrown.
      */
     static Set<Term> extractQueryTerms(Query query) {
-        if (query instanceof TermQuery) {
+        if (query instanceof MatchNoDocsQuery) {
+            // no terms to extract as this query matches no docs
+            return Collections.emptySet();
+        } else if (query instanceof TermQuery) {
             return Collections.singleton(((TermQuery) query).getTerm());
         } else if (query instanceof TermsQuery) {
             Set<Term> terms = new HashSet<>();

--- a/docs/reference/query-dsl/percolate-query.asciidoc
+++ b/docs/reference/query-dsl/percolate-query.asciidoc
@@ -334,3 +334,26 @@ At search time, the document specified in the request gets parsed into a Lucene 
 temporary Lucene index. This in-memory index can just hold this one document and it is optimized for that. After this
 a special query is build based on the terms in the in-memory index that select candidate percolator queries based on
 their indexed query terms. These queries are then evaluated by the in-memory index if they actually match.
+
+The selecting of candidate percolator queries matches is an important performance optimization during the execution
+of the `percolate` query as it can significantly reduce the number of candidate matches the in-memory index need to
+evaluate. The reason the `percolate` query can do this is because during indexing of the percolator queries the query
+terms are being extracted and indexed with the percolator query. Unfortunately the percolator cannot extract terms from
+all queries (for example the `wildcard` or `geo_shape` query) and as a result of that in certain cases the percolator
+can't do the selecting optimization (for example if an unsupported query is defined in a required clause of a boolean query
+or the unsupported query is the only query in the percolator document).  These queries are marked by the percolator and
+can be found by running the following search:
+
+[source,js]
+--------------------------------------------------
+curl -XGET "http://localhost:9200/_search" -d'
+{
+  "query": {
+    "term" : {
+      "query.unknown_query" : ""
+    }
+  }
+}'
+--------------------------------------------------
+
+NOTE: The above example assumes that there is a `query` field of type `percolator` in the mappings.


### PR DESCRIPTION
A `percolate` query that should have no matches was taking too long to execute. After some debugging I found that the 900k `match` query only contained stopwords. If a `match` query's text analysis returns no tokens it returns a MatchNoDocsQuery Lucene query. So the percolator was 'evaluating' 900k MatchNoDocsQuery queries... This PR fixes that.
