### PR TITLE
Fix filtering of node ids for TransportNodesAction

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -176,12 +176,10 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
             this.request = request;
             this.listener = listener;
             ClusterState clusterState = clusterService.state();
-            String[] nodesIdCandidates = resolveNodes(request, clusterState);
-            nodesIds = filterNodeIds(clusterState.nodes(), nodesIdCandidates);
-            ImmutableOpenMap<String, DiscoveryNode> nodesCandidates = clusterState.nodes().getNodes();
+            nodesIds = filterNodeIds(clusterState.nodes(), resolveNodes(request, clusterState));
             this.nodes = new DiscoveryNode[nodesIds.length];
             for (int i = 0; i < nodesIds.length; i++) {
-                this.nodes[i] = nodesCandidates.get(nodesIds[i]);
+                this.nodes[i] = clusterState.nodes().getNodes().get(nodesIds[i]);
             }
             this.responses = new AtomicReferenceArray<>(this.nodesIds.length);
         }

--- a/core/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -179,7 +179,7 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
             nodesIds = filterNodeIds(clusterState.nodes(), resolveNodes(request, clusterState));
             this.nodes = new DiscoveryNode[nodesIds.length];
             for (int i = 0; i < nodesIds.length; i++) {
-                this.nodes[i] = clusterState.nodes().getNodes().get(nodesIds[i]);
+                this.nodes[i] = clusterState.nodes().get(nodesIds[i]);
             }
             this.responses = new AtomicReferenceArray<>(this.nodesIds.length);
         }

--- a/core/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -176,12 +176,12 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
             this.request = request;
             this.listener = listener;
             ClusterState clusterState = clusterService.state();
-            String[] nodesIds = resolveNodes(request, clusterState);
-            this.nodesIds = filterNodeIds(clusterState.nodes(), nodesIds);
-            ImmutableOpenMap<String, DiscoveryNode> nodes = clusterState.nodes().getNodes();
+            String[] nodesIdCandidates = resolveNodes(request, clusterState);
+            nodesIds = filterNodeIds(clusterState.nodes(), nodesIdCandidates);
+            ImmutableOpenMap<String, DiscoveryNode> nodesCandidates = clusterState.nodes().getNodes();
             this.nodes = new DiscoveryNode[nodesIds.length];
             for (int i = 0; i < nodesIds.length; i++) {
-                this.nodes[i] = nodes.get(nodesIds[i]);
+                this.nodes[i] = nodesCandidates.get(nodesIds[i]);
             }
             this.responses = new AtomicReferenceArray<>(this.nodesIds.length);
         }


### PR DESCRIPTION
Don't mix up member variables  with local variables
in constructor.

closes #18618
