### PR TITLE
Port reindex's groovy tests to painless

### DIFF
--- a/qa/smoke-test-reindex-with-painless/build.gradle
+++ b/qa/smoke-test-reindex-with-painless/build.gradle
@@ -17,23 +17,4 @@
  * under the License.
  */
 
-package org.elasticsearch.smoketest;
-
-import com.carrotsearch.randomizedtesting.annotations.Name;
-import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.test.rest.ESRestTestCase;
-import org.elasticsearch.test.rest.RestTestCandidate;
-import org.elasticsearch.test.rest.parser.RestTestParseException;
-
-import java.io.IOException;
-
-public class SmokeTestReindexWithGroovyIT extends ESRestTestCase {
-    public SmokeTestReindexWithGroovyIT(@Name("yaml") RestTestCandidate testCandidate) {
-        super(testCandidate);
-    }
-
-    @ParametersFactory
-    public static Iterable<Object[]> parameters() throws IOException, RestTestParseException {
-        return ESRestTestCase.createParameters(0, 1);
-    }
-}
+apply plugin: 'elasticsearch.rest-test'

--- a/qa/smoke-test-reindex-with-painless/src/test/java/org/elasticsearch/smoketest/SmokeTestReindexWithPainlessIT.java
+++ b/qa/smoke-test-reindex-with-painless/src/test/java/org/elasticsearch/smoketest/SmokeTestReindexWithPainlessIT.java
@@ -17,10 +17,23 @@
  * under the License.
  */
 
-apply plugin: 'elasticsearch.rest-test'
+package org.elasticsearch.smoketest;
 
-integTest {
-  cluster {
-    setting 'script.inline', 'true'
-  }
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.test.rest.RestTestCandidate;
+import org.elasticsearch.test.rest.parser.RestTestParseException;
+
+import java.io.IOException;
+
+public class SmokeTestReindexWithPainlessIT extends ESRestTestCase {
+    public SmokeTestReindexWithPainlessIT(@Name("yaml") RestTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws IOException, RestTestParseException {
+        return ESRestTestCase.createParameters(0, 1);
+    }
 }

--- a/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/reindex/10_script.yaml
+++ b/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/reindex/10_script.yaml
@@ -18,6 +18,7 @@
           dest:
             index: new_twitter
           script:
+            lang: painless
             inline: ctx._source.user = "other" + ctx._source.user
   - match: {created: 1}
   - match: {noops: 0}
@@ -57,6 +58,7 @@
           dest:
             index: new_twitter
           script:
+            lang: painless
             inline: if (ctx._id == "1") {ctx._source.user = "other" + ctx._source.user}
   - match: {created: 2}
   - match: {noops: 0}
@@ -116,6 +118,7 @@
           dest:
             index: new_twitter
           script:
+            lang: painless
             inline: ctx._parent = ctx._source.user
   - match: {created: 1}
   - match: {noops: 0}
@@ -159,6 +162,7 @@
           dest:
             index: new_twitter
           script:
+            lang: painless
             inline: ctx._routing = ctx._source.user
   - match: {created: 2}
   - match: {noops: 0}
@@ -217,6 +221,7 @@
           dest:
             index: new_twitter
           script:
+            lang: painless
             inline: ctx._parent = ctx._source.user; ctx._routing = "cat"
   - match: {created: 1}
   - match: {noops: 0}
@@ -262,6 +267,7 @@
           dest:
             index: new_twitter
           script:
+            lang: painless
             inline: if (ctx._source.user == "kimchy") {ctx._source.user = "not" + ctx._source.user} else {ctx.op = "noop"}
   - match: {created: 1}
   - match: {noops: 1}
@@ -314,6 +320,7 @@
           dest:
             index: new_twitter
           script:
+            lang: painless
             inline: ctx.op = "noop"
   - match: {updated: 0}
   - match: {noops: 2}
@@ -354,6 +361,7 @@
             index: new_twitter
             version_type: external
           script:
+            lang: painless
             inline: ctx._source.user = "other" + ctx._source.user; ctx._version = null
   - match: {updated: 1}
   - match: {noops: 0}
@@ -393,6 +401,7 @@
           dest:
             index: new_twitter
           script:
+            lang: painless
             inline: ctx._source.user = "other" + ctx._source.user; ctx._id = null
   - match: {created: 1}
   - match: {noops: 0}
@@ -432,6 +441,7 @@
           dest:
             index: new_twitter
           script:
+            lang: painless
             inline: if (ctx._source.user == "kimchy") {ctx._index = 'other_new_twitter'}
   - match: {created: 2}
   - match: {noops: 0}
@@ -504,6 +514,7 @@
             index: index2
             type: type2
           script:
+            lang: painless
             inline: "ctx._id = ctx._source.lang + '_' + ctx._source.id;
                      if (ctx._source.lang != \"en\" ) {ctx.op = 'delete'}"
   - match: {created: 1}

--- a/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/reindex/20_broken.yaml
+++ b/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/reindex/20_broken.yaml
@@ -11,10 +11,14 @@
 
   - do:
       catch: request
-      update_by_query:
-        index:   twitter
+      reindex:
         refresh: true
         body:
+          source:
+            index: twitter
+          dest:
+            index: new_twitter
           script:
+            lang: painless
             inline: syntax errors are fun!
-  - match: {error.reason: 'Failed to compile inline script [syntax errors are fun!] using lang [groovy]'}
+  - match: {error.reason: 'compile error'}

--- a/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/reindex/30_timeout.yaml
+++ b/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/reindex/30_timeout.yaml
@@ -1,5 +1,8 @@
 ---
 "Timeout":
+  - skip:
+      version: "all"
+      reason:  painless doesn't support thread.sleep so we need to come up with a better way
   - do:
       index:
         index:  twitter
@@ -19,9 +22,10 @@
             timeout: 10
             query:
               script:
+                lang: painless
                 # Sleep 100x longer than the timeout. That should cause a timeout!
                 # Return true causes the document to try to be collected which is what actually triggers the timeout.
-                script: sleep(1000); return true
+                script: java.lang.Thread.sleep(1000); return true
           dest:
             index: new_twitter
   - is_true: timed_out

--- a/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/reindex/40_search_failures.yaml
+++ b/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/reindex/40_search_failures.yaml
@@ -17,7 +17,8 @@
             index:   source
             query:
               script:
-                script: 1/0 # Divide by 0 to cause a search time exception
+                lang: painless
+                script: throw new IllegalArgumentException("Cats!")
           dest:
             index:   dest
   - match: {created: 0}
@@ -27,8 +28,8 @@
   - is_true: failures.0.shard
   - match: {failures.0.index:  source}
   - is_true: failures.0.node
-  - match: {failures.0.reason.type:   general_script_exception}
-  - match: {failures.0.reason.reason: "failed to run inline script [1/0] using lang [groovy]"}
-  - match: {failures.0.reason.caused_by.type:   arithmetic_exception}
-  - match: {failures.0.reason.caused_by.reason: Division by zero}
+  - match: {failures.0.reason.type:   script_exception}
+  - match: {failures.0.reason.reason: runtime error}
+  - match: {failures.0.reason.caused_by.type:   illegal_argument_exception}
+  - match: {failures.0.reason.caused_by.reason: Cats!}
   - gte: { took: 0 }

--- a/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/update_by_query/10_script.yaml
+++ b/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/update_by_query/10_script.yaml
@@ -15,6 +15,7 @@
         refresh: true
         body:
           script:
+            lang: painless
             inline: ctx._source.user = "not" + ctx._source.user
   - match: {updated: 1}
   - match: {noops: 0}
@@ -51,6 +52,7 @@
         index:   twitter
         body:
           script:
+            lang: painless
             inline: if (ctx._source.user == "kimchy") {ctx._source.user = "not" + ctx._source.user} else {ctx.op = "noop"}
   - match: {updated: 1}
   - match: {noops: 1}
@@ -96,6 +98,7 @@
         index:   twitter
         body:
           script:
+            lang: painless
             inline: ctx.op = "noop"
   - match: {updated: 0}
   - match: {noops: 2}
@@ -118,6 +121,7 @@
         index: twitter
         body:
           script:
+            lang: painless
             inline: ctx.junk = "stuff"
 
 ---
@@ -137,6 +141,7 @@
         index: twitter
         body:
           script:
+            lang: painless
             inline: ctx._id = "stuff"
 
 ---
@@ -174,6 +179,7 @@
         index:   twitter
         body:
           script:
+            lang: painless
             inline: if (ctx._source.level != 11) {ctx._source.last_updated = "2016-01-02T00:00:00Z"} else {ctx.op = "delete"}
   - match: {updated: 3}
   - match: {deleted: 1}
@@ -237,17 +243,16 @@
         index:   twitter
         body:
           script:
-            inline: "switch (ctx._source.level % 3) {
-                      case 0:
-                        ctx._source.last_updated = \"2016-01-02T00:00:00Z\";
-                        break;
-                      case 1:
-                        ctx.op = \"noop\";
-                        break;
-                      case 2:
-                        ctx.op = \"delete\";
-                        break;
-                    }"
+            lang: painless
+            inline: |
+              int choice = ctx._source.level % 3;
+              if (choice == 0) {
+                ctx._source.last_updated = "2016-01-02T00:00:00Z";
+              } else if (choice == 1) {
+                ctx.op = "noop";
+              } else {
+                ctx.op = "delete";
+              }
   - match: {updated: 2}
   - match: {deleted: 1}
   - match: {noops: 1}
@@ -303,6 +308,7 @@
         index:   twitter
         body:
           script:
+            lang: painless
             inline: if (ctx._source.user == "kimchy") {ctx.op = "update"} else {ctx.op = "junk"}
 
   - match: { error.reason: 'Operation type [junk] not allowed, only [noop, index, delete] are allowed' }

--- a/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/update_by_query/20_broken.yaml
+++ b/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/update_by_query/20_broken.yaml
@@ -11,13 +11,11 @@
 
   - do:
       catch: request
-      reindex:
+      update_by_query:
+        index:   twitter
         refresh: true
         body:
-          source:
-            index: twitter
-          dest:
-            index: new_twitter
           script:
+            lang: painless
             inline: syntax errors are fun!
-  - match: {error.reason: 'Failed to compile inline script [syntax errors are fun!] using lang [groovy]'}
+  - match: {error.reason: 'compile error'}

--- a/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/update_by_query/30_timeout.yaml
+++ b/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/update_by_query/30_timeout.yaml
@@ -1,5 +1,8 @@
 ---
 "Timeout":
+  - skip:
+      version: "all"
+      reason:  painless doesn't support thread.sleep so we need to come up with a better way
   - do:
       index:
         index:  twitter
@@ -18,9 +21,10 @@
         body:
           query:
             script:
+              lang: painless
               # Sleep 100x longer than the timeout. That should cause a timeout!
               # Return true causes the document to try to be collected which is what actually triggers the timeout.
-              script: sleep(1000); return true
+              script: java.lang.Thread.sleep(1000); return true
   - is_true: timed_out
   - match: {updated: 0}
   - match: {noops: 0}

--- a/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/update_by_query/40_search_failure.yaml
+++ b/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/update_by_query/40_search_failure.yaml
@@ -16,15 +16,16 @@
         body:
           query:
             script:
-              script: 1/0 # Divide by 0 to cause a search time exception
+              lang: painless
+              script: throw new IllegalArgumentException("Cats!")
   - match: {updated: 0}
   - match: {version_conflicts: 0}
   - match: {batches: 0}
   - is_true: failures.0.shard
   - match: {failures.0.index:  source}
   - is_true: failures.0.node
-  - match: {failures.0.reason.type:   general_script_exception}
-  - match: {failures.0.reason.reason: "failed to run inline script [1/0] using lang [groovy]"}
-  - match: {failures.0.reason.caused_by.type:   arithmetic_exception}
-  - match: {failures.0.reason.caused_by.reason: Division by zero}
+  - match: {failures.0.reason.type:   script_exception}
+  - match: {failures.0.reason.reason: runtime error}
+  - match: {failures.0.reason.caused_by.type:   illegal_argument_exception}
+  - match: {failures.0.reason.caused_by.reason: Cats!}
   - gte: { took: 0 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -46,11 +46,11 @@ List projects = [
   'qa:backwards-5.0',
   'qa:evil-tests',
   'qa:smoke-test-client',
-  'qa:smoke-test-multinode',
-  'qa:smoke-test-reindex-with-groovy',
-  'qa:smoke-test-plugins',
   'qa:smoke-test-ingest-with-all-dependencies',
   'qa:smoke-test-ingest-disabled',
+  'qa:smoke-test-multinode',
+  'qa:smoke-test-plugins',
+  'qa:smoke-test-reindex-with-painless',
   'qa:vagrant',
 ]
 


### PR DESCRIPTION
This ports the reindex tests that rely on groovy to painless because we expect people to prefer painless over groovy because you can use inline scripts without opening a gaping security hole.
