### PR TITLE
Display plugins versions

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/ListPluginsCommand.java
+++ b/core/src/main/java/org/elasticsearch/plugins/ListPluginsCommand.java
@@ -60,8 +60,8 @@ class ListPluginsCommand extends SettingCommand {
         }
         Collections.sort(plugins);
         for (final Path plugin : plugins) {
-            terminal.println(plugin.getFileName().toString());
             PluginInfo info = PluginInfo.readFromProperties(env.pluginsFile().resolve(plugin.toAbsolutePath()));
+            terminal.println(plugin.getFileName().toString() + "@" + info.getVersion());
             terminal.println(Terminal.Verbosity.VERBOSE, info.toString());
         }
     }


### PR DESCRIPTION
This is useful to determine if a plugin needs to be updated when using deployment automation solution (like Ansible).

A similar feature is now available in Kibana: https://github.com/elastic/kibana/pull/7221
