### PR TITLE
Make timevalue writeable

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -33,8 +33,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.common.unit.TimeValue.readTimeValue;
-
 /**
  *
  */
@@ -160,7 +158,7 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
                 indices[i] = in.readString();
             }
         }
-        timeout = readTimeValue(in);
+        timeout = new TimeValue(in);
         if (in.readBoolean()) {
             waitForStatus = ClusterHealthStatus.fromValue(in.readByte());
         }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -187,7 +187,7 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
         timedOut = in.readBoolean();
         numberOfInFlightFetch = in.readInt();
         delayedUnassignedShards= in.readInt();
-        taskMaxWaitingTime = TimeValue.readTimeValue(in);
+        taskMaxWaitingTime = new TimeValue(in);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
@@ -101,7 +101,7 @@ public class NodesHotThreadsRequest extends BaseNodesRequest<NodesHotThreadsRequ
         threads = in.readInt();
         ignoreIdleThreads = in.readBoolean();
         type = in.readString();
-        interval = TimeValue.readTimeValue(in);
+        interval = new TimeValue(in);
         snapshots = in.readInt();
     }
 

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -544,7 +544,7 @@ public class BulkRequest extends ActionRequest<BulkRequest> implements Composite
             }
         }
         refreshPolicy = RefreshPolicy.readFrom(in);
-        timeout = TimeValue.readTimeValue(in);
+        timeout = new TimeValue(in);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -633,9 +633,8 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
         routing = in.readOptionalString();
         parent = in.readOptionalString();
         timestamp = in.readOptionalString();
-        ttl = in.readBoolean() ? TimeValue.readTimeValue(in) : null;
+        ttl = in.readOptionalWriteable(TimeValue::new);
         source = in.readBytesReference();
-
         opType = OpType.fromId(in.readByte());
         version = in.readLong();
         versionType = VersionType.fromValue(in.readByte());
@@ -650,12 +649,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
         out.writeOptionalString(routing);
         out.writeOptionalString(parent);
         out.writeOptionalString(timestamp);
-        if (ttl == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            ttl.writeTo(out);
-        }
+        out.writeOptionalWriteable(ttl);
         out.writeBytesReference(source);
         out.writeByte(opType.id());
         out.writeLong(version);

--- a/core/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.unit.TimeValue;
 
 import java.io.IOException;
 
-import static org.elasticsearch.common.unit.TimeValue.readTimeValue;
 import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
 
 /**
@@ -75,7 +74,7 @@ public abstract class AcknowledgedRequest<Request extends MasterNodeRequest<Requ
      * Reads the timeout value
      */
     protected void readTimeout(StreamInput in) throws IOException {
-        timeout = readTimeValue(in);
+        timeout = new TimeValue(in);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/support/master/MasterNodeRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/MasterNodeRequest.java
@@ -61,7 +61,7 @@ public abstract class MasterNodeRequest<Request extends MasterNodeRequest<Reques
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        masterNodeTimeout = TimeValue.readTimeValue(in);
+        masterNodeTimeout = new TimeValue(in);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
@@ -82,20 +82,13 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         nodesIds = in.readStringArray();
-        if (in.readBoolean()) {
-            timeout = TimeValue.readTimeValue(in);
-        }
+        timeout = in.readOptionalWriteable(TimeValue::new);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeStringArrayNullable(nodesIds);
-        if (timeout == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            timeout.writeTo(out);
-        }
+        out.writeOptionalWriteable(timeout);
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
@@ -181,7 +181,7 @@ public abstract class ReplicationRequest<Request extends ReplicationRequest<Requ
             shardId = null;
         }
         consistencyLevel = WriteConsistencyLevel.fromId(in.readByte());
-        timeout = TimeValue.readTimeValue(in);
+        timeout = new TimeValue(in);
         index = in.readString();
         routedBasedOnClusterVersion = in.readVLong();
         primaryTerm = in.readVLong();

--- a/core/src/main/java/org/elasticsearch/action/support/single/instance/InstanceShardOperationRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/single/instance/InstanceShardOperationRequest.java
@@ -121,7 +121,7 @@ public abstract class InstanceShardOperationRequest<Request extends InstanceShar
         } else {
             shardId = null;
         }
-        timeout = TimeValue.readTimeValue(in);
+        timeout = new TimeValue(in);
         concreteIndex = in.readOptionalString();
     }
 

--- a/core/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksRequest.java
@@ -144,9 +144,7 @@ public class BaseTasksRequest<Request extends BaseTasksRequest<Request>> extends
         parentTaskId = TaskId.readFromStream(in);
         nodesIds = in.readStringArray();
         actions = in.readStringArray();
-        if (in.readBoolean()) {
-            timeout = TimeValue.readTimeValue(in);
-        }
+        timeout = in.readOptionalWriteable(TimeValue::new);
     }
 
     @Override
@@ -156,7 +154,7 @@ public class BaseTasksRequest<Request extends BaseTasksRequest<Request>> extends
         parentTaskId.writeTo(out);
         out.writeStringArrayNullable(nodesIds);
         out.writeStringArrayNullable(actions);
-        out.writeOptionalStreamable(timeout);
+        out.writeOptionalWriteable(timeout);
     }
 
     public boolean match(Task task) {

--- a/core/src/main/java/org/elasticsearch/common/io/stream/Streamable.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/Streamable.java
@@ -26,6 +26,8 @@ import java.io.IOException;
  * across the wire" using Elasticsearch's internal protocol. If the implementer also implements equals and hashCode then a copy made by
  * serializing and deserializing must be equal and have the same hashCode. It isn't required that such a copy be entirely unchanged. For
  * example, {@link org.elasticsearch.common.unit.TimeValue} converts the time to nanoseconds for serialization.
+ * {@linkplain org.elasticsearch.common.unit.TimeValue} actually implements {@linkplain Writeable} not {@linkplain Streamable} but it has
+ * the same contract.
  *
  * Prefer implementing {@link Writeable} over implementing this interface where possible. Lots of code depends on this interface so this
  * isn't always possible.

--- a/core/src/main/java/org/elasticsearch/common/io/stream/Writeable.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/Writeable.java
@@ -26,8 +26,6 @@ import java.io.IOException;
  * across the wire" using Elasticsearch's internal protocol. If the implementer also implements equals and hashCode then a copy made by
  * serializing and deserializing must be equal and have the same hashCode. It isn't required that such a copy be entirely unchanged. For
  * example, {@link org.elasticsearch.common.unit.TimeValue} converts the time to nanoseconds for serialization.
- * {@linkplain org.elasticsearch.common.unit.TimeValue} actually implements {@linkplain Streamable} not {@linkplain Writeable} but it has
- * the same contract.
  *
  * Prefer implementing this interface over implementing {@link Streamable} where possible. Lots of code depends on {@linkplain Streamable}
  * so this isn't always possible.

--- a/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java
@@ -23,7 +23,7 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.joda.time.Period;
 import org.joda.time.PeriodType;
 import org.joda.time.format.PeriodFormat;
@@ -34,7 +34,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-public class TimeValue implements Streamable {
+public class TimeValue implements Writeable {
 
     /** How many nano-seconds in one milli-second */
     public static final long NSEC_PER_MSEC = 1000000;
@@ -59,13 +59,8 @@ public class TimeValue implements Streamable {
         return new TimeValue(hours, TimeUnit.HOURS);
     }
 
-    private long duration;
-
-    private TimeUnit timeUnit;
-
-    private TimeValue() {
-
-    }
+    private final long duration;
+    private final TimeUnit timeUnit;
 
     public TimeValue(long millis) {
         this(millis, TimeUnit.MILLISECONDS);
@@ -74,6 +69,19 @@ public class TimeValue implements Streamable {
     public TimeValue(long duration, TimeUnit timeUnit) {
         this.duration = duration;
         this.timeUnit = timeUnit;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public TimeValue(StreamInput in) throws IOException {
+        duration = in.readZLong();
+        timeUnit = TimeUnit.NANOSECONDS;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeZLong(nanos());
     }
 
     public long nanos() {
@@ -303,26 +311,6 @@ public class TimeValue implements Streamable {
     static final long C4 = C3 * 60L;
     static final long C5 = C4 * 60L;
     static final long C6 = C5 * 24L;
-
-    public static TimeValue readTimeValue(StreamInput in) throws IOException {
-        TimeValue timeValue = new TimeValue();
-        timeValue.readFrom(in);
-        return timeValue;
-    }
-
-    /**
-     * serialization converts TimeValue internally to NANOSECONDS
-     */
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        duration = in.readLong();
-        timeUnit = TimeUnit.NANOSECONDS;
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeLong(nanos());
-    }
 
     @Override
     public boolean equals(Object o) {

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.discovery.zen.ping.unicast;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
+
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
@@ -79,7 +80,6 @@ import java.util.function.Function;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
-import static org.elasticsearch.common.unit.TimeValue.readTimeValue;
 import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.newConcurrentMap;
 import static org.elasticsearch.discovery.zen.ping.ZenPing.PingResponse.readPingResponse;
 
@@ -545,7 +545,7 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
             id = in.readInt();
-            timeout = readTimeValue(in);
+            timeout = new TimeValue(in);
             pingResponse = readPingResponse(in);
         }
 

--- a/core/src/main/java/org/elasticsearch/search/Scroll.java
+++ b/core/src/main/java/org/elasticsearch/search/Scroll.java
@@ -26,8 +26,6 @@ import org.elasticsearch.common.unit.TimeValue;
 
 import java.io.IOException;
 
-import static org.elasticsearch.common.unit.TimeValue.readTimeValue;
-
 /**
  * A scroll enables scrolling of search request. It holds a {@link #keepAlive()} time that
  * will control how long to keep the scrolling resources open.
@@ -64,18 +62,11 @@ public class Scroll implements Streamable {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        if (in.readBoolean()) {
-            keepAlive = readTimeValue(in);
-        }
+        in.readOptionalWriteable(TimeValue::new);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (keepAlive == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            keepAlive.writeTo(out);
-        }
+        out.writeOptionalWriteable(keepAlive);
     }
 }

--- a/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -579,7 +579,7 @@ public class ThreadPool extends AbstractComponent implements Closeable {
             min = in.readInt();
             max = in.readInt();
             if (in.readBoolean()) {
-                keepAlive = TimeValue.readTimeValue(in);
+                keepAlive = new TimeValue(in);
             }
             if (in.readBoolean()) {
                 queueSize = SizeValue.readSizeValue(in);

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -299,9 +299,9 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
         abortOnVersionConflict = in.readBoolean();
         size = in.readVInt();
         refresh = in.readBoolean();
-        timeout = TimeValue.readTimeValue(in);
+        timeout = new TimeValue(in);
         consistency = WriteConsistencyLevel.fromId(in.readByte());
-        retryBackoffInitialTime = TimeValue.readTimeValue(in);
+        retryBackoffInitialTime = new TimeValue(in);
         maxRetries = in.readVInt();
         requestsPerSecond = in.readFloat();
     }

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
@@ -168,10 +168,10 @@ public class BulkByScrollTask extends CancellableTask {
             noops = in.readVLong();
             bulkRetries = in.readVLong();
             searchRetries = in.readVLong();
-            throttled = TimeValue.readTimeValue(in);
+            throttled = new TimeValue(in);
             requestsPerSecond = in.readFloat();
             reasonCancelled = in.readOptionalString();
-            throttledUntil = TimeValue.readTimeValue(in);
+            throttledUntil = new TimeValue(in);
         }
 
         @Override

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkIndexByScrollResponse.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkIndexByScrollResponse.java
@@ -153,7 +153,7 @@ public class BulkIndexByScrollResponse extends ActionResponse implements ToXCont
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        took = TimeValue.readTimeValue(in);
+        took = new TimeValue(in);
         status = new BulkByScrollTask.Status(in);
         int indexingFailuresCount = in.readVInt();
         List<Failure> indexingFailures = new ArrayList<>(indexingFailuresCount);


### PR DESCRIPTION
Writeable is better for immutable objects like TimeValue.

Switches serialization from `writeLong` to `writeZLong` which saves a couple of bytes.
