### PR TITLE
Fix global checkpoints test bug

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/seqno/CheckpointsIT.java
+++ b/core/src/test/java/org/elasticsearch/index/seqno/CheckpointsIT.java
@@ -60,17 +60,17 @@ public class CheckpointsIT extends ESIntegTestCase {
                 logger.debug("seq_no stats for {}: {}", shardStats.getShardRouting(),
                     XContentHelper.toString(shardStats.getSeqNoStats(),
                         new ToXContent.MapParams(Collections.singletonMap("pretty", "false"))));
-                final Matcher<Long> localCheckpointRule;
+                final Matcher<Long> globalCheckpointRule;
                 if (shardStats.getShardRouting().primary()) {
-                    localCheckpointRule = equalTo(numDocs - 1L);
+                    globalCheckpointRule = equalTo(numDocs - 1L);
                 } else {
-                    // nocommit:  recovery doesn't transfer local checkpoints yet (we don't persist them in lucene).
-                    localCheckpointRule = anyOf(equalTo(numDocs - 1L), equalTo(SequenceNumbersService.NO_OPS_PERFORMED));
+                    // nocommit: recovery doesn't transfer global checkpoints yet (we don't persist them in lucene).
+                    globalCheckpointRule = anyOf(equalTo(numDocs - 1L), equalTo(SequenceNumbersService.UNASSIGNED_SEQ_NO));
                 }
                 assertThat(shardStats.getShardRouting() + " local checkpoint mismatch",
-                    shardStats.getSeqNoStats().getLocalCheckpoint(), localCheckpointRule);
+                    shardStats.getSeqNoStats().getLocalCheckpoint(), equalTo(numDocs - 1L));
                 assertThat(shardStats.getShardRouting() + " global checkpoint mismatch",
-                    shardStats.getSeqNoStats().getGlobalCheckpoint(), equalTo(numDocs - 1L));
+                    shardStats.getSeqNoStats().getGlobalCheckpoint(), globalCheckpointRule);
                 assertThat(shardStats.getShardRouting() + " max seq no mismatch",
                     shardStats.getSeqNoStats().getMaxSeqNo(), equalTo(numDocs - 1L));
             }


### PR DESCRIPTION
This commit fixes a test bug in a global checkpoints integration
test. Namely, if the replica shard is slow to start and is peer
recovered from the primary, it will not have the expected global
checkpoint due to these not being persisted and transferred on recovery.
