### PR TITLE
Build: Use dash for deb package version and underscore for rpm

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -302,10 +302,6 @@ configure(subprojects.findAll { ['deb', 'rpm'].contains(it.name) }) {
       '''.stripIndent().replace('\n', ' ').trim()
     url 'https://www.elastic.co/'
 
-    /* The version of the package can't contain -SNAPSHOT so we rip it off if
-      we see it. We'll add it back on to the file name though. */
-    version project.version.replace('-SNAPSHOT', '')
-
     // signing setup
     if (project.hasProperty('signing.password') && System.getProperty('build.snapshot', 'true') == 'false') {
       signingKeyId = project.hasProperty('signing.keyId') ? project.property('signing.keyId') : 'D88E42B4'

--- a/distribution/deb/build.gradle
+++ b/distribution/deb/build.gradle
@@ -22,6 +22,8 @@ task buildDeb(type: Deb) {
   baseName 'elasticsearch' // this is what pom generation uses for artifactId
   // Follow elasticsearch's deb file naming convention
   archiveName "${packageName}-${project.version}.deb"
+  version = project.version
+
   packageGroup 'web'
   requires 'libc6'
   requires 'adduser'

--- a/distribution/rpm/build.gradle
+++ b/distribution/rpm/build.gradle
@@ -25,14 +25,8 @@ task buildRpm(type: Rpm) {
   packageGroup 'Application/Internet'
   prefix '/usr'
   packager 'Elasticsearch'
-  if (version.contains('~')) {
-    def tokenized = version.tokenize('~')
-    version tokenized[0]
-    release tokenized[1]
-  } else {
-    version version
-    release '1'
-  }
+  version = project.version.replace('-', '_')
+  release = '1'
   arch 'NOARCH'
   os 'LINUX'
   license '2009'


### PR DESCRIPTION
This change tweaks the metadata version associated with the deb and rpm
packages. For rpm, dashes are allowed in versions, so we can use the
version as it already exists. For rpm, dashes are not allowed, so this
uses underscores instead. This only affects prerelease versions (eg
alpha/beta/rc), and usually someone doesn't specify the version when installing, so the
inconsistency doesn't matter that much.
