### PR TITLE
Remove wrong json-data in example

### DIFF
--- a/docs/reference/search/suggesters/context-suggest.asciidoc
+++ b/docs/reference/search/suggesters/context-suggest.asciidoc
@@ -95,9 +95,6 @@ or as a single value
     "color": {
         "type": "category",
         "default": "red"
-        "contexts": {
-            "place_type": ["cafe", "food"] <1>
-        }
     }
 }
 --------------------------------------------------


### PR DESCRIPTION
It seems the json-data for the example copied and pasted wrongly from an earlier example. Since it was even missing the comma delimiter, it seems safe to assume it can simply be omitted. Without it, the example makes more sense again.
