### PR TITLE
Make random UUIDs reproducible in tests

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/RandomBasedUUIDGenerator.java
+++ b/core/src/main/java/org/elasticsearch/common/RandomBasedUUIDGenerator.java
@@ -30,7 +30,7 @@ class RandomBasedUUIDGenerator implements UUIDGenerator {
      */
     @Override
     public String getBase64UUID() {
-        return getBase64UUID(Randomness.getSecureRandom());
+        return getBase64UUID(Randomness.getSecure());
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/RandomBasedUUIDGenerator.java
+++ b/core/src/main/java/org/elasticsearch/common/RandomBasedUUIDGenerator.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.common;
 
-
-import java.io.IOException;
 import java.util.Base64;
 import java.util.Random;
 
@@ -32,7 +30,7 @@ class RandomBasedUUIDGenerator implements UUIDGenerator {
      */
     @Override
     public String getBase64UUID() {
-        return getBase64UUID(SecureRandomHolder.INSTANCE);
+        return getBase64UUID(Randomness.getSecureRandom());
     }
 
     /**
@@ -49,12 +47,13 @@ class RandomBasedUUIDGenerator implements UUIDGenerator {
          * stamp (bits 4 through 7 of the time_hi_and_version field).*/
         randomBytes[6] &= 0x0f;  /* clear the 4 most significant bits for the version  */
         randomBytes[6] |= 0x40;  /* set the version to 0100 / 0x40 */
-        
-        /* Set the variant: 
+
+        /* Set the variant:
          * The high field of th clock sequence multiplexed with the variant.
          * We set only the MSB of the variant*/
         randomBytes[8] &= 0x3f;  /* clear the 2 most significant bits */
         randomBytes[8] |= 0x80;  /* set the variant (MSB is set)*/
         return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/common/Randomness.java
+++ b/core/src/main/java/org/elasticsearch/common/Randomness.java
@@ -128,7 +128,7 @@ public final class Randomness {
      *                               RandomizedContext or tests are
      *                               running but tests.seed is not set
      */
-    public static Random getSecureRandom() {
+    public static Random getSecure() {
         if (currentMethod != null && getRandomMethod != null) {
             return get();
         } else {

--- a/core/src/main/java/org/elasticsearch/common/Randomness.java
+++ b/core/src/main/java/org/elasticsearch/common/Randomness.java
@@ -116,27 +116,21 @@ public final class Randomness {
     /**
      * Provides a source of secure randomness that is reproducible when
      * running under the Elasticsearch test suite, and otherwise
-     * produces a non-reproducible source of secure randomness.
-     * Reproducible sources of secure randomness are created when the
-     * system property "tests.seed" is set and the security policy
-     * allows reading this system property. Otherwise, non-reproducible
-     * sources of secure randomness are created.
+     * produces a non-reproducible source of randomness. Reproducible
+     * sources of randomness are created when the system property
+     * "tests.seed" is set and the security policy allows reading this
+     * system property. Otherwise, non-reproducible sources of secure
+     * randomness are created.
      *
-     * @return a source of secure randomness
+     * @return a source of randomness
      * @throws IllegalStateException if running tests but was not able
      *                               to acquire an instance of Random from
      *                               RandomizedContext or tests are
      *                               running but tests.seed is not set
      */
-    public static SecureRandom getSecureRandom() {
+    public static Random getSecureRandom() {
         if (currentMethod != null && getRandomMethod != null) {
-            try {
-                final SecureRandom sr = SecureRandom.getInstance("SHA1PRNG", "SUN");
-                sr.setSeed(get().nextLong());
-                return sr;
-            } catch (NoSuchAlgorithmException | NoSuchProviderException e) {
-                throw new IllegalStateException("running tests but failed to create reproducible SecureRandom", e);
-            }
+            return get();
         } else {
             return getSecureRandomWithoutSeed();
         }

--- a/core/src/main/java/org/elasticsearch/common/Randomness.java
+++ b/core/src/main/java/org/elasticsearch/common/Randomness.java
@@ -114,13 +114,13 @@ public final class Randomness {
     }
 
     /**
-     * Provides a source of secure randomness that is reproducible when
+     * Provides a source of randomness that is reproducible when
      * running under the Elasticsearch test suite, and otherwise
-     * produces a non-reproducible source of randomness. Reproducible
-     * sources of randomness are created when the system property
-     * "tests.seed" is set and the security policy allows reading this
-     * system property. Otherwise, non-reproducible sources of secure
-     * randomness are created.
+     * produces a non-reproducible source of secure randomness.
+     * Reproducible sources of randomness are created when the system
+     * property "tests.seed" is set and the security policy allows
+     * reading this system property. Otherwise, non-reproducible
+     * sources of secure randomness are created.
      *
      * @return a source of randomness
      * @throws IllegalStateException if running tests but was not able

--- a/core/src/main/java/org/elasticsearch/common/Randomness.java
+++ b/core/src/main/java/org/elasticsearch/common/Randomness.java
@@ -23,6 +23,9 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 
 import java.lang.reflect.Method;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -44,6 +47,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * DiscoveryService#NODE_ID_SEED_SETTING)).
  */
 public final class Randomness {
+
     private static final Method currentMethod;
     private static final Method getRandomMethod;
 
@@ -72,7 +76,7 @@ public final class Randomness {
      * @param setting  the setting to access the seed
      * @return a reproducible source of randomness
      */
-    public static Random get(Settings settings, Setting<Long> setting) {
+    public static Random get(final Settings settings, final Setting<Long> setting) {
         if (setting.exists(settings)) {
             return new Random(setting.get(settings));
         } else {
@@ -98,7 +102,7 @@ public final class Randomness {
     public static Random get() {
         if (currentMethod != null && getRandomMethod != null) {
             try {
-                Object randomizedContext = currentMethod.invoke(null);
+                final Object randomizedContext = currentMethod.invoke(null);
                 return (Random) getRandomMethod.invoke(randomizedContext);
             } catch (ReflectiveOperationException e) {
                 // unexpected, bail
@@ -109,13 +113,48 @@ public final class Randomness {
         }
     }
 
+    /**
+     * Provides a source of secure randomness that is reproducible when
+     * running under the Elasticsearch test suite, and otherwise
+     * produces a non-reproducible source of secure randomness.
+     * Reproducible sources of secure randomness are created when the
+     * system property "tests.seed" is set and the security policy
+     * allows reading this system property. Otherwise, non-reproducible
+     * sources of secure randomness are created.
+     *
+     * @return a source of secure randomness
+     * @throws IllegalStateException if running tests but was not able
+     *                               to acquire an instance of Random from
+     *                               RandomizedContext or tests are
+     *                               running but tests.seed is not set
+     */
+    public static SecureRandom getSecureRandom() {
+        if (currentMethod != null && getRandomMethod != null) {
+            try {
+                final SecureRandom sr = SecureRandom.getInstance("SHA1PRNG", "SUN");
+                sr.setSeed(get().nextLong());
+                return sr;
+            } catch (NoSuchAlgorithmException | NoSuchProviderException e) {
+                throw new IllegalStateException("running tests but failed to create reproducible SecureRandom", e);
+            }
+        } else {
+            return getSecureRandomWithoutSeed();
+        }
+    }
+
     @SuppressForbidden(reason = "ThreadLocalRandom is okay when not running tests")
     private static Random getWithoutSeed() {
         assert currentMethod == null && getRandomMethod == null : "running under tests but tried to create non-reproducible random";
         return ThreadLocalRandom.current();
     }
 
-    public static void shuffle(List<?> list) {
+    private static SecureRandom getSecureRandomWithoutSeed() {
+        assert currentMethod == null && getRandomMethod == null : "running under tests but tried to create non-reproducible random";
+        return SecureRandomHolder.INSTANCE;
+    }
+
+    public static void shuffle(final List<?> list) {
         Collections.shuffle(list, get());
     }
+
 }

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterChangedEventTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterChangedEventTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.transport.DummyTransportAddress;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
+import org.junit.BeforeClass;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,11 +55,17 @@ public class ClusterChangedEventTests extends ESTestCase {
 
     private static final ClusterName TEST_CLUSTER_NAME = new ClusterName("test");
     private static final String NODE_ID_PREFIX = "node_";
-    private static final String INITIAL_CLUSTER_ID = UUIDs.randomBase64UUID();
-    // the initial indices which every cluster state test starts out with
-    private static final List<Index> initialIndices = Arrays.asList(new Index("idx1", UUIDs.randomBase64UUID()),
-                                                                    new Index("idx2", UUIDs.randomBase64UUID()),
-                                                                    new Index("idx3", UUIDs.randomBase64UUID()));
+    private static String INITIAL_CLUSTER_ID;
+    private static List<Index> initialIndices;
+
+    @BeforeClass
+    public static void beforeClass() {
+        INITIAL_CLUSTER_ID = UUIDs.randomBase64UUID();
+        // the initial indices which every cluster state test starts out with
+        initialIndices = Arrays.asList(new Index("idx1", UUIDs.randomBase64UUID()),
+            new Index("idx2", UUIDs.randomBase64UUID()),
+            new Index("idx3", UUIDs.randomBase64UUID()));
+    }
 
     /**
      * Test basic properties of the ClusterChangedEvent class:

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexSameIndexTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexSameIndexTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
+import org.junit.BeforeClass;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -39,16 +40,22 @@ import static org.hamcrest.Matchers.containsString;
  * Tests that indexing from an index back into itself fails the request.
  */
 public class ReindexSameIndexTests extends ESTestCase {
-    private static final ClusterState STATE = ClusterState.builder(new ClusterName("test")).metaData(MetaData.builder()
-                .put(index("target", "target_alias", "target_multi"), true)
-                .put(index("target2", "target_multi"), true)
-                .put(index("foo"), true)
-                .put(index("bar"), true)
-                .put(index("baz"), true)
-                .put(index("source", "source_multi"), true)
-                .put(index("source2", "source_multi"), true)).build();
+
+    private static ClusterState STATE;
     private static final IndexNameExpressionResolver INDEX_NAME_EXPRESSION_RESOLVER = new IndexNameExpressionResolver(Settings.EMPTY);
-    private static final AutoCreateIndex AUTO_CREATE_INDEX = new AutoCreateIndex(Settings.EMPTY, INDEX_NAME_EXPRESSION_RESOLVER);
+    private static AutoCreateIndex AUTO_CREATE_INDEX = new AutoCreateIndex(Settings.EMPTY, INDEX_NAME_EXPRESSION_RESOLVER);
+
+    @BeforeClass
+    public static void beforeClass() {
+        STATE = ClusterState.builder(new ClusterName("test")).metaData(MetaData.builder()
+            .put(index("target", "target_alias", "target_multi"), true)
+            .put(index("target2", "target_multi"), true)
+            .put(index("foo"), true)
+            .put(index("bar"), true)
+            .put(index("baz"), true)
+            .put(index("source", "source_multi"), true)
+            .put(index("source2", "source_multi"), true)).build();
+    }
 
     public void testObviousCases() throws Exception {
         fails("target", "target");


### PR DESCRIPTION
Today we use a random source of UUIDs for assigning allocation IDs,
cluster IDs, etc. Yet, the source of randomness for this is not
reproducible in tests. Since allocation IDs end up as keys in hash maps,
this means allocation decisions and not reproducible in tests and this
leads to non-reproducible test failures. This commit modifies the
behavior of random UUIDs so that they are reproducible under tests. The
behavior for production code is not changed, we still use a true source
of secure randomness but under tests we just use a reproducible source
of non-secure randomness.

It is important to note that there is a test,
UUIDTests#testThreadedRandomUUID that relies on the UUIDs being truly
random. Thus, we have to modify the setup for this test to use a true
source of randomness. Thus, this is one test that will never be
reproducible but it is intentionally so.
