### PR TITLE
Fix misplaced cast when parsing seconds

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java
@@ -241,7 +241,7 @@ public class TimeValue implements Streamable {
             if (lowerSValue.endsWith("ms")) {
                 millis = (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 2)));
             } else if (lowerSValue.endsWith("s")) {
-                millis = (long) Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 1)) * 1000;
+                millis = (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 1)) * 1000);
             } else if (lowerSValue.endsWith("m")) {
                 millis = (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 1)) * 60 * 1000);
             } else if (lowerSValue.endsWith("h")) {

--- a/core/src/test/java/org/elasticsearch/common/unit/TimeValueTests.java
+++ b/core/src/test/java/org/elasticsearch/common/unit/TimeValueTests.java
@@ -83,6 +83,9 @@ public class TimeValueTests extends ESTestCase {
         assertEquals(new TimeValue(10, TimeUnit.SECONDS),
                      TimeValue.parseTimeValue("10S", null, "test"));
 
+        assertEquals(new TimeValue(100, TimeUnit.MILLISECONDS),
+                    TimeValue.parseTimeValue("0.1s", null, "test"));
+
         assertEquals(new TimeValue(10, TimeUnit.MINUTES),
                      TimeValue.parseTimeValue("10 m", null, "test"));
         assertEquals(new TimeValue(10, TimeUnit.MINUTES),


### PR DESCRIPTION
This commit fixes a misplaced cast when parsing seconds. Namely, the
input seconds are parsed as a double and then cast to a long before
multiplying by the scale. This can lead to truncation to zero before
multiplying by the scale thus leading to "0.1s" being parsed as zero
milliseconds. Instead, the cast should occur after multiplying by the
scale so as to not prematurely truncate.

Closes #18546
