### PR TITLE
bool query does not allow a "query" clause

### DIFF
--- a/docs/reference/query-dsl/bool-query.asciidoc
+++ b/docs/reference/query-dsl/bool-query.asciidoc
@@ -107,7 +107,7 @@ GET _search
 {
   "query": {
     "bool": {
-      "query": {
+      "must": {
         "match_all": {}
       },
       "filter": {


### PR DESCRIPTION
On ES 2.3 at least, the query in the documentation fails with a query parsing exception "[bool] query does not support [query]"
