### PR TITLE
Emit nicer error message when trying to install unknown plugin

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -134,9 +134,6 @@ class InstallPluginCommand extends SettingCommand {
         }
     }
 
-    // protocols allowed for direct url installation
-    private static final List<String> URL_PROTOCOLS = Arrays.asList("http", "https", "file");
-
     private final OptionSpec<Void> batchOption;
     private final OptionSpec<String> arguments;
 

--- a/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -134,6 +134,9 @@ class InstallPluginCommand extends SettingCommand {
         }
     }
 
+    // protocols allowed for direct url installation
+    private static final List<String> URL_PROTOCOLS = Arrays.asList("http", "https", "file");
+
     private final OptionSpec<Void> batchOption;
     private final OptionSpec<String> arguments;
 
@@ -237,6 +240,10 @@ class InstallPluginCommand extends SettingCommand {
         }
 
         // fall back to plain old URL
+        if (pluginId.contains("://") == false) {
+            // definitely not a valid url, so assume it is a plugin name
+            throw new UserError(ExitCodes.USAGE, "Unknown plugin " + pluginId);
+        }
         terminal.println("-> Downloading " + URLDecoder.decode(pluginId, "UTF-8"));
         return downloadZip(terminal, pluginId, tmpDir);
     }

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
@@ -307,6 +307,12 @@ public class InstallPluginCommandTests extends ESTestCase {
         assertTrue(e.getMessage(), e.getMessage().contains("no protocol"));
     }
 
+    public void testUnknownPlugin() throws Exception {
+        Tuple<Path, Environment> env = createEnv(fs, temp);
+        UserError e = expectThrows(UserError.class, () -> installPlugin("foo", env.v1()));
+        assertTrue(e.getMessage(), e.getMessage().contains("Unknown plugin foo"));
+    }
+
     public void testPluginsDirMissing() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Files.delete(env.v2().pluginsFile());


### PR DESCRIPTION
When installing plugins, we first try the elastic download service for
official plugins, then try maven coordinates, and finally try the
argument as a url. This can lead to confusing error messages about
unknown protocols when eg an official plugin name is mispelled. This
change adds a heuristic for determining if the argument in the final
case is in fact a url that we should try, and gives a simplified error
message in the case it is definitely not a url.

closes #17226
