### PR TITLE
Throw IllegalStateException when handshake fails due to version or cluster mismatch

### DIFF
--- a/core/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -353,7 +353,7 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
                     }
                 }).txGet();
         } catch (Exception e) {
-            throw new ConnectTransportException(node, "handshake failed", e);
+            throw new IllegalStateException("handshake failed with " + node, e);
         }
 
         if (checkClusterName && !Objects.equals(clusterName, response.clusterName)) {

--- a/core/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -316,8 +316,8 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
      * @param checkClusterName whether or not to ignore cluster name
      *                         mismatches
      * @return the connected node
-     * @throws ConnectTransportException if the connection or the
-     *                                   handshake failed
+     * @throws ConnectTransportException if the connection failed
+     * @throws IllegalStateException if the handshake failed
      */
     public DiscoveryNode connectToNodeLightAndHandshake(
             final DiscoveryNode node,
@@ -329,7 +329,7 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
         transport.connectToNodeLight(node);
         try {
             return handshake(node, handshakeTimeout, checkClusterName);
-        } catch (ConnectTransportException e) {
+        } catch (ConnectTransportException | IllegalStateException e) {
             transport.disconnectFromNode(node);
             throw e;
         }
@@ -357,9 +357,9 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
         }
 
         if (checkClusterName && !Objects.equals(clusterName, response.clusterName)) {
-            throw new ConnectTransportException(node, "handshake failed, mismatched cluster name [" + response.clusterName + "]");
+            throw new IllegalStateException("handshake failed, mismatched cluster name [" + response.clusterName + "] - " + node);
         } else if (!isVersionCompatible(response.version)) {
-            throw new ConnectTransportException(node, "handshake failed, incompatible version [" + response.version + "]");
+            throw new IllegalStateException("handshake failed, incompatible version [" + response.version + "] - " + node);
         }
 
         return response.discoveryNode;


### PR DESCRIPTION
We do throw ConnectTransportException which is logged in trace level hiding a potentially
important information  when an old or wrong node wants to connect. We should throw ISE and
log as warn.
