### PR TITLE
Copy headers and context to individual requests inside a bulk

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -111,6 +111,7 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
         Translog.Location location = null;
         for (int requestIndex = 0; requestIndex < request.items().length; requestIndex++) {
             BulkItemRequest item = request.items()[requestIndex];
+            item.request().copyContextAndHeadersFrom(request);
             if (item.request() instanceof IndexRequest) {
                 IndexRequest indexRequest = (IndexRequest) item.request();
                 preVersions[requestIndex] = indexRequest.version();


### PR DESCRIPTION
This change copies the headers and context values from the BulkShardRequest to the individual requests that are getting executed, so that the data stored in the headers and context is available during these requests when necessary.

I couldn't find a great way to test this change without a lot of other changes. This solves a [user reported issue](https://discuss.elastic.co/t/problem-with-indexed-groovy-script-bulk-api-and-shield/52234) in the dicsuss forums and only affects 2.x as we have the `ThreadContext` in master.
