### PR TITLE
Align description with implementation

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.rethrottle.json
@@ -15,7 +15,7 @@
         "requests_per_second": {
           "type": "float",
           "required": true,
-          "description": "The throttle to set on this request in sub-requests per second. 0 means set no throttle. As does \"unlimited\". Otherwise it must be a float."
+          "description": "The throttle to set on this request in sub-requests per second. \"unlimited\" means no throttle. Otherwise it must be a float greater than 0."
         }
       }
     },


### PR DESCRIPTION
[float value must now be greater than 0, or use `"unlimited"` for no throttle](https://github.com/elastic/elasticsearch/blob/a1172d816cc3d8404347b8770c162b4f938fc486/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBaseReindexRestHandler.java#L149)
