### PR TITLE
Fixed typo "field".

### DIFF
--- a/docs/reference/analysis/analyzers/custom-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/custom-analyzer.asciidoc
@@ -21,7 +21,7 @@ filters.
 filters.
 
 |`position_increment_gap` |An optional number of positions to increment
-between each field value of a field using this analyzer. Defaults to 100.
+between each value of a field using this analyzer. Defaults to 100.
 100 was chosen because it prevents phrase queries with reasonably large
 slops (less than 100) from matching terms across field values.
 |=======================================================================


### PR DESCRIPTION
Field was used twice: "field value of a field".
