### PR TITLE
Register "cloud.node.auto_attributes" setting in EC2 discovery plugin

### DIFF
--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/plugin/discovery/ec2/Ec2DiscoveryPlugin.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/plugin/discovery/ec2/Ec2DiscoveryPlugin.java
@@ -135,6 +135,9 @@ public class Ec2DiscoveryPlugin extends Plugin {
         settingsModule.registerSetting(AwsEc2Service.DISCOVERY_EC2.AVAILABILITY_ZONES_SETTING);
         settingsModule.registerSetting(AwsEc2Service.DISCOVERY_EC2.NODE_CACHE_TIME_SETTING);
         settingsModule.registerSetting(AwsEc2Service.DISCOVERY_EC2.TAG_SETTING);
+
+        // Register cloud node settings: cloud.node
+        settingsModule.registerSetting(AwsEc2Service.AUTO_ATTRIBUTE_SETTING);
     }
 
     /**


### PR DESCRIPTION
I'm unable to set "cloud.node.auto_attributes" setting. I get this

```
java.lang.IllegalArgumentException: unknown setting [cloud.node.auto_attributes]
```
