### PR TITLE
Move naming conventions check into buildSrc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,6 +160,7 @@ subprojects {
     them as external dependencies so the build plugin that we use can be used
     to build elasticsearch plugins outside of the elasticsearch source tree. */
   ext.projectSubstitutions = [
+    "org.elasticsearch.gradle:build-tools:${version}": ':build-tools',
     "org.elasticsearch:rest-api-spec:${version}": ':rest-api-spec',
     "org.elasticsearch:elasticsearch:${version}": ':core',
     "org.elasticsearch.test:framework:${version}": ':test:framework',

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -103,6 +103,7 @@ if (project == rootProject) {
       url "https://oss.sonatype.org/content/repositories/snapshots/"
     }
   }
+  test.exclude 'org/elasticsearch/test/NamingConventionsCheckBadClasses*'
 }
 
 /*****************************************************************************
@@ -122,8 +123,8 @@ if (project != rootProject) {
   // build-tools is not ready for primetime with these...
   dependencyLicenses.enabled = false
   forbiddenApisMain.enabled = false
+  forbiddenApisTest.enabled = false
   jarHell.enabled = false
-  loggerUsageCheck.enabled = false
   thirdPartyAudit.enabled = false
 
   // test for elasticsearch.build tries to run with ES...
@@ -136,5 +137,10 @@ if (project != rootProject) {
     exclude '**/*.wav'
     // the file that actually defines nocommit
     exclude '**/ForbiddenPatternsTask.groovy'
+  }
+
+  namingConventions {
+    testClass = 'org.elasticsearch.test.NamingConventionsCheckBadClasses$UnitTestCase'
+    integTestClass = 'org.elasticsearch.test.NamingConventionsCheckBadClasses$IntegTestCase'
   }
 }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/NamingConventionsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/NamingConventionsTask.groovy
@@ -21,6 +21,7 @@ package org.elasticsearch.gradle.precommit
 
 import org.elasticsearch.gradle.LoggedExec
 import org.elasticsearch.gradle.VersionProperties
+import org.gradle.api.artifacts.Dependency
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
@@ -57,8 +58,27 @@ public class NamingConventionsTask extends LoggedExec {
     @Input
     boolean skipIntegTestInDisguise = false
 
+    /**
+     * Superclass for all tests.
+     */
+    @Input
+    String testClass = 'org.apache.lucene.util.LuceneTestCase'
+
+    /**
+     * Superclass for all integration tests.
+     */
+    @Input
+    String integTestClass = 'org.elasticsearch.test.ESIntegTestCase'
+
     public NamingConventionsTask() {
-        dependsOn(classpath)
+        // Extra classpath contains the actual test
+        project.configurations.create('namingConventions')
+        Dependency buildToolsDep = project.dependencies.add('namingConventions',
+                "org.elasticsearch.gradle:build-tools:${VersionProperties.elasticsearch}")
+        buildToolsDep.transitive = false // We don't need gradle in the classpath. It conflicts.
+        FileCollection extraClasspath = project.configurations.namingConventions
+        dependsOn(extraClasspath)
+
         description = "Runs NamingConventionsCheck on ${classpath}"
         executable = new File(project.javaHome, 'bin/java')
         onlyIf { project.sourceSets.test.output.classesDir.exists() }
@@ -69,7 +89,8 @@ public class NamingConventionsTask extends LoggedExec {
         project.afterEvaluate {
             doFirst {
                 args('-Djna.nosys=true')
-                args('-cp', classpath.asPath, 'org.elasticsearch.test.NamingConventionsCheck')
+                args('-cp', (classpath + extraClasspath).asPath, 'org.elasticsearch.test.NamingConventionsCheck')
+                args(testClass, integTestClass)
                 if (skipIntegTestInDisguise) {
                     args('--skip-integ-tests-in-disguise')
                 }
@@ -79,7 +100,7 @@ public class NamingConventionsTask extends LoggedExec {
                  * process of ignoring them lets us validate that they were found so this ignore parameter acts
                  * as the test for the NamingConventionsCheck.
                  */
-                if (':test:framework'.equals(project.path)) {
+                if (':build-tools'.equals(project.path)) {
                     args('--self-test')
                 }
                 args('--', project.sourceSets.test.output.classesDir.absolutePath)

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
@@ -34,7 +34,6 @@ class PrecommitTasks {
             configureForbiddenApis(project),
             configureCheckstyle(project),
             configureNamingConventions(project),
-            configureLoggerUsage(project),
             project.tasks.create('forbiddenPatterns', ForbiddenPatternsTask.class),
             project.tasks.create('licenseHeaders', LicenseHeadersTask.class),
             project.tasks.create('jarHell', JarHellTask.class),
@@ -49,6 +48,20 @@ class PrecommitTasks {
             UpdateShasTask updateShas = project.tasks.create('updateShas', UpdateShasTask.class)
             updateShas.parentTask = dependencyLicenses
         }
+        if (project.path != ':build-tools') {
+            /*
+             * Sadly, build-tools can't have logger-usage-check because that
+             * would create a circular project dependency between build-tools
+             * (which provides NamingConventionsCheck) and :test:logger-usage
+             * which provides the logger usage check. Since the build tools
+             * don't use the logger usage check because they don't have any
+             * of Elaticsearch's loggers and :test:logger-usage actually does
+             * use the NamingConventionsCheck we break the circular dependency
+             * here.
+             */
+            precommitTasks.add(configureLoggerUsage(project))
+        }
+
 
         Map<String, Object> precommitOptions = [
             name: 'precommit',

--- a/buildSrc/src/test/java/org/elasticsearch/test/NamingConventionsCheckBadClasses.java
+++ b/buildSrc/src/test/java/org/elasticsearch/test/NamingConventionsCheckBadClasses.java
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.test.test;
-
-import org.elasticsearch.test.ESTestCase;
+package org.elasticsearch.test;
 
 import junit.framework.TestCase;
 
@@ -30,21 +28,35 @@ public class NamingConventionsCheckBadClasses {
     public static final class NotImplementingTests {
     }
 
-    public static final class WrongName extends ESTestCase {
+    public static final class WrongName extends UnitTestCase {
+        /*
+         * Dummy test so the tests pass. We do this *and* skip the tests so anyone who jumps back to a branch without these tests can still
+         * compile without a failure. That is because clean doesn't actually clean these....
+         */
+        public void testDummy() {}
     }
 
-    public static abstract class DummyAbstractTests extends ESTestCase {
+    public static abstract class DummyAbstractTests extends UnitTestCase {
     }
 
     public interface DummyInterfaceTests {
     }
 
-    public static final class InnerTests extends ESTestCase {
+    public static final class InnerTests extends UnitTestCase {
+        public void testDummy() {}
     }
 
-    public static final class WrongNameTheSecond extends ESTestCase {
+    public static final class WrongNameTheSecond extends UnitTestCase {
+        public void testDummy() {}
     }
 
     public static final class PlainUnit extends TestCase {
+        public void testDummy() {}
+    }
+
+    public abstract static class UnitTestCase extends TestCase {
+    }
+
+    public abstract static class IntegTestCase extends UnitTestCase {
     }
 }


### PR DESCRIPTION
This will let things that don't depend on :test:framework like the client use it.
