### PR TITLE
Remove inaccurate Javadoc on Setting constructor

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -122,7 +122,7 @@ public class Setting<T> extends ToXContentToBytes {
         this.defaultValue = defaultValue;
         this.parser = parser;
         if (properties == null) {
-            throw new IllegalArgumentException("properties can not be null for setting [" + key + "]");
+            throw new IllegalArgumentException("properties cannot be null for setting [" + key + "]");
         }
         if (properties.length == 0) {
             this.properties = EMPTY_PROPERTIES;
@@ -132,7 +132,7 @@ public class Setting<T> extends ToXContentToBytes {
     }
 
     /**
-     * Creates a new Setting instance. When no scope is provided, we default to {@link Property#NodeScope}.
+     * Creates a new Setting instance
      * @param key the settings key for this setting.
      * @param defaultValue a default value function that returns the default values string representation.
      * @param parser a parser that parses the string rep into a complex datatype.
@@ -165,7 +165,7 @@ public class Setting<T> extends ToXContentToBytes {
     }
 
     /**
-     * Creates a new Setting instance. When no scope is provided, we default to {@link Property#NodeScope}.
+     * Creates a new Setting instance
      * @param key the settings key for this setting.
      * @param fallbackSetting a setting who's value to fallback on if this setting is not defined
      * @param parser a parser that parses the string rep into a complex datatype.

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -475,7 +475,7 @@ public class SettingTests extends ESTestCase {
             Setting.simpleString("foo.bar", (Property[]) null);
             fail();
         } catch (IllegalArgumentException ex) {
-            assertThat(ex.getMessage(), containsString("properties can not be null for setting"));
+            assertThat(ex.getMessage(), containsString("properties cannot be null for setting"));
         }
     }
 }


### PR DESCRIPTION
The `Setting` constructor has some outdated Javadoc that suggested that it would automatically apply `Property.NodeScope` if no scope is supplied, but no scope is added in that case.
- Also fixed minor grammar issue: can not -> cannot
