### PR TITLE
GeoBoundingBoxQueryBuilder should throw IAE when topLeft and bottomRight are the same coordinate

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/geo/GeoHashUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoHashUtils.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import org.apache.lucene.spatial.geopoint.document.GeoPointField;
+import org.apache.lucene.geo.Rectangle;
 import org.apache.lucene.util.BitUtil;
 
 /**
@@ -174,6 +175,26 @@ public class GeoHashUtils {
 
     private static char encode(int x, int y) {
         return BASE_32[((x & 1) + ((y & 1) * 2) + ((x & 2) * 2) + ((y & 2) * 4) + ((x & 4) * 4)) % 32];
+    }
+
+    /**
+     * Computes the bounding box coordinates from a given geohash
+     *
+     * @param geohash Geohash of the defined cell
+     * @return GeoRect rectangle defining the bounding box
+     */
+    public static Rectangle bbox(final String geohash) {
+        // bottom left is the coordinate
+        GeoPoint bottomLeft = GeoPoint.fromGeohash(geohash);
+        long ghLong = longEncode(geohash);
+        // shift away the level
+        ghLong >>>= 4;
+        // deinterleave and add 1 to lat and lon to get topRight
+        long lat = BitUtil.deinterleave(ghLong >>> 1) + 1;
+        long lon = BitUtil.deinterleave(ghLong) + 1;
+        GeoPoint topRight = GeoPoint.fromGeohash(BitUtil.interleave((int)lon, (int)lat) << 4 | geohash.length());
+
+        return new Rectangle(bottomLeft.lat(), topRight.lat(), bottomLeft.lon(), topRight.lon());
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.geo.Rectangle;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.spatial.geopoint.document.GeoPointField;
@@ -28,6 +29,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.geo.GeoHashUtils;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -155,7 +157,13 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
             if (top < bottom) {
                 throw new IllegalArgumentException("top is below bottom corner: " +
                             top + " vs. " + bottom);
-                }
+            } else if (top == bottom) {
+                throw new IllegalArgumentException("top cannot be the same as bottom: " +
+                    top + " == " + bottom);
+            } else if (left == right) {
+                throw new IllegalArgumentException("left cannot be the same as right: " +
+                    left + " == " + right);
+            }
 
                 // we do not check longitudes as the query generation code can deal with flipped left/right values
         }
@@ -172,6 +180,16 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
      * */
     public GeoBoundingBoxQueryBuilder setCorners(GeoPoint topLeft, GeoPoint bottomRight) {
         return setCorners(topLeft.getLat(), topLeft.getLon(), bottomRight.getLat(), bottomRight.getLon());
+    }
+
+    /**
+     * Adds points from a single geohash.
+     * @param geohash The geohash for computing the bounding box.
+     */
+    public GeoBoundingBoxQueryBuilder setCorners(final String geohash) {
+        // get the bounding box of the geohash and set topLeft and bottomRight
+        Rectangle ghBBox = GeoHashUtils.bbox(geohash);
+        return setCorners(new GeoPoint(ghBBox.maxLat, ghBBox.minLon), new GeoPoint(ghBBox.minLat, ghBBox.maxLon));
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/common/geo/GeoHashTests.java
+++ b/core/src/test/java/org/elasticsearch/common/geo/GeoHashTests.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.common.geo;
 
+import org.apache.lucene.geo.Rectangle;
 import org.elasticsearch.test.ESTestCase;
 
 /**
@@ -56,5 +57,17 @@ public class GeoHashTests extends ESTestCase {
                 }
             }
         }
+    }
+
+    public void testBboxFromHash() {
+        String hash = randomGeohash(1, 12);
+        int level = hash.length();
+        Rectangle bbox = GeoHashUtils.bbox(hash);
+        // check that the length is as expected
+        double expectedLonDiff = 360.0 / (Math.pow(8.0, (level + 1) / 2) * Math.pow(4.0, level / 2));
+        double expectedLatDiff = 180.0 / (Math.pow(4.0, (level + 1) / 2) * Math.pow(8.0, level / 2));
+        assertEquals(expectedLonDiff, bbox.maxLon - bbox.minLon, 0.00001);
+        assertEquals(expectedLatDiff, bbox.maxLat - bbox.minLat, 0.00001);
+        assertEquals(hash, GeoHashUtils.stringEncode(bbox.minLon, bbox.minLat, level));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
@@ -349,7 +349,7 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
 
         @Override
         public void fillIn(double coordinate, GeoBoundingBoxQueryBuilder qb) {
-            qb.setCorners(qb.topLeft().getLat(), qb.topLeft().getLon(), qb.topLeft().getLat(), coordinate);
+            qb.setCorners(qb.topLeft().getLat(), qb.topLeft().getLon(), qb.bottomRight().getLat(), coordinate);
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridIT.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.aggregations.bucket;
 import com.carrotsearch.hppc.ObjectIntHashMap;
 import com.carrotsearch.hppc.ObjectIntMap;
 import com.carrotsearch.hppc.cursors.ObjectIntCursor;
-
 import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -202,7 +201,7 @@ public class GeoHashGridIT extends ESIntegTestCase {
 
     public void testFiltered() throws Exception {
         GeoBoundingBoxQueryBuilder bbox = new GeoBoundingBoxQueryBuilder("location");
-        bbox.setCorners(smallestGeoHash, smallestGeoHash).queryName("bbox");
+        bbox.setCorners(smallestGeoHash).queryName("bbox");
         for (int precision = 1; precision <= PRECISION; precision++) {
             SearchResponse response = client().prepareSearch("idx")
                     .addAggregation(

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.test;
 
-import com.carrotsearch.randomizedtesting.generators.CodepointSetGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 
@@ -128,7 +127,6 @@ import static org.hamcrest.Matchers.not;
 
 public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>> extends ESTestCase {
 
-    private static final GeohashGenerator geohashGenerator = new GeohashGenerator();
     public static final String STRING_FIELD_NAME = "mapped_string";
     protected static final String STRING_FIELD_NAME_2 = "mapped_string_2";
     protected static final String INT_FIELD_NAME = "mapped_int";
@@ -683,18 +681,6 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
 
     protected String getRandomType() {
         return (serviceHolder.currentTypes.length == 0) ? MetaData.ALL : randomFrom(serviceHolder.currentTypes);
-    }
-
-    public static String randomGeohash(int minPrecision, int maxPrecision) {
-        return geohashGenerator.ofStringLength(random(), minPrecision, maxPrecision);
-    }
-
-    public static class GeohashGenerator extends CodepointSetGenerator {
-        private static final char[] ASCII_SET = "0123456789bcdefghjkmnpqrstuvwxyz".toCharArray();
-
-        public GeohashGenerator() {
-            super(ASCII_SET);
-        }
     }
 
     protected static Fuzziness randomFuzziness(String fieldName) {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -24,6 +24,7 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakLingering;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope.Scope;
 import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
+import com.carrotsearch.randomizedtesting.generators.CodepointSetGenerator;
 import com.carrotsearch.randomizedtesting.generators.RandomInts;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
@@ -661,6 +662,20 @@ public abstract class ESTestCase extends LuceneTestCase {
         }
         // Oh well, we didn't get enough unique things. It'll be ok.
         return things;
+    }
+
+    public static String randomGeohash(int minPrecision, int maxPrecision) {
+        return geohashGenerator.ofStringLength(random(), minPrecision, maxPrecision);
+    }
+
+    private static final GeohashGenerator geohashGenerator = new GeohashGenerator();
+
+    public static class GeohashGenerator extends CodepointSetGenerator {
+        private final static char[] ASCII_SET = "0123456789bcdefghjkmnpqrstuvwxyz".toCharArray();
+
+        public GeohashGenerator() {
+            super(ASCII_SET);
+        }
     }
 
     /**


### PR DESCRIPTION
Related to #18458, GeoBoundingBoxQueryBuilder should check if topLeft and bottomRight are the same coordinate. If not caught at the parse phase the lucene `GeoPointInBBoxQuery` will throw an exception at query time. This PR adds exception handling at parse time and updates integration tests accordingly.

closes #18631
