### PR TITLE
Installation and removal instructions for Ingest Plugins

### DIFF
--- a/docs/plugins/ingest-attachment.asciidoc
+++ b/docs/plugins/ingest-attachment.asciidoc
@@ -11,6 +11,36 @@ the overhead of converting back and forth between base64, you can use the CBOR
 format instead of JSON and specify the field as a bytes array instead of a string
 representation. The processor will skip the base64 decoding then.
 
+[[ingest-attachment-install]]
+[float]
+==== Installation
+
+This plugin can be installed using the plugin manager:
+
+[source,sh]
+----------------------------------------------------------------
+sudo bin/elasticsearch-plugin install ingest-attachment
+----------------------------------------------------------------
+
+The plugin must be installed on every node in the cluster, and each node must
+be restarted after installation.
+
+[[ingest-attachment-remove]]
+[float]
+==== Removal
+
+The plugin can be removed with the following command:
+
+[source,sh]
+----------------------------------------------------------------
+sudo bin/elasticsearch-plugin remove ingest-attachment
+----------------------------------------------------------------
+
+The node must be stopped before removing the plugin.
+
+[[using-ingest-attachment]]
+==== Using the Attachment Processor in a Pipeline
+
 [[ingest-attachment-options]]
 .Attachment options
 [options="header"]

--- a/docs/plugins/ingest-geoip.asciidoc
+++ b/docs/plugins/ingest-geoip.asciidoc
@@ -11,7 +11,37 @@ The GeoIP processor can run with other geoip2 databases from Maxmind. The files 
 and the `database_file` option should be used to specify the filename of the custom database. The geoip config directory
 is located at `$ES_HOME/config/ingest/geoip` and holds the shipped databases too.
 
-[[geoip-options]]
+[[ingest-geoip-install]]
+[float]
+==== Installation
+
+This plugin can be installed using the plugin manager:
+
+[source,sh]
+----------------------------------------------------------------
+sudo bin/elasticsearch-plugin install ingest-geoip
+----------------------------------------------------------------
+
+The plugin must be installed on every node in the cluster, and each node must
+be restarted after installation.
+
+[[ingest-geoip-remove]]
+[float]
+==== Removal
+
+The plugin can be removed with the following command:
+
+[source,sh]
+----------------------------------------------------------------
+sudo bin/elasticsearch-plugin remove ingest-geoip
+----------------------------------------------------------------
+
+The node must be stopped before removing the plugin.
+
+[[using-ingest-geoip]]
+==== Using the Geoip Processor in a Pipeline
+
+[[ingest-geoip-options]]
 .Geoip options
 [options="header"]
 |======


### PR DESCRIPTION
There's no place in the v5 docs so far that correctly identifies the plugin IDs to be used to install the Geoip and Attachment plugins into Elasticsearch. This adds the instructions to the documentation.
