### PR TITLE
Configurable shard weights for shard balancing

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -871,7 +871,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
             return routingNode;
         }
 
-        public float totalShardWeight() {
+        public int totalShardWeight() {
             return totalShardWeight;
         }
 

--- a/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -81,7 +81,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexMetaData.INDEX_SHARED_FS_ALLOW_RECOVERY_ON_ANY_NODE_SETTING,
         IndexMetaData.INDEX_PRIORITY_SETTING,
         IndexMetaData.INDEX_DATA_PATH_SETTING,
-        BalancedShardsAllocator.INDEX_SHARD_WEIGHT_MULTIPLIER_SETTING,
+        BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT,
         SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_DEBUG_SETTING,
         SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_WARN_SETTING,
         SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_INFO_SETTING,

--- a/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -20,6 +20,7 @@ package org.elasticsearch.common.settings;
 
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
@@ -80,6 +81,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexMetaData.INDEX_SHARED_FS_ALLOW_RECOVERY_ON_ANY_NODE_SETTING,
         IndexMetaData.INDEX_PRIORITY_SETTING,
         IndexMetaData.INDEX_DATA_PATH_SETTING,
+        BalancedShardsAllocator.INDEX_SHARD_WEIGHT_MULTIPLIER_SETTING,
         SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_DEBUG_SETTING,
         SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_WARN_SETTING,
         SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_INFO_SETTING,

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalanceConfigurationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalanceConfigurationTests.java
@@ -118,7 +118,7 @@ public class BalanceConfigurationTests extends ESAllocationTestCase {
         for (int i = 0; i < numberOfIndices; i++) {
             IndexMetaData.Builder index = IndexMetaData.builder("test" + i)
                 .settings(settings(Version.CURRENT)
-                    .put(BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT.getKey(), randomIntBetween(1, 20) * 1.0f))
+                    .put(BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT.getKey(), randomIntBetween(1, 20)))
                 .numberOfShards(numberOfShards).numberOfReplicas(numberOfReplicas);
             metaDataBuilder = metaDataBuilder.put(index);
         }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalanceConfigurationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalanceConfigurationTests.java
@@ -118,7 +118,7 @@ public class BalanceConfigurationTests extends ESAllocationTestCase {
         for (int i = 0; i < numberOfIndices; i++) {
             IndexMetaData.Builder index = IndexMetaData.builder("test" + i)
                 .settings(settings(Version.CURRENT)
-                    .put(BalancedShardsAllocator.INDEX_SHARD_WEIGHT_MULTIPLIER_SETTING.getKey(), randomIntBetween(1, 20) * 1.0f))
+                    .put(BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT.getKey(), randomIntBetween(1, 20) * 1.0f))
                 .numberOfShards(numberOfShards).numberOfReplicas(numberOfReplicas);
             metaDataBuilder = metaDataBuilder.put(index);
         }
@@ -239,7 +239,7 @@ public class BalanceConfigurationTests extends ESAllocationTestCase {
         float highestMultiplier = Float.NEGATIVE_INFINITY;
         ObjectFloatMap<Index> weights = new ObjectFloatHashMap<>();
         for (IndexMetaData indexMetaData : clusterState.getMetaData()) {
-            float weightMultiplier = BalancedShardsAllocator.INDEX_SHARD_WEIGHT_MULTIPLIER_SETTING.get(indexMetaData.getSettings());
+            float weightMultiplier = BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT.get(indexMetaData.getSettings());
             totalWeight += weightMultiplier * indexMetaData.getTotalNumberOfShards();
             lowestMultiplier = Math.min(lowestMultiplier, weightMultiplier);
             highestMultiplier = Math.max(highestMultiplier, weightMultiplier);

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceTests.java
@@ -552,7 +552,7 @@ public class IndexBalanceTests extends ESAllocationTestCase {
             .put(IndexMetaData.builder("small3").settings(settings(Version.CURRENT)).numberOfShards(2).numberOfReplicas(0))
             .put(IndexMetaData.builder("small4").settings(settings(Version.CURRENT)).numberOfShards(2).numberOfReplicas(0))
             .put(IndexMetaData.builder("large").settings(settings(Version.CURRENT)
-                .put(BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT.getKey(), 2.0f)).numberOfShards(2).numberOfReplicas(0))
+                .put(BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT.getKey(), 2)).numberOfShards(2).numberOfReplicas(0))
             .build();
 
         RoutingTable.Builder routingTableBuilder = RoutingTable.builder();
@@ -579,11 +579,11 @@ public class IndexBalanceTests extends ESAllocationTestCase {
 
         MetaData metaData = MetaData.builder()
             .put(IndexMetaData.builder("small").settings(settings(Version.CURRENT)
-                .put(BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT.getKey(), 1.0f)).numberOfShards(2).numberOfReplicas(0))
+                .put(BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT.getKey(), 1)).numberOfShards(2).numberOfReplicas(0))
             .put(IndexMetaData.builder("medium").settings(settings(Version.CURRENT)
-                .put(BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT.getKey(), 10.0f)).numberOfShards(2).numberOfReplicas(0))
+                .put(BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT.getKey(), 10)).numberOfShards(2).numberOfReplicas(0))
             .put(IndexMetaData.builder("large").settings(settings(Version.CURRENT)
-                .put(BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT.getKey(), 100.0f)).numberOfShards(2).numberOfReplicas(0))
+                .put(BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT.getKey(), 100)).numberOfShards(2).numberOfReplicas(0))
             .build();
 
         RoutingTable.Builder routingTableBuilder = RoutingTable.builder();

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceTests.java
@@ -552,7 +552,7 @@ public class IndexBalanceTests extends ESAllocationTestCase {
             .put(IndexMetaData.builder("small3").settings(settings(Version.CURRENT)).numberOfShards(2).numberOfReplicas(0))
             .put(IndexMetaData.builder("small4").settings(settings(Version.CURRENT)).numberOfShards(2).numberOfReplicas(0))
             .put(IndexMetaData.builder("large").settings(settings(Version.CURRENT)
-                .put(BalancedShardsAllocator.INDEX_SHARD_WEIGHT_MULTIPLIER_SETTING.getKey(), 2.0f)).numberOfShards(2).numberOfReplicas(0))
+                .put(BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT.getKey(), 2.0f)).numberOfShards(2).numberOfReplicas(0))
             .build();
 
         RoutingTable.Builder routingTableBuilder = RoutingTable.builder();
@@ -579,11 +579,11 @@ public class IndexBalanceTests extends ESAllocationTestCase {
 
         MetaData metaData = MetaData.builder()
             .put(IndexMetaData.builder("small").settings(settings(Version.CURRENT)
-                .put(BalancedShardsAllocator.INDEX_SHARD_WEIGHT_MULTIPLIER_SETTING.getKey(), 1.0f)).numberOfShards(2).numberOfReplicas(0))
+                .put(BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT.getKey(), 1.0f)).numberOfShards(2).numberOfReplicas(0))
             .put(IndexMetaData.builder("medium").settings(settings(Version.CURRENT)
-                .put(BalancedShardsAllocator.INDEX_SHARD_WEIGHT_MULTIPLIER_SETTING.getKey(), 10.0f)).numberOfShards(2).numberOfReplicas(0))
+                .put(BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT.getKey(), 10.0f)).numberOfShards(2).numberOfReplicas(0))
             .put(IndexMetaData.builder("large").settings(settings(Version.CURRENT)
-                .put(BalancedShardsAllocator.INDEX_SHARD_WEIGHT_MULTIPLIER_SETTING.getKey(), 100.0f)).numberOfShards(2).numberOfReplicas(0))
+                .put(BalancedShardsAllocator.INDEX_BALANCE_SHARD_WEIGHT.getKey(), 100.0f)).numberOfShards(2).numberOfReplicas(0))
             .build();
 
         RoutingTable.Builder routingTableBuilder = RoutingTable.builder();

--- a/docs/reference/modules/cluster/shards_allocation.asciidoc
+++ b/docs/reference/modules/cluster/shards_allocation.asciidoc
@@ -98,7 +98,8 @@ of each node closer together by more then the `balance.threshold`.
 
      Defines the weight factor for shards allocated on a node
      (float). Defaults to `0.45f`.  Raising this raises the tendency to
-     equalize the number of shards across all nodes in the cluster.
+     equalize the number of shards across all nodes in the cluster. The
+     weight for shards can be adapted using an <<index-shard-weights,index-level setting>>.
 
 `cluster.routing.allocation.balance.index`::
 
@@ -115,3 +116,14 @@ of each node closer together by more then the `balance.threshold`.
 
 NOTE: Regardless of the result of the balancing algorithm, rebalancing might
 not be allowed due to forced awareness or allocation filtering.
+
+[float]
+[[index-shard-weights]]
+=== Index-level shard weights
+
+The index-level setting `index.shard.balance.weight_multiplier` can be used to give some shards more
+weight than others. The default weight multiplier is 1.0, and only multipliers greater than 1.0 are allowed.
+A multiplier of 5.0 means that shards of the respective index are attributed 5 times the weight of a regular
+shard during the shard balancing action. This is useful for example when only some of the indices in a cluster
+are getting a high percentage of the query load. By increasing the shard weight multiplier for these indices,
+the shards under load are more evenly distributed among all the nodes in the cluster.

--- a/docs/reference/modules/cluster/shards_allocation.asciidoc
+++ b/docs/reference/modules/cluster/shards_allocation.asciidoc
@@ -121,9 +121,9 @@ not be allowed due to forced awareness or allocation filtering.
 [[index-shard-weights]]
 === Index-level shard weights
 
-The index-level setting `index.balance.shard.weight` (float) can be used to give shards of an index more
-weight than shards of other indices. The default weight is 1.0, and only weights greater than 1.0 are allowed.
-A weight of 5.0 means that shards of the respective index are attributed 5 times the weight of a regular
-shard during the shard balancing action. This is useful for example when only some of the indices in a cluster
-are getting a high percentage of the query load. By increasing the shard weight for these indices, the shards
-under load are more evenly distributed among all the nodes in the cluster.
+The index-level setting `index.balance.shard.weight` can be used to increase the weight of all shards of an index.
+The default weight is 1, and only weights greater than or equal to 1 are allowed. A weight of 5 means that shards of
+the respective index are attributed 5 times the weight of a regular shard during the shard balancing action.
+This is useful for example when only some of the indices in a cluster are getting a high percentage of the query load.
+By increasing the shard weight for these indices, the shards under load are more evenly distributed among all the
+nodes in the cluster.

--- a/docs/reference/modules/cluster/shards_allocation.asciidoc
+++ b/docs/reference/modules/cluster/shards_allocation.asciidoc
@@ -121,9 +121,9 @@ not be allowed due to forced awareness or allocation filtering.
 [[index-shard-weights]]
 === Index-level shard weights
 
-The index-level setting `index.shard.balance.weight_multiplier` can be used to give some shards more
-weight than others. The default weight multiplier is 1.0, and only multipliers greater than 1.0 are allowed.
-A multiplier of 5.0 means that shards of the respective index are attributed 5 times the weight of a regular
+The index-level setting `index.balance.shard.weight` (float) can be used to give shards of an index more
+weight than shards of other indices. The default weight is 1.0, and only weights greater than 1.0 are allowed.
+A weight of 5.0 means that shards of the respective index are attributed 5 times the weight of a regular
 shard during the shard balancing action. This is useful for example when only some of the indices in a cluster
-are getting a high percentage of the query load. By increasing the shard weight multiplier for these indices,
-the shards under load are more evenly distributed among all the nodes in the cluster.
+are getting a high percentage of the query load. By increasing the shard weight for these indices, the shards
+under load are more evenly distributed among all the nodes in the cluster.


### PR DESCRIPTION
The shard balancer currently attributes the same weight to each shard when determining the best balance in the cluster. In situations where some shards are getting a larger share of the ingest or search load in the cluster, we would like to attribute these shards a higher weight so that there is a better overall load distribution. Similarly, attributing weights to shards helps with clusters that have shards varying largely in size and often see some nodes getting way more disk space usage than others.

This PR introduces a new index-level dynamic setting `index.shard.balance.weight_multiplier` that influences the weight of shards for the respective index. A multiplier of 5.0 means that shards of that index are attributed 5 times the weight of a regular shard during the shard balancing action.

The default weight multiplier is 1.0, and only multipliers greater than 1.0 are allowed.

Relates to #7171 and #18819.
