### PR TITLE
Remove parseElementst() method in RescorePhase and SuggestPhase

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/rescore/RescorePhase.java
+++ b/core/src/main/java/org/elasticsearch/search/rescore/RescorePhase.java
@@ -24,13 +24,10 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.SearchPhase;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
 
 /**
  */
@@ -39,15 +36,6 @@ public class RescorePhase extends AbstractComponent implements SearchPhase {
     @Inject
     public RescorePhase(Settings settings) {
         super(settings);
-    }
-
-    /**
-     * rescorers do not have a parse element, they use
-     * {@link RescoreBuilder#parseFromXContent(org.elasticsearch.index.query.QueryParseContext)} for parsing instead.
-     */
-    @Override
-    public Map<String, ? extends SearchParseElement> parseElements() {
-        return Collections.emptyMap();
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/suggest/SuggestPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/SuggestPhase.java
@@ -23,7 +23,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.SearchPhase;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.suggest.Suggest.Suggestion;
@@ -36,8 +35,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Collections.emptyMap;
-
 /**
  */
 public class SuggestPhase extends AbstractComponent implements SearchPhase {
@@ -45,13 +42,6 @@ public class SuggestPhase extends AbstractComponent implements SearchPhase {
     @Inject
     public SuggestPhase(Settings settings) {
         super(settings);
-    }
-
-    @Override
-    public Map<String, ? extends SearchParseElement> parseElements() {
-        // this is used to parse SearchSourceBuilder.ext() bytes
-        // we don't allow any suggestion parsing for the extension
-        return emptyMap();
     }
 
     @Override


### PR DESCRIPTION
A minor clean up. I think the default implementation in SearchPhase should be enough.
