### PR TITLE
Better error message when mapping configures null

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
@@ -239,6 +239,13 @@ public class TypeParsers {
             Map.Entry<String, Object> entry = iterator.next();
             final String propName = entry.getKey();
             final Object propNode = entry.getValue();
+            if (false == propName.equals("null_value") && propNode == null) {
+                /*
+                 * No properties *except* null_value are allowed to have null. So we catch it here and tell the user something useful rather
+                 * than send them a null pointer exception later.
+                 */
+                throw new MapperParsingException("[" + propName + "] must not have a [null] value");
+            }
             if (propName.equals("store")) {
                 builder.store(parseStore(name, propNode.toString(), parserContext));
                 iterator.remove();

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/DateFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/DateFieldMapperTests.java
@@ -302,4 +302,19 @@ public class DateFieldMapperTests extends ESSingleNodeTestCase {
         assertEquals(1457654400000L, dvField.numericValue().longValue());
         assertFalse(dvField.fieldType().stored());
     }
+
+    public void testNullConfigValuesFail() throws MapperParsingException, IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("type")
+                    .startObject("properties")
+                        .startObject("field")
+                            .field("type", "date")
+                            .field("format", (String) null)
+                        .endObject()
+                    .endObject()
+                .endObject().endObject().string();
+
+        Exception e = expectThrows(MapperParsingException.class, () -> parser.parse("type", new CompressedXContent(mapping)));
+        assertEquals("[format] must not have a [null] value", e.getMessage());
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/TextFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/TextFieldMapperTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.DocumentMapperParser;
+import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.mapper.core.TextFieldMapper.TextFieldType;
 import org.elasticsearch.index.mapper.ParsedDocument;
@@ -457,5 +458,20 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(fieldType.fielddataMinFrequency(), equalTo(2d));
         assertThat(fieldType.fielddataMaxFrequency(), equalTo((double) Integer.MAX_VALUE));
         assertThat(fieldType.fielddataMinSegmentSize(), equalTo(1000));
+    }
+
+    public void testNullConfigValuesFail() throws MapperParsingException, IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("type")
+                    .startObject("properties")
+                        .startObject("field")
+                            .field("type", "text")
+                            .field("analyzer", (String) null)
+                        .endObject()
+                    .endObject()
+                .endObject().endObject().string();
+
+        Exception e = expectThrows(MapperParsingException.class, () -> parser.parse("type", new CompressedXContent(mapping)));
+        assertEquals("[analyzer] must not have a [null] value", e.getMessage());
     }
 }


### PR DESCRIPTION
Improve the error message when the user sends something like:

``` js
"analyzer": null
```

Closes #18803
