### PR TITLE
Add an index setting to limit the maximum number of slices allowed in a scroll request.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -116,6 +116,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexSettings.ALLOW_UNMAPPED,
         IndexSettings.INDEX_CHECK_ON_STARTUP,
         IndexSettings.MAX_REFRESH_LISTENERS_PER_SHARD,
+        IndexSettings.MAX_SLICES_PER_SCROLL,
         ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING,
         IndexSettings.INDEX_GC_DELETES_SETTING,
         IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING,

--- a/core/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -121,6 +121,12 @@ public final class IndexSettings {
     public static final Setting<Integer> MAX_REFRESH_LISTENERS_PER_SHARD = Setting.intSetting("index.max_refresh_listeners", 1000, 0,
             Property.Dynamic, Property.IndexScope);
 
+    /**
+     * The maximum number of slices allowed in a scroll request
+     */
+    public static final Setting<Integer> MAX_SLICES_PER_SCROLL = Setting.intSetting("index.max_slices_per_scroll",
+        1024, 1, Property.Dynamic, Property.IndexScope);
+
     private final Index index;
     private final Version version;
     private final ESLogger logger;
@@ -154,6 +160,11 @@ public final class IndexSettings {
      * The maximum number of refresh listeners allows on this shard.
      */
     private volatile int maxRefreshListeners;
+    /**
+     * The maximum number of slices allowed in a scroll request.
+     */
+    private volatile int maxSlicesPerScroll;
+
 
     /**
      * Returns the default search field for this index.
@@ -239,6 +250,7 @@ public final class IndexSettings {
         maxRescoreWindow = scopedSettings.get(MAX_RESCORE_WINDOW_SETTING);
         TTLPurgeDisabled = scopedSettings.get(INDEX_TTL_DISABLE_PURGE_SETTING);
         maxRefreshListeners = scopedSettings.get(MAX_REFRESH_LISTENERS_PER_SHARD);
+        maxSlicesPerScroll = scopedSettings.get(MAX_SLICES_PER_SCROLL);
         this.mergePolicyConfig = new MergePolicyConfig(logger, this);
         assert indexNameMatcher.test(indexMetaData.getIndex().getName());
 
@@ -262,6 +274,7 @@ public final class IndexSettings {
         scopedSettings.addSettingsUpdateConsumer(INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING, this::setTranslogFlushThresholdSize);
         scopedSettings.addSettingsUpdateConsumer(INDEX_REFRESH_INTERVAL_SETTING, this::setRefreshInterval);
         scopedSettings.addSettingsUpdateConsumer(MAX_REFRESH_LISTENERS_PER_SHARD, this::setMaxRefreshListeners);
+        scopedSettings.addSettingsUpdateConsumer(MAX_SLICES_PER_SCROLL, this::setMaxSlicesPerScroll);
     }
 
     private void setTranslogFlushThresholdSize(ByteSizeValue byteSizeValue) {
@@ -519,6 +532,17 @@ public final class IndexSettings {
 
     private void setMaxRefreshListeners(int maxRefreshListeners) {
         this.maxRefreshListeners = maxRefreshListeners;
+    }
+
+    /**
+     * The maximum number of slices allowed in a scroll request.
+     */
+    public int getMaxSlicesPerScroll() {
+        return maxSlicesPerScroll;
+    }
+
+    private void setMaxSlicesPerScroll(int value) {
+        this.maxSlicesPerScroll = value;
     }
 
     IndexScopedSettings getScopedSettings() { return scopedSettings;}

--- a/core/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchService.java
@@ -826,9 +826,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> imp
             if (context.scrollContext() == null) {
                 throw new SearchContextException(context, "`slice` cannot be used outside of a scroll context");
             }
-            context.sliceFilter(source.slice().toFilter(queryShardContext,
-                context.shardTarget().getShardId().getId(),
-                queryShardContext.getIndexSettings().getNumberOfShards()));
+            context.sliceBuilder(source.slice());
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/search/simple/SimpleSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/simple/SimpleSearchIT.java
@@ -443,6 +443,6 @@ public class SimpleSearchIT extends ESIntegTestCase {
         assertThat(e.toString(), containsString("Rescore window [" + windowSize + "] is too large. It must "
                 + "be less than [" + IndexSettings.MAX_RESCORE_WINDOW_SETTING.get(Settings.EMPTY)));
         assertThat(e.toString(), containsString(
-                "This limit can be set by chaining the [" + IndexSettings.MAX_RESCORE_WINDOW_SETTING.getKey() + "] index level setting."));
+                "This limit can be set by changing the [" + IndexSettings.MAX_RESCORE_WINDOW_SETTING.getKey() + "] index level setting."));
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/slice/SearchSliceIT.java
+++ b/core/src/test/java/org/elasticsearch/search/slice/SearchSliceIT.java
@@ -35,7 +35,6 @@ import org.elasticsearch.test.ESIntegTestCase;
 import java.io.IOException;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Set;
 import java.util.HashSet;
 import java.util.concurrent.ExecutionException;
 
@@ -43,7 +42,6 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.startsWith;
 
 public class SearchSliceIT extends ESIntegTestCase {
@@ -71,7 +69,8 @@ public class SearchSliceIT extends ESIntegTestCase {
             .endObject().string();
         int numberOfShards = randomIntBetween(1, 7);
         assertAcked(client().admin().indices().prepareCreate("test")
-            .setSettings("number_of_shards", numberOfShards)
+            .setSettings("number_of_shards", numberOfShards,
+                         "index.max_slices_per_scroll", 10000)
             .addMapping("type", mapping));
         ensureGreen();
 

--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -264,3 +264,6 @@ curl -XGET 'localhost:9200/twitter/tweet/_search?scroll=1m' -d '
 --------------------------------------------------
 
 For append only time-based indices, the `timestamp` field can be used safely.
+
+NOTE: By default the maximum number of slices allowed per scroll is limited to 1024.
+You can update the `index.max_slices_per_scroll` index setting to bypass this limit.

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/12_slices.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/12_slices.yaml
@@ -1,0 +1,75 @@
+---
+"Sliced scroll":
+  - do:
+      indices.create:
+        index: test_sliced_scroll
+
+  - do:
+      index:
+        index:  test_sliced_scroll
+        type:   test
+        id:     42
+        body:   { foo: 1 }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: test_sliced_scroll
+        size: 1
+        scroll: 1m
+        sort: foo
+        body:
+          slice: {
+            id: 0,
+            max: 3
+          }
+          query:
+            match_all: {}
+
+  - set: {_scroll_id: scroll_id}
+
+  - do:
+        clear_scroll:
+          scroll_id: $scroll_id
+
+  - do:
+        catch:  /query_phase_execution_exception.*The number of slices.*index.max_slices_per_scroll/
+        search:
+          index: test_sliced_scroll
+          size: 1
+          scroll: 1m
+          body:
+            slice: {
+              id: 0,
+              max: 1025
+            }
+            query:
+              match_all: {}
+
+  - do:
+        indices.put_settings:
+          index: test_sliced_scroll
+          body:
+            index.max_slices_per_scroll: 1025
+
+  - do:
+        search:
+          index: test_sliced_scroll
+          size: 1
+          scroll: 1m
+          body:
+            slice: {
+              id: 0,
+              max: 1025
+            }
+            query:
+              match_all: {}
+
+  - set: {_scroll_id: scroll_id}
+
+  - do:
+        clear_scroll:
+          scroll_id: $scroll_id
+


### PR DESCRIPTION
This is a follow up for https://github.com/elastic/elasticsearch/pull/18237#discussion_r66096836
