### PR TITLE
Refactor matrix agg documentation from modules to main agg section

### DIFF
--- a/docs/reference/aggregations.asciidoc
+++ b/docs/reference/aggregations.asciidoc
@@ -23,6 +23,11 @@ it is often easier to break them into three main families:
 <<search-aggregations-metrics, _Metric_>>::
 				Aggregations that keep track and compute metrics over a set of documents.
 
+<<search-aggregations-matrix, _Matrix_>>::
+                A family of aggregations that operate on multiple fields and produce a matrix result based on the
+                values extracted from the requested document fields. Unlike metric and bucket aggregations, this
+                aggregation family does not yet support scripting.
+
 <<search-aggregations-pipeline, _Pipeline_>>::
 				Aggregations that aggregate the output of other aggregations and their associated metrics
 
@@ -99,5 +104,7 @@ include::aggregations/metrics.asciidoc[]
 include::aggregations/bucket.asciidoc[]
 
 include::aggregations/pipeline.asciidoc[]
+
+include::aggregations/matrix.asciidoc[]
 
 include::aggregations/misc.asciidoc[]

--- a/docs/reference/aggregations/matrix.asciidoc
+++ b/docs/reference/aggregations/matrix.asciidoc
@@ -1,4 +1,4 @@
-[[modules-aggregations-matrix]]
+[[search-aggregations-matrix]]
 == Matrix Aggregations
 
 experimental[]
@@ -6,4 +6,4 @@ experimental[]
 The aggregations in this family operate on multiple fields and produce a matrix result based on the values extracted from
 the requested document fields. Unlike metric and bucket aggregations, this aggregation family does not yet support scripting.
 
-include::aggregations/matrix/stats.asciidoc[]
+include::matrix/stats-aggregation.asciidoc[]

--- a/docs/reference/aggregations/matrix/stats-aggregation.asciidoc
+++ b/docs/reference/aggregations/matrix/stats-aggregation.asciidoc
@@ -1,4 +1,4 @@
-[[modules-matrix-aggregations-stats]]
+[[search-aggregations-matrix-stats-aggregation]]
 === Matrix Stats
 
 The `matrix_stats` aggregation is a numeric aggregation that computes the following statistics over a set of document fields:

--- a/docs/reference/modules.asciidoc
+++ b/docs/reference/modules.asciidoc
@@ -18,10 +18,6 @@ These settings can be dynamically updated on a live cluster with the
 
 The modules in this section are:
 
-<<modules-aggregations-matrix,Matrix Aggregations>>::
-
-    A family of aggregations that operate on multiple document fields and produce a matrix as output.
-
 <<modules-cluster,Cluster-level routing and shard allocation>>::
 
     Settings to control where, when, and how shards are allocated to nodes.
@@ -83,8 +79,6 @@ The modules in this section are:
     client across them.
 --
 
-
-include::modules/aggregations-matrix.asciidoc[]
 
 include::modules/cluster.asciidoc[]
 


### PR DESCRIPTION
Since Matrix aggregations are a module, the documentation was initially placed under the `Modules` documentation section. This PR refactors the documentation to the main `Aggregations` section, as requested.
