### PR TITLE
Add query functions to function_score

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
@@ -146,7 +146,7 @@ public class FiltersFunctionScoreQuery extends Query {
             filterWeights[i] = searcher.createNormalizedWeight(filterFunctions[i].filter, false);
             //TODO: Not sure if we should add such a method because it does nothing for any score function except for query_function but
             // I don't have a good idea where else to put it
-            filterFunctions[i].function.initWeight(searcher, needsScores);
+            filterFunctions[i].function.initWeight(searcher);
         }
         Weight subQueryWeight = subQuery.createWeight(searcher, subQueryNeedsScores);
         return new CustomBoostFactorWeight(this, subQueryWeight, filterWeights, subQueryNeedsScores);

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
@@ -144,6 +144,8 @@ public class FiltersFunctionScoreQuery extends Query {
         for (int i = 0; i < filterFunctions.length; ++i) {
             subQueryNeedsScores |= filterFunctions[i].function.needsScores();
             filterWeights[i] = searcher.createNormalizedWeight(filterFunctions[i].filter, false);
+            //TODO: Not sure if we should add such a method because it does nothing for any score function except for query_function but
+            // I don't have a good idea where else to put it
             filterFunctions[i].function.initWeight(searcher, needsScores);
         }
         Weight subQueryWeight = subQuery.createWeight(searcher, subQueryNeedsScores);

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
@@ -144,6 +144,7 @@ public class FiltersFunctionScoreQuery extends Query {
         for (int i = 0; i < filterFunctions.length; ++i) {
             subQueryNeedsScores |= filterFunctions[i].function.needsScores();
             filterWeights[i] = searcher.createNormalizedWeight(filterFunctions[i].filter, false);
+            filterFunctions[i].function.initWeight(searcher, needsScores);
         }
         Weight subQueryWeight = subQuery.createWeight(searcher, subQueryNeedsScores);
         return new CustomBoostFactorWeight(this, subQueryWeight, filterWeights, subQueryNeedsScores);
@@ -274,7 +275,7 @@ public class FiltersFunctionScoreQuery extends Query {
             return scoreCombiner.combine(subQueryScore, factor, maxBoost);
         }
 
-        protected double computeScore(int docId, float subQueryScore) {
+        protected double computeScore(int docId, float subQueryScore) throws IOException {
             double factor = 1d;
             switch(scoreMode) {
                 case FIRST:

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
@@ -91,7 +91,9 @@ public class FunctionScoreQuery extends Query {
         if (needsScores == false && minScore == null) {
             return subQuery.createWeight(searcher, needsScores);
         }
-
+        if (function != null) {
+            function.initWeight(searcher, needsScores);
+        }
         boolean subQueryNeedsScores =
                 combineFunction != CombineFunction.REPLACE // if we don't replace we need the original score
                 || function == null // when the function is null, we just multiply the score, so we need it

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
@@ -92,7 +92,7 @@ public class FunctionScoreQuery extends Query {
             return subQuery.createWeight(searcher, needsScores);
         }
         if (function != null) {
-            function.initWeight(searcher, needsScores);
+            function.initWeight(searcher);
         }
         boolean subQueryNeedsScores =
                 combineFunction != CombineFunction.REPLACE // if we don't replace we need the original score

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/LeafScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/LeafScoreFunction.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /** Per-leaf {@link ScoreFunction}. */
 public abstract class LeafScoreFunction {
 
-    public abstract double score(int docId, float subQueryScore);
+    public abstract double score(int docId, float subQueryScore) throws IOException;
 
     public abstract Explanation explainScore(int docId, Explanation subQueryScore) throws IOException;
 

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/QueryFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/QueryFunction.java
@@ -46,8 +46,7 @@ public class QueryFunction extends ScoreFunction {
 
     @Override
     public void initWeight(IndexSearcher searcher) throws IOException {
-        // TODO: which weight should be created here? normalized or not?
-        weight = query.createWeight(searcher, true);
+        weight = searcher.createNormalizedWeight(query, true);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/QueryFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/QueryFunction.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common.lucene.search.function;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.Bits;
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.index.query.functionscore.QueryFunctionBuilder;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Function that scores according to the query defined for it.
+ */
+public class QueryFunction extends ScoreFunction {
+    Query query;
+    Weight weight;
+    boolean needScores;
+
+    public QueryFunction(Query query) {
+        super(CombineFunction.MULTIPLY);
+        this.query = query;
+    }
+
+    @Override
+    public void initWeight(IndexSearcher searcher, boolean needsScores) throws IOException {
+        // TODO: which weight should be created here? normalized or not?
+        weight = query.createWeight(searcher, needsScores);
+        this.needScores = needsScores;
+    }
+
+    @Override
+    public LeafScoreFunction getLeafScoreFunction(LeafReaderContext ctx) throws IOException {
+        final Scorer scorer = weight.scorer(ctx);
+        // TODO: not sure if this is the most efficient way to do it
+        Bits bits = Lucene.asSequentialAccessBits(ctx.reader().maxDoc(), scorer);
+        return new LeafScoreFunction() {
+
+            @Override
+            public double score(int docId, float subQueryScore) throws IOException {
+                if (bits.get(docId)) {
+                    return scorer.score();
+                } else {
+                    return 0;
+                }
+            }
+
+            @Override
+            public Explanation explainScore(int docId, Explanation subQueryScore) throws IOException {
+                double score = score(docId, subQueryScore.getValue());
+                Explanation explanation = Explanation.match(
+                    CombineFunction.toFloat(score),
+                    String.format(Locale.ROOT,
+                        "%s score as computed by this query: %s: ", QueryFunctionBuilder.NAME, query.toString()), weight.explain(ctx,
+                        docId));
+                return explanation;
+            }
+        };
+    }
+
+    @Override
+    public boolean needsScores() {
+        return needScores;
+    }
+
+    @Override
+    protected boolean doEquals(ScoreFunction o) {
+        QueryFunction that = (QueryFunction) o;
+        if (needScores != that.needScores) return false;
+        if (query != null ? !query.equals(that.query) : that.query != null) return false;
+        return weight != null ? weight.equals(that.weight) : that.weight == null;
+    }
+
+    @Override
+    public int doHashCode() {
+        return Objects.hash(weight, needScores, query);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/QueryFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/QueryFunction.java
@@ -52,7 +52,6 @@ public class QueryFunction extends ScoreFunction {
     @Override
     public LeafScoreFunction getLeafScoreFunction(LeafReaderContext ctx) throws IOException {
         final Scorer scorer = weight.scorer(ctx);
-        // TODO: not sure if this is the most efficient way to do it
         Bits bits = Lucene.asSequentialAccessBits(ctx.reader().maxDoc(), scorer);
         return new LeafScoreFunction() {
 

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/QueryFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/QueryFunction.java
@@ -38,7 +38,6 @@ import java.util.Objects;
 public class QueryFunction extends ScoreFunction {
     Query query;
     Weight weight;
-    boolean needScores;
 
     public QueryFunction(Query query) {
         super(CombineFunction.MULTIPLY);
@@ -46,10 +45,9 @@ public class QueryFunction extends ScoreFunction {
     }
 
     @Override
-    public void initWeight(IndexSearcher searcher, boolean needsScores) throws IOException {
+    public void initWeight(IndexSearcher searcher) throws IOException {
         // TODO: which weight should be created here? normalized or not?
-        weight = query.createWeight(searcher, needsScores);
-        this.needScores = needsScores;
+        weight = query.createWeight(searcher, true);
     }
 
     @Override
@@ -83,19 +81,18 @@ public class QueryFunction extends ScoreFunction {
 
     @Override
     public boolean needsScores() {
-        return needScores;
+        return true;
     }
 
     @Override
     protected boolean doEquals(ScoreFunction o) {
         QueryFunction that = (QueryFunction) o;
-        if (needScores != that.needScores) return false;
         if (query != null ? !query.equals(that.query) : that.query != null) return false;
         return weight != null ? weight.equals(that.weight) : that.weight == null;
     }
 
     @Override
     public int doHashCode() {
-        return Objects.hash(weight, needScores, query);
+        return Objects.hash(weight, query);
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/QueryFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/QueryFunction.java
@@ -74,7 +74,7 @@ public class QueryFunction extends ScoreFunction {
                 Explanation explanation = Explanation.match(
                     CombineFunction.toFloat(score),
                     String.format(Locale.ROOT,
-                        "%s score as computed by this query: %s: ", QueryFunctionBuilder.NAME, query.toString()), weight.explain(ctx,
+                        "%s as computed by this query: %s: ", QueryFunctionBuilder.NAME, query.toString()), weight.explain(ctx,
                         docId));
                 return explanation;
             }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/QueryFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/QueryFunction.java
@@ -86,11 +86,26 @@ public class QueryFunction extends ScoreFunction {
     protected boolean doEquals(ScoreFunction o) {
         QueryFunction that = (QueryFunction) o;
         if (query != null ? !query.equals(that.query) : that.query != null) return false;
-        return weight != null ? weight.equals(that.weight) : that.weight == null;
+        if (weight != null) {
+            if (that.weight != null) {
+                if (weight.getQuery() != null ? !weight.getQuery().equals(that.weight.getQuery()) : that.weight.getQuery() != null)
+                    return false;
+                else
+                    return true;
+            } else {
+                return false;
+            }
+        } else {
+            return that.weight == null;
+        }
     }
 
     @Override
     public int doHashCode() {
-        return Objects.hash(weight, query);
+        if (weight != null) {
+            return Objects.hash(weight.getQuery(), query);
+        } else {
+            return Objects.hash(query);
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScoreFunction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.common.lucene.search.function;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.IndexSearcher;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -43,10 +44,14 @@ public abstract class ScoreFunction {
 
     /**
      * Indicates if document scores are needed by this function.
-     * 
+     *
      * @return {@code true} if scores are needed.
      */
     public abstract boolean needsScores();
+
+    public void initWeight(IndexSearcher searcher, boolean needsScores) throws IOException {
+       // do nothing iof you do not need it
+    }
 
     @Override
     public final boolean equals(Object obj) {

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScoreFunction.java
@@ -49,7 +49,7 @@ public abstract class ScoreFunction {
      */
     public abstract boolean needsScores();
 
-    public void initWeight(IndexSearcher searcher, boolean needsScores) throws IOException {
+    public void initWeight(IndexSearcher searcher) throws IOException {
        // do nothing iof you do not need it
     }
 

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/WeightFactorFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/WeightFactorFunction.java
@@ -55,7 +55,7 @@ public class WeightFactorFunction extends ScoreFunction {
         final LeafScoreFunction leafFunction = scoreFunction.getLeafScoreFunction(ctx);
         return new LeafScoreFunction() {
             @Override
-            public double score(int docId, float subQueryScore) {
+            public double score(int docId, float subQueryScore) throws IOException {
                 return leafFunction.score(docId, subQueryScore) * getWeight();
             }
 

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/QueryFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/QueryFunctionBuilder.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.query.functionscore;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.search.function.QueryFunction;
+import org.elasticsearch.common.lucene.search.function.ScoreFunction;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryShardContext;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A function that computes a score according to the provided query.
+ */
+public class QueryFunctionBuilder extends ScoreFunctionBuilder<QueryFunctionBuilder> {
+    public static final String NAME = "query_function";
+    public static final ParseField FUNCTION_NAME_FIELD = new ParseField(NAME);
+    QueryBuilder queryBuilder;
+
+    public QueryFunctionBuilder(StreamInput in) throws IOException {
+        super(in);
+        queryBuilder = in.readNamedWriteable(QueryBuilder.class);
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeNamedWriteable(queryBuilder);
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    public QueryFunctionBuilder(QueryBuilder query) {
+        this.queryBuilder = query;
+    }
+
+    @Override
+    public void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(getName());
+        builder.field("query");
+        queryBuilder.toXContent(builder, params);
+        builder.endObject();
+    }
+
+    @Override
+    protected boolean doEquals(QueryFunctionBuilder functionBuilder) {
+        return Objects.equals(this.queryBuilder, functionBuilder.queryBuilder);
+    }
+
+    @Override
+    public int doHashCode() {
+        return Objects.hash(this.queryBuilder);
+    }
+
+    @Override
+    protected ScoreFunction doToFunction(QueryShardContext context) throws IOException {
+        Query query = queryBuilder.toQuery(context);
+        return new QueryFunction(query);
+    }
+
+    public static QueryFunctionBuilder fromXContent(QueryParseContext parseContext)
+        throws IOException, ParsingException {
+        XContentParser parser = parseContext.parser();
+        XContentParser.Token token = parser.nextToken();
+        if (token.isValue()) {
+            throw new ParsingException(parser.getTokenLocation(), "Expected field \"query\"");
+        }
+        if (parser.currentName().equals("query") == false) {
+            throw new ParsingException(parser.getTokenLocation(), "Expected field \"query\"");
+        }
+        QueryBuilder queryBuilder = parseContext.parseInnerQueryBuilder();
+        token = parser.nextToken();
+        if (token.compareTo(XContentParser.Token.END_OBJECT) != 0) {
+            throw new ParsingException(parser.getTokenLocation(), "Expected }");
+        }
+        return new QueryFunctionBuilder(queryBuilder);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/QueryFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/QueryFunctionBuilder.java
@@ -38,7 +38,7 @@ import java.util.Objects;
  * A function that computes a score according to the provided query.
  */
 public class QueryFunctionBuilder extends ScoreFunctionBuilder<QueryFunctionBuilder> {
-    public static final String NAME = "query_function";
+    public static final String NAME = "query";
     public static final ParseField FUNCTION_NAME_FIELD = new ParseField(NAME);
     QueryBuilder queryBuilder;
 
@@ -63,10 +63,8 @@ public class QueryFunctionBuilder extends ScoreFunctionBuilder<QueryFunctionBuil
 
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(getName());
-        builder.field("query");
+        builder.field(getName());
         queryBuilder.toXContent(builder, params);
-        builder.endObject();
     }
 
     @Override
@@ -88,17 +86,13 @@ public class QueryFunctionBuilder extends ScoreFunctionBuilder<QueryFunctionBuil
     public static QueryFunctionBuilder fromXContent(QueryParseContext parseContext)
         throws IOException, ParsingException {
         XContentParser parser = parseContext.parser();
-        XContentParser.Token token = parser.nextToken();
-        if (token.isValue()) {
-            throw new ParsingException(parser.getTokenLocation(), "Expected field \"query\"");
-        }
-        if (parser.currentName().equals("query") == false) {
-            throw new ParsingException(parser.getTokenLocation(), "Expected field \"query\"");
+        XContentParser.Token token = parser.currentToken();
+        if (token.compareTo(XContentParser.Token.START_OBJECT) != 0) {
+            throw new ParsingException(parser.getTokenLocation(), "Expected START OBJECT");
         }
         QueryBuilder queryBuilder = parseContext.parseInnerQueryBuilder();
-        token = parser.nextToken();
-        if (token.compareTo(XContentParser.Token.END_OBJECT) != 0) {
-            throw new ParsingException(parser.getTokenLocation(), "Expected }");
+        if (parser.currentToken().compareTo(XContentParser.Token.END_OBJECT) != 0) {
+            throw new ParsingException(parser.getTokenLocation(), "Expected } but got " + parser.currentToken());
         }
         return new QueryFunctionBuilder(queryBuilder);
     }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/QueryFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/QueryFunctionBuilder.java
@@ -38,7 +38,7 @@ import java.util.Objects;
  * A function that computes a score according to the provided query.
  */
 public class QueryFunctionBuilder extends ScoreFunctionBuilder<QueryFunctionBuilder> {
-    public static final String NAME = "query";
+    public static final String NAME = "query_score";
     public static final ParseField FUNCTION_NAME_FIELD = new ParseField(NAME);
     QueryBuilder queryBuilder;
 
@@ -59,6 +59,9 @@ public class QueryFunctionBuilder extends ScoreFunctionBuilder<QueryFunctionBuil
 
     public QueryFunctionBuilder(QueryBuilder query) {
         this.queryBuilder = query;
+        if (queryBuilder == null) {
+            throw new IllegalArgumentException("Query in query_score must not be null.");
+        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -84,6 +84,7 @@ import org.elasticsearch.index.query.WildcardQueryBuilder;
 import org.elasticsearch.index.query.WrapperQueryBuilder;
 import org.elasticsearch.index.query.functionscore.ExponentialDecayFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.FieldValueFactorFunctionBuilder;
+import org.elasticsearch.index.query.functionscore.QueryFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.elasticsearch.index.query.functionscore.GaussDecayFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.LinearDecayFunctionBuilder;
@@ -606,6 +607,8 @@ public class SearchModule extends AbstractModule {
                 RandomScoreFunctionBuilder.FUNCTION_NAME_FIELD);
         registerScoreFunction(FieldValueFactorFunctionBuilder::new, FieldValueFactorFunctionBuilder::fromXContent,
                 FieldValueFactorFunctionBuilder.FUNCTION_NAME_FIELD);
+        registerScoreFunction(QueryFunctionBuilder::new, QueryFunctionBuilder::fromXContent,
+            QueryFunctionBuilder.FUNCTION_NAME_FIELD);
 
         //weight doesn't have its own parser, so every function supports it out of the box.
         //Can be a single function too when not associated to any other function, which is why it needs to be registered manually here.

--- a/core/src/test/java/org/elasticsearch/index/query/QueryShardContextTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryShardContextTests.java
@@ -38,17 +38,7 @@ import static org.mockito.Mockito.when;
 public class QueryShardContextTests extends ESTestCase {
 
     public void testFailIfFieldMappingNotFound() {
-        IndexMetaData.Builder indexMetadata = new IndexMetaData.Builder("index");
-        indexMetadata.settings(Settings.builder().put("index.version.created", Version.CURRENT)
-            .put("index.number_of_shards", 1)
-            .put("index.number_of_replicas", 1)
-        );
-        IndexSettings indexSettings = new IndexSettings(indexMetadata.build(), Settings.EMPTY);
-        MapperService mapperService = mock(MapperService.class);
-        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
-        QueryShardContext context = new QueryShardContext(
-            indexSettings, null, null, mapperService, null, null, null, null, null, null
-        );
+        QueryShardContext context = getMockQueryShardContext();
 
         context.setAllowUnmappedFields(false);
         MappedFieldType fieldType = new TextFieldMapper.TextFieldType();
@@ -75,6 +65,20 @@ public class QueryShardContextTests extends ESTestCase {
         assertThat(result, notNullValue());
         assertThat(result, instanceOf(TextFieldMapper.TextFieldType.class));
         assertThat(result.name(), equalTo("name"));
+    }
+
+    public static QueryShardContext getMockQueryShardContext() {
+        IndexMetaData.Builder indexMetadata = new IndexMetaData.Builder("index");
+        indexMetadata.settings(Settings.builder().put("index.version.created", Version.CURRENT)
+            .put("index.number_of_shards", 1)
+            .put("index.number_of_replicas", 1)
+        );
+        IndexSettings indexSettings = new IndexSettings(indexMetadata.build(), Settings.EMPTY);
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+        return new QueryShardContext(
+            indexSettings, null, null, mapperService, null, null, null, null, null, null
+        );
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
@@ -713,11 +713,9 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
             "              \"FIELD\": \"VALUE\"\n" +
             "            }\n" +
             "          },\n" +
-            "          \"query_function\": {\n" +
-            "            \"query\": {\n" +
-            "              \"match\": {\n" +
-            "                \"FIELD\": \"TEXT\"\n" +
-            "              }\n" +
+            "          \"query\": {\n" +
+            "            \"match\": {\n" +
+            "              \"FIELD\": \"TEXT\"\n" +
             "            }\n" +
             "          }\n" +
             "        }\n" +
@@ -730,6 +728,8 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
         FilterFunctionBuilder[] filterFunctionBuilders = queryBuilder.filterFunctionBuilders();
         assertThat(filterFunctionBuilders[0].getScoreFunction(), instanceOf(QueryFunctionBuilder.class));
         assertThat(((QueryFunctionBuilder)filterFunctionBuilders[0].getScoreFunction()).queryBuilder, instanceOf(MatchQueryBuilder.class));
+        assertThat(queryBuilder.boostMode(), equalTo(CombineFunction.SUM));
+        assertThat(queryBuilder.scoreMode(), equalTo(FiltersFunctionScoreQuery.ScoreMode.MAX));
     }
 
     private void expectParsingException(String json, Matcher<String> messageMatcher) {

--- a/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
@@ -713,7 +713,7 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
             "              \"FIELD\": \"VALUE\"\n" +
             "            }\n" +
             "          },\n" +
-            "          \"query\": {\n" +
+            "          \"query_score\": {\n" +
             "            \"match\": {\n" +
             "              \"FIELD\": \"TEXT\"\n" +
             "            }\n" +

--- a/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
@@ -33,11 +33,13 @@ import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
 import org.elasticsearch.common.lucene.search.function.FiltersFunctionScoreQuery;
 import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
+import org.elasticsearch.common.lucene.search.function.QueryFunction;
 import org.elasticsearch.common.lucene.search.function.WeightFactorFunction;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractQueryTestCase;
@@ -134,7 +136,7 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
             return new WeightBuilder().setWeight(randomFloat());
         }
         ScoreFunctionBuilder<?> functionBuilder;
-        switch (randomIntBetween(0, 3)) {
+        switch (randomIntBetween(0, 4)) {
         case 0:
             DecayFunctionBuilder<?> decayFunctionBuilder = createRandomDecayFunction();
             if (randomBoolean()) {
@@ -171,6 +173,9 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
                 randomScoreFunctionBuilder.seed(randomAsciiOfLengthBetween(1, 10));
             }
             functionBuilder = randomScoreFunctionBuilder;
+            break;
+        case 4:
+            functionBuilder = new QueryFunctionBuilder(new TermQueryBuilder("text", "value"));
             break;
         default:
             throw new UnsupportedOperationException();
@@ -689,6 +694,42 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
                 "    }\n" +
                 "}";
         expectParsingException(json, "[query] is already defined.");
+    }
+
+    public void testParseQueryFunction() throws IOException {
+        //verify that an error is thrown rather than setting the query twice (https://github.com/elastic/elasticsearch/issues/16583)
+        String json = "{\n" +
+            "    \"function_score\": {\n" +
+            "      \"score_mode\": \"max\",\n" +
+            "      \"query\": {\n" +
+            "        \"match\": {\n" +
+            "          \"FIELD\": \"TEXT\"\n" +
+            "        }\n" +
+            "      },\n" +
+            "      \"functions\": [\n" +
+            "        {\n" +
+            "          \"filter\": {\n" +
+            "            \"term\": {\n" +
+            "              \"FIELD\": \"VALUE\"\n" +
+            "            }\n" +
+            "          },\n" +
+            "          \"query_function\": {\n" +
+            "            \"query\": {\n" +
+            "              \"match\": {\n" +
+            "                \"FIELD\": \"TEXT\"\n" +
+            "              }\n" +
+            "            }\n" +
+            "          }\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"boost_mode\": \"sum\"\n" +
+            "    }" +
+            "}";
+
+        FunctionScoreQueryBuilder queryBuilder = (FunctionScoreQueryBuilder)parseQuery(json);
+        FilterFunctionBuilder[] filterFunctionBuilders = queryBuilder.filterFunctionBuilders();
+        assertThat(filterFunctionBuilders[0].getScoreFunction(), instanceOf(QueryFunctionBuilder.class));
+        assertThat(((QueryFunctionBuilder)filterFunctionBuilders[0].getScoreFunction()).queryBuilder, instanceOf(MatchQueryBuilder.class));
     }
 
     private void expectParsingException(String json, Matcher<String> messageMatcher) {

--- a/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryFunctionTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryFunctionTests.java
@@ -126,7 +126,7 @@ public class FunctionScoreQueryFunctionTests extends ESTestCase {
         Weight weight = searcher.createNormalizedWeight(query, true);
         Explanation explanation = weight.explain(searcher.getIndexReader().leaves().get(0), 0);
         assertThat(explanation.getDetails()[1].getDetails()[0].getDetails()[2].getDetails()[1].getDescription(),
-            containsString("query score as computed by this query: function score (*:*, functions: [{filter(test:named), " +
+            containsString("query_score as computed by this query: function score (*:*, functions: [{filter(test:named), " +
                 "function [org.elasticsearch.common.lucene.search.function.WeightFactorFunction"));
 
     }

--- a/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryFunctionTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryFunctionTests.java
@@ -126,7 +126,7 @@ public class FunctionScoreQueryFunctionTests extends ESTestCase {
         Weight weight = searcher.createNormalizedWeight(query, true);
         Explanation explanation = weight.explain(searcher.getIndexReader().leaves().get(0), 0);
         assertThat(explanation.getDetails()[1].getDetails()[0].getDetails()[2].getDetails()[1].getDescription(),
-            containsString("query_function score as computed by this query: function score (*:*, functions: [{filter(test:named), " +
+            containsString("query score as computed by this query: function score (*:*, functions: [{filter(test:named), " +
                 "function [org.elasticsearch.common.lucene.search.function.WeightFactorFunction"));
 
     }

--- a/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryFunctionTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryFunctionTests.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.functionscore;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.store.Directory;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
+import org.elasticsearch.common.lucene.search.function.QueryFunction;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+
+import static org.elasticsearch.index.query.QueryShardContextTests.getMockQueryShardContext;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FunctionScoreQueryFunctionTests extends ESTestCase {
+
+    public static final String FIELD = "test";
+    private Directory dir;
+    private IndexWriter w;
+    private DirectoryReader reader;
+    private IndexSearcher searcher;
+    public static final String TEXT_1 = "There once was a runner named Dwight";
+    public static final String TEXT_2 = "who could speed even faster than light.";
+    public static final String TEXT_3 = "He set out one day /in a relative way";
+    public static final String TEXT_4 = "and returned on the previous night.";
+
+    @Before
+    public void initSearcher() throws IOException {
+        dir = newDirectory();
+        w = new IndexWriter(dir, newIndexWriterConfig(new StandardAnalyzer()));
+        Document d = new Document();
+        d.add(new TextField(FIELD, TEXT_1, Field.Store.YES));
+        d.add(new TextField("_uid", "1", Field.Store.YES));
+        w.addDocument(d);
+        d = new Document();
+        d.add(new TextField(FIELD, TEXT_2, Field.Store.YES));
+        d.add(new TextField("_uid", "2", Field.Store.YES));
+        w.addDocument(d);
+        d = new Document();
+        d.add(new TextField(FIELD, TEXT_3, Field.Store.YES));
+        d.add(new TextField("_uid", "3", Field.Store.YES));
+        w.addDocument(d);
+        d = new Document();
+        d.add(new TextField(FIELD, TEXT_4, Field.Store.YES));
+        d.add(new TextField("_uid", "4", Field.Store.YES));
+        w.addDocument(d);
+        w.commit();
+        reader = DirectoryReader.open(w);
+        searcher = newSearcher(reader);
+    }
+
+    @After
+    public void closeAllTheReaders() throws IOException {
+        reader.close();
+        w.close();
+        dir.close();
+    }
+
+    public void testQueryFunctionFilterFunctionScore() throws IOException {
+        FunctionScoreQueryBuilder functionScoreQueryBuilder = getQueryFunctionQueryBuilder();
+        IndexMetaData.Builder indexMetadata = new IndexMetaData.Builder("index");
+        indexMetadata.settings(Settings.builder().put("index.version.created", Version.CURRENT)
+            .put("index.number_of_shards", 1)
+            .put("index.number_of_replicas", 1)
+        );
+        IndexSettings indexSettings = new IndexSettings(indexMetadata.build(), Settings.EMPTY);
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+        QueryShardContext context = new QueryShardContext(
+            indexSettings, null, null, mapperService, null, null, null, null, null, null
+        );
+        Query query = functionScoreQueryBuilder.toQuery(context);
+        TopDocs topDocs = searcher.search(query, 4);
+        assertThat(topDocs.scoreDocs[0].score, equalTo(5f));
+        assertThat(reader.document(topDocs.scoreDocs[0].doc).get("_uid"), equalTo("4"));
+        assertThat(topDocs.scoreDocs[1].score, equalTo(4f));
+        assertThat(reader.document(topDocs.scoreDocs[1].doc).get("_uid"), equalTo("1"));
+        assertThat(topDocs.scoreDocs[2].score, equalTo(3f));
+        assertThat(reader.document(topDocs.scoreDocs[2].doc).get("_uid"), equalTo("3"));
+        assertThat(topDocs.scoreDocs[3].score, equalTo(2f));
+        assertThat(reader.document(topDocs.scoreDocs[3].doc).get("_uid"), equalTo("2"));
+
+        // now test explain
+        Weight weight = searcher.createNormalizedWeight(query, true);
+        Explanation explanation = weight.explain(searcher.getIndexReader().leaves().get(0), 0);
+        assertThat(explanation.getDetails()[1].getDetails()[0].getDetails()[2].getDetails()[1].getDescription(),
+            containsString("query_function score as computed by this query: function score (*:*, functions: [{filter(test:named), " +
+                "function [org.elasticsearch.common.lucene.search.function.WeightFactorFunction"));
+
+    }
+
+    public void testQueryFunctionFunctionScore() throws IOException {
+        FunctionScoreQueryBuilder functionScoreQueryBuilder = getQueryFunctionQueryBuilder();
+        QueryShardContext context = getMockQueryShardContext();
+        Query query = functionScoreQueryBuilder.toQuery(context);
+        FunctionScoreQuery functionScoreQuery = new FunctionScoreQuery(new MatchAllDocsQuery(), new QueryFunction(query));
+        TopDocs topDocs = searcher.search(functionScoreQuery, 4);
+        assertThat(topDocs.scoreDocs[0].score, equalTo(5f));
+        assertThat(reader.document(topDocs.scoreDocs[0].doc).get("_uid"), equalTo("4"));
+        assertThat(topDocs.scoreDocs[1].score, equalTo(4f));
+        assertThat(reader.document(topDocs.scoreDocs[1].doc).get("_uid"), equalTo("1"));
+        assertThat(topDocs.scoreDocs[2].score, equalTo(3f));
+        assertThat(reader.document(topDocs.scoreDocs[2].doc).get("_uid"), equalTo("3"));
+        assertThat(topDocs.scoreDocs[3].score, equalTo(2f));
+        assertThat(reader.document(topDocs.scoreDocs[3].doc).get("_uid"), equalTo("2"));
+    }
+
+    public static FunctionScoreQueryBuilder getQueryFunctionQueryBuilder() {
+        FunctionScoreQueryBuilder.FilterFunctionBuilder[] filterFunctionBuilders = new FunctionScoreQueryBuilder.FilterFunctionBuilder[4];
+        String[] filterTerms = new String[]{"light", "relative", "named", "previous"};
+        for (int i = 0; i < 4; i++) {
+            FunctionScoreQueryBuilder functionScoreQueryBuilder = new FunctionScoreQueryBuilder(
+                new FunctionScoreQueryBuilder.FilterFunctionBuilder[]{
+                    new FunctionScoreQueryBuilder.FilterFunctionBuilder(new TermQueryBuilder(FIELD, filterTerms[i]),
+                        new WeightBuilder().setWeight(i + 2))});
+            filterFunctionBuilders[i] = new FunctionScoreQueryBuilder.FilterFunctionBuilder(new QueryFunctionBuilder
+                (functionScoreQueryBuilder));
+        }
+        return new FunctionScoreQueryBuilder(new MatchAllQueryBuilder(), filterFunctionBuilders);
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilderTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query.functionscore;
 
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.test.ESTestCase;
 
@@ -38,5 +39,6 @@ public class ScoreFunctionBuilderTests extends ESTestCase {
         expectThrows(IllegalArgumentException.class, () -> new ExponentialDecayFunctionBuilder(null, "", "", ""));
         expectThrows(IllegalArgumentException.class, () -> new ExponentialDecayFunctionBuilder("", "", null, ""));
         expectThrows(IllegalArgumentException.class, () -> new ExponentialDecayFunctionBuilder("", "", null, "", randomDouble()));
+        expectThrows(IllegalArgumentException.class, () -> new QueryFunctionBuilder((QueryBuilder) null));
     }
 }

--- a/docs/reference/query-dsl/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/function-score-query.asciidoc
@@ -415,6 +415,19 @@ Example:
     }
 --------------------------------------------------
 
+[[function-query]]
+==== Query function
+
+If the score for a function again should be computed by a different query, use the `query_function`:
+
+[source,js]
+--------------------------------------------------
+"query_function": {
+    "query": {
+          ARBITRARY QUERY
+    }
+}
+--------------------------------------------------
 
 ==== Detailed example
 

--- a/docs/reference/query-dsl/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/function-score-query.asciidoc
@@ -418,7 +418,7 @@ Example:
 [[function-query]]
 ==== Query function
 
-If the score for a function again should be computed by a different query, use the `query_function`:
+If the score for a function again should be computed by a different query, use the `query_score`:
 
 [source,js]
 --------------------------------------------------
@@ -426,6 +426,10 @@ If the score for a function again should be computed by a different query, use t
     ARBITRARY QUERY
 }
 --------------------------------------------------
+
+IMPORTANT: If the given query does not match the document then the score
+of this function will be 0. This will result in a score of 0 for the whole
+document if you use `"score_mode": "multiply"`.
 
 ==== Detailed example
 

--- a/docs/reference/query-dsl/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/function-score-query.asciidoc
@@ -422,10 +422,8 @@ If the score for a function again should be computed by a different query, use t
 
 [source,js]
 --------------------------------------------------
-"query_function": {
-    "query": {
-          ARBITRARY QUERY
-    }
+"query_score": {
+    ARBITRARY QUERY
 }
 --------------------------------------------------
 


### PR DESCRIPTION
Allows to combine query scores with mult, sum etc
by wrapping individual queries in a `query_function`
of a `function_score like` so:

[Edit, see discussion below]

```
{
  "query": {
    "function_score": {
      "score_mode": "multiply",
      "functions": [
        {
          "query": {
            "match": {
              "text": "cat"
            }
          }
        },
        {
          "query": {
            "match": {
              "text": "dog"
            }
          }
        }
      ],
      "boost_mode": "replace"
    }
  }
}
```

[Was initially: ]

```
{
  "query": {
    "function_score": {
      "score_mode": "multiply",
      "functions": [
        {
          "query_function": {
            "query": {
              "match": {
                "text": "cat"
 ...
```

relates to #17116
