### PR TITLE
Add note regarding Windows service heap size

### DIFF
--- a/docs/reference/setup/install/windows.asciidoc
+++ b/docs/reference/setup/install/windows.asciidoc
@@ -173,12 +173,11 @@ The Elasticsearch service can be configured prior to installation by setting the
 NOTE: At its core, `service.bat` relies on http://commons.apache.org/proper/commons-daemon/[Apache Commons Daemon] project
 to install the service. Environment variables set prior to the service installation are copied and will be used during the service lifecycle. This means any changes made to them after the installation will not be picked up unless the service is reinstalled.
 
-NOTE: How to configure the <<heap-size,heap size>> for the Windows
-service depends on whether or not the service is installed. If the
-service is not installed, you configure the <<heap-size,heap size>>
-settings as for any other Elasticsearch installation. However, after
-the service is installed, you must configure the heap size setting
-via the service manager: `bin/service.bat manager`.
+NOTE: On Windows, the <<heap-size,heap size>> can be configured as for
+any other Elasticsearch installation when running Elasticsearch from the
+command line, or when installing Elasticsearch as a service for the
+first time. To adjust the heap size for an already installed service,
+use the service manager: `bin\service.bat manager`.
 
 Using the Manager GUI::
 

--- a/docs/reference/setup/install/windows.asciidoc
+++ b/docs/reference/setup/install/windows.asciidoc
@@ -173,6 +173,13 @@ The Elasticsearch service can be configured prior to installation by setting the
 NOTE: At its core, `service.bat` relies on http://commons.apache.org/proper/commons-daemon/[Apache Commons Daemon] project
 to install the service. Environment variables set prior to the service installation are copied and will be used during the service lifecycle. This means any changes made to them after the installation will not be picked up unless the service is reinstalled.
 
+NOTE: How to configure the <<heap-size,heap size>> for the Windows
+service depends on whether or not the service is installed. If the
+service is not installed, you configure the <<heap-size,heap size>>
+settings as for any other Elasticsearch installation. However, after
+the service is installed, you must configure the heap size setting
+via the service manager: `bin/service.bat manager`.
+
 Using the Manager GUI::
 
 It is also possible to configure the service after it's been installed using the manager GUI (`elasticsearch-service-mgr.exe`), which offers insight into the installed service, including its status, startup type, JVM, start and stop settings amongst other things.  Simply invoking `service.bat manager` from the command-line will open up the manager window:

--- a/docs/reference/setup/sysconfig/heap_size.asciidoc
+++ b/docs/reference/setup/sysconfig/heap_size.asciidoc
@@ -65,3 +65,10 @@ ES_JAVA_OPTS="-Xms4000m -Xmx4000m" ./bin/elasticsearch <2>
 ------------------
 <1> Set the minimum and maximum heap size to 2 GB.
 <2> Set the minimum and maximum heap size to 4000 MB.
+
+NOTE: Configuring the heap for the <<windows-service,Windows service>>
+is different than the above. The values initiallly populated for the
+Windows service can be configured as above but are different after the
+service has been installed. Consult the
+<<windows-service,Windows service documentation>> for additional
+details.


### PR DESCRIPTION
This commit adds a note regarding the difference in configuration for
the Windows service heap size from any other installation of
Elasticsearch.
