### PR TITLE
Fix env. var placeholder test so it's reproducible

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -602,7 +602,8 @@ public final class Settings implements ToXContent {
 
         private final Map<String, String> map = new LinkedHashMap<>();
 
-        private Builder() {
+        // visible for testing
+        Builder() {
 
         }
 
@@ -964,7 +965,7 @@ public final class Settings implements ToXContent {
             PropertyPlaceholder.PlaceholderResolver placeholderResolver = new PropertyPlaceholder.PlaceholderResolver() {
                     @Override
                     public String resolvePlaceholder(String placeholderName) {
-                        final String value = System.getenv(placeholderName);
+                        final String value = getenv(placeholderName);
                         if (value != null) {
                             return value;
                         }
@@ -998,6 +999,11 @@ public final class Settings implements ToXContent {
                 }
             }
             return this;
+        }
+
+        // visible for testing
+        String getenv(String placeholderName) {
+            return System.getenv(placeholderName);
         }
 
         /**

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -62,14 +62,18 @@ public class SettingsTests extends ESTestCase {
     }
 
     public void testReplacePropertiesPlaceholderByEnvironmentVariables() {
-        final Map.Entry<String, String> entry = randomSubsetOf(1, System.getenv().entrySet()).get(0);
-        assertNotNull(entry.getValue());
-
-        final Settings implicitEnvSettings = Settings.builder()
-            .put("setting1", "${" + entry.getKey() + "}")
+        final String hostname = randomAsciiOfLength(16);
+        final Settings.Builder builder = new Settings.Builder() {
+            @Override
+            protected String getenv(String placeholderName) {
+                return "HOSTNAME".equals(placeholderName) ? hostname : null;
+            }
+        };
+        final Settings implicitEnvSettings = builder
+            .put("setting1", "${HOSTNAME}")
             .replacePropertyPlaceholders()
             .build();
-        assertThat(implicitEnvSettings.get("setting1"), equalTo(entry.getValue()));
+        assertThat(implicitEnvSettings.get("setting1"), equalTo(hostname));
     }
 
     public void testReplacePropertiesPlaceholderIgnoresPrompt() {


### PR DESCRIPTION
This commit modifies the settings test for environment variables
placeholders so that it is reproducible. The underlying issue is that
the set of environment variables from system to system can vary, and
this means that's we can never be sure that a failing test will be
reproducible. This commit simplifies this test to not rely on external
forces that could influence reproducbility.
