### PR TITLE
default values for BM25 Similarity

### DIFF
--- a/docs/reference/index-modules/similarity.asciidoc
+++ b/docs/reference/index-modules/similarity.asciidoc
@@ -73,10 +73,11 @@ This similarity has the following options:
 [horizontal]
 `k1`::
     Controls non-linear term frequency normalization
-    (saturation).
+    (saturation). The default value is `1.2`.
 
 `b`::
     Controls to what degree document length normalizes tf values.
+    The default value is `0.75`.
 
 `discount_overlaps`::
     Determines whether overlap tokens (Tokens with


### PR DESCRIPTION
added the lucene default values for BM25 similarity - assuming elastic search uses them
