### PR TITLE
Never trip circuit breaker in liveness request

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/liveness/TransportLivenessAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/liveness/TransportLivenessAction.java
@@ -38,7 +38,8 @@ public final class TransportLivenessAction implements TransportRequestHandler<Li
                                    ClusterService clusterService, TransportService transportService) {
         this.clusterService = clusterService;
         this.clusterName = clusterName;
-        transportService.registerRequestHandler(NAME, LivenessRequest::new, ThreadPool.Names.SAME, this);
+        transportService.registerRequestHandler(NAME, LivenessRequest::new, ThreadPool.Names.SAME,
+            false, false /*can not trip circuit breaker*/, this);
     }
 
     @Override


### PR DESCRIPTION
We don't want transport clients to disconnect due to circuit breakers
preventing the liveness request from executing.

Relates to #17951

@danielmitterdorfer can you take a look I think it causes these [failures](https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+multijob-os-compatibility/os=fedora/494/console)
