### PR TITLE
Throw exception if using a closed transport client

### DIFF
--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -211,7 +211,15 @@ public class TransportClientNodesService extends AbstractComponent {
     }
 
     public <Response> void execute(NodeListenerCallback<Response> callback, ActionListener<Response> listener) {
-        List<DiscoveryNode> nodes = this.nodes;
+        // we first read nodes before checking the closed state; this
+        // is because otherwise we could be subject to a race where we
+        // read the state as not being closed, and then the client is
+        // closed and the nodes list is cleared, and then a
+        // NoNodeAvailableException is thrown
+        // it is important that the order of first setting the state of
+        // closed and then clearing the list of nodes is maintained in
+        // the close method
+        final List<DiscoveryNode> nodes = this.nodes;
         if (closed) {
             throw new IllegalStateException("transport client is closed");
         }

--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -211,7 +211,13 @@ public class TransportClientNodesService extends AbstractComponent {
     }
 
     public <Response> void execute(NodeListenerCallback<Response> callback, ActionListener<Response> listener) {
-        List<DiscoveryNode> nodes = this.nodes;
+        List<DiscoveryNode> nodes;
+        synchronized (mutex) {
+            if (closed) {
+                throw new IllegalStateException("transport client is closed");
+            }
+            nodes = this.nodes;
+        }
         ensureNodesAreAvailable(nodes);
         int index = getNodeNumber();
         RetryListener<Response> retryListener = new RetryListener<>(callback, listener, nodes, index);

--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -211,12 +211,9 @@ public class TransportClientNodesService extends AbstractComponent {
     }
 
     public <Response> void execute(NodeListenerCallback<Response> callback, ActionListener<Response> listener) {
-        List<DiscoveryNode> nodes;
-        synchronized (mutex) {
-            if (closed) {
-                throw new IllegalStateException("transport client is closed");
-            }
-            nodes = this.nodes;
+        List<DiscoveryNode> nodes = this.nodes;
+        if (closed) {
+            throw new IllegalStateException("transport client is closed");
         }
         ensureNodesAreAvailable(nodes);
         int index = getNodeNumber();

--- a/core/src/test/java/org/elasticsearch/client/transport/TransportClientTests.java
+++ b/core/src/test/java/org/elasticsearch/client/transport/TransportClientTests.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.transport;
+
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.object.HasToString.hasToString;
+
+public class TransportClientTests extends ESTestCase {
+
+    public void testThatUsingAClosedClientThrowsAnException() throws ExecutionException, InterruptedException {
+        final TransportClient client = TransportClient.builder().settings(Settings.EMPTY).build();
+        client.close();
+        final IllegalStateException e =
+            expectThrows(IllegalStateException.class, () -> client.admin().cluster().health(new ClusterHealthRequest()).get());
+        assertThat(e, hasToString(containsString("transport client is closed")));
+    }
+
+}


### PR DESCRIPTION
Today when attempting to use a closed transport client, an exception
saying that no nodes are available is thrown. This is because when a
transport client is closed, its internal list of nodes is cleared. But
this exception is puzzling and can be made clearer. This commit changes
the behavior so that attempting to execute a request using a closed
transport client throws an illegal state exception.

Closes #18708
