### PR TITLE
Fixed NPE when percolator filter option is "empty".

### DIFF
--- a/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -318,8 +318,10 @@ public class PercolatorService extends AbstractComponent {
                         if (context.percolateQuery() != null) {
                             throw new ElasticsearchParseException("Either specify query or filter, not both");
                         }
-                        Query filter = documentIndexService.queryParserService().parseInnerFilter(parser).query();
-                        context.percolateQuery(new ConstantScoreQuery(filter));
+                        ParsedQuery parsedQuery = documentIndexService.queryParserService().parseInnerFilter(parser);
+                        if(parsedQuery != null) {
+                            context.percolateQuery(new ConstantScoreQuery(parsedQuery.query()));
+                        }
                     } else if ("sort".equals(currentFieldName)) {
                         parseSort(parser, context);
                     } else if (element != null) {


### PR DESCRIPTION
Any "empty" (null) percolator filter option resulted in an NPE:
`GET /index/type/doc/_percolate { "filter": { "or": { "filters": [ {} ] } } }`
`GET /index/type/_percolate { "filter": {} }`

This PR updates the logic to ignore the filter option if it is `null` (all percolators executed).
Not an issue on current master (percolator was rewritten).

Not possible to integration test since [PercolateRequestBuilder](https://github.com/elastic/elasticsearch/blob/2.x/core/src/main/java/org/elasticsearch/action/percolate/PercolateRequestBuilder.java) and [PercolateSourceBuilder](https://github.com/elastic/elasticsearch/blob/2.x/core/src/main/java/org/elasticsearch/action/percolate/PercolateSourceBuilder.java) had the `filter` option removed in this commit: [Query DSL: Remove filter parsers.](https://github.com/elastic/elasticsearch/commit/a0af88e99630b9d3f0c2cf4997f2e82f1f834d41) Also these filters are deprecated.

Closes #6172 
