### PR TITLE
remove trailing whitespace

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -298,7 +298,7 @@
 # and master node is elected. Multicast discovery is the default.
 
 # Set to ensure a node sees N other master eligible nodes to be considered
-# operational within the cluster. This should be set to a quorum/majority of 
+# operational within the cluster. This should be set to a quorum/majority of
 # the master-eligible nodes in the cluster.
 #
 #discovery.zen.minimum_master_nodes: 1


### PR DESCRIPTION
As most modern text editors remove trailing whitespaces automatically, this just becomes annoying when working with configuration management and other systems. 
