### PR TITLE
Rename boostrap.mlockall to bootstrap.memory_lock

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -45,7 +45,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Path;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
@@ -151,7 +150,7 @@ final class Bootstrap {
     private void setup(boolean addShutdownHook, Settings settings, Environment environment) throws Exception {
         initializeNatives(
                 environment.tmpFile(),
-                BootstrapSettings.MLOCKALL_SETTING.get(settings),
+                BootstrapSettings.MEMORY_LOCK_SETTING.get(settings),
                 BootstrapSettings.SECCOMP_SETTING.get(settings),
                 BootstrapSettings.CTRLHANDLER_SETTING.get(settings));
 

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
@@ -152,7 +152,7 @@ final class BootstrapCheck {
         final FileDescriptorCheck fileDescriptorCheck
             = Constants.MAC_OS_X ? new OsXFileDescriptorCheck() : new FileDescriptorCheck();
         checks.add(fileDescriptorCheck);
-        checks.add(new MlockallCheck(BootstrapSettings.MLOCKALL_SETTING.get(settings)));
+        checks.add(new MlockallCheck(BootstrapSettings.MEMORY_LOCK_SETTING.get(settings)));
         if (Constants.LINUX) {
             checks.add(new MaxNumberOfThreadsCheck());
         }

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapSettings.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapSettings.java
@@ -31,8 +31,8 @@ public final class BootstrapSettings {
     public static final Setting<Boolean> SECURITY_FILTER_BAD_DEFAULTS_SETTING =
             Setting.boolSetting("security.manager.filter_bad_defaults", true, Property.NodeScope);
 
-    public static final Setting<Boolean> MLOCKALL_SETTING =
-        Setting.boolSetting("bootstrap.mlockall", false, Property.NodeScope);
+    public static final Setting<Boolean> MEMORY_LOCK_SETTING =
+        Setting.boolSetting("bootstrap.memory_lock", false, Property.NodeScope);
     public static final Setting<Boolean> SECCOMP_SETTING =
         Setting.boolSetting("bootstrap.seccomp", true, Property.NodeScope);
     public static final Setting<Boolean> CTRLHANDLER_SETTING =

--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -81,7 +81,6 @@ import org.elasticsearch.monitor.jvm.JvmService;
 import org.elasticsearch.monitor.os.OsService;
 import org.elasticsearch.monitor.process.ProcessService;
 import org.elasticsearch.node.Node;
-import org.elasticsearch.node.internal.InternalSettingsPreparer;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.repositories.uri.URLRepository;
@@ -407,7 +406,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     PageCacheRecycler.TYPE_SETTING,
                     PluginsService.MANDATORY_SETTING,
                     BootstrapSettings.SECURITY_FILTER_BAD_DEFAULTS_SETTING,
-                    BootstrapSettings.MLOCKALL_SETTING,
+                    BootstrapSettings.MEMORY_LOCK_SETTING,
                     BootstrapSettings.SECCOMP_SETTING,
                     BootstrapSettings.CTRLHANDLER_SETTING,
                     BootstrapSettings.IGNORE_SYSTEM_BOOTSTRAP_CHECKS,

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapSettingsTests.java
@@ -26,7 +26,7 @@ public class BootstrapSettingsTests extends ESTestCase {
 
     public void testDefaultSettings() {
         assertTrue(BootstrapSettings.SECURITY_FILTER_BAD_DEFAULTS_SETTING.get(Settings.EMPTY));
-        assertFalse(BootstrapSettings.MLOCKALL_SETTING.get(Settings.EMPTY));
+        assertFalse(BootstrapSettings.MEMORY_LOCK_SETTING.get(Settings.EMPTY));
         assertTrue(BootstrapSettings.SECCOMP_SETTING.get(Settings.EMPTY));
         assertTrue(BootstrapSettings.CTRLHANDLER_SETTING.get(Settings.EMPTY));
     }

--- a/distribution/src/main/packaging/env/elasticsearch
+++ b/distribution/src/main/packaging/env/elasticsearch
@@ -53,7 +53,7 @@ ES_STARTUP_SLEEP_TIME=5
 #MAX_OPEN_FILES=65536
 
 # The maximum number of bytes of memory that may be locked into RAM
-# Set to "unlimited" if you use the 'bootstrap.mlockall: true' option
+# Set to "unlimited" if you use the 'bootstrap.memory_lock: true' option
 # in elasticsearch.yml.
 # When using Systemd, the LimitMEMLOCK property must be set
 # in /usr/lib/systemd/system/elasticsearch.service

--- a/distribution/src/main/packaging/systemd/elasticsearch.service
+++ b/distribution/src/main/packaging/systemd/elasticsearch.service
@@ -32,7 +32,7 @@ StandardError=inherit
 LimitNOFILE=65536
 
 # Specifies the maximum number of bytes of memory that may be locked into RAM
-# Set to "infinity" if you use the 'bootstrap.mlockall: true' option
+# Set to "infinity" if you use the 'bootstrap.memory_lock: true' option
 # in elasticsearch.yml and 'MAX_LOCKED_MEMORY=unlimited' in ${path.env}
 #LimitMEMLOCK=infinity
 

--- a/distribution/src/main/resources/config/elasticsearch.yml
+++ b/distribution/src/main/resources/config/elasticsearch.yml
@@ -40,7 +40,7 @@
 #
 # Lock the memory on startup:
 #
-# bootstrap.mlockall: true
+# bootstrap.memory_lock: true
 #
 # Make sure that the heap size is set to about half the memory available
 # on the system and that the owner of the process is allowed to use this

--- a/docs/reference/migration/migrate_5_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_5_0/settings.asciidoc
@@ -259,3 +259,8 @@ set `script.line: true` or `script.stored: true`.
 The setting `index.query.bool.max_clause_count` has been removed. In order to
 set the maximum number of boolean clauses `indices.query.bool.max_clause_count`
 should be used instead.
+
+==== Memory lock settings
+
+The setting `bootstrap.mlockall` has been renamed to
+`bootstrap.memory_lock`.

--- a/docs/reference/setup/bootstrap-checks.asciidoc
+++ b/docs/reference/setup/bootstrap-checks.asciidoc
@@ -34,7 +34,7 @@ If a JVM is started with unequal initial and max heap size, it can be
 prone to pauses as the JVM heap is resized during system usage. To avoid
 these resize pauses, it's best to start the JVM with the initial heap
 size equal to the maximum heap size. Additionally, if
-<<bootstrap.mlockall,`bootstrap.mlockall`>> is enabled, the JVM will
+<<bootstrap.memory_lock,`bootstrap.memory_lock`>> is enabled, the JVM will
 lock the initial size of the heap on startup. If the initial heap size
 is not equal to the maximum heap size, after a resize it will not be the
 case that all of the JVM heap is locked in memory. To pass the heap size
@@ -62,11 +62,11 @@ Elasticsearch would much rather use to service requests. There are
 several ways to configure a system to disallow swapping. One way is by
 requesting the JVM to lock the heap in memory through `mlockall` (Unix)
 or virtual lock (Windows). This is done via the Elasticsearch setting
-<<bootstrap.mlockall,`bootstrap.mlockall`>>. However, there are cases
+<<bootstrap.memory_lock,`bootstrap.memory_lock`>>. However, there are cases
 where this setting can be passed to Elasticsearch but Elasticsearch is
 not able to lock the heap (e.g., if the `elasticsearch` user does not
 have `memlock unlimited`). The memory lock check verifies that *if* the
-`bootstrap.mlockall` setting is enabled, that the JVM was successfully
+`bootstrap.memory_lock` setting is enabled, that the JVM was successfully
 able to lock the heap. To pass the memory lock check, you might have to
 configure <<mlockall,`mlockall`>>.
 

--- a/docs/reference/setup/important-settings.asciidoc
+++ b/docs/reference/setup/important-settings.asciidoc
@@ -8,7 +8,7 @@ configured before going into production.
 * <<path-settings,`path.data` and `path.logs`>>
 * <<cluster.name,`cluster.name`>>
 * <<node.name,`node.name`>>
-* <<bootstrap.mlockall,`bootstrap.mlockall`>>
+* <<bootstrap.memory_lock,`bootstrap.memory_lock`>>
 * <<network.host,`network.host`>>
 * <<unicast.hosts,`discovery.zen.ping.unicast.hosts`>>
 * <<minimum_master_nodes,`discovery.zen.minimum_master_nodes`>>
@@ -90,12 +90,12 @@ node.name: ${HOSTNAME}
 --------------------------------------------------
 
 [float]
-[[bootstrap.mlockall]]
-=== `bootstrap.mlockall`
+[[bootstrap.memory_lock]]
+=== `bootstrap.memory_lock`
 
 It is vitally important to the health of your node that none of the JVM is
 ever swapped out to disk.  One way of achieving that is set the
-`bootstrap.mlockall` setting to `true`.
+`bootstrap.memory_lock` setting to `true`.
 
 For this setting to have effect, other system settings need to be configured
 first. See <<mlockall>> for more details about how to set up memory locking

--- a/docs/reference/setup/install/sysconfig-file.asciidoc
+++ b/docs/reference/setup/install/sysconfig-file.asciidoc
@@ -18,7 +18,7 @@
 `MAX_LOCKED_MEMORY`::
 
     Maximum locked memory size. Set to `unlimited if you use the
-    `bootstrap.mlockall` option in elasticsearch.yml.
+    `bootstrap.memory_lock` option in elasticsearch.yml.
 
 `MAX_MAP_COUNT`::
 

--- a/docs/reference/setup/sysconfig/swap.asciidoc
+++ b/docs/reference/setup/sysconfig/swap.asciidoc
@@ -13,7 +13,7 @@ disconnect from the cluster.
 There are three approaches to disabling swapping:
 
 [[mlockall]]
-==== Enable `bootstrap.mlockall`
+==== Enable `bootstrap.memory_lock`
 
 The first option is to use
 http://opengroup.org/onlinepubs/007908799/xsh/mlockall.html[mlockall] on Linux/Unix systems, or https://msdn.microsoft.com/en-us/library/windows/desktop/aa366895%28v=vs.85%29.aspx[VirtualLock] on Windows, to
@@ -23,7 +23,7 @@ to the `config/elasticsearch.yml` file:
 
 [source,yaml]
 --------------
-bootstrap.mlockall: true
+bootstrap.memory_lock: true
 --------------
 
 WARNING: `mlockall` might cause the JVM or shell session to exit if it tries


### PR DESCRIPTION
The setting bootstrap.mlockall is useful on both POSIX-like systems
(POSIX mlockall) and Windows (Win32 VirtualLock). But mlockall is really
a POSIX only thing so the name should not be tied POSIX. This commit
renames the setting to "bootstrap.memory_lock".
