### PR TITLE
Don't mkdir directly in deb init script

### DIFF
--- a/distribution/deb/src/main/packaging/init.d/elasticsearch
+++ b/distribution/deb/src/main/packaging/init.d/elasticsearch
@@ -116,15 +116,6 @@ case "$1" in
 		exit 0
 	fi
 
-	# Prepare environment
-	# Check $DATA_DIR for a comma
-	if [ "${DATA_DIR#*,}" != "$DATA_DIR" ]; then
-		# $DATA_DIR contains a comma, so we should not mkdir it
-		mkdir -p "$LOG_DIR" && chown "$ES_USER":"$ES_GROUP" "$LOG_DIR"
-	else
-		mkdir -p "$LOG_DIR" "$DATA_DIR" && chown "$ES_USER":"$ES_GROUP" "$LOG_DIR" "$DATA_DIR"
-	fi
-
 	# Ensure that the PID_DIR exists (it is cleaned at OS startup time)
 	if [ -n "$PID_DIR" ] && [ ! -e "$PID_DIR" ]; then
 		mkdir -p "$PID_DIR" && chown "$ES_USER":"$ES_GROUP" "$PID_DIR"


### PR DESCRIPTION
Elasticsearch will create the log and data path directories when it
starts, there is no need to do this in the init script

Resolves #18307
