### PR TITLE
Use JAVA_HOME or java.exe in PATH like the Linux scripts do

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-plugin.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin.bat
@@ -2,16 +2,18 @@
 
 SETLOCAL enabledelayedexpansion
 
-if NOT DEFINED JAVA_HOME IF EXIST %ProgramData%\Oracle\java\javapath\java.exe (
-    for /f "tokens=2 delims=[]" %%a in ('dir %ProgramData%\Oracle\java\javapath\java.exe') do @set JAVA_EXE=%%a
+IF DEFINED JAVA_HOME (
+  set JAVA=%JAVA_HOME%\bin\java.exe
+) ELSE (
+  FOR %%I IN (java.exe) DO set JAVA=%%~$PATH:I
 )
-if DEFINED JAVA_EXE set JAVA_HOME=%JAVA_EXE:\bin\java.exe=%
-if DEFINED JAVA_EXE (
-    ECHO Using JAVA_HOME=%JAVA_HOME% retrieved from %ProgramData%\Oracle\java\javapath\java.exe
-)
-set JAVA_EXE=
-if NOT DEFINED JAVA_HOME goto err
+IF EXIST "%JAVA%" GOTO cont
 
+:err
+ECHO Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME 1>&2
+EXIT /B 1
+
+:cont
 set SCRIPT_DIR=%~dp0
 for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
 
@@ -56,15 +58,6 @@ GOTO loop
 
 SET HOSTNAME=%COMPUTERNAME%
 
-"%JAVA_HOME%\bin\java" %ES_JAVA_OPTS% -Des.path.home="%ES_HOME%" !properties! -cp "%ES_HOME%/lib/*;" "org.elasticsearch.plugins.PluginCli" !args!
-goto finally
-
-
-:err
-echo JAVA_HOME environment variable must be set!
-pause
-
-
-:finally
+"%JAVA%" %ES_JAVA_OPTS% -Des.path.home="%ES_HOME%" !properties! -cp "%ES_HOME%/lib/*;" "org.elasticsearch.plugins.PluginCli" !args!
 
 ENDLOCAL

--- a/distribution/src/main/resources/bin/elasticsearch-plugin.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin.bat
@@ -9,7 +9,6 @@ IF DEFINED JAVA_HOME (
 )
 IF EXIST "%JAVA%" GOTO cont
 
-:err
 ECHO Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME 1>&2
 EXIT /B 1
 

--- a/distribution/src/main/resources/bin/elasticsearch-plugin.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin.bat
@@ -2,6 +2,13 @@
 
 SETLOCAL enabledelayedexpansion
 
+if NOT DEFINED JAVA_HOME IF EXIST %ProgramData%\Oracle\java\javapath\java.exe (
+    for /f "tokens=2 delims=[]" %%a in ('dir %ProgramData%\Oracle\java\javapath\java.exe') do @set JAVA_EXE=%%a
+)
+if DEFINED JAVA_EXE set JAVA_HOME=%JAVA_EXE:\bin\java.exe=%
+if DEFINED JAVA_EXE (
+    ECHO Using JAVA_HOME=%JAVA_HOME% retrieved from %ProgramData%\Oracle\java\javapath\java.exe
+)
 if NOT DEFINED JAVA_HOME goto err
 
 set SCRIPT_DIR=%~dp0

--- a/distribution/src/main/resources/bin/elasticsearch-plugin.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin.bat
@@ -9,6 +9,7 @@ if DEFINED JAVA_EXE set JAVA_HOME=%JAVA_EXE:\bin\java.exe=%
 if DEFINED JAVA_EXE (
     ECHO Using JAVA_HOME=%JAVA_HOME% retrieved from %ProgramData%\Oracle\java\javapath\java.exe
 )
+set JAVA_EXE=
 if NOT DEFINED JAVA_HOME goto err
 
 set SCRIPT_DIR=%~dp0

--- a/distribution/src/main/resources/bin/elasticsearch-plugin.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin.bat
@@ -7,12 +7,11 @@ IF DEFINED JAVA_HOME (
 ) ELSE (
   FOR %%I IN (java.exe) DO set JAVA=%%~$PATH:I
 )
-IF EXIST "%JAVA%" GOTO cont
+IF NOT EXIST "%JAVA%" (
+  ECHO Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME 1>&2
+  EXIT /B 1
+)
 
-ECHO Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME 1>&2
-EXIT /B 1
-
-:cont
 set SCRIPT_DIR=%~dp0
 for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
 

--- a/distribution/src/main/resources/bin/elasticsearch.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.bat
@@ -35,14 +35,14 @@ FOR /F "usebackq tokens=1* delims= " %%A IN (!params!) DO (
     SET current=%%A
     SET params='%%B'
 	SET silent=N
-	
+
 	IF "!current!" == "-s" (
 		SET silent=Y
 	)
 	IF "!current!" == "--silent" (
 		SET silent=Y
-	)	
-	
+	)
+
 	IF "!silent!" == "Y" (
 		SET nopauseonerror=Y
 	) ELSE (
@@ -52,7 +52,7 @@ FOR /F "usebackq tokens=1* delims= " %%A IN (!params!) DO (
             SET newparams=!current!
         )
 	)
-	
+
     IF "x!params!" NEQ "x" (
 		GOTO loop
 	)
@@ -79,6 +79,6 @@ IF ERRORLEVEL 1 (
 	EXIT /B %ERRORLEVEL%
 )
 
-"%JAVA_HOME%\bin\java" %ES_JAVA_OPTS% %ES_PARAMS% -cp "%ES_CLASSPATH%" "org.elasticsearch.bootstrap.Elasticsearch" !newparams!
+"%JAVA%" %ES_JAVA_OPTS% %ES_PARAMS% -cp "%ES_CLASSPATH%" "org.elasticsearch.bootstrap.Elasticsearch" !newparams!
 
 ENDLOCAL

--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -1,5 +1,12 @@
 @echo off
 
+if NOT DEFINED JAVA_HOME IF EXIST %ProgramData%\Oracle\java\javapath\java.exe (
+    for /f "tokens=2 delims=[]" %%a in ('dir %ProgramData%\Oracle\java\javapath\java.exe') do @set JAVA_EXE=%%a
+)
+if DEFINED JAVA_EXE set JAVA_HOME=%JAVA_EXE:\bin\java.exe=%
+if DEFINED JAVA_EXE (
+    ECHO Using JAVA_HOME=%JAVA_HOME% retrieved from %ProgramData%\Oracle\java\javapath\java.exe
+)
 if DEFINED JAVA_HOME goto cont
 
 :err

--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -7,6 +7,7 @@ if DEFINED JAVA_EXE set JAVA_HOME=%JAVA_EXE:\bin\java.exe=%
 if DEFINED JAVA_EXE (
     ECHO Using JAVA_HOME=%JAVA_HOME% retrieved from %ProgramData%\Oracle\java\javapath\java.exe
 )
+set JAVA_EXE=
 if DEFINED JAVA_HOME goto cont
 
 :err

--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -1,17 +1,14 @@
 @echo off
 
-if NOT DEFINED JAVA_HOME IF EXIST %ProgramData%\Oracle\java\javapath\java.exe (
-    for /f "tokens=2 delims=[]" %%a in ('dir %ProgramData%\Oracle\java\javapath\java.exe') do @set JAVA_EXE=%%a
+IF DEFINED JAVA_HOME (
+  set JAVA=%JAVA_HOME%\bin\java.exe
+) ELSE (
+  FOR %%I IN (java.exe) DO set JAVA=%%~$PATH:I
 )
-if DEFINED JAVA_EXE set JAVA_HOME=%JAVA_EXE:\bin\java.exe=%
-if DEFINED JAVA_EXE (
-    ECHO Using JAVA_HOME=%JAVA_HOME% retrieved from %ProgramData%\Oracle\java\javapath\java.exe
-)
-set JAVA_EXE=
-if DEFINED JAVA_HOME goto cont
+IF EXIST "%JAVA%" GOTO cont
 
 :err
-ECHO JAVA_HOME environment variable must be set! 1>&2
+ECHO Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME 1>&2
 EXIT /B 1
 
 :cont

--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -5,12 +5,11 @@ IF DEFINED JAVA_HOME (
 ) ELSE (
   FOR %%I IN (java.exe) DO set JAVA=%%~$PATH:I
 )
-IF EXIST "%JAVA%" GOTO cont
+IF NOT EXIST "%JAVA%" (
+  ECHO Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME 1>&2
+  EXIT /B 1
+)
 
-ECHO Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME 1>&2
-EXIT /B 1
-
-:cont
 set SCRIPT_DIR=%~dp0
 for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
 

--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -7,7 +7,6 @@ IF DEFINED JAVA_HOME (
 )
 IF EXIST "%JAVA%" GOTO cont
 
-:err
 ECHO Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME 1>&2
 EXIT /B 1
 

--- a/distribution/src/main/resources/bin/service.bat
+++ b/distribution/src/main/resources/bin/service.bat
@@ -28,6 +28,13 @@ if %bad_env_var% == 1 (
 )
 rem end TODO: remove for Elasticsearch 6.x
 
+if NOT DEFINED JAVA_HOME IF EXIST %ProgramData%\Oracle\java\javapath\java.exe (
+    for /f "tokens=2 delims=[]" %%a in ('dir %ProgramData%\Oracle\java\javapath\java.exe') do @set JAVA_EXE=%%a
+)
+if DEFINED JAVA_EXE set JAVA_HOME=%JAVA_EXE:\bin\java.exe=%
+if DEFINED JAVA_EXE (
+    ECHO Using JAVA_HOME=%JAVA_HOME% retrieved from %ProgramData%\Oracle\java\javapath\java.exe
+)
 if NOT DEFINED JAVA_HOME goto err
 
 if not "%CONF_FILE%" == "" goto conffileset

--- a/distribution/src/main/resources/bin/service.bat
+++ b/distribution/src/main/resources/bin/service.bat
@@ -35,6 +35,7 @@ if DEFINED JAVA_EXE set JAVA_HOME=%JAVA_EXE:\bin\java.exe=%
 if DEFINED JAVA_EXE (
     ECHO Using JAVA_HOME=%JAVA_HOME% retrieved from %ProgramData%\Oracle\java\javapath\java.exe
 )
+set JAVA_EXE=
 if NOT DEFINED JAVA_HOME goto err
 
 if not "%CONF_FILE%" == "" goto conffileset

--- a/distribution/src/main/resources/bin/service.bat
+++ b/distribution/src/main/resources/bin/service.bat
@@ -40,7 +40,7 @@ IF NOT EXIST "%JAVA%" (
 IF DEFINED JAVA_HOME GOTO :cont
 
 IF NOT "%JAVA:~-13%" == "\bin\java.exe" (
-  FOR /f "tokens=2 delims=[]" %%I IN ('dir %ProgramData%\Oracle\java\javapath\java.exe') DO @set JAVA=%%I
+  FOR /f "tokens=2 delims=[]" %%I IN ('dir %JAVA%') DO @set JAVA=%%I
 )
 IF "%JAVA:~-13%" == "\bin\java.exe" (
   SET JAVA_HOME=%JAVA:~0,-13%


### PR DESCRIPTION
I've enhanced the Windows batch scripts to retrieve the JAVA_HOME environment from the symlink installed by Oracle's Java. See also the PR elastic/logstash#4913 in logstash repo.
