### PR TITLE
Bootstrap check for OnOutOfMemoryError and seccomp

### DIFF
--- a/core/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/core/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -116,6 +116,12 @@ public class JvmInfo implements Streamable, ToXContent {
             Method valueMethod = vmOptionClazz.getMethod("getValue");
 
             try {
+                Object onOutOfMemoryError = vmOptionMethod.invoke(hotSpotDiagnosticMXBean, "OnOutOfMemoryError");
+                info.onOutOfMemoryError = (String) valueMethod.invoke(onOutOfMemoryError);
+            } catch (Exception ignored) {
+            }
+
+            try {
                 Object useCompressedOopsVmOption = vmOptionMethod.invoke(hotSpotDiagnosticMXBean, "UseCompressedOops");
                 info.useCompressedOops = (String) valueMethod.invoke(useCompressedOopsVmOption);
             } catch (Exception ignored) {
@@ -178,6 +184,8 @@ public class JvmInfo implements Streamable, ToXContent {
 
     String[] gcCollectors = Strings.EMPTY_ARRAY;
     String[] memoryPools = Strings.EMPTY_ARRAY;
+
+    private String onOutOfMemoryError;
 
     private String useCompressedOops = "unknown";
 
@@ -312,6 +320,10 @@ public class JvmInfo implements Streamable, ToXContent {
 
     public long getConfiguredMaxHeapSize() {
         return configuredMaxHeapSize;
+    }
+
+    public String onOutOfMemoryError() {
+        return onOutOfMemoryError;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/core/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -116,6 +116,12 @@ public class JvmInfo implements Streamable, ToXContent {
             Method valueMethod = vmOptionClazz.getMethod("getValue");
 
             try {
+                Object onError = vmOptionMethod.invoke(hotSpotDiagnosticMXBean, "OnError");
+                info.onError = (String) valueMethod.invoke(onError);
+            } catch (Exception ignored) {
+            }
+
+            try {
                 Object onOutOfMemoryError = vmOptionMethod.invoke(hotSpotDiagnosticMXBean, "OnOutOfMemoryError");
                 info.onOutOfMemoryError = (String) valueMethod.invoke(onOutOfMemoryError);
             } catch (Exception ignored) {
@@ -184,6 +190,8 @@ public class JvmInfo implements Streamable, ToXContent {
 
     String[] gcCollectors = Strings.EMPTY_ARRAY;
     String[] memoryPools = Strings.EMPTY_ARRAY;
+
+    private String onError;
 
     private String onOutOfMemoryError;
 
@@ -320,6 +328,10 @@ public class JvmInfo implements Streamable, ToXContent {
 
     public long getConfiguredMaxHeapSize() {
         return configuredMaxHeapSize;
+    }
+
+    public String onError() {
+        return onError;
     }
 
     public String onOutOfMemoryError() {

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCheckTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCheckTests.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -396,10 +397,66 @@ public class BootstrapCheckTests extends ESTestCase {
         BootstrapCheck.check(true, false, Collections.singletonList(check), "testClientJvmCheck");
     }
 
+    public void testMightForkCheck() {
+        final AtomicBoolean isSeccompInstalled = new AtomicBoolean();
+        final AtomicBoolean mightFork = new AtomicBoolean();
+        final BootstrapCheck.MightForkCheck check = new BootstrapCheck.MightForkCheck() {
+            @Override
+            boolean isSeccompInstalled() {
+                return isSeccompInstalled.get();
+            }
+
+            @Override
+            boolean mightFork() {
+                return mightFork.get();
+            }
+
+            @Override
+            public String errorMessage() {
+                return "error";
+            }
+        };
+
+        runMightForkTest(
+            check,
+            isSeccompInstalled,
+            () -> mightFork.set(false),
+            () -> mightFork.set(true),
+            e -> assertThat(e.getMessage(), containsString("error")));
+    }
+
+    public void testOnErrorCheck() {
+        final AtomicBoolean isSeccompInstalled = new AtomicBoolean();
+        final AtomicReference<String> onError = new AtomicReference<>();
+        final BootstrapCheck.MightForkCheck check = new BootstrapCheck.OnErrorCheck() {
+            @Override
+            boolean isSeccompInstalled() {
+                return isSeccompInstalled.get();
+            }
+
+            @Override
+            String onError() {
+                return onError.get();
+            }
+        };
+
+        final String command = randomAsciiOfLength(16);
+        runMightForkTest(
+            check,
+            isSeccompInstalled,
+            () -> onError.set(randomBoolean() ? "" : null),
+            () -> onError.set(command),
+            e -> assertThat(
+                e.getMessage(),
+                containsString(
+                    "OnError [" + command + "] requires forking but is prevented by system call filters ([bootstrap.seccomp=true]);"
+                        + " upgrade to at least Java 8u92 and use ExitOnOutOfMemoryError")));
+    }
+
     public void testOnOutOfMemoryErrorCheck() {
         final AtomicBoolean isSeccompInstalled = new AtomicBoolean();
         final AtomicReference<String> onOutOfMemoryError = new AtomicReference<>();
-        final BootstrapCheck.Check check = new BootstrapCheck.OnOutOfMemoryErrorCheck() {
+        final BootstrapCheck.MightForkCheck check = new BootstrapCheck.OnOutOfMemoryErrorCheck() {
             @Override
             boolean isSeccompInstalled() {
                 return isSeccompInstalled.get();
@@ -411,31 +468,52 @@ public class BootstrapCheckTests extends ESTestCase {
             }
         };
 
+        final String command = randomAsciiOfLength(16);
+        runMightForkTest(
+            check,
+            isSeccompInstalled,
+            () -> onOutOfMemoryError.set(randomBoolean() ? "" : null),
+            () -> onOutOfMemoryError.set(command),
+            e -> assertThat(
+                e.getMessage(),
+                containsString(
+                    "OnOutOfMemoryError [" + command + "]"
+                        + " requires forking but is prevented by system call filters ([bootstrap.seccomp=true]);"
+                        + " upgrade to at least Java 8u92 and use ExitOnOutOfMemoryError")));
+    }
+
+    private void runMightForkTest(
+        final BootstrapCheck.MightForkCheck check,
+        final AtomicBoolean isSeccompInstalled,
+        final Runnable disableMightFork,
+        final Runnable enableMightFork,
+        final Consumer<RuntimeException> consumer) {
+
         // if seccomp is disabled, nothing should happen
         isSeccompInstalled.set(false);
-        onOutOfMemoryError.set(randomBoolean() ? "" : randomAsciiOfLength(16));
-        BootstrapCheck.check(true, false, Collections.singletonList(check), "testOnOutOfMemoryErrorCheck");
+        if (randomBoolean()) {
+            disableMightFork.run();
+        } else {
+            enableMightFork.run();
+        }
+        BootstrapCheck.check(true, randomBoolean(), Collections.singletonList(check), "testMightFork");
 
-        // if seccomp is enabled, and OnOutOfMemoryError is not, nothing
-        // should happen
+        // if seccomp is enabled, but we will not fork, nothing should
+        // happen
         isSeccompInstalled.set(true);
-        onOutOfMemoryError.set("");
-        BootstrapCheck.check(true, false, Collections.singletonList(check), "testOnOutOfMemoryErrorCheck");
+        disableMightFork.run();
+        BootstrapCheck.check(true, randomBoolean(), Collections.singletonList(check), "testMightFork");
 
-        // if seccomp is enabled, and OnOutOfMemoryError is, the check
-        // should be enforced, regardless of bootstrap checks being
-        // enabled or not
+        // if seccomp is enabled, and we might fork, the check should
+        // be enforced, regardless of bootstrap checks being enabled or
+        // not
         isSeccompInstalled.set(true);
-        final String command = randomAsciiOfLength(16);
-        onOutOfMemoryError.set(command);
+        enableMightFork.run();
+
         final RuntimeException e = expectThrows(
             RuntimeException.class,
-            () -> BootstrapCheck.check(randomBoolean(), randomBoolean(), Collections.singletonList(check), "testOnOutOfMemoryErrorCheck"));
-        assertThat(
-            e.getMessage(),
-            containsString(
-                "OnOutOfMemoryError [" + command + "] requires forking but is prevented by system call filters ([bootstrap.seccomp=true]);"
-                    + " upgrade to at least Java 8u92 and use ExitOnOutOfMemoryError"));
+            () -> BootstrapCheck.check(randomBoolean(), randomBoolean(), Collections.singletonList(check), "testMightFork"));
+        consumer.accept(e);
     }
 
     public void testIgnoringSystemChecks() {

--- a/docs/reference/setup/bootstrap-checks.asciidoc
+++ b/docs/reference/setup/bootstrap-checks.asciidoc
@@ -16,6 +16,10 @@ checks that fail appear as warnings in the Elasticsearch log. If
 Elasticsearch is in production mode, any bootstrap checks that fail will
 cause Elasticsearch to refuse to start.
 
+There are some bootstrap checks that are always enforced to prevent
+Elasticsearch from running with incompatible settings. These checks are
+documented individually.
+
 [float]
 === Development vs. production mode
 
@@ -152,3 +156,15 @@ JVM check, you must start Elasticsearch with the server VM. On modern
 systems and operating systems, the server VM is the
 default. Additionally, Elasticsearch is configured by default to force
 the server VM.
+
+=== OnOutOfMemoryError check
+
+The JVM option `OnOutOfMemoryError` enables executing an arbitrary
+command if the JVM throws an `OutOfMemoryError`. However, by default,
+Elasticsearch system call filters (seccomp) are enabled and these
+filters prevent forking. Thus, using `OnOutOfMemoryError` and system
+call filters are incompatible. The `OnOutOfMemoryError` check prevents
+Elasticsearch from starting if this JVM option is used and system call
+filters are enabled. This check is always enforced. To pass this check
+do not enable `OnOutOfMemoryError`; instead, upgrade to Java 8u92 and
+use the JVM flag `ExitOnOutOfMemoryError`.

--- a/docs/reference/setup/bootstrap-checks.asciidoc
+++ b/docs/reference/setup/bootstrap-checks.asciidoc
@@ -157,14 +157,18 @@ systems and operating systems, the server VM is the
 default. Additionally, Elasticsearch is configured by default to force
 the server VM.
 
-=== OnOutOfMemoryError check
+=== OnError and OnOutOfMemoryError checks
 
-The JVM option `OnOutOfMemoryError` enables executing an arbitrary
-command if the JVM throws an `OutOfMemoryError`. However, by default,
+The JVM options `OnError` and `OnOutOfMemoryError` enable executing
+arbitrary commands if the JVM encounters a fatal error (`OnError`) or an
+`OutOfMemoryError` (`OnOutOfMemoryError`). However, by default,
 Elasticsearch system call filters (seccomp) are enabled and these
-filters prevent forking. Thus, using `OnOutOfMemoryError` and system
-call filters are incompatible. The `OnOutOfMemoryError` check prevents
-Elasticsearch from starting if this JVM option is used and system call
-filters are enabled. This check is always enforced. To pass this check
-do not enable `OnOutOfMemoryError`; instead, upgrade to Java 8u92 and
-use the JVM flag `ExitOnOutOfMemoryError`.
+filters prevent forking. Thus, using `OnError` or `OnOutOfMemoryError`
+and system call filters are incompatible. The `OnError` and
+`OnOutOfMemoryError` checks prevent Elasticsearch from starting if
+either of these JVM options are used and system call filters are
+enabled. This check is always enforced. To pass this check do not enable
+`OnError` nor `OnOutOfMemoryError`; instead, upgrade to Java 8u92 and
+use the JVM flag `ExitOnOutOfMemoryError`. While this does not have the
+full capabilities of `OnError` nor `OnOutOfMemoryError`, arbitrary
+forking will not be supported with seccomp enabled.


### PR DESCRIPTION
This commit adds a bootstrap check for the JVM option OnOutOfMemoryError
being in use and seccomp being enabled. These two options are
incompatible because OnOutOfMemoryError allows the user to specify an
arbitrary program to fork when the JVM encounters an
OutOfMemoryError, and seccomp enables system call filters that prevents
forking.

This commit also adds support for bootstrap checks that are always
enforced, whether or not Elasticsearch is in production mode.

Closes #18736
