### PR TITLE
Plugins: Add status bar on download

### DIFF
--- a/core/src/main/java/org/elasticsearch/cli/Terminal.java
+++ b/core/src/main/java/org/elasticsearch/cli/Terminal.java
@@ -19,14 +19,14 @@
 
 package org.elasticsearch.cli;
 
+import org.elasticsearch.common.SuppressForbidden;
+
 import java.io.BufferedReader;
 import java.io.Console;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
-
-import org.elasticsearch.common.SuppressForbidden;
 
 /**
  * A Terminal wraps access to reading input and writing output for a cli.
@@ -81,8 +81,13 @@ public abstract class Terminal {
 
     /** Prints a line to the terminal at {@code verbosity} level. */
     public final void println(Verbosity verbosity, String msg) {
+        print(verbosity, msg + lineSeparator);
+    }
+
+    /** Prints message to the terminal at {@code verbosity} level, without a newline. */
+    public final void print(Verbosity verbosity, String msg) {
         if (this.verbosity.ordinal() >= verbosity.ordinal()) {
-            getWriter().print(msg + lineSeparator);
+            getWriter().print(msg);
             getWriter().flush();
         }
     }

--- a/core/src/main/java/org/elasticsearch/plugins/PluginCli.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginCli.java
@@ -26,8 +26,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.internal.InternalSettingsPreparer;
 
-import java.util.Collections;
-
 /**
  * A cli tool for adding, removing and listing plugins for elasticsearch.
  */

--- a/core/src/main/java/org/elasticsearch/plugins/ProgressInputStream.java
+++ b/core/src/main/java/org/elasticsearch/plugins/ProgressInputStream.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * An input stream that allows to add a listener to monitor progress
+ * The listener is triggered whenever a full percent is increased
+ * The listener is never triggered twice on the same percentage
+ * The listener will always return 99 percent, if the expectedTotalSize is exceeded, until it is finished
+ *
+ * Only used by the InstallPluginCommand, thus package private here
+ */
+abstract class ProgressInputStream extends FilterInputStream {
+
+    private final int expectedTotalSize;
+    private int currentPercent;
+    private int count = 0;
+
+    public ProgressInputStream(InputStream is, int expectedTotalSize) {
+        super(is);
+        this.expectedTotalSize = expectedTotalSize;
+        this.currentPercent = 0;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int read = in.read();
+        checkProgress(read == -1 ? -1 : 1);
+        return read;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        int byteCount = super.read(b, off, len);
+        checkProgress(byteCount);
+        return byteCount;
+    }
+
+    @Override
+    public int read(byte b[]) throws IOException {
+        return read(b, 0, b.length);
+    }
+
+    void checkProgress(int byteCount) {
+        // are we done?
+        if (byteCount == -1) {
+            currentPercent = 100;
+            onProgress(currentPercent);
+        } else {
+            count += byteCount;
+            // rounding up to 100% would mean we say we are done, before we are...
+            // this also catches issues, when expectedTotalSize was guessed wrong
+            int percent = Math.min(99, (int) Math.floor(100.0*count/expectedTotalSize));
+            if (percent > currentPercent) {
+                currentPercent = percent;
+                onProgress(percent);
+            }
+        }
+    }
+
+    public void onProgress(int percent) {}
+}

--- a/core/src/test/java/org/elasticsearch/plugins/ProgressInputStreamTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/ProgressInputStreamTests.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+
+public class ProgressInputStreamTests extends ESTestCase {
+
+    private List<Integer> progresses = new ArrayList<>();
+
+    public void testThatProgressListenerIsCalled() throws Exception {
+        ProgressInputStream is = newProgressInputStream(0);
+        is.checkProgress(-1);
+
+        assertThat(progresses, hasSize(1));
+        assertThat(progresses, hasItems(100));
+    }
+
+    public void testThatProgressListenerIsCalledOnUnexpectedCompletion() throws Exception {
+        ProgressInputStream is = newProgressInputStream(2);
+        is.checkProgress(-1);
+        assertThat(progresses, hasItems(100));
+    }
+
+    public void testThatProgressListenerReturnsMaxValueOnWrongExpectedSize() throws Exception {
+        ProgressInputStream is = newProgressInputStream(2);
+
+        is.checkProgress(1);
+        assertThat(progresses, hasItems(50));
+
+        is.checkProgress(3);
+        assertThat(progresses, hasItems(50, 99));
+
+        is.checkProgress(-1);
+        assertThat(progresses, hasItems(50, 99, 100));
+    }
+
+    public void testOneByte() throws Exception {
+        ProgressInputStream is = newProgressInputStream(1);
+        is.checkProgress(1);
+        is.checkProgress(-1);
+
+        assertThat(progresses, hasItems(99, 100));
+
+    }
+
+    public void testOddBytes() throws Exception {
+        int odd = (randomIntBetween(100, 200) / 2) + 1;
+        ProgressInputStream is = newProgressInputStream(odd);
+        for (int i = 0; i < odd; i++) {
+            is.checkProgress(1);
+        }
+        is.checkProgress(-1);
+
+        assertThat(progresses, hasSize(odd+1));
+        assertThat(progresses, hasItem(100));
+    }
+
+    public void testEvenBytes() throws Exception {
+        int even = (randomIntBetween(100, 200) / 2);
+        ProgressInputStream is = newProgressInputStream(even);
+
+        for (int i = 0; i < even; i++) {
+            is.checkProgress(1);
+        }
+        is.checkProgress(-1);
+
+        assertThat(progresses, hasSize(even+1));
+        assertThat(progresses, hasItem(100));
+    }
+
+    public void testOnProgressCannotBeCalledMoreThanOncePerPercent() throws Exception {
+        int count = randomIntBetween(150, 300);
+        ProgressInputStream is = newProgressInputStream(count);
+
+        for (int i = 0; i < count; i++) {
+            is.checkProgress(1);
+        }
+        is.checkProgress(-1);
+
+        assertThat(progresses, hasSize(100));
+    }
+
+    private ProgressInputStream newProgressInputStream(int expectedSize) {
+        return new ProgressInputStream(null, expectedSize) {
+            @Override
+            public void onProgress(int percent) {
+                progresses.add(percent);
+            }
+        };
+    }
+}

--- a/docs/plugins/plugin-script.asciidoc
+++ b/docs/plugins/plugin-script.asciidoc
@@ -51,7 +51,7 @@ sudo bin/elasticsearch-plugin install analysis-icu
 -----------------------------------
 
 This command will install the version of the plugin that matches your
-Elasticsearch version.
+Elasticsearch version and also show a progress bar while downloading.
 
 [float]
 === Custom URL or file system
@@ -117,8 +117,8 @@ The `plugin` scripts supports a number of other command line parameters:
 === Silent/Verbose mode
 
 The `--verbose` parameter outputs more debug information, while the `--silent`
-parameter turns off all output.  The script may return the following exit
-codes:
+parameter turns off all output including the progress bar. The script may
+return the following exit codes:
 
 [horizontal]
 `0`:: everything was OK

--- a/qa/evil-tests/build.gradle
+++ b/qa/evil-tests/build.gradle
@@ -26,7 +26,7 @@
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile 'com.google.jimfs:jimfs:1.0'
+  testCompile 'com.google.jimfs:jimfs:1.1'
 }
 
 // TODO: give each evil test its own fresh JVM for more isolation.


### PR DESCRIPTION
As some plugins are becoming biggish now, it is hard for the user to know, if the plugin
is being downloaded or just nothing happens. I also had some cases running on a VM where I did not know if the networking was broken or still downloading, while testing.

This commit adds a progress bar during download, which can be disabled by using the `-q`
parameter - it is pretty much unstyled right now, but at least shows an indicator that things are happening.

In addition this updates to jimfs 1.1, which allows us to test the batch mode, as adding
security policies are now supported due to having jimfs:// protocol support in URL stream
handlers.

TODO: Update docs
TODO: Test on windows (only tested under osx/linux so far)

This is how it looks like right now

![Video demo](https://files.slack.com/files-pri/T0CUZ52US-F1DH7FLUR/output3.gif?pub_secret=a70887fc29)
