### PR TITLE
Fix EC2 discovery settings

### DIFF
--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2ServiceImpl.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2ServiceImpl.java
@@ -117,15 +117,15 @@ public class AwsEc2ServiceImpl extends AbstractLifecycleComponent<AwsEc2Service>
 
         AWSCredentialsProvider credentials;
 
-        if (key == null && secret == null) {
+        if (key.isEmpty() && secret.isEmpty()) {
             credentials = new AWSCredentialsProviderChain(
-                    new EnvironmentVariableCredentialsProvider(),
-                    new SystemPropertiesCredentialsProvider(),
-                    new InstanceProfileCredentialsProvider()
+                new EnvironmentVariableCredentialsProvider(),
+                new SystemPropertiesCredentialsProvider(),
+                new InstanceProfileCredentialsProvider()
             );
         } else {
             credentials = new AWSCredentialsProviderChain(
-                    new StaticCredentialsProvider(new BasicAWSCredentials(key, secret))
+                new StaticCredentialsProvider(new BasicAWSCredentials(key, secret))
             );
         }
 


### PR DESCRIPTION
`cloud.aws.ec2.access_key` has fallback setting `cloud.aws.access_key`.

```
Setting<String> KEY_SETTING = new Setting<>("cloud.aws.ec2.access_key", AwsEc2Service.KEY_SETTING, Function.identity(),
            Property.NodeScope, Property.Filtered);
```

`cloud.aws.access_key`'s default value is empty string.

```
Setting<String> KEY_SETTING =
        Setting.simpleString("cloud.aws.access_key", Property.NodeScope, Property.Filtered);
```

```
public static Setting<String> simpleString(String key, Property... properties) {
        return new Setting<>(key, s -> "", Function.identity(), properties);
    }
```

Same for `cloud.aws.ec2.secret_key`

Closes #18652
