### PR TITLE
Simplify NodeJoinController to make use of new cluster state batching infra

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
@@ -40,8 +40,10 @@ public interface ClusterStateTaskExecutor<T> {
     /**
      * Callback invoked after new cluster state is published. Note that
      * this method is not invoked if the cluster state was not updated.
+     * @param clusterChangedEvent the change event for this cluster state change, containing
+     *                            both old and new states
      */
-    default void clusterStatePublished(ClusterState newClusterState) {
+    default void clusterStatePublished(ClusterChangedEvent clusterChangedEvent) {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
@@ -94,7 +94,8 @@ public interface ClusterStateTaskExecutor<T> {
             }
 
             private Builder<T> result(T task, TaskResult executionResult) {
-                executionResults.put(task, executionResult);
+                TaskResult existing = executionResults.put(task, executionResult);
+                assert existing == null : task + " already has result " + existing;
                 return this;
             }
 

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cluster.action.shard;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.ClusterStateTaskConfig;
@@ -312,8 +313,8 @@ public class ShardStateAction extends AbstractComponent {
         }
 
         @Override
-        public void clusterStatePublished(ClusterState newClusterState) {
-            int numberOfUnassignedShards = newClusterState.getRoutingNodes().unassigned().size();
+        public void clusterStatePublished(ClusterChangedEvent clusterChangedEvent) {
+            int numberOfUnassignedShards = clusterChangedEvent.state().getRoutingNodes().unassigned().size();
             if (numberOfUnassignedShards > 0) {
                 String reason = String.format(Locale.ROOT, "[%d] unassigned shards after failing shards", numberOfUnassignedShards);
                 if (logger.isTraceEnabled()) {

--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -614,5 +614,9 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
         public static DiscoveryNodes readFrom(StreamInput in, @Nullable DiscoveryNode localNode) throws IOException {
             return PROTO.readFrom(in, localNode);
         }
+
+        public boolean isLocalNodeElectedMaster() {
+            return masterNodeId != null && masterNodeId.equals(localNodeId);
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -378,11 +378,11 @@ public class ClusterService extends AbstractLifecycleComponent<ClusterService> {
     }
 
     /**
-     * Submits a set of cluster state update task; submitted updates are guaranteed to be processed together,
+     * Submits a batch of cluster state update tasks; submitted updates are guaranteed to be processed together,
      * potentially with more tasks of the same executor.
      *
      * @param source   the source of the cluster state update task
-     * @param tasks    a map of update tasks and a corresponding listener to notify of their result
+     * @param tasks    a map of update tasks and their corresponding listeners
      * @param config   the cluster state update task configuration
      * @param executor the cluster state update task executor; tasks
      *                 that share the same executor will be executed

--- a/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -406,7 +406,7 @@ public class ClusterService extends AbstractLifecycleComponent<ClusterService> {
                 List<UpdateTask> existingTasks = updateTasksPerExecutor.computeIfAbsent(executor, k -> new ArrayList<>());
                 for (UpdateTask existing : existingTasks) {
                     //noinspection SuspiciousMethodCalls
-                    if (tasks.containsKey(existing.task)) {
+                    if (tasks.get(existing.task) == existing.task) { // we require object level identity
                         throw new IllegalArgumentException("task [" + existing.task + "] is already queued");
                     }
                 }

--- a/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -702,7 +702,7 @@ public class ClusterService extends AbstractLifecycleComponent<ClusterService> {
             }
 
             try {
-                executor.clusterStatePublished(newClusterState);
+                executor.clusterStatePublished(clusterChangedEvent);
             } catch (Exception e) {
                 logger.error("exception thrown while notifying executor of new cluster state publication [{}]", e, source);
             }

--- a/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -407,8 +407,7 @@ public class ClusterService extends AbstractLifecycleComponent<ClusterService> {
 
             synchronized (updateTasksPerExecutor) {
                 List<UpdateTask> existingTasks = updateTasksPerExecutor.computeIfAbsent(executor, k -> new ArrayList<>());
-                for (UpdateTask existing : existingTasks) {
-                    //noinspection SuspiciousMethodCalls
+                for (@SuppressWarnings("unchecked") UpdateTask<T> existing : existingTasks) {
                     if (tasksIdentity.containsKey(existing.task)) {
                         throw new IllegalArgumentException("task [" + existing.task + "] is already queued");
                     }

--- a/core/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
@@ -126,10 +126,7 @@ public class NodeJoinController extends AbstractComponent {
 
             }
             if (logger.isTraceEnabled()) {
-                final int pendingNodes;
-                synchronized (this) {
-                    pendingNodes = myElectionContext.getPendingMasterJoinsCount();
-                }
+                final int pendingNodes = myElectionContext.getPendingMasterJoinsCount();
                 logger.trace("timed out waiting to be elected. waited [{}]. pending master node joins [{}]", timeValue, pendingNodes);
             }
             failContext(myElectionContext, "timed out waiting to be elected");
@@ -260,7 +257,6 @@ public class NodeJoinController extends AbstractComponent {
         }
 
         public synchronized int getPendingMasterJoinsCount() {
-            ensureOpen();
             int pendingMasterJoins = 0;
             for (DiscoveryNode node : joinRequestAccumulator.keySet()) {
                 if (node.isMasterNode()) {

--- a/core/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
@@ -57,14 +57,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class NodeJoinController extends AbstractComponent {
 
-    final ClusterService clusterService;
-    final RoutingService routingService;
-    final ElectMasterService electMaster;
-    final DiscoverySettings discoverySettings;
-    final JoinTaskExecutor joinTaskExecutor = new JoinTaskExecutor();
+    private final ClusterService clusterService;
+    private final RoutingService routingService;
+    private final ElectMasterService electMaster;
+    private final DiscoverySettings discoverySettings;
+    private final JoinTaskExecutor joinTaskExecutor = new JoinTaskExecutor();
 
-    // this is set while trying to become a master mutation should be done under lock
-    ElectionContext electionContext = null;
+    // this is set while trying to become a master
+    // mutation should be done under lock
+    private ElectionContext electionContext = null;
 
 
     public NodeJoinController(ClusterService clusterService, RoutingService routingService, ElectMasterService electMaster, DiscoverySettings discoverySettings, Settings settings) {
@@ -445,15 +446,12 @@ public class NodeJoinController extends AbstractComponent {
                 results.success(node);
             }
 
-            // we must return a new cluster state instance to force publishing. This is important
-            // for the joining node to finalize it's join and set us as a master
             if (nodesChanged) {
                 newState.nodes(nodesBuilder);
             }
 
             // we must return a new cluster state instance to force publishing. This is important
-            // for the joining node to finalize it's join and set us as a master
-
+            // for the joining node to finalize its join and set us as a master
             return results.build(newState.build());
         }
 

--- a/core/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
@@ -19,7 +19,12 @@
 package org.elasticsearch.discovery.zen;
 
 import org.elasticsearch.ElasticsearchTimeoutException;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskConfig;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor;
+import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.block.ClusterBlocks;
@@ -30,21 +35,22 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.DummyTransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.zen.elect.ElectMasterService;
 import org.elasticsearch.discovery.zen.membership.MembershipAction;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * This class processes incoming join request (passed zia {@link ZenDiscovery}). Incoming nodes
@@ -56,13 +62,12 @@ public class NodeJoinController extends AbstractComponent {
     final RoutingService routingService;
     final ElectMasterService electMaster;
     final DiscoverySettings discoverySettings;
-    final AtomicBoolean accumulateJoins = new AtomicBoolean(false);
+    final JoinTaskExecutor joinTaskExecutor = new JoinTaskExecutor();
 
-    // this is site while trying to become a master
-    final AtomicReference<ElectionContext> electionContext = new AtomicReference<>();
+    // this is set while trying to become a master mutation should be done under lock
+    ElectionContext electionContext = null;
 
 
-    protected final Map<DiscoveryNode, List<MembershipAction.JoinCallback>> pendingJoinRequests = new HashMap<>();
 
     public NodeJoinController(ClusterService clusterService, RoutingService routingService, ElectMasterService electMaster, DiscoverySettings discoverySettings, Settings settings) {
         super(settings);
@@ -75,7 +80,7 @@ public class NodeJoinController extends AbstractComponent {
     /**
      * waits for enough incoming joins from master eligible nodes to complete the master election
      * <p>
-     * You must start accumulating joins before calling this method. See {@link #startAccumulatingJoins()}
+     * You must start accumulating joins before calling this method. See {@link #startElectionContext()}
      * <p>
      * The method will return once the local node has been elected as master or some failure/timeout has happened.
      * The exact outcome is communicated via the callback parameter, which is guaranteed to be called.
@@ -86,26 +91,30 @@ public class NodeJoinController extends AbstractComponent {
      *                            object
      **/
     public void waitToBeElectedAsMaster(int requiredMasterJoins, TimeValue timeValue, final ElectionCallback callback) {
-        assert accumulateJoins.get() : "waitToBeElectedAsMaster is called we are not accumulating joins";
-
         final CountDownLatch done = new CountDownLatch(1);
-        final ElectionContext newContext = new ElectionContext(callback, requiredMasterJoins) {
+        final ElectionCallback wrapperCallback = new ElectionCallback() {
             @Override
-            void onClose() {
-                if (electionContext.compareAndSet(this, null)) {
-                    stopAccumulatingJoins("election closed");
-                } else {
-                    assert false : "failed to remove current election context";
-                }
+            public void onElectedAsMaster(ClusterState state) {
                 done.countDown();
+                callback.onElectedAsMaster(state);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                done.countDown();
+                callback.onFailure(t);
             }
         };
 
-        if (electionContext.compareAndSet(null, newContext) == false) {
-            // should never happen, but be conservative
-            failContext(newContext, new IllegalStateException("double waiting for election"));
-            return;
+
+        // capture the context we add the callback to make sure we fail our own
+        final ElectionContext myElectionContext;
+        synchronized (this) {
+            assert electionContext != null : "waitToBeElectedAsMaster is called we are not accumulating joins";
+            electionContext.attemptToBeElected(requiredMasterJoins, wrapperCallback);
+            myElectionContext = electionContext;
         }
+
         try {
             // check what we have so far..
             checkPendingJoinsAndElectIfNeeded();
@@ -120,16 +129,16 @@ public class NodeJoinController extends AbstractComponent {
             }
             if (logger.isTraceEnabled()) {
                 final int pendingNodes;
-                synchronized (pendingJoinRequests) {
-                    pendingNodes = pendingJoinRequests.size();
+                synchronized (this) {
+                    pendingNodes = myElectionContext.getPendingMasterJoinsCount();
                 }
-                logger.trace("timed out waiting to be elected. waited [{}]. pending node joins [{}]", timeValue, pendingNodes);
+                logger.trace("timed out waiting to be elected. waited [{}]. pending master node joins [{}]", timeValue, pendingNodes);
             }
             // callback will clear the context, if it's active
-            failContext(newContext, new ElasticsearchTimeoutException("timed out waiting to be elected"));
+            failContext(myElectionContext, new ElasticsearchTimeoutException("timed out waiting to be elected"));
         } catch (Throwable t) {
             logger.error("unexpected failure while waiting for incoming joins", t);
-            failContext(newContext, "unexpected failure while waiting for pending joins", t);
+            failContext(myElectionContext, "unexpected failure while waiting for pending joins", t);
         }
     }
 
@@ -138,7 +147,11 @@ public class NodeJoinController extends AbstractComponent {
     }
 
     /** utility method to fail the given election context under the cluster state thread */
-    private void failContext(final ElectionContext context, final String reason, final Throwable throwable) {
+    private synchronized void failContext(final ElectionContext context, final String reason, final Throwable throwable) {
+        if (electionContext == context) {
+            // remove the context if still active
+            electionContext = null;
+        }
         clusterService.submitStateUpdateTask("zen-disco-join(failure [" + reason + "])", new ClusterStateUpdateTask(Priority.IMMEDIATE) {
 
             @Override
@@ -163,25 +176,25 @@ public class NodeJoinController extends AbstractComponent {
 
     /**
      * Accumulates any future incoming join request. Pending join requests will be processed in the final steps of becoming a
-     * master or when {@link #stopAccumulatingJoins(String)} is called.
+     * master or when {@link #stopElectionContext(String)} is called.
      */
-    public void startAccumulatingJoins() {
-        logger.trace("starting to accumulate joins");
-        boolean b = accumulateJoins.getAndSet(true);
-        assert b == false : "double startAccumulatingJoins() calls";
-        assert electionContext.get() == null : "startAccumulatingJoins() called, but there is an ongoing election context";
+    public synchronized void startElectionContext() {
+        logger.trace("starting an election context, will accumulate joins");
+        assert electionContext == null : "double startElectionContext() calls";
+        electionContext = new ElectionContext(logger);
     }
 
-    /** Stopped accumulating joins. All pending joins will be processed. Future joins will be processed immediately */
-    public void stopAccumulatingJoins(String reason) {
-        logger.trace("stopping join accumulation ([{}])", reason);
-        assert electionContext.get() == null : "stopAccumulatingJoins() called, but there is an ongoing election context";
-        boolean b = accumulateJoins.getAndSet(false);
-        assert b : "stopAccumulatingJoins() called but not accumulating";
-        synchronized (pendingJoinRequests) {
-            if (pendingJoinRequests.size() > 0) {
-                processJoins("pending joins after accumulation stop [" + reason + "]");
-            }
+    /**
+     * Stopped accumulating joins. All pending joins will be processed. Future joins will be processed immediately
+     */
+    public void stopElectionContext(String reason) {
+        logger.trace("stopping election ([{}])", reason);
+        synchronized (this) {
+            assert electionContext != null : "stopElectionContext() called but not accumulating";
+            assert electionContext.getCallback() == null : "stopElectionContext is called, but we are also actively";
+            clusterService.submitStateUpdateTasks("election stop [" + reason + "]",
+                electionContext.getPendingAsTasks(), ClusterStateTaskConfig.build(Priority.URGENT), joinTaskExecutor);
+            electionContext = null;
         }
     }
 
@@ -190,19 +203,14 @@ public class NodeJoinController extends AbstractComponent {
      * <p>
      * Note: doesn't do any validation. This should have been done before.
      */
-    public void handleJoinRequest(final DiscoveryNode node, final MembershipAction.JoinCallback callback) {
-        synchronized (pendingJoinRequests) {
-            List<MembershipAction.JoinCallback> nodeCallbacks = pendingJoinRequests.get(node);
-            if (nodeCallbacks == null) {
-                nodeCallbacks = new ArrayList<>();
-                pendingJoinRequests.put(node, nodeCallbacks);
-            }
-            nodeCallbacks.add(callback);
-        }
-        if (accumulateJoins.get() == false) {
-            processJoins("join from node[" + node + "]");
-        } else {
+    public synchronized void handleJoinRequest(final DiscoveryNode node, final MembershipAction.JoinCallback callback) {
+        if (electionContext != null) {
+            electionContext.addIncomingJoin(node, callback);
             checkPendingJoinsAndElectIfNeeded();
+        } else {
+            clusterService.submitStateUpdateTask("zen-disco-join(node " + node + "])",
+                node, ClusterStateTaskConfig.build(Priority.URGENT),
+                joinTaskExecutor, new JoinTaskListener(callback, logger));
         }
     }
 
@@ -210,85 +218,37 @@ public class NodeJoinController extends AbstractComponent {
      * checks if there is an on going request to become master and if it has enough pending joins. If so, the node will
      * become master via a ClusterState update task.
      */
-    private void checkPendingJoinsAndElectIfNeeded() {
-        assert accumulateJoins.get() : "election check requested but we are not accumulating joins";
-        final ElectionContext context = electionContext.get();
-        if (context == null) {
-            return;
-        }
-
-        int pendingMasterJoins = 0;
-        synchronized (pendingJoinRequests) {
-            for (DiscoveryNode node : pendingJoinRequests.keySet()) {
-                if (node.isMasterNode()) {
-                    pendingMasterJoins++;
-                }
+    private synchronized void checkPendingJoinsAndElectIfNeeded() {
+        assert electionContext != null : "election check requested but no active context";
+        final int pendingMasterJoins = electionContext.getPendingMasterJoinsCount();
+        if (electionContext.isEnoughPendingJoins(pendingMasterJoins) == false) {
+            if (logger.isTraceEnabled()) {
+                logger.trace("not enough joins for election. Got [{}], required [{}]", pendingMasterJoins,
+                    electionContext.requiredMasterJoins);
             }
-        }
-        if (pendingMasterJoins < context.requiredMasterJoins) {
-            if (context.pendingSetAsMasterTask.get() == false) {
-                logger.trace("not enough joins for election. Got [{}], required [{}]", pendingMasterJoins, context.requiredMasterJoins);
-            }
-            return;
-        }
-        if (context.pendingSetAsMasterTask.getAndSet(true)) {
-            logger.trace("elected as master task already submitted, ignoring...");
-            return;
-        }
+        } else {
+            final String source = "zen-disco-join(elected_as_master, [" + pendingMasterJoins + "] joins received)";
+            ElectionContext context = electionContext;
+            electionContext = null; // clear this out so future joins won't be accumulated
+            Map<DiscoveryNode, ClusterStateTaskListener> tasks = context.getPendingAsTasks();
+            tasks.put(BECOME_MASTER_TASK, new ClusterStateTaskListener() {
 
-        final String source = "zen-disco-join(elected_as_master, [" + pendingMasterJoins + "] joins received)";
-        clusterService.submitStateUpdateTask(source, new ProcessJoinsTask(Priority.IMMEDIATE) {
-            @Override
-            public ClusterState execute(ClusterState currentState) {
-                // Take into account the previous known nodes, if they happen not to be available
-                // then fault detection will remove these nodes.
-
-                if (currentState.nodes().getMasterNode() != null) {
-                    // TODO can we tie break here? we don't have a remote master cluster state version to decide on
-                    logger.trace("join thread elected local node as master, but there is already a master in place: {}", currentState.nodes().getMasterNode());
-                    throw new NotMasterException("Node [" + clusterService.localNode() + "] not master for join request");
+                @Override
+                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    assert newState.nodes().isLocalNodeElectedMaster() : "should have become a master but isn't " + newState.prettyPrint();
+                    context.onElectedAsMaster(newState);
                 }
 
-                DiscoveryNodes.Builder builder = new DiscoveryNodes.Builder(currentState.nodes()).masterNodeId(currentState.nodes().getLocalNode().getId());
-                // update the fact that we are the master...
-                ClusterBlocks clusterBlocks = ClusterBlocks.builder().blocks(currentState.blocks()).removeGlobalBlock(discoverySettings.getNoMasterBlock()).build();
-                currentState = ClusterState.builder(currentState).nodes(builder).blocks(clusterBlocks).build();
-
-                // reroute now to remove any dead nodes (master may have stepped down when they left and didn't update the routing table)
-                RoutingAllocation.Result result = routingService.getAllocationService().reroute(currentState, "nodes joined");
-                if (result.changed()) {
-                    currentState = ClusterState.builder(currentState).routingResult(result).build();
+                @Override
+                public void onFailure(String source, Throwable t) {
+                    context.onFailure(t);
                 }
-
-                // Add the incoming join requests.
-                // Note: we only do this now (after the reroute) to avoid assigning shards to these nodes.
-                return super.execute(currentState);
-            }
-
-            @Override
-            public boolean runOnlyOnMaster() {
-                return false;
-            }
-
-            @Override
-            public void onFailure(String source, Throwable t) {
-                super.onFailure(source, t);
-                context.onFailure(t);
-            }
-
-            @Override
-            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                super.clusterStateProcessed(source, oldState, newState);
-                context.onElectedAsMaster(newState);
-            }
-        });
+            });
+            clusterService.submitStateUpdateTasks(source,
+                tasks, ClusterStateTaskConfig.build(Priority.URGENT),
+                joinTaskExecutor);
+        }
     }
-
-    /** process all pending joins */
-    private void processJoins(String reason) {
-        clusterService.submitStateUpdateTask("zen-disco-join(" + reason + ")", new ProcessJoinsTask(Priority.URGENT));
-    }
-
 
     public interface ElectionCallback {
         /**
@@ -304,27 +264,72 @@ public class NodeJoinController extends AbstractComponent {
         void onFailure(Throwable t);
     }
 
-    static abstract class ElectionContext implements ElectionCallback {
-        private final ElectionCallback callback;
-        private final int requiredMasterJoins;
+    static class ElectionContext implements ElectionCallback {
+        private ElectionCallback callback = null;
+        private int requiredMasterJoins = -1;
+        private final Map<DiscoveryNode, List<MembershipAction.JoinCallback>> joinRequestAccumulator = new HashMap<>();
 
-        /** set to true after enough joins have been seen and a cluster update task is submitted to become master */
-        final AtomicBoolean pendingSetAsMasterTask = new AtomicBoolean();
         final AtomicBoolean closed = new AtomicBoolean();
+        final private ESLogger logger;
 
-        ElectionContext(ElectionCallback callback, int requiredMasterJoins) {
-            this.callback = callback;
-            this.requiredMasterJoins = requiredMasterJoins;
+        ElectionContext(ESLogger logger) {
+            this.logger = logger;
         }
 
-        abstract void onClose();
+        protected void onClose() {
+
+        }
+
+        public synchronized void attemptToBeElected(int requiredMasterJoins, ElectionCallback callback) {
+            assert this.requiredMasterJoins < 0;
+            assert this.callback == null;
+            this.requiredMasterJoins = requiredMasterJoins;
+            this.callback = callback;
+        }
+
+        public synchronized void addIncomingJoin(DiscoveryNode node, MembershipAction.JoinCallback callback) {
+            joinRequestAccumulator.computeIfAbsent(node, n -> new ArrayList<>()).add(callback);
+        }
+
+
+        public synchronized boolean isEnoughPendingJoins(int pendingMasterJoins) {
+            final boolean hasEngough;
+            if (requiredMasterJoins < 0) {
+                // requiredMasterNodes is unknown yet, return false and keep on waiting
+                hasEngough = false;
+            } else {
+                assert callback != null : "requiredMasterJoins is set but not the callback";
+                hasEngough = pendingMasterJoins >= requiredMasterJoins;
+            }
+            return hasEngough;
+        }
+
+        public synchronized Map<DiscoveryNode, ClusterStateTaskListener> getPendingAsTasks() {
+            Map<DiscoveryNode, ClusterStateTaskListener> tasks = new HashMap<>();
+            joinRequestAccumulator.entrySet().stream().forEach(e -> tasks.put(e.getKey(), new JoinTaskListener(e.getValue(), logger)));
+            return tasks;
+        }
+
+        public synchronized int getPendingMasterJoinsCount() {
+            int pendingMasterJoins = 0;
+            for (DiscoveryNode node : joinRequestAccumulator.keySet()) {
+                if (node.isMasterNode()) {
+                    pendingMasterJoins++;
+                }
+            }
+            return pendingMasterJoins;
+        }
+
+        private synchronized ElectionCallback getCallback() {
+            return callback;
+        }
 
         @Override
         public void onElectedAsMaster(ClusterState state) {
-            assert pendingSetAsMasterTask.get() : "onElectedAsMaster called but pendingSetAsMasterTask is not set";
             ClusterService.assertClusterStateThread();
             assert state.nodes().isLocalNodeElectedMaster() : "onElectedAsMaster called but local node is not master";
             if (closed.compareAndSet(false, true)) {
+                ElectionCallback callback = getCallback(); // get under lock
                 try {
                     onClose();
                 } finally {
@@ -337,6 +342,7 @@ public class NodeJoinController extends AbstractComponent {
         public void onFailure(Throwable t) {
             ClusterService.assertClusterStateThread();
             if (closed.compareAndSet(false, true)) {
+                ElectionCallback callback = getCallback(); // get under lock
                 try {
                     onClose();
                 } finally {
@@ -346,77 +352,22 @@ public class NodeJoinController extends AbstractComponent {
         }
     }
 
+    static class JoinTaskListener implements ClusterStateTaskListener {
+        final List<MembershipAction.JoinCallback> callbacks;
+        final private ESLogger logger;
 
-    /**
-     * Processes any pending joins via a ClusterState update task.
-     * Note: this task automatically fails (and fails all pending joins) if the current node is not marked as master
-     */
-    class ProcessJoinsTask extends ClusterStateUpdateTask {
+        JoinTaskListener(MembershipAction.JoinCallback callback, ESLogger logger) {
+            this(Collections.singletonList(callback), logger);
+        }
 
-        private final List<MembershipAction.JoinCallback> joinCallbacksToRespondTo = new ArrayList<>();
-        private boolean nodeAdded = false;
-
-        public ProcessJoinsTask(Priority priority) {
-            super(priority);
+        JoinTaskListener(List<MembershipAction.JoinCallback> callbacks, ESLogger logger) {
+            this.callbacks = callbacks;
+            this.logger = logger;
         }
 
         @Override
-        public ClusterState execute(ClusterState currentState) {
-            DiscoveryNodes.Builder nodesBuilder;
-            synchronized (pendingJoinRequests) {
-                if (pendingJoinRequests.isEmpty()) {
-                    return currentState;
-                }
-
-                nodesBuilder = DiscoveryNodes.builder(currentState.nodes());
-                Iterator<Map.Entry<DiscoveryNode, List<MembershipAction.JoinCallback>>> iterator = pendingJoinRequests.entrySet().iterator();
-                while (iterator.hasNext()) {
-                    Map.Entry<DiscoveryNode, List<MembershipAction.JoinCallback>> entry = iterator.next();
-                    final DiscoveryNode node = entry.getKey();
-                    joinCallbacksToRespondTo.addAll(entry.getValue());
-                    iterator.remove();
-                    if (currentState.nodes().nodeExists(node.getId())) {
-                        logger.debug("received a join request for an existing node [{}]", node);
-                    } else {
-                        nodeAdded = true;
-                        nodesBuilder.put(node);
-                        for (DiscoveryNode existingNode : currentState.nodes()) {
-                            if (node.getAddress().equals(existingNode.getAddress())) {
-                                nodesBuilder.remove(existingNode.getId());
-                                logger.warn("received join request from node [{}], but found existing node {} with same address, removing existing node", node, existingNode);
-                            }
-                        }
-                    }
-                }
-            }
-
-            // we must return a new cluster state instance to force publishing. This is important
-            // for the joining node to finalize it's join and set us as a master
-            final ClusterState.Builder newState = ClusterState.builder(currentState);
-            if (nodeAdded) {
-                newState.nodes(nodesBuilder);
-            }
-
-            return newState.build();
-        }
-
-        @Override
-        public void onNoLongerMaster(String source) {
-            // we are rejected, so drain all pending task (execute never run)
-            synchronized (pendingJoinRequests) {
-                Iterator<Map.Entry<DiscoveryNode, List<MembershipAction.JoinCallback>>> iterator = pendingJoinRequests.entrySet().iterator();
-                while (iterator.hasNext()) {
-                    Map.Entry<DiscoveryNode, List<MembershipAction.JoinCallback>> entry = iterator.next();
-                    joinCallbacksToRespondTo.addAll(entry.getValue());
-                    iterator.remove();
-                }
-            }
-            Exception e = new NotMasterException("Node [" + clusterService.localNode() + "] not master for join request");
-            innerOnFailure(e);
-        }
-
-        void innerOnFailure(Throwable t) {
-            for (MembershipAction.JoinCallback callback : joinCallbacksToRespondTo) {
+        public void onFailure(String source, Throwable t) {
+            for (MembershipAction.JoinCallback callback : callbacks) {
                 try {
                     callback.onFailure(t);
                 } catch (Exception e) {
@@ -426,28 +377,108 @@ public class NodeJoinController extends AbstractComponent {
         }
 
         @Override
-        public void onFailure(String source, Throwable t) {
-            logger.error("unexpected failure during [{}]", t, source);
-            innerOnFailure(t);
-        }
-
-        @Override
         public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-            if (nodeAdded) {
-                // we reroute not in the same cluster state update since in certain areas we rely on
-                // the node to be in the cluster state (sampled from ClusterService#state) to be there, also
-                // shard transitions need to better be handled in such cases
-                routingService.reroute("post_node_add");
-            }
-            for (MembershipAction.JoinCallback callback : joinCallbacksToRespondTo) {
+            for (MembershipAction.JoinCallback callback : callbacks) {
                 try {
                     callback.onSuccess();
                 } catch (Exception e) {
                     logger.error("unexpected error during [{}]", e, source);
                 }
             }
+        }
+    }
 
-            NodeJoinController.this.electMaster.logMinimumMasterNodesWarningIfNecessary(oldState, newState);
+    // a task indicated that the current node should become master, if no current master is known
+    private final static DiscoveryNode BECOME_MASTER_TASK = new DiscoveryNode("_BECOME_MASTER_TASK_", DummyTransportAddress.INSTANCE,
+        Collections.emptyMap(), Collections.emptySet(), Version.CURRENT);
+
+    class JoinTaskExecutor implements ClusterStateTaskExecutor<DiscoveryNode> {
+
+        @Override
+        public BatchResult<DiscoveryNode> execute(ClusterState currentState, List<DiscoveryNode> joiningNodes) throws Exception {
+            final DiscoveryNodes currentNodes = currentState.nodes();
+            final BatchResult.Builder<DiscoveryNode> results = BatchResult.builder();
+            boolean nodesChanged = false;
+            ClusterState.Builder newState = ClusterState.builder(currentState);
+            DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(currentNodes);
+
+            if (currentNodes.getMasterNode() == null && joiningNodes.contains(BECOME_MASTER_TASK)) {
+                // use these joins to try and become the master.
+                // Note that we don't have to do any validation of the amount of joining nodes - the commit
+                // during the cluster state publishing guarantees that we have enough
+
+                nodesBuilder.masterNodeId(currentNodes.getLocalNodeId());
+                ClusterBlocks clusterBlocks = ClusterBlocks.builder().blocks(currentState.blocks())
+                    .removeGlobalBlock(discoverySettings.getNoMasterBlock()).build();
+                newState.blocks(clusterBlocks);
+                newState.nodes(nodesBuilder);
+                nodesChanged = true;
+
+                // reroute now to remove any dead nodes (master may have stepped down when they left and didn't update the routing table)
+                // Note: also do it now to avoid assigning shards to these nodes. We will have another reroute after the cluster
+                // state is published.
+                // TODO: this publishing of a cluster state with no nodes assigned to joining nodes shouldn't be needed anymore. remove.
+
+                final ClusterState tmpState = newState.build();
+                RoutingAllocation.Result result = routingService.getAllocationService().reroute(tmpState, "nodes joined");
+                newState = ClusterState.builder(tmpState);
+                if (result.changed()) {
+                    newState.routingResult(result);
+                }
+                nodesBuilder = DiscoveryNodes.builder(tmpState.nodes());
+            }
+
+            if (nodesBuilder.isLocalNodeElectedMaster() == false) {
+                logger.trace("processing node joins, but we are not the master. current master: {}", currentNodes.getMasterNode());
+                throw new NotMasterException("Node [" + currentNodes.getLocalNode() + "] not master for join request");
+            }
+
+            for (final DiscoveryNode node : joiningNodes) {
+                if (node.equals(BECOME_MASTER_TASK)) {
+                    // noop
+                } else if (currentNodes.nodeExists(node.getId())) {
+                    logger.debug("received a join request for an existing node [{}]", node);
+                } else {
+                    nodesChanged = true;
+                    nodesBuilder.put(node);
+                    for (DiscoveryNode existingNode : currentNodes) {
+                        if (node.getAddress().equals(existingNode.getAddress())) {
+                            nodesBuilder.remove(existingNode.getId());
+                            logger.warn("received join request from node [{}], but found existing node {} with same address, removing existing node", node, existingNode);
+                        }
+                    }
+                }
+                results.success(node);
+            }
+
+            // we must return a new cluster state instance to force publishing. This is important
+            // for the joining node to finalize it's join and set us as a master
+            if (nodesChanged) {
+                newState.nodes(nodesBuilder);
+            }
+
+            // we must return a new cluster state instance to force publishing. This is important
+            // for the joining node to finalize it's join and set us as a master
+
+            return results.build(newState.build());
+        }
+
+        @Override
+        public boolean runOnlyOnMaster() {
+            // we validate that we are allowed to change the cluster state during cluster state processing
+            return false;
+        }
+
+        @Override
+        public void clusterStatePublished(ClusterChangedEvent event) {
+            if (event.nodesDelta().hasChanges()) {
+                // we reroute not in the same cluster state update since in certain areas we rely on
+                // the node to be in the cluster state (sampled from ClusterService#state) to be there, also
+                // shard transitions need to better be handled in such cases
+                routingService.reroute("post_node_add");
+            }
+
+            NodeJoinController.this.electMaster.logMinimumMasterNodesWarningIfNecessary(event.previousState(), event.state());
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -372,7 +372,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
     private void innerJoinCluster() {
         DiscoveryNode masterNode = null;
         final Thread currentThread = Thread.currentThread();
-        nodeJoinController.startAccumulatingJoins();
+        nodeJoinController.startElectionContext();
         while (masterNode == null && joinThreadControl.joinThreadActive(currentThread)) {
             masterNode = findMaster();
         }
@@ -406,7 +406,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
             );
         } else {
             // process any incoming joins (they will fail because we are not the master)
-            nodeJoinController.stopAccumulatingJoins("not master");
+            nodeJoinController.stopElectionContext("not master");
 
             // send join request
             final boolean success = joinElectedMaster(masterNode);

--- a/core/src/test/java/org/elasticsearch/cluster/service/ClusterServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/service/ClusterServiceTests.java
@@ -275,7 +275,7 @@ public class ClusterServiceTests extends ESTestCase {
                 }
 
                 @Override
-                public void clusterStatePublished(ClusterState newClusterState) {
+                public void clusterStatePublished(ClusterChangedEvent clusterChangedEvent) {
                     published.set(true);
                     latch.countDown();
                 }
@@ -471,7 +471,7 @@ public class ClusterServiceTests extends ESTestCase {
             }
 
             @Override
-            public void clusterStatePublished(ClusterState newClusterState) {
+            public void clusterStatePublished(ClusterChangedEvent clusterChangedEvent) {
                 published.incrementAndGet();
                 semaphore.release();
             }

--- a/core/src/test/java/org/elasticsearch/discovery/zen/NodeJoinControllerTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/NodeJoinControllerTests.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.discovery.zen;
 
-import com.carrotsearch.randomizedtesting.annotations.Seed;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
@@ -227,7 +226,6 @@ public class NodeJoinControllerTests extends ESTestCase {
         electionFuture.get();
     }
 
-    @Seed("DE4D608991D6D518")
     public void testSimpleMasterElection() throws InterruptedException, ExecutionException {
         DiscoveryNodes.Builder nodes = DiscoveryNodes.builder(clusterService.state().nodes()).masterNodeId(null);
         setState(clusterService, ClusterState.builder(clusterService.state()).nodes(nodes));
@@ -588,7 +586,7 @@ public class NodeJoinControllerTests extends ESTestCase {
     private SimpleFuture joinNodeAsync(final DiscoveryNode node) throws InterruptedException {
         final SimpleFuture future = new SimpleFuture("join of " + node + " (id [" + joinId.incrementAndGet() + "]");
         logger.debug("starting {}", future);
-        // clone the node before submitting to simulate an incoming join , which is guaranteed to have a new
+        // clone the node before submitting to simulate an incoming join, which is guaranteed to have a new
         // disco node object serialized off the network
         nodeJoinController.handleJoinRequest(cloneNode(node), new MembershipAction.JoinCallback() {
             @Override


### PR DESCRIPTION
The NodeJoinController is responsible for processing joins from nodes, both normally and during master election. For both use cases, the class processes incoming joins in batches in order to be efficient and to accumulated enough joins (i.e., >= min_master_nodes) to seal an election and ensure the new cluster state can be committed. Since the class was written, we introduced a new infrastructure to support batch changes to the cluster state at the `ClusterService` level. This PR rewrites NodeJoinController to use that infra and be simpler.

The PR also introduces a new concept to ClusterService allowing to submit tasks in batches, guaranteeing that all tasks submitted in a batch will be processed together (potentially with more tasks).  On top of that I added some extra safety checks to the ClusterService, around potential double submission of task objects into the queue.

This is done in preparation to revive #17811
