### PR TITLE
Expose version type  to Update & Delete by query

### DIFF
--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -69,6 +69,30 @@ these documents. In case a search or bulk request got rejected, `_delete_by_quer
 If you'd like to count version conflicts rather than cause them to abort then
 set `conflicts=proceed` on the url or `"conflicts": "proceed"` in the request body.
 
+By default `_delete_by_query` uses `internal` versioning and expects version
+numbers to be greater or equal to 1. If the version of documents are externally managed
+ and are equal to zero, executing `_delete_by_query` will report version conflicts.
+In this specific case, you can change the version type from the default `internal`
+ to the `force` value. The documents will then be deleted regardless of the version
+ of the stored documents. Note that forcing the version should be used with care.
+
+[source,js]
+--------------------------------------------------
+POST twitter/_delete_by_query
+{
+  "query": {
+    "term": {
+      "user": "kimchy"
+    }
+  },
+  "version_type": "force" <1>
+}
+--------------------------------------------------
+// TEST[setup:twitter]
+
+<1> Indicates to use a forced version type. Possible values are either `internal`
+or `force`.
+
 Back to the API format, you can limit `_delete_by_query` to a single type. This
 will only delete `tweet` documents from the `twitter` index:
 

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -46,6 +46,30 @@ conflict if the document changes between the time when the snapshot was taken
 and when the index request is processed. When the versions match the document
 is updated and the version number is incremented.
 
+By default `_update_by_query` uses `internal` versioning and expects version
+numbers to be greater or equal to 1. If the version of documents are externally managed
+ and are equal to zero, executing `_update_by_query` will report version conflicts.
+In this specific case, you can change the version type from the default `internal`
+ to the `force` value. The documents will then be updated regardless of the version
+ of the stored documents. Note that forcing the version should be used with care.
+
+[source,js]
+--------------------------------------------------
+POST twitter/_update_by_query
+{
+  "query": {
+    "term": {
+      "user": "kimchy"
+    }
+  },
+  "version_type": "force" <1>
+}
+--------------------------------------------------
+// TEST[setup:twitter]
+
+<1> Indicates to use a forced version type. Possible values are either `internal`
+or `force`.
+
 All update and query failures cause the `_update_by_query` to abort and are
 returned in the `failures` of the response. The updates that have been
 performed still stick. In other words, the process is not rolled back, only

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryRequest.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryRequest.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.index.VersionType;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -45,6 +46,11 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  */
 public class DeleteByQueryRequest extends AbstractBulkByScrollRequest<DeleteByQueryRequest> implements IndicesRequest {
 
+    /**
+     * Versioning type to set on index requests made by this action.
+     */
+    private VersionType versionType = VersionType.INTERNAL;
+
     public DeleteByQueryRequest() {
     }
 
@@ -52,6 +58,14 @@ public class DeleteByQueryRequest extends AbstractBulkByScrollRequest<DeleteByQu
         super(search);
         // Delete-By-Query does not require the source
         search.source().fetchSource(false);
+    }
+
+    public VersionType getVersionType() {
+        return versionType;
+    }
+
+    public void setVersionType(VersionType versionType) {
+        this.versionType = versionType;
     }
 
     @Override
@@ -67,6 +81,11 @@ public class DeleteByQueryRequest extends AbstractBulkByScrollRequest<DeleteByQu
         }
         if (getSearchRequest() == null || getSearchRequest().source() == null) {
             e = addValidationError("source is missing", e);
+        }
+        if (versionType == null) {
+            e = addValidationError("version type is missing", e);
+        } else if (versionType != VersionType.INTERNAL && versionType != VersionType.FORCE) {
+            e = addValidationError("version type [" + versionType.toString() + "] is not supported", e);
         }
         return e;
     }

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestDeleteByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestDeleteByQueryAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.VersionType;
 import org.elasticsearch.indices.query.IndicesQueriesRegistry;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
@@ -69,6 +70,7 @@ public class RestDeleteByQueryAction extends AbstractBulkByQueryRestHandler<Dele
 
         Map<String, Consumer<Object>> consumers = new HashMap<>();
         consumers.put("conflicts", o -> internal.setConflicts((String) o));
+        consumers.put("version_type", o -> internal.setVersionType(VersionType.fromString((String) o)));
 
         parseInternalRequest(internal, request, consumers);
 

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestUpdateByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestUpdateByQueryAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.VersionType;
 import org.elasticsearch.indices.query.IndicesQueriesRegistry;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
@@ -68,6 +69,7 @@ public class RestUpdateByQueryAction extends AbstractBulkByQueryRestHandler<Upda
         Map<String, Consumer<Object>> consumers = new HashMap<>();
         consumers.put("conflicts", o -> internal.setConflicts((String) o));
         consumers.put("script", o -> internal.setScript(Script.parse((Map<String, Object>)o, false, parseFieldMatcher)));
+        consumers.put("version_type", o -> internal.setVersionType(VersionType.fromString((String) o)));
 
         parseInternalRequest(internal, request, consumers);
 

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportDeleteByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportDeleteByQueryAction.java
@@ -91,6 +91,7 @@ public class TransportDeleteByQueryAction extends HandledTransportAction<DeleteB
             delete.type(doc.type());
             delete.id(doc.id());
             delete.version(doc.version());
+            delete.versionType(mainRequest.getVersionType());
             return wrap(delete);
         }
 

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportUpdateByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportUpdateByQueryAction.java
@@ -104,8 +104,8 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
             index.type(doc.type());
             index.id(doc.id());
             index.source(doc.sourceRef());
-            index.versionType(VersionType.INTERNAL);
             index.version(doc.version());
+            index.versionType(mainRequest.getVersionType());
             index.setPipeline(mainRequest.getPipeline());
             return wrap(index);
         }

--- a/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/40_versioning.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/40_versioning.yaml
@@ -1,0 +1,245 @@
+---
+"delete_by_query with various versioning types and version zero":
+  - do:
+      index:
+        index:        index1
+        type:         type1
+        id:           1
+        version:      0 # Starting version is zero
+        version_type: external
+        body:    {"update": 0}
+  - do:
+      indices.refresh: {}
+
+  # Delete by query with default version_type ("internal") must fail
+  # because zero is not allowed as an internal version number
+  - do:
+      catch: /illegal version value \[0\] for version type \[INTERNAL\]./
+      delete_by_query:
+        index: index1
+        refresh: true
+        body:
+          query:
+            match_all: {}
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 0}
+
+  # Delete by query with explicit version_type "internal" must fail (see previous for explanation)
+  - do:
+      catch: /illegal version value \[0\] for version type \[INTERNAL\]./
+      delete_by_query:
+        index: index1
+        refresh: true
+        body:
+          version_type: internal
+          query:
+            match_all: {}
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 0}
+
+  # Delete by query with version_type "external" is not supported
+  - do:
+      catch: /version type \[EXTERNAL\] is not supported./
+      delete_by_query:
+        index: index1
+        refresh: true
+        body:
+          version_type: external
+          query:
+            match_all: {}
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 0}
+
+  # Delete by query with version_type "external_gt" is not supported
+  - do:
+      catch: /version type \[EXTERNAL\] is not supported./
+      delete_by_query:
+        index: index1
+        refresh: true
+        body:
+          version_type: external_gt
+          query:
+            match_all: {}
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 0}
+
+  # Delete by query with version_type of "external_gte" is not supported
+  - do:
+      catch: /version type \[EXTERNAL_GTE\] is not supported./
+      delete_by_query:
+        index: index1
+        refresh: true
+        body:
+          version_type: external_gte
+          query:
+            match_all: {}
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 0}
+
+  # Delete by query with version_type of "force" must succeed
+  - do:
+      delete_by_query:
+        index: index1
+        refresh: true
+        body:
+          version_type: force
+          query:
+            match_all: {}
+  - match: {deleted: 1}
+  - match: {version_conflicts: 0}
+
+  - do:
+      catch: missing
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {found: false}
+
+
+---
+"delete_by_query with various versioning types and value greater than zero":
+  - do:
+      index:
+        index:        index1
+        type:         type1
+        id:           1
+        version:      123
+        version_type: external
+        body:    {"update": 0}
+  - do:
+      indices.refresh: {}
+
+  # Delete by query with default version_type ("internal") must succeed
+  - do:
+      delete_by_query:
+        index: index1
+        refresh: true
+        body:
+          query:
+            match_all: {}
+  - match: {deleted: 1}
+  - match: {version_conflicts: 0}
+
+  - do:
+      catch: missing
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {found: false}
+
+  # Delete by query with explicit version_type "internal" must succeed
+  - do:
+      index:
+        index:        index1
+        type:         type1
+        id:           2
+        version:      123
+        version_type: external
+        body:    {"update": 0}
+  - do:
+      indices.refresh: {}
+
+  - do:
+      delete_by_query:
+        index: index1
+        refresh: true
+        body:
+          version_type: internal
+          query:
+            match_all: {}
+  - match: {deleted: 1}
+  - match: {version_conflicts: 0}
+
+  - do:
+      catch: missing
+      get:
+        index: index1
+        type:  type1
+        id:    2
+  - match: {found: false}
+
+  # Delete by query with version_type "external" is not supported
+  - do:
+      catch: /version type \[EXTERNAL\] is not supported./
+      delete_by_query:
+        index: index1
+        refresh: true
+        body:
+          version_type: external
+          query:
+            match_all: {}
+
+  # Delete by query with version_type "external_gt" is not supported
+  - do:
+      catch: /version type \[EXTERNAL\] is not supported./
+      delete_by_query:
+        index: index1
+        refresh: true
+        body:
+          version_type: external_gt
+          query:
+            match_all: {}
+
+  # Delete by query with version_type of "external_gte" is not supported
+  - do:
+      catch: /version type \[EXTERNAL_GTE\] is not supported./
+      delete_by_query:
+        index: index1
+        refresh: true
+        body:
+          version_type: external_gte
+          query:
+            match_all: {}
+
+  # Delete by query with version_type of "force" must succeed
+  - do:
+      index:
+        index:        index1
+        type:         type1
+        id:           3
+        version:      123
+        version_type: external
+        body:    {"update": 0}
+  - do:
+      indices.refresh: {}
+
+  - do:
+      delete_by_query:
+        index: index1
+        refresh: true
+        body:
+          version_type: force
+          query:
+            match_all: {}
+  - match: {deleted: 1}
+  - match: {version_conflicts: 0}
+
+  - do:
+      catch: missing
+      get:
+        index: index1
+        type:  type1
+        id:    3
+  - match: {found: false}

--- a/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/40_versioning.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/40_versioning.yaml
@@ -21,3 +21,205 @@
         type:  test
         id:    1
   - match: {_version: 2}
+
+---
+"update_by_query with various versioning types and version zero":
+  - do:
+      index:
+        index:        index1
+        type:         type1
+        id:           1
+        version:      0 # Starting version is zero
+        version_type: external
+        body:    {"update": 0}
+  - do:
+      indices.refresh: {}
+
+  # Update by query with default version_type ("internal") must fail
+  # because zero is not allowed as an internal version number
+  - do:
+      catch: /illegal version value \[0\] for version type \[INTERNAL\]./
+      update_by_query:
+        index: index1
+        refresh: true
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 0}
+
+  # Update by query with explicit version_type "internal" must fail (see previous for explanation)
+  - do:
+      catch: /illegal version value \[0\] for version type \[INTERNAL\]./
+      update_by_query:
+        index: index1
+        refresh: true
+        body:    {"version_type": internal}
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 0}
+
+  # Update by query with version_type "external" is not supported
+  - do:
+      catch: /version type \[EXTERNAL\] is not supported./
+      update_by_query:
+        index: index1
+        refresh: true
+        body:    {"version_type": external}
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 0}
+
+  # Update by query with version_type "external_gt" is not supported
+  - do:
+      catch: /version type \[EXTERNAL\] is not supported./
+      update_by_query:
+        index: index1
+        refresh: true
+        body:    {"version_type": external_gt}
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 0}
+
+  # Update by query with version_type of "external_gte" is not supported
+  - do:
+      catch: /version type \[EXTERNAL_GTE\] is not supported./
+      update_by_query:
+        index: index1
+        refresh: true
+        body:    {"version_type": external_gte}
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 0}
+
+  # Update by query with version_type of "force" must succeed
+  - do:
+      update_by_query:
+        index: index1
+        refresh: true
+        body:    {"version_type": force}
+  - match: {updated: 1}
+  - match: {version_conflicts: 0}
+
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 0} # Updated with same version number
+
+
+---
+"update_by_query with various versioning types and value greater than zero":
+  - do:
+      index:
+        index:        index1
+        type:         type1
+        id:           1
+        version:      123
+        version_type: external
+        body:    {"update": 0}
+  - do:
+      indices.refresh: {}
+
+  # Update by query with default version_type ("internal") must succeed
+  - do:
+      update_by_query:
+        index: index1
+        refresh: true
+  - match: {updated: 1}
+  - match: {version_conflicts: 0}
+
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 124}
+
+  # Update by query with explicit version_type "internal" must succeed
+  - do:
+      update_by_query:
+        index: index1
+        refresh: true
+        body:    {"version_type": internal}
+  - match: {updated: 1}
+  - match: {version_conflicts: 0}
+
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 125}
+
+  # Update by query with version_type "external" is not supported
+  - do:
+      catch: /version type \[EXTERNAL\] is not supported./
+      update_by_query:
+        index: index1
+        refresh: true
+        body:    {"version_type": external}
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 125}
+
+  # Update by query with version_type "external_gt" is not supported
+  - do:
+      catch: /version type \[EXTERNAL\] is not supported./
+      update_by_query:
+        index: index1
+        refresh: true
+        body:    {"version_type": external_gt}
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 125}
+
+  # Update by query with version_type of "external_gte" is not supported
+  - do:
+      catch: /version type \[EXTERNAL_GTE\] is not supported./
+      update_by_query:
+        index: index1
+        refresh: true
+        body:    {"version_type": external_gte}
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 125}
+
+  # Update by query with version_type of "force" must succeed
+  - do:
+      update_by_query:
+        index: index1
+        refresh: true
+        body:    {"version_type": force}
+  - match: {updated: 1}
+  - match: {version_conflicts: 0}
+
+  - do:
+      get:
+        index: index1
+        type:  type1
+        id:    1
+  - match: {_version: 125} # Updated with same version number

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -168,10 +168,6 @@
           "type" : "boolean",
           "description" : "Specify whether to return document version as part of a hit"
         },
-        "version_type": {
-          "type" : "boolean",
-          "description" : "Should the document increment the version number (internal) on hit or not (reindex)"
-        },
         "request_cache": {
           "type" : "boolean",
           "description" : "Specify if request cache should be used for this request or not, defaults to index level setting"


### PR DESCRIPTION
This commit adds a `version_type` option to the request body for both Update-by-query and Delete-by-query. The option can take the value `internal` (default) and `force`. This last one can help to update or delete documents that have been created with an external version number equal to zero.

closes #16654
