### PR TITLE
Remove explicit parallel new GC flag

### DIFF
--- a/distribution/src/main/resources/config/jvm.options
+++ b/distribution/src/main/resources/config/jvm.options
@@ -33,7 +33,6 @@
 ################################################################
 
 ## GC configuration
--XX:+UseParNewGC
 -XX:+UseConcMarkSweepGC
 -XX:CMSInitiatingOccupancyFraction=75
 -XX:+UseCMSInitiatingOccupancyOnly


### PR DESCRIPTION
Unless explicitly disabled, the parallel new collector is enabled
automatically as soon as the CMS collector is enabled:

``` c++
  void Arguments::set_cms_and_parnew_gc_flags() {
    assert(
      !UseSerialGC && !UseParallelOldGC && !UseParallelGC,
      "Error");
    assert(UseConcMarkSweepGC, "CMS is expected to be on here");

    // If we are using CMS, we prefer to UseParNewGC,
    // unless explicitly forbidden.
    if (FLAG_IS_DEFAULT(UseParNewGC)) {
      FLAG_SET_ERGO(bool, UseParNewGC, true);
    }
```

While it's fine to be explicit, the UseParNewGC flag is deprecated in JDK
8 and produces warning messages in JDK 9:

```
  Java HotSpot(TM) 64-Bit Server VM warning: Option UseParNewGC was
  deprecated in version 9.0 and will likely be removed in a future
  release.
```

Thus, we can and should just remove this flag from the default JVM
options.
