### PR TITLE
Add Method to Get New MethodWriters

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Writer.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Writer.java
@@ -41,8 +41,7 @@ import java.util.BitSet;
 final class Writer {
 
     static byte[] write(CompilerSettings settings, String name, String source, Variables variables, SSource root, BitSet expressions) {
-        Writer writer = new Writer(settings, name, source, variables, root, expressions);
-        return writer.getBytes();
+        return new Writer(settings, name, source, variables, root, expressions).getBytes();
     }
 
     private final CompilerSettings settings;
@@ -66,7 +65,7 @@ final class Writer {
         writeBegin();
         writeConstructor();
 
-        adapter = new MethodWriter(Opcodes.ACC_PUBLIC, EXECUTE, null, writer, expressions);
+        adapter = new MethodWriter(Opcodes.ACC_PUBLIC, EXECUTE, writer, expressions);
 
         writeExecute();
         writeEnd();

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/WriterConstants.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/WriterConstants.java
@@ -143,7 +143,7 @@ public final class WriterConstants {
 
     public final static Method CHECKEQUALS = getAsmMethod(boolean.class, "checkEquals", Object.class, Object.class);
 
-    private static Method getAsmMethod(final Class<?> rtype, final String name, final Class<?>... ptypes) {
+    public static Method getAsmMethod(final Class<?> rtype, final String name, final Class<?>... ptypes) {
         return new Method(name, MethodType.methodType(rtype, ptypes).toMethodDescriptorString());
     }
 


### PR DESCRIPTION
Add a method in MethodWriter to allow other MethodWriters to be created for adding static methods to the Executable class on-the-fly.
