### PR TITLE
Remove casts and boxing for dynamic math

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
@@ -264,41 +264,42 @@ public final class MethodWriter extends GeneratorAdapter {
 
     /** Writes a dynamic binary instruction: returnType, lhs, and rhs can be different */
     public void writeDynamicBinaryInstruction(Location location, Type returnType, Type lhs, Type rhs, Operation operation) {
-        org.objectweb.asm.Type descriptor = org.objectweb.asm.Type.getMethodType(returnType.type, lhs.type, rhs.type);
+        org.objectweb.asm.Type methodType = org.objectweb.asm.Type.getMethodType(returnType.type, lhs.type, rhs.type);
+        String descriptor = methodType.getDescriptor();
         
         switch (operation) {
             case MUL:
-                invokeDynamic("mul", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
+                invokeDynamic("mul", descriptor, DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
                 break;
             case DIV:
-                invokeDynamic("div", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
+                invokeDynamic("div", descriptor, DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
                 break;
             case REM:
-                invokeDynamic("rem", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
+                invokeDynamic("rem", descriptor, DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
                 break;
             case ADD:
-                invokeDynamic("add", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
+                invokeDynamic("add", descriptor, DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
                 break;
             case SUB:
-                invokeDynamic("sub", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
+                invokeDynamic("sub", descriptor, DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
                 break;
             case LSH:
-                invokeDynamic("lsh", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.SHIFT_OPERATOR); 
+                invokeDynamic("lsh", descriptor, DEF_BOOTSTRAP_HANDLE, DefBootstrap.SHIFT_OPERATOR); 
                 break;
             case USH:
-                invokeDynamic("ush", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.SHIFT_OPERATOR); 
+                invokeDynamic("ush", descriptor, DEF_BOOTSTRAP_HANDLE, DefBootstrap.SHIFT_OPERATOR); 
                 break;
             case RSH:
-                invokeDynamic("rsh", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.SHIFT_OPERATOR); 
+                invokeDynamic("rsh", descriptor, DEF_BOOTSTRAP_HANDLE, DefBootstrap.SHIFT_OPERATOR); 
                 break;
             case BWAND: 
-                invokeDynamic("and", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR);
+                invokeDynamic("and", descriptor, DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR);
                 break;
             case XOR:   
-                invokeDynamic("xor", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR);
+                invokeDynamic("xor", descriptor, DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR);
                 break;
             case BWOR:  
-                invokeDynamic("or", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR);
+                invokeDynamic("or", descriptor, DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR);
                 break;
             default:
                 throw location.createError(new IllegalStateException("Illegal tree structure."));

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
@@ -262,6 +262,50 @@ public final class MethodWriter extends GeneratorAdapter {
         }
     }
 
+    /** Writes a dynamic binary instruction: returnType, lhs, and rhs can be different */
+    public void writeDynamicBinaryInstruction(Location location, Type returnType, Type lhs, Type rhs, Operation operation) {
+        org.objectweb.asm.Type descriptor = org.objectweb.asm.Type.getMethodType(returnType.type, lhs.type, rhs.type);
+        
+        switch (operation) {
+            case MUL:
+                invokeDynamic("mul", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
+                break;
+            case DIV:
+                invokeDynamic("div", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
+                break;
+            case REM:
+                invokeDynamic("rem", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
+                break;
+            case ADD:
+                invokeDynamic("add", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
+                break;
+            case SUB:
+                invokeDynamic("sub", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
+                break;
+            case LSH:
+                invokeDynamic("lsh", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.SHIFT_OPERATOR); 
+                break;
+            case USH:
+                invokeDynamic("ush", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.SHIFT_OPERATOR); 
+                break;
+            case RSH:
+                invokeDynamic("rsh", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.SHIFT_OPERATOR); 
+                break;
+            case BWAND: 
+                invokeDynamic("and", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR);
+                break;
+            case XOR:   
+                invokeDynamic("xor", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR);
+                break;
+            case BWOR:  
+                invokeDynamic("or", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR);
+                break;
+            default:
+                throw location.createError(new IllegalStateException("Illegal tree structure."));
+        }
+    }
+    
+    /** Writes a static binary instruction */
     public void writeBinaryInstruction(Location location, Type type, Operation operation) {
         final Sort sort = type.sort;
 
@@ -272,64 +316,20 @@ public final class MethodWriter extends GeneratorAdapter {
             throw location.createError(new IllegalStateException("Illegal tree structure."));
         }
 
-        if (sort == Sort.DEF) {
-            // XXX: move this out, so we can populate descriptor with what we really have (instead of casts/boxing!)
-            org.objectweb.asm.Type objectType = org.objectweb.asm.Type.getType(Object.class);
-            org.objectweb.asm.Type descriptor = org.objectweb.asm.Type.getMethodType(objectType, objectType, objectType);
-            
-            switch (operation) {
-                case MUL:
-                    invokeDynamic("mul", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
-                    break;
-                case DIV:
-                    invokeDynamic("div", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
-                    break;
-                case REM:
-                    invokeDynamic("rem", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
-                    break;
-                case ADD:
-                    invokeDynamic("add", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
-                    break;
-                case SUB:
-                    invokeDynamic("sub", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR); 
-                    break;
-                case LSH:
-                    invokeDynamic("lsh", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.SHIFT_OPERATOR); 
-                    break;
-                case USH:
-                    invokeDynamic("ush", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.SHIFT_OPERATOR); 
-                    break;
-                case RSH:
-                    invokeDynamic("rsh", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.SHIFT_OPERATOR); 
-                    break;
-                case BWAND: 
-                    invokeDynamic("and", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR);
-                    break;
-                case XOR:   
-                    invokeDynamic("xor", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR);
-                    break;
-                case BWOR:  
-                    invokeDynamic("or", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR);
-                    break;
-                default:
-                    throw location.createError(new IllegalStateException("Illegal tree structure."));
-            }
-        } else {
-            switch (operation) {
-                case MUL:   math(GeneratorAdapter.MUL,  type.type); break;
-                case DIV:   math(GeneratorAdapter.DIV,  type.type); break;
-                case REM:   math(GeneratorAdapter.REM,  type.type); break;
-                case ADD:   math(GeneratorAdapter.ADD,  type.type); break;
-                case SUB:   math(GeneratorAdapter.SUB,  type.type); break;
-                case LSH:   math(GeneratorAdapter.SHL,  type.type); break;
-                case USH:   math(GeneratorAdapter.USHR, type.type); break;
-                case RSH:   math(GeneratorAdapter.SHR,  type.type); break;
-                case BWAND: math(GeneratorAdapter.AND,  type.type); break;
-                case XOR:   math(GeneratorAdapter.XOR,  type.type); break;
-                case BWOR:  math(GeneratorAdapter.OR,   type.type); break;
-                default:
-                    throw location.createError(new IllegalStateException("Illegal tree structure."));
-            }
+        switch (operation) {
+            case MUL:   math(GeneratorAdapter.MUL,  type.type); break;
+            case DIV:   math(GeneratorAdapter.DIV,  type.type); break;
+            case REM:   math(GeneratorAdapter.REM,  type.type); break;
+            case ADD:   math(GeneratorAdapter.ADD,  type.type); break;
+            case SUB:   math(GeneratorAdapter.SUB,  type.type); break;
+            case LSH:   math(GeneratorAdapter.SHL,  type.type); break;
+            case USH:   math(GeneratorAdapter.USHR, type.type); break;
+            case RSH:   math(GeneratorAdapter.SHR,  type.type); break;
+            case BWAND: math(GeneratorAdapter.AND,  type.type); break;
+            case XOR:   math(GeneratorAdapter.XOR,  type.type); break;
+            case BWOR:  math(GeneratorAdapter.OR,   type.type); break;
+            default:
+                throw location.createError(new IllegalStateException("Illegal tree structure."));
         }
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EChain.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EChain.java
@@ -334,7 +334,15 @@ public final class EChain extends AExpression {
                     writer.writeCast(there);                                     // if necessary cast the current link's value
                                                                                  // to the promotion type between the lhs and rhs types
                     expression.write(writer);                                    // write the bytecode for the rhs expression
-                    writer.writeBinaryInstruction(location, promote, operation); // write the operation instruction for compound assignment
+                    // XXX: fix these types, but first we need def compound assignment tests.
+                    // (and also corner cases such as shifts). its tricky here as there are possibly explicit casts, too.
+                    // write the operation instruction for compound assignment
+                    if (promote.sort == Sort.DEF) {
+                        writer.writeDynamicBinaryInstruction(location, promote, 
+                            Definition.DEF_TYPE, Definition.DEF_TYPE, operation);
+                    } else {
+                        writer.writeBinaryInstruction(location, promote, operation);
+                    }
 
                     writer.writeCast(back); // if necessary cast the promotion type value back to the link's type
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EComp.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EComp.java
@@ -42,6 +42,7 @@ public final class EComp extends AExpression {
     final Operation operation;
     AExpression left;
     AExpression right;
+    Type promotedType;
 
     public EComp(Location location, Operation operation, AExpression left, AExpression right) {
         super(location);
@@ -78,15 +79,20 @@ public final class EComp extends AExpression {
         left.analyze(variables);
         right.analyze(variables);
 
-        Type promote = AnalyzerCaster.promoteEquality(left.actual, right.actual);
+        promotedType = AnalyzerCaster.promoteEquality(left.actual, right.actual);
 
-        if (promote == null) {
+        if (promotedType == null) {
             throw createError(new ClassCastException("Cannot apply equals [==] to types " +
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        left.expected = promote;
-        right.expected = promote;
+        if (promotedType.sort == Sort.DEF) {
+            left.expected = left.actual;
+            right.expected = right.actual;
+        } else {
+            left.expected = promotedType;
+            right.expected = promotedType;
+        }
 
         left = left.cast(variables);
         right = right.cast(variables);
@@ -96,7 +102,7 @@ public final class EComp extends AExpression {
         }
 
         if ((left.constant != null || left.isNull) && (right.constant != null || right.isNull)) {
-            Sort sort = promote.sort;
+            Sort sort = promotedType.sort;
 
             if (sort == Sort.BOOL) {
                 constant = (boolean)left.constant == (boolean)right.constant;
@@ -124,15 +130,20 @@ public final class EComp extends AExpression {
         left.analyze(variables);
         right.analyze(variables);
 
-        Type promote = AnalyzerCaster.promoteEquality(left.actual, right.actual);
+        promotedType = AnalyzerCaster.promoteEquality(left.actual, right.actual);
 
-        if (promote == null) {
+        if (promotedType == null) {
             throw createError(new ClassCastException("Cannot apply reference equals [===] to types " +
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        left.expected = promote;
-        right.expected = promote;
+        if (promotedType.sort == Sort.DEF) {
+            left.expected = left.actual;
+            right.expected = right.actual;
+        } else {
+            left.expected = promotedType;
+            right.expected = promotedType;
+        }
 
         left = left.cast(variables);
         right = right.cast(variables);
@@ -142,7 +153,7 @@ public final class EComp extends AExpression {
         }
 
         if ((left.constant != null || left.isNull) && (right.constant != null || right.isNull)) {
-            Sort sort = promote.sort;
+            Sort sort = promotedType.sort;
 
             if (sort == Sort.BOOL) {
                 constant = (boolean)left.constant == (boolean)right.constant;
@@ -166,15 +177,20 @@ public final class EComp extends AExpression {
         left.analyze(variables);
         right.analyze(variables);
 
-        Type promote = AnalyzerCaster.promoteEquality(left.actual, right.actual);
+        promotedType = AnalyzerCaster.promoteEquality(left.actual, right.actual);
 
-        if (promote == null) {
+        if (promotedType == null) {
             throw createError(new ClassCastException("Cannot apply not equals [!=] to types " +
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        left.expected = promote;
-        right.expected = promote;
+        if (promotedType.sort == Sort.DEF) {
+            left.expected = left.actual;
+            right.expected = right.actual;
+        } else {
+            left.expected = promotedType;
+            right.expected = promotedType;
+        }
 
         left = left.cast(variables);
         right = right.cast(variables);
@@ -184,7 +200,7 @@ public final class EComp extends AExpression {
         }
 
         if ((left.constant != null || left.isNull) && (right.constant != null || right.isNull)) {
-            Sort sort = promote.sort;
+            Sort sort = promotedType.sort;
 
             if (sort == Sort.BOOL) {
                 constant = (boolean)left.constant != (boolean)right.constant;
@@ -212,15 +228,20 @@ public final class EComp extends AExpression {
         left.analyze(variables);
         right.analyze(variables);
 
-        Type promote = AnalyzerCaster.promoteEquality(left.actual, right.actual);
+        promotedType = AnalyzerCaster.promoteEquality(left.actual, right.actual);
 
-        if (promote == null) {
+        if (promotedType == null) {
             throw createError(new ClassCastException("Cannot apply reference not equals [!==] to types " +
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        left.expected = promote;
-        right.expected = promote;
+        if (promotedType.sort == Sort.DEF) {
+            left.expected = left.actual;
+            right.expected = right.actual;
+        } else {
+            left.expected = promotedType;
+            right.expected = promotedType;
+        }
 
         left = left.cast(variables);
         right = right.cast(variables);
@@ -230,7 +251,7 @@ public final class EComp extends AExpression {
         }
 
         if ((left.constant != null || left.isNull) && (right.constant != null || right.isNull)) {
-            Sort sort = promote.sort;
+            Sort sort = promotedType.sort;
 
             if (sort == Sort.BOOL) {
                 constant = (boolean)left.constant != (boolean)right.constant;
@@ -254,21 +275,26 @@ public final class EComp extends AExpression {
         left.analyze(variables);
         right.analyze(variables);
 
-        Type promote = AnalyzerCaster.promoteNumeric(left.actual, right.actual, true);
+        promotedType = AnalyzerCaster.promoteNumeric(left.actual, right.actual, true);
 
-        if (promote == null) {
+        if (promotedType == null) {
             throw createError(new ClassCastException("Cannot apply greater than or equals [>=] to types " +
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        left.expected = promote;
-        right.expected = promote;
+        if (promotedType.sort == Sort.DEF) {
+            left.expected = left.actual;
+            right.expected = right.actual;
+        } else {
+            left.expected = promotedType;
+            right.expected = promotedType;
+        }
 
         left = left.cast(variables);
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = promote.sort;
+            Sort sort = promotedType.sort;
 
             if (sort == Sort.INT) {
                 constant = (int)left.constant >= (int)right.constant;
@@ -290,21 +316,26 @@ public final class EComp extends AExpression {
         left.analyze(variables);
         right.analyze(variables);
 
-        Type promote = AnalyzerCaster.promoteNumeric(left.actual, right.actual, true);
+        promotedType = AnalyzerCaster.promoteNumeric(left.actual, right.actual, true);
 
-        if (promote == null) {
+        if (promotedType == null) {
             throw createError(new ClassCastException("Cannot apply greater than [>] to types " +
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        left.expected = promote;
-        right.expected = promote;
+        if (promotedType.sort == Sort.DEF) {
+            left.expected = left.actual;
+            right.expected = right.actual;
+        } else {
+            left.expected = promotedType;
+            right.expected = promotedType;
+        }
 
         left = left.cast(variables);
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = promote.sort;
+            Sort sort = promotedType.sort;
 
             if (sort == Sort.INT) {
                 constant = (int)left.constant > (int)right.constant;
@@ -326,21 +357,26 @@ public final class EComp extends AExpression {
         left.analyze(variables);
         right.analyze(variables);
 
-        Type promote = AnalyzerCaster.promoteNumeric(left.actual, right.actual, true);
+        promotedType = AnalyzerCaster.promoteNumeric(left.actual, right.actual, true);
 
-        if (promote == null) {
+        if (promotedType == null) {
             throw createError(new ClassCastException("Cannot apply less than or equals [<=] to types " +
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        left.expected = promote;
-        right.expected = promote;
+        if (promotedType.sort == Sort.DEF) {
+            left.expected = left.actual;
+            right.expected = right.actual;
+        } else {
+            left.expected = promotedType;
+            right.expected = promotedType;
+        }
 
         left = left.cast(variables);
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = promote.sort;
+            Sort sort = promotedType.sort;
 
             if (sort == Sort.INT) {
                 constant = (int)left.constant <= (int)right.constant;
@@ -362,21 +398,26 @@ public final class EComp extends AExpression {
         left.analyze(variables);
         right.analyze(variables);
 
-        Type promote = AnalyzerCaster.promoteNumeric(left.actual, right.actual, true);
+        promotedType = AnalyzerCaster.promoteNumeric(left.actual, right.actual, true);
 
-        if (promote == null) {
+        if (promotedType == null) {
             throw createError(new ClassCastException("Cannot apply less than [>=] to types " +
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        left.expected = promote;
-        right.expected = promote;
+        if (promotedType.sort == Sort.DEF) {
+            left.expected = left.actual;
+            right.expected = right.actual;
+        } else {
+            left.expected = promotedType;
+            right.expected = promotedType;
+        }
 
         left = left.cast(variables);
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = promote.sort;
+            Sort sort = promotedType.sort;
 
             if (sort == Sort.INT) {
                 constant = (int)left.constant < (int)right.constant;
@@ -399,8 +440,6 @@ public final class EComp extends AExpression {
         writer.writeDebugInfo(location);
 
         boolean branch = tru != null || fals != null;
-        org.objectweb.asm.Type rtype = right.actual.type;
-        Sort rsort = right.actual.sort;
 
         left.write(writer);
 
@@ -422,7 +461,7 @@ public final class EComp extends AExpression {
 
         boolean writejump = true;
 
-        switch (rsort) {
+        switch (promotedType.sort) {
             case VOID:
             case BYTE:
             case SHORT:
@@ -440,12 +479,12 @@ public final class EComp extends AExpression {
             case LONG:
             case FLOAT:
             case DOUBLE:
-                if      (eq)  writer.ifCmp(rtype, MethodWriter.EQ, jump);
-                else if (ne)  writer.ifCmp(rtype, MethodWriter.NE, jump);
-                else if (lt)  writer.ifCmp(rtype, MethodWriter.LT, jump);
-                else if (lte) writer.ifCmp(rtype, MethodWriter.LE, jump);
-                else if (gt)  writer.ifCmp(rtype, MethodWriter.GT, jump);
-                else if (gte) writer.ifCmp(rtype, MethodWriter.GE, jump);
+                if      (eq)  writer.ifCmp(promotedType.type, MethodWriter.EQ, jump);
+                else if (ne)  writer.ifCmp(promotedType.type, MethodWriter.NE, jump);
+                else if (lt)  writer.ifCmp(promotedType.type, MethodWriter.LT, jump);
+                else if (lte) writer.ifCmp(promotedType.type, MethodWriter.LE, jump);
+                else if (gt)  writer.ifCmp(promotedType.type, MethodWriter.GT, jump);
+                else if (gte) writer.ifCmp(promotedType.type, MethodWriter.GE, jump);
                 else {
                     throw createError(new IllegalStateException("Illegal tree structure."));
                 }
@@ -454,8 +493,7 @@ public final class EComp extends AExpression {
             case DEF:
                 // XXX: move this out, so we can populate descriptor with what we really have (instead of casts/boxing!)
                 org.objectweb.asm.Type booleanType = org.objectweb.asm.Type.getType(boolean.class);
-                org.objectweb.asm.Type objectType = org.objectweb.asm.Type.getType(Object.class);
-                org.objectweb.asm.Type descriptor = org.objectweb.asm.Type.getMethodType(booleanType, objectType, objectType);
+                org.objectweb.asm.Type descriptor = org.objectweb.asm.Type.getMethodType(booleanType, left.actual.type, right.actual.type);
                 if (eq) {
                     if (right.isNull) {
                         writer.ifNull(jump);
@@ -463,7 +501,7 @@ public final class EComp extends AExpression {
                         writer.invokeDynamic("eq", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR);
                         writejump = false;
                     } else {
-                        writer.ifCmp(rtype, MethodWriter.EQ, jump);
+                        writer.ifCmp(promotedType.type, MethodWriter.EQ, jump);
                     }
                 } else if (ne) {
                     if (right.isNull) {
@@ -472,7 +510,7 @@ public final class EComp extends AExpression {
                         writer.invokeDynamic("eq", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR);
                         writer.ifZCmp(MethodWriter.EQ, jump);
                     } else {
-                        writer.ifCmp(rtype, MethodWriter.NE, jump);
+                        writer.ifCmp(promotedType.type, MethodWriter.NE, jump);
                     }
                 } else if (lt) {
                     writer.invokeDynamic("lt", descriptor.getDescriptor(), DEF_BOOTSTRAP_HANDLE, DefBootstrap.BINARY_OPERATOR);
@@ -508,7 +546,7 @@ public final class EComp extends AExpression {
 
                         writejump = false;
                     } else {
-                        writer.ifCmp(rtype, MethodWriter.EQ, jump);
+                        writer.ifCmp(promotedType.type, MethodWriter.EQ, jump);
                     }
                 } else if (ne) {
                     if (right.isNull) {
@@ -517,7 +555,7 @@ public final class EComp extends AExpression {
                         writer.invokeStatic(OBJECTS_TYPE, EQUALS);
                         writer.ifZCmp(MethodWriter.EQ, jump);
                     } else {
-                        writer.ifCmp(rtype, MethodWriter.NE, jump);
+                        writer.ifCmp(promotedType.type, MethodWriter.NE, jump);
                     }
                 } else {
                     throw createError(new IllegalStateException("Illegal tree structure."));

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/DefOperationTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/DefOperationTests.java
@@ -125,6 +125,138 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(4F, exec("def x = (float)2; def y = (float)2; return x * y"));
         assertEquals(4D, exec("def x = (double)2; def y = (double)2; return x * y"));
     }
+    
+    public void testMulTypedLHS() {
+        assertEquals(4, exec("byte x = (byte)2; def y = (byte)2; return x * y"));
+        assertEquals(4, exec("short x = (short)2; def y = (byte)2; return x * y"));
+        assertEquals(4, exec("char x = (char)2; def y = (byte)2; return x * y"));
+        assertEquals(4, exec("int x = (int)2; def y = (byte)2; return x * y"));
+        assertEquals(4L, exec("long x = (long)2; def y = (byte)2; return x * y"));
+        assertEquals(4F, exec("float x = (float)2; def y = (byte)2; return x * y"));
+        assertEquals(4D, exec("double x = (double)2; def y = (byte)2; return x * y"));
+
+        assertEquals(4, exec("byte x = (byte)2; def y = (short)2; return x * y"));
+        assertEquals(4, exec("short x = (short)2; def y = (short)2; return x * y"));
+        assertEquals(4, exec("char x = (char)2; def y = (short)2; return x * y"));
+        assertEquals(4, exec("int x = (int)2; def y = (short)2; return x * y"));
+        assertEquals(4L, exec("long x = (long)2; def y = (short)2; return x * y"));
+        assertEquals(4F, exec("float x = (float)2; def y = (short)2; return x * y"));
+        assertEquals(4D, exec("double x = (double)2; def y = (short)2; return x * y"));
+
+        assertEquals(4, exec("byte x = (byte)2; def y = (char)2; return x * y"));
+        assertEquals(4, exec("short x = (short)2; def y = (char)2; return x * y"));
+        assertEquals(4, exec("char x = (char)2; def y = (char)2; return x * y"));
+        assertEquals(4, exec("int x = (int)2; def y = (char)2; return x * y"));
+        assertEquals(4L, exec("long x = (long)2; def y = (char)2; return x * y"));
+        assertEquals(4F, exec("float x = (float)2; def y = (char)2; return x * y"));
+        assertEquals(4D, exec("double x = (double)2; def y = (char)2; return x * y"));
+
+        assertEquals(4, exec("byte x = (byte)2; def y = (int)2; return x * y"));
+        assertEquals(4, exec("short x = (short)2; def y = (int)2; return x * y"));
+        assertEquals(4, exec("char x = (char)2; def y = (int)2; return x * y"));
+        assertEquals(4, exec("int x = (int)2; def y = (int)2; return x * y"));
+        assertEquals(4L, exec("long x = (long)2; def y = (int)2; return x * y"));
+        assertEquals(4F, exec("float x = (float)2; def y = (int)2; return x * y"));
+        assertEquals(4D, exec("double x = (double)2; def y = (int)2; return x * y"));
+
+        assertEquals(4L, exec("byte x = (byte)2; def y = (long)2; return x * y"));
+        assertEquals(4L, exec("short x = (short)2; def y = (long)2; return x * y"));
+        assertEquals(4L, exec("char x = (char)2; def y = (long)2; return x * y"));
+        assertEquals(4L, exec("int x = (int)2; def y = (long)2; return x * y"));
+        assertEquals(4L, exec("long x = (long)2; def y = (long)2; return x * y"));
+        assertEquals(4F, exec("float x = (float)2; def y = (long)2; return x * y"));
+        assertEquals(4D, exec("double x = (double)2; def y = (long)2; return x * y"));
+
+        assertEquals(4F, exec("byte x = (byte)2; def y = (float)2; return x * y"));
+        assertEquals(4F, exec("short x = (short)2; def y = (float)2; return x * y"));
+        assertEquals(4F, exec("char x = (char)2; def y = (float)2; return x * y"));
+        assertEquals(4F, exec("int x = (int)2; def y = (float)2; return x * y"));
+        assertEquals(4F, exec("long x = (long)2; def y = (float)2; return x * y"));
+        assertEquals(4F, exec("float x = (float)2; def y = (float)2; return x * y"));
+        assertEquals(4D, exec("double x = (double)2; def y = (float)2; return x * y"));
+
+        assertEquals(4D, exec("byte x = (byte)2; def y = (double)2; return x * y"));
+        assertEquals(4D, exec("short x = (short)2; def y = (double)2; return x * y"));
+        assertEquals(4D, exec("char x = (char)2; def y = (double)2; return x * y"));
+        assertEquals(4D, exec("int x = (int)2; def y = (double)2; return x * y"));
+        assertEquals(4D, exec("long x = (long)2; def y = (double)2; return x * y"));
+        assertEquals(4D, exec("float x = (float)2; def y = (double)2; return x * y"));
+        assertEquals(4D, exec("double x = (double)2; def y = (double)2; return x * y"));
+
+        assertEquals(4, exec("byte x = (byte)2; def y = (byte)2; return x * y"));
+        assertEquals(4, exec("short x = (short)2; def y = (short)2; return x * y"));
+        assertEquals(4, exec("char x = (char)2; def y = (char)2; return x * y"));
+        assertEquals(4, exec("int x = (int)2; def y = (int)2; return x * y"));
+        assertEquals(4L, exec("long x = (long)2; def y = (long)2; return x * y"));
+        assertEquals(4F, exec("float x = (float)2; def y = (float)2; return x * y"));
+        assertEquals(4D, exec("double x = (double)2; def y = (double)2; return x * y"));
+    }
+    
+    public void testMulTypedRHS() {
+        assertEquals(4, exec("def x = (byte)2; byte y = (byte)2; return x * y"));
+        assertEquals(4, exec("def x = (short)2; byte y = (byte)2; return x * y"));
+        assertEquals(4, exec("def x = (char)2; byte y = (byte)2; return x * y"));
+        assertEquals(4, exec("def x = (int)2; byte y = (byte)2; return x * y"));
+        assertEquals(4L, exec("def x = (long)2; byte y = (byte)2; return x * y"));
+        assertEquals(4F, exec("def x = (float)2; byte y = (byte)2; return x * y"));
+        assertEquals(4D, exec("def x = (double)2; byte y = (byte)2; return x * y"));
+
+        assertEquals(4, exec("def x = (byte)2; short y = (short)2; return x * y"));
+        assertEquals(4, exec("def x = (short)2; short y = (short)2; return x * y"));
+        assertEquals(4, exec("def x = (char)2; short y = (short)2; return x * y"));
+        assertEquals(4, exec("def x = (int)2; short y = (short)2; return x * y"));
+        assertEquals(4L, exec("def x = (long)2; short y = (short)2; return x * y"));
+        assertEquals(4F, exec("def x = (float)2; short y = (short)2; return x * y"));
+        assertEquals(4D, exec("def x = (double)2; short y = (short)2; return x * y"));
+
+        assertEquals(4, exec("def x = (byte)2; char y = (char)2; return x * y"));
+        assertEquals(4, exec("def x = (short)2; char y = (char)2; return x * y"));
+        assertEquals(4, exec("def x = (char)2; char y = (char)2; return x * y"));
+        assertEquals(4, exec("def x = (int)2; char y = (char)2; return x * y"));
+        assertEquals(4L, exec("def x = (long)2; char y = (char)2; return x * y"));
+        assertEquals(4F, exec("def x = (float)2; char y = (char)2; return x * y"));
+        assertEquals(4D, exec("def x = (double)2; char y = (char)2; return x * y"));
+
+        assertEquals(4, exec("def x = (byte)2; int y = (int)2; return x * y"));
+        assertEquals(4, exec("def x = (short)2; int y = (int)2; return x * y"));
+        assertEquals(4, exec("def x = (char)2; int y = (int)2; return x * y"));
+        assertEquals(4, exec("def x = (int)2; int y = (int)2; return x * y"));
+        assertEquals(4L, exec("def x = (long)2; int y = (int)2; return x * y"));
+        assertEquals(4F, exec("def x = (float)2; int y = (int)2; return x * y"));
+        assertEquals(4D, exec("def x = (double)2; int y = (int)2; return x * y"));
+
+        assertEquals(4L, exec("def x = (byte)2; long y = (long)2; return x * y"));
+        assertEquals(4L, exec("def x = (short)2; long y = (long)2; return x * y"));
+        assertEquals(4L, exec("def x = (char)2; long y = (long)2; return x * y"));
+        assertEquals(4L, exec("def x = (int)2; long y = (long)2; return x * y"));
+        assertEquals(4L, exec("def x = (long)2; long y = (long)2; return x * y"));
+        assertEquals(4F, exec("def x = (float)2; long y = (long)2; return x * y"));
+        assertEquals(4D, exec("def x = (double)2; long y = (long)2; return x * y"));
+
+        assertEquals(4F, exec("def x = (byte)2; float y = (float)2; return x * y"));
+        assertEquals(4F, exec("def x = (short)2; float y = (float)2; return x * y"));
+        assertEquals(4F, exec("def x = (char)2; float y = (float)2; return x * y"));
+        assertEquals(4F, exec("def x = (int)2; float y = (float)2; return x * y"));
+        assertEquals(4F, exec("def x = (long)2; float y = (float)2; return x * y"));
+        assertEquals(4F, exec("def x = (float)2; float y = (float)2; return x * y"));
+        assertEquals(4D, exec("def x = (double)2; float y = (float)2; return x * y"));
+
+        assertEquals(4D, exec("def x = (byte)2; double y = (double)2; return x * y"));
+        assertEquals(4D, exec("def x = (short)2; double y = (double)2; return x * y"));
+        assertEquals(4D, exec("def x = (char)2; double y = (double)2; return x * y"));
+        assertEquals(4D, exec("def x = (int)2; double y = (double)2; return x * y"));
+        assertEquals(4D, exec("def x = (long)2; double y = (double)2; return x * y"));
+        assertEquals(4D, exec("def x = (float)2; double y = (double)2; return x * y"));
+        assertEquals(4D, exec("def x = (double)2; double y = (double)2; return x * y"));
+
+        assertEquals(4, exec("def x = (byte)2; byte y = (byte)2; return x * y"));
+        assertEquals(4, exec("def x = (short)2; short y = (short)2; return x * y"));
+        assertEquals(4, exec("def x = (char)2; char y = (char)2; return x * y"));
+        assertEquals(4, exec("def x = (int)2; int y = (int)2; return x * y"));
+        assertEquals(4L, exec("def x = (long)2; long y = (long)2; return x * y"));
+        assertEquals(4F, exec("def x = (float)2; float y = (float)2; return x * y"));
+        assertEquals(4D, exec("def x = (double)2; double y = (double)2; return x * y"));
+    }
 
     public void testDiv() {
         assertEquals(1, exec("def x = (byte)2; def y = (byte)2; return x / y"));
@@ -190,6 +322,138 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(1L, exec("def x = (long)2; def y = (long)2; return x / y"));
         assertEquals(1F, exec("def x = (float)2; def y = (float)2; return x / y"));
         assertEquals(1D, exec("def x = (double)2; def y = (double)2; return x / y"));
+    }
+    
+    public void testDivTypedLHS() {
+        assertEquals(1, exec("byte x = (byte)2; def y = (byte)2; return x / y"));
+        assertEquals(1, exec("short x = (short)2; def y = (byte)2; return x / y"));
+        assertEquals(1, exec("char x = (char)2; def y = (byte)2; return x / y"));
+        assertEquals(1, exec("int x = (int)2; def y = (byte)2; return x / y"));
+        assertEquals(1L, exec("long x = (long)2; def y = (byte)2; return x / y"));
+        assertEquals(1F, exec("float x = (float)2; def y = (byte)2; return x / y"));
+        assertEquals(1D, exec("double x = (double)2; def y = (byte)2; return x / y"));
+
+        assertEquals(1, exec("byte x = (byte)2; def y = (short)2; return x / y"));
+        assertEquals(1, exec("short x = (short)2; def y = (short)2; return x / y"));
+        assertEquals(1, exec("char x = (char)2; def y = (short)2; return x / y"));
+        assertEquals(1, exec("int x = (int)2; def y = (short)2; return x / y"));
+        assertEquals(1L, exec("long x = (long)2; def y = (short)2; return x / y"));
+        assertEquals(1F, exec("float x = (float)2; def y = (short)2; return x / y"));
+        assertEquals(1D, exec("double x = (double)2; def y = (short)2; return x / y"));
+
+        assertEquals(1, exec("byte x = (byte)2; def y = (char)2; return x / y"));
+        assertEquals(1, exec("short x = (short)2; def y = (char)2; return x / y"));
+        assertEquals(1, exec("char x = (char)2; def y = (char)2; return x / y"));
+        assertEquals(1, exec("int x = (int)2; def y = (char)2; return x / y"));
+        assertEquals(1L, exec("long x = (long)2; def y = (char)2; return x / y"));
+        assertEquals(1F, exec("float x = (float)2; def y = (char)2; return x / y"));
+        assertEquals(1D, exec("double x = (double)2; def y = (char)2; return x / y"));
+
+        assertEquals(1, exec("byte x = (byte)2; def y = (int)2; return x / y"));
+        assertEquals(1, exec("short x = (short)2; def y = (int)2; return x / y"));
+        assertEquals(1, exec("char x = (char)2; def y = (int)2; return x / y"));
+        assertEquals(1, exec("int x = (int)2; def y = (int)2; return x / y"));
+        assertEquals(1L, exec("long x = (long)2; def y = (int)2; return x / y"));
+        assertEquals(1F, exec("float x = (float)2; def y = (int)2; return x / y"));
+        assertEquals(1D, exec("double x = (double)2; def y = (int)2; return x / y"));
+
+        assertEquals(1L, exec("byte x = (byte)2; def y = (long)2; return x / y"));
+        assertEquals(1L, exec("short x = (short)2; def y = (long)2; return x / y"));
+        assertEquals(1L, exec("char x = (char)2; def y = (long)2; return x / y"));
+        assertEquals(1L, exec("int x = (int)2; def y = (long)2; return x / y"));
+        assertEquals(1L, exec("long x = (long)2; def y = (long)2; return x / y"));
+        assertEquals(1F, exec("float x = (float)2; def y = (long)2; return x / y"));
+        assertEquals(1D, exec("double x = (double)2; def y = (long)2; return x / y"));
+
+        assertEquals(1F, exec("byte x = (byte)2; def y = (float)2; return x / y"));
+        assertEquals(1F, exec("short x = (short)2; def y = (float)2; return x / y"));
+        assertEquals(1F, exec("char x = (char)2; def y = (float)2; return x / y"));
+        assertEquals(1F, exec("int x = (int)2; def y = (float)2; return x / y"));
+        assertEquals(1F, exec("long x = (long)2; def y = (float)2; return x / y"));
+        assertEquals(1F, exec("float x = (float)2; def y = (float)2; return x / y"));
+        assertEquals(1D, exec("double x = (double)2; def y = (float)2; return x / y"));
+
+        assertEquals(1D, exec("byte x = (byte)2; def y = (double)2; return x / y"));
+        assertEquals(1D, exec("short x = (short)2; def y = (double)2; return x / y"));
+        assertEquals(1D, exec("char x = (char)2; def y = (double)2; return x / y"));
+        assertEquals(1D, exec("int x = (int)2; def y = (double)2; return x / y"));
+        assertEquals(1D, exec("long x = (long)2; def y = (double)2; return x / y"));
+        assertEquals(1D, exec("float x = (float)2; def y = (double)2; return x / y"));
+        assertEquals(1D, exec("double x = (double)2; def y = (double)2; return x / y"));
+
+        assertEquals(1, exec("byte x = (byte)2; def y = (byte)2; return x / y"));
+        assertEquals(1, exec("short x = (short)2; def y = (short)2; return x / y"));
+        assertEquals(1, exec("char x = (char)2; def y = (char)2; return x / y"));
+        assertEquals(1, exec("int x = (int)2; def y = (int)2; return x / y"));
+        assertEquals(1L, exec("long x = (long)2; def y = (long)2; return x / y"));
+        assertEquals(1F, exec("float x = (float)2; def y = (float)2; return x / y"));
+        assertEquals(1D, exec("double x = (double)2; def y = (double)2; return x / y"));
+    }
+    
+    public void testDivTypedRHS() {
+        assertEquals(1, exec("def x = (byte)2; byte y = (byte)2; return x / y"));
+        assertEquals(1, exec("def x = (short)2; byte y = (byte)2; return x / y"));
+        assertEquals(1, exec("def x = (char)2; byte y = (byte)2; return x / y"));
+        assertEquals(1, exec("def x = (int)2; byte y = (byte)2; return x / y"));
+        assertEquals(1L, exec("def x = (long)2; byte y = (byte)2; return x / y"));
+        assertEquals(1F, exec("def x = (float)2; byte y = (byte)2; return x / y"));
+        assertEquals(1D, exec("def x = (double)2; byte y = (byte)2; return x / y"));
+
+        assertEquals(1, exec("def x = (byte)2; short y = (short)2; return x / y"));
+        assertEquals(1, exec("def x = (short)2; short y = (short)2; return x / y"));
+        assertEquals(1, exec("def x = (char)2; short y = (short)2; return x / y"));
+        assertEquals(1, exec("def x = (int)2; short y = (short)2; return x / y"));
+        assertEquals(1L, exec("def x = (long)2; short y = (short)2; return x / y"));
+        assertEquals(1F, exec("def x = (float)2; short y = (short)2; return x / y"));
+        assertEquals(1D, exec("def x = (double)2; short y = (short)2; return x / y"));
+
+        assertEquals(1, exec("def x = (byte)2; char y = (char)2; return x / y"));
+        assertEquals(1, exec("def x = (short)2; char y = (char)2; return x / y"));
+        assertEquals(1, exec("def x = (char)2; char y = (char)2; return x / y"));
+        assertEquals(1, exec("def x = (int)2; char y = (char)2; return x / y"));
+        assertEquals(1L, exec("def x = (long)2; char y = (char)2; return x / y"));
+        assertEquals(1F, exec("def x = (float)2; char y = (char)2; return x / y"));
+        assertEquals(1D, exec("def x = (double)2; char y = (char)2; return x / y"));
+
+        assertEquals(1, exec("def x = (byte)2; int y = (int)2; return x / y"));
+        assertEquals(1, exec("def x = (short)2; int y = (int)2; return x / y"));
+        assertEquals(1, exec("def x = (char)2; int y = (int)2; return x / y"));
+        assertEquals(1, exec("def x = (int)2; int y = (int)2; return x / y"));
+        assertEquals(1L, exec("def x = (long)2; int y = (int)2; return x / y"));
+        assertEquals(1F, exec("def x = (float)2; int y = (int)2; return x / y"));
+        assertEquals(1D, exec("def x = (double)2; int y = (int)2; return x / y"));
+
+        assertEquals(1L, exec("def x = (byte)2; long y = (long)2; return x / y"));
+        assertEquals(1L, exec("def x = (short)2; long y = (long)2; return x / y"));
+        assertEquals(1L, exec("def x = (char)2; long y = (long)2; return x / y"));
+        assertEquals(1L, exec("def x = (int)2; long y = (long)2; return x / y"));
+        assertEquals(1L, exec("def x = (long)2; long y = (long)2; return x / y"));
+        assertEquals(1F, exec("def x = (float)2; long y = (long)2; return x / y"));
+        assertEquals(1D, exec("def x = (double)2; long y = (long)2; return x / y"));
+
+        assertEquals(1F, exec("def x = (byte)2; float y = (float)2; return x / y"));
+        assertEquals(1F, exec("def x = (short)2; float y = (float)2; return x / y"));
+        assertEquals(1F, exec("def x = (char)2; float y = (float)2; return x / y"));
+        assertEquals(1F, exec("def x = (int)2; float y = (float)2; return x / y"));
+        assertEquals(1F, exec("def x = (long)2; float y = (float)2; return x / y"));
+        assertEquals(1F, exec("def x = (float)2; float y = (float)2; return x / y"));
+        assertEquals(1D, exec("def x = (double)2; float y = (float)2; return x / y"));
+
+        assertEquals(1D, exec("def x = (byte)2; double y = (double)2; return x / y"));
+        assertEquals(1D, exec("def x = (short)2; double y = (double)2; return x / y"));
+        assertEquals(1D, exec("def x = (char)2; double y = (double)2; return x / y"));
+        assertEquals(1D, exec("def x = (int)2; double y = (double)2; return x / y"));
+        assertEquals(1D, exec("def x = (long)2; double y = (double)2; return x / y"));
+        assertEquals(1D, exec("def x = (float)2; double y = (double)2; return x / y"));
+        assertEquals(1D, exec("def x = (double)2; double y = (double)2; return x / y"));
+
+        assertEquals(1, exec("def x = (byte)2; byte y = (byte)2; return x / y"));
+        assertEquals(1, exec("def x = (short)2; short y = (short)2; return x / y"));
+        assertEquals(1, exec("def x = (char)2; char y = (char)2; return x / y"));
+        assertEquals(1, exec("def x = (int)2; int y = (int)2; return x / y"));
+        assertEquals(1L, exec("def x = (long)2; long y = (long)2; return x / y"));
+        assertEquals(1F, exec("def x = (float)2; float y = (float)2; return x / y"));
+        assertEquals(1D, exec("def x = (double)2; double y = (double)2; return x / y"));
     }
 
     public void testRem() {
@@ -257,6 +521,138 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(0F, exec("def x = (float)2; def y = (float)2; return x % y"));
         assertEquals(0D, exec("def x = (double)2; def y = (double)2; return x % y"));
     }
+    
+    public void testRemTypedLHS() {
+        assertEquals(0, exec("byte x = (byte)2; def y = (byte)2; return x % y"));
+        assertEquals(0, exec("short x = (short)2; def y = (byte)2; return x % y"));
+        assertEquals(0, exec("char x = (char)2; def y = (byte)2; return x % y"));
+        assertEquals(0, exec("int x = (int)2; def y = (byte)2; return x % y"));
+        assertEquals(0L, exec("long x = (long)2; def y = (byte)2; return x % y"));
+        assertEquals(0F, exec("float x = (float)2; def y = (byte)2; return x % y"));
+        assertEquals(0D, exec("double x = (double)2; def y = (byte)2; return x % y"));
+
+        assertEquals(0, exec("byte x = (byte)2; def y = (short)2; return x % y"));
+        assertEquals(0, exec("short x = (short)2; def y = (short)2; return x % y"));
+        assertEquals(0, exec("char x = (char)2; def y = (short)2; return x % y"));
+        assertEquals(0, exec("int x = (int)2; def y = (short)2; return x % y"));
+        assertEquals(0L, exec("long x = (long)2; def y = (short)2; return x % y"));
+        assertEquals(0F, exec("float x = (float)2; def y = (short)2; return x % y"));
+        assertEquals(0D, exec("double x = (double)2; def y = (short)2; return x % y"));
+
+        assertEquals(0, exec("byte x = (byte)2; def y = (char)2; return x % y"));
+        assertEquals(0, exec("short x = (short)2; def y = (char)2; return x % y"));
+        assertEquals(0, exec("char x = (char)2; def y = (char)2; return x % y"));
+        assertEquals(0, exec("int x = (int)2; def y = (char)2; return x % y"));
+        assertEquals(0L, exec("long x = (long)2; def y = (char)2; return x % y"));
+        assertEquals(0F, exec("float x = (float)2; def y = (char)2; return x % y"));
+        assertEquals(0D, exec("double x = (double)2; def y = (char)2; return x % y"));
+
+        assertEquals(0, exec("byte x = (byte)2; def y = (int)2; return x % y"));
+        assertEquals(0, exec("short x = (short)2; def y = (int)2; return x % y"));
+        assertEquals(0, exec("char x = (char)2; def y = (int)2; return x % y"));
+        assertEquals(0, exec("int x = (int)2; def y = (int)2; return x % y"));
+        assertEquals(0L, exec("long x = (long)2; def y = (int)2; return x % y"));
+        assertEquals(0F, exec("float x = (float)2; def y = (int)2; return x % y"));
+        assertEquals(0D, exec("double x = (double)2; def y = (int)2; return x % y"));
+
+        assertEquals(0L, exec("byte x = (byte)2; def y = (long)2; return x % y"));
+        assertEquals(0L, exec("short x = (short)2; def y = (long)2; return x % y"));
+        assertEquals(0L, exec("char x = (char)2; def y = (long)2; return x % y"));
+        assertEquals(0L, exec("int x = (int)2; def y = (long)2; return x % y"));
+        assertEquals(0L, exec("long x = (long)2; def y = (long)2; return x % y"));
+        assertEquals(0F, exec("float x = (float)2; def y = (long)2; return x % y"));
+        assertEquals(0D, exec("double x = (double)2; def y = (long)2; return x % y"));
+
+        assertEquals(0F, exec("byte x = (byte)2; def y = (float)2; return x % y"));
+        assertEquals(0F, exec("short x = (short)2; def y = (float)2; return x % y"));
+        assertEquals(0F, exec("char x = (char)2; def y = (float)2; return x % y"));
+        assertEquals(0F, exec("int x = (int)2; def y = (float)2; return x % y"));
+        assertEquals(0F, exec("long x = (long)2; def y = (float)2; return x % y"));
+        assertEquals(0F, exec("float x = (float)2; def y = (float)2; return x % y"));
+        assertEquals(0D, exec("double x = (double)2; def y = (float)2; return x % y"));
+
+        assertEquals(0D, exec("byte x = (byte)2; def y = (double)2; return x % y"));
+        assertEquals(0D, exec("short x = (short)2; def y = (double)2; return x % y"));
+        assertEquals(0D, exec("char x = (char)2; def y = (double)2; return x % y"));
+        assertEquals(0D, exec("int x = (int)2; def y = (double)2; return x % y"));
+        assertEquals(0D, exec("long x = (long)2; def y = (double)2; return x % y"));
+        assertEquals(0D, exec("float x = (float)2; def y = (double)2; return x % y"));
+        assertEquals(0D, exec("double x = (double)2; def y = (double)2; return x % y"));
+
+        assertEquals(0, exec("byte x = (byte)2; def y = (byte)2; return x % y"));
+        assertEquals(0, exec("short x = (short)2; def y = (short)2; return x % y"));
+        assertEquals(0, exec("char x = (char)2; def y = (char)2; return x % y"));
+        assertEquals(0, exec("int x = (int)2; def y = (int)2; return x % y"));
+        assertEquals(0L, exec("long x = (long)2; def y = (long)2; return x % y"));
+        assertEquals(0F, exec("float x = (float)2; def y = (float)2; return x % y"));
+        assertEquals(0D, exec("double x = (double)2; def y = (double)2; return x % y"));
+    }
+
+    public void testRemTypedRHS() {
+        assertEquals(0, exec("def x = (byte)2; byte y = (byte)2; return x % y"));
+        assertEquals(0, exec("def x = (short)2; byte y = (byte)2; return x % y"));
+        assertEquals(0, exec("def x = (char)2; byte y = (byte)2; return x % y"));
+        assertEquals(0, exec("def x = (int)2; byte y = (byte)2; return x % y"));
+        assertEquals(0L, exec("def x = (long)2; byte y = (byte)2; return x % y"));
+        assertEquals(0F, exec("def x = (float)2; byte y = (byte)2; return x % y"));
+        assertEquals(0D, exec("def x = (double)2; byte y = (byte)2; return x % y"));
+
+        assertEquals(0, exec("def x = (byte)2; short y = (short)2; return x % y"));
+        assertEquals(0, exec("def x = (short)2; short y = (short)2; return x % y"));
+        assertEquals(0, exec("def x = (char)2; short y = (short)2; return x % y"));
+        assertEquals(0, exec("def x = (int)2; short y = (short)2; return x % y"));
+        assertEquals(0L, exec("def x = (long)2; short y = (short)2; return x % y"));
+        assertEquals(0F, exec("def x = (float)2; short y = (short)2; return x % y"));
+        assertEquals(0D, exec("def x = (double)2; short y = (short)2; return x % y"));
+
+        assertEquals(0, exec("def x = (byte)2; char y = (char)2; return x % y"));
+        assertEquals(0, exec("def x = (short)2; char y = (char)2; return x % y"));
+        assertEquals(0, exec("def x = (char)2; char y = (char)2; return x % y"));
+        assertEquals(0, exec("def x = (int)2; char y = (char)2; return x % y"));
+        assertEquals(0L, exec("def x = (long)2; char y = (char)2; return x % y"));
+        assertEquals(0F, exec("def x = (float)2; char y = (char)2; return x % y"));
+        assertEquals(0D, exec("def x = (double)2; char y = (char)2; return x % y"));
+
+        assertEquals(0, exec("def x = (byte)2; int y = (int)2; return x % y"));
+        assertEquals(0, exec("def x = (short)2; int y = (int)2; return x % y"));
+        assertEquals(0, exec("def x = (char)2; int y = (int)2; return x % y"));
+        assertEquals(0, exec("def x = (int)2; int y = (int)2; return x % y"));
+        assertEquals(0L, exec("def x = (long)2; int y = (int)2; return x % y"));
+        assertEquals(0F, exec("def x = (float)2; int y = (int)2; return x % y"));
+        assertEquals(0D, exec("def x = (double)2; int y = (int)2; return x % y"));
+
+        assertEquals(0L, exec("def x = (byte)2; long y = (long)2; return x % y"));
+        assertEquals(0L, exec("def x = (short)2; long y = (long)2; return x % y"));
+        assertEquals(0L, exec("def x = (char)2; long y = (long)2; return x % y"));
+        assertEquals(0L, exec("def x = (int)2; long y = (long)2; return x % y"));
+        assertEquals(0L, exec("def x = (long)2; long y = (long)2; return x % y"));
+        assertEquals(0F, exec("def x = (float)2; long y = (long)2; return x % y"));
+        assertEquals(0D, exec("def x = (double)2; long y = (long)2; return x % y"));
+
+        assertEquals(0F, exec("def x = (byte)2; float y = (float)2; return x % y"));
+        assertEquals(0F, exec("def x = (short)2; float y = (float)2; return x % y"));
+        assertEquals(0F, exec("def x = (char)2; float y = (float)2; return x % y"));
+        assertEquals(0F, exec("def x = (int)2; float y = (float)2; return x % y"));
+        assertEquals(0F, exec("def x = (long)2; float y = (float)2; return x % y"));
+        assertEquals(0F, exec("def x = (float)2; float y = (float)2; return x % y"));
+        assertEquals(0D, exec("def x = (double)2; float y = (float)2; return x % y"));
+
+        assertEquals(0D, exec("def x = (byte)2; double y = (double)2; return x % y"));
+        assertEquals(0D, exec("def x = (short)2; double y = (double)2; return x % y"));
+        assertEquals(0D, exec("def x = (char)2; double y = (double)2; return x % y"));
+        assertEquals(0D, exec("def x = (int)2; double y = (double)2; return x % y"));
+        assertEquals(0D, exec("def x = (long)2; double y = (double)2; return x % y"));
+        assertEquals(0D, exec("def x = (float)2; double y = (double)2; return x % y"));
+        assertEquals(0D, exec("def x = (double)2; double y = (double)2; return x % y"));
+
+        assertEquals(0, exec("def x = (byte)2; byte y = (byte)2; return x % y"));
+        assertEquals(0, exec("def x = (short)2; short y = (short)2; return x % y"));
+        assertEquals(0, exec("def x = (char)2; char y = (char)2; return x % y"));
+        assertEquals(0, exec("def x = (int)2; int y = (int)2; return x % y"));
+        assertEquals(0L, exec("def x = (long)2; long y = (long)2; return x % y"));
+        assertEquals(0F, exec("def x = (float)2; float y = (float)2; return x % y"));
+        assertEquals(0D, exec("def x = (double)2; double y = (double)2; return x % y"));
+    }
 
     public void testAdd() {
         assertEquals(2, exec("def x = (byte)1; def y = (byte)1; return x + y"));
@@ -314,14 +710,122 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(2D, exec("def x = (long)1; def y = (double)1; return x + y"));
         assertEquals(2D, exec("def x = (float)1; def y = (double)1; return x + y"));
         assertEquals(2D, exec("def x = (double)1; def y = (double)1; return x + y"));
+    }
+    
+    public void testAddTypedLHS() {
+        assertEquals(2, exec("byte x = (byte)1; def y = (byte)1; return x + y"));
+        assertEquals(2, exec("short x = (short)1; def y = (byte)1; return x + y"));
+        assertEquals(2, exec("char x = (char)1; def y = (byte)1; return x + y"));
+        assertEquals(2, exec("int x = (int)1; def y = (byte)1; return x + y"));
+        assertEquals(2L, exec("long x = (long)1; def y = (byte)1; return x + y"));
+        assertEquals(2F, exec("float x = (float)1; def y = (byte)1; return x + y"));
+        assertEquals(2D, exec("double x = (double)1; def y = (byte)1; return x + y"));
 
-        assertEquals(2, exec("def x = (byte)1; def y = (byte)1; return x + y"));
-        assertEquals(2, exec("def x = (short)1; def y = (short)1; return x + y"));
-        assertEquals(2, exec("def x = (char)1; def y = (char)1; return x + y"));
-        assertEquals(2, exec("def x = (int)1; def y = (int)1; return x + y"));
-        assertEquals(2L, exec("def x = (long)1; def y = (long)1; return x + y"));
-        assertEquals(2F, exec("def x = (float)1; def y = (float)1; return x + y"));
-        assertEquals(2D, exec("def x = (double)1; def y = (double)1; return x + y"));
+        assertEquals(2, exec("byte x = (byte)1; def y = (short)1; return x + y"));
+        assertEquals(2, exec("short x = (short)1; def y = (short)1; return x + y"));
+        assertEquals(2, exec("char x = (char)1; def y = (short)1; return x + y"));
+        assertEquals(2, exec("int x = (int)1; def y = (short)1; return x + y"));
+        assertEquals(2L, exec("long x = (long)1; def y = (short)1; return x + y"));
+        assertEquals(2F, exec("float x = (float)1; def y = (short)1; return x + y"));
+        assertEquals(2D, exec("double x = (double)1; def y = (short)1; return x + y"));
+
+        assertEquals(2, exec("byte x = (byte)1; def y = (char)1; return x + y"));
+        assertEquals(2, exec("short x = (short)1; def y = (char)1; return x + y"));
+        assertEquals(2, exec("char x = (char)1; def y = (char)1; return x + y"));
+        assertEquals(2, exec("int x = (int)1; def y = (char)1; return x + y"));
+        assertEquals(2L, exec("long x = (long)1; def y = (char)1; return x + y"));
+        assertEquals(2F, exec("float x = (float)1; def y = (char)1; return x + y"));
+        assertEquals(2D, exec("double x = (double)1; def y = (char)1; return x + y"));
+
+        assertEquals(2, exec("byte x = (byte)1; def y = (int)1; return x + y"));
+        assertEquals(2, exec("short x = (short)1; def y = (int)1; return x + y"));
+        assertEquals(2, exec("char x = (char)1; def y = (int)1; return x + y"));
+        assertEquals(2, exec("int x = (int)1; def y = (int)1; return x + y"));
+        assertEquals(2L, exec("long x = (long)1; def y = (int)1; return x + y"));
+        assertEquals(2F, exec("float x = (float)1; def y = (int)1; return x + y"));
+        assertEquals(2D, exec("double x = (double)1; def y = (int)1; return x + y"));
+
+        assertEquals(2L, exec("byte x = (byte)1; def y = (long)1; return x + y"));
+        assertEquals(2L, exec("short x = (short)1; def y = (long)1; return x + y"));
+        assertEquals(2L, exec("char x = (char)1; def y = (long)1; return x + y"));
+        assertEquals(2L, exec("int x = (int)1; def y = (long)1; return x + y"));
+        assertEquals(2L, exec("long x = (long)1; def y = (long)1; return x + y"));
+        assertEquals(2F, exec("float x = (float)1; def y = (long)1; return x + y"));
+        assertEquals(2D, exec("double x = (double)1; def y = (long)1; return x + y"));
+
+        assertEquals(2F, exec("byte x = (byte)1; def y = (float)1; return x + y"));
+        assertEquals(2F, exec("short x = (short)1; def y = (float)1; return x + y"));
+        assertEquals(2F, exec("char x = (char)1; def y = (float)1; return x + y"));
+        assertEquals(2F, exec("int x = (int)1; def y = (float)1; return x + y"));
+        assertEquals(2F, exec("long x = (long)1; def y = (float)1; return x + y"));
+        assertEquals(2F, exec("float x = (float)1; def y = (float)1; return x + y"));
+        assertEquals(2D, exec("double x = (double)1; def y = (float)1; return x + y"));
+
+        assertEquals(2D, exec("byte x = (byte)1; def y = (double)1; return x + y"));
+        assertEquals(2D, exec("short x = (short)1; def y = (double)1; return x + y"));
+        assertEquals(2D, exec("char x = (char)1; def y = (double)1; return x + y"));
+        assertEquals(2D, exec("int x = (int)1; def y = (double)1; return x + y"));
+        assertEquals(2D, exec("long x = (long)1; def y = (double)1; return x + y"));
+        assertEquals(2D, exec("float x = (float)1; def y = (double)1; return x + y"));
+        assertEquals(2D, exec("double x = (double)1; def y = (double)1; return x + y"));
+    }
+    
+    public void testAddTypedRHS() {
+        assertEquals(2, exec("def x = (byte)1; byte y = (byte)1; return x + y"));
+        assertEquals(2, exec("def x = (short)1; byte y = (byte)1; return x + y"));
+        assertEquals(2, exec("def x = (char)1; byte y = (byte)1; return x + y"));
+        assertEquals(2, exec("def x = (int)1; byte y = (byte)1; return x + y"));
+        assertEquals(2L, exec("def x = (long)1; byte y = (byte)1; return x + y"));
+        assertEquals(2F, exec("def x = (float)1; byte y = (byte)1; return x + y"));
+        assertEquals(2D, exec("def x = (double)1; byte y = (byte)1; return x + y"));
+
+        assertEquals(2, exec("def x = (byte)1; short y = (short)1; return x + y"));
+        assertEquals(2, exec("def x = (short)1; short y = (short)1; return x + y"));
+        assertEquals(2, exec("def x = (char)1; short y = (short)1; return x + y"));
+        assertEquals(2, exec("def x = (int)1; short y = (short)1; return x + y"));
+        assertEquals(2L, exec("def x = (long)1; short y = (short)1; return x + y"));
+        assertEquals(2F, exec("def x = (float)1; short y = (short)1; return x + y"));
+        assertEquals(2D, exec("def x = (double)1; short y = (short)1; return x + y"));
+
+        assertEquals(2, exec("def x = (byte)1; char y = (char)1; return x + y"));
+        assertEquals(2, exec("def x = (short)1; char y = (char)1; return x + y"));
+        assertEquals(2, exec("def x = (char)1; char y = (char)1; return x + y"));
+        assertEquals(2, exec("def x = (int)1; char y = (char)1; return x + y"));
+        assertEquals(2L, exec("def x = (long)1; char y = (char)1; return x + y"));
+        assertEquals(2F, exec("def x = (float)1; char y = (char)1; return x + y"));
+        assertEquals(2D, exec("def x = (double)1; char y = (char)1; return x + y"));
+
+        assertEquals(2, exec("def x = (byte)1; int y = (int)1; return x + y"));
+        assertEquals(2, exec("def x = (short)1; int y = (int)1; return x + y"));
+        assertEquals(2, exec("def x = (char)1; int y = (int)1; return x + y"));
+        assertEquals(2, exec("def x = (int)1; int y = (int)1; return x + y"));
+        assertEquals(2L, exec("def x = (long)1; int y = (int)1; return x + y"));
+        assertEquals(2F, exec("def x = (float)1; int y = (int)1; return x + y"));
+        assertEquals(2D, exec("def x = (double)1; int y = (int)1; return x + y"));
+
+        assertEquals(2L, exec("def x = (byte)1; long y = (long)1; return x + y"));
+        assertEquals(2L, exec("def x = (short)1; long y = (long)1; return x + y"));
+        assertEquals(2L, exec("def x = (char)1; long y = (long)1; return x + y"));
+        assertEquals(2L, exec("def x = (int)1; long y = (long)1; return x + y"));
+        assertEquals(2L, exec("def x = (long)1; long y = (long)1; return x + y"));
+        assertEquals(2F, exec("def x = (float)1; long y = (long)1; return x + y"));
+        assertEquals(2D, exec("def x = (double)1; long y = (long)1; return x + y"));
+
+        assertEquals(2F, exec("def x = (byte)1; float y = (float)1; return x + y"));
+        assertEquals(2F, exec("def x = (short)1; float y = (float)1; return x + y"));
+        assertEquals(2F, exec("def x = (char)1; float y = (float)1; return x + y"));
+        assertEquals(2F, exec("def x = (int)1; float y = (float)1; return x + y"));
+        assertEquals(2F, exec("def x = (long)1; float y = (float)1; return x + y"));
+        assertEquals(2F, exec("def x = (float)1; float y = (float)1; return x + y"));
+        assertEquals(2D, exec("def x = (double)1; float y = (float)1; return x + y"));
+
+        assertEquals(2D, exec("def x = (byte)1; double y = (double)1; return x + y"));
+        assertEquals(2D, exec("def x = (short)1; double y = (double)1; return x + y"));
+        assertEquals(2D, exec("def x = (char)1; double y = (double)1; return x + y"));
+        assertEquals(2D, exec("def x = (int)1; double y = (double)1; return x + y"));
+        assertEquals(2D, exec("def x = (long)1; double y = (double)1; return x + y"));
+        assertEquals(2D, exec("def x = (float)1; double y = (double)1; return x + y"));
+        assertEquals(2D, exec("def x = (double)1; double y = (double)1; return x + y"));
     }
     
     public void testAddConcat() {
@@ -403,14 +907,122 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(0D, exec("def x = (long)1; def y = (double)1; return x - y"));
         assertEquals(0D, exec("def x = (float)1; def y = (double)1; return x - y"));
         assertEquals(0D, exec("def x = (double)1; def y = (double)1; return x - y"));
+    }
+    
+    public void testSubTypedLHS() {
+        assertEquals(0, exec("byte x = (byte)1; def y = (byte)1; return x - y"));
+        assertEquals(0, exec("short x = (short)1; def y = (byte)1; return x - y"));
+        assertEquals(0, exec("char x = (char)1; def y = (byte)1; return x - y"));
+        assertEquals(0, exec("int x = (int)1; def y = (byte)1; return x - y"));
+        assertEquals(0L, exec("long x = (long)1; def y = (byte)1; return x - y"));
+        assertEquals(0F, exec("float x = (float)1; def y = (byte)1; return x - y"));
+        assertEquals(0D, exec("double x = (double)1; def y = (byte)1; return x - y"));
 
-        assertEquals(0, exec("def x = (byte)1; def y = (byte)1; return x - y"));
-        assertEquals(0, exec("def x = (short)1; def y = (short)1; return x - y"));
-        assertEquals(0, exec("def x = (char)1; def y = (char)1; return x - y"));
-        assertEquals(0, exec("def x = (int)1; def y = (int)1; return x - y"));
-        assertEquals(0L, exec("def x = (long)1; def y = (long)1; return x - y"));
-        assertEquals(0F, exec("def x = (float)1; def y = (float)1; return x - y"));
-        assertEquals(0D, exec("def x = (double)1; def y = (double)1; return x - y"));
+        assertEquals(0, exec("byte x = (byte)1; def y = (short)1; return x - y"));
+        assertEquals(0, exec("short x = (short)1; def y = (short)1; return x - y"));
+        assertEquals(0, exec("char x = (char)1; def y = (short)1; return x - y"));
+        assertEquals(0, exec("int x = (int)1; def y = (short)1; return x - y"));
+        assertEquals(0L, exec("long x = (long)1; def y = (short)1; return x - y"));
+        assertEquals(0F, exec("float x = (float)1; def y = (short)1; return x - y"));
+        assertEquals(0D, exec("double x = (double)1; def y = (short)1; return x - y"));
+
+        assertEquals(0, exec("byte x = (byte)1; def y = (char)1; return x - y"));
+        assertEquals(0, exec("short x = (short)1; def y = (char)1; return x - y"));
+        assertEquals(0, exec("char x = (char)1; def y = (char)1; return x - y"));
+        assertEquals(0, exec("int x = (int)1; def y = (char)1; return x - y"));
+        assertEquals(0L, exec("long x = (long)1; def y = (char)1; return x - y"));
+        assertEquals(0F, exec("float x = (float)1; def y = (char)1; return x - y"));
+        assertEquals(0D, exec("double x = (double)1; def y = (char)1; return x - y"));
+
+        assertEquals(0, exec("byte x = (byte)1; def y = (int)1; return x - y"));
+        assertEquals(0, exec("short x = (short)1; def y = (int)1; return x - y"));
+        assertEquals(0, exec("char x = (char)1; def y = (int)1; return x - y"));
+        assertEquals(0, exec("int x = (int)1; def y = (int)1; return x - y"));
+        assertEquals(0L, exec("long x = (long)1; def y = (int)1; return x - y"));
+        assertEquals(0F, exec("float x = (float)1; def y = (int)1; return x - y"));
+        assertEquals(0D, exec("double x = (double)1; def y = (int)1; return x - y"));
+
+        assertEquals(0L, exec("byte x = (byte)1; def y = (long)1; return x - y"));
+        assertEquals(0L, exec("short x = (short)1; def y = (long)1; return x - y"));
+        assertEquals(0L, exec("char x = (char)1; def y = (long)1; return x - y"));
+        assertEquals(0L, exec("int x = (int)1; def y = (long)1; return x - y"));
+        assertEquals(0L, exec("long x = (long)1; def y = (long)1; return x - y"));
+        assertEquals(0F, exec("float x = (float)1; def y = (long)1; return x - y"));
+        assertEquals(0D, exec("double x = (double)1; def y = (long)1; return x - y"));
+
+        assertEquals(0F, exec("byte x = (byte)1; def y = (float)1; return x - y"));
+        assertEquals(0F, exec("short x = (short)1; def y = (float)1; return x - y"));
+        assertEquals(0F, exec("char x = (char)1; def y = (float)1; return x - y"));
+        assertEquals(0F, exec("int x = (int)1; def y = (float)1; return x - y"));
+        assertEquals(0F, exec("long x = (long)1; def y = (float)1; return x - y"));
+        assertEquals(0F, exec("float x = (float)1; def y = (float)1; return x - y"));
+        assertEquals(0D, exec("double x = (double)1; def y = (float)1; return x - y"));
+
+        assertEquals(0D, exec("byte x = (byte)1; def y = (double)1; return x - y"));
+        assertEquals(0D, exec("short x = (short)1; def y = (double)1; return x - y"));
+        assertEquals(0D, exec("char x = (char)1; def y = (double)1; return x - y"));
+        assertEquals(0D, exec("int x = (int)1; def y = (double)1; return x - y"));
+        assertEquals(0D, exec("long x = (long)1; def y = (double)1; return x - y"));
+        assertEquals(0D, exec("float x = (float)1; def y = (double)1; return x - y"));
+        assertEquals(0D, exec("double x = (double)1; def y = (double)1; return x - y"));
+    }
+    
+    public void testSubTypedRHS() {
+        assertEquals(0, exec("def x = (byte)1; byte y = (byte)1; return x - y"));
+        assertEquals(0, exec("def x = (short)1; byte y = (byte)1; return x - y"));
+        assertEquals(0, exec("def x = (char)1; byte y = (byte)1; return x - y"));
+        assertEquals(0, exec("def x = (int)1; byte y = (byte)1; return x - y"));
+        assertEquals(0L, exec("def x = (long)1; byte y = (byte)1; return x - y"));
+        assertEquals(0F, exec("def x = (float)1; byte y = (byte)1; return x - y"));
+        assertEquals(0D, exec("def x = (double)1; byte y = (byte)1; return x - y"));
+
+        assertEquals(0, exec("def x = (byte)1; short y = (short)1; return x - y"));
+        assertEquals(0, exec("def x = (short)1; short y = (short)1; return x - y"));
+        assertEquals(0, exec("def x = (char)1; short y = (short)1; return x - y"));
+        assertEquals(0, exec("def x = (int)1; short y = (short)1; return x - y"));
+        assertEquals(0L, exec("def x = (long)1; short y = (short)1; return x - y"));
+        assertEquals(0F, exec("def x = (float)1; short y = (short)1; return x - y"));
+        assertEquals(0D, exec("def x = (double)1; short y = (short)1; return x - y"));
+
+        assertEquals(0, exec("def x = (byte)1; char y = (char)1; return x - y"));
+        assertEquals(0, exec("def x = (short)1; char y = (char)1; return x - y"));
+        assertEquals(0, exec("def x = (char)1; char y = (char)1; return x - y"));
+        assertEquals(0, exec("def x = (int)1; char y = (char)1; return x - y"));
+        assertEquals(0L, exec("def x = (long)1; char y = (char)1; return x - y"));
+        assertEquals(0F, exec("def x = (float)1; char y = (char)1; return x - y"));
+        assertEquals(0D, exec("def x = (double)1; char y = (char)1; return x - y"));
+
+        assertEquals(0, exec("def x = (byte)1; int y = (int)1; return x - y"));
+        assertEquals(0, exec("def x = (short)1; int y = (int)1; return x - y"));
+        assertEquals(0, exec("def x = (char)1; int y = (int)1; return x - y"));
+        assertEquals(0, exec("def x = (int)1; int y = (int)1; return x - y"));
+        assertEquals(0L, exec("def x = (long)1; int y = (int)1; return x - y"));
+        assertEquals(0F, exec("def x = (float)1; int y = (int)1; return x - y"));
+        assertEquals(0D, exec("def x = (double)1; int y = (int)1; return x - y"));
+
+        assertEquals(0L, exec("def x = (byte)1; long y = (long)1; return x - y"));
+        assertEquals(0L, exec("def x = (short)1; long y = (long)1; return x - y"));
+        assertEquals(0L, exec("def x = (char)1; long y = (long)1; return x - y"));
+        assertEquals(0L, exec("def x = (int)1; long y = (long)1; return x - y"));
+        assertEquals(0L, exec("def x = (long)1; long y = (long)1; return x - y"));
+        assertEquals(0F, exec("def x = (float)1; long y = (long)1; return x - y"));
+        assertEquals(0D, exec("def x = (double)1; long y = (long)1; return x - y"));
+
+        assertEquals(0F, exec("def x = (byte)1; float y = (float)1; return x - y"));
+        assertEquals(0F, exec("def x = (short)1; float y = (float)1; return x - y"));
+        assertEquals(0F, exec("def x = (char)1; float y = (float)1; return x - y"));
+        assertEquals(0F, exec("def x = (int)1; float y = (float)1; return x - y"));
+        assertEquals(0F, exec("def x = (long)1; float y = (float)1; return x - y"));
+        assertEquals(0F, exec("def x = (float)1; float y = (float)1; return x - y"));
+        assertEquals(0D, exec("def x = (double)1; float y = (float)1; return x - y"));
+
+        assertEquals(0D, exec("def x = (byte)1; double y = (double)1; return x - y"));
+        assertEquals(0D, exec("def x = (short)1; double y = (double)1; return x - y"));
+        assertEquals(0D, exec("def x = (char)1; double y = (double)1; return x - y"));
+        assertEquals(0D, exec("def x = (int)1; double y = (double)1; return x - y"));
+        assertEquals(0D, exec("def x = (long)1; double y = (double)1; return x - y"));
+        assertEquals(0D, exec("def x = (float)1; double y = (double)1; return x - y"));
+        assertEquals(0D, exec("def x = (double)1; double y = (double)1; return x - y"));
     }
 
     public void testLsh() {
@@ -450,6 +1062,82 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(2, exec("def x = (int)1; def y = (int)1; return x << y"));
         assertEquals(2L, exec("def x = (long)1; def y = (long)1; return x << y"));
     }
+    
+    public void testLshTypedLHS() {
+        assertEquals(2, exec("byte x = (byte)1; def y = (byte)1; return x << y"));
+        assertEquals(2, exec("short x = (short)1; def y = (byte)1; return x << y"));
+        assertEquals(2, exec("char x = (char)1; def y = (byte)1; return x << y"));
+        assertEquals(2, exec("int x = (int)1; def y = (byte)1; return x << y"));
+        assertEquals(2L, exec("long x = (long)1; def y = (byte)1; return x << y"));
+
+        assertEquals(2, exec("byte x = (byte)1; def y = (short)1; return x << y"));
+        assertEquals(2, exec("short x = (short)1; def y = (short)1; return x << y"));
+        assertEquals(2, exec("char x = (char)1; def y = (short)1; return x << y"));
+        assertEquals(2, exec("int x = (int)1; def y = (short)1; return x << y"));
+        assertEquals(2L, exec("long x = (long)1; def y = (short)1; return x << y"));
+
+        assertEquals(2, exec("byte x = (byte)1; def y = (char)1; return x << y"));
+        assertEquals(2, exec("short x = (short)1; def y = (char)1; return x << y"));
+        assertEquals(2, exec("char x = (char)1; def y = (char)1; return x << y"));
+        assertEquals(2, exec("int x = (int)1; def y = (char)1; return x << y"));
+        assertEquals(2L, exec("long x = (long)1; def y = (char)1; return x << y"));
+
+        assertEquals(2, exec("byte x = (byte)1; def y = (int)1; return x << y"));
+        assertEquals(2, exec("short x = (short)1; def y = (int)1; return x << y"));
+        assertEquals(2, exec("char x = (char)1; def y = (int)1; return x << y"));
+        assertEquals(2, exec("int x = (int)1; def y = (int)1; return x << y"));
+        assertEquals(2L, exec("long x = (long)1; def y = (int)1; return x << y"));
+
+        assertEquals(2, exec("byte x = (byte)1; def y = (long)1; return x << y"));
+        assertEquals(2, exec("short x = (short)1; def y = (long)1; return x << y"));
+        assertEquals(2, exec("char x = (char)1; def y = (long)1; return x << y"));
+        assertEquals(2, exec("int x = (int)1; def y = (long)1; return x << y"));
+        assertEquals(2L, exec("long x = (long)1; def y = (long)1; return x << y"));
+
+        assertEquals(2, exec("byte x = (byte)1; def y = (byte)1; return x << y"));
+        assertEquals(2, exec("short x = (short)1; def y = (short)1; return x << y"));
+        assertEquals(2, exec("char x = (char)1; def y = (char)1; return x << y"));
+        assertEquals(2, exec("int x = (int)1; def y = (int)1; return x << y"));
+        assertEquals(2L, exec("long x = (long)1; def y = (long)1; return x << y"));
+    }
+    
+    public void testLshTypedRHS() {
+        assertEquals(2, exec("def x = (byte)1; byte y = (byte)1; return x << y"));
+        assertEquals(2, exec("def x = (short)1; byte y = (byte)1; return x << y"));
+        assertEquals(2, exec("def x = (char)1; byte y = (byte)1; return x << y"));
+        assertEquals(2, exec("def x = (int)1; byte y = (byte)1; return x << y"));
+        assertEquals(2L, exec("def x = (long)1; byte y = (byte)1; return x << y"));
+
+        assertEquals(2, exec("def x = (byte)1; short y = (short)1; return x << y"));
+        assertEquals(2, exec("def x = (short)1; short y = (short)1; return x << y"));
+        assertEquals(2, exec("def x = (char)1; short y = (short)1; return x << y"));
+        assertEquals(2, exec("def x = (int)1; short y = (short)1; return x << y"));
+        assertEquals(2L, exec("def x = (long)1; short y = (short)1; return x << y"));
+
+        assertEquals(2, exec("def x = (byte)1; char y = (char)1; return x << y"));
+        assertEquals(2, exec("def x = (short)1; char y = (char)1; return x << y"));
+        assertEquals(2, exec("def x = (char)1; char y = (char)1; return x << y"));
+        assertEquals(2, exec("def x = (int)1; char y = (char)1; return x << y"));
+        assertEquals(2L, exec("def x = (long)1; char y = (char)1; return x << y"));
+
+        assertEquals(2, exec("def x = (byte)1; int y = (int)1; return x << y"));
+        assertEquals(2, exec("def x = (short)1; int y = (int)1; return x << y"));
+        assertEquals(2, exec("def x = (char)1; int y = (int)1; return x << y"));
+        assertEquals(2, exec("def x = (int)1; int y = (int)1; return x << y"));
+        assertEquals(2L, exec("def x = (long)1; int y = (int)1; return x << y"));
+
+        assertEquals(2, exec("def x = (byte)1; long y = (long)1; return x << y"));
+        assertEquals(2, exec("def x = (short)1; long y = (long)1; return x << y"));
+        assertEquals(2, exec("def x = (char)1; long y = (long)1; return x << y"));
+        assertEquals(2, exec("def x = (int)1; long y = (long)1; return x << y"));
+        assertEquals(2L, exec("def x = (long)1; long y = (long)1; return x << y"));
+
+        assertEquals(2, exec("def x = (byte)1; byte y = (byte)1; return x << y"));
+        assertEquals(2, exec("def x = (short)1; short y = (short)1; return x << y"));
+        assertEquals(2, exec("def x = (char)1; char y = (char)1; return x << y"));
+        assertEquals(2, exec("def x = (int)1; int y = (int)1; return x << y"));
+        assertEquals(2L, exec("def x = (long)1; long y = (long)1; return x << y"));
+    }
 
     public void testRsh() {
         assertEquals(2, exec("def x = (byte)4; def y = (byte)1; return x >> y"));
@@ -487,6 +1175,82 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(2, exec("def x = (char)4; def y = (char)1; return x >> y"));
         assertEquals(2, exec("def x = (int)4; def y = (int)1; return x >> y"));
         assertEquals(2L, exec("def x = (long)4; def y = (long)1; return x >> y"));
+    }
+    
+    public void testRshTypeLHS() {
+        assertEquals(2, exec("byte x = (byte)4; def y = (byte)1; return x >> y"));
+        assertEquals(2, exec("short x = (short)4; def y = (byte)1; return x >> y"));
+        assertEquals(2, exec("char x = (char)4; def y = (byte)1; return x >> y"));
+        assertEquals(2, exec("int x = (int)4; def y = (byte)1; return x >> y"));
+        assertEquals(2L, exec("long x = (long)4; def y = (byte)1; return x >> y"));
+
+        assertEquals(2, exec("byte x = (byte)4; def y = (short)1; return x >> y"));
+        assertEquals(2, exec("short x = (short)4; def y = (short)1; return x >> y"));
+        assertEquals(2, exec("char x = (char)4; def y = (short)1; return x >> y"));
+        assertEquals(2, exec("int x = (int)4; def y = (short)1; return x >> y"));
+        assertEquals(2L, exec("long x = (long)4; def y = (short)1; return x >> y"));
+
+        assertEquals(2, exec("byte x = (byte)4; def y = (char)1; return x >> y"));
+        assertEquals(2, exec("short x = (short)4; def y = (char)1; return x >> y"));
+        assertEquals(2, exec("char x = (char)4; def y = (char)1; return x >> y"));
+        assertEquals(2, exec("int x = (int)4; def y = (char)1; return x >> y"));
+        assertEquals(2L, exec("long x = (long)4; def y = (char)1; return x >> y"));
+
+        assertEquals(2, exec("byte x = (byte)4; def y = (int)1; return x >> y"));
+        assertEquals(2, exec("short x = (short)4; def y = (int)1; return x >> y"));
+        assertEquals(2, exec("char x = (char)4; def y = (int)1; return x >> y"));
+        assertEquals(2, exec("int x = (int)4; def y = (int)1; return x >> y"));
+        assertEquals(2L, exec("long x = (long)4; def y = (int)1; return x >> y"));
+
+        assertEquals(2, exec("byte x = (byte)4; def y = (long)1; return x >> y"));
+        assertEquals(2, exec("short x = (short)4; def y = (long)1; return x >> y"));
+        assertEquals(2, exec("char x = (char)4; def y = (long)1; return x >> y"));
+        assertEquals(2, exec("int x = (int)4; def y = (long)1; return x >> y"));
+        assertEquals(2L, exec("long x = (long)4; def y = (long)1; return x >> y"));
+
+        assertEquals(2, exec("byte x = (byte)4; def y = (byte)1; return x >> y"));
+        assertEquals(2, exec("short x = (short)4; def y = (short)1; return x >> y"));
+        assertEquals(2, exec("char x = (char)4; def y = (char)1; return x >> y"));
+        assertEquals(2, exec("int x = (int)4; def y = (int)1; return x >> y"));
+        assertEquals(2L, exec("long x = (long)4; def y = (long)1; return x >> y"));
+    }
+    
+    public void testRshTypedLHS() {
+        assertEquals(2, exec("def x = (byte)4; byte y = (byte)1; return x >> y"));
+        assertEquals(2, exec("def x = (short)4; byte y = (byte)1; return x >> y"));
+        assertEquals(2, exec("def x = (char)4; byte y = (byte)1; return x >> y"));
+        assertEquals(2, exec("def x = (int)4; byte y = (byte)1; return x >> y"));
+        assertEquals(2L, exec("def x = (long)4; byte y = (byte)1; return x >> y"));
+
+        assertEquals(2, exec("def x = (byte)4; short y = (short)1; return x >> y"));
+        assertEquals(2, exec("def x = (short)4; short y = (short)1; return x >> y"));
+        assertEquals(2, exec("def x = (char)4; short y = (short)1; return x >> y"));
+        assertEquals(2, exec("def x = (int)4; short y = (short)1; return x >> y"));
+        assertEquals(2L, exec("def x = (long)4; short y = (short)1; return x >> y"));
+
+        assertEquals(2, exec("def x = (byte)4; char y = (char)1; return x >> y"));
+        assertEquals(2, exec("def x = (short)4; char y = (char)1; return x >> y"));
+        assertEquals(2, exec("def x = (char)4; char y = (char)1; return x >> y"));
+        assertEquals(2, exec("def x = (int)4; char y = (char)1; return x >> y"));
+        assertEquals(2L, exec("def x = (long)4; char y = (char)1; return x >> y"));
+
+        assertEquals(2, exec("def x = (byte)4; int y = (int)1; return x >> y"));
+        assertEquals(2, exec("def x = (short)4; int y = (int)1; return x >> y"));
+        assertEquals(2, exec("def x = (char)4; int y = (int)1; return x >> y"));
+        assertEquals(2, exec("def x = (int)4; int y = (int)1; return x >> y"));
+        assertEquals(2L, exec("def x = (long)4; int y = (int)1; return x >> y"));
+
+        assertEquals(2, exec("def x = (byte)4; long y = (long)1; return x >> y"));
+        assertEquals(2, exec("def x = (short)4; long y = (long)1; return x >> y"));
+        assertEquals(2, exec("def x = (char)4; long y = (long)1; return x >> y"));
+        assertEquals(2, exec("def x = (int)4; long y = (long)1; return x >> y"));
+        assertEquals(2L, exec("def x = (long)4; long y = (long)1; return x >> y"));
+
+        assertEquals(2, exec("def x = (byte)4; byte y = (byte)1; return x >> y"));
+        assertEquals(2, exec("def x = (short)4; short y = (short)1; return x >> y"));
+        assertEquals(2, exec("def x = (char)4; char y = (char)1; return x >> y"));
+        assertEquals(2, exec("def x = (int)4; int y = (int)1; return x >> y"));
+        assertEquals(2L, exec("def x = (long)4; long y = (long)1; return x >> y"));
     }
 
     public void testUsh() {
@@ -527,6 +1291,82 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(2L, exec("def x = (long)4; def y = (long)1; return x >>> y"));
     }
     
+    public void testUshTypedLHS() {
+        assertEquals(2, exec("byte x = (byte)4; def y = (byte)1; return x >>> y"));
+        assertEquals(2, exec("short x = (short)4; def y = (byte)1; return x >>> y"));
+        assertEquals(2, exec("char x = (char)4; def y = (byte)1; return x >>> y"));
+        assertEquals(2, exec("int x = (int)4; def y = (byte)1; return x >>> y"));
+        assertEquals(2L, exec("long x = (long)4; def y = (byte)1; return x >>> y"));
+
+        assertEquals(2, exec("byte x = (byte)4; def y = (short)1; return x >>> y"));
+        assertEquals(2, exec("short x = (short)4; def y = (short)1; return x >>> y"));
+        assertEquals(2, exec("char x = (char)4; def y = (short)1; return x >>> y"));
+        assertEquals(2, exec("int x = (int)4; def y = (short)1; return x >>> y"));
+        assertEquals(2L, exec("long x = (long)4; def y = (short)1; return x >>> y"));
+
+        assertEquals(2, exec("byte x = (byte)4; def y = (char)1; return x >>> y"));
+        assertEquals(2, exec("short x = (short)4; def y = (char)1; return x >>> y"));
+        assertEquals(2, exec("char x = (char)4; def y = (char)1; return x >>> y"));
+        assertEquals(2, exec("int x = (int)4; def y = (char)1; return x >>> y"));
+        assertEquals(2L, exec("long x = (long)4; def y = (char)1; return x >>> y"));
+
+        assertEquals(2, exec("byte x = (byte)4; def y = (int)1; return x >>> y"));
+        assertEquals(2, exec("short x = (short)4; def y = (int)1; return x >>> y"));
+        assertEquals(2, exec("char x = (char)4; def y = (int)1; return x >>> y"));
+        assertEquals(2, exec("int x = (int)4; def y = (int)1; return x >>> y"));
+        assertEquals(2L, exec("long x = (long)4; def y = (int)1; return x >>> y"));
+
+        assertEquals(2, exec("byte x = (byte)4; def y = (long)1; return x >>> y"));
+        assertEquals(2, exec("short x = (short)4; def y = (long)1; return x >>> y"));
+        assertEquals(2, exec("char x = (char)4; def y = (long)1; return x >>> y"));
+        assertEquals(2, exec("int x = (int)4; def y = (long)1; return x >>> y"));
+        assertEquals(2L, exec("long x = (long)4; def y = (long)1; return x >>> y"));
+
+        assertEquals(2, exec("byte x = (byte)4; def y = (byte)1; return x >>> y"));
+        assertEquals(2, exec("short x = (short)4; def y = (short)1; return x >>> y"));
+        assertEquals(2, exec("char x = (char)4; def y = (char)1; return x >>> y"));
+        assertEquals(2, exec("int x = (int)4; def y = (int)1; return x >>> y"));
+        assertEquals(2L, exec("long x = (long)4; def y = (long)1; return x >>> y"));
+    }
+    
+    public void testUshTypedRHS() {
+        assertEquals(2, exec("def x = (byte)4; byte y = (byte)1; return x >>> y"));
+        assertEquals(2, exec("def x = (short)4; byte y = (byte)1; return x >>> y"));
+        assertEquals(2, exec("def x = (char)4; byte y = (byte)1; return x >>> y"));
+        assertEquals(2, exec("def x = (int)4; byte y = (byte)1; return x >>> y"));
+        assertEquals(2L, exec("def x = (long)4; byte y = (byte)1; return x >>> y"));
+
+        assertEquals(2, exec("def x = (byte)4; short y = (short)1; return x >>> y"));
+        assertEquals(2, exec("def x = (short)4; short y = (short)1; return x >>> y"));
+        assertEquals(2, exec("def x = (char)4; short y = (short)1; return x >>> y"));
+        assertEquals(2, exec("def x = (int)4; short y = (short)1; return x >>> y"));
+        assertEquals(2L, exec("def x = (long)4; short y = (short)1; return x >>> y"));
+
+        assertEquals(2, exec("def x = (byte)4; char y = (char)1; return x >>> y"));
+        assertEquals(2, exec("def x = (short)4; char y = (char)1; return x >>> y"));
+        assertEquals(2, exec("def x = (char)4; char y = (char)1; return x >>> y"));
+        assertEquals(2, exec("def x = (int)4; char y = (char)1; return x >>> y"));
+        assertEquals(2L, exec("def x = (long)4; char y = (char)1; return x >>> y"));
+
+        assertEquals(2, exec("def x = (byte)4; int y = (int)1; return x >>> y"));
+        assertEquals(2, exec("def x = (short)4; int y = (int)1; return x >>> y"));
+        assertEquals(2, exec("def x = (char)4; int y = (int)1; return x >>> y"));
+        assertEquals(2, exec("def x = (int)4; int y = (int)1; return x >>> y"));
+        assertEquals(2L, exec("def x = (long)4; int y = (int)1; return x >>> y"));
+
+        assertEquals(2, exec("def x = (byte)4; long y = (long)1; return x >>> y"));
+        assertEquals(2, exec("def x = (short)4; long y = (long)1; return x >>> y"));
+        assertEquals(2, exec("def x = (char)4; long y = (long)1; return x >>> y"));
+        assertEquals(2, exec("def x = (int)4; long y = (long)1; return x >>> y"));
+        assertEquals(2L, exec("def x = (long)4; long y = (long)1; return x >>> y"));
+
+        assertEquals(2, exec("def x = (byte)4; byte y = (byte)1; return x >>> y"));
+        assertEquals(2, exec("def x = (short)4; short y = (short)1; return x >>> y"));
+        assertEquals(2, exec("def x = (char)4; char y = (char)1; return x >>> y"));
+        assertEquals(2, exec("def x = (int)4; int y = (int)1; return x >>> y"));
+        assertEquals(2L, exec("def x = (long)4; long y = (long)1; return x >>> y"));
+    }
+    
     public void testBogusShifts() {
         expectScriptThrows(ClassCastException.class, ()-> {
             exec("def x = 1L; def y = 2F; return x << y;");
@@ -565,6 +1405,88 @@ public class DefOperationTests extends ScriptTestCase {
         });
         expectScriptThrows(ClassCastException.class, ()-> {
             exec("def x = 1D; def y = 2L; return x >>> y;");
+        });
+    }
+    
+    public void testBogusShiftsTypedLHS() {
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("long x = 1L; def y = 2F; return x << y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("int x = 1; def y = 2D; return x << y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("float x = 1F; def y = 2; return x << y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("double x = 1D; def y = 2L; return x << y;");
+        });
+        
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("long x = 1L; def y = 2F; return x >> y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("int x = 1; def y = 2D; return x >> y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("float x = 1F; def y = 2; return x >> y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("double x = 1D; def y = 2L; return x >> y;");
+        });
+        
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("long x = 1L; def y = 2F; return x >>> y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("int x = 1; def y = 2D; return x >>> y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("float x = 1F; def y = 2; return x >>> y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("double x = 1D; def y = 2L; return x >>> y;");
+        });
+    }
+    
+    public void testBogusShiftsTypedRHS() {
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("def x = 1L; float y = 2F; return x << y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("def x = 1; double y = 2D; return x << y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("def x = 1F; int y = 2; return x << y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("def x = 1D; long y = 2L; return x << y;");
+        });
+        
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("def x = 1L; float y = 2F; return x >> y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("def x = 1; double y = 2D; return x >> y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("def x = 1F; int y = 2; return x >> y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("def x = 1D; long y = 2L; return x >> y;");
+        });
+        
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("def x = 1L; float y = 2F; return x >>> y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("def x = 1; double y = 2D; return x >>> y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("def x = 1F; int y = 2; return x >>> y;");
+        });
+        expectScriptThrows(ClassCastException.class, ()-> {
+            exec("def x = 1D; long y = 2L; return x >>> y;");
         });
     }
 
@@ -616,6 +1538,104 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(false, exec("def x = false; def y = true; return x & y"));
         assertEquals(false, exec("def x = false; def y = false; return x & y"));
     }
+    
+    public void testAndTypedLHS() {
+        expectScriptThrows(ClassCastException.class, () -> {
+            exec("float x = (float)4; def y = (byte)1; return x & y");
+        });
+        expectScriptThrows(ClassCastException.class, () -> {
+            exec("double x = (double)4; def y = (byte)1; return x & y");
+        });
+        assertEquals(0, exec("byte x = (byte)4; def y = (byte)1; return x & y"));
+        assertEquals(0, exec("short x = (short)4; def y = (byte)1; return x & y"));
+        assertEquals(0, exec("char x = (char)4; def y = (byte)1; return x & y"));
+        assertEquals(0, exec("int x = (int)4; def y = (byte)1; return x & y"));
+        assertEquals(0L, exec("long x = (long)4; def y = (byte)1; return x & y"));
+
+        assertEquals(0, exec("byte x = (byte)4; def y = (short)1; return x & y"));
+        assertEquals(0, exec("short x = (short)4; def y = (short)1; return x & y"));
+        assertEquals(0, exec("char x = (char)4; def y = (short)1; return x & y"));
+        assertEquals(0, exec("int x = (int)4; def y = (short)1; return x & y"));
+        assertEquals(0L, exec("long x = (long)4; def y = (short)1; return x & y"));
+
+        assertEquals(0, exec("byte x = (byte)4; def y = (char)1; return x & y"));
+        assertEquals(0, exec("short x = (short)4; def y = (char)1; return x & y"));
+        assertEquals(0, exec("char x = (char)4; def y = (char)1; return x & y"));
+        assertEquals(0, exec("int x = (int)4; def y = (char)1; return x & y"));
+        assertEquals(0L, exec("long x = (long)4; def y = (char)1; return x & y"));
+
+        assertEquals(0, exec("byte x = (byte)4; def y = (int)1; return x & y"));
+        assertEquals(0, exec("short x = (short)4; def y = (int)1; return x & y"));
+        assertEquals(0, exec("char x = (char)4; def y = (int)1; return x & y"));
+        assertEquals(0, exec("int x = (int)4; def y = (int)1; return x & y"));
+        assertEquals(0L, exec("long x = (long)4; def y = (int)1; return x & y"));
+
+        assertEquals(0L, exec("byte x = (byte)4; def y = (long)1; return x & y"));
+        assertEquals(0L, exec("short x = (short)4; def y = (long)1; return x & y"));
+        assertEquals(0L, exec("char x = (char)4; def y = (long)1; return x & y"));
+        assertEquals(0L, exec("int x = (int)4; def y = (long)1; return x & y"));
+        assertEquals(0L, exec("long x = (long)4; def y = (long)1; return x & y"));
+
+        assertEquals(0, exec("byte x = (byte)4; def y = (byte)1; return x & y"));
+        assertEquals(0, exec("short x = (short)4; def y = (short)1; return x & y"));
+        assertEquals(0, exec("char x = (char)4; def y = (char)1; return x & y"));
+        assertEquals(0, exec("int x = (int)4; def y = (int)1; return x & y"));
+        assertEquals(0L, exec("long x = (long)4; def y = (long)1; return x & y"));
+
+        assertEquals(true,  exec("boolean x = true;  def y = true; return x & y"));
+        assertEquals(false, exec("boolean x = true;  def y = false; return x & y"));
+        assertEquals(false, exec("boolean x = false; def y = true; return x & y"));
+        assertEquals(false, exec("boolean x = false; def y = false; return x & y"));
+    }
+    
+    public void testAndTypedRHS() {
+        expectScriptThrows(ClassCastException.class, () -> {
+            exec("def x = (float)4; byte y = (byte)1; return x & y");
+        });
+        expectScriptThrows(ClassCastException.class, () -> {
+            exec("def x = (double)4; byte y = (byte)1; return x & y");
+        });
+        assertEquals(0, exec("def x = (byte)4; byte y = (byte)1; return x & y"));
+        assertEquals(0, exec("def x = (short)4; byte y = (byte)1; return x & y"));
+        assertEquals(0, exec("def x = (char)4; byte y = (byte)1; return x & y"));
+        assertEquals(0, exec("def x = (int)4; byte y = (byte)1; return x & y"));
+        assertEquals(0L, exec("def x = (long)4; byte y = (byte)1; return x & y"));
+
+        assertEquals(0, exec("def x = (byte)4; short y = (short)1; return x & y"));
+        assertEquals(0, exec("def x = (short)4; short y = (short)1; return x & y"));
+        assertEquals(0, exec("def x = (char)4; short y = (short)1; return x & y"));
+        assertEquals(0, exec("def x = (int)4; short y = (short)1; return x & y"));
+        assertEquals(0L, exec("def x = (long)4; short y = (short)1; return x & y"));
+
+        assertEquals(0, exec("def x = (byte)4; char y = (char)1; return x & y"));
+        assertEquals(0, exec("def x = (short)4; char y = (char)1; return x & y"));
+        assertEquals(0, exec("def x = (char)4; char y = (char)1; return x & y"));
+        assertEquals(0, exec("def x = (int)4; char y = (char)1; return x & y"));
+        assertEquals(0L, exec("def x = (long)4; char y = (char)1; return x & y"));
+
+        assertEquals(0, exec("def x = (byte)4; int y = (int)1; return x & y"));
+        assertEquals(0, exec("def x = (short)4; int y = (int)1; return x & y"));
+        assertEquals(0, exec("def x = (char)4; int y = (int)1; return x & y"));
+        assertEquals(0, exec("def x = (int)4; int y = (int)1; return x & y"));
+        assertEquals(0L, exec("def x = (long)4; int y = (int)1; return x & y"));
+
+        assertEquals(0L, exec("def x = (byte)4; long y = (long)1; return x & y"));
+        assertEquals(0L, exec("def x = (short)4; long y = (long)1; return x & y"));
+        assertEquals(0L, exec("def x = (char)4; long y = (long)1; return x & y"));
+        assertEquals(0L, exec("def x = (int)4; long y = (long)1; return x & y"));
+        assertEquals(0L, exec("def x = (long)4; long y = (long)1; return x & y"));
+
+        assertEquals(0, exec("def x = (byte)4; byte y = (byte)1; return x & y"));
+        assertEquals(0, exec("def x = (short)4; short y = (short)1; return x & y"));
+        assertEquals(0, exec("def x = (char)4; char y = (char)1; return x & y"));
+        assertEquals(0, exec("def x = (int)4; int y = (int)1; return x & y"));
+        assertEquals(0L, exec("def x = (long)4; long y = (long)1; return x & y"));
+
+        assertEquals(true,  exec("def x = true;  boolean y = true; return x & y"));
+        assertEquals(false, exec("def x = true;  boolean y = false; return x & y"));
+        assertEquals(false, exec("def x = false; boolean y = true; return x & y"));
+        assertEquals(false, exec("def x = false; boolean y = false; return x & y"));
+    }
 
     public void testXor() {
         expectScriptThrows(ClassCastException.class, () -> {
@@ -664,6 +1684,104 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(true,  exec("def x = true;  def y = false; return x ^ y"));
         assertEquals(true,  exec("def x = false; def y = true; return x ^ y"));
         assertEquals(false, exec("def x = false; def y = false; return x ^ y"));
+    }
+    
+    public void testXorTypedLHS() {
+        expectScriptThrows(ClassCastException.class, () -> {
+            exec("float x = (float)4; def y = (byte)1; return x ^ y");
+        });
+        expectScriptThrows(ClassCastException.class, () -> {
+            exec("double x = (double)4; def y = (byte)1; return x ^ y");
+        });
+        assertEquals(5, exec("def x = (byte)4; def y = (byte)1; return x ^ y"));
+        assertEquals(5, exec("def x = (short)4; def y = (byte)1; return x ^ y"));
+        assertEquals(5, exec("def x = (char)4; def y = (byte)1; return x ^ y"));
+        assertEquals(5, exec("def x = (int)4; def y = (byte)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4; def y = (byte)1; return x ^ y"));
+
+        assertEquals(5, exec("def x = (byte)4; def y = (short)1; return x ^ y"));
+        assertEquals(5, exec("def x = (short)4; def y = (short)1; return x ^ y"));
+        assertEquals(5, exec("def x = (char)4; def y = (short)1; return x ^ y"));
+        assertEquals(5, exec("def x = (int)4; def y = (short)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4; def y = (short)1; return x ^ y"));
+
+        assertEquals(5, exec("def x = (byte)4; def y = (char)1; return x ^ y"));
+        assertEquals(5, exec("def x = (short)4; def y = (char)1; return x ^ y"));
+        assertEquals(5, exec("def x = (char)4; def y = (char)1; return x ^ y"));
+        assertEquals(5, exec("def x = (int)4; def y = (char)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4; def y = (char)1; return x ^ y"));
+
+        assertEquals(5, exec("def x = (byte)4; def y = (int)1; return x ^ y"));
+        assertEquals(5, exec("def x = (short)4; def y = (int)1; return x ^ y"));
+        assertEquals(5, exec("def x = (char)4; def y = (int)1; return x ^ y"));
+        assertEquals(5, exec("def x = (int)4; def y = (int)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4; def y = (int)1; return x ^ y"));
+
+        assertEquals(5L, exec("def x = (byte)4; def y = (long)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (short)4; def y = (long)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (char)4; def y = (long)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (int)4; def y = (long)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4; def y = (long)1; return x ^ y"));
+
+        assertEquals(5, exec("def x = (byte)4; def y = (byte)1; return x ^ y"));
+        assertEquals(5, exec("def x = (short)4; def y = (short)1; return x ^ y"));
+        assertEquals(5, exec("def x = (char)4; def y = (char)1; return x ^ y"));
+        assertEquals(5, exec("def x = (int)4; def y = (int)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4; def y = (long)1; return x ^ y"));
+        
+        assertEquals(false, exec("def x = true;  def y = true; return x ^ y"));
+        assertEquals(true,  exec("def x = true;  def y = false; return x ^ y"));
+        assertEquals(true,  exec("def x = false; def y = true; return x ^ y"));
+        assertEquals(false, exec("def x = false; def y = false; return x ^ y"));
+    }
+    
+    public void testXorTypedRHS() {
+        expectScriptThrows(ClassCastException.class, () -> {
+            exec("def x = (float)4; byte y = (byte)1; return x ^ y");
+        });
+        expectScriptThrows(ClassCastException.class, () -> {
+            exec("def x = (double)4; byte y = (byte)1; return x ^ y");
+        });
+        assertEquals(5, exec("def x = (byte)4; byte y = (byte)1; return x ^ y"));
+        assertEquals(5, exec("def x = (short)4; byte y = (byte)1; return x ^ y"));
+        assertEquals(5, exec("def x = (char)4; byte y = (byte)1; return x ^ y"));
+        assertEquals(5, exec("def x = (int)4; byte y = (byte)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4; byte y = (byte)1; return x ^ y"));
+
+        assertEquals(5, exec("def x = (byte)4; short y = (short)1; return x ^ y"));
+        assertEquals(5, exec("def x = (short)4; short y = (short)1; return x ^ y"));
+        assertEquals(5, exec("def x = (char)4; short y = (short)1; return x ^ y"));
+        assertEquals(5, exec("def x = (int)4; short y = (short)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4; short y = (short)1; return x ^ y"));
+
+        assertEquals(5, exec("def x = (byte)4; char y = (char)1; return x ^ y"));
+        assertEquals(5, exec("def x = (short)4; char y = (char)1; return x ^ y"));
+        assertEquals(5, exec("def x = (char)4; char y = (char)1; return x ^ y"));
+        assertEquals(5, exec("def x = (int)4; char y = (char)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4; char y = (char)1; return x ^ y"));
+
+        assertEquals(5, exec("def x = (byte)4; int y = (int)1; return x ^ y"));
+        assertEquals(5, exec("def x = (short)4; int y = (int)1; return x ^ y"));
+        assertEquals(5, exec("def x = (char)4; int y = (int)1; return x ^ y"));
+        assertEquals(5, exec("def x = (int)4; int y = (int)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4; int y = (int)1; return x ^ y"));
+
+        assertEquals(5L, exec("def x = (byte)4; long y = (long)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (short)4; long y = (long)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (char)4; long y = (long)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (int)4; long y = (long)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4; long y = (long)1; return x ^ y"));
+
+        assertEquals(5, exec("def x = (byte)4; byte y = (byte)1; return x ^ y"));
+        assertEquals(5, exec("def x = (short)4; short y = (short)1; return x ^ y"));
+        assertEquals(5, exec("def x = (char)4; char y = (char)1; return x ^ y"));
+        assertEquals(5, exec("def x = (int)4; int y = (int)1; return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4; long y = (long)1; return x ^ y"));
+        
+        assertEquals(false, exec("def x = true;  boolean y = true; return x ^ y"));
+        assertEquals(true,  exec("def x = true;  boolean y = false; return x ^ y"));
+        assertEquals(true,  exec("def x = false; boolean y = true; return x ^ y"));
+        assertEquals(false, exec("def x = false; boolean y = false; return x ^ y"));
     }
 
     public void testOr() {
@@ -714,6 +1832,104 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(true,  exec("def x = false; def y = true; return x | y"));
         assertEquals(false, exec("def x = false; def y = false; return x | y"));
     }
+    
+    public void testOrTypedLHS() {
+        expectScriptThrows(ClassCastException.class, () -> {
+            exec("float x = (float)4; def y = (byte)1; return x | y");
+        });
+        expectScriptThrows(ClassCastException.class, () -> {
+            exec("double x = (double)4; def y = (byte)1; return x | y");
+        });
+        assertEquals(5, exec("byte x = (byte)4; def y = (byte)1; return x | y"));
+        assertEquals(5, exec("short x = (short)4; def y = (byte)1; return x | y"));
+        assertEquals(5, exec("char x = (char)4; def y = (byte)1; return x | y"));
+        assertEquals(5, exec("int x = (int)4; def y = (byte)1; return x | y"));
+        assertEquals(5L, exec("long x = (long)4; def y = (byte)1; return x | y"));
+
+        assertEquals(5, exec("byte x = (byte)4; def y = (short)1; return x | y"));
+        assertEquals(5, exec("short x = (short)4; def y = (short)1; return x | y"));
+        assertEquals(5, exec("char x = (char)4; def y = (short)1; return x | y"));
+        assertEquals(5, exec("int x = (int)4; def y = (short)1; return x | y"));
+        assertEquals(5L, exec("long x = (long)4; def y = (short)1; return x | y"));
+
+        assertEquals(5, exec("byte x = (byte)4; def y = (char)1; return x | y"));
+        assertEquals(5, exec("short x = (short)4; def y = (char)1; return x | y"));
+        assertEquals(5, exec("char x = (char)4; def y = (char)1; return x | y"));
+        assertEquals(5, exec("int x = (int)4; def y = (char)1; return x | y"));
+        assertEquals(5L, exec("long x = (long)4; def y = (char)1; return x | y"));
+
+        assertEquals(5, exec("byte x = (byte)4; def y = (int)1; return x | y"));
+        assertEquals(5, exec("short x = (short)4; def y = (int)1; return x | y"));
+        assertEquals(5, exec("char x = (char)4; def y = (int)1; return x | y"));
+        assertEquals(5, exec("int x = (int)4; def y = (int)1; return x | y"));
+        assertEquals(5L, exec("long x = (long)4; def y = (int)1; return x | y"));
+
+        assertEquals(5L, exec("byte x = (byte)4; def y = (long)1; return x | y"));
+        assertEquals(5L, exec("short x = (short)4; def y = (long)1; return x | y"));
+        assertEquals(5L, exec("char x = (char)4; def y = (long)1; return x | y"));
+        assertEquals(5L, exec("int x = (int)4; def y = (long)1; return x | y"));
+        assertEquals(5L, exec("long x = (long)4; def y = (long)1; return x | y"));
+
+        assertEquals(5, exec("byte x = (byte)4; def y = (byte)1; return x | y"));
+        assertEquals(5, exec("short x = (short)4; def y = (short)1; return x | y"));
+        assertEquals(5, exec("char x = (char)4; def y = (char)1; return x | y"));
+        assertEquals(5, exec("int x = (int)4; def y = (int)1; return x | y"));
+        assertEquals(5L, exec("long x = (long)4; def y = (long)1; return x | y"));
+        
+        assertEquals(true,  exec("boolean x = true;  def y = true; return x | y"));
+        assertEquals(true,  exec("boolean x = true;  def y = false; return x | y"));
+        assertEquals(true,  exec("boolean x = false; def y = true; return x | y"));
+        assertEquals(false, exec("boolean x = false; def y = false; return x | y"));
+    }
+    
+    public void testOrTypedRHS() {
+        expectScriptThrows(ClassCastException.class, () -> {
+            exec("def x = (float)4; byte y = (byte)1; return x | y");
+        });
+        expectScriptThrows(ClassCastException.class, () -> {
+            exec("def x = (double)4; byte y = (byte)1; return x | y");
+        });
+        assertEquals(5, exec("def x = (byte)4; byte y = (byte)1; return x | y"));
+        assertEquals(5, exec("def x = (short)4; byte y = (byte)1; return x | y"));
+        assertEquals(5, exec("def x = (char)4; byte y = (byte)1; return x | y"));
+        assertEquals(5, exec("def x = (int)4; byte y = (byte)1; return x | y"));
+        assertEquals(5L, exec("def x = (long)4; byte y = (byte)1; return x | y"));
+
+        assertEquals(5, exec("def x = (byte)4; short y = (short)1; return x | y"));
+        assertEquals(5, exec("def x = (short)4; short y = (short)1; return x | y"));
+        assertEquals(5, exec("def x = (char)4; short y = (short)1; return x | y"));
+        assertEquals(5, exec("def x = (int)4; short y = (short)1; return x | y"));
+        assertEquals(5L, exec("def x = (long)4; short y = (short)1; return x | y"));
+
+        assertEquals(5, exec("def x = (byte)4; char y = (char)1; return x | y"));
+        assertEquals(5, exec("def x = (short)4; char y = (char)1; return x | y"));
+        assertEquals(5, exec("def x = (char)4; char y = (char)1; return x | y"));
+        assertEquals(5, exec("def x = (int)4; char y = (char)1; return x | y"));
+        assertEquals(5L, exec("def x = (long)4; char y = (char)1; return x | y"));
+
+        assertEquals(5, exec("def x = (byte)4; int y = (int)1; return x | y"));
+        assertEquals(5, exec("def x = (short)4; int y = (int)1; return x | y"));
+        assertEquals(5, exec("def x = (char)4; int y = (int)1; return x | y"));
+        assertEquals(5, exec("def x = (int)4; int y = (int)1; return x | y"));
+        assertEquals(5L, exec("def x = (long)4; int y = (int)1; return x | y"));
+
+        assertEquals(5L, exec("def x = (byte)4; long y = (long)1; return x | y"));
+        assertEquals(5L, exec("def x = (short)4; long y = (long)1; return x | y"));
+        assertEquals(5L, exec("def x = (char)4; long y = (long)1; return x | y"));
+        assertEquals(5L, exec("def x = (int)4; long y = (long)1; return x | y"));
+        assertEquals(5L, exec("def x = (long)4; long y = (long)1; return x | y"));
+
+        assertEquals(5, exec("def x = (byte)4; byte y = (byte)1; return x | y"));
+        assertEquals(5, exec("def x = (short)4; short y = (short)1; return x | y"));
+        assertEquals(5, exec("def x = (char)4; char y = (char)1; return x | y"));
+        assertEquals(5, exec("def x = (int)4; int y = (int)1; return x | y"));
+        assertEquals(5L, exec("def x = (long)4; long y = (long)1; return x | y"));
+        
+        assertEquals(true,  exec("def x = true;  boolean y = true; return x | y"));
+        assertEquals(true,  exec("def x = true;  boolean y = false; return x | y"));
+        assertEquals(true,  exec("def x = false; boolean y = true; return x | y"));
+        assertEquals(false, exec("def x = false; boolean y = false; return x | y"));
+    }
 
     public void testEq() {
         assertEquals(true, exec("def x = (byte)7; def y = (int)7; return x == y"));
@@ -743,11 +1959,64 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(false, exec("def x = new HashMap(); x.put(3, 3); def y = new HashMap(); return x == y"));
         assertEquals(true, exec("def x = new HashMap(); x.put(3, 3); def y = new HashMap(); y.put(3, 3); return x == y"));
         assertEquals(true, exec("def x = new HashMap(); def y = x; x.put(3, 3); y.put(3, 3); return x == y"));
+    }
+    
+    public void testEqTypedLHS() {
+        assertEquals(true, exec("byte x = (byte)7; def y = (int)7; return x == y"));
+        assertEquals(true, exec("short x = (short)6; def y = (int)6; return x == y"));
+        assertEquals(true, exec("char x = (char)5; def y = (int)5; return x == y"));
+        assertEquals(true, exec("int x = (int)4; def y = (int)4; return x == y"));
+        assertEquals(false, exec("long x = (long)5; def y = (int)3; return x == y"));
+        assertEquals(false, exec("float x = (float)6; def y = (int)2; return x == y"));
+        assertEquals(false, exec("double x = (double)7; def y = (int)1; return x == y"));
+
+        assertEquals(true, exec("byte x = (byte)7; def y = (double)7; return x == y"));
+        assertEquals(true, exec("short x = (short)6; def y = (double)6; return x == y"));
+        assertEquals(true, exec("char x = (char)5; def y = (double)5; return x == y"));
+        assertEquals(true, exec("int x = (int)4; def y = (double)4; return x == y"));
+        assertEquals(false, exec("long x = (long)5; def y = (double)3; return x == y"));
+        assertEquals(false, exec("float x = (float)6; def y = (double)2; return x == y"));
+        assertEquals(false, exec("double x = (double)7; def y = (double)1; return x == y"));
         
-        assertEquals(true,  exec("def x = true;  def y = true; return x == y"));
-        assertEquals(false, exec("def x = true;  def y = false; return x == y"));
-        assertEquals(false, exec("def x = false; def y = true; return x == y"));
-        assertEquals(true,  exec("def x = false; def y = false; return x == y"));
+        assertEquals(false, exec("boolean x = false; def y = true; return x == y"));
+        assertEquals(false, exec("boolean x = true; def y = false; return x == y"));
+        assertEquals(false, exec("boolean x = true; def y = null; return x == y"));
+        assertEquals(true, exec("boolean x = true; def y = true; return x == y"));
+        assertEquals(true, exec("boolean x = false; def y = false; return x == y"));
+
+        assertEquals(true, exec("Map x = new HashMap(); def y = new HashMap(); return x == y"));
+        assertEquals(false, exec("Map x = new HashMap(); x.put(3, 3); def y = new HashMap(); return x == y"));
+        assertEquals(true, exec("Map x = new HashMap(); x.put(3, 3); def y = new HashMap(); y.put(3, 3); return x == y"));
+        assertEquals(true, exec("Map x = new HashMap(); def y = x; x.put(3, 3); y.put(3, 3); return x == y"));
+    }
+    
+    public void testEqTypedRHS() {
+        assertEquals(true, exec("def x = (byte)7; int y = (int)7; return x == y"));
+        assertEquals(true, exec("def x = (short)6; int y = (int)6; return x == y"));
+        assertEquals(true, exec("def x = (char)5; int y = (int)5; return x == y"));
+        assertEquals(true, exec("def x = (int)4; int y = (int)4; return x == y"));
+        assertEquals(false, exec("def x = (long)5; int y = (int)3; return x == y"));
+        assertEquals(false, exec("def x = (float)6; int y = (int)2; return x == y"));
+        assertEquals(false, exec("def x = (double)7; int y = (int)1; return x == y"));
+
+        assertEquals(true, exec("def x = (byte)7; double y = (double)7; return x == y"));
+        assertEquals(true, exec("def x = (short)6; double y = (double)6; return x == y"));
+        assertEquals(true, exec("def x = (char)5; double y = (double)5; return x == y"));
+        assertEquals(true, exec("def x = (int)4; double y = (double)4; return x == y"));
+        assertEquals(false, exec("def x = (long)5; double y = (double)3; return x == y"));
+        assertEquals(false, exec("def x = (float)6; double y = (double)2; return x == y"));
+        assertEquals(false, exec("def x = (double)7; double y = (double)1; return x == y"));
+        
+        assertEquals(false, exec("def x = false; boolean y = true; return x == y"));
+        assertEquals(false, exec("def x = true; boolean y = false; return x == y"));
+        assertEquals(false, exec("def x = null; boolean y = true; return x == y"));
+        assertEquals(true, exec("def x = true; boolean y = true; return x == y"));
+        assertEquals(true, exec("def x = false; boolean y = false; return x == y"));
+
+        assertEquals(true, exec("def x = new HashMap(); Map y = new HashMap(); return x == y"));
+        assertEquals(false, exec("def x = new HashMap(); x.put(3, 3); Map y = new HashMap(); return x == y"));
+        assertEquals(true, exec("def x = new HashMap(); x.put(3, 3); Map y = new HashMap(); y.put(3, 3); return x == y"));
+        assertEquals(true, exec("def x = new HashMap(); Map y = x; x.put(3, 3); y.put(3, 3); return x == y"));
     }
 
     public void testEqr() {
@@ -793,6 +2062,62 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(true,   exec("def x = false; def y = true; return x != y"));
         assertEquals(false,  exec("def x = false; def y = false; return x != y"));
     }
+    
+    public void testNeTypedLHS() {
+        assertEquals(false, exec("byte x = (byte)7; def y = (int)7; return x != y"));
+        assertEquals(false, exec("short x = (short)6; def y = (int)6; return x != y"));
+        assertEquals(false, exec("char x = (char)5; def y = (int)5; return x != y"));
+        assertEquals(false, exec("int x = (int)4; def y = (int)4; return x != y"));
+        assertEquals(true, exec("long x = (long)5; def y = (int)3; return x != y"));
+        assertEquals(true, exec("float x = (float)6; def y = (int)2; return x != y"));
+        assertEquals(true, exec("double x = (double)7; def y = (int)1; return x != y"));
+
+        assertEquals(false, exec("byte x = (byte)7; def y = (double)7; return x != y"));
+        assertEquals(false, exec("short x = (short)6; def y = (double)6; return x != y"));
+        assertEquals(false, exec("char x = (char)5; def y = (double)5; return x != y"));
+        assertEquals(false, exec("int x = (int)4; def y = (double)4; return x != y"));
+        assertEquals(true, exec("long x = (long)5; def y = (double)3; return x != y"));
+        assertEquals(true, exec("float x = (float)6; def y = (double)2; return x != y"));
+        assertEquals(true, exec("double x = (double)7; def y = (double)1; return x != y"));
+
+        assertEquals(false, exec("Map x = new HashMap(); def y = new HashMap(); return x != y"));
+        assertEquals(true, exec("Map x = new HashMap(); x.put(3, 3); def y = new HashMap(); return x != y"));
+        assertEquals(false, exec("Map x = new HashMap(); x.put(3, 3); def y = new HashMap(); y.put(3, 3); return x != y"));
+        assertEquals(false, exec("Map x = new HashMap(); def y = x; x.put(3, 3); y.put(3, 3); return x != y"));
+        
+        assertEquals(false,  exec("boolean x = true;  def y = true; return x != y"));
+        assertEquals(true,   exec("boolean x = true;  def y = false; return x != y"));
+        assertEquals(true,   exec("boolean x = false; def y = true; return x != y"));
+        assertEquals(false,  exec("boolean x = false; def y = false; return x != y"));
+    }
+    
+    public void testNeTypedRHS() {
+        assertEquals(false, exec("def x = (byte)7; int y = (int)7; return x != y"));
+        assertEquals(false, exec("def x = (short)6; int y = (int)6; return x != y"));
+        assertEquals(false, exec("def x = (char)5; int y = (int)5; return x != y"));
+        assertEquals(false, exec("def x = (int)4; int y = (int)4; return x != y"));
+        assertEquals(true, exec("def x = (long)5; int y = (int)3; return x != y"));
+        assertEquals(true, exec("def x = (float)6; int y = (int)2; return x != y"));
+        assertEquals(true, exec("def x = (double)7; int y = (int)1; return x != y"));
+
+        assertEquals(false, exec("def x = (byte)7; double y = (double)7; return x != y"));
+        assertEquals(false, exec("def x = (short)6; double y = (double)6; return x != y"));
+        assertEquals(false, exec("def x = (char)5; double y = (double)5; return x != y"));
+        assertEquals(false, exec("def x = (int)4; double y = (double)4; return x != y"));
+        assertEquals(true, exec("def x = (long)5; double y = (double)3; return x != y"));
+        assertEquals(true, exec("def x = (float)6; double y = (double)2; return x != y"));
+        assertEquals(true, exec("def x = (double)7; double y = (double)1; return x != y"));
+
+        assertEquals(false, exec("def x = new HashMap(); Map y = new HashMap(); return x != y"));
+        assertEquals(true, exec("def x = new HashMap(); x.put(3, 3); Map y = new HashMap(); return x != y"));
+        assertEquals(false, exec("def x = new HashMap(); x.put(3, 3); Map y = new HashMap(); y.put(3, 3); return x != y"));
+        assertEquals(false, exec("def x = new HashMap(); Map y = x; x.put(3, 3); y.put(3, 3); return x != y"));
+        
+        assertEquals(false,  exec("def x = true;  boolean y = true; return x != y"));
+        assertEquals(true,   exec("def x = true;  boolean y = false; return x != y"));
+        assertEquals(true,   exec("def x = false; boolean y = true; return x != y"));
+        assertEquals(false,  exec("def x = false; boolean y = false; return x != y"));
+    }
 
     public void testNer() {
         assertEquals(true, exec("def x = (byte)7; def y = (int)7; return x !== y"));
@@ -826,6 +2151,42 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(false, exec("def x = (float)6; def y = (double)2; return x < y"));
         assertEquals(false, exec("def x = (double)7; def y = (double)1; return x < y"));
     }
+    
+    public void testLtTypedLHS() {
+        assertEquals(true, exec("byte x = (byte)1; def y = (int)7; return x < y"));
+        assertEquals(true, exec("short x = (short)2; def y = (int)6; return x < y"));
+        assertEquals(true, exec("char x = (char)3; def y = (int)5; return x < y"));
+        assertEquals(false, exec("int x = (int)4; def y = (int)4; return x < y"));
+        assertEquals(false, exec("long x = (long)5; def y = (int)3; return x < y"));
+        assertEquals(false, exec("float x = (float)6; def y = (int)2; return x < y"));
+        assertEquals(false, exec("double x = (double)7; def y = (int)1; return x < y"));
+
+        assertEquals(true, exec("byte x = (byte)1; def y = (double)7; return x < y"));
+        assertEquals(true, exec("short x = (short)2; def y = (double)6; return x < y"));
+        assertEquals(true, exec("char x = (char)3; def y = (double)5; return x < y"));
+        assertEquals(false, exec("int x = (int)4; def y = (double)4; return x < y"));
+        assertEquals(false, exec("long x = (long)5; def y = (double)3; return x < y"));
+        assertEquals(false, exec("float x = (float)6; def y = (double)2; return x < y"));
+        assertEquals(false, exec("double x = (double)7; def y = (double)1; return x < y"));
+    }
+    
+    public void testLtTypedRHS() {
+        assertEquals(true, exec("def x = (byte)1; int y = (int)7; return x < y"));
+        assertEquals(true, exec("def x = (short)2; int y = (int)6; return x < y"));
+        assertEquals(true, exec("def x = (char)3; int y = (int)5; return x < y"));
+        assertEquals(false, exec("def x = (int)4; int y = (int)4; return x < y"));
+        assertEquals(false, exec("def x = (long)5; int y = (int)3; return x < y"));
+        assertEquals(false, exec("def x = (float)6; int y = (int)2; return x < y"));
+        assertEquals(false, exec("def x = (double)7; int y = (int)1; return x < y"));
+
+        assertEquals(true, exec("def x = (byte)1; double y = (double)7; return x < y"));
+        assertEquals(true, exec("def x = (short)2; double y = (double)6; return x < y"));
+        assertEquals(true, exec("def x = (char)3; double y = (double)5; return x < y"));
+        assertEquals(false, exec("def x = (int)4; double y = (double)4; return x < y"));
+        assertEquals(false, exec("def x = (long)5; double y = (double)3; return x < y"));
+        assertEquals(false, exec("def x = (float)6; double y = (double)2; return x < y"));
+        assertEquals(false, exec("def x = (double)7; double y = (double)1; return x < y"));
+    }
 
     public void testLte() {
         assertEquals(true, exec("def x = (byte)1; def y = (int)7; return x <= y"));
@@ -843,6 +2204,42 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(false, exec("def x = (long)5; def y = (double)3; return x <= y"));
         assertEquals(false, exec("def x = (float)6; def y = (double)2; return x <= y"));
         assertEquals(false, exec("def x = (double)7; def y = (double)1; return x <= y"));
+    }
+    
+    public void testLteTypedLHS() {
+        assertEquals(true, exec("byte x = (byte)1; def y = (int)7; return x <= y"));
+        assertEquals(true, exec("short x = (short)2; def y = (int)6; return x <= y"));
+        assertEquals(true, exec("char x = (char)3; def y = (int)5; return x <= y"));
+        assertEquals(true, exec("int x = (int)4; def y = (int)4; return x <= y"));
+        assertEquals(false, exec("long x = (long)5; def y = (int)3; return x <= y"));
+        assertEquals(false, exec("float x = (float)6; def y = (int)2; return x <= y"));
+        assertEquals(false, exec("double x = (double)7; def y = (int)1; return x <= y"));
+
+        assertEquals(true, exec("byte x = (byte)1; def y = (double)7; return x <= y"));
+        assertEquals(true, exec("short x = (short)2; def y = (double)6; return x <= y"));
+        assertEquals(true, exec("char x = (char)3; def y = (double)5; return x <= y"));
+        assertEquals(true, exec("int x = (int)4; def y = (double)4; return x <= y"));
+        assertEquals(false, exec("long x = (long)5; def y = (double)3; return x <= y"));
+        assertEquals(false, exec("float x = (float)6; def y = (double)2; return x <= y"));
+        assertEquals(false, exec("double x = (double)7; def y = (double)1; return x <= y"));
+    }
+    
+    public void testLteTypedRHS() {
+        assertEquals(true, exec("def x = (byte)1; int y = (int)7; return x <= y"));
+        assertEquals(true, exec("def x = (short)2; int y = (int)6; return x <= y"));
+        assertEquals(true, exec("def x = (char)3; int y = (int)5; return x <= y"));
+        assertEquals(true, exec("def x = (int)4; int y = (int)4; return x <= y"));
+        assertEquals(false, exec("def x = (long)5; int y = (int)3; return x <= y"));
+        assertEquals(false, exec("def x = (float)6; int y = (int)2; return x <= y"));
+        assertEquals(false, exec("def x = (double)7; int y = (int)1; return x <= y"));
+
+        assertEquals(true, exec("def x = (byte)1; double y = (double)7; return x <= y"));
+        assertEquals(true, exec("def x = (short)2; double y = (double)6; return x <= y"));
+        assertEquals(true, exec("def x = (char)3; double y = (double)5; return x <= y"));
+        assertEquals(true, exec("def x = (int)4; double y = (double)4; return x <= y"));
+        assertEquals(false, exec("def x = (long)5; double y = (double)3; return x <= y"));
+        assertEquals(false, exec("def x = (float)6; double y = (double)2; return x <= y"));
+        assertEquals(false, exec("def x = (double)7; double y = (double)1; return x <= y"));
     }
 
     public void testGt() {
@@ -862,6 +2259,42 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(true, exec("def x = (float)6; def y = (double)2; return x > y"));
         assertEquals(true, exec("def x = (double)7; def y = (double)1; return x > y"));
     }
+    
+    public void testGtTypedLHS() {
+        assertEquals(false, exec("byte x = (byte)1; def y = (int)7; return x > y"));
+        assertEquals(false, exec("short x = (short)2; def y = (int)6; return x > y"));
+        assertEquals(false, exec("char x = (char)3; def y = (int)5; return x > y"));
+        assertEquals(false, exec("int x = (int)4; def y = (int)4; return x > y"));
+        assertEquals(true, exec("long x = (long)5; def y = (int)3; return x > y"));
+        assertEquals(true, exec("float x = (float)6; def y = (int)2; return x > y"));
+        assertEquals(true, exec("double x = (double)7; def y = (int)1; return x > y"));
+
+        assertEquals(false, exec("byte x = (byte)1; def y = (double)7; return x > y"));
+        assertEquals(false, exec("short x = (short)2; def y = (double)6; return x > y"));
+        assertEquals(false, exec("char x = (char)3; def y = (double)5; return x > y"));
+        assertEquals(false, exec("int x = (int)4; def y = (double)4; return x > y"));
+        assertEquals(true, exec("long x = (long)5; def y = (double)3; return x > y"));
+        assertEquals(true, exec("float x = (float)6; def y = (double)2; return x > y"));
+        assertEquals(true, exec("double x = (double)7; def y = (double)1; return x > y"));
+    }
+    
+    public void testGtTypedRHS() {
+        assertEquals(false, exec("def x = (byte)1; int y = (int)7; return x > y"));
+        assertEquals(false, exec("def x = (short)2; int y = (int)6; return x > y"));
+        assertEquals(false, exec("def x = (char)3; int y = (int)5; return x > y"));
+        assertEquals(false, exec("def x = (int)4; int y = (int)4; return x > y"));
+        assertEquals(true, exec("def x = (long)5; int y = (int)3; return x > y"));
+        assertEquals(true, exec("def x = (float)6; int y = (int)2; return x > y"));
+        assertEquals(true, exec("def x = (double)7; int y = (int)1; return x > y"));
+
+        assertEquals(false, exec("def x = (byte)1; double y = (double)7; return x > y"));
+        assertEquals(false, exec("def x = (short)2; double y = (double)6; return x > y"));
+        assertEquals(false, exec("def x = (char)3; double y = (double)5; return x > y"));
+        assertEquals(false, exec("def x = (int)4; double y = (double)4; return x > y"));
+        assertEquals(true, exec("def x = (long)5; double y = (double)3; return x > y"));
+        assertEquals(true, exec("def x = (float)6; double y = (double)2; return x > y"));
+        assertEquals(true, exec("def x = (double)7; double y = (double)1; return x > y"));
+    }
 
     public void testGte() {
         assertEquals(false, exec("def x = (byte)1; def y = (int)7; return x >= y"));
@@ -879,5 +2312,41 @@ public class DefOperationTests extends ScriptTestCase {
         assertEquals(true, exec("def x = (long)5; def y = (double)3; return x >= y"));
         assertEquals(true, exec("def x = (float)6; def y = (double)2; return x >= y"));
         assertEquals(true, exec("def x = (double)7; def y = (double)1; return x >= y"));
+    }
+    
+    public void testGteTypedLHS() {
+        assertEquals(false, exec("byte x = (byte)1; def y = (int)7; return x >= y"));
+        assertEquals(false, exec("short x = (short)2; def y = (int)6; return x >= y"));
+        assertEquals(false, exec("char x = (char)3; def y = (int)5; return x >= y"));
+        assertEquals(true, exec("int x = (int)4; def y = (int)4; return x >= y"));
+        assertEquals(true, exec("long x = (long)5; def y = (int)3; return x >= y"));
+        assertEquals(true, exec("float x = (float)6; def y = (int)2; return x >= y"));
+        assertEquals(true, exec("double x = (double)7; def y = (int)1; return x >= y"));
+
+        assertEquals(false, exec("byte x = (byte)1; def y = (double)7; return x >= y"));
+        assertEquals(false, exec("short x = (short)2; def y = (double)6; return x >= y"));
+        assertEquals(false, exec("char x = (char)3; def y = (double)5; return x >= y"));
+        assertEquals(true, exec("int x = (int)4; def y = (double)4; return x >= y"));
+        assertEquals(true, exec("long x = (long)5; def y = (double)3; return x >= y"));
+        assertEquals(true, exec("float x = (float)6; def y = (double)2; return x >= y"));
+        assertEquals(true, exec("double x = (double)7; def y = (double)1; return x >= y"));
+    }
+    
+    public void testGteTypedRHS() {
+        assertEquals(false, exec("def x = (byte)1; int y = (int)7; return x >= y"));
+        assertEquals(false, exec("def x = (short)2; int y = (int)6; return x >= y"));
+        assertEquals(false, exec("def x = (char)3; int y = (int)5; return x >= y"));
+        assertEquals(true, exec("def x = (int)4; int y = (int)4; return x >= y"));
+        assertEquals(true, exec("def x = (long)5; int y = (int)3; return x >= y"));
+        assertEquals(true, exec("def x = (float)6; int y = (int)2; return x >= y"));
+        assertEquals(true, exec("def x = (double)7; int y = (int)1; return x >= y"));
+
+        assertEquals(false, exec("def x = (byte)1; double y = (double)7; return x >= y"));
+        assertEquals(false, exec("def x = (short)2; double y = (double)6; return x >= y"));
+        assertEquals(false, exec("def x = (char)3; double y = (double)5; return x >= y"));
+        assertEquals(true, exec("def x = (int)4; double y = (double)4; return x >= y"));
+        assertEquals(true, exec("def x = (long)5; double y = (double)3; return x >= y"));
+        assertEquals(true, exec("def x = (float)6; double y = (double)2; return x >= y"));
+        assertEquals(true, exec("def x = (double)7; double y = (double)1; return x >= y"));
     }
 }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/DefOptimizationTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/DefOptimizationTests.java
@@ -178,4 +178,229 @@ public class DefOptimizationTests extends ScriptTestCase {
         });
         assertTrue(exception.getMessage().contains("Cannot cast java.lang.Double to java.lang.Integer"));
     }
+    
+    public void testMulOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x * y", 
+                             "INVOKEDYNAMIC mul(ILjava/lang/Object;)Ljava/lang/Object;");
+    }
+    
+    public void testMulOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x * y", 
+                             "INVOKEDYNAMIC mul(Ljava/lang/Object;I)Ljava/lang/Object;");
+    }
+    
+    public void testMulOptRet() {
+        assertBytecodeExists("def x = 1; def y = 2; double d = x * y", 
+                             "INVOKEDYNAMIC mul(Ljava/lang/Object;Ljava/lang/Object;)D");
+    }
+    
+    public void testDivOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x / y", 
+                             "INVOKEDYNAMIC div(ILjava/lang/Object;)Ljava/lang/Object;");
+    }
+    
+    public void testDivOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x / y", 
+                             "INVOKEDYNAMIC div(Ljava/lang/Object;I)Ljava/lang/Object;");
+    }
+    
+    public void testDivOptRet() {
+        assertBytecodeExists("def x = 1; def y = 2; double d = x / y", 
+                             "INVOKEDYNAMIC div(Ljava/lang/Object;Ljava/lang/Object;)D");
+    }
+    
+    public void testRemOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x % y", 
+                             "INVOKEDYNAMIC rem(ILjava/lang/Object;)Ljava/lang/Object;");
+    }
+    
+    public void testRemOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x % y", 
+                             "INVOKEDYNAMIC rem(Ljava/lang/Object;I)Ljava/lang/Object;");
+    }
+    
+    public void testRemOptRet() {
+        assertBytecodeExists("def x = 1; def y = 2; double d = x % y", 
+                             "INVOKEDYNAMIC rem(Ljava/lang/Object;Ljava/lang/Object;)D");
+    }
+    
+    public void testAddOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x + y", 
+                             "INVOKEDYNAMIC add(ILjava/lang/Object;)Ljava/lang/Object;");
+    }
+    
+    public void testAddOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x + y", 
+                             "INVOKEDYNAMIC add(Ljava/lang/Object;I)Ljava/lang/Object;");
+    }
+    
+    public void testAddOptRet() {
+        assertBytecodeExists("def x = 1; def y = 2; double d = x + y", 
+                             "INVOKEDYNAMIC add(Ljava/lang/Object;Ljava/lang/Object;)D");
+    }
+    
+    public void testSubOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x - y", 
+                             "INVOKEDYNAMIC sub(ILjava/lang/Object;)Ljava/lang/Object;");
+    }
+    
+    public void testSubOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x - y", 
+                             "INVOKEDYNAMIC sub(Ljava/lang/Object;I)Ljava/lang/Object;");
+    }
+    
+    public void testSubOptRet() {
+        assertBytecodeExists("def x = 1; def y = 2; double d = x - y", 
+                             "INVOKEDYNAMIC sub(Ljava/lang/Object;Ljava/lang/Object;)D");
+    }
+    
+    public void testLshOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x << y", 
+                             "INVOKEDYNAMIC lsh(ILjava/lang/Object;)Ljava/lang/Object;");
+    }
+    
+    public void testLshOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x << y", 
+                             "INVOKEDYNAMIC lsh(Ljava/lang/Object;I)Ljava/lang/Object;");
+    }
+    
+    public void testLshOptRet() {
+        assertBytecodeExists("def x = 1; def y = 2; double d = x << y", 
+                             "INVOKEDYNAMIC lsh(Ljava/lang/Object;Ljava/lang/Object;)D");
+    }
+    
+    public void testRshOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x >> y", 
+                             "INVOKEDYNAMIC rsh(ILjava/lang/Object;)Ljava/lang/Object;");
+    }
+    
+    public void testRshOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x >> y", 
+                             "INVOKEDYNAMIC rsh(Ljava/lang/Object;I)Ljava/lang/Object;");
+    }
+    
+    public void testRshOptRet() {
+        assertBytecodeExists("def x = 1; def y = 2; double d = x >> y", 
+                             "INVOKEDYNAMIC rsh(Ljava/lang/Object;Ljava/lang/Object;)D");
+    }
+    
+    public void testUshOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x >>> y", 
+                             "INVOKEDYNAMIC ush(ILjava/lang/Object;)Ljava/lang/Object;");
+    }
+    
+    public void testUshOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x >>> y", 
+                             "INVOKEDYNAMIC ush(Ljava/lang/Object;I)Ljava/lang/Object;");
+    }
+    
+    public void testUshOptRet() {
+        assertBytecodeExists("def x = 1; def y = 2; double d = x >>> y", 
+                             "INVOKEDYNAMIC ush(Ljava/lang/Object;Ljava/lang/Object;)D");
+    }
+    
+    public void testAndOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x & y", 
+                             "INVOKEDYNAMIC and(ILjava/lang/Object;)Ljava/lang/Object;");
+    }
+    
+    public void testAndOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x & y", 
+                             "INVOKEDYNAMIC and(Ljava/lang/Object;I)Ljava/lang/Object;");
+    }
+    
+    public void testAndOptRet() {
+        assertBytecodeExists("def x = 1; def y = 2; double d = x & y", 
+                             "INVOKEDYNAMIC and(Ljava/lang/Object;Ljava/lang/Object;)D");
+    }
+    
+    public void testOrOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x | y", 
+                             "INVOKEDYNAMIC or(ILjava/lang/Object;)Ljava/lang/Object;");
+    }
+    
+    public void testOrOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x | y", 
+                             "INVOKEDYNAMIC or(Ljava/lang/Object;I)Ljava/lang/Object;");
+    }
+    
+    public void testOrOptRet() {
+        assertBytecodeExists("def x = 1; def y = 2; double d = x | y", 
+                             "INVOKEDYNAMIC or(Ljava/lang/Object;Ljava/lang/Object;)D");
+    }
+    
+    public void testXorOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x ^ y", 
+                             "INVOKEDYNAMIC xor(ILjava/lang/Object;)Ljava/lang/Object;");
+    }
+    
+    public void testXorOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x ^ y", 
+                             "INVOKEDYNAMIC xor(Ljava/lang/Object;I)Ljava/lang/Object;");
+    }
+    
+    public void testXorOptRet() {
+        assertBytecodeExists("def x = 1; def y = 2; double d = x ^ y", 
+                             "INVOKEDYNAMIC xor(Ljava/lang/Object;Ljava/lang/Object;)D");
+    }
+    
+    public void testLtOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x < y", 
+                             "INVOKEDYNAMIC lt(ILjava/lang/Object;)Z");
+    }
+    
+    public void testLtOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x < y", 
+                             "INVOKEDYNAMIC lt(Ljava/lang/Object;I)Z");
+    }
+    
+    public void testLteOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x <= y", 
+                             "INVOKEDYNAMIC lte(ILjava/lang/Object;)Z");
+    }
+    
+    public void testLteOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x <= y", 
+                             "INVOKEDYNAMIC lte(Ljava/lang/Object;I)Z");
+    }
+    
+    public void testEqOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x == y", 
+                             "INVOKEDYNAMIC eq(ILjava/lang/Object;)Z");
+    }
+    
+    public void testEqOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x == y", 
+                             "INVOKEDYNAMIC eq(Ljava/lang/Object;I)Z");
+    }
+    
+    public void testNeqOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x != y", 
+                             "INVOKEDYNAMIC eq(ILjava/lang/Object;)Z");
+    }
+    
+    public void testNeqOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x != y", 
+                             "INVOKEDYNAMIC eq(Ljava/lang/Object;I)Z");
+    }
+    
+    public void testGteOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x >= y", 
+                             "INVOKEDYNAMIC gte(ILjava/lang/Object;)Z");
+    }
+    
+    public void testGteOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x >= y", 
+                             "INVOKEDYNAMIC gte(Ljava/lang/Object;I)Z");
+    }
+    
+    public void testGtOptLHS() {
+        assertBytecodeExists("int x = 1; def y = 2; return x > y", 
+                             "INVOKEDYNAMIC gt(ILjava/lang/Object;)Z");
+    }
+    
+    public void testGtOptRHS() {
+        assertBytecodeExists("def x = 1; int y = 2; return x > y", 
+                             "INVOKEDYNAMIC gt(Ljava/lang/Object;I)Z");
+    }
 }


### PR DESCRIPTION
#18847 gave us the ability to optimize this stuff when we know types, but we don't use it yet.

This patch removes the manual boxing/promotion/conversion and just hands over what we have for the binary math and comparison operators. For example in the script in the nightly benchmark:

```
(Math.log(Math.abs(doc['population'].value)) + doc['elevation'].value * doc['latitude'].value)/_score
```

We remove two calls to Double.valueOf: one because we know the `_score` is a double argument, we don't need to box it, and another because we know the math function returns a double.

Instead of:

```
    ALOAD 2
    INVOKEVIRTUAL org/apache/lucene/search/Scorer.score ()F
    F2D
    DSTORE 5
    ALOAD 3
    LDC "population"
    INVOKEINTERFACE java/util/Map.get (Ljava/lang/Object;)Ljava/lang/Object;
    INVOKEDYNAMIC value(Ljava/lang/Object;)D [...]
    INVOKESTATIC java/lang/Math.abs (D)D
    INVOKESTATIC java/lang/Math.log (D)D
    INVOKESTATIC java/lang/Double.valueOf (D)Ljava/lang/Double;
    ALOAD 3
    LDC "elevation"
    INVOKEINTERFACE java/util/Map.get (Ljava/lang/Object;)Ljava/lang/Object;
    INVOKEDYNAMIC value(Ljava/lang/Object;)Ljava/lang/Object; [...]
    ALOAD 3
    LDC "latitude"
    INVOKEINTERFACE java/util/Map.get (Ljava/lang/Object;)Ljava/lang/Object;
    INVOKEDYNAMIC value(Ljava/lang/Object;)Ljava/lang/Object; [...]
    INVOKEDYNAMIC mul(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; [...]
    INVOKEDYNAMIC add(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; [...]
    DLOAD 5
    INVOKESTATIC java/lang/Double.valueOf (D)Ljava/lang/Double;
    INVOKEDYNAMIC div(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; [...]
    ARETURN
```

We do:

```
    ALOAD 2
    INVOKEVIRTUAL org/apache/lucene/search/Scorer.score ()F
    F2D
    DSTORE 5
    ALOAD 3
    LDC "population"
    INVOKEINTERFACE java/util/Map.get (Ljava/lang/Object;)Ljava/lang/Object;
    INVOKEDYNAMIC value(Ljava/lang/Object;)D [ ... ]
    INVOKESTATIC java/lang/Math.abs (D)D
    INVOKESTATIC java/lang/Math.log (D)D
    ALOAD 3
    LDC "elevation"
    INVOKEINTERFACE java/util/Map.get (Ljava/lang/Object;)Ljava/lang/Object;
    INVOKEDYNAMIC value(Ljava/lang/Object;)Ljava/lang/Object; [ ... ]
    ALOAD 3
    LDC "latitude"
    INVOKEINTERFACE java/util/Map.get (Ljava/lang/Object;)Ljava/lang/Object;
    INVOKEDYNAMIC value(Ljava/lang/Object;)Ljava/lang/Object; [ ... ]
    INVOKEDYNAMIC mul(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; [ ... ]
    INVOKEDYNAMIC add(DLjava/lang/Object;)Ljava/lang/Object; [ ... ]
    DLOAD 5
    INVOKEDYNAMIC div(Ljava/lang/Object;D)Ljava/lang/Object; [ ... ]
    ARETURN
```

I added lots of tests to DefOptimizationTests for parameter and return values, and also correctness tests to DefOperationsTests for when we have partial types. I also found and fixed some bugs along the way (e.g. EComp did not work correctly when only one operand was `def`, it only looked at the RHS).
