### PR TITLE
Make ip fields backward-compatible at query time.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/ip/LegacyIpIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ip/LegacyIpIndexFieldData.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.mapper.ip;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.fielddata.AtomicFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
+import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
+import org.elasticsearch.search.MultiValueMode;
+
+final class LegacyIpIndexFieldData implements IndexFieldData<AtomicFieldData> {
+
+    protected final Index index;
+    protected final String fieldName;
+    protected final ESLogger logger;
+
+    public LegacyIpIndexFieldData(Index index, String fieldName) {
+        this.index = index;
+        this.fieldName = fieldName;
+        this.logger = Loggers.getLogger(getClass());
+    }
+
+    public final String getFieldName() {
+        return fieldName;
+    }
+
+    public final void clear() {
+        // nothing to do
+    }
+
+    public final void clear(IndexReader reader) {
+        // nothing to do
+    }
+
+    public final Index index() {
+        return index;
+    }
+
+    @Override
+    public AtomicFieldData load(LeafReaderContext context) {
+        return new AtomicFieldData() {
+            
+            @Override
+            public void close() {
+                // no-op
+            }
+            
+            @Override
+            public long ramBytesUsed() {
+                return 0;
+            }
+            
+            @Override
+            public ScriptDocValues<?> getScriptValues() {
+                throw new UnsupportedOperationException("Cannot run scripts on ip fields");
+            }
+            
+            @Override
+            public SortedBinaryDocValues getBytesValues() {
+                SortedNumericDocValues values;
+                try {
+                    values = DocValues.getSortedNumeric(context.reader(), fieldName);
+                } catch (IOException e) {
+                    throw new IllegalStateException("Cannot load doc values", e);
+                }
+                return new SortedBinaryDocValues() {
+
+                    final ByteBuffer scratch = ByteBuffer.allocate(4);
+
+                    @Override
+                    public BytesRef valueAt(int index) {
+                        // we do not need to reorder ip addresses since both the numeric
+                        // encoding of LegacyIpFieldMapper and the binary encoding of
+                        // IpFieldMapper match the sort order of ip addresses
+                        long ip = values.valueAt(index);
+                        scratch.putInt(0, (int) ip);
+                        InetAddress inet;
+                        try {
+                            inet = InetAddress.getByAddress(scratch.array());
+                        } catch (UnknownHostException e) {
+                            throw new IllegalStateException("Cannot happen", e);
+                        }
+                        byte[] encoded = InetAddressPoint.encode(inet);
+                        return new BytesRef(encoded);
+                    }
+                    
+                    @Override
+                    public void setDocument(int docId) {
+                        values.setDocument(docId);
+                    }
+                    
+                    @Override
+                    public int count() {
+                        return values.count();
+                    }
+                };
+            }
+        };
+    }
+
+    @Override
+    public AtomicFieldData loadDirect(LeafReaderContext context)
+            throws Exception {
+        return load(context);
+    }
+
+    @Override
+    public IndexFieldData.XFieldComparatorSource comparatorSource(
+            Object missingValue, MultiValueMode sortMode, Nested nested) {
+        return new BytesRefFieldComparatorSource(this, missingValue, sortMode, nested);
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/search/DocValueFormat.java
+++ b/core/src/main/java/org/elasticsearch/search/DocValueFormat.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.joda.FormatDateTimeFormatter;
 import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.network.NetworkAddress;
-import org.elasticsearch.index.mapper.ip.LegacyIpFieldMapper;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
@@ -284,12 +283,12 @@ public interface DocValueFormat extends NamedWriteable {
 
         @Override
         public String format(long value) {
-            return LegacyIpFieldMapper.longToIp(value);
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public String format(double value) {
-            return format((long) value);
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -301,13 +300,12 @@ public interface DocValueFormat extends NamedWriteable {
 
         @Override
         public long parseLong(String value, boolean roundUp, Callable<Long> now) {
-            // TODO: throw exception in 6.0
-            return LegacyIpFieldMapper.ipToLong(value);
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public double parseDouble(String value, boolean roundUp, Callable<Long> now) {
-            return parseLong(value, roundUp, now);
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/bwcompat/IpFieldBwCompatIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/IpFieldBwCompatIT.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.bwcompat;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+
+import java.util.Collection;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.range.Range;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+
+@ESIntegTestCase.SuiteScopeTestCase
+public class IpFieldBwCompatIT extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return pluginList(InternalSettingsPlugin.class); // uses index.merge.enabled
+    }
+
+    @Override
+    public void setupSuiteScopeCluster() throws Exception {
+        assertAcked(prepareCreate("old_index")
+                .setSettings(IndexMetaData.SETTING_VERSION_CREATED, Version.V_2_3_3.id)
+                .addMapping("type", "ip_field", "type=ip"));
+        assertAcked(prepareCreate("new_index")
+                .addMapping("type", "ip_field", "type=ip"));
+
+        indexRandom(true,
+                client().prepareIndex("old_index", "type", "1").setSource("ip_field", "127.0.0.1"),
+                client().prepareIndex("new_index", "type", "1").setSource("ip_field", "127.0.0.1"),
+                client().prepareIndex("new_index", "type", "2").setSource("ip_field", "::1"));
+    }
+
+    public void testSort() {
+        SearchResponse response = client().prepareSearch("old_index", "new_index")
+                .addSort(SortBuilders.fieldSort("ip_field")).get();
+        assertNoFailures(response);
+        assertEquals(3, response.getHits().totalHits());
+        assertEquals("::1", response.getHits().getAt(0).getSortValues()[0]);
+        assertEquals("127.0.0.1", response.getHits().getAt(1).getSortValues()[0]);
+        assertEquals("127.0.0.1", response.getHits().getAt(2).getSortValues()[0]);
+    }
+
+    public void testRangeAgg() {
+        SearchResponse response = client().prepareSearch("old_index", "new_index")
+                .addAggregation(AggregationBuilders.ipRange("ip_range").field("ip_field")
+                        .addMaskRange("127.0.0.1/16")
+                        .addMaskRange("::1/64")).get();
+        assertNoFailures(response);
+        assertEquals(3, response.getHits().totalHits());
+        Range range = response.getAggregations().get("ip_range");
+        assertEquals(2, range.getBuckets().size());
+        assertEquals("::1/64", range.getBuckets().get(0).getKeyAsString());
+        assertEquals(3, range.getBuckets().get(0).getDocCount());
+        assertEquals("127.0.0.1/16", range.getBuckets().get(1).getKeyAsString());
+        assertEquals(2, range.getBuckets().get(1).getDocCount());
+    }
+
+    public void testTermsAgg() {
+        SearchResponse response = client().prepareSearch("old_index", "new_index")
+                .addAggregation(AggregationBuilders.terms("ip_terms").field("ip_field")).get();
+        assertNoFailures(response);
+        assertEquals(3, response.getHits().totalHits());
+        Terms terms = response.getAggregations().get("ip_terms");
+        assertEquals(2, terms.getBuckets().size());
+        assertEquals(2, terms.getBucketByKey("127.0.0.1").getDocCount());
+        assertEquals(1, terms.getBucketByKey("::1").getDocCount());
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregatorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregatorTests.java
@@ -26,7 +26,9 @@ import java.util.Set;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.TestUtil;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
+import org.elasticsearch.search.aggregations.bucket.range.BinaryRangeAggregator.SortedBinaryRangeLeafCollector;
 import org.elasticsearch.search.aggregations.bucket.range.BinaryRangeAggregator.SortedSetRangeLeafCollector;
 import org.elasticsearch.test.ESTestCase;
 
@@ -137,6 +139,103 @@ public class BinaryRangeAggregatorTests extends ESTestCase {
         final int iters = randomInt(10);
         for (int i = 0; i < iters; ++i) {
             doTestSortedSetRangeLeafCollector(5);
+        }
+    }
+
+    private static class FakeSortedBinaryDocValues extends SortedBinaryDocValues {
+
+        private final BytesRef[] terms;
+        long[] ords;
+
+        FakeSortedBinaryDocValues(BytesRef[] terms) {
+            this.terms = terms;
+        }
+
+        @Override
+        public void setDocument(int docID) {
+            // no-op
+        }
+
+        @Override
+        public int count() {
+            return ords.length;
+        }
+
+        @Override
+        public BytesRef valueAt(int index) {
+            return terms[(int) ords[index]];
+        }
+
+    }
+
+    private void doTestSortedBinaryRangeLeafCollector(int maxNumValuesPerDoc) throws Exception {
+        final Set<BytesRef> termSet = new HashSet<>();
+        final int numTerms = TestUtil.nextInt(random(), maxNumValuesPerDoc, 100);
+        while (termSet.size() < numTerms) {
+            termSet.add(new BytesRef(TestUtil.randomSimpleString(random(), randomInt(2))));
+        }
+        final BytesRef[] terms = termSet.toArray(new BytesRef[0]);
+        Arrays.sort(terms);
+
+        final int numRanges = randomIntBetween(1, 10);
+        BinaryRangeAggregator.Range[] ranges = new BinaryRangeAggregator.Range[numRanges];
+        for (int i = 0; i < numRanges; ++i) {
+            ranges[i] = new BinaryRangeAggregator.Range(Integer.toString(i),
+                    randomBoolean() ? null : new BytesRef(TestUtil.randomSimpleString(random(), randomInt(2))),
+                    randomBoolean() ? null : new BytesRef(TestUtil.randomSimpleString(random(), randomInt(2))));
+        }
+        Arrays.sort(ranges, BinaryRangeAggregator.RANGE_COMPARATOR);
+
+        FakeSortedBinaryDocValues values = new FakeSortedBinaryDocValues(terms);
+        final int[] counts = new int[ranges.length];
+        SortedBinaryRangeLeafCollector collector = new SortedBinaryRangeLeafCollector(values, ranges, null) {
+            @Override
+            protected void doCollect(LeafBucketCollector sub, int doc, long bucket) throws IOException {
+                counts[(int) bucket]++;
+            }
+        };
+
+        final int[] expectedCounts = new int[ranges.length];
+        final int maxDoc = randomIntBetween(5, 10);
+        for (int doc = 0; doc < maxDoc; ++doc) {
+            LongHashSet ordinalSet = new LongHashSet();
+            final int numValues = randomInt(maxNumValuesPerDoc);
+            while (ordinalSet.size() < numValues) {
+                ordinalSet.add(random().nextInt(terms.length));
+            }
+            final long[] ords = ordinalSet.toArray();
+            Arrays.sort(ords);
+            values.ords = ords;
+
+            // simulate aggregation
+            collector.collect(doc);
+
+            // now do it the naive way
+            for (int i = 0; i < ranges.length; ++i) {
+                for (long ord : ords) {
+                    BytesRef term = terms[(int) ord];
+                    if ((ranges[i].from == null || ranges[i].from.compareTo(term) <= 0)
+                            && (ranges[i].to == null || ranges[i].to.compareTo(term) > 0)) {
+                        expectedCounts[i]++;
+                        break;
+                    }
+                }
+            }
+        }
+        assertArrayEquals(expectedCounts, counts);
+    }
+
+    public void testSortedBinaryRangeLeafCollectorSingleValued() throws Exception {
+        final int iters = randomInt(10);
+        for (int i = 0; i < iters; ++i) {
+            doTestSortedBinaryRangeLeafCollector(1);
+        }
+    }
+
+    public void testSortedBinaryRangeLeafCollectorMultiValued() throws Exception {
+        final int iters = randomInt(10);
+        for (int i = 0; i < iters; ++i) {
+            doTestSortedBinaryRangeLeafCollector(5);
         }
     }
 }


### PR DESCRIPTION
The fact that ip fields used a different doc values representation in 2.x causes
issues when querying 2.x and 5.0 indices in the same request. This changes 2.x
doc values on ip fields/2.x to be hidden behind binary doc values that use the
same encoding as 5.0. This way the coordinating node will be able to merge shard
responses that have different major versions.

One known issue is that this makes sorting/aggregating slower on ip fields for
indices that have been generated with elasticsearch 2.x.

Relates to #17971
