### PR TITLE
Fix a leftover tests.logger.level

### DIFF
--- a/test/framework/src/main/resources/log4j.properties
+++ b/test/framework/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
-tests.logger.level=INFO
-log4j.rootLogger=${tests.logger.level}, out
+tests.es.logger.level=INFO
+log4j.rootLogger=${tests.es.logger.level}, out
 
 log4j.logger.org.apache.http=INFO, out
 log4j.additivity.org.apache.http=false


### PR DESCRIPTION
This is a leftover spot that wasn't changed. It was breaking
ClusterSettingsIT#ClusterSettingsIT because that test expected
the test's log level to default to the default logger level for
the nodes.
