### PR TITLE
TransportClient instead of Client in the code snippet at Transport Client documentation

### DIFF
--- a/docs/java-api/client.asciidoc
+++ b/docs/java-api/client.asciidoc
@@ -37,7 +37,7 @@ be "two hop" operations).
 --------------------------------------------------
 // on startup
 
-Client client = TransportClient.builder().build()
+TransportClient client = TransportClient.builder().build()
         .addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("host1"), 9300))
         .addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("host2"), 9300));
 
@@ -53,7 +53,7 @@ Note that you have to set the cluster name if you use one different than
 --------------------------------------------------
 Settings settings = Settings.builder()
         .put("cluster.name", "myClusterName").build();
-Client client = TransportClient.builder().settings(settings).build();
+TransportClient client = TransportClient.builder().settings(settings).build();
 //Add transport addresses and do something with the client...
 --------------------------------------------------
 


### PR DESCRIPTION
Code snippet in Transport Client section is still using Client class. It should be TransportClient class.
`addTransportAddress` is not available in Client class, it's only available in TransportClient.
