### PR TITLE
Clean up RoutingNodes

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
@@ -38,7 +38,6 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
-import org.elasticsearch.cluster.routing.RoutingNodes.RoutingNodesIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
@@ -226,10 +225,8 @@ public class TransportClusterAllocationExplainAction
         // get the existing unassigned info if available
         UnassignedInfo ui = shard.unassignedInfo();
 
-        RoutingNodesIterator iter = routingNodes.nodes();
         Map<DiscoveryNode, Decision> nodeToDecision = new HashMap<>();
-        while (iter.hasNext()) {
-            RoutingNode node = iter.next();
+        for (RoutingNode node : routingNodes) {
             DiscoveryNode discoNode = node.node();
             if (discoNode.isDataNode()) {
                 Decision d = tryShardOnNode(shard, node, allocation, includeYesDecisions);

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -30,7 +30,7 @@ import org.elasticsearch.cluster.MasterNodeChangePredicate;
 import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
-import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingService;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -301,13 +301,11 @@ public class ShardStateAction extends AbstractComponent {
                 }
             }
 
-            RoutingNodes.RoutingNodeIterator routingNodeIterator =
-                currentState.getRoutingNodes().routingNodeIter(task.getShardRouting().currentNodeId());
-            if (routingNodeIterator != null) {
-                for (ShardRouting maybe : routingNodeIterator) {
-                    if (task.getShardRouting().isSameAllocation(maybe)) {
-                        return ValidationResult.VALID;
-                    }
+            RoutingNode routingNode = currentState.getRoutingNodes().node(task.getShardRouting().currentNodeId());
+            if (routingNode != null) {
+                ShardRouting maybe = routingNode.getByShardId(task.getShardRouting().shardId());
+                if (maybe != null && maybe.isSameAllocation(task.getShardRouting())) {
+                    return ValidationResult.VALID;
                 }
             }
             return ValidationResult.SHARD_MISSING;

--- a/core/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -486,10 +486,10 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
          * Adds a new shard routing (makes a copy of it), with reference data used from the index shard routing table
          * if it needs to be created.
          */
-        public Builder addShard(IndexShardRoutingTable refData, ShardRouting shard) {
+        public Builder addShard(ShardRouting shard) {
             IndexShardRoutingTable indexShard = shards.get(shard.id());
             if (indexShard == null) {
-                indexShard = new IndexShardRoutingTable.Builder(refData.shardId()).addShard(shard).build();
+                indexShard = new IndexShardRoutingTable.Builder(shard.shardId()).addShard(shard).build();
             } else {
                 indexShard = new IndexShardRoutingTable.Builder(indexShard).addShard(shard).build();
             }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
@@ -69,10 +69,6 @@ public class RoutingNode implements Iterable<ShardRouting> {
         return Collections.unmodifiableCollection(shards.values()).iterator();
     }
 
-    Iterator<ShardRouting> mutableIterator() {
-        return shards.values().iterator();
-    }
-
     /**
      * Returns the nodes {@link DiscoveryNode}.
      *
@@ -117,6 +113,11 @@ public class RoutingNode implements Iterable<ShardRouting> {
         }
         ShardRouting previousValue = shards.put(newShard.shardId(), newShard);
         assert previousValue == oldShard : "expected shard " + previousValue + " but was " + oldShard;
+    }
+
+    void remove(ShardRouting shard) {
+        ShardRouting previousValue = shards.remove(shard.shardId());
+        assert previousValue == shard : "expected shard " + previousValue + " but was " + shard;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -23,6 +23,7 @@ import com.carrotsearch.hppc.ObjectIntHashMap;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Randomness;
@@ -304,9 +305,9 @@ public class RoutingNodes implements Iterable<RoutingNode> {
     /**
      * Returns <code>true</code> iff all replicas are active for the given shard routing. Otherwise <code>false</code>
      */
-    public boolean allReplicasActive(ShardId shardId, int expectedAssignedShardsCount) {
+    public boolean allReplicasActive(ShardId shardId, MetaData metaData) {
         final List<ShardRouting> shards = assignedShards(shardId);
-        if (shards.isEmpty() || shards.size() < expectedAssignedShardsCount) {
+        if (shards.isEmpty() || shards.size() < metaData.getIndexSafe(shardId.getIndex()).getNumberOfReplicas() + 1) {
             return false; // if we are empty nothing is active if we have less than total at least one is unassigned
         }
         for (ShardRouting shard : shards) {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -404,9 +404,9 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
             }
         }
 
-        public Builder updateNodes(RoutingNodes routingNodes) {
+        public Builder updateNodes(long version, RoutingNodes routingNodes) {
             // this is being called without pre initializing the routing table, so we must copy over the version as well
-            this.version = routingNodes.routingTable().version();
+            this.version = version;
 
             Map<String, IndexRoutingTable.Builder> indexRoutingTableBuilders = new HashMap<>();
             for (RoutingNode routingNode : routingNodes) {
@@ -422,8 +422,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                         indexRoutingTableBuilders.put(index.getName(), indexBuilder);
                     }
 
-                    IndexShardRoutingTable refData = routingNodes.routingTable().index(shardRoutingEntry.index().getName()).shard(shardRoutingEntry.id());
-                    indexBuilder.addShard(refData, shardRoutingEntry);
+                    indexBuilder.addShard(shardRoutingEntry);
                 }
             }
 
@@ -436,8 +435,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                     indexBuilder = new IndexRoutingTable.Builder(index);
                     indexRoutingTableBuilders.put(index.getName(), indexBuilder);
                 }
-                IndexShardRoutingTable refData = routingNodes.routingTable().index(shardRoutingEntry.index().getName()).shard(shardRoutingEntry.id());
-                indexBuilder.addShard(refData, shardRoutingEntry);
+                indexBuilder.addShard(shardRoutingEntry);
             }
 
             for (IndexRoutingTable.Builder indexBuilder : indexRoutingTableBuilders.values()) {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -19,14 +19,12 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.health.ClusterStateHealth;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.AllocationId;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
@@ -47,6 +45,7 @@ import org.elasticsearch.index.shard.ShardId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -93,7 +92,7 @@ public class AllocationService extends AbstractComponent {
         // shuffle the unassigned nodes, just so we won't have things like poison failed shards
         routingNodes.unassigned().shuffle();
         StartedRerouteAllocation allocation = new StartedRerouteAllocation(allocationDeciders, routingNodes, clusterState, startedShards, clusterInfoService.getClusterInfo(), currentNanoTime());
-        boolean changed = applyStartedShards(routingNodes, startedShards);
+        boolean changed = applyStartedShards(allocation, startedShards);
         if (!changed) {
             return new RoutingAllocation.Result(false, clusterState.routingTable(), clusterState.metaData());
         }
@@ -114,7 +113,7 @@ public class AllocationService extends AbstractComponent {
         MetaData oldMetaData = allocation.metaData();
         RoutingTable oldRoutingTable = allocation.routingTable();
         RoutingNodes newRoutingNodes = allocation.routingNodes();
-        final RoutingTable newRoutingTable = new RoutingTable.Builder().updateNodes(newRoutingNodes).build();
+        final RoutingTable newRoutingTable = new RoutingTable.Builder().updateNodes(oldRoutingTable.version(), newRoutingNodes).build();
         MetaData newMetaData = updateMetaDataWithRoutingTable(oldMetaData, oldRoutingTable, newRoutingTable);
         assert newRoutingTable.validate(newMetaData); // validates the routing table is coherent with the cluster state metadata
         logClusterHealthStateChange(
@@ -339,9 +338,6 @@ public class AllocationService extends AbstractComponent {
         // first, clear from the shards any node id they used to belong to that is now dead
         changed |= deassociateDeadNodes(allocation);
 
-        // create a sorted list of from nodes with least number of shards to the maximum ones
-        applyNewNodes(allocation);
-
         // elect primaries *before* allocating unassigned, so backups of primaries that failed
         // will be moved to primary state and not wait for primaries to be allocated and recovered (*from gateway*)
         changed |= electPrimariesAndUnassignedDanglingReplicas(allocation);
@@ -372,7 +368,7 @@ public class AllocationService extends AbstractComponent {
             if (shardEntry.primary()) {
                 // remove dangling replicas that are initializing for primary shards
                 changed |= failReplicasForUnassignedPrimary(allocation, shardEntry);
-                ShardRouting candidate = allocation.routingNodes().activeReplica(shardEntry);
+                ShardRouting candidate = allocation.routingNodes().activeReplica(shardEntry.shardId());
                 if (candidate != null) {
                     shardEntry = unassignedIterator.demotePrimaryToReplicaShard();
                     ShardRouting primarySwappedCandidate = routingNodes.promoteAssignedReplicaShardToPrimary(candidate);
@@ -401,23 +397,9 @@ public class AllocationService extends AbstractComponent {
         return changed;
     }
 
-    /**
-     * Applies the new nodes to the routing nodes and returns them (just the
-     * new nodes);
-     */
-    private void applyNewNodes(RoutingAllocation allocation) {
-        final RoutingNodes routingNodes = allocation.routingNodes();
-        for (ObjectCursor<DiscoveryNode> cursor : allocation.nodes().getDataNodes().values()) {
-            DiscoveryNode node = cursor.value;
-            if (!routingNodes.isKnown(node)) {
-                routingNodes.addNode(node);
-            }
-        }
-    }
-
     private boolean deassociateDeadNodes(RoutingAllocation allocation) {
         boolean changed = false;
-        for (RoutingNodes.RoutingNodesIterator it = allocation.routingNodes().nodes(); it.hasNext(); ) {
+        for (Iterator<RoutingNode> it = allocation.routingNodes().mutableIterator(); it.hasNext(); ) {
             RoutingNode node = it.next();
             if (allocation.nodes().getDataNodes().containsKey(node.nodeId())) {
                 // its a live node, continue
@@ -441,7 +423,7 @@ public class AllocationService extends AbstractComponent {
 
     private boolean failReplicasForUnassignedPrimary(RoutingAllocation allocation, ShardRouting primary) {
         List<ShardRouting> replicas = new ArrayList<>();
-        for (ShardRouting routing : allocation.routingNodes().assignedShards(primary)) {
+        for (ShardRouting routing : allocation.routingNodes().assignedShards(primary.shardId())) {
             if (!routing.primary() && routing.initializing()) {
                 replicas.add(routing);
             }
@@ -455,18 +437,18 @@ public class AllocationService extends AbstractComponent {
         return changed;
     }
 
-    private boolean applyStartedShards(RoutingNodes routingNodes, Iterable<? extends ShardRouting> startedShardEntries) {
+    private boolean applyStartedShards(RoutingAllocation routingAllocation, Iterable<? extends ShardRouting> startedShardEntries) {
         boolean dirty = false;
         // apply shards might be called several times with the same shard, ignore it
+        RoutingNodes routingNodes = routingAllocation.routingNodes();
         for (ShardRouting startedShard : startedShardEntries) {
             assert startedShard.initializing();
 
             // validate index still exists. strictly speaking this is not needed but it gives clearer logs
-            if (routingNodes.routingTable().index(startedShard.index()) == null) {
+            if (routingAllocation.metaData().index(startedShard.index()) == null) {
                 logger.debug("{} ignoring shard started, unknown index (routing: {})", startedShard.shardId(), startedShard);
                 continue;
             }
-
 
             RoutingNode currentRoutingNode = routingNodes.node(startedShard.currentNodeId());
             if (currentRoutingNode == null) {
@@ -480,32 +462,25 @@ public class AllocationService extends AbstractComponent {
             } else if (matchingShard.isSameAllocation(startedShard) == false) {
                 logger.debug("{} failed to find shard with matching allocation id in order to start it [failed to find matching shard], ignoring (routing: {}, matched shard routing: {})", startedShard.shardId(), startedShard, matchingShard);
             } else {
-                if (matchingShard.active()) {
+                startedShard = matchingShard;
+                if (startedShard.active()) {
                     logger.trace("{} shard is already started, ignoring (routing: {})", startedShard.shardId(), startedShard);
                 } else {
+                    assert startedShard.initializing();
                     dirty = true;
-                    // override started shard with the latest copy.
-                    startedShard = matchingShard;
-                    routingNodes.started(matchingShard);
+                    routingNodes.started(startedShard);
                     logger.trace("{} marked shard as started (routing: {})", startedShard.shardId(), startedShard);
-                }
-            }
 
-            // startedShard is the current state of the shard (post relocation for example)
-            // this means that after relocation, the state will be started and the currentNodeId will be
-            // the node we relocated to
-            if (startedShard.relocatingNodeId() == null) {
-                continue;
-            }
-
-            RoutingNodes.RoutingNodeIterator sourceRoutingNode = routingNodes.routingNodeIter(startedShard.relocatingNodeId());
-            if (sourceRoutingNode != null) {
-                while (sourceRoutingNode.hasNext()) {
-                    ShardRouting shard = sourceRoutingNode.next();
-                    if (shard.isRelocationSourceOf(startedShard)) {
-                        dirty = true;
-                        sourceRoutingNode.remove();
-                        break;
+                    if (startedShard.relocatingNodeId() != null) {
+                        // relocation target has been started, remove relocation source
+                        RoutingNode relocationSourceNode = routingNodes.node(startedShard.relocatingNodeId());
+                        if (relocationSourceNode != null) {
+                            ShardRouting relocationSourceShard = relocationSourceNode.getByShardId(startedShard.shardId());
+                            if (relocationSourceShard != null && relocationSourceShard.isRelocationSourceOf(startedShard)) {
+                                dirty = true;
+                                routingNodes.remove(relocationSourceShard);
+                            }
+                        }
                     }
                 }
             }
@@ -525,35 +500,26 @@ public class AllocationService extends AbstractComponent {
         }
         RoutingNodes routingNodes = allocation.routingNodes();
 
-        RoutingNodes.RoutingNodeIterator matchedNode = routingNodes.routingNodeIter(failedShard.currentNodeId());
+        RoutingNode matchedNode = routingNodes.node(failedShard.currentNodeId());
         if (matchedNode == null) {
             logger.debug("{} ignoring shard failure, unknown node in {} ({})", failedShard.shardId(), failedShard, unassignedInfo.shortSummary());
             return false;
         }
 
-        boolean matchedShard = false;
-        while (matchedNode.hasNext()) {
-            ShardRouting routing = matchedNode.next();
-            if (routing.isSameAllocation(failedShard)) {
-                matchedShard = true;
-                logger.debug("{} failed shard {} found in routingNodes, failing it ({})", failedShard.shardId(), failedShard, unassignedInfo.shortSummary());
-                break;
-            }
-        }
-
-        if (matchedShard == false) {
+        ShardRouting matchedShard = matchedNode.getByShardId(failedShard.shardId());
+        if (matchedShard != null && matchedShard.isSameAllocation(failedShard)) {
+            logger.debug("{} failed shard {} found in routingNodes, failing it ({})", failedShard.shardId(), failedShard, unassignedInfo.shortSummary());
+            // replace incoming instance to make sure we work on the latest one
+            failedShard = matchedShard;
+        } else {
             logger.debug("{} ignoring shard failure, unknown allocation id in {} ({})", failedShard.shardId(), failedShard, unassignedInfo.shortSummary());
             return false;
         }
+
         if (failedShard.primary()) {
             // fail replicas first otherwise we move RoutingNodes into an inconsistent state
             failReplicasForUnassignedPrimary(allocation, failedShard);
         }
-        // replace incoming instance to make sure we work on the latest one
-        failedShard = matchedNode.current();
-
-        // remove the current copy of the shard
-        matchedNode.remove();
 
         if (addToIgnoreList) {
             // make sure we ignore this shard on the relevant node
@@ -567,48 +533,46 @@ public class AllocationService extends AbstractComponent {
             logger.trace("{} is a relocation target, resolving source to cancel relocation ({})", failedShard, unassignedInfo.shortSummary());
             RoutingNode relocatingFromNode = routingNodes.node(failedShard.relocatingNodeId());
             if (relocatingFromNode != null) {
-                for (ShardRouting shardRouting : relocatingFromNode) {
-                    if (shardRouting.isRelocationSourceOf(failedShard)) {
-                        logger.trace("{}, resolved source to [{}]. canceling relocation ... ({})", failedShard.shardId(), shardRouting, unassignedInfo.shortSummary());
-                        routingNodes.cancelRelocation(shardRouting);
-                        break;
-                    }
+                ShardRouting shardRouting = relocatingFromNode.getByShardId(failedShard.shardId());
+                if (shardRouting != null && shardRouting.isRelocationSourceOf(failedShard)) {
+                    logger.trace("{}, resolved source to [{}]. canceling relocation ... ({})", failedShard.shardId(), shardRouting, unassignedInfo.shortSummary());
+                    routingNodes.cancelRelocation(shardRouting);
                 }
             }
+
+            routingNodes.remove(failedShard);
         } else {
             // The fail shard is the main copy of the current shard routing.
-
-            boolean addAsUnassigned = true;
+            boolean moveToUnassigned = true;
             if (failedShard.relocatingNodeId() != null) {
                 // now, find the shard that is initializing on the target node
                 assert failedShard.relocating();
 
-                RoutingNodes.RoutingNodeIterator initializingNode = routingNodes.routingNodeIter(failedShard.relocatingNodeId());
-                if (initializingNode != null) {
-                    while (initializingNode.hasNext()) {
-                        ShardRouting shardRouting = initializingNode.next();
-                        if (shardRouting.isRelocationTargetOf(failedShard)) {
-                            if (failedShard.primary()) {
-                                logger.trace("{} is removed due to the failure of the source shard", shardRouting);
-                                // cancel and remove target shard
-                                initializingNode.remove();
-                            } else {
-                                logger.trace("{}, relocation source failed, mark as initializing without relocation source", shardRouting);
-                                // promote to initializing shard without relocation source and ensure that removed relocation source
-                                // is not added back as unassigned shard
-                                initializingNode.removeRelocationSource();
-                                addAsUnassigned = false;
-                            }
-                            break;
+                RoutingNode targetNode = routingNodes.node(failedShard.relocatingNodeId());
+                if (targetNode != null) {
+                    ShardRouting targetShard = targetNode.getByShardId(failedShard.shardId());
+                    if (targetShard != null && targetShard.isRelocationTargetOf(failedShard)) {
+                        if (failedShard.primary()) {
+                            logger.trace("{} is removed due to the failure of the source shard", targetShard);
+                            // cancel and remove target shard
+                            routingNodes.remove(targetShard);
+                        } else {
+                            logger.trace("{}, relocation source failed, mark as initializing without relocation source", targetShard);
+                            // promote to initializing shard without relocation source and ensure that removed relocation source
+                            // is not added back as unassigned shard
+                            routingNodes.removeRelocationSource(targetShard);
+                            moveToUnassigned = false;
                         }
                     }
                 }
             }
-            if (addAsUnassigned) {
-                matchedNode.moveToUnassigned(unassignedInfo);
+            if (moveToUnassigned) {
+                routingNodes.moveToUnassigned(failedShard, unassignedInfo);
+            } else {
+                routingNodes.remove(failedShard);
             }
         }
-        assert matchedNode.isRemoved() : "failedShard " + failedShard + " was matched but wasn't removed";
+        assert matchedNode.getByShardId(failedShard.shardId()) == null : "failedShard " + failedShard + " was matched but wasn't removed";
         return true;
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -120,6 +120,8 @@ public class RoutingAllocation {
 
     private final MetaData metaData;
 
+    private final RoutingTable routingTable;
+
     private final DiscoveryNodes nodes;
 
     private final ImmutableOpenMap<String, ClusterState.Custom> customs;
@@ -152,6 +154,7 @@ public class RoutingAllocation {
         this.deciders = deciders;
         this.routingNodes = routingNodes;
         this.metaData = clusterState.metaData();
+        this.routingTable = clusterState.routingTable();
         this.nodes = clusterState.nodes();
         this.customs = clusterState.customs();
         this.clusterInfo = clusterInfo;
@@ -177,7 +180,7 @@ public class RoutingAllocation {
      * @return current routing table
      */
     public RoutingTable routingTable() {
-        return routingNodes.routingTable();
+        return routingTable;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
@@ -167,7 +167,7 @@ public class AwarenessAllocationDecider extends AllocationDecider {
 
             // build the count of shards per attribute value
             ObjectIntHashMap<String> shardPerAttribute = new ObjectIntHashMap<>();
-            for (ShardRouting assignedShard : allocation.routingNodes().assignedShards(shardRouting)) {
+            for (ShardRouting assignedShard : allocation.routingNodes().assignedShards(shardRouting.shardId())) {
                 if (assignedShard.started() || assignedShard.initializing()) {
                     // Note: this also counts relocation targets as that will be the new location of the shard.
                     // Relocation sources should not be counted as the shard is moving away

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeVersionAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeVersionAllocationDecider.java
@@ -59,7 +59,7 @@ public class NodeVersionAllocationDecider extends AllocationDecider {
                 return isVersionCompatible(allocation.routingNodes(), shardRouting.currentNodeId(), node, allocation);
             }
         } else {
-            final ShardRouting primary = allocation.routingNodes().activePrimary(shardRouting);
+            final ShardRouting primary = allocation.routingNodes().activePrimary(shardRouting.shardId());
             // check that active primary has a newer version so that peer recovery works
             if (primary != null) {
                 return isVersionCompatible(allocation.routingNodes(), primary.currentNodeId(), node, allocation);

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RebalanceOnlyWhenActiveAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RebalanceOnlyWhenActiveAllocationDecider.java
@@ -40,7 +40,8 @@ public class RebalanceOnlyWhenActiveAllocationDecider extends AllocationDecider 
     public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
         // its ok to check for active here, since in relocation, a shard is split into two in routing
         // nodes, once relocating, and one initializing
-        if (!allocation.routingNodes().allReplicasActive(shardRouting)) {
+        int expectedAssignedShardsCount = allocation.routingTable().index(shardRouting.index().getName()).shard(shardRouting.id()).size();
+        if (!allocation.routingNodes().allReplicasActive(shardRouting.shardId(), expectedAssignedShardsCount)) {
             return allocation.decision(Decision.NO, NAME, "rebalancing can not occur if not all replicas are active in the cluster");
         }
         return allocation.decision(Decision.YES, NAME, "all replicas are active in the cluster, rebalancing can occur");

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RebalanceOnlyWhenActiveAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RebalanceOnlyWhenActiveAllocationDecider.java
@@ -38,10 +38,7 @@ public class RebalanceOnlyWhenActiveAllocationDecider extends AllocationDecider 
 
     @Override
     public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
-        // its ok to check for active here, since in relocation, a shard is split into two in routing
-        // nodes, once relocating, and one initializing
-        int expectedAssignedShardsCount = allocation.routingTable().index(shardRouting.index().getName()).shard(shardRouting.id()).size();
-        if (!allocation.routingNodes().allReplicasActive(shardRouting.shardId(), expectedAssignedShardsCount)) {
+        if (!allocation.routingNodes().allReplicasActive(shardRouting.shardId(), allocation.metaData())) {
             return allocation.decision(Decision.NO, NAME, "rebalancing can not occur if not all replicas are active in the cluster");
         }
         return allocation.decision(Decision.YES, NAME, "all replicas are active in the cluster, rebalancing can occur");

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ReplicaAfterPrimaryActiveAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ReplicaAfterPrimaryActiveAllocationDecider.java
@@ -47,7 +47,7 @@ public class ReplicaAfterPrimaryActiveAllocationDecider extends AllocationDecide
         if (shardRouting.primary()) {
             return allocation.decision(Decision.YES, NAME, "shard is primary and can be allocated");
         }
-        ShardRouting primary = allocation.routingNodes().activePrimary(shardRouting);
+        ShardRouting primary = allocation.routingNodes().activePrimary(shardRouting.shardId());
         if (primary == null) {
             return allocation.decision(Decision.NO, NAME, "primary shard for this replica is not yet active");
         }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
@@ -58,7 +58,7 @@ public class SameShardAllocationDecider extends AllocationDecider {
 
     @Override
     public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
-        Iterable<ShardRouting> assignedShards = allocation.routingNodes().assignedShards(shardRouting);
+        Iterable<ShardRouting> assignedShards = allocation.routingNodes().assignedShards(shardRouting.shardId());
         for (ShardRouting assignedShard : assignedShards) {
             if (node.nodeId().equals(assignedShard.currentNodeId())) {
                 return allocation.decision(Decision.NO, NAME,

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
@@ -170,8 +170,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
         }
         ClusterService clusterService = internalTestCluster.getInstance(ClusterService.class, internalTestCluster.getMasterName());
         ClusterState state = clusterService.state();
-        RoutingNodes routingNodes = state.getRoutingNodes();
-        for (ShardRouting shard : routingNodes.getRoutingTable().allShards()) {
+        for (ShardRouting shard : state.routingTable().allShards()) {
             String dataPath = info.getDataPath(shard);
             assertNotNull(dataPath);
 

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
@@ -260,7 +260,7 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
         for (ObjectCursor<IndexShardRoutingTable> indexShardRoutingTable :  original.shards().values()) {
             for (ShardRouting shardRouting : indexShardRoutingTable.value.shards()) {
                 final ShardRouting updatedShardRouting = randomChange(shardRouting, nodes);
-                builder.addShard(indexShardRoutingTable.value, updatedShardRouting);
+                builder.addShard(updatedShardRouting);
             }
         }
         return builder.build();

--- a/core/src/test/java/org/elasticsearch/cluster/ack/AckIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ack/AckIT.java
@@ -99,7 +99,7 @@ public class AckIT extends ESIntegTestCase {
 
         for (Client client : clients()) {
             ClusterState clusterState = getLocalClusterState(client);
-            for (ShardRouting shardRouting : clusterState.getRoutingNodes().routingNodeIter(moveAllocationCommand.fromNode())) {
+            for (ShardRouting shardRouting : clusterState.getRoutingNodes().node(moveAllocationCommand.fromNode())) {
                 //if the shard that we wanted to move is still on the same node, it must be relocating
                 if (shardRouting.shardId().equals(commandShard)) {
                     assertThat(shardRouting.relocating(), equalTo(true));
@@ -108,7 +108,7 @@ public class AckIT extends ESIntegTestCase {
             }
 
             boolean found = false;
-            for (ShardRouting shardRouting : clusterState.getRoutingNodes().routingNodeIter(moveAllocationCommand.toNode())) {
+            for (ShardRouting shardRouting : clusterState.getRoutingNodes().node(moveAllocationCommand.toNode())) {
                 if (shardRouting.shardId().equals(commandShard)) {
                     assertThat(shardRouting.state(), anyOf(equalTo(ShardRoutingState.INITIALIZING), equalTo(ShardRoutingState.STARTED)));
                     found = true;
@@ -150,7 +150,7 @@ public class AckIT extends ESIntegTestCase {
         //all nodes hold the same cluster state version. We only know there was no need to change anything, thus no need for ack on this update.
         ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().get();
         boolean found = false;
-        for (ShardRouting shardRouting : clusterStateResponse.getState().getRoutingNodes().routingNodeIter(moveAllocationCommand.fromNode())) {
+        for (ShardRouting shardRouting : clusterStateResponse.getState().getRoutingNodes().node(moveAllocationCommand.fromNode())) {
             //the shard that we wanted to move is still on the same node, as we had dryRun flag
             if (shardRouting.shardId().equals(commandShard)) {
                 assertThat(shardRouting.started(), equalTo(true));
@@ -160,7 +160,7 @@ public class AckIT extends ESIntegTestCase {
         }
         assertThat(found, equalTo(true));
 
-        for (ShardRouting shardRouting : clusterStateResponse.getState().getRoutingNodes().routingNodeIter(moveAllocationCommand.toNode())) {
+        for (ShardRouting shardRouting : clusterStateResponse.getState().getRoutingNodes().node(moveAllocationCommand.toNode())) {
             if (shardRouting.shardId().equals(commandShard)) {
                 fail("shard [" + shardRouting + "] shouldn't be on node [" + moveAllocationCommand.toString() + "]");
             }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/DelayedAllocationServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/DelayedAllocationServiceTests.java
@@ -156,7 +156,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
             .build();
         assertFalse("no shards should be unassigned", clusterState.getRoutingNodes().unassigned().size() > 0);
         String nodeId = null;
-        final List<ShardRouting> allShards = clusterState.getRoutingNodes().routingTable().allShards("test");
+        final List<ShardRouting> allShards = clusterState.getRoutingTable().allShards("test");
         // we need to find the node with the replica otherwise we will not reroute
         for (ShardRouting shardRouting : allShards) {
             if (shardRouting.primary() == false) {
@@ -254,7 +254,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
 
         // find replica of short_delay
         ShardRouting shortDelayReplica = null;
-        for (ShardRouting shardRouting : clusterState.getRoutingNodes().routingTable().allShards("short_delay")) {
+        for (ShardRouting shardRouting : clusterState.getRoutingTable().allShards("short_delay")) {
             if (shardRouting.primary() == false) {
                 shortDelayReplica = shardRouting;
                 break;
@@ -264,7 +264,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
 
         // find replica of long_delay
         ShardRouting longDelayReplica = null;
-        for (ShardRouting shardRouting : clusterState.getRoutingNodes().routingTable().allShards("long_delay")) {
+        for (ShardRouting shardRouting : clusterState.getRoutingTable().allShards("long_delay")) {
             if (shardRouting.primary() == false) {
                 longDelayReplica = shardRouting;
                 break;
@@ -413,7 +413,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
             .build();
         assertFalse("no shards should be unassigned", clusterState.getRoutingNodes().unassigned().size() > 0);
         String nodeIdOfFooReplica = null;
-        for (ShardRouting shardRouting : clusterState.getRoutingNodes().routingTable().allShards("foo")) {
+        for (ShardRouting shardRouting : clusterState.getRoutingTable().allShards("foo")) {
             if (shardRouting.primary() == false) {
                 nodeIdOfFooReplica = shardRouting.currentNodeId();
                 break;
@@ -456,7 +456,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
         } else {
             // node leaves with replica shard of index bar that has shorter delay
             String nodeIdOfBarReplica = null;
-            for (ShardRouting shardRouting : stateWithDelayedShard.getRoutingNodes().routingTable().allShards("bar")) {
+            for (ShardRouting shardRouting : stateWithDelayedShard.getRoutingTable().allShards("bar")) {
                 if (shardRouting.primary() == false) {
                     nodeIdOfBarReplica = shardRouting.currentNodeId();
                     break;

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ExpectedShardSizeAllocationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ExpectedShardSizeAllocationTests.java
@@ -85,7 +85,7 @@ public class ExpectedShardSizeAllocationTests extends ESAllocationTestCase {
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
 
         assertEquals(1, clusterState.getRoutingNodes().node("node1").numberOfShardsWithState(ShardRoutingState.INITIALIZING));
-        assertEquals(byteSize, clusterState.getRoutingNodes().getRoutingTable().shardsWithState(ShardRoutingState.INITIALIZING).get(0).getExpectedShardSize());
+        assertEquals(byteSize, clusterState.getRoutingTable().shardsWithState(ShardRoutingState.INITIALIZING).get(0).getExpectedShardSize());
         logger.info("Start the primary shard");
         RoutingNodes routingNodes = clusterState.getRoutingNodes();
         routingTable = strategy.applyStartedShards(clusterState, routingNodes.shardsWithState(INITIALIZING)).routingTable();
@@ -100,7 +100,7 @@ public class ExpectedShardSizeAllocationTests extends ESAllocationTestCase {
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
 
         assertEquals(1, clusterState.getRoutingNodes().node("node2").numberOfShardsWithState(ShardRoutingState.INITIALIZING));
-        assertEquals(byteSize, clusterState.getRoutingNodes().getRoutingTable().shardsWithState(ShardRoutingState.INITIALIZING).get(0).getExpectedShardSize());
+        assertEquals(byteSize, clusterState.getRoutingTable().shardsWithState(ShardRoutingState.INITIALIZING).get(0).getExpectedShardSize());
     }
 
     public void testExpectedSizeOnMove() {

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -418,7 +418,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
                     toId, routingNodes.node(toId).node().getVersion());
                 assertTrue(routingNodes.node(toId).node().getVersion().onOrAfter(routingNodes.node(fromId).node().getVersion()));
             } else {
-                ShardRouting primary = routingNodes.activePrimary(r);
+                ShardRouting primary = routingNodes.activePrimary(r.shardId());
                 assertThat(primary, notNullValue());
                 String fromId = primary.currentNodeId();
                 String toId = r.relocatingNodeId();
@@ -431,7 +431,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
         mutableShardRoutings = routingNodes.shardsWithState(ShardRoutingState.INITIALIZING);
         for (ShardRouting r : mutableShardRoutings) {
             if (!r.primary()) {
-                ShardRouting primary = routingNodes.activePrimary(r);
+                ShardRouting primary = routingNodes.activePrimary(r.shardId());
                 assertThat(primary, notNullValue());
                 String fromId = primary.currentNodeId();
                 String toId = r.currentNodeId();

--- a/core/src/test/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/core/src/test/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -285,7 +285,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         }
         assertThat(response.getStatus(), is(ClusterHealthStatus.RED));
         ClusterState state = client().admin().cluster().prepareState().get().getState();
-        GroupShardsIterator shardIterators = state.getRoutingNodes().getRoutingTable().activePrimaryShardsGrouped(new String[]{"test"}, false);
+        GroupShardsIterator shardIterators = state.getRoutingTable().activePrimaryShardsGrouped(new String[]{"test"}, false);
         for (ShardIterator iterator : shardIterators) {
             ShardRouting routing;
             while ((routing = iterator.nextOrNull()) != null) {
@@ -445,7 +445,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         // we are green so primaries got not corrupted.
         // ensure that no shard is actually allocated on the unlucky node
         ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().get();
-        for (IndexShardRoutingTable table : clusterStateResponse.getState().getRoutingNodes().getRoutingTable().index("test")) {
+        for (IndexShardRoutingTable table : clusterStateResponse.getState().getRoutingTable().index("test")) {
             for (ShardRouting routing : table) {
                 if (unluckyNode.getNode().getId().equals(routing.currentNodeId())) {
                     assertThat(routing.state(), not(equalTo(ShardRoutingState.STARTED)));
@@ -584,7 +584,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
 
     private int numShards(String... index) {
         ClusterState state = client().admin().cluster().prepareState().get().getState();
-        GroupShardsIterator shardIterators = state.getRoutingNodes().getRoutingTable().activePrimaryShardsGrouped(index, false);
+        GroupShardsIterator shardIterators = state.getRoutingTable().activePrimaryShardsGrouped(index, false);
         return shardIterators.size();
     }
 
@@ -612,7 +612,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
     private ShardRouting corruptRandomPrimaryFile(final boolean includePerCommitFiles) throws IOException {
         ClusterState state = client().admin().cluster().prepareState().get().getState();
         Index test = state.metaData().index("test").getIndex();
-        GroupShardsIterator shardIterators = state.getRoutingNodes().getRoutingTable().activePrimaryShardsGrouped(new String[]{"test"}, false);
+        GroupShardsIterator shardIterators = state.getRoutingTable().activePrimaryShardsGrouped(new String[]{"test"}, false);
         List<ShardIterator> iterators = iterableAsArrayList(shardIterators);
         ShardIterator shardIterator = RandomPicks.randomFrom(random(), iterators);
         ShardRouting shardRouting = shardIterator.nextOrNull();

--- a/core/src/test/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
+++ b/core/src/test/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
@@ -110,7 +110,7 @@ public class CorruptedTranslogIT extends ESIntegTestCase {
 
     private void corruptRandomTranslogFiles() throws IOException {
         ClusterState state = client().admin().cluster().prepareState().get().getState();
-        GroupShardsIterator shardIterators = state.getRoutingNodes().getRoutingTable().activePrimaryShardsGrouped(new String[]{"test"}, false);
+        GroupShardsIterator shardIterators = state.getRoutingTable().activePrimaryShardsGrouped(new String[]{"test"}, false);
         final Index test = state.metaData().index("test").getIndex();
         List<ShardIterator> iterators = iterableAsArrayList(shardIterators);
         ShardIterator shardIterator = RandomPicks.randomFrom(random(), iterators);


### PR DESCRIPTION
This PR contains a number of cleanups related to recent changes in RoutingNodes:
- PR #17821 (Immutable ShardRouting) changed RoutingNode to use a map indexed by ShardId to manage ShardRouting elements. This means that we can directly select the right ShardRouting without iterating over all elements. This lets us get rid of RoutingNodeIterator and all kind of iterations all over the place.
- Second cleanup is an extension of #18390 (Expose cluster state before reroute in RoutingAllocation instead of RoutingNodes). We should not reexpose RoutingTable in RoutingNodes and only use it in the constructor. This makes it clear that the RoutingTable is only used to construct the RoutingNodes and can diverge from it afterwards (only RoutingNodes is mutable).
- Remove AllocationService.applyNewNodes() (that is already done as part of construction of RoutingNodes)
