### PR TITLE
Index creation does not cause the cluster health to go RED

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -770,7 +770,6 @@
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]cluster[/\\]allocation[/\\]ShardsAllocatorModuleIT.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]cluster[/\\]allocation[/\\]SimpleAllocationIT.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]cluster[/\\]health[/\\]ClusterIndexHealthTests.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]cluster[/\\]health[/\\]ClusterStateHealthTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]cluster[/\\]metadata[/\\]AutoExpandReplicasTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]cluster[/\\]metadata[/\\]DateMathExpressionResolverTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]cluster[/\\]metadata[/\\]HumanReadableIndexSettingsTests.java" checks="LineLength" />

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
@@ -101,9 +101,7 @@ public class TransportIndicesShardStoresAction extends TransportMasterNodeReadAc
             }
             for (IndexShardRoutingTable routing : indexShardRoutingTables) {
                 final int shardId = routing.shardId().id();
-                ClusterShardHealth shardHealth = new ClusterShardHealth(shardId,
-                                                                        routing,
-                                                                        indexMetaData.activeAllocationIds(shardId).isEmpty());
+                ClusterShardHealth shardHealth = new ClusterShardHealth(shardId, routing, indexMetaData);
                 if (request.shardStatuses().contains(shardHealth.getStatus())) {
                     shardIdsToFetch.add(routing.shardId());
                 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.health.ClusterShardHealth;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -93,12 +94,16 @@ public class TransportIndicesShardStoresAction extends TransportMasterNodeReadAc
         logger.trace("using cluster state version [{}] to determine shards", state.version());
         // collect relevant shard ids of the requested indices for fetching store infos
         for (String index : concreteIndices) {
+            IndexMetaData indexMetaData = state.metaData().index(index);
             IndexRoutingTable indexShardRoutingTables = routingTables.index(index);
             if (indexShardRoutingTables == null) {
                 continue;
             }
             for (IndexShardRoutingTable routing : indexShardRoutingTables) {
-                ClusterShardHealth shardHealth = new ClusterShardHealth(routing.shardId().id(), routing);
+                final int shardId = routing.shardId().id();
+                ClusterShardHealth shardHealth = new ClusterShardHealth(shardId,
+                                                                        routing,
+                                                                        indexMetaData.activeAllocationIds(shardId).isEmpty());
                 if (request.shardStatuses().contains(shardHealth.getStatus())) {
                     shardIdsToFetch.add(routing.shardId());
                 }

--- a/core/src/main/java/org/elasticsearch/cluster/health/ClusterIndexHealth.java
+++ b/core/src/main/java/org/elasticsearch/cluster/health/ClusterIndexHealth.java
@@ -54,7 +54,7 @@ public final class ClusterIndexHealth implements Iterable<ClusterShardHealth>, W
 
         for (IndexShardRoutingTable shardRoutingTable : indexRoutingTable) {
             int shardId = shardRoutingTable.shardId().id();
-            shards.put(shardId, new ClusterShardHealth(shardId, shardRoutingTable));
+            shards.put(shardId, new ClusterShardHealth(shardId, shardRoutingTable, indexMetaData.activeAllocationIds(shardId).isEmpty()));
         }
 
         // update the index status

--- a/core/src/main/java/org/elasticsearch/cluster/health/ClusterIndexHealth.java
+++ b/core/src/main/java/org/elasticsearch/cluster/health/ClusterIndexHealth.java
@@ -54,7 +54,7 @@ public final class ClusterIndexHealth implements Iterable<ClusterShardHealth>, W
 
         for (IndexShardRoutingTable shardRoutingTable : indexRoutingTable) {
             int shardId = shardRoutingTable.shardId().id();
-            shards.put(shardId, new ClusterShardHealth(shardId, shardRoutingTable, indexMetaData.activeAllocationIds(shardId).isEmpty()));
+            shards.put(shardId, new ClusterShardHealth(shardId, shardRoutingTable, indexMetaData));
         }
 
         // update the index status

--- a/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -21,8 +21,8 @@ package org.elasticsearch.cluster.routing;
 
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -37,6 +37,8 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Locale;
+import java.util.Objects;
 
 /**
  * Holds additional information as to why the shard is in unassigned state.
@@ -106,7 +108,94 @@ public final class UnassignedInfo implements ToXContent, Writeable {
         /**
          * Unassigned as a result of a failed primary while the replica was initializing.
          */
-        PRIMARY_FAILED;
+        PRIMARY_FAILED
+    }
+
+    /**
+     * Captures the status of an unsuccessful allocation attempt for the shard,
+     * causing it to remain in the unassigned state.
+     *
+     * Note, ordering of the enum is important, make sure to add new values
+     * at the end and handle version serialization properly.
+     */
+    public enum AllocationStatus implements Writeable {
+        /**
+         * The shard was denied allocation to a node because the allocation deciders all returned a NO decision
+         */
+        DECIDERS_NO((byte) 0),
+        /**
+         * The shard was denied allocation to a node because there were no valid shard copies found for it;
+         * this can happen on node restart with gateway allocation
+         */
+        NO_VALID_SHARD_COPY((byte) 1),
+        /**
+         * The allocation attempt was throttled on the shard by the allocation deciders
+         */
+        DECIDERS_THROTTLED((byte) 2),
+        /**
+         * Waiting on getting shard data from all nodes before making a decision about where to allocate the shard
+         */
+        FETCHING_SHARD_DATA((byte) 3),
+        /**
+         * Allocation decision has been delayed
+         */
+        DELAYED_ALLOCATION((byte) 4),
+        /**
+         * No allocation attempt has been made yet
+         */
+        NO_ATTEMPT((byte) 5);
+
+        private final byte id;
+
+        AllocationStatus(byte id) {
+            this.id = id;
+        }
+
+        // package private for testing
+        byte getId() {
+            return id;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeByte(id);
+        }
+
+        public static AllocationStatus readFrom(StreamInput in) throws IOException {
+            byte id = in.readByte();
+            switch (id) {
+                case 0:
+                    return DECIDERS_NO;
+                case 1:
+                    return NO_VALID_SHARD_COPY;
+                case 2:
+                    return DECIDERS_THROTTLED;
+                case 3:
+                    return FETCHING_SHARD_DATA;
+                case 4:
+                    return DELAYED_ALLOCATION;
+                case 5:
+                    return NO_ATTEMPT;
+                default:
+                    throw new IllegalArgumentException("Unknown AllocationStatus value [" + id + "]");
+            }
+        }
+
+        public static AllocationStatus fromDecision(Decision decision) {
+            Objects.requireNonNull(decision);
+            switch (decision.type()) {
+                case NO:
+                    return DECIDERS_NO;
+                case THROTTLE:
+                    return DECIDERS_THROTTLED;
+                default:
+                    throw new IllegalArgumentException("no allocation attempt from decision[" + decision.type() + "]");
+            }
+        }
+
+        public String value() {
+            return toString().toLowerCase(Locale.ROOT);
+        }
     }
 
     private final Reason reason;
@@ -116,6 +205,7 @@ public final class UnassignedInfo implements ToXContent, Writeable {
     private final String message;
     private final Throwable failure;
     private final int failedAllocations;
+    private final AllocationStatus lastAllocationStatus; // result of the last allocation attempt for this shard
 
     /**
      * creates an UnassignedInfo object based on **current** time
@@ -124,7 +214,8 @@ public final class UnassignedInfo implements ToXContent, Writeable {
      * @param message more information about cause.
      **/
     public UnassignedInfo(Reason reason, String message) {
-        this(reason, message, null, reason == Reason.ALLOCATION_FAILED ? 1 : 0, System.nanoTime(), System.currentTimeMillis(), false);
+        this(reason, message, null, reason == Reason.ALLOCATION_FAILED ? 1 : 0, System.nanoTime(), System.currentTimeMillis(), false,
+             AllocationStatus.NO_ATTEMPT);
     }
 
     /**
@@ -134,16 +225,18 @@ public final class UnassignedInfo implements ToXContent, Writeable {
      * @param unassignedTimeNanos  the time to use as the base for any delayed re-assignment calculation
      * @param unassignedTimeMillis the time of unassignment used to display to in our reporting.
      * @param delayed              if allocation of this shard is delayed due to INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.
+     * @param lastAllocationStatus the result of the last allocation attempt for this shard
      */
     public UnassignedInfo(Reason reason, @Nullable String message, @Nullable Throwable failure, int failedAllocations,
-        long unassignedTimeNanos, long unassignedTimeMillis, boolean delayed) {
-        this.reason = reason;
+                          long unassignedTimeNanos, long unassignedTimeMillis, boolean delayed, AllocationStatus lastAllocationStatus) {
+        this.reason = Objects.requireNonNull(reason);
         this.unassignedTimeMillis = unassignedTimeMillis;
         this.unassignedTimeNanos = unassignedTimeNanos;
         this.delayed = delayed;
         this.message = message;
         this.failure = failure;
         this.failedAllocations = failedAllocations;
+        this.lastAllocationStatus = Objects.requireNonNull(lastAllocationStatus);
         assert (failedAllocations > 0) == (reason == Reason.ALLOCATION_FAILED) :
             "failedAllocations: " + failedAllocations + " for reason " + reason;
         assert !(message == null && failure != null) : "provide a message if a failure exception is provided";
@@ -160,6 +253,7 @@ public final class UnassignedInfo implements ToXContent, Writeable {
         this.message = in.readOptionalString();
         this.failure = in.readThrowable();
         this.failedAllocations = in.readVInt();
+        this.lastAllocationStatus = AllocationStatus.readFrom(in);
     }
 
     public void writeTo(StreamOutput out) throws IOException {
@@ -170,6 +264,7 @@ public final class UnassignedInfo implements ToXContent, Writeable {
         out.writeOptionalString(message);
         out.writeThrowable(failure);
         out.writeVInt(failedAllocations);
+        lastAllocationStatus.writeTo(out);
     }
 
     public UnassignedInfo readFrom(StreamInput in) throws IOException {
@@ -242,6 +337,13 @@ public final class UnassignedInfo implements ToXContent, Writeable {
     }
 
     /**
+     * Get the status for the last allocation attempt for this shard.
+     */
+    public AllocationStatus getLastAllocationStatus() {
+        return lastAllocationStatus;
+    }
+
+    /**
      * Calculates the delay left based on current time (in nanoseconds) and the delay defined by the index settings.
      * Only relevant if shard is effectively delayed (see {@link #isDelayed()})
      * Returns 0 if delay is negative
@@ -290,35 +392,6 @@ public final class UnassignedInfo implements ToXContent, Writeable {
         return nextDelayNanos == Long.MAX_VALUE ? -1L : nextDelayNanos;
     }
 
-    /**
-     * Returns the appropriate {@link ClusterHealthStatus} for an unassigned primary shard
-     * based on its unassigned information and allocation id history.
-     */
-    public static ClusterHealthStatus unassignedPrimaryShardHealth(final UnassignedInfo unassignedInfo,
-                                                                   final boolean noActiveAllocationIds) {
-        assert unassignedInfo != null;
-        final UnassignedInfo.Reason reason = unassignedInfo.getReason();
-        /**
-         * Normally, an inactive primary shard in an index should cause the cluster health to be RED.  However,
-         * there are exceptions where a health status of RED is inappropriate, namely in these scenarios:
-         *   1. Index Creation.  When an index is first created, the primary shards are in the initializing state, so
-         *      there is a small window where the cluster health is RED due to the primaries not being activated yet.
-         *      However, this leads to a false sense that the cluster is in an unhealthy state, when in reality, its
-         *      simply a case of needing to wait for the primaries to initialize.
-         *   2. When a cluster is in the recovery state, and the shard never had any allocation ids assigned to it,
-         *      which indicates the index was created and before allocation of the primary occurred for this shard,
-         *      a cluster restart happened.
-         *
-         * Here, we check for these scenarios and set the cluster health to YELLOW if any are applicable.
-         */
-        if (reason == UnassignedInfo.Reason.INDEX_CREATED
-                || (reason == UnassignedInfo.Reason.CLUSTER_RECOVERED && noActiveAllocationIds)) {
-            return ClusterHealthStatus.YELLOW;
-        } else {
-            return ClusterHealthStatus.RED;
-        }
-    }
-
     public String shortSummary() {
         StringBuilder sb = new StringBuilder();
         sb.append("[reason=").append(reason).append("]");
@@ -332,6 +405,7 @@ public final class UnassignedInfo implements ToXContent, Writeable {
         if (details != null) {
             sb.append(", details[").append(details).append("]");
         }
+        sb.append(", allocation_status[").append(lastAllocationStatus.value()).append("]");
         return sb.toString();
     }
 
@@ -353,6 +427,7 @@ public final class UnassignedInfo implements ToXContent, Writeable {
         if (details != null) {
             builder.field("details", details);
         }
+        builder.field("allocation_status", lastAllocationStatus.value());
         builder.endObject();
         return builder;
     }
@@ -383,17 +458,21 @@ public final class UnassignedInfo implements ToXContent, Writeable {
         if (message != null ? !message.equals(that.message) : that.message != null) {
             return false;
         }
+        if (lastAllocationStatus != that.lastAllocationStatus) {
+            return false;
+        }
         return !(failure != null ? !failure.equals(that.failure) : that.failure != null);
     }
 
     @Override
     public int hashCode() {
-        int result = reason != null ? reason.hashCode() : 0;
+        int result = reason.hashCode();
         result = 31 * result + Boolean.hashCode(delayed);
         result = 31 * result + Integer.hashCode(failedAllocations);
         result = 31 * result + Long.hashCode(unassignedTimeMillis);
         result = 31 * result + (message != null ? message.hashCode() : 0);
         result = 31 * result + (failure != null ? failure.hashCode() : 0);
+        result = 31 * result + lastAllocationStatus.hashCode();
         return result;
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -21,7 +21,7 @@ package org.elasticsearch.cluster.routing;
 
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -290,6 +290,35 @@ public final class UnassignedInfo implements ToXContent, Writeable {
         return nextDelayNanos == Long.MAX_VALUE ? -1L : nextDelayNanos;
     }
 
+    /**
+     * Returns the appropriate {@link ClusterHealthStatus} for an unassigned primary shard
+     * based on its unassigned information and allocation id history.
+     */
+    public static ClusterHealthStatus unassignedPrimaryShardHealth(final UnassignedInfo unassignedInfo,
+                                                                   final boolean noActiveAllocationIds) {
+        assert unassignedInfo != null;
+        final UnassignedInfo.Reason reason = unassignedInfo.getReason();
+        /**
+         * Normally, an inactive primary shard in an index should cause the cluster health to be RED.  However,
+         * there are exceptions where a health status of RED is inappropriate, namely in these scenarios:
+         *   1. Index Creation.  When an index is first created, the primary shards are in the initializing state, so
+         *      there is a small window where the cluster health is RED due to the primaries not being activated yet.
+         *      However, this leads to a false sense that the cluster is in an unhealthy state, when in reality, its
+         *      simply a case of needing to wait for the primaries to initialize.
+         *   2. When a cluster is in the recovery state, and the shard never had any allocation ids assigned to it,
+         *      which indicates the index was created and before allocation of the primary occurred for this shard,
+         *      a cluster restart happened.
+         *
+         * Here, we check for these scenarios and set the cluster health to YELLOW if any are applicable.
+         */
+        if (reason == UnassignedInfo.Reason.INDEX_CREATED
+                || (reason == UnassignedInfo.Reason.CLUSTER_RECOVERED && noActiveAllocationIds)) {
+            return ClusterHealthStatus.YELLOW;
+        } else {
+            return ClusterHealthStatus.RED;
+        }
+    }
+
     public String shortSummary() {
         StringBuilder sb = new StringBuilder();
         sb.append("[reason=").append(reason).append("]");
@@ -329,7 +358,7 @@ public final class UnassignedInfo implements ToXContent, Writeable {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(Objeclusterct o) {
         if (this == o) {
             return true;
         }
@@ -367,4 +396,5 @@ public final class UnassignedInfo implements ToXContent, Writeable {
         result = 31 * result + (failure != null ? failure.hashCode() : 0);
         return result;
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AbstractAllocateAllocationCommand.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AbstractAllocateAllocationCommand.java
@@ -39,8 +39,6 @@ import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * Abstract base class for allocating an unassigned shard to a node

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateEmptyPrimaryAllocationCommand.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateEmptyPrimaryAllocationCommand.java
@@ -125,7 +125,8 @@ public class AllocateEmptyPrimaryAllocationCommand extends BasePrimaryAllocation
             // we need to move the unassigned info back to treat it as if it was index creation
             unassignedInfoToUpdate = new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED,
                 "force empty allocation from previous reason " + shardRouting.unassignedInfo().getReason() + ", " + shardRouting.unassignedInfo().getMessage(),
-                shardRouting.unassignedInfo().getFailure(), 0, System.nanoTime(), System.currentTimeMillis(), false);
+                shardRouting.unassignedInfo().getFailure(), 0, System.nanoTime(), System.currentTimeMillis(), false,
+                shardRouting.unassignedInfo().getLastAllocationStatus());
         }
 
         initializeUnassignedShard(allocation, routingNodes, routingNode, shardRouting, unassignedInfoToUpdate);

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.cluster.routing.allocation.decider;
 
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -29,11 +30,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * This abstract class defining basic {@link Decision} used during shard
  * allocation process.
- * 
+ *
  * @see AllocationDecider
  */
 public abstract class Decision implements ToXContent {
@@ -44,7 +46,7 @@ public abstract class Decision implements ToXContent {
     public static final Decision THROTTLE = new Single(Type.THROTTLE);
 
     /**
-     * Creates a simple decision 
+     * Creates a simple decision
      * @param type {@link Type} of the decision
      * @param label label for the Decider that produced this decision
      * @param explanation explanation of the decision
@@ -95,10 +97,10 @@ public abstract class Decision implements ToXContent {
     }
 
     /**
-     * This enumeration defines the 
-     * possible types of decisions 
+     * This enumeration defines the
+     * possible types of decisions
      */
-    public static enum Type {
+    public enum Type {
         YES,
         NO,
         THROTTLE;
@@ -144,6 +146,7 @@ public abstract class Decision implements ToXContent {
      */
     public abstract Type type();
 
+    @Nullable
     public abstract String label();
 
     /**
@@ -166,7 +169,7 @@ public abstract class Decision implements ToXContent {
         }
 
         /**
-         * Creates a new {@link Single} decision of a given type 
+         * Creates a new {@link Single} decision of a given type
          * @param type {@link Type} of the decision
          */
         public Single(Type type) {
@@ -175,12 +178,12 @@ public abstract class Decision implements ToXContent {
 
         /**
          * Creates a new {@link Single} decision of a given type
-         *  
+         *
          * @param type {@link Type} of the decision
          * @param explanation An explanation of this {@link Decision}
          * @param explanationParams A set of additional parameters
          */
-        public Single(Type type, String label, String explanation, Object... explanationParams) {
+        public Single(Type type, @Nullable String label, @Nullable String explanation, @Nullable Object... explanationParams) {
             this.type = type;
             this.label = label;
             this.explanation = explanation;
@@ -193,6 +196,7 @@ public abstract class Decision implements ToXContent {
         }
 
         @Override
+        @Nullable
         public String label() {
             return this.label;
         }
@@ -205,6 +209,7 @@ public abstract class Decision implements ToXContent {
         /**
          * Returns the explanation string, fully formatted. Only formats the string once
          */
+        @Nullable
         public String getExplanation() {
             if (explanationString == null && explanation != null) {
                 explanationString = String.format(Locale.ROOT, explanation, explanationParams);
@@ -224,15 +229,16 @@ public abstract class Decision implements ToXContent {
 
             Decision.Single s = (Decision.Single) object;
             return this.type == s.type &&
-                    this.label.equals(s.label) &&
-                    this.getExplanation().equals(s.getExplanation());
+                       Objects.equals(label, s.label) &&
+                       Objects.equals(getExplanation(), s.getExplanation());
         }
 
         @Override
         public int hashCode() {
-            int result = this.type.hashCode();
-            result = 31 * result + this.label.hashCode();
-            result = 31 * result + this.getExplanation().hashCode();
+            int result = type.hashCode();
+            result = 31 * result + (label == null ? 0 : label.hashCode());
+            String explanationStr = getExplanation();
+            result = 31 * result + (explanationStr == null ? 0 : explanationStr.hashCode());
             return result;
         }
 
@@ -288,6 +294,7 @@ public abstract class Decision implements ToXContent {
         }
 
         @Override
+        @Nullable
         public String label() {
             // Multi decisions have no labels
             return null;

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
@@ -59,7 +59,7 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
             Integer.toString(DEFAULT_CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES),
             (s) -> Setting.parseInt(s, 0, "cluster.routing.allocation.node_concurrent_recoveries"),
             Property.Dynamic, Property.NodeScope);
-    public static final Setting<Integer>  CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING =
+    public static final Setting<Integer> CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING =
         Setting.intSetting("cluster.routing.allocation.node_initial_primaries_recoveries",
             DEFAULT_CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES, 0,
             Property.Dynamic, Property.NodeScope);

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
@@ -59,7 +59,7 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
             Integer.toString(DEFAULT_CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES),
             (s) -> Setting.parseInt(s, 0, "cluster.routing.allocation.node_concurrent_recoveries"),
             Property.Dynamic, Property.NodeScope);
-    public static final Setting<Integer> CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING =
+    public static final Setting<Integer>  CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING =
         Setting.intSetting("cluster.routing.allocation.node_initial_primaries_recoveries",
             DEFAULT_CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES, 0,
             Property.Dynamic, Property.NodeScope);

--- a/core/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/core/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -344,5 +344,19 @@ public class TransportNodesListGatewayStartedShards extends
             result = 31 * result + (storeException != null ? storeException.hashCode() : 0);
             return result;
         }
+
+        @Override
+        public String toString() {
+            StringBuilder buf = new StringBuilder();
+            buf.append("NodeGatewayStartedShards[")
+               .append("allocationId=").append(allocationId)
+               .append(",primary=").append(primary)
+               .append(",legacyVersion=").append(legacyVersion);
+            if (storeException != null) {
+                buf.append(",storeException=").append(storeException);
+            }
+            buf.append("]");
+            return buf.toString();
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -20,39 +20,15 @@
 package org.elasticsearch.cluster;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
-import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
-import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
-import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.cluster.routing.ShardRouting;
-import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 public class ClusterHealthIT extends ESIntegTestCase {
-
-    private static ThreadPool threadPool;
-
-    @BeforeClass
-    public static void customBeforeClass() throws Exception {
-        threadPool = new ThreadPool("ClusterHealthIT");
-    }
-
-    @AfterClass
-    public static void customAfterClass() throws Exception {
-        ThreadPool.terminate(threadPool, 10L, TimeUnit.SECONDS);
-        threadPool = null;
-    }
 
     public void testSimpleLocalHealth() {
         createIndex("test");
@@ -60,11 +36,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
 
         for (String node : internalCluster().getNodeNames()) {
             // a very high time out, which should never fire due to the local flag
-            ClusterHealthResponse health = client(node).admin().cluster().prepareHealth()
-                                                                         .setLocal(true)
-                                                                         .setWaitForEvents(Priority.LANGUID)
-                                                                         .setTimeout("30s")
-                                                                         .get("10s");
+            ClusterHealthResponse health = client(node).admin().cluster().prepareHealth().setLocal(true).setWaitForEvents(Priority.LANGUID).setTimeout("30s").get("10s");
             assertThat(health.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(health.isTimedOut(), equalTo(false));
         }
@@ -72,11 +44,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
 
     public void testHealth() {
         logger.info("--> running cluster health on an index that does not exists");
-        ClusterHealthResponse healthResponse = client().admin().cluster().prepareHealth("test1")
-                                                                         .setWaitForYellowStatus()
-                                                                         .setTimeout("1s")
-                                                                         .execute()
-                                                                         .actionGet();
+        ClusterHealthResponse healthResponse = client().admin().cluster().prepareHealth("test1").setWaitForYellowStatus().setTimeout("1s").execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(true));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.RED));
         assertThat(healthResponse.getIndices().isEmpty(), equalTo(true));
@@ -97,11 +65,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
         assertThat(healthResponse.getIndices().get("test1").getStatus(), equalTo(ClusterHealthStatus.GREEN));
 
         logger.info("--> running cluster health on an index that does exists and an index that doesn't exists");
-        healthResponse = client().admin().cluster().prepareHealth("test1", "test2")
-                                                   .setWaitForYellowStatus()
-                                                   .setTimeout("1s")
-                                                   .execute()
-                                                   .actionGet();
+        healthResponse = client().admin().cluster().prepareHealth("test1", "test2").setWaitForYellowStatus().setTimeout("1s").execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(true));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.RED));
         assertThat(healthResponse.getIndices().get("test1").getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -109,79 +73,22 @@ public class ClusterHealthIT extends ESIntegTestCase {
     }
 
     public void testHealthOnIndexCreation() throws Exception {
-        final int numNodes = randomIntBetween(2, 5);
-        logger.info("--> starting {} nodes", numNodes);
-        final Settings nodeSettings = Settings.builder().put(
-            ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING.getKey(), numNodes
-        ).build();
-        internalCluster().ensureAtLeastNumDataNodes(numNodes, nodeSettings);
-
-        ClusterHealthResponse healthResponse = client().admin().cluster()
-                                                               .prepareHealth()
-                                                               .setWaitForGreenStatus()
-                                                               .setTimeout("10s")
-                                                               .execute()
-                                                               .actionGet();
-        assertThat(healthResponse.isTimedOut(), equalTo(false));
-        assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.GREEN));
-
-        // first, register a cluster state observer that checks cluster health
-        // upon index creation in the cluster state
-        final String masterNode = internalCluster().getMasterName();
-        final String indexName = "test-idx";
-        final ClusterService clusterService = internalCluster().clusterService(masterNode);
-        final ClusterStateObserver observer = new ClusterStateObserver(clusterService, logger, threadPool.getThreadContext());
-        final ClusterStateObserver.ChangePredicate validationPredicate = new ClusterStateObserver.ValidationPredicate() {
+        final AtomicBoolean finished = new AtomicBoolean(false);
+        Thread clusterHealthThread = new Thread() {
             @Override
-            protected boolean validate(ClusterState newState) {
-                return newState.status() == ClusterState.ClusterStateStatus.APPLIED
-                           && newState.metaData().hasIndex(indexName);
-            }
-        };
-
-        final ClusterStateObserver.Listener stateListener = new ClusterStateObserver.Listener() {
-            @Override
-            public void onNewClusterState(ClusterState clusterState) {
-                // make sure we have inactive primaries
-                // see if we can terminate observing on the cluster state
-                final ClusterStateResponse csResponse = client().admin().cluster().prepareState().execute().actionGet();
-                boolean inactivePrimaries = false;
-                for (ShardRouting shardRouting : csResponse.getState().routingTable().allShards(indexName)) {
-                    if (shardRouting.primary() == false) {
-                        continue;
-                    }
-                    if (shardRouting.active() == false) {
-                        inactivePrimaries = true;
-                        break;
-                    }
+            public void run() {
+                while (finished.get() == false) {
+                    ClusterHealthResponse health = client().admin().cluster().prepareHealth().get();
+                    assertThat(health.getStatus(), not(equalTo(ClusterHealthStatus.RED)));
                 }
-                assertTrue(inactivePrimaries);
-                // verify cluster health is YELLOW (even though primaries are still being allocated)
-                final ClusterHealthResponse response = client().admin().cluster().prepareHealth(indexName).get();
-                assertThat(response.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
-            }
-            @Override
-            public void onClusterServiceClose() {
-                fail("cluster service should not have closed");
-            }
-            @Override
-            public void onTimeout(TimeValue timeout) {
-                fail("timeout on cluster state observer");
             }
         };
-        observer.waitForNextChange(stateListener, validationPredicate, TimeValue.timeValueSeconds(30L));
-        final Settings settings = Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, numNodes)
-                                                    .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, numNodes - 1)
-                                                    .build();
-        CreateIndexResponse response = client().admin().indices().prepareCreate(indexName)
-                                                                 .setSettings(settings)
-                                                                 .execute()
-                                                                 .actionGet();
-        assertTrue(response.isAcknowledged());
-
-        // now, make sure we eventually get to the green state,
-        // we have at least two nodes so this should happen
-        ensureGreen(indexName);
+        clusterHealthThread.start();
+        for (int i = 0; i < 10; i++) {
+            createIndex("test" + i);
+        }
+        finished.set(true);
+        clusterHealthThread.join();
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -20,20 +20,51 @@
 package org.elasticsearch.cluster;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public class ClusterHealthIT extends ESIntegTestCase {
+
+    private static ThreadPool threadPool;
+
+    @BeforeClass
+    public static void customBeforeClass() throws Exception {
+        threadPool = new ThreadPool("ClusterHealthIT");
+    }
+
+    @AfterClass
+    public static void customAfterClass() throws Exception {
+        ThreadPool.terminate(threadPool, 10L, TimeUnit.SECONDS);
+        threadPool = null;
+    }
+
     public void testSimpleLocalHealth() {
         createIndex("test");
         ensureGreen(); // master should thing it's green now.
 
         for (String node : internalCluster().getNodeNames()) {
             // a very high time out, which should never fire due to the local flag
-            ClusterHealthResponse health = client(node).admin().cluster().prepareHealth().setLocal(true).setWaitForEvents(Priority.LANGUID).setTimeout("30s").get("10s");
+            ClusterHealthResponse health = client(node).admin().cluster().prepareHealth()
+                                                                         .setLocal(true)
+                                                                         .setWaitForEvents(Priority.LANGUID)
+                                                                         .setTimeout("30s")
+                                                                         .get("10s");
             assertThat(health.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(health.isTimedOut(), equalTo(false));
         }
@@ -41,7 +72,11 @@ public class ClusterHealthIT extends ESIntegTestCase {
 
     public void testHealth() {
         logger.info("--> running cluster health on an index that does not exists");
-        ClusterHealthResponse healthResponse = client().admin().cluster().prepareHealth("test1").setWaitForYellowStatus().setTimeout("1s").execute().actionGet();
+        ClusterHealthResponse healthResponse = client().admin().cluster().prepareHealth("test1")
+                                                                         .setWaitForYellowStatus()
+                                                                         .setTimeout("1s")
+                                                                         .execute()
+                                                                         .actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(true));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.RED));
         assertThat(healthResponse.getIndices().isEmpty(), equalTo(true));
@@ -62,10 +97,91 @@ public class ClusterHealthIT extends ESIntegTestCase {
         assertThat(healthResponse.getIndices().get("test1").getStatus(), equalTo(ClusterHealthStatus.GREEN));
 
         logger.info("--> running cluster health on an index that does exists and an index that doesn't exists");
-        healthResponse = client().admin().cluster().prepareHealth("test1", "test2").setWaitForYellowStatus().setTimeout("1s").execute().actionGet();
+        healthResponse = client().admin().cluster().prepareHealth("test1", "test2")
+                                                   .setWaitForYellowStatus()
+                                                   .setTimeout("1s")
+                                                   .execute()
+                                                   .actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(true));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.RED));
         assertThat(healthResponse.getIndices().get("test1").getStatus(), equalTo(ClusterHealthStatus.GREEN));
         assertThat(healthResponse.getIndices().size(), equalTo(1));
     }
+
+    public void testHealthOnIndexCreation() throws Exception {
+        final int numNodes = randomIntBetween(2, 5);
+        logger.info("--> starting {} nodes", numNodes);
+        final Settings nodeSettings = Settings.builder().put(
+            ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING.getKey(), numNodes
+        ).build();
+        internalCluster().ensureAtLeastNumDataNodes(numNodes, nodeSettings);
+
+        ClusterHealthResponse healthResponse = client().admin().cluster()
+                                                               .prepareHealth()
+                                                               .setWaitForGreenStatus()
+                                                               .setTimeout("10s")
+                                                               .execute()
+                                                               .actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+        assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.GREEN));
+
+        // first, register a cluster state observer that checks cluster health
+        // upon index creation in the cluster state
+        final String masterNode = internalCluster().getMasterName();
+        final String indexName = "test-idx";
+        final ClusterService clusterService = internalCluster().clusterService(masterNode);
+        final ClusterStateObserver observer = new ClusterStateObserver(clusterService, logger, threadPool.getThreadContext());
+        final ClusterStateObserver.ChangePredicate validationPredicate = new ClusterStateObserver.ValidationPredicate() {
+            @Override
+            protected boolean validate(ClusterState newState) {
+                return newState.status() == ClusterState.ClusterStateStatus.APPLIED
+                           && newState.metaData().hasIndex(indexName);
+            }
+        };
+
+        final ClusterStateObserver.Listener stateListener = new ClusterStateObserver.Listener() {
+            @Override
+            public void onNewClusterState(ClusterState clusterState) {
+                // make sure we have inactive primaries
+                // see if we can terminate observing on the cluster state
+                final ClusterStateResponse csResponse = client().admin().cluster().prepareState().execute().actionGet();
+                boolean inactivePrimaries = false;
+                for (ShardRouting shardRouting : csResponse.getState().routingTable().allShards(indexName)) {
+                    if (shardRouting.primary() == false) {
+                        continue;
+                    }
+                    if (shardRouting.active() == false) {
+                        inactivePrimaries = true;
+                        break;
+                    }
+                }
+                assertTrue(inactivePrimaries);
+                // verify cluster health is YELLOW (even though primaries are still being allocated)
+                final ClusterHealthResponse response = client().admin().cluster().prepareHealth(indexName).get();
+                assertThat(response.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
+            }
+            @Override
+            public void onClusterServiceClose() {
+                fail("cluster service should not have closed");
+            }
+            @Override
+            public void onTimeout(TimeValue timeout) {
+                fail("timeout on cluster state observer");
+            }
+        };
+        observer.waitForNextChange(stateListener, validationPredicate, TimeValue.timeValueSeconds(30L));
+        final Settings settings = Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, numNodes)
+                                                    .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, numNodes - 1)
+                                                    .build();
+        CreateIndexResponse response = client().admin().indices().prepareCreate(indexName)
+                                                                 .setSettings(settings)
+                                                                 .execute()
+                                                                 .actionGet();
+        assertTrue(response.isAcknowledged());
+
+        // now, make sure we eventually get to the green state,
+        // we have at least two nodes so this should happen
+        ensureGreen(indexName);
+    }
+
 }

--- a/core/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
@@ -18,6 +18,8 @@
  */
 package org.elasticsearch.cluster.health;
 
+import com.carrotsearch.hppc.cursors.IntObjectCursor;
+import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -32,12 +34,18 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTableGenerator;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.collect.ImmutableOpenIntMap;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.gateway.NoopGatewayAllocator;
 import org.elasticsearch.test.transport.CapturingTransport;
@@ -50,7 +58,10 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -64,7 +75,6 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class ClusterStateHealthTests extends ESTestCase {
     private final IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver(Settings.EMPTY);
-
 
     private static ThreadPool threadPool;
 
@@ -129,7 +139,6 @@ public class ClusterStateHealthTests extends ESTestCase {
         TransportClusterHealthAction action = new TransportClusterHealthAction(Settings.EMPTY, transportService,
             clusterService, threadPool, new ActionFilters(new HashSet<>()), indexNameExpressionResolver, NoopGatewayAllocator.INSTANCE);
         PlainActionFuture<ClusterHealthResponse> listener = new PlainActionFuture<>();
-
         action.execute(new ClusterHealthRequest(), listener);
 
         assertFalse(listener.isDone());
@@ -137,7 +146,6 @@ public class ClusterStateHealthTests extends ESTestCase {
         applyLatch.countDown();
         listener.get();
     }
-
 
     public void testClusterHealth() throws IOException {
         RoutingTableGenerator routingTableGenerator = new RoutingTableGenerator();
@@ -165,6 +173,110 @@ public class ClusterStateHealthTests extends ESTestCase {
         assertClusterHealth(clusterStateHealth, counter);
     }
 
+    public void testClusterHealthOnIndexCreation() {
+        final String indexName = "test-idx";
+        final String[] indices = new String[] { indexName };
+        final List<ClusterState> clusterStates = simulateIndexCreationStates(indexName, false);
+        for (int i = 0; i < clusterStates.size(); i++) {
+            // make sure cluster health is always YELLOW, up until the last state where it should be GREEN
+            final ClusterState clusterState = clusterStates.get(i);
+            final ClusterStateHealth health = new ClusterStateHealth(clusterState, indices);
+            if (i < clusterStates.size() - 1) {
+                assertThat(health.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
+            } else {
+                assertThat(health.getStatus(), equalTo(ClusterHealthStatus.GREEN));
+            }
+        }
+    }
+
+    public void testClusterHealthOnIndexCreationWithFailedAllocations() {
+        final String indexName = "test-idx";
+        final String[] indices = new String[] { indexName };
+        final List<ClusterState> clusterStates = simulateIndexCreationStates(indexName, true);
+        for (int i = 0; i < clusterStates.size(); i++) {
+            // make sure cluster health is YELLOW up until the final cluster state, which contains primary shard
+            // failed allocations that should make the cluster health RED
+            final ClusterState clusterState = clusterStates.get(i);
+            final ClusterStateHealth health = new ClusterStateHealth(clusterState, indices);
+            if (i < clusterStates.size() - 1) {
+                assertThat(health.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
+            } else {
+                assertThat(health.getStatus(), equalTo(ClusterHealthStatus.RED));
+            }
+        }
+    }
+
+    public void testClusterHealthOnClusterRecovery() {
+        final String indexName = "test-idx";
+        final String[] indices = new String[] { indexName };
+        final List<ClusterState> clusterStates = simulateClusterRecoveryStates(indexName, false, false);
+        for (int i = 0; i < clusterStates.size(); i++) {
+            // make sure cluster health is YELLOW up until the final cluster state, when it turns GREEN
+            final ClusterState clusterState = clusterStates.get(i);
+            final ClusterStateHealth health = new ClusterStateHealth(clusterState, indices);
+            if (i < clusterStates.size() - 1) {
+                assertThat(health.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
+            } else {
+                assertThat(health.getStatus(), equalTo(ClusterHealthStatus.GREEN));
+            }
+        }
+    }
+
+    public void testClusterHealthOnClusterRecoveryWithFailures() {
+        final String indexName = "test-idx";
+        final String[] indices = new String[] { indexName };
+        final List<ClusterState> clusterStates = simulateClusterRecoveryStates(indexName, false, true);
+        for (int i = 0; i < clusterStates.size(); i++) {
+            // make sure cluster health is YELLOW up until the final cluster state, which contains primary shard
+            // failed allocations that should make the cluster health RED
+            final ClusterState clusterState = clusterStates.get(i);
+            final ClusterStateHealth health = new ClusterStateHealth(clusterState, indices);
+            if (i < clusterStates.size() - 1) {
+                assertThat(health.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
+            } else {
+                assertThat(health.getStatus(), equalTo(ClusterHealthStatus.RED));
+            }
+        }
+    }
+
+    public void testClusterHealthOnClusterRecoveryWithPreviousAllocationIds() {
+        final String indexName = "test-idx";
+        final String[] indices = new String[] { indexName };
+        final List<ClusterState> clusterStates = simulateClusterRecoveryStates(indexName, true, false);
+        for (int i = 0; i < clusterStates.size(); i++) {
+            // because there were previous allocation ids, we should be RED until the primaries are started,
+            // then move to YELLOW, and the last state should be GREEN when all shards have been started
+            final ClusterState clusterState = clusterStates.get(i);
+            final ClusterStateHealth health = new ClusterStateHealth(clusterState, indices);
+            if (i < clusterStates.size() - 1) {
+                // if the inactive primaries are due solely to recovery (not failed allocation or previously being allocated),
+                // then cluster health is YELLOW, otherwise RED
+                if (primaryInactiveDueToRecovery(indexName, clusterState)) {
+                    assertThat(health.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
+                } else {
+                    assertThat(health.getStatus(), equalTo(ClusterHealthStatus.RED));
+                }
+            } else {
+                assertThat(health.getStatus(), equalTo(ClusterHealthStatus.GREEN));
+            }
+        }
+    }
+
+    public void testClusterHealthOnClusterRecoveryWithPreviousAllocationIdsAndAllocationFailures() {
+        final String indexName = "test-idx";
+        final String[] indices = new String[] { indexName };
+        for (final ClusterState clusterState : simulateClusterRecoveryStates(indexName, true, true)) {
+            final ClusterStateHealth health = new ClusterStateHealth(clusterState, indices);
+            // if the inactive primaries are due solely to recovery (not failed allocation or previously being allocated)
+            // then cluster health is YELLOW, otherwise RED
+            if (primaryInactiveDueToRecovery(indexName, clusterState)) {
+                assertThat(health.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
+            } else {
+                assertThat(health.getStatus(), equalTo(ClusterHealthStatus.RED));
+            }
+        }
+    }
+
     ClusterStateHealth maybeSerialize(ClusterStateHealth clusterStateHealth) throws IOException {
         if (randomBoolean()) {
             BytesStreamOutput out = new BytesStreamOutput();
@@ -173,6 +285,250 @@ public class ClusterStateHealthTests extends ESTestCase {
             clusterStateHealth = new ClusterStateHealth(in);
         }
         return clusterStateHealth;
+    }
+
+    private List<ClusterState> simulateIndexCreationStates(final String indexName, final boolean withPrimaryAllocationFailures) {
+        final int numberOfShards = randomIntBetween(1, 5);
+        final int numberOfReplicas = randomIntBetween(1, numberOfShards);
+        // initial index creation and new routing table info
+        final IndexMetaData indexMetaData = IndexMetaData.builder(indexName)
+                                                         .settings(settings(Version.CURRENT)
+                                                                       .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID()))
+                                                         .numberOfShards(numberOfShards)
+                                                         .numberOfReplicas(numberOfReplicas)
+                                                         .state(IndexMetaData.State.OPEN)
+                                                         .build();
+        final MetaData metaData = MetaData.builder().put(indexMetaData, true).build();
+        final RoutingTable routingTable = RoutingTable.builder().addAsNew(indexMetaData).build();
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test_cluster"))
+                                                .metaData(metaData)
+                                                .routingTable(routingTable)
+                                                .build();
+        return generateClusterStates(clusterState, indexName, numberOfReplicas, withPrimaryAllocationFailures);
+    }
+
+    private List<ClusterState> simulateClusterRecoveryStates(final String indexName,
+                                                             final boolean withPreviousAllocationIds,
+                                                             final boolean withPrimaryAllocationFailures) {
+        final int numberOfShards = randomIntBetween(1, 5);
+        final int numberOfReplicas = randomIntBetween(1, numberOfShards);
+        // initial index creation and new routing table info
+        IndexMetaData indexMetaData = IndexMetaData.builder(indexName)
+                                                   .settings(settings(Version.CURRENT)
+                                                                 .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID()))
+                                                   .numberOfShards(numberOfShards)
+                                                   .numberOfReplicas(numberOfReplicas)
+                                                   .state(IndexMetaData.State.OPEN)
+                                                   .build();
+        if (withPreviousAllocationIds) {
+            final IndexMetaData.Builder idxMetaWithAllocationIds = IndexMetaData.builder(indexMetaData);
+            boolean atLeastOne = false;
+            for (int i = 0; i < numberOfShards; i++) {
+                if (atLeastOne == false || randomBoolean()) {
+                    idxMetaWithAllocationIds.putActiveAllocationIds(i, Sets.newHashSet(UUIDs.randomBase64UUID()));
+                    atLeastOne = true;
+                }
+            }
+            indexMetaData = idxMetaWithAllocationIds.build();
+        }
+        final MetaData metaData = MetaData.builder().put(indexMetaData, true).build();
+        final RoutingTable routingTable = RoutingTable.builder().addAsRecovery(indexMetaData).build();
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test_cluster"))
+                                                .metaData(metaData)
+                                                .routingTable(routingTable)
+                                                .build();
+        return generateClusterStates(clusterState, indexName, numberOfReplicas, withPrimaryAllocationFailures);
+    }
+
+    private List<ClusterState> generateClusterStates(final ClusterState originalClusterState,
+                                                     final String indexName,
+                                                     final int numberOfReplicas,
+                                                     final boolean withPrimaryAllocationFailures) {
+        // generate random node ids
+        final List<String> nodeIds = new ArrayList<>();
+        final int numNodes = randomIntBetween(numberOfReplicas + 1, 10);
+        for (int i = 0; i < numNodes; i++) {
+            nodeIds.add(randomAsciiOfLength(8));
+        }
+
+        final List<ClusterState> clusterStates = new ArrayList<>();
+        clusterStates.add(originalClusterState);
+        ClusterState clusterState = originalClusterState;
+
+        // initialize primaries
+        RoutingTable routingTable = originalClusterState.routingTable();
+        IndexRoutingTable indexRoutingTable = routingTable.index(indexName);
+        IndexRoutingTable.Builder newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
+        for (final ObjectCursor<IndexShardRoutingTable> shardEntry : indexRoutingTable.getShards().values()) {
+            final IndexShardRoutingTable shardRoutingTable = shardEntry.value;
+            for (final ShardRouting shardRouting : shardRoutingTable.getShards()) {
+                if (shardRouting.primary()) {
+                    newIndexRoutingTable.addShard(
+                        shardRouting.initialize(nodeIds.get(randomIntBetween(0, numNodes - 1)), null, shardRouting.getExpectedShardSize())
+                    );
+                } else {
+                    newIndexRoutingTable.addShard(shardRouting);
+                }
+            }
+        }
+        routingTable = RoutingTable.builder(routingTable).add(newIndexRoutingTable).build();
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+        clusterStates.add(clusterState);
+
+        // some primaries started
+        indexRoutingTable = routingTable.index(indexName);
+        newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
+        ImmutableOpenIntMap.Builder<Set<String>> allocationIds = ImmutableOpenIntMap.<Set<String>>builder();
+        for (final ObjectCursor<IndexShardRoutingTable> shardEntry : indexRoutingTable.getShards().values()) {
+            final IndexShardRoutingTable shardRoutingTable = shardEntry.value;
+            for (final ShardRouting shardRouting : shardRoutingTable.getShards()) {
+                if (shardRouting.primary() && randomBoolean()) {
+                    final ShardRouting newShardRouting = shardRouting.moveToStarted();
+                    allocationIds.fPut(newShardRouting.getId(), Sets.newHashSet(newShardRouting.allocationId().getId()));
+                    newIndexRoutingTable.addShard(newShardRouting);
+                } else {
+                    newIndexRoutingTable.addShard(shardRouting);
+                }
+            }
+        }
+        routingTable = RoutingTable.builder(routingTable).add(newIndexRoutingTable).build();
+        IndexMetaData.Builder idxMetaBuilder = IndexMetaData.builder(clusterState.metaData().index(indexName));
+        for (final IntObjectCursor<Set<String>> entry : allocationIds.build()) {
+            idxMetaBuilder.putActiveAllocationIds(entry.key, entry.value);
+        }
+        MetaData.Builder metaDataBuilder = MetaData.builder(clusterState.metaData()).put(idxMetaBuilder);
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).metaData(metaDataBuilder).build();
+        clusterStates.add(clusterState);
+
+        if (withPrimaryAllocationFailures) {
+            boolean alreadyFailedPrimary = false;
+            // some primaries failed to allocate
+            indexRoutingTable = routingTable.index(indexName);
+            newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
+            for (final ObjectCursor<IndexShardRoutingTable> shardEntry : indexRoutingTable.getShards().values()) {
+                final IndexShardRoutingTable shardRoutingTable = shardEntry.value;
+                for (final ShardRouting shardRouting : shardRoutingTable.getShards()) {
+                    if (shardRouting.primary() && (shardRouting.started() == false || alreadyFailedPrimary == false)) {
+                        newIndexRoutingTable.addShard(shardRouting.moveToUnassigned(
+                            new UnassignedInfo(UnassignedInfo.Reason.ALLOCATION_FAILED, "unlucky shard")));
+                        alreadyFailedPrimary = true;
+                    } else {
+                        newIndexRoutingTable.addShard(shardRouting);
+                    }
+                }
+            }
+            routingTable = RoutingTable.builder(routingTable).add(newIndexRoutingTable).build();
+            clusterStates.add(ClusterState.builder(clusterState).routingTable(routingTable).build());
+            return clusterStates;
+        }
+
+        // all primaries started
+        indexRoutingTable = routingTable.index(indexName);
+        newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
+        allocationIds = ImmutableOpenIntMap.<Set<String>>builder();
+        for (final ObjectCursor<IndexShardRoutingTable> shardEntry : indexRoutingTable.getShards().values()) {
+            final IndexShardRoutingTable shardRoutingTable = shardEntry.value;
+            for (final ShardRouting shardRouting : shardRoutingTable.getShards()) {
+                if (shardRouting.primary() && shardRouting.started() == false) {
+                    final ShardRouting newShardRouting = shardRouting.moveToStarted();
+                    allocationIds.fPut(newShardRouting.getId(), Sets.newHashSet(newShardRouting.allocationId().getId()));
+                    newIndexRoutingTable.addShard(newShardRouting);
+                } else {
+                    newIndexRoutingTable.addShard(shardRouting);
+                }
+            }
+        }
+        routingTable = RoutingTable.builder(routingTable).add(newIndexRoutingTable).build();
+        idxMetaBuilder = IndexMetaData.builder(clusterState.metaData().index(indexName));
+        for (final IntObjectCursor<Set<String>> entry : allocationIds.build()) {
+            idxMetaBuilder.putActiveAllocationIds(entry.key, entry.value);
+        }
+        metaDataBuilder = MetaData.builder(clusterState.metaData()).put(idxMetaBuilder);
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).metaData(metaDataBuilder).build();
+        clusterStates.add(clusterState);
+
+        // initialize replicas
+        indexRoutingTable = routingTable.index(indexName);
+        newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
+        for (final ObjectCursor<IndexShardRoutingTable> shardEntry : indexRoutingTable.getShards().values()) {
+            final IndexShardRoutingTable shardRoutingTable = shardEntry.value;
+            for (final ShardRouting shardRouting : shardRoutingTable.getShards()) {
+                if (shardRouting.primary() == false) {
+                    // give the replica a different node id than the primary
+                    final String primaryNodeId = shardRoutingTable.primaryShard().currentNodeId();
+                    String replicaNodeId;
+                    do {
+                        replicaNodeId = nodeIds.get(randomIntBetween(0, numNodes - 1));
+                    } while (primaryNodeId.equals(replicaNodeId));
+                    newIndexRoutingTable.addShard(
+                        shardRouting.initialize(replicaNodeId, null, shardRouting.getExpectedShardSize())
+                    );
+                } else {
+                    newIndexRoutingTable.addShard(shardRouting);
+                }
+            }
+        }
+        routingTable = RoutingTable.builder(routingTable).add(newIndexRoutingTable).build();
+        clusterStates.add(ClusterState.builder(clusterState).routingTable(routingTable).build());
+
+        // some replicas started
+        indexRoutingTable = routingTable.index(indexName);
+        newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
+        for (final ObjectCursor<IndexShardRoutingTable> shardEntry : indexRoutingTable.getShards().values()) {
+            final IndexShardRoutingTable shardRoutingTable = shardEntry.value;
+            for (final ShardRouting shardRouting : shardRoutingTable.getShards()) {
+                if (shardRouting.primary() == false && randomBoolean()) {
+                    newIndexRoutingTable.addShard(shardRouting.moveToStarted());
+                } else {
+                    newIndexRoutingTable.addShard(shardRouting);
+                }
+            }
+        }
+        routingTable = RoutingTable.builder(routingTable).add(newIndexRoutingTable).build();
+        clusterStates.add(ClusterState.builder(clusterState).routingTable(routingTable).build());
+
+        // all replicas started
+        boolean replicaStateChanged = false;
+        indexRoutingTable = routingTable.index(indexName);
+        newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
+        for (final ObjectCursor<IndexShardRoutingTable> shardEntry : indexRoutingTable.getShards().values()) {
+            final IndexShardRoutingTable shardRoutingTable = shardEntry.value;
+            for (final ShardRouting shardRouting : shardRoutingTable.getShards()) {
+                if (shardRouting.primary() == false && shardRouting.started() == false) {
+                    newIndexRoutingTable.addShard(shardRouting.moveToStarted());
+                    replicaStateChanged = true;
+                } else {
+                    newIndexRoutingTable.addShard(shardRouting);
+                }
+            }
+        }
+        // all of the replicas may have moved to started in the previous phase already
+        if (replicaStateChanged) {
+            routingTable = RoutingTable.builder(routingTable).add(newIndexRoutingTable).build();
+            clusterStates.add(ClusterState.builder(clusterState).routingTable(routingTable).build());
+        }
+
+        return clusterStates;
+    }
+
+    // returns true if the inactive primaries in the index are only due to cluster recovery
+    // (not because of allocation failure or previously having allocation ids assigned)
+    private boolean primaryInactiveDueToRecovery(final String indexName, final ClusterState clusterState) {
+        for (final IntObjectCursor<IndexShardRoutingTable> shardRouting : clusterState.routingTable().index(indexName).shards()) {
+            final ShardRouting primaryShard = shardRouting.value.primaryShard();
+            if (primaryShard.active() == false) {
+                if (clusterState.metaData().index(indexName).activeAllocationIds(shardRouting.key).isEmpty() == false) {
+                    return false;
+                }
+                if (primaryShard.unassignedInfo() != null &&
+                        primaryShard.unassignedInfo().getReason() == UnassignedInfo.Reason.ALLOCATION_FAILED) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     private void assertClusterHealth(ClusterStateHealth clusterStateHealth, RoutingTableGenerator.ShardCounter counter) {

--- a/core/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
@@ -82,7 +82,7 @@ public class ClusterStateHealthTests extends ESTestCase {
     private TransportService transportService;
 
     @BeforeClass
-    public static void beforeClass() {
+    public static void setupThreadPool() {
         threadPool = new TestThreadPool("ClusterStateHealthTests");
     }
 
@@ -104,7 +104,7 @@ public class ClusterStateHealthTests extends ESTestCase {
     }
 
     @AfterClass
-    public static void afterClass() {
+    public static void terminateThreadPool() {
         ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
         threadPool = null;
     }
@@ -296,7 +296,6 @@ public class ClusterStateHealthTests extends ESTestCase {
                                                                        .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID()))
                                                          .numberOfShards(numberOfShards)
                                                          .numberOfReplicas(numberOfReplicas)
-                                                         .state(IndexMetaData.State.OPEN)
                                                          .build();
         final MetaData metaData = MetaData.builder().put(indexMetaData, true).build();
         final RoutingTable routingTable = RoutingTable.builder().addAsNew(indexMetaData).build();

--- a/core/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
@@ -165,8 +165,13 @@ public class ClusterStateHealthTests extends ESTestCase {
             metaData.put(indexMetaData, true);
             routingTable.add(indexRoutingTable);
         }
-        ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY)).metaData(metaData).routingTable(routingTable.build()).build();
-        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, IndicesOptions.strictExpand(), (String[]) null);
+        ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+                                                .metaData(metaData)
+                                                .routingTable(routingTable.build())
+                                                .build();
+        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(
+            clusterState, IndicesOptions.strictExpand(), (String[]) null
+        );
         ClusterStateHealth clusterStateHealth = new ClusterStateHealth(clusterState, concreteIndices);
         logger.info("cluster status: {}, expected {}", clusterStateHealth.getStatus(), counter.status());
         clusterStateHealth = maybeSerialize(clusterStateHealth);

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
@@ -642,7 +643,7 @@ public class ClusterRebalanceRoutingTests extends ESAllocationTestCase {
                     while (iterator.hasNext()) {
                         ShardRouting next = iterator.next();
                         if ("test1".equals(next.index().getName())) {
-                            iterator.removeAndIgnore();
+                            iterator.removeAndIgnore(UnassignedInfo.AllocationStatus.NO_ATTEMPT);
                         }
 
                     }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/DecisionsImpactOnClusterHealthTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/DecisionsImpactOnClusterHealthTests.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.EmptyClusterInfoService;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.health.ClusterStateHealth;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.test.ESAllocationTestCase;
+import org.elasticsearch.test.gateway.NoopGatewayAllocator;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * This class of tests exercise various scenarios of
+ * primary shard allocation and assert the cluster health
+ * has the correct status based on those allocation decisions.
+ */
+public class DecisionsImpactOnClusterHealthTests extends ESAllocationTestCase {
+
+    public void testPrimaryShardNoDecisionOnIndexCreation() throws IOException {
+        final String indexName = "test-idx";
+        Settings settings = Settings.builder()
+                                .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
+                                .build();
+        AllocationDecider decider = new TestAllocateDecision(Decision.NO);
+        // if deciders say NO to allocating a primary shard, then the cluster health should be RED
+        runAllocationTest(
+            settings, indexName, Collections.singleton(decider), ClusterHealthStatus.RED
+        );
+    }
+
+    public void testPrimaryShardThrottleDecisionOnIndexCreation() throws IOException {
+        final String indexName = "test-idx";
+        Settings settings = Settings.builder()
+                                .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
+                                .build();
+        AllocationDecider decider = new TestAllocateDecision(Decision.THROTTLE) {
+            // the only allocation decider that implements this is ShardsLimitAllocationDecider and it always
+            // returns only YES or NO, never THROTTLE
+            @Override
+            public Decision canAllocate(RoutingNode node, RoutingAllocation allocation) {
+                return randomBoolean() ? Decision.YES : Decision.NO;
+            }
+        };
+        // if deciders THROTTLE allocating a primary shard, stay in YELLOW state
+        runAllocationTest(
+            settings, indexName, Collections.singleton(decider), ClusterHealthStatus.YELLOW
+        );
+    }
+
+    public void testPrimaryShardYesDecisionOnIndexCreation() throws IOException {
+        final String indexName = "test-idx";
+        Settings settings = Settings.builder()
+                                .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
+                                .build();
+        AllocationDecider decider = new TestAllocateDecision(Decision.YES) {
+            @Override
+            public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+                if (node.getByShardId(shardRouting.shardId()) == null) {
+                    return Decision.YES;
+                } else {
+                    return Decision.NO;
+                }
+            }
+        };
+        // if deciders say YES to allocating primary shards, stay in YELLOW state
+        ClusterState clusterState = runAllocationTest(
+            settings, indexName, Collections.singleton(decider), ClusterHealthStatus.YELLOW
+        );
+        // make sure primaries are initialized
+        RoutingTable routingTable = clusterState.routingTable();
+        for (IndexShardRoutingTable indexShardRoutingTable : routingTable.index(indexName)) {
+            assertTrue(indexShardRoutingTable.primaryShard().initializing());
+        }
+    }
+
+    private ClusterState runAllocationTest(final Settings settings,
+                                           final String indexName,
+                                           final Set<AllocationDecider> allocationDeciders,
+                                           final ClusterHealthStatus expectedStatus) throws IOException {
+
+        final String clusterName = "test-cluster";
+        final AllocationService allocationService = newAllocationService(settings, allocationDeciders);
+
+        logger.info("Building initial routing table");
+        final int numShards = randomIntBetween(1, 5);
+        MetaData metaData = MetaData.builder()
+                                .put(IndexMetaData.builder(indexName)
+                                         .settings(settings(Version.CURRENT))
+                                         .numberOfShards(numShards)
+                                         .numberOfReplicas(1))
+                                .build();
+
+        RoutingTable routingTable = RoutingTable.builder()
+                                        .addAsNew(metaData.index(indexName))
+                                        .build();
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName(clusterName))
+                                        .metaData(metaData)
+                                        .routingTable(routingTable)
+                                        .build();
+
+        logger.info("--> adding nodes");
+        // we need at least as many nodes as shards for the THROTTLE case, because
+        // once a shard has been throttled on a node, that node no longer accepts
+        // any allocations on it
+        final DiscoveryNodes.Builder discoveryNodes = DiscoveryNodes.builder();
+        for (int i = 0; i < numShards; i++) {
+            discoveryNodes.put(newNode("node" + i));
+        }
+        clusterState = ClusterState.builder(clusterState).nodes(discoveryNodes).build();
+
+        logger.info("--> do the reroute");
+        routingTable = allocationService.reroute(clusterState, "reroute").routingTable();
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+
+        logger.info("--> assert cluster health");
+        ClusterStateHealth health = new ClusterStateHealth(clusterState);
+        assertThat(health.getStatus(), equalTo(expectedStatus));
+
+        return clusterState;
+    }
+
+    private static AllocationService newAllocationService(Settings settings, Set<AllocationDecider> deciders) {
+        return new AllocationService(settings,
+                                     new AllocationDeciders(settings, deciders),
+                                     NoopGatewayAllocator.INSTANCE,
+                                     new BalancedShardsAllocator(settings),
+                                     EmptyClusterInfoService.INSTANCE);
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -21,7 +21,10 @@ package org.elasticsearch.gateway;
 
 import org.apache.lucene.index.CorruptIndexException;
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.health.ClusterStateHealth;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.snapshots.SnapshotId;
@@ -50,6 +53,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 /**
  */
@@ -77,6 +81,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(changed, equalTo(false));
         assertThat(allocation.routingNodes().unassigned().size(), equalTo(1));
         assertThat(allocation.routingNodes().unassigned().iterator().next().shardId(), equalTo(shardId));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     /**
@@ -90,9 +95,10 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
             allocation = routingAllocationWithOnePrimaryNoReplicas(yesAllocationDeciders(), false, Version.V_2_1_0);
         }
         boolean changed = testAllocator.allocateUnassigned(allocation);
-        assertThat(changed, equalTo(false));
+        assertThat(changed, equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
         assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     /**
@@ -108,9 +114,10 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         }
         testAllocator.addData(node1, ShardStateMetaData.NO_VERSION, null, randomBoolean());
         boolean changed = testAllocator.allocateUnassigned(allocation);
-        assertThat(changed, equalTo(false));
+        assertThat(changed, equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
         assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     /**
@@ -120,9 +127,10 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         RoutingAllocation allocation = routingAllocationWithOnePrimaryNoReplicas(yesAllocationDeciders(), false, Version.CURRENT, "id2");
         testAllocator.addData(node1, ShardStateMetaData.NO_VERSION, "id1", randomBoolean());
         boolean changed = testAllocator.allocateUnassigned(allocation);
-        assertThat(changed, equalTo(false));
+        assertThat(changed, equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
         assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     /**
@@ -137,6 +145,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(), equalTo(node1.getId()));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     /**
@@ -152,9 +161,10 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
             testAllocator.addData(node1, 3, null, randomBoolean(), new CorruptIndexException("test", "test"));
         }
         boolean changed = testAllocator.allocateUnassigned(allocation);
-        assertThat(changed, equalTo(false));
+        assertThat(changed, equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
         assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     /**
@@ -179,6 +189,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
             // check that allocation id is reused
             assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).allocationId().getId(), equalTo("allocId1"));
         }
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     /**
@@ -197,6 +208,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
         DiscoveryNode allocatedNode = node1HasPrimaryShard ? node1 : node2;
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(), equalTo(allocatedNode.getId()));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     /**
@@ -213,9 +225,10 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
             testAllocator.addData(node1, 3, null, randomBoolean());
         }
         boolean changed = testAllocator.allocateUnassigned(allocation);
-        assertThat(changed, equalTo(false));
+        assertThat(changed, equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
         assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     /**
@@ -236,6 +249,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(), equalTo(node1.getId()));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     /**
@@ -249,6 +263,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(), equalTo(node2.getId()));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     /**
@@ -268,6 +283,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(), equalTo(node2.getId()));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).allocationId().getId(), equalTo("some allocId"));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     /**
@@ -285,6 +301,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(changed, equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     /**
@@ -299,8 +316,9 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         RoutingAllocation allocation = getRestoreRoutingAllocation(throttleAllocationDeciders(), clusterHasActiveAllocationIds);
         testAllocator.addData(node1, legacyVersion, allocationId, randomBoolean());
         boolean changed = testAllocator.allocateUnassigned(allocation);
-        assertThat(changed, equalTo(false));
+        assertThat(changed, equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(false));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     /**
@@ -318,6 +336,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(changed, equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     /**
@@ -331,6 +350,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(changed, equalTo(false));
         assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
         assertThat(allocation.routingNodes().unassigned().size(), equalTo(1));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     private RoutingAllocation getRestoreRoutingAllocation(AllocationDeciders allocationDeciders, boolean hasActiveAllocation) {
@@ -365,6 +385,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(changed, equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.RED);
     }
 
     /**
@@ -378,8 +399,9 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         RoutingAllocation allocation = getRecoverOnAnyNodeRoutingAllocation(throttleAllocationDeciders(), hasActiveAllocation);
         testAllocator.addData(node1, legacyVersion, allocationId, randomBoolean());
         boolean changed = testAllocator.allocateUnassigned(allocation);
-        assertThat(changed, equalTo(false));
+        assertThat(changed, equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(false));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     /**
@@ -396,6 +418,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(changed, equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.RED);
     }
 
     /**
@@ -409,6 +432,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(changed, equalTo(false));
         assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
         assertThat(allocation.routingNodes().unassigned().size(), equalTo(1));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 
     private RoutingAllocation getRecoverOnAnyNodeRoutingAllocation(AllocationDeciders allocationDeciders, boolean hasActiveAllocation) {
@@ -448,18 +472,20 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
 
         RoutingAllocation allocation = new RoutingAllocation(yesAllocationDeciders(), new RoutingNodes(state, false), state, null, System.nanoTime(), false);
         boolean changed = testAllocator.allocateUnassigned(allocation);
-        assertThat(changed, equalTo(false));
+        assertThat(changed, equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
         assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(2)); // replicas
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.RED);
 
         testAllocator.addData(node1, 1, null, randomBoolean());
         allocation = new RoutingAllocation(yesAllocationDeciders(), new RoutingNodes(state, false), state, null, System.nanoTime(), false);
         changed = testAllocator.allocateUnassigned(allocation);
-        assertThat(changed, equalTo(false));
+        assertThat(changed, equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
         assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(2)); // replicas
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.RED);
 
         testAllocator.addData(node2, 1, null, randomBoolean());
         allocation = new RoutingAllocation(yesAllocationDeciders(), new RoutingNodes(state, false), state, null, System.nanoTime(), false);
@@ -469,6 +495,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(2)); // replicas
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(), anyOf(equalTo(node2.getId()), equalTo(node1.getId())));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.RED);
     }
 
     /**
@@ -489,18 +516,20 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
 
         RoutingAllocation allocation = new RoutingAllocation(yesAllocationDeciders(), new RoutingNodes(state, false), state, null, System.nanoTime(), false);
         boolean changed = testAllocator.allocateUnassigned(allocation);
-        assertThat(changed, equalTo(false));
+        assertThat(changed, equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
         assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(2)); // replicas
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.RED);
 
         testAllocator.addData(node1, 1, null, randomBoolean());
         allocation = new RoutingAllocation(yesAllocationDeciders(), new RoutingNodes(state, false), state, null, System.nanoTime(), false);
         changed = testAllocator.allocateUnassigned(allocation);
-        assertThat(changed, equalTo(false));
+        assertThat(changed, equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
         assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(2)); // replicas
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.RED);
 
         testAllocator.addData(node2, 2, null, randomBoolean());
         allocation = new RoutingAllocation(yesAllocationDeciders(), new RoutingNodes(state, false), state, null, System.nanoTime(), false);
@@ -510,6 +539,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(2)); // replicas
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(), equalTo(node2.getId()));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.RED);
     }
 
     private RoutingAllocation routingAllocationWithOnePrimaryNoReplicas(AllocationDeciders deciders, boolean asNew, Version version, String... activeAllocationIds) {
@@ -528,6 +558,19 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
                 .routingTable(routingTableBuilder.build())
                 .nodes(DiscoveryNodes.builder().put(node1).put(node2).put(node3)).build();
         return new RoutingAllocation(deciders, new RoutingNodes(state, false), state, null, System.nanoTime(), false);
+    }
+
+    private void assertClusterHealthStatus(RoutingAllocation allocation, ClusterHealthStatus expectedStatus) {
+        RoutingTable oldRoutingTable = allocation.routingTable();
+        RoutingNodes newRoutingNodes = allocation.routingNodes();
+        final RoutingTable newRoutingTable = new RoutingTable.Builder()
+                                                             .updateNodes(oldRoutingTable.version(), newRoutingNodes)
+                                                             .build();
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test-cluster"))
+                                                .routingTable(newRoutingTable)
+                                                .build();
+        ClusterStateHealth clusterStateHealth = new ClusterStateHealth(clusterState);
+        assertThat(clusterStateHealth.getStatus().ordinal(), lessThanOrEqualTo(expectedStatus.ordinal()));
     }
 
     class TestAllocator extends PrimaryShardAllocator {

--- a/core/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
@@ -36,7 +36,6 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
-import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
@@ -298,7 +297,7 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
                                         .addShard(primaryShard)
                                         .addShard(ShardRouting.newUnassigned(shardId, null, false,
                                             new UnassignedInfo(reason, null, null, failedAllocations, System.nanoTime(),
-                                                System.currentTimeMillis(), delayed)))
+                                                System.currentTimeMillis(), delayed, UnassignedInfo.AllocationStatus.NO_ATTEMPT)))
                                         .build())
                 )
                 .build();

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -528,15 +528,25 @@ public final class InternalTestCluster extends TestCluster {
      * stop any of the running nodes.
      */
     public void ensureAtLeastNumDataNodes(int n) {
+        ensureAtLeastNumDataNodes(n, Settings.EMPTY);
+    }
+
+    /**
+     * Ensures that at least <code>n</code> data nodes are present in the cluster.
+     * if more nodes than <code>n</code> are present this method will not
+     * stop any of the running nodes.  Each newly started node will use the given
+     * input settings.
+     */
+    public void ensureAtLeastNumDataNodes(final int n, final Settings settings) {
         final List<Async<String>> asyncs = new ArrayList<>();
         synchronized (this) {
             int size = numDataNodes();
             for (int i = size; i < n; i++) {
                 logger.info("increasing cluster size from {} to {}", size, n);
                 if (numSharedDedicatedMasterNodes > 0) {
-                    asyncs.add(startDataOnlyNodeAsync());
+                    asyncs.add(startDataOnlyNodeAsync(settings));
                 } else {
-                    asyncs.add(startNodeAsync());
+                    asyncs.add(startNodeAsync(settings));
                 }
             }
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -528,25 +528,15 @@ public final class InternalTestCluster extends TestCluster {
      * stop any of the running nodes.
      */
     public void ensureAtLeastNumDataNodes(int n) {
-        ensureAtLeastNumDataNodes(n, Settings.EMPTY);
-    }
-
-    /**
-     * Ensures that at least <code>n</code> data nodes are present in the cluster.
-     * if more nodes than <code>n</code> are present this method will not
-     * stop any of the running nodes.  Each newly started node will use the given
-     * input settings.
-     */
-    public void ensureAtLeastNumDataNodes(final int n, final Settings settings) {
         final List<Async<String>> asyncs = new ArrayList<>();
         synchronized (this) {
             int size = numDataNodes();
             for (int i = size; i < n; i++) {
                 logger.info("increasing cluster size from {} to {}", size, n);
                 if (numSharedDedicatedMasterNodes > 0) {
-                    asyncs.add(startDataOnlyNodeAsync(settings));
+                    asyncs.add(startDataOnlyNodeAsync());
                 } else {
-                    asyncs.add(startNodeAsync(settings));
+                    asyncs.add(startNodeAsync());
                 }
             }
         }


### PR DESCRIPTION
Previously, index creation would momentarily cause the cluster health to
go RED, because the primaries were still being assigned and activated.
This commit ensures that when an index is created or an index is being
recovered during cluster recovery and it does not have any active
allocation ids, then the cluster health status will not go RED, but
instead be YELLOW.

Relates #9126 

Closes #9106
