### PR TITLE
Improve TimeUnitRounding for edge cases and DST transitions

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/rounding/DateTimeUnit.java
+++ b/core/src/main/java/org/elasticsearch/common/rounding/DateTimeUnit.java
@@ -21,45 +21,42 @@ package org.elasticsearch.common.rounding;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.joda.Joda;
 import org.joda.time.DateTimeField;
+import org.joda.time.DateTimeZone;
 import org.joda.time.chrono.ISOChronology;
+
+import java.util.function.Function;
 
 /**
  *
  */
 public enum DateTimeUnit {
 
-    WEEK_OF_WEEKYEAR(   (byte) 1, ISOChronology.getInstanceUTC().weekOfWeekyear()),
-    YEAR_OF_CENTURY(    (byte) 2, ISOChronology.getInstanceUTC().yearOfCentury()),
-    QUARTER(            (byte) 3, Joda.QuarterOfYear.getField(ISOChronology.getInstanceUTC())),
-    MONTH_OF_YEAR(      (byte) 4, ISOChronology.getInstanceUTC().monthOfYear()),
-    DAY_OF_MONTH(       (byte) 5, ISOChronology.getInstanceUTC().dayOfMonth()),
-    HOUR_OF_DAY(        (byte) 6, ISOChronology.getInstanceUTC().hourOfDay()),
-    MINUTES_OF_HOUR(    (byte) 7, ISOChronology.getInstanceUTC().minuteOfHour()),
-    SECOND_OF_MINUTE(   (byte) 8, ISOChronology.getInstanceUTC().secondOfMinute());
+    WEEK_OF_WEEKYEAR(   (byte) 1, tz -> ISOChronology.getInstance(tz).weekOfWeekyear()),
+    YEAR_OF_CENTURY(    (byte) 2, tz -> ISOChronology.getInstance(tz).yearOfCentury()),
+    QUARTER(            (byte) 3, tz -> Joda.QuarterOfYear.getField(ISOChronology.getInstance(tz))),
+    MONTH_OF_YEAR(      (byte) 4, tz -> ISOChronology.getInstance(tz).monthOfYear()),
+    DAY_OF_MONTH(       (byte) 5, tz -> ISOChronology.getInstance(tz).dayOfMonth()),
+    HOUR_OF_DAY(        (byte) 6, tz -> ISOChronology.getInstance(tz).hourOfDay()),
+    MINUTES_OF_HOUR(    (byte) 7, tz -> ISOChronology.getInstance(tz).minuteOfHour()),
+    SECOND_OF_MINUTE(   (byte) 8, tz -> ISOChronology.getInstance(tz).secondOfMinute());
 
     private final byte id;
-    private final DateTimeField field;
+    private final Function<DateTimeZone, DateTimeField> fieldFunction;
 
-    private DateTimeUnit(byte id, DateTimeField field) {
+    private DateTimeUnit(byte id, Function<DateTimeZone, DateTimeField> fieldFunction) {
         this.id = id;
-        this.field = field;
+        this.fieldFunction = fieldFunction;
     }
 
     public byte id() {
         return id;
     }
 
-    public DateTimeField field() {
-        return field;
-    }
-
     /**
-     * @param unit the {@link DateTimeUnit} to check
-     * @return true if the unit is a day or longer
+     * @return the {@link DateTimeField} for the provided {@link DateTimeZone} for this time unit
      */
-    public static boolean isDayOrLonger(DateTimeUnit unit) {
-        return (unit == DateTimeUnit.HOUR_OF_DAY || unit == DateTimeUnit.MINUTES_OF_HOUR
-                || unit == DateTimeUnit.SECOND_OF_MINUTE) == false;
+    public DateTimeField field(DateTimeZone tz) {
+        return fieldFunction.apply(tz);
     }
 
     public static DateTimeUnit resolve(byte id) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/DerivativePipelineAggregatorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/DerivativePipelineAggregatorBuilder.java
@@ -19,12 +19,6 @@
 
 package org.elasticsearch.search.aggregations.pipeline.derivative;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -42,6 +36,13 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInter
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorBuilder;
+import org.joda.time.DateTimeZone;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 public class DerivativePipelineAggregatorBuilder extends PipelineAggregatorBuilder<DerivativePipelineAggregatorBuilder> {
     public static final String NAME = DerivativePipelineAggregator.TYPE.name();
@@ -142,7 +143,7 @@ public class DerivativePipelineAggregatorBuilder extends PipelineAggregatorBuild
         if (units != null) {
             DateTimeUnit dateTimeUnit = DateHistogramAggregatorFactory.DATE_FIELD_UNITS.get(units);
             if (dateTimeUnit != null) {
-                xAxisUnits = dateTimeUnit.field().getDurationField().getUnitMillis();
+                xAxisUnits = dateTimeUnit.field(DateTimeZone.UTC).getDurationField().getUnitMillis();
             } else {
                 TimeValue timeValue = TimeValue.parseTimeValue(units, null, getClass().getSimpleName() + ".unit");
                 if (timeValue != null) {

--- a/core/src/test/java/org/elasticsearch/common/rounding/DateTimeUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/common/rounding/DateTimeUnitTests.java
@@ -20,14 +20,14 @@ package org.elasticsearch.common.rounding;
 
 import org.elasticsearch.test.ESTestCase;
 
-import static org.elasticsearch.common.rounding.DateTimeUnit.WEEK_OF_WEEKYEAR;
-import static org.elasticsearch.common.rounding.DateTimeUnit.YEAR_OF_CENTURY;
-import static org.elasticsearch.common.rounding.DateTimeUnit.QUARTER;
-import static org.elasticsearch.common.rounding.DateTimeUnit.MONTH_OF_YEAR;
 import static org.elasticsearch.common.rounding.DateTimeUnit.DAY_OF_MONTH;
 import static org.elasticsearch.common.rounding.DateTimeUnit.HOUR_OF_DAY;
 import static org.elasticsearch.common.rounding.DateTimeUnit.MINUTES_OF_HOUR;
+import static org.elasticsearch.common.rounding.DateTimeUnit.MONTH_OF_YEAR;
+import static org.elasticsearch.common.rounding.DateTimeUnit.QUARTER;
 import static org.elasticsearch.common.rounding.DateTimeUnit.SECOND_OF_MINUTE;
+import static org.elasticsearch.common.rounding.DateTimeUnit.WEEK_OF_WEEKYEAR;
+import static org.elasticsearch.common.rounding.DateTimeUnit.YEAR_OF_CENTURY;
 
 public class DateTimeUnitTests extends ESTestCase {
 
@@ -59,17 +59,4 @@ public class DateTimeUnitTests extends ESTestCase {
         assertEquals(8, SECOND_OF_MINUTE.id());
         assertEquals(SECOND_OF_MINUTE, DateTimeUnit.resolve((byte) 8));
     }
-
-    public void testIsDayOrLonger() {
-        for (DateTimeUnit unit : DateTimeUnit.values()) {
-            if (DateTimeUnit.isDayOrLonger(unit)) {
-                assertTrue(unit == DAY_OF_MONTH ||
-                        unit == MONTH_OF_YEAR ||
-                        unit == QUARTER ||
-                        unit == YEAR_OF_CENTURY ||
-                        unit == WEEK_OF_WEEKYEAR);
-            }
-        }
-    }
-
 }

--- a/core/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
+++ b/core/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
@@ -19,9 +19,12 @@
 
 package org.elasticsearch.common.rounding;
 
+import org.elasticsearch.common.rounding.TimeZoneRounding.TimeIntervalRounding;
+import org.elasticsearch.common.rounding.TimeZoneRounding.TimeUnitRounding;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeConstants;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.ISODateTimeFormat;
 
@@ -29,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 /**
@@ -208,50 +212,54 @@ public class TimeZoneRoundingTests extends ESTestCase {
     }
 
     /**
-     * randomized test on TimeUnitRounding with random time units and time zone offsets
+     * Randomized test on TimeUnitRounding.
+     * Test uses random {@link DateTimeUnit} and {@link DateTimeZone} and often (50% of the time) chooses
+     * test dates that are exactly on or close to offset changes (e.g. DST) in the chosen time zone.
+     *
+     * It rounds the test date down and up and performs various checks on the rounding unit interval that is
+     * defined by this. Assumptions tested are described in {@link #assertInterval(long, long, long, TimeZoneRounding)}
      */
     public void testTimeZoneRoundingRandom() {
         for (int i = 0; i < 1000; ++i) {
             DateTimeUnit timeUnit = randomTimeUnit();
-            TimeZoneRounding rounding;
-            int timezoneOffset = randomIntBetween(-23, 23);
-            rounding = new TimeZoneRounding.TimeUnitRounding(timeUnit, DateTimeZone.forOffsetHours(timezoneOffset));
-            long date = Math.abs(randomLong() % ((long) 10e11));
+            DateTimeZone timezone = randomDateTimeZone();
+            TimeZoneRounding rounding = new TimeZoneRounding.TimeUnitRounding(timeUnit, timezone);
+            long date = Math.abs(randomLong() % (2 * (long) 10e11)); // 1970-01-01T00:00:00Z - 2033-05-18T05:33:20.000+02:00
+            long unitMillis = timeUnit.field(timezone).getDurationField().getUnitMillis();
+            if (randomBoolean()) {
+                nastyDate(date, timezone, unitMillis);
+            }
             final long roundedDate = rounding.round(date);
             final long nextRoundingValue = rounding.nextRoundingValue(roundedDate);
-            assertThat("Rounding should be idempotent", roundedDate, equalTo(rounding.round(roundedDate)));
-            assertThat("Rounded value smaller or equal than unrounded, regardless of timezone", roundedDate, lessThanOrEqualTo(date));
-            assertThat("NextRounding value should be greater than date", nextRoundingValue, greaterThan(roundedDate));
-            assertThat("NextRounding value should be a rounded date", nextRoundingValue, equalTo(rounding.round(nextRoundingValue)));
+
+            assertInterval(roundedDate, date, nextRoundingValue, rounding);
+
+            // check correct unit interval width for units smaller than a day, they should be fixed size except for transitions
+            if (unitMillis <= DateTimeConstants.MILLIS_PER_DAY) {
+                // if the interval defined didn't cross timezone offset transition, it should cover unitMillis width
+                if (timezone.getOffset(roundedDate - 1) == timezone.getOffset(nextRoundingValue + 1)) {
+                    assertThat("unit interval width not as expected for [" + timeUnit + "], [" + timezone + "] at "
+                            + new DateTime(roundedDate), nextRoundingValue - roundedDate, equalTo(unitMillis));
+                }
+            }
         }
     }
 
     /**
-     * Test that nextRoundingValue() for hour rounding (and smaller) is equally spaced (see #18326)
-     * Start at a random date in a random time zone, then find the next zone offset transition (if any).
-     * From there, check that when we advance by using rounding#nextRoundingValue(), we always advance by the same
-     * amount of milliseconds.
+     * To be even more nasty, go to a transition in the selected time zone.
+     * In one third of the cases stay there, otherwise go half a unit back or forth
      */
-    public void testSubHourNextRoundingEquallySpaced() {
-        DateTimeUnit unit = randomFrom(new DateTimeUnit[] { DateTimeUnit.HOUR_OF_DAY, DateTimeUnit.MINUTES_OF_HOUR,
-                DateTimeUnit.SECOND_OF_MINUTE });
-        DateTimeZone timezone = randomDateTimeZone();
-        TimeZoneRounding rounding = new TimeZoneRounding.TimeUnitRounding(unit, timezone);
-        // move the random date to transition for timezones that have offset change due to dst transition
-        long nextTransition = timezone.nextTransition(Math.abs(randomLong() % ((long) 10e11)));
-        final long millisPerUnit = unit.field().getDurationField().getUnitMillis();
-        // start ten units before transition
-        long roundedDate = rounding.round(nextTransition - (10 * millisPerUnit));
-        while (roundedDate < nextTransition + 10 * millisPerUnit) {
-            long delta = rounding.nextRoundingValue(roundedDate) - roundedDate;
-            assertEquals("Difference between rounded values not equally spaced for [" + unit.name() + "], [" + timezone + "] at "
-                    + new DateTime(roundedDate), millisPerUnit, delta);
-            roundedDate = rounding.nextRoundingValue(roundedDate);
+    private static long nastyDate(long initialDate, DateTimeZone timezone, long unitMillis) {
+        long date = timezone.nextTransition(initialDate);
+        if (randomBoolean()) {
+            return date + (randomLong() % unitMillis);  // positive and negative offset possible
+        } else {
+            return date;
         }
     }
 
     /**
-     * randomized test on TimeIntervalRounding with random interval and time zone offsets
+     * randomized test on {@link TimeIntervalRounding} with random interval and time zone offsets
      */
     public void testIntervalRoundingRandom() {
         for (int i = 0; i < 1000; ++i) {
@@ -324,20 +332,135 @@ public class TimeZoneRoundingTests extends ESTestCase {
         }
     }
 
-    private DateTimeUnit randomTimeUnit() {
+    public void testEdgeCasesTransition() {
+        {
+            // standard +/-1 hour DST transition, CET
+            DateTimeUnit timeUnit = DateTimeUnit.HOUR_OF_DAY;
+            DateTimeZone timezone = DateTimeZone.forID("CET");
+            TimeZoneRounding rounding = new TimeZoneRounding.TimeUnitRounding(timeUnit, timezone);
+
+            // 29 Mar 2015 - Daylight Saving Time Started
+            // at 02:00:00 clocks were turned forward 1 hour to 03:00:00
+            assertInterval(time("2015-03-29T00:00:00.000+01:00"), time("2015-03-29T01:00:00.000+01:00"), rounding, 60);
+            assertInterval(time("2015-03-29T01:00:00.000+01:00"), time("2015-03-29T03:00:00.000+02:00"), rounding, 60);
+            assertInterval(time("2015-03-29T03:00:00.000+02:00"), time("2015-03-29T04:00:00.000+02:00"), rounding, 60);
+
+            // 25 Oct 2015 - Daylight Saving Time Ended
+            // at 03:00:00 clocks were turned backward 1 hour to 02:00:00
+            assertInterval(time("2015-10-25T01:00:00.000+02:00"), time("2015-10-25T02:00:00.000+02:00"), rounding, 60);
+            assertInterval(time("2015-10-25T02:00:00.000+02:00"), time("2015-10-25T02:00:00.000+01:00"), rounding, 60);
+            assertInterval(time("2015-10-25T02:00:00.000+01:00"), time("2015-10-25T03:00:00.000+01:00"), rounding, 60);
+        }
+
+        {
+            // time zone "Asia/Kathmandu"
+            // 1 Jan 1986 - Time Zone Change (IST → NPT), at 00:00:00 clocks were turned forward 00:15 minutes
+            //
+            // hour rounding is stable before 1985-12-31T23:00:00.000 and after 1986-01-01T01:00:00.000+05:45
+            // the interval between is 105 minutes long because the hour after transition starts at 00:15
+            // which is not a round value for hourly rounding
+            DateTimeUnit timeUnit = DateTimeUnit.HOUR_OF_DAY;
+            DateTimeZone timezone = DateTimeZone.forID("Asia/Kathmandu");
+            TimeZoneRounding rounding = new TimeZoneRounding.TimeUnitRounding(timeUnit, timezone);
+
+            assertInterval(time("1985-12-31T22:00:00.000+05:30"), time("1985-12-31T23:00:00.000+05:30"), rounding, 60);
+            assertInterval(time("1985-12-31T23:00:00.000+05:30"), time("1986-01-01T01:00:00.000+05:45"), rounding, 105);
+            assertInterval(time("1986-01-01T01:00:00.000+05:45"), time("1986-01-01T02:00:00.000+05:45"), rounding, 60);
+        }
+
+        {
+            // time zone "Australia/Lord_Howe"
+            // 3 Mar 1991 - Daylight Saving Time Ended
+            // at 02:00:00 clocks were turned backward 0:30 hours to Sunday, 3 March 1991, 01:30:00
+            DateTimeUnit timeUnit = DateTimeUnit.HOUR_OF_DAY;
+            DateTimeZone timezone = DateTimeZone.forID("Australia/Lord_Howe");
+            TimeZoneRounding rounding = new TimeZoneRounding.TimeUnitRounding(timeUnit, timezone);
+
+            assertInterval(time("1991-03-03T00:00:00.000+11:00"), time("1991-03-03T01:00:00.000+11:00"), rounding, 60);
+            assertInterval(time("1991-03-03T01:00:00.000+11:00"), time("1991-03-03T02:00:00.000+10:30"), rounding, 90);
+            assertInterval(time("1991-03-03T02:00:00.000+10:30"), time("1991-03-03T03:00:00.000+10:30"), rounding, 60);
+
+            // 27 Oct 1991 - Daylight Saving Time Started
+            // at 02:00:00 clocks were turned forward 0:30 hours to 02:30:00
+            assertInterval(time("1991-10-27T00:00:00.000+10:30"), time("1991-10-27T01:00:00.000+10:30"), rounding, 60);
+            // the interval containing the switch time is 90 minutes long
+            assertInterval(time("1991-10-27T01:00:00.000+10:30"), time("1991-10-27T03:00:00.000+11:00"), rounding, 90);
+            assertInterval(time("1991-10-27T03:00:00.000+11:00"), time("1991-10-27T04:00:00.000+11:00"), rounding, 60);
+        }
+
+        {
+            // time zone "Pacific/Chatham"
+            // 5 Apr 2015 - Daylight Saving Time Ended
+            // at 03:45:00 clocks were turned backward 1 hour to 02:45:00
+            DateTimeUnit timeUnit = DateTimeUnit.HOUR_OF_DAY;
+            DateTimeZone timezone = DateTimeZone.forID("Pacific/Chatham");
+            TimeZoneRounding rounding = new TimeZoneRounding.TimeUnitRounding(timeUnit, timezone);
+
+            assertInterval(time("2015-04-05T02:00:00.000+13:45"), time("2015-04-05T03:00:00.000+13:45"), rounding, 60);
+            assertInterval(time("2015-04-05T03:00:00.000+13:45"), time("2015-04-05T03:00:00.000+12:45"), rounding, 60);
+            assertInterval(time("2015-04-05T03:00:00.000+12:45"), time("2015-04-05T04:00:00.000+12:45"), rounding, 60);
+
+            // 27 Sep 2015 - Daylight Saving Time Started
+            // at 02:45:00 clocks were turned forward 1 hour to 03:45:00
+
+            assertInterval(time("2015-09-27T01:00:00.000+12:45"), time("2015-09-27T02:00:00.000+12:45"), rounding, 60);
+            assertInterval(time("2015-09-27T02:00:00.000+12:45"), time("2015-09-27T04:00:00.000+13:45"), rounding, 60);
+            assertInterval(time("2015-09-27T04:00:00.000+13:45"), time("2015-09-27T05:00:00.000+13:45"), rounding, 60);
+        }
+    }
+
+    private static void assertInterval(long rounded, long nextRoundingValue, TimeZoneRounding rounding, int minutes) {
+        assertInterval(rounded, dateBetween(rounded, nextRoundingValue), nextRoundingValue, rounding);
+        assertEquals(DateTimeConstants.MILLIS_PER_MINUTE * minutes, nextRoundingValue - rounded);
+    }
+
+    /**
+     * perform a number on assertions and checks on {@link TimeUnitRounding} intervals
+     * @param rounded the expected low end of the rounding interval
+     * @param unrounded a date in the interval to be checked for rounding
+     * @param nextRoundingValue the expected upper end of the rounding interval
+     * @param rounding the rounding instance
+     */
+    private static void assertInterval(long rounded, long unrounded, long nextRoundingValue, TimeZoneRounding rounding) {
+        assert rounded <= unrounded && unrounded <= nextRoundingValue;
+        assertThat("rounding should be idempotent " + rounding, rounded, equalTo(rounding.round(rounded)));
+        assertThat("rounded value smaller or equal than unrounded" + rounding, rounded, lessThanOrEqualTo(unrounded));
+        assertThat("values less than rounded should round further down" + rounding, rounding.round(rounded - 1), lessThan(rounded));
+        assertThat("nextRounding value should be greater than date" + rounding, nextRoundingValue, greaterThan(unrounded));
+        assertThat("nextRounding value should be a rounded date" + rounding, nextRoundingValue, equalTo(rounding.round(nextRoundingValue)));
+        assertThat("values above nextRounding should round down there" + rounding, rounding.round(nextRoundingValue + 1),
+                equalTo(nextRoundingValue));
+
+        long dateBetween = dateBetween(rounded, nextRoundingValue);
+        assertThat("dateBetween should round down to roundedDate" + rounding, rounding.round(dateBetween), equalTo(rounded));
+        assertThat("dateBetween should round up to nextRoundingValue" + rounding, rounding.nextRoundingValue(dateBetween),
+                equalTo(nextRoundingValue));
+    }
+
+    private static long dateBetween(long lower, long upper) {
+        long dateBetween = lower + Math.abs((randomLong() % (upper - lower)));
+        assert lower <= dateBetween && dateBetween <= upper;
+        return dateBetween;
+    }
+
+    private static DateTimeUnit randomTimeUnit() {
         byte id = (byte) randomIntBetween(1, 8);
         return DateTimeUnit.resolve(id);
     }
 
-    private String toUTCDateString(long time) {
+    private static String toUTCDateString(long time) {
         return new DateTime(time, DateTimeZone.UTC).toString();
     }
 
-    private long utc(String time) {
+    private static long utc(String time) {
         return time(time, DateTimeZone.UTC);
     }
 
-    private long time(String time, DateTimeZone zone) {
+    private static long time(String time) {
+        return ISODateTimeFormat.dateOptionalTimeParser().parseMillis(time);
+    }
+
+    private static long time(String time, DateTimeZone zone) {
         return ISODateTimeFormat.dateOptionalTimeParser().withZone(zone).parseMillis(time);
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/DateDerivativeIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/DateDerivativeIT.java
@@ -30,6 +30,7 @@ import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.search.aggregations.pipeline.derivative.Derivative;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
@@ -54,6 +55,11 @@ import static org.hamcrest.core.IsNull.nullValue;
 @ESIntegTestCase.SuiteScopeTestCase
 public class DateDerivativeIT extends ESIntegTestCase {
 
+    // some index names used during these tests
+    private static final String IDX_DST_START = "idx_dst_start";
+    private static final String IDX_DST_END = "idx_dst_end";
+    private static final String IDX_DST_KATHMANDU = "idx_dst_kathmandu";
+
     private DateTime date(int month, int day) {
         return new DateTime(2012, month, day, 0, 0, DateTimeZone.UTC);
     }
@@ -66,10 +72,9 @@ public class DateDerivativeIT extends ESIntegTestCase {
         return DateTimeFormat.forPattern(pattern).print(date);
     }
 
-    private IndexRequestBuilder indexDoc(String idx, DateTime date, int value) throws Exception {
+    private static IndexRequestBuilder indexDoc(String idx, DateTime date, int value) throws Exception {
         return client().prepareIndex(idx, "type").setSource(
-                jsonBuilder().startObject().field("date", date).field("value", value).startArray("dates").value(date)
-                        .value(date.plusMonths(1).plusDays(1)).endArray().endObject());
+                jsonBuilder().startObject().field("date", date).field("value", value).endObject());
     }
 
     private IndexRequestBuilder indexDoc(int month, int day, int value) throws Exception {
@@ -101,7 +106,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
 
     @After
     public void afterEachTest() throws IOException {
-        internalCluster().wipeIndices("idx2");
+        internalCluster().wipeIndices(IDX_DST_START, IDX_DST_END, IDX_DST_KATHMANDU);
     }
 
     public void testSingleValuedField() throws Exception {
@@ -189,6 +194,145 @@ public class DateDerivativeIT extends ESIntegTestCase {
         assertThat(docCountDeriv, notNullValue());
         assertThat(docCountDeriv.value(), closeTo(1d, 0.00001));
         assertThat(docCountDeriv.normalizedValue(), closeTo(1d / 29d, 0.00001));
+    }
+
+    /**
+     * Do a derivative on a date histogram with time zone CET at DST start
+     */
+    public void testSingleValuedFieldNormalised_timeZone_CET_DstStart() throws Exception {
+        createIndex(IDX_DST_START);
+        List<IndexRequestBuilder> builders = new ArrayList<>();
+
+        DateTimeZone timezone = DateTimeZone.forID("CET");
+        addNTimes(1, IDX_DST_START, new DateTime("2012-03-24T01:00:00", timezone), builders);
+        addNTimes(2, IDX_DST_START, new DateTime("2012-03-25T01:00:00", timezone), builders); // day with dst shift, only 23h long
+        addNTimes(3, IDX_DST_START, new DateTime("2012-03-26T01:00:00", timezone), builders);
+        addNTimes(4, IDX_DST_START, new DateTime("2012-03-27T01:00:00", timezone), builders);
+        indexRandom(true, builders);
+        ensureSearchable();
+
+        SearchResponse response = client()
+                .prepareSearch(IDX_DST_START)
+                .addAggregation(dateHistogram("histo").field("date").dateHistogramInterval(DateHistogramInterval.DAY)
+                        .timeZone(timezone).minDocCount(0)
+                        .subAggregation(derivative("deriv", "_count").unit(DateHistogramInterval.HOUR)))
+                .execute()
+                .actionGet();
+
+        assertSearchResponse(response);
+
+        InternalHistogram deriv = response.getAggregations().get("histo");
+        assertThat(deriv, notNullValue());
+        assertThat(deriv.getName(), equalTo("histo"));
+        List<? extends Bucket> buckets = deriv.getBuckets();
+        assertThat(buckets.size(), equalTo(4));
+
+        assertBucket(buckets.get(0), new DateTime("2012-03-24", timezone).toDateTime(DateTimeZone.UTC), 1L, nullValue(), null, null);
+        assertBucket(buckets.get(1), new DateTime("2012-03-25", timezone).toDateTime(DateTimeZone.UTC), 2L, notNullValue(), 1d, 1d / 24d);
+        // the following is normalized using a 23h bucket width
+        assertBucket(buckets.get(2), new DateTime("2012-03-26", timezone).toDateTime(DateTimeZone.UTC), 3L, notNullValue(), 1d, 1d / 23d);
+        assertBucket(buckets.get(3), new DateTime("2012-03-27", timezone).toDateTime(DateTimeZone.UTC), 4L, notNullValue(), 1d, 1d / 24d);
+    }
+
+    /**
+     * Do a derivative on a date histogram with time zone CET at DST end
+     */
+    public void testSingleValuedFieldNormalised_timeZone_CET_DstEnd() throws Exception {
+        createIndex(IDX_DST_END);
+        DateTimeZone timezone = DateTimeZone.forID("CET");
+        List<IndexRequestBuilder> builders = new ArrayList<>();
+
+        addNTimes(1, IDX_DST_END, new DateTime("2012-10-27T01:00:00", timezone), builders);
+        addNTimes(2, IDX_DST_END, new DateTime("2012-10-28T01:00:00", timezone), builders); // day with dst shift -1h, 25h long
+        addNTimes(3, IDX_DST_END, new DateTime("2012-10-29T01:00:00", timezone), builders);
+        addNTimes(4, IDX_DST_END, new DateTime("2012-10-30T01:00:00", timezone), builders);
+        indexRandom(true, builders);
+        ensureSearchable();
+
+        SearchResponse response = client()
+                .prepareSearch(IDX_DST_END)
+                .addAggregation(dateHistogram("histo").field("date").dateHistogramInterval(DateHistogramInterval.DAY)
+                        .timeZone(timezone).minDocCount(0)
+                        .subAggregation(derivative("deriv", "_count").unit(DateHistogramInterval.HOUR)))
+                .execute()
+                .actionGet();
+
+        assertSearchResponse(response);
+
+        InternalHistogram deriv = response.getAggregations().get("histo");
+        assertThat(deriv, notNullValue());
+        assertThat(deriv.getName(), equalTo("histo"));
+        List<? extends Bucket> buckets = deriv.getBuckets();
+        assertThat(buckets.size(), equalTo(4));
+
+        assertBucket(buckets.get(0), new DateTime("2012-10-27", timezone).toDateTime(DateTimeZone.UTC), 1L, nullValue(), null, null);
+        assertBucket(buckets.get(1), new DateTime("2012-10-28", timezone).toDateTime(DateTimeZone.UTC), 2L, notNullValue(), 1d, 1d / 24d);
+        // the following is normalized using a 25h bucket width
+        assertBucket(buckets.get(2), new DateTime("2012-10-29", timezone).toDateTime(DateTimeZone.UTC), 3L, notNullValue(), 1d, 1d / 25d);
+        assertBucket(buckets.get(3), new DateTime("2012-10-30", timezone).toDateTime(DateTimeZone.UTC), 4L, notNullValue(), 1d, 1d / 24d);
+    }
+
+    /**
+     * also check for time zone shifts that are not one hour, e.g.
+     * "Asia/Kathmandu, 1 Jan 1986 - Time Zone Change (IST → NPT), at 00:00:00 clocks were turned forward 00:15 minutes
+     */
+    public void testSingleValuedFieldNormalised_timeZone_AsiaKathmandu() throws Exception {
+        createIndex(IDX_DST_KATHMANDU);
+        DateTimeZone timezone = DateTimeZone.forID("Asia/Kathmandu");
+        List<IndexRequestBuilder> builders = new ArrayList<>();
+
+        addNTimes(1, IDX_DST_KATHMANDU, new DateTime("1985-12-31T22:30:00", timezone), builders);
+        // the shift happens during the next bucket, which includes the 45min that do not start on the full hour
+        addNTimes(2, IDX_DST_KATHMANDU, new DateTime("1985-12-31T23:30:00", timezone), builders);
+        addNTimes(3, IDX_DST_KATHMANDU, new DateTime("1986-01-01T01:30:00", timezone), builders);
+        addNTimes(4, IDX_DST_KATHMANDU, new DateTime("1986-01-01T02:30:00", timezone), builders);
+        indexRandom(true, builders);
+        ensureSearchable();
+
+        SearchResponse response = client()
+                .prepareSearch(IDX_DST_KATHMANDU)
+                .addAggregation(dateHistogram("histo").field("date").dateHistogramInterval(DateHistogramInterval.HOUR)
+                        .timeZone(timezone).minDocCount(0)
+                        .subAggregation(derivative("deriv", "_count").unit(DateHistogramInterval.MINUTE)))
+                .execute()
+                .actionGet();
+
+        assertSearchResponse(response);
+
+        InternalHistogram deriv = response.getAggregations().get("histo");
+        assertThat(deriv, notNullValue());
+        assertThat(deriv.getName(), equalTo("histo"));
+        List<? extends Bucket> buckets = deriv.getBuckets();
+        assertThat(buckets.size(), equalTo(4));
+
+        assertBucket(buckets.get(0), new DateTime("1985-12-31T22:00:00", timezone).toDateTime(DateTimeZone.UTC), 1L, nullValue(), null,
+                null);
+        assertBucket(buckets.get(1), new DateTime("1985-12-31T23:00:00", timezone).toDateTime(DateTimeZone.UTC), 2L, notNullValue(), 1d,
+                1d / 60d);
+        // the following is normalized using a 105min bucket width
+        assertBucket(buckets.get(2), new DateTime("1986-01-01T01:00:00", timezone).toDateTime(DateTimeZone.UTC), 3L, notNullValue(), 1d,
+                1d / 105d);
+        assertBucket(buckets.get(3), new DateTime("1986-01-01T02:00:00", timezone).toDateTime(DateTimeZone.UTC), 4L, notNullValue(), 1d,
+                1d / 60d);
+    }
+
+    private static void addNTimes(int amount, String index, DateTime dateTime, List<IndexRequestBuilder> builders) throws Exception {
+        for (int i = 0; i < amount; i++) {
+            builders.add(indexDoc(index, dateTime, 1));
+        }
+    }
+
+    private static void assertBucket(Histogram.Bucket bucket, DateTime expectedKey, long expectedDocCount,
+            Matcher<Object> derivativeMatcher, Double derivative, Double normalizedDerivative) {
+        assertThat(bucket, notNullValue());
+        assertThat((DateTime) bucket.getKey(), equalTo(expectedKey));
+        assertThat(bucket.getDocCount(), equalTo(expectedDocCount));
+        Derivative docCountDeriv = bucket.getAggregations().get("deriv");
+        assertThat(docCountDeriv, derivativeMatcher);
+        if (docCountDeriv != null) {
+            assertThat(docCountDeriv.value(), closeTo(derivative, 0.00001));
+            assertThat(docCountDeriv.normalizedValue(), closeTo(normalizedDerivative, 0.00001));
+        }
     }
 
     public void testSingleValuedFieldWithSubAggregation() throws Exception {


### PR DESCRIPTION
Our current testing for TimeUnitRoundings `rounding()` and `nextRoundingValue()` methods that are used especially for date histograms lacked proper randomization for time zones. We only did randomized tests for fixed offset time tones (e.g. +01:00, -05:00) but didn't account for real world time zones with DST transitions. 

Adding those tests revealed a couple of problems with our current rounding logic. In some cases, usually happening around those transitions, rounding a value down could land on a value that itself is not a proper rounded value. Also sometimes the nextRoundingValue would not line up properly with the rounded value of all dates in the next unit interval.

This change improves the current rounding logic in TimeUnitRounding in two ways: it makes sure that calling round(date) always returns a date that when rounded again won't change (making round() idempotent) by handling special cases happening during dst transitions by performing a second rounding. It also changes the `nextRoundingValue()` method to itself rely on the round method to make sure we always return rounded values for the unit interval boundaries.

Also adding tests for randomized TimeUnitRounding that assert important basic properties the rounding values should have. For better understanding and readability a few of the pathological edge cases are also added as a special test case.
