### PR TITLE
Remove extra bin/ directory in bin folder

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -196,8 +196,8 @@ configure(subprojects.findAll { ['zip', 'tar', 'integ-test-zip'].contains(it.nam
       into('bin') {
         with copySpec {
           with binFiles
-          from('../src/main/resources') {
-            include 'bin/*.bat'
+          from('../src/main/resources/bin') {
+            include '*.bat'
             filter(FixCrLfFilter, eol: FixCrLfFilter.CrLf.newInstance('crlf'))
           }
           MavenFilteringHack.filter(it, expansions)


### PR DESCRIPTION
Recent changes adds an extra bin/ directory that contains Windows bat files in the normal Bin folder of elasticsearch. For exemple the script elasticsearch.bat is located in bin/bin/elasticsearch.bat instead of bin/elasticsearch.bat.
