### PR TITLE
Array constructor references

### DIFF
--- a/modules/lang-painless/src/main/antlr/PainlessParser.g4
+++ b/modules/lang-painless/src/main/antlr/PainlessParser.g4
@@ -204,7 +204,7 @@ funcref
 // reference to a static or instance method, e.g. ArrayList::size or Integer::compare
 classFuncref
     : TYPE REF ID
-	;
+    ;
 
 // reference to a constructor, e.g. ArrayList::new
 // currently limited to simple non-array types

--- a/modules/lang-painless/src/main/antlr/PainlessParser.g4
+++ b/modules/lang-painless/src/main/antlr/PainlessParser.g4
@@ -195,6 +195,30 @@ lamtype
     ;
 
 funcref
-    : TYPE REF ( ID | NEW )
-    | ( ID | THIS ) REF ID
+    : classFuncref
+    | constructorFuncref
+    | capturingFuncref
+    | localFuncref
+    ;
+
+// reference to a static or instance method, e.g. ArrayList::size or Integer::compare
+classFuncref
+    : TYPE REF ID
+	;
+
+// reference to a constructor, e.g. ArrayList::new
+// currently limited to simple non-array types
+constructorFuncref
+    : TYPE REF NEW
+    ;
+
+// reference to an instance method, e.g. object::toString
+// currently limited to capture of a simple variable (id).
+capturingFuncref
+    : ID REF ID
+    ;
+
+// reference to a local function, e.g. this::myfunc
+localFuncref
+    : THIS REF ID
     ;

--- a/modules/lang-painless/src/main/antlr/PainlessParser.g4
+++ b/modules/lang-painless/src/main/antlr/PainlessParser.g4
@@ -209,7 +209,7 @@ classFuncref
 // reference to a constructor, e.g. ArrayList::new
 // currently limited to simple non-array types
 constructorFuncref
-    : TYPE REF NEW
+    : decltype REF NEW
     ;
 
 // reference to an instance method, e.g. object::toString

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessParser.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessParser.java
@@ -2969,7 +2969,9 @@ class PainlessParser extends Parser {
   }
 
   public static class ConstructorFuncrefContext extends ParserRuleContext {
-    public TerminalNode TYPE() { return getToken(PainlessParser.TYPE, 0); }
+    public DecltypeContext decltype() {
+      return getRuleContext(DecltypeContext.class,0);
+    }
     public TerminalNode REF() { return getToken(PainlessParser.REF, 0); }
     public TerminalNode NEW() { return getToken(PainlessParser.NEW, 0); }
     public ConstructorFuncrefContext(ParserRuleContext parent, int invokingState) {
@@ -2990,7 +2992,7 @@ class PainlessParser extends Parser {
       enterOuterAlt(_localctx, 1);
       {
       setState(460);
-      match(TYPE);
+      decltype();
       setState(461);
       match(REF);
       setState(462);
@@ -3350,7 +3352,7 @@ class PainlessParser extends Parser {
     "\u01c4\u01c9\5\66\34\2\u01c5\u01c9\58\35\2\u01c6\u01c9\5:\36\2\u01c7\u01c9"+
     "\5<\37\2\u01c8\u01c4\3\2\2\2\u01c8\u01c5\3\2\2\2\u01c8\u01c6\3\2\2\2\u01c8"+
     "\u01c7\3\2\2\2\u01c9\65\3\2\2\2\u01ca\u01cb\7L\2\2\u01cb\u01cc\7\64\2"+
-    "\2\u01cc\u01cd\7M\2\2\u01cd\67\3\2\2\2\u01ce\u01cf\7L\2\2\u01cf\u01d0"+
+    "\2\u01cc\u01cd\7M\2\2\u01cd\67\3\2\2\2\u01ce\u01cf\5\26\f\2\u01cf\u01d0"+
     "\7\64\2\2\u01d0\u01d1\7\26\2\2\u01d19\3\2\2\2\u01d2\u01d3\7M\2\2\u01d3"+
     "\u01d4\7\64\2\2\u01d4\u01d5\7M\2\2\u01d5;\3\2\2\2\u01d6\u01d7\7\32\2\2"+
     "\u01d7\u01d8\7\64\2\2\u01d8\u01d9\7M\2\2\u01d9=\3\2\2\2*AGZ]iq~\u0082"+

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessParser.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessParser.java
@@ -34,12 +34,14 @@ class PainlessParser extends Parser {
     RULE_trap = 12, RULE_delimiter = 13, RULE_expression = 14, RULE_unary = 15, 
     RULE_chain = 16, RULE_primary = 17, RULE_secondary = 18, RULE_dot = 19, 
     RULE_brace = 20, RULE_arguments = 21, RULE_argument = 22, RULE_lambda = 23, 
-    RULE_lamtype = 24, RULE_funcref = 25;
+    RULE_lamtype = 24, RULE_funcref = 25, RULE_classFuncref = 26, RULE_constructorFuncref = 27, 
+    RULE_capturingFuncref = 28, RULE_localFuncref = 29;
   public static final String[] ruleNames = {
     "source", "function", "parameters", "statement", "trailer", "block", "empty", 
     "initializer", "afterthought", "declaration", "decltype", "declvar", "trap", 
     "delimiter", "expression", "unary", "chain", "primary", "secondary", "dot", 
-    "brace", "arguments", "argument", "lambda", "lamtype", "funcref"
+    "brace", "arguments", "argument", "lambda", "lamtype", "funcref", "classFuncref", 
+    "constructorFuncref", "capturingFuncref", "localFuncref"
   };
 
   private static final String[] _LITERAL_NAMES = {
@@ -144,39 +146,39 @@ class PainlessParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(55);
+      setState(63);
       _errHandler.sync(this);
       _alt = getInterpreter().adaptivePredict(_input,0,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           {
           {
-          setState(52);
+          setState(60);
           function();
           }
           } 
         }
-        setState(57);
+        setState(65);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,0,_ctx);
       }
-      setState(61);
+      setState(69);
       _errHandler.sync(this);
       _alt = getInterpreter().adaptivePredict(_input,1,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           {
           {
-          setState(58);
+          setState(66);
           statement();
           }
           } 
         }
-        setState(63);
+        setState(71);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,1,_ctx);
       }
-      setState(64);
+      setState(72);
       match(EOF);
       }
     }
@@ -219,13 +221,13 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(66);
+      setState(74);
       decltype();
-      setState(67);
+      setState(75);
       match(ID);
-      setState(68);
+      setState(76);
       parameters();
-      setState(69);
+      setState(77);
       block();
       }
     }
@@ -275,38 +277,38 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(71);
+      setState(79);
       match(LP);
-      setState(83);
+      setState(91);
       _la = _input.LA(1);
       if (_la==TYPE) {
         {
-        setState(72);
-        decltype();
-        setState(73);
-        match(ID);
         setState(80);
+        decltype();
+        setState(81);
+        match(ID);
+        setState(88);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(74);
+          setState(82);
           match(COMMA);
-          setState(75);
+          setState(83);
           decltype();
-          setState(76);
+          setState(84);
           match(ID);
           }
           }
-          setState(82);
+          setState(90);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
         }
       }
 
-      setState(85);
+      setState(93);
       match(RP);
       }
     }
@@ -552,35 +554,35 @@ class PainlessParser extends Parser {
     enterRule(_localctx, 6, RULE_statement);
     try {
       int _alt;
-      setState(165);
+      setState(173);
       switch ( getInterpreter().adaptivePredict(_input,11,_ctx) ) {
       case 1:
         _localctx = new IfContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(87);
-        match(IF);
-        setState(88);
-        match(LP);
-        setState(89);
-        expression(0);
-        setState(90);
-        match(RP);
-        setState(91);
-        trailer();
         setState(95);
+        match(IF);
+        setState(96);
+        match(LP);
+        setState(97);
+        expression(0);
+        setState(98);
+        match(RP);
+        setState(99);
+        trailer();
+        setState(103);
         switch ( getInterpreter().adaptivePredict(_input,4,_ctx) ) {
         case 1:
           {
-          setState(92);
+          setState(100);
           match(ELSE);
-          setState(93);
+          setState(101);
           trailer();
           }
           break;
         case 2:
           {
-          setState(94);
+          setState(102);
           if (!( _input.LA(1) != ELSE )) throw new FailedPredicateException(this, " _input.LA(1) != ELSE ");
           }
           break;
@@ -591,25 +593,25 @@ class PainlessParser extends Parser {
         _localctx = new WhileContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(97);
+        setState(105);
         match(WHILE);
-        setState(98);
+        setState(106);
         match(LP);
-        setState(99);
+        setState(107);
         expression(0);
-        setState(100);
+        setState(108);
         match(RP);
-        setState(103);
+        setState(111);
         switch ( getInterpreter().adaptivePredict(_input,5,_ctx) ) {
         case 1:
           {
-          setState(101);
+          setState(109);
           trailer();
           }
           break;
         case 2:
           {
-          setState(102);
+          setState(110);
           empty();
           }
           break;
@@ -620,19 +622,19 @@ class PainlessParser extends Parser {
         _localctx = new DoContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(105);
+        setState(113);
         match(DO);
-        setState(106);
+        setState(114);
         block();
-        setState(107);
+        setState(115);
         match(WHILE);
-        setState(108);
+        setState(116);
         match(LP);
-        setState(109);
+        setState(117);
         expression(0);
-        setState(110);
+        setState(118);
         match(RP);
-        setState(111);
+        setState(119);
         delimiter();
         }
         break;
@@ -640,54 +642,54 @@ class PainlessParser extends Parser {
         _localctx = new ForContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(113);
+        setState(121);
         match(FOR);
-        setState(114);
+        setState(122);
         match(LP);
-        setState(116);
+        setState(124);
         switch ( getInterpreter().adaptivePredict(_input,6,_ctx) ) {
         case 1:
           {
-          setState(115);
+          setState(123);
           initializer();
           }
           break;
         }
-        setState(118);
+        setState(126);
         match(SEMICOLON);
-        setState(120);
+        setState(128);
         switch ( getInterpreter().adaptivePredict(_input,7,_ctx) ) {
         case 1:
           {
-          setState(119);
+          setState(127);
           expression(0);
           }
           break;
         }
-        setState(122);
+        setState(130);
         match(SEMICOLON);
-        setState(124);
+        setState(132);
         switch ( getInterpreter().adaptivePredict(_input,8,_ctx) ) {
         case 1:
           {
-          setState(123);
+          setState(131);
           afterthought();
           }
           break;
         }
-        setState(126);
+        setState(134);
         match(RP);
-        setState(129);
+        setState(137);
         switch ( getInterpreter().adaptivePredict(_input,9,_ctx) ) {
         case 1:
           {
-          setState(127);
+          setState(135);
           trailer();
           }
           break;
         case 2:
           {
-          setState(128);
+          setState(136);
           empty();
           }
           break;
@@ -698,21 +700,21 @@ class PainlessParser extends Parser {
         _localctx = new EachContext(_localctx);
         enterOuterAlt(_localctx, 5);
         {
-        setState(131);
+        setState(139);
         match(FOR);
-        setState(132);
+        setState(140);
         match(LP);
-        setState(133);
+        setState(141);
         decltype();
-        setState(134);
+        setState(142);
         match(ID);
-        setState(135);
+        setState(143);
         match(COLON);
-        setState(136);
+        setState(144);
         expression(0);
-        setState(137);
+        setState(145);
         match(RP);
-        setState(138);
+        setState(146);
         trailer();
         }
         break;
@@ -720,9 +722,9 @@ class PainlessParser extends Parser {
         _localctx = new DeclContext(_localctx);
         enterOuterAlt(_localctx, 6);
         {
-        setState(140);
+        setState(148);
         declaration();
-        setState(141);
+        setState(149);
         delimiter();
         }
         break;
@@ -730,9 +732,9 @@ class PainlessParser extends Parser {
         _localctx = new ContinueContext(_localctx);
         enterOuterAlt(_localctx, 7);
         {
-        setState(143);
+        setState(151);
         match(CONTINUE);
-        setState(144);
+        setState(152);
         delimiter();
         }
         break;
@@ -740,9 +742,9 @@ class PainlessParser extends Parser {
         _localctx = new BreakContext(_localctx);
         enterOuterAlt(_localctx, 8);
         {
-        setState(145);
+        setState(153);
         match(BREAK);
-        setState(146);
+        setState(154);
         delimiter();
         }
         break;
@@ -750,11 +752,11 @@ class PainlessParser extends Parser {
         _localctx = new ReturnContext(_localctx);
         enterOuterAlt(_localctx, 9);
         {
-        setState(147);
+        setState(155);
         match(RETURN);
-        setState(148);
+        setState(156);
         expression(0);
-        setState(149);
+        setState(157);
         delimiter();
         }
         break;
@@ -762,11 +764,11 @@ class PainlessParser extends Parser {
         _localctx = new TryContext(_localctx);
         enterOuterAlt(_localctx, 10);
         {
-        setState(151);
+        setState(159);
         match(TRY);
-        setState(152);
+        setState(160);
         block();
-        setState(154); 
+        setState(162); 
         _errHandler.sync(this);
         _alt = 1;
         do {
@@ -774,7 +776,7 @@ class PainlessParser extends Parser {
           case 1:
             {
             {
-            setState(153);
+            setState(161);
             trap();
             }
             }
@@ -782,7 +784,7 @@ class PainlessParser extends Parser {
           default:
             throw new NoViableAltException(this);
           }
-          setState(156); 
+          setState(164); 
           _errHandler.sync(this);
           _alt = getInterpreter().adaptivePredict(_input,10,_ctx);
         } while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER );
@@ -792,11 +794,11 @@ class PainlessParser extends Parser {
         _localctx = new ThrowContext(_localctx);
         enterOuterAlt(_localctx, 11);
         {
-        setState(158);
+        setState(166);
         match(THROW);
-        setState(159);
+        setState(167);
         expression(0);
-        setState(160);
+        setState(168);
         delimiter();
         }
         break;
@@ -804,9 +806,9 @@ class PainlessParser extends Parser {
         _localctx = new ExprContext(_localctx);
         enterOuterAlt(_localctx, 12);
         {
-        setState(162);
+        setState(170);
         expression(0);
-        setState(163);
+        setState(171);
         delimiter();
         }
         break;
@@ -845,19 +847,19 @@ class PainlessParser extends Parser {
     TrailerContext _localctx = new TrailerContext(_ctx, getState());
     enterRule(_localctx, 8, RULE_trailer);
     try {
-      setState(169);
+      setState(177);
       switch ( getInterpreter().adaptivePredict(_input,12,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(167);
+        setState(175);
         block();
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(168);
+        setState(176);
         statement();
         }
         break;
@@ -901,25 +903,25 @@ class PainlessParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(171);
+      setState(179);
       match(LBRACK);
-      setState(175);
+      setState(183);
       _errHandler.sync(this);
       _alt = getInterpreter().adaptivePredict(_input,13,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           {
           {
-          setState(172);
+          setState(180);
           statement();
           }
           } 
         }
-        setState(177);
+        setState(185);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,13,_ctx);
       }
-      setState(178);
+      setState(186);
       match(RBRACK);
       }
     }
@@ -953,7 +955,7 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(180);
+      setState(188);
       match(SEMICOLON);
       }
     }
@@ -990,19 +992,19 @@ class PainlessParser extends Parser {
     InitializerContext _localctx = new InitializerContext(_ctx, getState());
     enterRule(_localctx, 14, RULE_initializer);
     try {
-      setState(184);
+      setState(192);
       switch ( getInterpreter().adaptivePredict(_input,14,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(182);
+        setState(190);
         declaration();
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(183);
+        setState(191);
         expression(0);
         }
         break;
@@ -1040,7 +1042,7 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(186);
+      setState(194);
       expression(0);
       }
     }
@@ -1087,23 +1089,23 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(188);
+      setState(196);
       decltype();
-      setState(189);
+      setState(197);
       declvar();
-      setState(194);
+      setState(202);
       _errHandler.sync(this);
       _la = _input.LA(1);
       while (_la==COMMA) {
         {
         {
-        setState(190);
+        setState(198);
         match(COMMA);
-        setState(191);
+        setState(199);
         declvar();
         }
         }
-        setState(196);
+        setState(204);
         _errHandler.sync(this);
         _la = _input.LA(1);
       }
@@ -1148,21 +1150,21 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(197);
+      setState(205);
       match(TYPE);
-      setState(202);
+      setState(210);
       _errHandler.sync(this);
       _la = _input.LA(1);
       while (_la==LBRACE) {
         {
         {
-        setState(198);
+        setState(206);
         match(LBRACE);
-        setState(199);
+        setState(207);
         match(RBRACE);
         }
         }
-        setState(204);
+        setState(212);
         _errHandler.sync(this);
         _la = _input.LA(1);
       }
@@ -1203,15 +1205,15 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(205);
+      setState(213);
       match(ID);
-      setState(208);
+      setState(216);
       _la = _input.LA(1);
       if (_la==ASSIGN) {
         {
-        setState(206);
+        setState(214);
         match(ASSIGN);
-        setState(207);
+        setState(215);
         expression(0);
         }
       }
@@ -1255,17 +1257,17 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(210);
+      setState(218);
       match(CATCH);
-      setState(211);
+      setState(219);
       match(LP);
-      setState(212);
+      setState(220);
       match(TYPE);
-      setState(213);
+      setState(221);
       match(ID);
-      setState(214);
+      setState(222);
       match(RP);
-      setState(215);
+      setState(223);
       block();
       }
     }
@@ -1299,19 +1301,19 @@ class PainlessParser extends Parser {
     DelimiterContext _localctx = new DelimiterContext(_ctx, getState());
     enterRule(_localctx, 26, RULE_delimiter);
     try {
-      setState(222);
+      setState(230);
       switch (_input.LA(1)) {
       case SEMICOLON:
         enterOuterAlt(_localctx, 1);
         {
-        setState(217);
+        setState(225);
         match(SEMICOLON);
         }
         break;
       case EOF:
         enterOuterAlt(_localctx, 2);
         {
-        setState(218);
+        setState(226);
         match(EOF);
         }
         break;
@@ -1319,7 +1321,7 @@ class PainlessParser extends Parser {
         enterOuterAlt(_localctx, 3);
         {
          int mark = _input.mark(); int index = _input.index(); 
-        setState(220);
+        setState(228);
         match(RBRACK);
          _input.seek(index); _input.release(mark); 
         }
@@ -1488,7 +1490,7 @@ class PainlessParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(233);
+      setState(241);
       switch ( getInterpreter().adaptivePredict(_input,19,_ctx) ) {
       case 1:
         {
@@ -1496,16 +1498,16 @@ class PainlessParser extends Parser {
         _ctx = _localctx;
         _prevctx = _localctx;
 
-        setState(225);
+        setState(233);
         chain(true);
-        setState(226);
+        setState(234);
         _la = _input.LA(1);
         if ( !(((((_la - 54)) & ~0x3f) == 0 && ((1L << (_la - 54)) & ((1L << (ASSIGN - 54)) | (1L << (AADD - 54)) | (1L << (ASUB - 54)) | (1L << (AMUL - 54)) | (1L << (ADIV - 54)) | (1L << (AREM - 54)) | (1L << (AAND - 54)) | (1L << (AXOR - 54)) | (1L << (AOR - 54)) | (1L << (ALSH - 54)) | (1L << (ARSH - 54)) | (1L << (AUSH - 54)))) != 0)) ) {
         _errHandler.recoverInline(this);
         } else {
           consume();
         }
-        setState(227);
+        setState(235);
         expression(1);
          ((AssignmentContext)_localctx).s =  false; 
         }
@@ -1515,14 +1517,14 @@ class PainlessParser extends Parser {
         _localctx = new SingleContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(230);
+        setState(238);
         ((SingleContext)_localctx).u = unary(false);
          ((SingleContext)_localctx).s =  ((SingleContext)_localctx).u.s; 
         }
         break;
       }
       _ctx.stop = _input.LT(-1);
-      setState(294);
+      setState(302);
       _errHandler.sync(this);
       _alt = getInterpreter().adaptivePredict(_input,21,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
@@ -1530,22 +1532,22 @@ class PainlessParser extends Parser {
           if ( _parseListeners!=null ) triggerExitRuleEvent();
           _prevctx = _localctx;
           {
-          setState(292);
+          setState(300);
           switch ( getInterpreter().adaptivePredict(_input,20,_ctx) ) {
           case 1:
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(235);
+            setState(243);
             if (!(precpred(_ctx, 12))) throw new FailedPredicateException(this, "precpred(_ctx, 12)");
-            setState(236);
+            setState(244);
             _la = _input.LA(1);
             if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << MUL) | (1L << DIV) | (1L << REM))) != 0)) ) {
             _errHandler.recoverInline(this);
             } else {
               consume();
             }
-            setState(237);
+            setState(245);
             expression(13);
              ((BinaryContext)_localctx).s =  false; 
             }
@@ -1554,16 +1556,16 @@ class PainlessParser extends Parser {
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(240);
+            setState(248);
             if (!(precpred(_ctx, 11))) throw new FailedPredicateException(this, "precpred(_ctx, 11)");
-            setState(241);
+            setState(249);
             _la = _input.LA(1);
             if ( !(_la==ADD || _la==SUB) ) {
             _errHandler.recoverInline(this);
             } else {
               consume();
             }
-            setState(242);
+            setState(250);
             expression(12);
              ((BinaryContext)_localctx).s =  false; 
             }
@@ -1572,16 +1574,16 @@ class PainlessParser extends Parser {
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(245);
+            setState(253);
             if (!(precpred(_ctx, 10))) throw new FailedPredicateException(this, "precpred(_ctx, 10)");
-            setState(246);
+            setState(254);
             _la = _input.LA(1);
             if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LSH) | (1L << RSH) | (1L << USH))) != 0)) ) {
             _errHandler.recoverInline(this);
             } else {
               consume();
             }
-            setState(247);
+            setState(255);
             expression(11);
              ((BinaryContext)_localctx).s =  false; 
             }
@@ -1590,16 +1592,16 @@ class PainlessParser extends Parser {
             {
             _localctx = new CompContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(250);
+            setState(258);
             if (!(precpred(_ctx, 9))) throw new FailedPredicateException(this, "precpred(_ctx, 9)");
-            setState(251);
+            setState(259);
             _la = _input.LA(1);
             if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LT) | (1L << LTE) | (1L << GT) | (1L << GTE))) != 0)) ) {
             _errHandler.recoverInline(this);
             } else {
               consume();
             }
-            setState(252);
+            setState(260);
             expression(10);
              ((CompContext)_localctx).s =  false; 
             }
@@ -1608,16 +1610,16 @@ class PainlessParser extends Parser {
             {
             _localctx = new CompContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(255);
+            setState(263);
             if (!(precpred(_ctx, 8))) throw new FailedPredicateException(this, "precpred(_ctx, 8)");
-            setState(256);
+            setState(264);
             _la = _input.LA(1);
             if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EQ) | (1L << EQR) | (1L << NE) | (1L << NER))) != 0)) ) {
             _errHandler.recoverInline(this);
             } else {
               consume();
             }
-            setState(257);
+            setState(265);
             expression(9);
              ((CompContext)_localctx).s =  false; 
             }
@@ -1626,11 +1628,11 @@ class PainlessParser extends Parser {
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(260);
+            setState(268);
             if (!(precpred(_ctx, 7))) throw new FailedPredicateException(this, "precpred(_ctx, 7)");
-            setState(261);
+            setState(269);
             match(BWAND);
-            setState(262);
+            setState(270);
             expression(8);
              ((BinaryContext)_localctx).s =  false; 
             }
@@ -1639,11 +1641,11 @@ class PainlessParser extends Parser {
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(265);
+            setState(273);
             if (!(precpred(_ctx, 6))) throw new FailedPredicateException(this, "precpred(_ctx, 6)");
-            setState(266);
+            setState(274);
             match(XOR);
-            setState(267);
+            setState(275);
             expression(7);
              ((BinaryContext)_localctx).s =  false; 
             }
@@ -1652,11 +1654,11 @@ class PainlessParser extends Parser {
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(270);
+            setState(278);
             if (!(precpred(_ctx, 5))) throw new FailedPredicateException(this, "precpred(_ctx, 5)");
-            setState(271);
+            setState(279);
             match(BWOR);
-            setState(272);
+            setState(280);
             expression(6);
              ((BinaryContext)_localctx).s =  false; 
             }
@@ -1665,11 +1667,11 @@ class PainlessParser extends Parser {
             {
             _localctx = new BoolContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(275);
+            setState(283);
             if (!(precpred(_ctx, 4))) throw new FailedPredicateException(this, "precpred(_ctx, 4)");
-            setState(276);
+            setState(284);
             match(BOOLAND);
-            setState(277);
+            setState(285);
             expression(5);
              ((BoolContext)_localctx).s =  false; 
             }
@@ -1678,11 +1680,11 @@ class PainlessParser extends Parser {
             {
             _localctx = new BoolContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(280);
+            setState(288);
             if (!(precpred(_ctx, 3))) throw new FailedPredicateException(this, "precpred(_ctx, 3)");
-            setState(281);
+            setState(289);
             match(BOOLOR);
-            setState(282);
+            setState(290);
             expression(4);
              ((BoolContext)_localctx).s =  false; 
             }
@@ -1691,15 +1693,15 @@ class PainlessParser extends Parser {
             {
             _localctx = new ConditionalContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(285);
+            setState(293);
             if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-            setState(286);
+            setState(294);
             match(COND);
-            setState(287);
+            setState(295);
             ((ConditionalContext)_localctx).e0 = expression(0);
-            setState(288);
+            setState(296);
             match(COLON);
-            setState(289);
+            setState(297);
             ((ConditionalContext)_localctx).e1 = expression(2);
              ((ConditionalContext)_localctx).s =  ((ConditionalContext)_localctx).e0.s && ((ConditionalContext)_localctx).e1.s; 
             }
@@ -1707,7 +1709,7 @@ class PainlessParser extends Parser {
           }
           } 
         }
-        setState(296);
+        setState(304);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,21,_ctx);
       }
@@ -1854,22 +1856,22 @@ class PainlessParser extends Parser {
     enterRule(_localctx, 30, RULE_unary);
     int _la;
     try {
-      setState(326);
+      setState(334);
       switch ( getInterpreter().adaptivePredict(_input,22,_ctx) ) {
       case 1:
         _localctx = new PreContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(297);
+        setState(305);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(298);
+        setState(306);
         _la = _input.LA(1);
         if ( !(_la==INCR || _la==DECR) ) {
         _errHandler.recoverInline(this);
         } else {
           consume();
         }
-        setState(299);
+        setState(307);
         chain(true);
         }
         break;
@@ -1877,11 +1879,11 @@ class PainlessParser extends Parser {
         _localctx = new PostContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(300);
+        setState(308);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(301);
+        setState(309);
         chain(true);
-        setState(302);
+        setState(310);
         _la = _input.LA(1);
         if ( !(_la==INCR || _la==DECR) ) {
         _errHandler.recoverInline(this);
@@ -1894,9 +1896,9 @@ class PainlessParser extends Parser {
         _localctx = new ReadContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(304);
+        setState(312);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(305);
+        setState(313);
         chain(false);
         }
         break;
@@ -1904,9 +1906,9 @@ class PainlessParser extends Parser {
         _localctx = new NumericContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(306);
+        setState(314);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(307);
+        setState(315);
         _la = _input.LA(1);
         if ( !(((((_la - 66)) & ~0x3f) == 0 && ((1L << (_la - 66)) & ((1L << (OCTAL - 66)) | (1L << (HEX - 66)) | (1L << (INTEGER - 66)) | (1L << (DECIMAL - 66)))) != 0)) ) {
         _errHandler.recoverInline(this);
@@ -1920,9 +1922,9 @@ class PainlessParser extends Parser {
         _localctx = new TrueContext(_localctx);
         enterOuterAlt(_localctx, 5);
         {
-        setState(309);
+        setState(317);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(310);
+        setState(318);
         match(TRUE);
          ((TrueContext)_localctx).s =  false; 
         }
@@ -1931,9 +1933,9 @@ class PainlessParser extends Parser {
         _localctx = new FalseContext(_localctx);
         enterOuterAlt(_localctx, 6);
         {
-        setState(312);
+        setState(320);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(313);
+        setState(321);
         match(FALSE);
          ((FalseContext)_localctx).s =  false; 
         }
@@ -1942,9 +1944,9 @@ class PainlessParser extends Parser {
         _localctx = new NullContext(_localctx);
         enterOuterAlt(_localctx, 7);
         {
-        setState(315);
+        setState(323);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(316);
+        setState(324);
         match(NULL);
          ((NullContext)_localctx).s =  false; 
         }
@@ -1953,16 +1955,16 @@ class PainlessParser extends Parser {
         _localctx = new OperatorContext(_localctx);
         enterOuterAlt(_localctx, 8);
         {
-        setState(318);
+        setState(326);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(319);
+        setState(327);
         _la = _input.LA(1);
         if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L << SUB))) != 0)) ) {
         _errHandler.recoverInline(this);
         } else {
           consume();
         }
-        setState(320);
+        setState(328);
         unary(false);
         }
         break;
@@ -1970,13 +1972,13 @@ class PainlessParser extends Parser {
         _localctx = new CastContext(_localctx);
         enterOuterAlt(_localctx, 9);
         {
-        setState(321);
+        setState(329);
         match(LP);
-        setState(322);
+        setState(330);
         decltype();
-        setState(323);
+        setState(331);
         match(RP);
-        setState(324);
+        setState(332);
         unary(_localctx.c);
         }
         break;
@@ -2085,27 +2087,27 @@ class PainlessParser extends Parser {
     enterRule(_localctx, 32, RULE_chain);
     try {
       int _alt;
-      setState(362);
+      setState(370);
       switch ( getInterpreter().adaptivePredict(_input,28,_ctx) ) {
       case 1:
         _localctx = new DynamicContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(328);
+        setState(336);
         ((DynamicContext)_localctx).p = primary(_localctx.c);
-        setState(332);
+        setState(340);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
         while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
           if ( _alt==1 ) {
             {
             {
-            setState(329);
+            setState(337);
             secondary(((DynamicContext)_localctx).p.s);
             }
             } 
           }
-          setState(334);
+          setState(342);
           _errHandler.sync(this);
           _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
         }
@@ -2115,23 +2117,23 @@ class PainlessParser extends Parser {
         _localctx = new StaticContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(335);
+        setState(343);
         decltype();
-        setState(336);
+        setState(344);
         dot();
-        setState(340);
+        setState(348);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,24,_ctx);
         while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
           if ( _alt==1 ) {
             {
             {
-            setState(337);
+            setState(345);
             secondary(true);
             }
             } 
           }
-          setState(342);
+          setState(350);
           _errHandler.sync(this);
           _alt = getInterpreter().adaptivePredict(_input,24,_ctx);
         }
@@ -2141,11 +2143,11 @@ class PainlessParser extends Parser {
         _localctx = new NewarrayContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(343);
+        setState(351);
         match(NEW);
-        setState(344);
+        setState(352);
         match(TYPE);
-        setState(349); 
+        setState(357); 
         _errHandler.sync(this);
         _alt = 1;
         do {
@@ -2153,11 +2155,11 @@ class PainlessParser extends Parser {
           case 1:
             {
             {
-            setState(345);
+            setState(353);
             match(LBRACE);
-            setState(346);
+            setState(354);
             expression(0);
-            setState(347);
+            setState(355);
             match(RBRACE);
             }
             }
@@ -2165,29 +2167,29 @@ class PainlessParser extends Parser {
           default:
             throw new NoViableAltException(this);
           }
-          setState(351); 
+          setState(359); 
           _errHandler.sync(this);
           _alt = getInterpreter().adaptivePredict(_input,25,_ctx);
         } while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER );
-        setState(360);
+        setState(368);
         switch ( getInterpreter().adaptivePredict(_input,27,_ctx) ) {
         case 1:
           {
-          setState(353);
+          setState(361);
           dot();
-          setState(357);
+          setState(365);
           _errHandler.sync(this);
           _alt = getInterpreter().adaptivePredict(_input,26,_ctx);
           while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
             if ( _alt==1 ) {
               {
               {
-              setState(354);
+              setState(362);
               secondary(true);
               }
               } 
             }
-            setState(359);
+            setState(367);
             _errHandler.sync(this);
             _alt = getInterpreter().adaptivePredict(_input,26,_ctx);
           }
@@ -2301,19 +2303,19 @@ class PainlessParser extends Parser {
     PrimaryContext _localctx = new PrimaryContext(_ctx, getState(), c);
     enterRule(_localctx, 34, RULE_primary);
     try {
-      setState(382);
+      setState(390);
       switch ( getInterpreter().adaptivePredict(_input,29,_ctx) ) {
       case 1:
         _localctx = new ExprprecContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(364);
+        setState(372);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(365);
+        setState(373);
         match(LP);
-        setState(366);
+        setState(374);
         ((ExprprecContext)_localctx).e = expression(0);
-        setState(367);
+        setState(375);
         match(RP);
          ((ExprprecContext)_localctx).s =  ((ExprprecContext)_localctx).e.s; 
         }
@@ -2322,13 +2324,13 @@ class PainlessParser extends Parser {
         _localctx = new ChainprecContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(370);
+        setState(378);
         if (!( _localctx.c )) throw new FailedPredicateException(this, " $c ");
-        setState(371);
+        setState(379);
         match(LP);
-        setState(372);
+        setState(380);
         unary(true);
-        setState(373);
+        setState(381);
         match(RP);
         }
         break;
@@ -2336,7 +2338,7 @@ class PainlessParser extends Parser {
         _localctx = new StringContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(375);
+        setState(383);
         match(STRING);
         }
         break;
@@ -2344,7 +2346,7 @@ class PainlessParser extends Parser {
         _localctx = new VariableContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(376);
+        setState(384);
         match(ID);
         }
         break;
@@ -2352,9 +2354,9 @@ class PainlessParser extends Parser {
         _localctx = new CalllocalContext(_localctx);
         enterOuterAlt(_localctx, 5);
         {
-        setState(377);
+        setState(385);
         match(ID);
-        setState(378);
+        setState(386);
         arguments();
         }
         break;
@@ -2362,11 +2364,11 @@ class PainlessParser extends Parser {
         _localctx = new NewobjectContext(_localctx);
         enterOuterAlt(_localctx, 6);
         {
-        setState(379);
+        setState(387);
         match(NEW);
-        setState(380);
+        setState(388);
         match(TYPE);
-        setState(381);
+        setState(389);
         arguments();
         }
         break;
@@ -2408,23 +2410,23 @@ class PainlessParser extends Parser {
     SecondaryContext _localctx = new SecondaryContext(_ctx, getState(), s);
     enterRule(_localctx, 36, RULE_secondary);
     try {
-      setState(388);
+      setState(396);
       switch ( getInterpreter().adaptivePredict(_input,30,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(384);
+        setState(392);
         if (!( _localctx.s )) throw new FailedPredicateException(this, " $s ");
-        setState(385);
+        setState(393);
         dot();
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(386);
+        setState(394);
         if (!( _localctx.s )) throw new FailedPredicateException(this, " $s ");
-        setState(387);
+        setState(395);
         brace();
         }
         break;
@@ -2482,17 +2484,17 @@ class PainlessParser extends Parser {
     enterRule(_localctx, 38, RULE_dot);
     int _la;
     try {
-      setState(395);
+      setState(403);
       switch ( getInterpreter().adaptivePredict(_input,31,_ctx) ) {
       case 1:
         _localctx = new CallinvokeContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(390);
+        setState(398);
         match(DOT);
-        setState(391);
+        setState(399);
         match(DOTID);
-        setState(392);
+        setState(400);
         arguments();
         }
         break;
@@ -2500,9 +2502,9 @@ class PainlessParser extends Parser {
         _localctx = new FieldaccessContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(393);
+        setState(401);
         match(DOT);
-        setState(394);
+        setState(402);
         _la = _input.LA(1);
         if ( !(_la==DOTINTEGER || _la==DOTID) ) {
         _errHandler.recoverInline(this);
@@ -2556,11 +2558,11 @@ class PainlessParser extends Parser {
       _localctx = new BraceaccessContext(_localctx);
       enterOuterAlt(_localctx, 1);
       {
-      setState(397);
+      setState(405);
       match(LBRACE);
-      setState(398);
+      setState(406);
       expression(0);
-      setState(399);
+      setState(407);
       match(RBRACE);
       }
     }
@@ -2607,34 +2609,34 @@ class PainlessParser extends Parser {
       enterOuterAlt(_localctx, 1);
       {
       {
-      setState(401);
+      setState(409);
       match(LP);
-      setState(410);
+      setState(418);
       switch ( getInterpreter().adaptivePredict(_input,33,_ctx) ) {
       case 1:
         {
-        setState(402);
+        setState(410);
         argument();
-        setState(407);
+        setState(415);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(403);
+          setState(411);
           match(COMMA);
-          setState(404);
+          setState(412);
           argument();
           }
           }
-          setState(409);
+          setState(417);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
         }
         break;
       }
-      setState(412);
+      setState(420);
       match(RP);
       }
       }
@@ -2675,26 +2677,26 @@ class PainlessParser extends Parser {
     ArgumentContext _localctx = new ArgumentContext(_ctx, getState());
     enterRule(_localctx, 44, RULE_argument);
     try {
-      setState(417);
+      setState(425);
       switch ( getInterpreter().adaptivePredict(_input,34,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(414);
+        setState(422);
         expression(0);
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(415);
+        setState(423);
         lambda();
         }
         break;
       case 3:
         enterOuterAlt(_localctx, 3);
         {
-        setState(416);
+        setState(424);
         funcref();
         }
         break;
@@ -2746,54 +2748,54 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(432);
+      setState(440);
       switch (_input.LA(1)) {
       case TYPE:
       case ID:
         {
-        setState(419);
+        setState(427);
         lamtype();
         }
         break;
       case LP:
         {
-        setState(420);
+        setState(428);
         match(LP);
-        setState(429);
+        setState(437);
         _la = _input.LA(1);
         if (_la==TYPE || _la==ID) {
           {
-          setState(421);
+          setState(429);
           lamtype();
-          setState(426);
+          setState(434);
           _errHandler.sync(this);
           _la = _input.LA(1);
           while (_la==COMMA) {
             {
             {
-            setState(422);
+            setState(430);
             match(COMMA);
-            setState(423);
+            setState(431);
             lamtype();
             }
             }
-            setState(428);
+            setState(436);
             _errHandler.sync(this);
             _la = _input.LA(1);
           }
           }
         }
 
-        setState(431);
+        setState(439);
         match(RP);
         }
         break;
       default:
         throw new NoViableAltException(this);
       }
-      setState(434);
+      setState(442);
       match(ARROW);
-      setState(435);
+      setState(443);
       block();
       }
     }
@@ -2831,16 +2833,16 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(438);
+      setState(446);
       _la = _input.LA(1);
       if (_la==TYPE) {
         {
-        setState(437);
+        setState(445);
         decltype();
         }
       }
 
-      setState(440);
+      setState(448);
       match(ID);
       }
     }
@@ -2856,14 +2858,18 @@ class PainlessParser extends Parser {
   }
 
   public static class FuncrefContext extends ParserRuleContext {
-    public TerminalNode TYPE() { return getToken(PainlessParser.TYPE, 0); }
-    public TerminalNode REF() { return getToken(PainlessParser.REF, 0); }
-    public List<TerminalNode> ID() { return getTokens(PainlessParser.ID); }
-    public TerminalNode ID(int i) {
-      return getToken(PainlessParser.ID, i);
+    public ClassFuncrefContext classFuncref() {
+      return getRuleContext(ClassFuncrefContext.class,0);
     }
-    public TerminalNode NEW() { return getToken(PainlessParser.NEW, 0); }
-    public TerminalNode THIS() { return getToken(PainlessParser.THIS, 0); }
+    public ConstructorFuncrefContext constructorFuncref() {
+      return getRuleContext(ConstructorFuncrefContext.class,0);
+    }
+    public CapturingFuncrefContext capturingFuncref() {
+      return getRuleContext(CapturingFuncrefContext.class,0);
+    }
+    public LocalFuncrefContext localFuncref() {
+      return getRuleContext(LocalFuncrefContext.class,0);
+    }
     public FuncrefContext(ParserRuleContext parent, int invokingState) {
       super(parent, invokingState);
     }
@@ -2878,45 +2884,199 @@ class PainlessParser extends Parser {
   public final FuncrefContext funcref() throws RecognitionException {
     FuncrefContext _localctx = new FuncrefContext(_ctx, getState());
     enterRule(_localctx, 50, RULE_funcref);
-    int _la;
     try {
-      setState(448);
-      switch (_input.LA(1)) {
-      case TYPE:
+      setState(454);
+      switch ( getInterpreter().adaptivePredict(_input,39,_ctx) ) {
+      case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(442);
-        match(TYPE);
-        setState(443);
-        match(REF);
-        setState(444);
-        _la = _input.LA(1);
-        if ( !(_la==NEW || _la==ID) ) {
-        _errHandler.recoverInline(this);
-        } else {
-          consume();
-        }
+        setState(450);
+        classFuncref();
         }
         break;
-      case THIS:
-      case ID:
+      case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(445);
-        _la = _input.LA(1);
-        if ( !(_la==THIS || _la==ID) ) {
-        _errHandler.recoverInline(this);
-        } else {
-          consume();
-        }
-        setState(446);
-        match(REF);
-        setState(447);
-        match(ID);
+        setState(451);
+        constructorFuncref();
         }
         break;
-      default:
-        throw new NoViableAltException(this);
+      case 3:
+        enterOuterAlt(_localctx, 3);
+        {
+        setState(452);
+        capturingFuncref();
+        }
+        break;
+      case 4:
+        enterOuterAlt(_localctx, 4);
+        {
+        setState(453);
+        localFuncref();
+        }
+        break;
+      }
+    }
+    catch (RecognitionException re) {
+      _localctx.exception = re;
+      _errHandler.reportError(this, re);
+      _errHandler.recover(this, re);
+    }
+    finally {
+      exitRule();
+    }
+    return _localctx;
+  }
+
+  public static class ClassFuncrefContext extends ParserRuleContext {
+    public TerminalNode TYPE() { return getToken(PainlessParser.TYPE, 0); }
+    public TerminalNode REF() { return getToken(PainlessParser.REF, 0); }
+    public TerminalNode ID() { return getToken(PainlessParser.ID, 0); }
+    public ClassFuncrefContext(ParserRuleContext parent, int invokingState) {
+      super(parent, invokingState);
+    }
+    @Override public int getRuleIndex() { return RULE_classFuncref; }
+    @Override
+    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitClassFuncref(this);
+      else return visitor.visitChildren(this);
+    }
+  }
+
+  public final ClassFuncrefContext classFuncref() throws RecognitionException {
+    ClassFuncrefContext _localctx = new ClassFuncrefContext(_ctx, getState());
+    enterRule(_localctx, 52, RULE_classFuncref);
+    try {
+      enterOuterAlt(_localctx, 1);
+      {
+      setState(456);
+      match(TYPE);
+      setState(457);
+      match(REF);
+      setState(458);
+      match(ID);
+      }
+    }
+    catch (RecognitionException re) {
+      _localctx.exception = re;
+      _errHandler.reportError(this, re);
+      _errHandler.recover(this, re);
+    }
+    finally {
+      exitRule();
+    }
+    return _localctx;
+  }
+
+  public static class ConstructorFuncrefContext extends ParserRuleContext {
+    public TerminalNode TYPE() { return getToken(PainlessParser.TYPE, 0); }
+    public TerminalNode REF() { return getToken(PainlessParser.REF, 0); }
+    public TerminalNode NEW() { return getToken(PainlessParser.NEW, 0); }
+    public ConstructorFuncrefContext(ParserRuleContext parent, int invokingState) {
+      super(parent, invokingState);
+    }
+    @Override public int getRuleIndex() { return RULE_constructorFuncref; }
+    @Override
+    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitConstructorFuncref(this);
+      else return visitor.visitChildren(this);
+    }
+  }
+
+  public final ConstructorFuncrefContext constructorFuncref() throws RecognitionException {
+    ConstructorFuncrefContext _localctx = new ConstructorFuncrefContext(_ctx, getState());
+    enterRule(_localctx, 54, RULE_constructorFuncref);
+    try {
+      enterOuterAlt(_localctx, 1);
+      {
+      setState(460);
+      match(TYPE);
+      setState(461);
+      match(REF);
+      setState(462);
+      match(NEW);
+      }
+    }
+    catch (RecognitionException re) {
+      _localctx.exception = re;
+      _errHandler.reportError(this, re);
+      _errHandler.recover(this, re);
+    }
+    finally {
+      exitRule();
+    }
+    return _localctx;
+  }
+
+  public static class CapturingFuncrefContext extends ParserRuleContext {
+    public List<TerminalNode> ID() { return getTokens(PainlessParser.ID); }
+    public TerminalNode ID(int i) {
+      return getToken(PainlessParser.ID, i);
+    }
+    public TerminalNode REF() { return getToken(PainlessParser.REF, 0); }
+    public CapturingFuncrefContext(ParserRuleContext parent, int invokingState) {
+      super(parent, invokingState);
+    }
+    @Override public int getRuleIndex() { return RULE_capturingFuncref; }
+    @Override
+    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitCapturingFuncref(this);
+      else return visitor.visitChildren(this);
+    }
+  }
+
+  public final CapturingFuncrefContext capturingFuncref() throws RecognitionException {
+    CapturingFuncrefContext _localctx = new CapturingFuncrefContext(_ctx, getState());
+    enterRule(_localctx, 56, RULE_capturingFuncref);
+    try {
+      enterOuterAlt(_localctx, 1);
+      {
+      setState(464);
+      match(ID);
+      setState(465);
+      match(REF);
+      setState(466);
+      match(ID);
+      }
+    }
+    catch (RecognitionException re) {
+      _localctx.exception = re;
+      _errHandler.reportError(this, re);
+      _errHandler.recover(this, re);
+    }
+    finally {
+      exitRule();
+    }
+    return _localctx;
+  }
+
+  public static class LocalFuncrefContext extends ParserRuleContext {
+    public TerminalNode THIS() { return getToken(PainlessParser.THIS, 0); }
+    public TerminalNode REF() { return getToken(PainlessParser.REF, 0); }
+    public TerminalNode ID() { return getToken(PainlessParser.ID, 0); }
+    public LocalFuncrefContext(ParserRuleContext parent, int invokingState) {
+      super(parent, invokingState);
+    }
+    @Override public int getRuleIndex() { return RULE_localFuncref; }
+    @Override
+    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitLocalFuncref(this);
+      else return visitor.visitChildren(this);
+    }
+  }
+
+  public final LocalFuncrefContext localFuncref() throws RecognitionException {
+    LocalFuncrefContext _localctx = new LocalFuncrefContext(_ctx, getState());
+    enterRule(_localctx, 58, RULE_localFuncref);
+    try {
+      enterOuterAlt(_localctx, 1);
+      {
+      setState(468);
+      match(THIS);
+      setState(469);
+      match(REF);
+      setState(470);
+      match(ID);
       }
     }
     catch (RecognitionException re) {
@@ -3020,175 +3180,183 @@ class PainlessParser extends Parser {
   }
 
   public static final String _serializedATN =
-    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3O\u01c5\4\2\t\2\4"+
+    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3O\u01db\4\2\t\2\4"+
     "\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t"+
     "\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
     "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
-    "\4\32\t\32\4\33\t\33\3\2\7\28\n\2\f\2\16\2;\13\2\3\2\7\2>\n\2\f\2\16\2"+
-    "A\13\2\3\2\3\2\3\3\3\3\3\3\3\3\3\3\3\4\3\4\3\4\3\4\3\4\3\4\3\4\7\4Q\n"+
-    "\4\f\4\16\4T\13\4\5\4V\n\4\3\4\3\4\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\5\5"+
-    "b\n\5\3\5\3\5\3\5\3\5\3\5\3\5\5\5j\n\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5"+
-    "\3\5\3\5\3\5\5\5w\n\5\3\5\3\5\5\5{\n\5\3\5\3\5\5\5\177\n\5\3\5\3\5\3\5"+
-    "\5\5\u0084\n\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5"+
-    "\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\6\5\u009d\n\5\r\5\16\5\u009e\3\5"+
-    "\3\5\3\5\3\5\3\5\3\5\3\5\5\5\u00a8\n\5\3\6\3\6\5\6\u00ac\n\6\3\7\3\7\7"+
-    "\7\u00b0\n\7\f\7\16\7\u00b3\13\7\3\7\3\7\3\b\3\b\3\t\3\t\5\t\u00bb\n\t"+
-    "\3\n\3\n\3\13\3\13\3\13\3\13\7\13\u00c3\n\13\f\13\16\13\u00c6\13\13\3"+
-    "\f\3\f\3\f\7\f\u00cb\n\f\f\f\16\f\u00ce\13\f\3\r\3\r\3\r\5\r\u00d3\n\r"+
-    "\3\16\3\16\3\16\3\16\3\16\3\16\3\16\3\17\3\17\3\17\3\17\3\17\5\17\u00e1"+
-    "\n\17\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\5\20\u00ec\n\20\3\20"+
+    "\4\32\t\32\4\33\t\33\4\34\t\34\4\35\t\35\4\36\t\36\4\37\t\37\3\2\7\2@"+
+    "\n\2\f\2\16\2C\13\2\3\2\7\2F\n\2\f\2\16\2I\13\2\3\2\3\2\3\3\3\3\3\3\3"+
+    "\3\3\3\3\4\3\4\3\4\3\4\3\4\3\4\3\4\7\4Y\n\4\f\4\16\4\\\13\4\5\4^\n\4\3"+
+    "\4\3\4\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\5\5j\n\5\3\5\3\5\3\5\3\5\3\5\3"+
+    "\5\5\5r\n\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\5\5\177\n\5\3"+
+    "\5\3\5\5\5\u0083\n\5\3\5\3\5\5\5\u0087\n\5\3\5\3\5\3\5\5\5\u008c\n\5\3"+
+    "\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5"+
+    "\3\5\3\5\3\5\3\5\3\5\6\5\u00a5\n\5\r\5\16\5\u00a6\3\5\3\5\3\5\3\5\3\5"+
+    "\3\5\3\5\5\5\u00b0\n\5\3\6\3\6\5\6\u00b4\n\6\3\7\3\7\7\7\u00b8\n\7\f\7"+
+    "\16\7\u00bb\13\7\3\7\3\7\3\b\3\b\3\t\3\t\5\t\u00c3\n\t\3\n\3\n\3\13\3"+
+    "\13\3\13\3\13\7\13\u00cb\n\13\f\13\16\13\u00ce\13\13\3\f\3\f\3\f\7\f\u00d3"+
+    "\n\f\f\f\16\f\u00d6\13\f\3\r\3\r\3\r\5\r\u00db\n\r\3\16\3\16\3\16\3\16"+
+    "\3\16\3\16\3\16\3\17\3\17\3\17\3\17\3\17\5\17\u00e9\n\17\3\20\3\20\3\20"+
+    "\3\20\3\20\3\20\3\20\3\20\3\20\5\20\u00f4\n\20\3\20\3\20\3\20\3\20\3\20"+
     "\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20"+
     "\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20"+
     "\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20"+
-    "\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20"+
-    "\7\20\u0127\n\20\f\20\16\20\u012a\13\20\3\21\3\21\3\21\3\21\3\21\3\21"+
-    "\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21"+
-    "\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\5\21\u0149\n\21\3\22\3\22"+
-    "\7\22\u014d\n\22\f\22\16\22\u0150\13\22\3\22\3\22\3\22\7\22\u0155\n\22"+
-    "\f\22\16\22\u0158\13\22\3\22\3\22\3\22\3\22\3\22\3\22\6\22\u0160\n\22"+
-    "\r\22\16\22\u0161\3\22\3\22\7\22\u0166\n\22\f\22\16\22\u0169\13\22\5\22"+
-    "\u016b\n\22\5\22\u016d\n\22\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3"+
-    "\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\5\23\u0181\n\23\3\24"+
-    "\3\24\3\24\3\24\5\24\u0187\n\24\3\25\3\25\3\25\3\25\3\25\5\25\u018e\n"+
-    "\25\3\26\3\26\3\26\3\26\3\27\3\27\3\27\3\27\7\27\u0198\n\27\f\27\16\27"+
-    "\u019b\13\27\5\27\u019d\n\27\3\27\3\27\3\30\3\30\3\30\5\30\u01a4\n\30"+
-    "\3\31\3\31\3\31\3\31\3\31\7\31\u01ab\n\31\f\31\16\31\u01ae\13\31\5\31"+
-    "\u01b0\n\31\3\31\5\31\u01b3\n\31\3\31\3\31\3\31\3\32\5\32\u01b9\n\32\3"+
-    "\32\3\32\3\33\3\33\3\33\3\33\3\33\3\33\5\33\u01c3\n\33\3\33\2\3\36\34"+
-    "\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62\64\2\16\3\28C\3"+
-    "\2\35\37\3\2 !\3\2\"$\3\2%(\3\2),\3\2\66\67\3\2DG\4\2\33\34 !\3\2NO\4"+
-    "\2\26\26MM\4\2\32\32MM\u01f3\29\3\2\2\2\4D\3\2\2\2\6I\3\2\2\2\b\u00a7"+
-    "\3\2\2\2\n\u00ab\3\2\2\2\f\u00ad\3\2\2\2\16\u00b6\3\2\2\2\20\u00ba\3\2"+
-    "\2\2\22\u00bc\3\2\2\2\24\u00be\3\2\2\2\26\u00c7\3\2\2\2\30\u00cf\3\2\2"+
-    "\2\32\u00d4\3\2\2\2\34\u00e0\3\2\2\2\36\u00eb\3\2\2\2 \u0148\3\2\2\2\""+
-    "\u016c\3\2\2\2$\u0180\3\2\2\2&\u0186\3\2\2\2(\u018d\3\2\2\2*\u018f\3\2"+
-    "\2\2,\u0193\3\2\2\2.\u01a3\3\2\2\2\60\u01b2\3\2\2\2\62\u01b8\3\2\2\2\64"+
-    "\u01c2\3\2\2\2\668\5\4\3\2\67\66\3\2\2\28;\3\2\2\29\67\3\2\2\29:\3\2\2"+
-    "\2:?\3\2\2\2;9\3\2\2\2<>\5\b\5\2=<\3\2\2\2>A\3\2\2\2?=\3\2\2\2?@\3\2\2"+
-    "\2@B\3\2\2\2A?\3\2\2\2BC\7\2\2\3C\3\3\2\2\2DE\5\26\f\2EF\7M\2\2FG\5\6"+
-    "\4\2GH\5\f\7\2H\5\3\2\2\2IU\7\t\2\2JK\5\26\f\2KR\7M\2\2LM\7\f\2\2MN\5"+
-    "\26\f\2NO\7M\2\2OQ\3\2\2\2PL\3\2\2\2QT\3\2\2\2RP\3\2\2\2RS\3\2\2\2SV\3"+
-    "\2\2\2TR\3\2\2\2UJ\3\2\2\2UV\3\2\2\2VW\3\2\2\2WX\7\n\2\2X\7\3\2\2\2YZ"+
-    "\7\16\2\2Z[\7\t\2\2[\\\5\36\20\2\\]\7\n\2\2]a\5\n\6\2^_\7\17\2\2_b\5\n"+
-    "\6\2`b\6\5\2\2a^\3\2\2\2a`\3\2\2\2b\u00a8\3\2\2\2cd\7\20\2\2de\7\t\2\2"+
-    "ef\5\36\20\2fi\7\n\2\2gj\5\n\6\2hj\5\16\b\2ig\3\2\2\2ih\3\2\2\2j\u00a8"+
-    "\3\2\2\2kl\7\21\2\2lm\5\f\7\2mn\7\20\2\2no\7\t\2\2op\5\36\20\2pq\7\n\2"+
-    "\2qr\5\34\17\2r\u00a8\3\2\2\2st\7\22\2\2tv\7\t\2\2uw\5\20\t\2vu\3\2\2"+
-    "\2vw\3\2\2\2wx\3\2\2\2xz\7\r\2\2y{\5\36\20\2zy\3\2\2\2z{\3\2\2\2{|\3\2"+
-    "\2\2|~\7\r\2\2}\177\5\22\n\2~}\3\2\2\2~\177\3\2\2\2\177\u0080\3\2\2\2"+
-    "\u0080\u0083\7\n\2\2\u0081\u0084\5\n\6\2\u0082\u0084\5\16\b\2\u0083\u0081"+
-    "\3\2\2\2\u0083\u0082\3\2\2\2\u0084\u00a8\3\2\2\2\u0085\u0086\7\22\2\2"+
-    "\u0086\u0087\7\t\2\2\u0087\u0088\5\26\f\2\u0088\u0089\7M\2\2\u0089\u008a"+
-    "\7\63\2\2\u008a\u008b\5\36\20\2\u008b\u008c\7\n\2\2\u008c\u008d\5\n\6"+
-    "\2\u008d\u00a8\3\2\2\2\u008e\u008f\5\24\13\2\u008f\u0090\5\34\17\2\u0090"+
-    "\u00a8\3\2\2\2\u0091\u0092\7\23\2\2\u0092\u00a8\5\34\17\2\u0093\u0094"+
-    "\7\24\2\2\u0094\u00a8\5\34\17\2\u0095\u0096\7\25\2\2\u0096\u0097\5\36"+
-    "\20\2\u0097\u0098\5\34\17\2\u0098\u00a8\3\2\2\2\u0099\u009a\7\27\2\2\u009a"+
-    "\u009c\5\f\7\2\u009b\u009d\5\32\16\2\u009c\u009b\3\2\2\2\u009d\u009e\3"+
-    "\2\2\2\u009e\u009c\3\2\2\2\u009e\u009f\3\2\2\2\u009f\u00a8\3\2\2\2\u00a0"+
-    "\u00a1\7\31\2\2\u00a1\u00a2\5\36\20\2\u00a2\u00a3\5\34\17\2\u00a3\u00a8"+
-    "\3\2\2\2\u00a4\u00a5\5\36\20\2\u00a5\u00a6\5\34\17\2\u00a6\u00a8\3\2\2"+
-    "\2\u00a7Y\3\2\2\2\u00a7c\3\2\2\2\u00a7k\3\2\2\2\u00a7s\3\2\2\2\u00a7\u0085"+
-    "\3\2\2\2\u00a7\u008e\3\2\2\2\u00a7\u0091\3\2\2\2\u00a7\u0093\3\2\2\2\u00a7"+
-    "\u0095\3\2\2\2\u00a7\u0099\3\2\2\2\u00a7\u00a0\3\2\2\2\u00a7\u00a4\3\2"+
-    "\2\2\u00a8\t\3\2\2\2\u00a9\u00ac\5\f\7\2\u00aa\u00ac\5\b\5\2\u00ab\u00a9"+
-    "\3\2\2\2\u00ab\u00aa\3\2\2\2\u00ac\13\3\2\2\2\u00ad\u00b1\7\5\2\2\u00ae"+
-    "\u00b0\5\b\5\2\u00af\u00ae\3\2\2\2\u00b0\u00b3\3\2\2\2\u00b1\u00af\3\2"+
-    "\2\2\u00b1\u00b2\3\2\2\2\u00b2\u00b4\3\2\2\2\u00b3\u00b1\3\2\2\2\u00b4"+
-    "\u00b5\7\6\2\2\u00b5\r\3\2\2\2\u00b6\u00b7\7\r\2\2\u00b7\17\3\2\2\2\u00b8"+
-    "\u00bb\5\24\13\2\u00b9\u00bb\5\36\20\2\u00ba\u00b8\3\2\2\2\u00ba\u00b9"+
-    "\3\2\2\2\u00bb\21\3\2\2\2\u00bc\u00bd\5\36\20\2\u00bd\23\3\2\2\2\u00be"+
-    "\u00bf\5\26\f\2\u00bf\u00c4\5\30\r\2\u00c0\u00c1\7\f\2\2\u00c1\u00c3\5"+
-    "\30\r\2\u00c2\u00c0\3\2\2\2\u00c3\u00c6\3\2\2\2\u00c4\u00c2\3\2\2\2\u00c4"+
-    "\u00c5\3\2\2\2\u00c5\25\3\2\2\2\u00c6\u00c4\3\2\2\2\u00c7\u00cc\7L\2\2"+
-    "\u00c8\u00c9\7\7\2\2\u00c9\u00cb\7\b\2\2\u00ca\u00c8\3\2\2\2\u00cb\u00ce"+
-    "\3\2\2\2\u00cc\u00ca\3\2\2\2\u00cc\u00cd\3\2\2\2\u00cd\27\3\2\2\2\u00ce"+
-    "\u00cc\3\2\2\2\u00cf\u00d2\7M\2\2\u00d0\u00d1\78\2\2\u00d1\u00d3\5\36"+
-    "\20\2\u00d2\u00d0\3\2\2\2\u00d2\u00d3\3\2\2\2\u00d3\31\3\2\2\2\u00d4\u00d5"+
-    "\7\30\2\2\u00d5\u00d6\7\t\2\2\u00d6\u00d7\7L\2\2\u00d7\u00d8\7M\2\2\u00d8"+
-    "\u00d9\7\n\2\2\u00d9\u00da\5\f\7\2\u00da\33\3\2\2\2\u00db\u00e1\7\r\2"+
-    "\2\u00dc\u00e1\7\2\2\3\u00dd\u00de\b\17\1\2\u00de\u00df\7\6\2\2\u00df"+
-    "\u00e1\b\17\1\2\u00e0\u00db\3\2\2\2\u00e0\u00dc\3\2\2\2\u00e0\u00dd\3"+
-    "\2\2\2\u00e1\35\3\2\2\2\u00e2\u00e3\b\20\1\2\u00e3\u00e4\5\"\22\2\u00e4"+
-    "\u00e5\t\2\2\2\u00e5\u00e6\5\36\20\3\u00e6\u00e7\b\20\1\2\u00e7\u00ec"+
-    "\3\2\2\2\u00e8\u00e9\5 \21\2\u00e9\u00ea\b\20\1\2\u00ea\u00ec\3\2\2\2"+
-    "\u00eb\u00e2\3\2\2\2\u00eb\u00e8\3\2\2\2\u00ec\u0128\3\2\2\2\u00ed\u00ee"+
-    "\f\16\2\2\u00ee\u00ef\t\3\2\2\u00ef\u00f0\5\36\20\17\u00f0\u00f1\b\20"+
-    "\1\2\u00f1\u0127\3\2\2\2\u00f2\u00f3\f\r\2\2\u00f3\u00f4\t\4\2\2\u00f4"+
-    "\u00f5\5\36\20\16\u00f5\u00f6\b\20\1\2\u00f6\u0127\3\2\2\2\u00f7\u00f8"+
-    "\f\f\2\2\u00f8\u00f9\t\5\2\2\u00f9\u00fa\5\36\20\r\u00fa\u00fb\b\20\1"+
-    "\2\u00fb\u0127\3\2\2\2\u00fc\u00fd\f\13\2\2\u00fd\u00fe\t\6\2\2\u00fe"+
-    "\u00ff\5\36\20\f\u00ff\u0100\b\20\1\2\u0100\u0127\3\2\2\2\u0101\u0102"+
-    "\f\n\2\2\u0102\u0103\t\7\2\2\u0103\u0104\5\36\20\13\u0104\u0105\b\20\1"+
-    "\2\u0105\u0127\3\2\2\2\u0106\u0107\f\t\2\2\u0107\u0108\7-\2\2\u0108\u0109"+
-    "\5\36\20\n\u0109\u010a\b\20\1\2\u010a\u0127\3\2\2\2\u010b\u010c\f\b\2"+
-    "\2\u010c\u010d\7.\2\2\u010d\u010e\5\36\20\t\u010e\u010f\b\20\1\2\u010f"+
-    "\u0127\3\2\2\2\u0110\u0111\f\7\2\2\u0111\u0112\7/\2\2\u0112\u0113\5\36"+
-    "\20\b\u0113\u0114\b\20\1\2\u0114\u0127\3\2\2\2\u0115\u0116\f\6\2\2\u0116"+
-    "\u0117\7\60\2\2\u0117\u0118\5\36\20\7\u0118\u0119\b\20\1\2\u0119\u0127"+
-    "\3\2\2\2\u011a\u011b\f\5\2\2\u011b\u011c\7\61\2\2\u011c\u011d\5\36\20"+
-    "\6\u011d\u011e\b\20\1\2\u011e\u0127\3\2\2\2\u011f\u0120\f\4\2\2\u0120"+
-    "\u0121\7\62\2\2\u0121\u0122\5\36\20\2\u0122\u0123\7\63\2\2\u0123\u0124"+
-    "\5\36\20\4\u0124\u0125\b\20\1\2\u0125\u0127\3\2\2\2\u0126\u00ed\3\2\2"+
-    "\2\u0126\u00f2\3\2\2\2\u0126\u00f7\3\2\2\2\u0126\u00fc\3\2\2\2\u0126\u0101"+
-    "\3\2\2\2\u0126\u0106\3\2\2\2\u0126\u010b\3\2\2\2\u0126\u0110\3\2\2\2\u0126"+
-    "\u0115\3\2\2\2\u0126\u011a\3\2\2\2\u0126\u011f\3\2\2\2\u0127\u012a\3\2"+
-    "\2\2\u0128\u0126\3\2\2\2\u0128\u0129\3\2\2\2\u0129\37\3\2\2\2\u012a\u0128"+
-    "\3\2\2\2\u012b\u012c\6\21\16\3\u012c\u012d\t\b\2\2\u012d\u0149\5\"\22"+
-    "\2\u012e\u012f\6\21\17\3\u012f\u0130\5\"\22\2\u0130\u0131\t\b\2\2\u0131"+
-    "\u0149\3\2\2\2\u0132\u0133\6\21\20\3\u0133\u0149\5\"\22\2\u0134\u0135"+
-    "\6\21\21\3\u0135\u0136\t\t\2\2\u0136\u0149\b\21\1\2\u0137\u0138\6\21\22"+
-    "\3\u0138\u0139\7I\2\2\u0139\u0149\b\21\1\2\u013a\u013b\6\21\23\3\u013b"+
-    "\u013c\7J\2\2\u013c\u0149\b\21\1\2\u013d\u013e\6\21\24\3\u013e\u013f\7"+
-    "K\2\2\u013f\u0149\b\21\1\2\u0140\u0141\6\21\25\3\u0141\u0142\t\n\2\2\u0142"+
-    "\u0149\5 \21\2\u0143\u0144\7\t\2\2\u0144\u0145\5\26\f\2\u0145\u0146\7"+
-    "\n\2\2\u0146\u0147\5 \21\2\u0147\u0149\3\2\2\2\u0148\u012b\3\2\2\2\u0148"+
-    "\u012e\3\2\2\2\u0148\u0132\3\2\2\2\u0148\u0134\3\2\2\2\u0148\u0137\3\2"+
-    "\2\2\u0148\u013a\3\2\2\2\u0148\u013d\3\2\2\2\u0148\u0140\3\2\2\2\u0148"+
-    "\u0143\3\2\2\2\u0149!\3\2\2\2\u014a\u014e\5$\23\2\u014b\u014d\5&\24\2"+
-    "\u014c\u014b\3\2\2\2\u014d\u0150\3\2\2\2\u014e\u014c\3\2\2\2\u014e\u014f"+
-    "\3\2\2\2\u014f\u016d\3\2\2\2\u0150\u014e\3\2\2\2\u0151\u0152\5\26\f\2"+
-    "\u0152\u0156\5(\25\2\u0153\u0155\5&\24\2\u0154\u0153\3\2\2\2\u0155\u0158"+
-    "\3\2\2\2\u0156\u0154\3\2\2\2\u0156\u0157\3\2\2\2\u0157\u016d\3\2\2\2\u0158"+
-    "\u0156\3\2\2\2\u0159\u015a\7\26\2\2\u015a\u015f\7L\2\2\u015b\u015c\7\7"+
-    "\2\2\u015c\u015d\5\36\20\2\u015d\u015e\7\b\2\2\u015e\u0160\3\2\2\2\u015f"+
-    "\u015b\3\2\2\2\u0160\u0161\3\2\2\2\u0161\u015f\3\2\2\2\u0161\u0162\3\2"+
-    "\2\2\u0162\u016a\3\2\2\2\u0163\u0167\5(\25\2\u0164\u0166\5&\24\2\u0165"+
-    "\u0164\3\2\2\2\u0166\u0169\3\2\2\2\u0167\u0165\3\2\2\2\u0167\u0168\3\2"+
-    "\2\2\u0168\u016b\3\2\2\2\u0169\u0167\3\2\2\2\u016a\u0163\3\2\2\2\u016a"+
-    "\u016b\3\2\2\2\u016b\u016d\3\2\2\2\u016c\u014a\3\2\2\2\u016c\u0151\3\2"+
-    "\2\2\u016c\u0159\3\2\2\2\u016d#\3\2\2\2\u016e\u016f\6\23\26\3\u016f\u0170"+
-    "\7\t\2\2\u0170\u0171\5\36\20\2\u0171\u0172\7\n\2\2\u0172\u0173\b\23\1"+
-    "\2\u0173\u0181\3\2\2\2\u0174\u0175\6\23\27\3\u0175\u0176\7\t\2\2\u0176"+
-    "\u0177\5 \21\2\u0177\u0178\7\n\2\2\u0178\u0181\3\2\2\2\u0179\u0181\7H"+
-    "\2\2\u017a\u0181\7M\2\2\u017b\u017c\7M\2\2\u017c\u0181\5,\27\2\u017d\u017e"+
-    "\7\26\2\2\u017e\u017f\7L\2\2\u017f\u0181\5,\27\2\u0180\u016e\3\2\2\2\u0180"+
-    "\u0174\3\2\2\2\u0180\u0179\3\2\2\2\u0180\u017a\3\2\2\2\u0180\u017b\3\2"+
-    "\2\2\u0180\u017d\3\2\2\2\u0181%\3\2\2\2\u0182\u0183\6\24\30\3\u0183\u0187"+
-    "\5(\25\2\u0184\u0185\6\24\31\3\u0185\u0187\5*\26\2\u0186\u0182\3\2\2\2"+
-    "\u0186\u0184\3\2\2\2\u0187\'\3\2\2\2\u0188\u0189\7\13\2\2\u0189\u018a"+
-    "\7O\2\2\u018a\u018e\5,\27\2\u018b\u018c\7\13\2\2\u018c\u018e\t\13\2\2"+
-    "\u018d\u0188\3\2\2\2\u018d\u018b\3\2\2\2\u018e)\3\2\2\2\u018f\u0190\7"+
-    "\7\2\2\u0190\u0191\5\36\20\2\u0191\u0192\7\b\2\2\u0192+\3\2\2\2\u0193"+
-    "\u019c\7\t\2\2\u0194\u0199\5.\30\2\u0195\u0196\7\f\2\2\u0196\u0198\5."+
-    "\30\2\u0197\u0195\3\2\2\2\u0198\u019b\3\2\2\2\u0199\u0197\3\2\2\2\u0199"+
-    "\u019a\3\2\2\2\u019a\u019d\3\2\2\2\u019b\u0199\3\2\2\2\u019c\u0194\3\2"+
-    "\2\2\u019c\u019d\3\2\2\2\u019d\u019e\3\2\2\2\u019e\u019f\7\n\2\2\u019f"+
-    "-\3\2\2\2\u01a0\u01a4\5\36\20\2\u01a1\u01a4\5\60\31\2\u01a2\u01a4\5\64"+
-    "\33\2\u01a3\u01a0\3\2\2\2\u01a3\u01a1\3\2\2\2\u01a3\u01a2\3\2\2\2\u01a4"+
-    "/\3\2\2\2\u01a5\u01b3\5\62\32\2\u01a6\u01af\7\t\2\2\u01a7\u01ac\5\62\32"+
-    "\2\u01a8\u01a9\7\f\2\2\u01a9\u01ab\5\62\32\2\u01aa\u01a8\3\2\2\2\u01ab"+
-    "\u01ae\3\2\2\2\u01ac\u01aa\3\2\2\2\u01ac\u01ad\3\2\2\2\u01ad\u01b0\3\2"+
-    "\2\2\u01ae\u01ac\3\2\2\2\u01af\u01a7\3\2\2\2\u01af\u01b0\3\2\2\2\u01b0"+
-    "\u01b1\3\2\2\2\u01b1\u01b3\7\n\2\2\u01b2\u01a5\3\2\2\2\u01b2\u01a6\3\2"+
-    "\2\2\u01b3\u01b4\3\2\2\2\u01b4\u01b5\7\65\2\2\u01b5\u01b6\5\f\7\2\u01b6"+
-    "\61\3\2\2\2\u01b7\u01b9\5\26\f\2\u01b8\u01b7\3\2\2\2\u01b8\u01b9\3\2\2"+
-    "\2\u01b9\u01ba\3\2\2\2\u01ba\u01bb\7M\2\2\u01bb\63\3\2\2\2\u01bc\u01bd"+
-    "\7L\2\2\u01bd\u01be\7\64\2\2\u01be\u01c3\t\f\2\2\u01bf\u01c0\t\r\2\2\u01c0"+
-    "\u01c1\7\64\2\2\u01c1\u01c3\7M\2\2\u01c2\u01bc\3\2\2\2\u01c2\u01bf\3\2"+
-    "\2\2\u01c3\65\3\2\2\2*9?RUaivz~\u0083\u009e\u00a7\u00ab\u00b1\u00ba\u00c4"+
-    "\u00cc\u00d2\u00e0\u00eb\u0126\u0128\u0148\u014e\u0156\u0161\u0167\u016a"+
-    "\u016c\u0180\u0186\u018d\u0199\u019c\u01a3\u01ac\u01af\u01b2\u01b8\u01c2";
+    "\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\7\20\u012f\n\20\f\20"+
+    "\16\20\u0132\13\20\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3"+
+    "\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3"+
+    "\21\3\21\3\21\3\21\3\21\5\21\u0151\n\21\3\22\3\22\7\22\u0155\n\22\f\22"+
+    "\16\22\u0158\13\22\3\22\3\22\3\22\7\22\u015d\n\22\f\22\16\22\u0160\13"+
+    "\22\3\22\3\22\3\22\3\22\3\22\3\22\6\22\u0168\n\22\r\22\16\22\u0169\3\22"+
+    "\3\22\7\22\u016e\n\22\f\22\16\22\u0171\13\22\5\22\u0173\n\22\5\22\u0175"+
+    "\n\22\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23"+
+    "\3\23\3\23\3\23\3\23\3\23\5\23\u0189\n\23\3\24\3\24\3\24\3\24\5\24\u018f"+
+    "\n\24\3\25\3\25\3\25\3\25\3\25\5\25\u0196\n\25\3\26\3\26\3\26\3\26\3\27"+
+    "\3\27\3\27\3\27\7\27\u01a0\n\27\f\27\16\27\u01a3\13\27\5\27\u01a5\n\27"+
+    "\3\27\3\27\3\30\3\30\3\30\5\30\u01ac\n\30\3\31\3\31\3\31\3\31\3\31\7\31"+
+    "\u01b3\n\31\f\31\16\31\u01b6\13\31\5\31\u01b8\n\31\3\31\5\31\u01bb\n\31"+
+    "\3\31\3\31\3\31\3\32\5\32\u01c1\n\32\3\32\3\32\3\33\3\33\3\33\3\33\5\33"+
+    "\u01c9\n\33\3\34\3\34\3\34\3\34\3\35\3\35\3\35\3\35\3\36\3\36\3\36\3\36"+
+    "\3\37\3\37\3\37\3\37\3\37\2\3\36 \2\4\6\b\n\f\16\20\22\24\26\30\32\34"+
+    "\36 \"$&(*,.\60\62\64\668:<\2\f\3\28C\3\2\35\37\3\2 !\3\2\"$\3\2%(\3\2"+
+    "),\3\2\66\67\3\2DG\4\2\33\34 !\3\2NO\u0207\2A\3\2\2\2\4L\3\2\2\2\6Q\3"+
+    "\2\2\2\b\u00af\3\2\2\2\n\u00b3\3\2\2\2\f\u00b5\3\2\2\2\16\u00be\3\2\2"+
+    "\2\20\u00c2\3\2\2\2\22\u00c4\3\2\2\2\24\u00c6\3\2\2\2\26\u00cf\3\2\2\2"+
+    "\30\u00d7\3\2\2\2\32\u00dc\3\2\2\2\34\u00e8\3\2\2\2\36\u00f3\3\2\2\2 "+
+    "\u0150\3\2\2\2\"\u0174\3\2\2\2$\u0188\3\2\2\2&\u018e\3\2\2\2(\u0195\3"+
+    "\2\2\2*\u0197\3\2\2\2,\u019b\3\2\2\2.\u01ab\3\2\2\2\60\u01ba\3\2\2\2\62"+
+    "\u01c0\3\2\2\2\64\u01c8\3\2\2\2\66\u01ca\3\2\2\28\u01ce\3\2\2\2:\u01d2"+
+    "\3\2\2\2<\u01d6\3\2\2\2>@\5\4\3\2?>\3\2\2\2@C\3\2\2\2A?\3\2\2\2AB\3\2"+
+    "\2\2BG\3\2\2\2CA\3\2\2\2DF\5\b\5\2ED\3\2\2\2FI\3\2\2\2GE\3\2\2\2GH\3\2"+
+    "\2\2HJ\3\2\2\2IG\3\2\2\2JK\7\2\2\3K\3\3\2\2\2LM\5\26\f\2MN\7M\2\2NO\5"+
+    "\6\4\2OP\5\f\7\2P\5\3\2\2\2Q]\7\t\2\2RS\5\26\f\2SZ\7M\2\2TU\7\f\2\2UV"+
+    "\5\26\f\2VW\7M\2\2WY\3\2\2\2XT\3\2\2\2Y\\\3\2\2\2ZX\3\2\2\2Z[\3\2\2\2"+
+    "[^\3\2\2\2\\Z\3\2\2\2]R\3\2\2\2]^\3\2\2\2^_\3\2\2\2_`\7\n\2\2`\7\3\2\2"+
+    "\2ab\7\16\2\2bc\7\t\2\2cd\5\36\20\2de\7\n\2\2ei\5\n\6\2fg\7\17\2\2gj\5"+
+    "\n\6\2hj\6\5\2\2if\3\2\2\2ih\3\2\2\2j\u00b0\3\2\2\2kl\7\20\2\2lm\7\t\2"+
+    "\2mn\5\36\20\2nq\7\n\2\2or\5\n\6\2pr\5\16\b\2qo\3\2\2\2qp\3\2\2\2r\u00b0"+
+    "\3\2\2\2st\7\21\2\2tu\5\f\7\2uv\7\20\2\2vw\7\t\2\2wx\5\36\20\2xy\7\n\2"+
+    "\2yz\5\34\17\2z\u00b0\3\2\2\2{|\7\22\2\2|~\7\t\2\2}\177\5\20\t\2~}\3\2"+
+    "\2\2~\177\3\2\2\2\177\u0080\3\2\2\2\u0080\u0082\7\r\2\2\u0081\u0083\5"+
+    "\36\20\2\u0082\u0081\3\2\2\2\u0082\u0083\3\2\2\2\u0083\u0084\3\2\2\2\u0084"+
+    "\u0086\7\r\2\2\u0085\u0087\5\22\n\2\u0086\u0085\3\2\2\2\u0086\u0087\3"+
+    "\2\2\2\u0087\u0088\3\2\2\2\u0088\u008b\7\n\2\2\u0089\u008c\5\n\6\2\u008a"+
+    "\u008c\5\16\b\2\u008b\u0089\3\2\2\2\u008b\u008a\3\2\2\2\u008c\u00b0\3"+
+    "\2\2\2\u008d\u008e\7\22\2\2\u008e\u008f\7\t\2\2\u008f\u0090\5\26\f\2\u0090"+
+    "\u0091\7M\2\2\u0091\u0092\7\63\2\2\u0092\u0093\5\36\20\2\u0093\u0094\7"+
+    "\n\2\2\u0094\u0095\5\n\6\2\u0095\u00b0\3\2\2\2\u0096\u0097\5\24\13\2\u0097"+
+    "\u0098\5\34\17\2\u0098\u00b0\3\2\2\2\u0099\u009a\7\23\2\2\u009a\u00b0"+
+    "\5\34\17\2\u009b\u009c\7\24\2\2\u009c\u00b0\5\34\17\2\u009d\u009e\7\25"+
+    "\2\2\u009e\u009f\5\36\20\2\u009f\u00a0\5\34\17\2\u00a0\u00b0\3\2\2\2\u00a1"+
+    "\u00a2\7\27\2\2\u00a2\u00a4\5\f\7\2\u00a3\u00a5\5\32\16\2\u00a4\u00a3"+
+    "\3\2\2\2\u00a5\u00a6\3\2\2\2\u00a6\u00a4\3\2\2\2\u00a6\u00a7\3\2\2\2\u00a7"+
+    "\u00b0\3\2\2\2\u00a8\u00a9\7\31\2\2\u00a9\u00aa\5\36\20\2\u00aa\u00ab"+
+    "\5\34\17\2\u00ab\u00b0\3\2\2\2\u00ac\u00ad\5\36\20\2\u00ad\u00ae\5\34"+
+    "\17\2\u00ae\u00b0\3\2\2\2\u00afa\3\2\2\2\u00afk\3\2\2\2\u00afs\3\2\2\2"+
+    "\u00af{\3\2\2\2\u00af\u008d\3\2\2\2\u00af\u0096\3\2\2\2\u00af\u0099\3"+
+    "\2\2\2\u00af\u009b\3\2\2\2\u00af\u009d\3\2\2\2\u00af\u00a1\3\2\2\2\u00af"+
+    "\u00a8\3\2\2\2\u00af\u00ac\3\2\2\2\u00b0\t\3\2\2\2\u00b1\u00b4\5\f\7\2"+
+    "\u00b2\u00b4\5\b\5\2\u00b3\u00b1\3\2\2\2\u00b3\u00b2\3\2\2\2\u00b4\13"+
+    "\3\2\2\2\u00b5\u00b9\7\5\2\2\u00b6\u00b8\5\b\5\2\u00b7\u00b6\3\2\2\2\u00b8"+
+    "\u00bb\3\2\2\2\u00b9\u00b7\3\2\2\2\u00b9\u00ba\3\2\2\2\u00ba\u00bc\3\2"+
+    "\2\2\u00bb\u00b9\3\2\2\2\u00bc\u00bd\7\6\2\2\u00bd\r\3\2\2\2\u00be\u00bf"+
+    "\7\r\2\2\u00bf\17\3\2\2\2\u00c0\u00c3\5\24\13\2\u00c1\u00c3\5\36\20\2"+
+    "\u00c2\u00c0\3\2\2\2\u00c2\u00c1\3\2\2\2\u00c3\21\3\2\2\2\u00c4\u00c5"+
+    "\5\36\20\2\u00c5\23\3\2\2\2\u00c6\u00c7\5\26\f\2\u00c7\u00cc\5\30\r\2"+
+    "\u00c8\u00c9\7\f\2\2\u00c9\u00cb\5\30\r\2\u00ca\u00c8\3\2\2\2\u00cb\u00ce"+
+    "\3\2\2\2\u00cc\u00ca\3\2\2\2\u00cc\u00cd\3\2\2\2\u00cd\25\3\2\2\2\u00ce"+
+    "\u00cc\3\2\2\2\u00cf\u00d4\7L\2\2\u00d0\u00d1\7\7\2\2\u00d1\u00d3\7\b"+
+    "\2\2\u00d2\u00d0\3\2\2\2\u00d3\u00d6\3\2\2\2\u00d4\u00d2\3\2\2\2\u00d4"+
+    "\u00d5\3\2\2\2\u00d5\27\3\2\2\2\u00d6\u00d4\3\2\2\2\u00d7\u00da\7M\2\2"+
+    "\u00d8\u00d9\78\2\2\u00d9\u00db\5\36\20\2\u00da\u00d8\3\2\2\2\u00da\u00db"+
+    "\3\2\2\2\u00db\31\3\2\2\2\u00dc\u00dd\7\30\2\2\u00dd\u00de\7\t\2\2\u00de"+
+    "\u00df\7L\2\2\u00df\u00e0\7M\2\2\u00e0\u00e1\7\n\2\2\u00e1\u00e2\5\f\7"+
+    "\2\u00e2\33\3\2\2\2\u00e3\u00e9\7\r\2\2\u00e4\u00e9\7\2\2\3\u00e5\u00e6"+
+    "\b\17\1\2\u00e6\u00e7\7\6\2\2\u00e7\u00e9\b\17\1\2\u00e8\u00e3\3\2\2\2"+
+    "\u00e8\u00e4\3\2\2\2\u00e8\u00e5\3\2\2\2\u00e9\35\3\2\2\2\u00ea\u00eb"+
+    "\b\20\1\2\u00eb\u00ec\5\"\22\2\u00ec\u00ed\t\2\2\2\u00ed\u00ee\5\36\20"+
+    "\3\u00ee\u00ef\b\20\1\2\u00ef\u00f4\3\2\2\2\u00f0\u00f1\5 \21\2\u00f1"+
+    "\u00f2\b\20\1\2\u00f2\u00f4\3\2\2\2\u00f3\u00ea\3\2\2\2\u00f3\u00f0\3"+
+    "\2\2\2\u00f4\u0130\3\2\2\2\u00f5\u00f6\f\16\2\2\u00f6\u00f7\t\3\2\2\u00f7"+
+    "\u00f8\5\36\20\17\u00f8\u00f9\b\20\1\2\u00f9\u012f\3\2\2\2\u00fa\u00fb"+
+    "\f\r\2\2\u00fb\u00fc\t\4\2\2\u00fc\u00fd\5\36\20\16\u00fd\u00fe\b\20\1"+
+    "\2\u00fe\u012f\3\2\2\2\u00ff\u0100\f\f\2\2\u0100\u0101\t\5\2\2\u0101\u0102"+
+    "\5\36\20\r\u0102\u0103\b\20\1\2\u0103\u012f\3\2\2\2\u0104\u0105\f\13\2"+
+    "\2\u0105\u0106\t\6\2\2\u0106\u0107\5\36\20\f\u0107\u0108\b\20\1\2\u0108"+
+    "\u012f\3\2\2\2\u0109\u010a\f\n\2\2\u010a\u010b\t\7\2\2\u010b\u010c\5\36"+
+    "\20\13\u010c\u010d\b\20\1\2\u010d\u012f\3\2\2\2\u010e\u010f\f\t\2\2\u010f"+
+    "\u0110\7-\2\2\u0110\u0111\5\36\20\n\u0111\u0112\b\20\1\2\u0112\u012f\3"+
+    "\2\2\2\u0113\u0114\f\b\2\2\u0114\u0115\7.\2\2\u0115\u0116\5\36\20\t\u0116"+
+    "\u0117\b\20\1\2\u0117\u012f\3\2\2\2\u0118\u0119\f\7\2\2\u0119\u011a\7"+
+    "/\2\2\u011a\u011b\5\36\20\b\u011b\u011c\b\20\1\2\u011c\u012f\3\2\2\2\u011d"+
+    "\u011e\f\6\2\2\u011e\u011f\7\60\2\2\u011f\u0120\5\36\20\7\u0120\u0121"+
+    "\b\20\1\2\u0121\u012f\3\2\2\2\u0122\u0123\f\5\2\2\u0123\u0124\7\61\2\2"+
+    "\u0124\u0125\5\36\20\6\u0125\u0126\b\20\1\2\u0126\u012f\3\2\2\2\u0127"+
+    "\u0128\f\4\2\2\u0128\u0129\7\62\2\2\u0129\u012a\5\36\20\2\u012a\u012b"+
+    "\7\63\2\2\u012b\u012c\5\36\20\4\u012c\u012d\b\20\1\2\u012d\u012f\3\2\2"+
+    "\2\u012e\u00f5\3\2\2\2\u012e\u00fa\3\2\2\2\u012e\u00ff\3\2\2\2\u012e\u0104"+
+    "\3\2\2\2\u012e\u0109\3\2\2\2\u012e\u010e\3\2\2\2\u012e\u0113\3\2\2\2\u012e"+
+    "\u0118\3\2\2\2\u012e\u011d\3\2\2\2\u012e\u0122\3\2\2\2\u012e\u0127\3\2"+
+    "\2\2\u012f\u0132\3\2\2\2\u0130\u012e\3\2\2\2\u0130\u0131\3\2\2\2\u0131"+
+    "\37\3\2\2\2\u0132\u0130\3\2\2\2\u0133\u0134\6\21\16\3\u0134\u0135\t\b"+
+    "\2\2\u0135\u0151\5\"\22\2\u0136\u0137\6\21\17\3\u0137\u0138\5\"\22\2\u0138"+
+    "\u0139\t\b\2\2\u0139\u0151\3\2\2\2\u013a\u013b\6\21\20\3\u013b\u0151\5"+
+    "\"\22\2\u013c\u013d\6\21\21\3\u013d\u013e\t\t\2\2\u013e\u0151\b\21\1\2"+
+    "\u013f\u0140\6\21\22\3\u0140\u0141\7I\2\2\u0141\u0151\b\21\1\2\u0142\u0143"+
+    "\6\21\23\3\u0143\u0144\7J\2\2\u0144\u0151\b\21\1\2\u0145\u0146\6\21\24"+
+    "\3\u0146\u0147\7K\2\2\u0147\u0151\b\21\1\2\u0148\u0149\6\21\25\3\u0149"+
+    "\u014a\t\n\2\2\u014a\u0151\5 \21\2\u014b\u014c\7\t\2\2\u014c\u014d\5\26"+
+    "\f\2\u014d\u014e\7\n\2\2\u014e\u014f\5 \21\2\u014f\u0151\3\2\2\2\u0150"+
+    "\u0133\3\2\2\2\u0150\u0136\3\2\2\2\u0150\u013a\3\2\2\2\u0150\u013c\3\2"+
+    "\2\2\u0150\u013f\3\2\2\2\u0150\u0142\3\2\2\2\u0150\u0145\3\2\2\2\u0150"+
+    "\u0148\3\2\2\2\u0150\u014b\3\2\2\2\u0151!\3\2\2\2\u0152\u0156\5$\23\2"+
+    "\u0153\u0155\5&\24\2\u0154\u0153\3\2\2\2\u0155\u0158\3\2\2\2\u0156\u0154"+
+    "\3\2\2\2\u0156\u0157\3\2\2\2\u0157\u0175\3\2\2\2\u0158\u0156\3\2\2\2\u0159"+
+    "\u015a\5\26\f\2\u015a\u015e\5(\25\2\u015b\u015d\5&\24\2\u015c\u015b\3"+
+    "\2\2\2\u015d\u0160\3\2\2\2\u015e\u015c\3\2\2\2\u015e\u015f\3\2\2\2\u015f"+
+    "\u0175\3\2\2\2\u0160\u015e\3\2\2\2\u0161\u0162\7\26\2\2\u0162\u0167\7"+
+    "L\2\2\u0163\u0164\7\7\2\2\u0164\u0165\5\36\20\2\u0165\u0166\7\b\2\2\u0166"+
+    "\u0168\3\2\2\2\u0167\u0163\3\2\2\2\u0168\u0169\3\2\2\2\u0169\u0167\3\2"+
+    "\2\2\u0169\u016a\3\2\2\2\u016a\u0172\3\2\2\2\u016b\u016f\5(\25\2\u016c"+
+    "\u016e\5&\24\2\u016d\u016c\3\2\2\2\u016e\u0171\3\2\2\2\u016f\u016d\3\2"+
+    "\2\2\u016f\u0170\3\2\2\2\u0170\u0173\3\2\2\2\u0171\u016f\3\2\2\2\u0172"+
+    "\u016b\3\2\2\2\u0172\u0173\3\2\2\2\u0173\u0175\3\2\2\2\u0174\u0152\3\2"+
+    "\2\2\u0174\u0159\3\2\2\2\u0174\u0161\3\2\2\2\u0175#\3\2\2\2\u0176\u0177"+
+    "\6\23\26\3\u0177\u0178\7\t\2\2\u0178\u0179\5\36\20\2\u0179\u017a\7\n\2"+
+    "\2\u017a\u017b\b\23\1\2\u017b\u0189\3\2\2\2\u017c\u017d\6\23\27\3\u017d"+
+    "\u017e\7\t\2\2\u017e\u017f\5 \21\2\u017f\u0180\7\n\2\2\u0180\u0189\3\2"+
+    "\2\2\u0181\u0189\7H\2\2\u0182\u0189\7M\2\2\u0183\u0184\7M\2\2\u0184\u0189"+
+    "\5,\27\2\u0185\u0186\7\26\2\2\u0186\u0187\7L\2\2\u0187\u0189\5,\27\2\u0188"+
+    "\u0176\3\2\2\2\u0188\u017c\3\2\2\2\u0188\u0181\3\2\2\2\u0188\u0182\3\2"+
+    "\2\2\u0188\u0183\3\2\2\2\u0188\u0185\3\2\2\2\u0189%\3\2\2\2\u018a\u018b"+
+    "\6\24\30\3\u018b\u018f\5(\25\2\u018c\u018d\6\24\31\3\u018d\u018f\5*\26"+
+    "\2\u018e\u018a\3\2\2\2\u018e\u018c\3\2\2\2\u018f\'\3\2\2\2\u0190\u0191"+
+    "\7\13\2\2\u0191\u0192\7O\2\2\u0192\u0196\5,\27\2\u0193\u0194\7\13\2\2"+
+    "\u0194\u0196\t\13\2\2\u0195\u0190\3\2\2\2\u0195\u0193\3\2\2\2\u0196)\3"+
+    "\2\2\2\u0197\u0198\7\7\2\2\u0198\u0199\5\36\20\2\u0199\u019a\7\b\2\2\u019a"+
+    "+\3\2\2\2\u019b\u01a4\7\t\2\2\u019c\u01a1\5.\30\2\u019d\u019e\7\f\2\2"+
+    "\u019e\u01a0\5.\30\2\u019f\u019d\3\2\2\2\u01a0\u01a3\3\2\2\2\u01a1\u019f"+
+    "\3\2\2\2\u01a1\u01a2\3\2\2\2\u01a2\u01a5\3\2\2\2\u01a3\u01a1\3\2\2\2\u01a4"+
+    "\u019c\3\2\2\2\u01a4\u01a5\3\2\2\2\u01a5\u01a6\3\2\2\2\u01a6\u01a7\7\n"+
+    "\2\2\u01a7-\3\2\2\2\u01a8\u01ac\5\36\20\2\u01a9\u01ac\5\60\31\2\u01aa"+
+    "\u01ac\5\64\33\2\u01ab\u01a8\3\2\2\2\u01ab\u01a9\3\2\2\2\u01ab\u01aa\3"+
+    "\2\2\2\u01ac/\3\2\2\2\u01ad\u01bb\5\62\32\2\u01ae\u01b7\7\t\2\2\u01af"+
+    "\u01b4\5\62\32\2\u01b0\u01b1\7\f\2\2\u01b1\u01b3\5\62\32\2\u01b2\u01b0"+
+    "\3\2\2\2\u01b3\u01b6\3\2\2\2\u01b4\u01b2\3\2\2\2\u01b4\u01b5\3\2\2\2\u01b5"+
+    "\u01b8\3\2\2\2\u01b6\u01b4\3\2\2\2\u01b7\u01af\3\2\2\2\u01b7\u01b8\3\2"+
+    "\2\2\u01b8\u01b9\3\2\2\2\u01b9\u01bb\7\n\2\2\u01ba\u01ad\3\2\2\2\u01ba"+
+    "\u01ae\3\2\2\2\u01bb\u01bc\3\2\2\2\u01bc\u01bd\7\65\2\2\u01bd\u01be\5"+
+    "\f\7\2\u01be\61\3\2\2\2\u01bf\u01c1\5\26\f\2\u01c0\u01bf\3\2\2\2\u01c0"+
+    "\u01c1\3\2\2\2\u01c1\u01c2\3\2\2\2\u01c2\u01c3\7M\2\2\u01c3\63\3\2\2\2"+
+    "\u01c4\u01c9\5\66\34\2\u01c5\u01c9\58\35\2\u01c6\u01c9\5:\36\2\u01c7\u01c9"+
+    "\5<\37\2\u01c8\u01c4\3\2\2\2\u01c8\u01c5\3\2\2\2\u01c8\u01c6\3\2\2\2\u01c8"+
+    "\u01c7\3\2\2\2\u01c9\65\3\2\2\2\u01ca\u01cb\7L\2\2\u01cb\u01cc\7\64\2"+
+    "\2\u01cc\u01cd\7M\2\2\u01cd\67\3\2\2\2\u01ce\u01cf\7L\2\2\u01cf\u01d0"+
+    "\7\64\2\2\u01d0\u01d1\7\26\2\2\u01d19\3\2\2\2\u01d2\u01d3\7M\2\2\u01d3"+
+    "\u01d4\7\64\2\2\u01d4\u01d5\7M\2\2\u01d5;\3\2\2\2\u01d6\u01d7\7\32\2\2"+
+    "\u01d7\u01d8\7\64\2\2\u01d8\u01d9\7M\2\2\u01d9=\3\2\2\2*AGZ]iq~\u0082"+
+    "\u0086\u008b\u00a6\u00af\u00b3\u00b9\u00c2\u00cc\u00d4\u00da\u00e8\u00f3"+
+    "\u012e\u0130\u0150\u0156\u015e\u0169\u016f\u0172\u0174\u0188\u018e\u0195"+
+    "\u01a1\u01a4\u01ab\u01b4\u01b7\u01ba\u01c0\u01c8";
   public static final ATN _ATN =
     new ATNDeserializer().deserialize(_serializedATN.toCharArray());
   static {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessParserBaseVisitor.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessParserBaseVisitor.java
@@ -417,4 +417,32 @@ class PainlessParserBaseVisitor<T> extends AbstractParseTreeVisitor<T> implement
    * {@link #visitChildren} on {@code ctx}.</p>
    */
   @Override public T visitFuncref(PainlessParser.FuncrefContext ctx) { return visitChildren(ctx); }
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The default implementation returns the result of calling
+   * {@link #visitChildren} on {@code ctx}.</p>
+   */
+  @Override public T visitClassFuncref(PainlessParser.ClassFuncrefContext ctx) { return visitChildren(ctx); }
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The default implementation returns the result of calling
+   * {@link #visitChildren} on {@code ctx}.</p>
+   */
+  @Override public T visitConstructorFuncref(PainlessParser.ConstructorFuncrefContext ctx) { return visitChildren(ctx); }
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The default implementation returns the result of calling
+   * {@link #visitChildren} on {@code ctx}.</p>
+   */
+  @Override public T visitCapturingFuncref(PainlessParser.CapturingFuncrefContext ctx) { return visitChildren(ctx); }
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The default implementation returns the result of calling
+   * {@link #visitChildren} on {@code ctx}.</p>
+   */
+  @Override public T visitLocalFuncref(PainlessParser.LocalFuncrefContext ctx) { return visitChildren(ctx); }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessParserVisitor.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessParserVisitor.java
@@ -397,4 +397,28 @@ interface PainlessParserVisitor<T> extends ParseTreeVisitor<T> {
    * @return the visitor result
    */
   T visitFuncref(PainlessParser.FuncrefContext ctx);
+  /**
+   * Visit a parse tree produced by {@link PainlessParser#classFuncref}.
+   * @param ctx the parse tree
+   * @return the visitor result
+   */
+  T visitClassFuncref(PainlessParser.ClassFuncrefContext ctx);
+  /**
+   * Visit a parse tree produced by {@link PainlessParser#constructorFuncref}.
+   * @param ctx the parse tree
+   * @return the visitor result
+   */
+  T visitConstructorFuncref(PainlessParser.ConstructorFuncrefContext ctx);
+  /**
+   * Visit a parse tree produced by {@link PainlessParser#capturingFuncref}.
+   * @param ctx the parse tree
+   * @return the visitor result
+   */
+  T visitCapturingFuncref(PainlessParser.CapturingFuncrefContext ctx);
+  /**
+   * Visit a parse tree produced by {@link PainlessParser#localFuncref}.
+   * @param ctx the parse tree
+   * @return the visitor result
+   */
+  T visitLocalFuncref(PainlessParser.LocalFuncrefContext ctx);
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EChain.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EChain.java
@@ -29,6 +29,7 @@ import org.elasticsearch.painless.Operation;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.MethodWriter;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -46,6 +47,11 @@ public final class EChain extends AExpression {
     Type promote = null;
     Cast there = null;
     Cast back = null;
+    
+    /** Creates a new simple EChain */
+    public EChain(Location location, ALink link) {
+        this(location, Arrays.asList(link), false, false, null, null);
+    }
 
     public EChain(Location location, List<ALink> links,
                   boolean pre, boolean post, Operation operation, AExpression expression) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EChain.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EChain.java
@@ -48,7 +48,7 @@ public final class EChain extends AExpression {
     Cast there = null;
     Cast back = null;
     
-    /** Creates a new simple EChain */
+    /** Creates a new RHS-only EChain */
     public EChain(Location location, ALink link) {
         this(location, Arrays.asList(link), false, false, null, null);
     }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SFunction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SFunction.java
@@ -50,6 +50,7 @@ public class SFunction extends AStatement {
     final List<String> paramTypeStrs;
     final List<String> paramNameStrs;
     final List<AStatement> statements;
+    final boolean synthetic;
 
     Type rtnType = null;
     List<Parameter> parameters = new ArrayList<>();
@@ -58,7 +59,8 @@ public class SFunction extends AStatement {
     Locals locals = null;
 
     public SFunction(FunctionReserved reserved, Location location,
-                     String rtnType, String name, List<String> paramTypes, List<String> paramNames, List<AStatement> statements) {
+                     String rtnType, String name, List<String> paramTypes, 
+                     List<String> paramNames, List<AStatement> statements, boolean synthetic) {
         super(location);
 
         this.reserved = reserved;
@@ -67,6 +69,7 @@ public class SFunction extends AStatement {
         this.paramTypeStrs = Collections.unmodifiableList(paramTypes);
         this.paramNameStrs = Collections.unmodifiableList(paramNames);
         this.statements = Collections.unmodifiableList(statements);
+        this.synthetic = synthetic;
     }
 
     void generate() {
@@ -138,7 +141,11 @@ public class SFunction extends AStatement {
     
     /** Writes the function to given ClassWriter. */
     void write (ClassWriter writer, BitSet statements) {
-        final MethodWriter function = new MethodWriter(Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC, method.method, writer, statements);
+        int access = Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC;
+        if (synthetic) {
+            access |= Opcodes.ACC_SYNTHETIC;
+        }
+        final MethodWriter function = new MethodWriter(access, method.method, writer, statements);
         write(function);
         function.endMethod();
     }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ArrayTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ArrayTests.java
@@ -70,6 +70,10 @@ public class ArrayTests extends ScriptTestCase {
         assertEquals(1, exec("int x; def y = new def[1]; x = y[0] = 1; return x;"));
     }
 
+    public void testArrayVariable() {
+        assertEquals(1, exec("int x = 1; int[] y = new int[x]; return y.length"));
+    }
+
     public void testForLoop() {
         assertEquals(999*1000/2, exec("def a = new int[1000]; for (int x = 0; x < a.length; x++) { a[x] = x; } "+
             "int total = 0; for (int x = 0; x < a.length; x++) { total += a[x]; } return total;"));

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/FunctionRefTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/FunctionRefTests.java
@@ -56,7 +56,21 @@ public class FunctionRefTests extends ScriptTestCase {
                                                   "DoubleSummaryStatistics::combine); " + 
                  "return stats.getSum()"));
     }
-    
+
+    public void testArrayCtorMethodRef() {
+        assertEquals(1.0D, 
+                exec("List l = new ArrayList(); l.add(1.0); l.add(2.0); " + 
+                     "def[] array = l.stream().toArray(Double[]::new);" + 
+                     "return array[0];"));
+    }
+
+    public void testArrayCtorMethodRefDef() {
+        assertEquals(1.0D, 
+                exec("def l = new ArrayList(); l.add(1.0); l.add(2.0); " + 
+                     "def[] array = l.stream().toArray(Double[]::new);" + 
+                     "return array[0];"));
+    }
+
     public void testCapturingMethodReference() {
         assertEquals("5", exec("Integer x = Integer.valueOf(5); return Optional.empty().orElseGet(x::toString);"));
         assertEquals("[]", exec("List l = new ArrayList(); return Optional.empty().orElseGet(l::toString);"));


### PR DESCRIPTION
This adds support for stuff like `list.stream().toArray(String[]::new)`

In this case we generate a synthetic method such as:

```
private static synthetic String[] lambda$0(int size) {
  return new String[size];
}
```

Then we just return an ordinary reference to that (`this::lambda$0`).

I also refactored the grammar portion for references so the different types are organized better.
