### PR TITLE
Updating CustomBoostFactorScorer to fix must_not + function score issue

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/search/function/CustomBoostFactorScorer.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/CustomBoostFactorScorer.java
@@ -116,7 +116,7 @@ abstract class CustomBoostFactorScorer extends Scorer {
             }
             currentScore = innerScore();
             if (currentScore < minScore) {
-                return scorer.nextDoc();
+                return nextDoc();
             }
             return doc;
         }

--- a/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
+++ b/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
@@ -2640,4 +2640,39 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
                     equalTo(true));
         }
     }
+
+    @Test // see #18315
+    public void testFunctionScoreWithinMustNotQuery() throws Exception {
+        // Bug only presents when the number of documents exceeds the number of shards,
+        //  so I'm using a single shard to limit the scope of the issue
+        prepareCreate("fnscore-test-index", 1, ImmutableSettings.builder()
+                .put("index.number_of_replicas", 0)
+                .put("index.number_of_shards", 1)
+        ).get();
+        ensureYellow("fnscore-test-index");
+
+        // Index two documents (doc count must exceed number of shards)
+        // NOTE: Bug does not present consistently when indexing documents separately,
+        //  so I'm using a bulk request very intentionally
+        client().prepareBulk()
+                .add(client().prepareIndex("fnscore-test-index", "event", "1").setSource("{\"field\":\"value-1\"}"))
+                .add(client().prepareIndex("fnscore-test-index", "event", "2").setSource("{\"field\":\"value-2\"}"))
+                .add(client().prepareIndex("fnscore-test-index", "event", "3").setSource("{\"field\":\"value-3\"}"))
+                .add(client().prepareIndex("fnscore-test-index", "event", "4").setSource("{\"field\":\"value-4\"}"))
+                .add(client().prepareIndex("fnscore-test-index", "event", "5").setSource("{\"field\":\"value-5\"}"))
+                .setRefresh(true)
+                .get();
+
+        // The function script should never hit any documents, so the inverse
+        //  should always return all documents
+        SearchResponse resp = client().prepareSearch("fnscore-test-index")
+                .setQuery(QueryBuilders.boolQuery()
+                        .mustNot(QueryBuilders.functionScoreQuery()
+                                .add(scriptFunction("-1", "expression"))
+                                .scoreMode("sum")
+                                .boostMode("replace")
+                                .setMinScore(0)))
+                .get();
+        assertHitCount(resp, 5L);
+    }
 }


### PR DESCRIPTION
When using a function score query within a must_not clause, the query was returning the wrong results.

Note that this PR is pointed at 1.7 for two reasons:
1. ES 2.0 upgraded to Lucene 5, where the `ReqExclScorer` class was rewritten in such a way that this bug doesn't manifest in 2.0, 2.1, or the 2.2 branches (though as I'm investigating, there may be a different bug that excludes all results...)
2. ES 2.3 removed the `CustomBoostFactorScorer` class

Closes #18315
