### PR TITLE
Move semicolon hack into lexer

### DIFF
--- a/modules/lang-painless/src/main/antlr/PainlessLexer.g4
+++ b/modules/lang-painless/src/main/antlr/PainlessLexer.g4
@@ -56,7 +56,7 @@ THIS:      'this';
 BOOLNOT: '!';
 BWNOT:   '~';
 MUL:     '*';
-DIV:     '/' { false == SlashStrategy.slashIsRegex(_factory) }?;
+DIV:     '/' { false == SlashStrategy.slashIsRegex(this) }?;
 REM:     '%';
 ADD:     '+';
 SUB:     '-';
@@ -104,7 +104,7 @@ INTEGER: ( '0' | [1-9] [0-9]* ) [lLfFdD]?;
 DECIMAL: ( '0' | [1-9] [0-9]* ) (DOT [0-9]+)? ( [eE] [+\-]? [0-9]+ )? [fF]?;
 
 STRING: ( '"' ( '\\"' | '\\\\' | ~[\\"] )*? '"' ) | ( '\'' ( '\\\'' | '\\\\' | ~[\\"] )*? '\'' );
-REGEX: '/' ( ~('/' | '\n') | '\\' ~'\n' )+ '/' [cilmsUux]* { SlashStrategy.slashIsRegex(_factory) }?;
+REGEX: '/' ( ~('/' | '\n') | '\\' ~'\n' )+ '/' [cilmsUux]* { SlashStrategy.slashIsRegex(this) }?;
 
 TRUE:  'true';
 FALSE: 'false';

--- a/modules/lang-painless/src/main/antlr/PainlessParser.g4
+++ b/modules/lang-painless/src/main/antlr/PainlessParser.g4
@@ -92,17 +92,6 @@ trap
 delimiter
     : SEMICOLON
     | EOF
-    // RBRACK is a delimiter but we don't consume it because it is only valid
-    // in places where RBRACK can follow the statement. It is simpler to not
-    // consume it here then it is to consume it here. Unfortunately, they
-    // obvious syntax to do this `| { _input.LA(1) == RBRACK }?` generates an
-    // amazingly intense `adaptivePredict` call that doesn't actually work
-    // and builds a serious DFA. Huge. So instead we use standard ANTLR syntax
-    // to consume the token and then undo the consumption. This looks hairy but
-    // it is better than the alternatives.
-    |   { int mark = _input.mark(); int index = _input.index(); }
-            RBRACK
-        { _input.seek(index); _input.release(mark); }
     ;
 
 // Note we return the boolean s.  This is returned as true

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/EnhancedPainlessLexer.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/EnhancedPainlessLexer.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.painless.antlr;
+
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.LexerNoViableAltException;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenSource;
+import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.runtime.misc.Pair;
+import org.elasticsearch.painless.Location;
+
+/**
+ * A lexer that is customized for painless. It will:
+ * <ul>
+ * <li>will override the default error behavior to fail on the first error
+ * <li>store the last token in case we need to do lookbehind for semicolon insertion and regex vs division detection
+ * <li>insert semicolons where they'd improve the language's readability. Rather than hack this into the parser and create a ton of
+ * ambiguity we hack them here where we can use heuristics to do it quickly.
+ * </ul>
+ */
+final class EnhancedPainlessLexer extends PainlessLexer {
+    final String sourceName;
+    private Token stashedNext = null;
+    private Token previous = null;
+
+    EnhancedPainlessLexer(CharStream charStream, String sourceName) {
+        super(charStream);
+        this.sourceName = sourceName;
+    }
+
+    public Token getPreviousToken() {
+        return previous;
+    }
+
+    @Override
+    public Token nextToken() {
+        if (stashedNext != null) {
+            previous = stashedNext;
+            stashedNext = null;
+            return previous;
+        }
+        Token next = super.nextToken();
+        if (insertSemicolon(previous, next)) {
+            stashedNext = next;
+            previous = _factory.create(new Pair<TokenSource, CharStream>(this, _input), PainlessLexer.SEMICOLON, ";",
+                    Lexer.DEFAULT_TOKEN_CHANNEL, next.getStartIndex(), next.getStopIndex(), next.getLine(), next.getCharPositionInLine());
+            return previous;
+        } else {
+            previous = next;
+            return next;
+        }
+    }
+
+    @Override
+    public void recover(final LexerNoViableAltException lnvae) {
+        final CharStream charStream = lnvae.getInputStream();
+        final int startIndex = lnvae.getStartIndex();
+        final String text = charStream.getText(Interval.of(startIndex, charStream.index()));
+
+        Location location = new Location(sourceName, _tokenStartCharIndex);
+        throw location.createError(new IllegalArgumentException("unexpected character [" + getErrorDisplay(text) + "].", lnvae));
+    }
+
+    private static boolean insertSemicolon(Token previous, Token next) {
+        if (previous == null || next.getType() != PainlessLexer.RBRACK) {
+            return false;
+        }
+        switch (previous.getType()) {
+        case PainlessLexer.RBRACK:     // };} would be weird!
+        case PainlessLexer.SEMICOLON:  // already have a semicolon, no need to add one
+        case PainlessLexer.LBRACK:     // empty blocks don't need a semicolon
+            return false;
+        default:
+            return true;
+        }
+    }
+}

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessLexer.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessLexer.java
@@ -140,14 +140,14 @@ class PainlessLexer extends Lexer {
   private boolean DIV_sempred(RuleContext _localctx, int predIndex) {
     switch (predIndex) {
     case 0:
-      return  false == SlashStrategy.slashIsRegex(_factory) ;
+      return  false == SlashStrategy.slashIsRegex(this) ;
     }
     return true;
   }
   private boolean REGEX_sempred(RuleContext _localctx, int predIndex) {
     switch (predIndex) {
     case 1:
-      return  SlashStrategy.slashIsRegex(_factory) ;
+      return  SlashStrategy.slashIsRegex(this) ;
     }
     return true;
   }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessParser.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessParser.java
@@ -1287,7 +1287,6 @@ class PainlessParser extends Parser {
   public static class DelimiterContext extends ParserRuleContext {
     public TerminalNode SEMICOLON() { return getToken(PainlessParser.SEMICOLON, 0); }
     public TerminalNode EOF() { return getToken(PainlessParser.EOF, 0); }
-    public TerminalNode RBRACK() { return getToken(PainlessParser.RBRACK, 0); }
     public DelimiterContext(ParserRuleContext parent, int invokingState) {
       super(parent, invokingState);
     }
@@ -1302,34 +1301,17 @@ class PainlessParser extends Parser {
   public final DelimiterContext delimiter() throws RecognitionException {
     DelimiterContext _localctx = new DelimiterContext(_ctx, getState());
     enterRule(_localctx, 26, RULE_delimiter);
+    int _la;
     try {
-      setState(230);
-      switch (_input.LA(1)) {
-      case SEMICOLON:
-        enterOuterAlt(_localctx, 1);
-        {
-        setState(225);
-        match(SEMICOLON);
-        }
-        break;
-      case EOF:
-        enterOuterAlt(_localctx, 2);
-        {
-        setState(226);
-        match(EOF);
-        }
-        break;
-      case RBRACK:
-        enterOuterAlt(_localctx, 3);
-        {
-         int mark = _input.mark(); int index = _input.index(); 
-        setState(228);
-        match(RBRACK);
-         _input.seek(index); _input.release(mark); 
-        }
-        break;
-      default:
-        throw new NoViableAltException(this);
+      enterOuterAlt(_localctx, 1);
+      {
+      setState(225);
+      _la = _input.LA(1);
+      if ( !(_la==EOF || _la==SEMICOLON) ) {
+      _errHandler.recoverInline(this);
+      } else {
+        consume();
+      }
       }
     }
     catch (RecognitionException re) {
@@ -1494,24 +1476,24 @@ class PainlessParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(241);
-      switch ( getInterpreter().adaptivePredict(_input,19,_ctx) ) {
+      setState(236);
+      switch ( getInterpreter().adaptivePredict(_input,18,_ctx) ) {
       case 1:
         {
         _localctx = new AssignmentContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
 
-        setState(233);
+        setState(228);
         chain(true);
-        setState(234);
+        setState(229);
         _la = _input.LA(1);
         if ( !(((((_la - 56)) & ~0x3f) == 0 && ((1L << (_la - 56)) & ((1L << (ASSIGN - 56)) | (1L << (AADD - 56)) | (1L << (ASUB - 56)) | (1L << (AMUL - 56)) | (1L << (ADIV - 56)) | (1L << (AREM - 56)) | (1L << (AAND - 56)) | (1L << (AXOR - 56)) | (1L << (AOR - 56)) | (1L << (ALSH - 56)) | (1L << (ARSH - 56)) | (1L << (AUSH - 56)))) != 0)) ) {
         _errHandler.recoverInline(this);
         } else {
           consume();
         }
-        setState(235);
+        setState(230);
         expression(1);
          ((AssignmentContext)_localctx).s =  false; 
         }
@@ -1521,37 +1503,37 @@ class PainlessParser extends Parser {
         _localctx = new SingleContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(238);
+        setState(233);
         ((SingleContext)_localctx).u = unary(false);
          ((SingleContext)_localctx).s =  ((SingleContext)_localctx).u.s; 
         }
         break;
       }
       _ctx.stop = _input.LT(-1);
-      setState(307);
+      setState(302);
       _errHandler.sync(this);
-      _alt = getInterpreter().adaptivePredict(_input,21,_ctx);
+      _alt = getInterpreter().adaptivePredict(_input,20,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           if ( _parseListeners!=null ) triggerExitRuleEvent();
           _prevctx = _localctx;
           {
-          setState(305);
-          switch ( getInterpreter().adaptivePredict(_input,20,_ctx) ) {
+          setState(300);
+          switch ( getInterpreter().adaptivePredict(_input,19,_ctx) ) {
           case 1:
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(243);
+            setState(238);
             if (!(precpred(_ctx, 13))) throw new FailedPredicateException(this, "precpred(_ctx, 13)");
-            setState(244);
+            setState(239);
             _la = _input.LA(1);
             if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << MUL) | (1L << DIV) | (1L << REM))) != 0)) ) {
             _errHandler.recoverInline(this);
             } else {
               consume();
             }
-            setState(245);
+            setState(240);
             expression(14);
              ((BinaryContext)_localctx).s =  false; 
             }
@@ -1560,16 +1542,16 @@ class PainlessParser extends Parser {
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(248);
+            setState(243);
             if (!(precpred(_ctx, 12))) throw new FailedPredicateException(this, "precpred(_ctx, 12)");
-            setState(249);
+            setState(244);
             _la = _input.LA(1);
             if ( !(_la==ADD || _la==SUB) ) {
             _errHandler.recoverInline(this);
             } else {
               consume();
             }
-            setState(250);
+            setState(245);
             expression(13);
              ((BinaryContext)_localctx).s =  false; 
             }
@@ -1578,16 +1560,16 @@ class PainlessParser extends Parser {
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(253);
+            setState(248);
             if (!(precpred(_ctx, 11))) throw new FailedPredicateException(this, "precpred(_ctx, 11)");
-            setState(254);
+            setState(249);
             _la = _input.LA(1);
             if ( !(_la==FIND || _la==MATCH) ) {
             _errHandler.recoverInline(this);
             } else {
               consume();
             }
-            setState(255);
+            setState(250);
             expression(12);
              ((BinaryContext)_localctx).s =  false; 
             }
@@ -1596,16 +1578,16 @@ class PainlessParser extends Parser {
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(258);
+            setState(253);
             if (!(precpred(_ctx, 10))) throw new FailedPredicateException(this, "precpred(_ctx, 10)");
-            setState(259);
+            setState(254);
             _la = _input.LA(1);
             if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LSH) | (1L << RSH) | (1L << USH))) != 0)) ) {
             _errHandler.recoverInline(this);
             } else {
               consume();
             }
-            setState(260);
+            setState(255);
             expression(11);
              ((BinaryContext)_localctx).s =  false; 
             }
@@ -1614,16 +1596,16 @@ class PainlessParser extends Parser {
             {
             _localctx = new CompContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(263);
+            setState(258);
             if (!(precpred(_ctx, 9))) throw new FailedPredicateException(this, "precpred(_ctx, 9)");
-            setState(264);
+            setState(259);
             _la = _input.LA(1);
             if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LT) | (1L << LTE) | (1L << GT) | (1L << GTE))) != 0)) ) {
             _errHandler.recoverInline(this);
             } else {
               consume();
             }
-            setState(265);
+            setState(260);
             expression(10);
              ((CompContext)_localctx).s =  false; 
             }
@@ -1632,16 +1614,16 @@ class PainlessParser extends Parser {
             {
             _localctx = new CompContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(268);
+            setState(263);
             if (!(precpred(_ctx, 8))) throw new FailedPredicateException(this, "precpred(_ctx, 8)");
-            setState(269);
+            setState(264);
             _la = _input.LA(1);
             if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EQ) | (1L << EQR) | (1L << NE) | (1L << NER))) != 0)) ) {
             _errHandler.recoverInline(this);
             } else {
               consume();
             }
-            setState(270);
+            setState(265);
             expression(9);
              ((CompContext)_localctx).s =  false; 
             }
@@ -1650,11 +1632,11 @@ class PainlessParser extends Parser {
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(273);
+            setState(268);
             if (!(precpred(_ctx, 7))) throw new FailedPredicateException(this, "precpred(_ctx, 7)");
-            setState(274);
+            setState(269);
             match(BWAND);
-            setState(275);
+            setState(270);
             expression(8);
              ((BinaryContext)_localctx).s =  false; 
             }
@@ -1663,11 +1645,11 @@ class PainlessParser extends Parser {
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(278);
+            setState(273);
             if (!(precpred(_ctx, 6))) throw new FailedPredicateException(this, "precpred(_ctx, 6)");
-            setState(279);
+            setState(274);
             match(XOR);
-            setState(280);
+            setState(275);
             expression(7);
              ((BinaryContext)_localctx).s =  false; 
             }
@@ -1676,11 +1658,11 @@ class PainlessParser extends Parser {
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(283);
+            setState(278);
             if (!(precpred(_ctx, 5))) throw new FailedPredicateException(this, "precpred(_ctx, 5)");
-            setState(284);
+            setState(279);
             match(BWOR);
-            setState(285);
+            setState(280);
             expression(6);
              ((BinaryContext)_localctx).s =  false; 
             }
@@ -1689,11 +1671,11 @@ class PainlessParser extends Parser {
             {
             _localctx = new BoolContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(288);
+            setState(283);
             if (!(precpred(_ctx, 4))) throw new FailedPredicateException(this, "precpred(_ctx, 4)");
-            setState(289);
+            setState(284);
             match(BOOLAND);
-            setState(290);
+            setState(285);
             expression(5);
              ((BoolContext)_localctx).s =  false; 
             }
@@ -1702,11 +1684,11 @@ class PainlessParser extends Parser {
             {
             _localctx = new BoolContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(293);
+            setState(288);
             if (!(precpred(_ctx, 3))) throw new FailedPredicateException(this, "precpred(_ctx, 3)");
-            setState(294);
+            setState(289);
             match(BOOLOR);
-            setState(295);
+            setState(290);
             expression(4);
              ((BoolContext)_localctx).s =  false; 
             }
@@ -1715,15 +1697,15 @@ class PainlessParser extends Parser {
             {
             _localctx = new ConditionalContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(298);
+            setState(293);
             if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-            setState(299);
+            setState(294);
             match(COND);
-            setState(300);
+            setState(295);
             ((ConditionalContext)_localctx).e0 = expression(0);
-            setState(301);
+            setState(296);
             match(COLON);
-            setState(302);
+            setState(297);
             ((ConditionalContext)_localctx).e1 = expression(2);
              ((ConditionalContext)_localctx).s =  ((ConditionalContext)_localctx).e0.s && ((ConditionalContext)_localctx).e1.s; 
             }
@@ -1731,9 +1713,9 @@ class PainlessParser extends Parser {
           }
           } 
         }
-        setState(309);
+        setState(304);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,21,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,20,_ctx);
       }
       }
     }
@@ -1878,22 +1860,22 @@ class PainlessParser extends Parser {
     enterRule(_localctx, 30, RULE_unary);
     int _la;
     try {
-      setState(339);
-      switch ( getInterpreter().adaptivePredict(_input,22,_ctx) ) {
+      setState(334);
+      switch ( getInterpreter().adaptivePredict(_input,21,_ctx) ) {
       case 1:
         _localctx = new PreContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(310);
+        setState(305);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(311);
+        setState(306);
         _la = _input.LA(1);
         if ( !(_la==INCR || _la==DECR) ) {
         _errHandler.recoverInline(this);
         } else {
           consume();
         }
-        setState(312);
+        setState(307);
         chain(true);
         }
         break;
@@ -1901,11 +1883,11 @@ class PainlessParser extends Parser {
         _localctx = new PostContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(313);
+        setState(308);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(314);
+        setState(309);
         chain(true);
-        setState(315);
+        setState(310);
         _la = _input.LA(1);
         if ( !(_la==INCR || _la==DECR) ) {
         _errHandler.recoverInline(this);
@@ -1918,9 +1900,9 @@ class PainlessParser extends Parser {
         _localctx = new ReadContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(317);
+        setState(312);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(318);
+        setState(313);
         chain(false);
         }
         break;
@@ -1928,9 +1910,9 @@ class PainlessParser extends Parser {
         _localctx = new NumericContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(319);
+        setState(314);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(320);
+        setState(315);
         _la = _input.LA(1);
         if ( !(((((_la - 68)) & ~0x3f) == 0 && ((1L << (_la - 68)) & ((1L << (OCTAL - 68)) | (1L << (HEX - 68)) | (1L << (INTEGER - 68)) | (1L << (DECIMAL - 68)))) != 0)) ) {
         _errHandler.recoverInline(this);
@@ -1944,9 +1926,9 @@ class PainlessParser extends Parser {
         _localctx = new TrueContext(_localctx);
         enterOuterAlt(_localctx, 5);
         {
-        setState(322);
+        setState(317);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(323);
+        setState(318);
         match(TRUE);
          ((TrueContext)_localctx).s =  false; 
         }
@@ -1955,9 +1937,9 @@ class PainlessParser extends Parser {
         _localctx = new FalseContext(_localctx);
         enterOuterAlt(_localctx, 6);
         {
-        setState(325);
+        setState(320);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(326);
+        setState(321);
         match(FALSE);
          ((FalseContext)_localctx).s =  false; 
         }
@@ -1966,9 +1948,9 @@ class PainlessParser extends Parser {
         _localctx = new NullContext(_localctx);
         enterOuterAlt(_localctx, 7);
         {
-        setState(328);
+        setState(323);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(329);
+        setState(324);
         match(NULL);
          ((NullContext)_localctx).s =  false; 
         }
@@ -1977,16 +1959,16 @@ class PainlessParser extends Parser {
         _localctx = new OperatorContext(_localctx);
         enterOuterAlt(_localctx, 8);
         {
-        setState(331);
+        setState(326);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(332);
+        setState(327);
         _la = _input.LA(1);
         if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L << SUB))) != 0)) ) {
         _errHandler.recoverInline(this);
         } else {
           consume();
         }
-        setState(333);
+        setState(328);
         unary(false);
         }
         break;
@@ -1994,13 +1976,13 @@ class PainlessParser extends Parser {
         _localctx = new CastContext(_localctx);
         enterOuterAlt(_localctx, 9);
         {
-        setState(334);
+        setState(329);
         match(LP);
-        setState(335);
+        setState(330);
         decltype();
-        setState(336);
+        setState(331);
         match(RP);
-        setState(337);
+        setState(332);
         unary(_localctx.c);
         }
         break;
@@ -2109,29 +2091,29 @@ class PainlessParser extends Parser {
     enterRule(_localctx, 32, RULE_chain);
     try {
       int _alt;
-      setState(375);
-      switch ( getInterpreter().adaptivePredict(_input,28,_ctx) ) {
+      setState(370);
+      switch ( getInterpreter().adaptivePredict(_input,27,_ctx) ) {
       case 1:
         _localctx = new DynamicContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(341);
+        setState(336);
         ((DynamicContext)_localctx).p = primary(_localctx.c);
-        setState(345);
+        setState(340);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,22,_ctx);
         while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
           if ( _alt==1 ) {
             {
             {
-            setState(342);
+            setState(337);
             secondary(((DynamicContext)_localctx).p.s);
             }
             } 
           }
-          setState(347);
+          setState(342);
           _errHandler.sync(this);
-          _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
+          _alt = getInterpreter().adaptivePredict(_input,22,_ctx);
         }
         }
         break;
@@ -2139,25 +2121,25 @@ class PainlessParser extends Parser {
         _localctx = new StaticContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(348);
+        setState(343);
         decltype();
-        setState(349);
+        setState(344);
         dot();
-        setState(353);
+        setState(348);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,24,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
         while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
           if ( _alt==1 ) {
             {
             {
-            setState(350);
+            setState(345);
             secondary(true);
             }
             } 
           }
-          setState(355);
+          setState(350);
           _errHandler.sync(this);
-          _alt = getInterpreter().adaptivePredict(_input,24,_ctx);
+          _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
         }
         }
         break;
@@ -2165,11 +2147,11 @@ class PainlessParser extends Parser {
         _localctx = new NewarrayContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(356);
+        setState(351);
         match(NEW);
-        setState(357);
+        setState(352);
         match(TYPE);
-        setState(362); 
+        setState(357); 
         _errHandler.sync(this);
         _alt = 1;
         do {
@@ -2177,11 +2159,11 @@ class PainlessParser extends Parser {
           case 1:
             {
             {
-            setState(358);
+            setState(353);
             match(LBRACE);
-            setState(359);
+            setState(354);
             expression(0);
-            setState(360);
+            setState(355);
             match(RBRACE);
             }
             }
@@ -2189,31 +2171,31 @@ class PainlessParser extends Parser {
           default:
             throw new NoViableAltException(this);
           }
-          setState(364); 
+          setState(359); 
           _errHandler.sync(this);
-          _alt = getInterpreter().adaptivePredict(_input,25,_ctx);
+          _alt = getInterpreter().adaptivePredict(_input,24,_ctx);
         } while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER );
-        setState(373);
-        switch ( getInterpreter().adaptivePredict(_input,27,_ctx) ) {
+        setState(368);
+        switch ( getInterpreter().adaptivePredict(_input,26,_ctx) ) {
         case 1:
           {
-          setState(366);
+          setState(361);
           dot();
-          setState(370);
+          setState(365);
           _errHandler.sync(this);
-          _alt = getInterpreter().adaptivePredict(_input,26,_ctx);
+          _alt = getInterpreter().adaptivePredict(_input,25,_ctx);
           while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
             if ( _alt==1 ) {
               {
               {
-              setState(367);
+              setState(362);
               secondary(true);
               }
               } 
             }
-            setState(372);
+            setState(367);
             _errHandler.sync(this);
-            _alt = getInterpreter().adaptivePredict(_input,26,_ctx);
+            _alt = getInterpreter().adaptivePredict(_input,25,_ctx);
           }
           }
           break;
@@ -2334,19 +2316,19 @@ class PainlessParser extends Parser {
     PrimaryContext _localctx = new PrimaryContext(_ctx, getState(), c);
     enterRule(_localctx, 34, RULE_primary);
     try {
-      setState(396);
-      switch ( getInterpreter().adaptivePredict(_input,29,_ctx) ) {
+      setState(391);
+      switch ( getInterpreter().adaptivePredict(_input,28,_ctx) ) {
       case 1:
         _localctx = new ExprprecContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(377);
+        setState(372);
         if (!( !_localctx.c )) throw new FailedPredicateException(this, " !$c ");
-        setState(378);
+        setState(373);
         match(LP);
-        setState(379);
+        setState(374);
         ((ExprprecContext)_localctx).e = expression(0);
-        setState(380);
+        setState(375);
         match(RP);
          ((ExprprecContext)_localctx).s =  ((ExprprecContext)_localctx).e.s; 
         }
@@ -2355,13 +2337,13 @@ class PainlessParser extends Parser {
         _localctx = new ChainprecContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(383);
+        setState(378);
         if (!( _localctx.c )) throw new FailedPredicateException(this, " $c ");
-        setState(384);
+        setState(379);
         match(LP);
-        setState(385);
+        setState(380);
         unary(true);
-        setState(386);
+        setState(381);
         match(RP);
         }
         break;
@@ -2369,7 +2351,7 @@ class PainlessParser extends Parser {
         _localctx = new StringContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(388);
+        setState(383);
         match(STRING);
         }
         break;
@@ -2377,7 +2359,7 @@ class PainlessParser extends Parser {
         _localctx = new RegexContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(389);
+        setState(384);
         match(REGEX);
         }
         break;
@@ -2385,7 +2367,7 @@ class PainlessParser extends Parser {
         _localctx = new VariableContext(_localctx);
         enterOuterAlt(_localctx, 5);
         {
-        setState(390);
+        setState(385);
         match(ID);
         }
         break;
@@ -2393,9 +2375,9 @@ class PainlessParser extends Parser {
         _localctx = new CalllocalContext(_localctx);
         enterOuterAlt(_localctx, 6);
         {
-        setState(391);
+        setState(386);
         match(ID);
-        setState(392);
+        setState(387);
         arguments();
         }
         break;
@@ -2403,11 +2385,11 @@ class PainlessParser extends Parser {
         _localctx = new NewobjectContext(_localctx);
         enterOuterAlt(_localctx, 7);
         {
-        setState(393);
+        setState(388);
         match(NEW);
-        setState(394);
+        setState(389);
         match(TYPE);
-        setState(395);
+        setState(390);
         arguments();
         }
         break;
@@ -2449,23 +2431,23 @@ class PainlessParser extends Parser {
     SecondaryContext _localctx = new SecondaryContext(_ctx, getState(), s);
     enterRule(_localctx, 36, RULE_secondary);
     try {
-      setState(402);
-      switch ( getInterpreter().adaptivePredict(_input,30,_ctx) ) {
+      setState(397);
+      switch ( getInterpreter().adaptivePredict(_input,29,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(398);
+        setState(393);
         if (!( _localctx.s )) throw new FailedPredicateException(this, " $s ");
-        setState(399);
+        setState(394);
         dot();
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(400);
+        setState(395);
         if (!( _localctx.s )) throw new FailedPredicateException(this, " $s ");
-        setState(401);
+        setState(396);
         brace();
         }
         break;
@@ -2523,17 +2505,17 @@ class PainlessParser extends Parser {
     enterRule(_localctx, 38, RULE_dot);
     int _la;
     try {
-      setState(409);
-      switch ( getInterpreter().adaptivePredict(_input,31,_ctx) ) {
+      setState(404);
+      switch ( getInterpreter().adaptivePredict(_input,30,_ctx) ) {
       case 1:
         _localctx = new CallinvokeContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(404);
+        setState(399);
         match(DOT);
-        setState(405);
+        setState(400);
         match(DOTID);
-        setState(406);
+        setState(401);
         arguments();
         }
         break;
@@ -2541,9 +2523,9 @@ class PainlessParser extends Parser {
         _localctx = new FieldaccessContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(407);
+        setState(402);
         match(DOT);
-        setState(408);
+        setState(403);
         _la = _input.LA(1);
         if ( !(_la==DOTINTEGER || _la==DOTID) ) {
         _errHandler.recoverInline(this);
@@ -2597,11 +2579,11 @@ class PainlessParser extends Parser {
       _localctx = new BraceaccessContext(_localctx);
       enterOuterAlt(_localctx, 1);
       {
-      setState(411);
+      setState(406);
       match(LBRACE);
-      setState(412);
+      setState(407);
       expression(0);
-      setState(413);
+      setState(408);
       match(RBRACE);
       }
     }
@@ -2648,34 +2630,34 @@ class PainlessParser extends Parser {
       enterOuterAlt(_localctx, 1);
       {
       {
-      setState(415);
+      setState(410);
       match(LP);
-      setState(424);
-      switch ( getInterpreter().adaptivePredict(_input,33,_ctx) ) {
+      setState(419);
+      switch ( getInterpreter().adaptivePredict(_input,32,_ctx) ) {
       case 1:
         {
-        setState(416);
+        setState(411);
         argument();
-        setState(421);
+        setState(416);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(417);
+          setState(412);
           match(COMMA);
-          setState(418);
+          setState(413);
           argument();
           }
           }
-          setState(423);
+          setState(418);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
         }
         break;
       }
-      setState(426);
+      setState(421);
       match(RP);
       }
       }
@@ -2716,26 +2698,26 @@ class PainlessParser extends Parser {
     ArgumentContext _localctx = new ArgumentContext(_ctx, getState());
     enterRule(_localctx, 44, RULE_argument);
     try {
-      setState(431);
-      switch ( getInterpreter().adaptivePredict(_input,34,_ctx) ) {
+      setState(426);
+      switch ( getInterpreter().adaptivePredict(_input,33,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(428);
+        setState(423);
         expression(0);
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(429);
+        setState(424);
         lambda();
         }
         break;
       case 3:
         enterOuterAlt(_localctx, 3);
         {
-        setState(430);
+        setState(425);
         funcref();
         }
         break;
@@ -2790,64 +2772,64 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(446);
+      setState(441);
       switch (_input.LA(1)) {
       case TYPE:
       case ID:
         {
-        setState(433);
+        setState(428);
         lamtype();
         }
         break;
       case LP:
         {
-        setState(434);
+        setState(429);
         match(LP);
-        setState(443);
+        setState(438);
         _la = _input.LA(1);
         if (_la==TYPE || _la==ID) {
           {
-          setState(435);
+          setState(430);
           lamtype();
-          setState(440);
+          setState(435);
           _errHandler.sync(this);
           _la = _input.LA(1);
           while (_la==COMMA) {
             {
             {
-            setState(436);
+            setState(431);
             match(COMMA);
-            setState(437);
+            setState(432);
             lamtype();
             }
             }
-            setState(442);
+            setState(437);
             _errHandler.sync(this);
             _la = _input.LA(1);
           }
           }
         }
 
-        setState(445);
+        setState(440);
         match(RP);
         }
         break;
       default:
         throw new NoViableAltException(this);
       }
-      setState(448);
+      setState(443);
       match(ARROW);
-      setState(451);
-      switch ( getInterpreter().adaptivePredict(_input,38,_ctx) ) {
+      setState(446);
+      switch ( getInterpreter().adaptivePredict(_input,37,_ctx) ) {
       case 1:
         {
-        setState(449);
+        setState(444);
         block();
         }
         break;
       case 2:
         {
-        setState(450);
+        setState(445);
         expression(0);
         }
         break;
@@ -2888,16 +2870,16 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(454);
+      setState(449);
       _la = _input.LA(1);
       if (_la==TYPE) {
         {
-        setState(453);
+        setState(448);
         decltype();
         }
       }
 
-      setState(456);
+      setState(451);
       match(ID);
       }
     }
@@ -2940,33 +2922,33 @@ class PainlessParser extends Parser {
     FuncrefContext _localctx = new FuncrefContext(_ctx, getState());
     enterRule(_localctx, 50, RULE_funcref);
     try {
-      setState(462);
-      switch ( getInterpreter().adaptivePredict(_input,40,_ctx) ) {
+      setState(457);
+      switch ( getInterpreter().adaptivePredict(_input,39,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(458);
+        setState(453);
         classFuncref();
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(459);
+        setState(454);
         constructorFuncref();
         }
         break;
       case 3:
         enterOuterAlt(_localctx, 3);
         {
-        setState(460);
+        setState(455);
         capturingFuncref();
         }
         break;
       case 4:
         enterOuterAlt(_localctx, 4);
         {
-        setState(461);
+        setState(456);
         localFuncref();
         }
         break;
@@ -3004,11 +2986,11 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(464);
+      setState(459);
       match(TYPE);
-      setState(465);
+      setState(460);
       match(REF);
-      setState(466);
+      setState(461);
       match(ID);
       }
     }
@@ -3046,11 +3028,11 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(468);
+      setState(463);
       decltype();
-      setState(469);
+      setState(464);
       match(REF);
-      setState(470);
+      setState(465);
       match(NEW);
       }
     }
@@ -3088,11 +3070,11 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(472);
+      setState(467);
       match(ID);
-      setState(473);
+      setState(468);
       match(REF);
-      setState(474);
+      setState(469);
       match(ID);
       }
     }
@@ -3128,11 +3110,11 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(476);
+      setState(471);
       match(THIS);
-      setState(477);
+      setState(472);
       match(REF);
-      setState(478);
+      setState(473);
       match(ID);
       }
     }
@@ -3239,7 +3221,7 @@ class PainlessParser extends Parser {
   }
 
   public static final String _serializedATN =
-    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3R\u01e3\4\2\t\2\4"+
+    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3R\u01de\4\2\t\2\4"+
     "\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t"+
     "\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
     "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
@@ -3255,171 +3237,169 @@ class PainlessParser extends Parser {
     "\16\7\u00bb\13\7\3\7\3\7\3\b\3\b\3\t\3\t\5\t\u00c3\n\t\3\n\3\n\3\13\3"+
     "\13\3\13\3\13\7\13\u00cb\n\13\f\13\16\13\u00ce\13\13\3\f\3\f\3\f\7\f\u00d3"+
     "\n\f\f\f\16\f\u00d6\13\f\3\r\3\r\3\r\5\r\u00db\n\r\3\16\3\16\3\16\3\16"+
-    "\3\16\3\16\3\16\3\17\3\17\3\17\3\17\3\17\5\17\u00e9\n\17\3\20\3\20\3\20"+
-    "\3\20\3\20\3\20\3\20\3\20\3\20\5\20\u00f4\n\20\3\20\3\20\3\20\3\20\3\20"+
+    "\3\16\3\16\3\16\3\17\3\17\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20"+
+    "\5\20\u00ef\n\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20"+
     "\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20"+
     "\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20"+
     "\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20"+
-    "\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20"+
-    "\3\20\7\20\u0134\n\20\f\20\16\20\u0137\13\20\3\21\3\21\3\21\3\21\3\21"+
+    "\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\7\20\u012f\n\20\f\20\16"+
+    "\20\u0132\13\20\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21"+
     "\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21"+
-    "\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\5\21\u0156\n\21\3\22"+
-    "\3\22\7\22\u015a\n\22\f\22\16\22\u015d\13\22\3\22\3\22\3\22\7\22\u0162"+
-    "\n\22\f\22\16\22\u0165\13\22\3\22\3\22\3\22\3\22\3\22\3\22\6\22\u016d"+
-    "\n\22\r\22\16\22\u016e\3\22\3\22\7\22\u0173\n\22\f\22\16\22\u0176\13\22"+
-    "\5\22\u0178\n\22\5\22\u017a\n\22\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3"+
-    "\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\5\23\u018f"+
-    "\n\23\3\24\3\24\3\24\3\24\5\24\u0195\n\24\3\25\3\25\3\25\3\25\3\25\5\25"+
-    "\u019c\n\25\3\26\3\26\3\26\3\26\3\27\3\27\3\27\3\27\7\27\u01a6\n\27\f"+
-    "\27\16\27\u01a9\13\27\5\27\u01ab\n\27\3\27\3\27\3\30\3\30\3\30\5\30\u01b2"+
-    "\n\30\3\31\3\31\3\31\3\31\3\31\7\31\u01b9\n\31\f\31\16\31\u01bc\13\31"+
-    "\5\31\u01be\n\31\3\31\5\31\u01c1\n\31\3\31\3\31\3\31\5\31\u01c6\n\31\3"+
-    "\32\5\32\u01c9\n\32\3\32\3\32\3\33\3\33\3\33\3\33\5\33\u01d1\n\33\3\34"+
-    "\3\34\3\34\3\34\3\35\3\35\3\35\3\35\3\36\3\36\3\36\3\36\3\37\3\37\3\37"+
-    "\3\37\3\37\2\3\36 \2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60"+
-    "\62\64\668:<\2\r\3\2:E\3\2\35\37\3\2 !\3\2\66\67\3\2\"$\3\2%(\3\2),\3"+
-    "\289\3\2FI\4\2\33\34 !\3\2QR\u0212\2A\3\2\2\2\4L\3\2\2\2\6Q\3\2\2\2\b"+
-    "\u00af\3\2\2\2\n\u00b3\3\2\2\2\f\u00b5\3\2\2\2\16\u00be\3\2\2\2\20\u00c2"+
-    "\3\2\2\2\22\u00c4\3\2\2\2\24\u00c6\3\2\2\2\26\u00cf\3\2\2\2\30\u00d7\3"+
-    "\2\2\2\32\u00dc\3\2\2\2\34\u00e8\3\2\2\2\36\u00f3\3\2\2\2 \u0155\3\2\2"+
-    "\2\"\u0179\3\2\2\2$\u018e\3\2\2\2&\u0194\3\2\2\2(\u019b\3\2\2\2*\u019d"+
-    "\3\2\2\2,\u01a1\3\2\2\2.\u01b1\3\2\2\2\60\u01c0\3\2\2\2\62\u01c8\3\2\2"+
-    "\2\64\u01d0\3\2\2\2\66\u01d2\3\2\2\28\u01d6\3\2\2\2:\u01da\3\2\2\2<\u01de"+
-    "\3\2\2\2>@\5\4\3\2?>\3\2\2\2@C\3\2\2\2A?\3\2\2\2AB\3\2\2\2BG\3\2\2\2C"+
-    "A\3\2\2\2DF\5\b\5\2ED\3\2\2\2FI\3\2\2\2GE\3\2\2\2GH\3\2\2\2HJ\3\2\2\2"+
-    "IG\3\2\2\2JK\7\2\2\3K\3\3\2\2\2LM\5\26\f\2MN\7P\2\2NO\5\6\4\2OP\5\f\7"+
-    "\2P\5\3\2\2\2Q]\7\t\2\2RS\5\26\f\2SZ\7P\2\2TU\7\f\2\2UV\5\26\f\2VW\7P"+
-    "\2\2WY\3\2\2\2XT\3\2\2\2Y\\\3\2\2\2ZX\3\2\2\2Z[\3\2\2\2[^\3\2\2\2\\Z\3"+
-    "\2\2\2]R\3\2\2\2]^\3\2\2\2^_\3\2\2\2_`\7\n\2\2`\7\3\2\2\2ab\7\16\2\2b"+
-    "c\7\t\2\2cd\5\36\20\2de\7\n\2\2ei\5\n\6\2fg\7\17\2\2gj\5\n\6\2hj\6\5\2"+
-    "\2if\3\2\2\2ih\3\2\2\2j\u00b0\3\2\2\2kl\7\20\2\2lm\7\t\2\2mn\5\36\20\2"+
-    "nq\7\n\2\2or\5\n\6\2pr\5\16\b\2qo\3\2\2\2qp\3\2\2\2r\u00b0\3\2\2\2st\7"+
-    "\21\2\2tu\5\f\7\2uv\7\20\2\2vw\7\t\2\2wx\5\36\20\2xy\7\n\2\2yz\5\34\17"+
-    "\2z\u00b0\3\2\2\2{|\7\22\2\2|~\7\t\2\2}\177\5\20\t\2~}\3\2\2\2~\177\3"+
-    "\2\2\2\177\u0080\3\2\2\2\u0080\u0082\7\r\2\2\u0081\u0083\5\36\20\2\u0082"+
-    "\u0081\3\2\2\2\u0082\u0083\3\2\2\2\u0083\u0084\3\2\2\2\u0084\u0086\7\r"+
-    "\2\2\u0085\u0087\5\22\n\2\u0086\u0085\3\2\2\2\u0086\u0087\3\2\2\2\u0087"+
-    "\u0088\3\2\2\2\u0088\u008b\7\n\2\2\u0089\u008c\5\n\6\2\u008a\u008c\5\16"+
-    "\b\2\u008b\u0089\3\2\2\2\u008b\u008a\3\2\2\2\u008c\u00b0\3\2\2\2\u008d"+
-    "\u008e\7\22\2\2\u008e\u008f\7\t\2\2\u008f\u0090\5\26\f\2\u0090\u0091\7"+
-    "P\2\2\u0091\u0092\7\63\2\2\u0092\u0093\5\36\20\2\u0093\u0094\7\n\2\2\u0094"+
-    "\u0095\5\n\6\2\u0095\u00b0\3\2\2\2\u0096\u0097\5\24\13\2\u0097\u0098\5"+
-    "\34\17\2\u0098\u00b0\3\2\2\2\u0099\u009a\7\23\2\2\u009a\u00b0\5\34\17"+
-    "\2\u009b\u009c\7\24\2\2\u009c\u00b0\5\34\17\2\u009d\u009e\7\25\2\2\u009e"+
-    "\u009f\5\36\20\2\u009f\u00a0\5\34\17\2\u00a0\u00b0\3\2\2\2\u00a1\u00a2"+
-    "\7\27\2\2\u00a2\u00a4\5\f\7\2\u00a3\u00a5\5\32\16\2\u00a4\u00a3\3\2\2"+
-    "\2\u00a5\u00a6\3\2\2\2\u00a6\u00a4\3\2\2\2\u00a6\u00a7\3\2\2\2\u00a7\u00b0"+
-    "\3\2\2\2\u00a8\u00a9\7\31\2\2\u00a9\u00aa\5\36\20\2\u00aa\u00ab\5\34\17"+
-    "\2\u00ab\u00b0\3\2\2\2\u00ac\u00ad\5\36\20\2\u00ad\u00ae\5\34\17\2\u00ae"+
-    "\u00b0\3\2\2\2\u00afa\3\2\2\2\u00afk\3\2\2\2\u00afs\3\2\2\2\u00af{\3\2"+
-    "\2\2\u00af\u008d\3\2\2\2\u00af\u0096\3\2\2\2\u00af\u0099\3\2\2\2\u00af"+
-    "\u009b\3\2\2\2\u00af\u009d\3\2\2\2\u00af\u00a1\3\2\2\2\u00af\u00a8\3\2"+
-    "\2\2\u00af\u00ac\3\2\2\2\u00b0\t\3\2\2\2\u00b1\u00b4\5\f\7\2\u00b2\u00b4"+
-    "\5\b\5\2\u00b3\u00b1\3\2\2\2\u00b3\u00b2\3\2\2\2\u00b4\13\3\2\2\2\u00b5"+
-    "\u00b9\7\5\2\2\u00b6\u00b8\5\b\5\2\u00b7\u00b6\3\2\2\2\u00b8\u00bb\3\2"+
-    "\2\2\u00b9\u00b7\3\2\2\2\u00b9\u00ba\3\2\2\2\u00ba\u00bc\3\2\2\2\u00bb"+
-    "\u00b9\3\2\2\2\u00bc\u00bd\7\6\2\2\u00bd\r\3\2\2\2\u00be\u00bf\7\r\2\2"+
-    "\u00bf\17\3\2\2\2\u00c0\u00c3\5\24\13\2\u00c1\u00c3\5\36\20\2\u00c2\u00c0"+
-    "\3\2\2\2\u00c2\u00c1\3\2\2\2\u00c3\21\3\2\2\2\u00c4\u00c5\5\36\20\2\u00c5"+
-    "\23\3\2\2\2\u00c6\u00c7\5\26\f\2\u00c7\u00cc\5\30\r\2\u00c8\u00c9\7\f"+
-    "\2\2\u00c9\u00cb\5\30\r\2\u00ca\u00c8\3\2\2\2\u00cb\u00ce\3\2\2\2\u00cc"+
-    "\u00ca\3\2\2\2\u00cc\u00cd\3\2\2\2\u00cd\25\3\2\2\2\u00ce\u00cc\3\2\2"+
-    "\2\u00cf\u00d4\7O\2\2\u00d0\u00d1\7\7\2\2\u00d1\u00d3\7\b\2\2\u00d2\u00d0"+
-    "\3\2\2\2\u00d3\u00d6\3\2\2\2\u00d4\u00d2\3\2\2\2\u00d4\u00d5\3\2\2\2\u00d5"+
-    "\27\3\2\2\2\u00d6\u00d4\3\2\2\2\u00d7\u00da\7P\2\2\u00d8\u00d9\7:\2\2"+
-    "\u00d9\u00db\5\36\20\2\u00da\u00d8\3\2\2\2\u00da\u00db\3\2\2\2\u00db\31"+
-    "\3\2\2\2\u00dc\u00dd\7\30\2\2\u00dd\u00de\7\t\2\2\u00de\u00df\7O\2\2\u00df"+
-    "\u00e0\7P\2\2\u00e0\u00e1\7\n\2\2\u00e1\u00e2\5\f\7\2\u00e2\33\3\2\2\2"+
-    "\u00e3\u00e9\7\r\2\2\u00e4\u00e9\7\2\2\3\u00e5\u00e6\b\17\1\2\u00e6\u00e7"+
-    "\7\6\2\2\u00e7\u00e9\b\17\1\2\u00e8\u00e3\3\2\2\2\u00e8\u00e4\3\2\2\2"+
-    "\u00e8\u00e5\3\2\2\2\u00e9\35\3\2\2\2\u00ea\u00eb\b\20\1\2\u00eb\u00ec"+
-    "\5\"\22\2\u00ec\u00ed\t\2\2\2\u00ed\u00ee\5\36\20\3\u00ee\u00ef\b\20\1"+
-    "\2\u00ef\u00f4\3\2\2\2\u00f0\u00f1\5 \21\2\u00f1\u00f2\b\20\1\2\u00f2"+
-    "\u00f4\3\2\2\2\u00f3\u00ea\3\2\2\2\u00f3\u00f0\3\2\2\2\u00f4\u0135\3\2"+
-    "\2\2\u00f5\u00f6\f\17\2\2\u00f6\u00f7\t\3\2\2\u00f7\u00f8\5\36\20\20\u00f8"+
-    "\u00f9\b\20\1\2\u00f9\u0134\3\2\2\2\u00fa\u00fb\f\16\2\2\u00fb\u00fc\t"+
-    "\4\2\2\u00fc\u00fd\5\36\20\17\u00fd\u00fe\b\20\1\2\u00fe\u0134\3\2\2\2"+
-    "\u00ff\u0100\f\r\2\2\u0100\u0101\t\5\2\2\u0101\u0102\5\36\20\16\u0102"+
-    "\u0103\b\20\1\2\u0103\u0134\3\2\2\2\u0104\u0105\f\f\2\2\u0105\u0106\t"+
-    "\6\2\2\u0106\u0107\5\36\20\r\u0107\u0108\b\20\1\2\u0108\u0134\3\2\2\2"+
-    "\u0109\u010a\f\13\2\2\u010a\u010b\t\7\2\2\u010b\u010c\5\36\20\f\u010c"+
-    "\u010d\b\20\1\2\u010d\u0134\3\2\2\2\u010e\u010f\f\n\2\2\u010f\u0110\t"+
-    "\b\2\2\u0110\u0111\5\36\20\13\u0111\u0112\b\20\1\2\u0112\u0134\3\2\2\2"+
-    "\u0113\u0114\f\t\2\2\u0114\u0115\7-\2\2\u0115\u0116\5\36\20\n\u0116\u0117"+
-    "\b\20\1\2\u0117\u0134\3\2\2\2\u0118\u0119\f\b\2\2\u0119\u011a\7.\2\2\u011a"+
-    "\u011b\5\36\20\t\u011b\u011c\b\20\1\2\u011c\u0134\3\2\2\2\u011d\u011e"+
-    "\f\7\2\2\u011e\u011f\7/\2\2\u011f\u0120\5\36\20\b\u0120\u0121\b\20\1\2"+
-    "\u0121\u0134\3\2\2\2\u0122\u0123\f\6\2\2\u0123\u0124\7\60\2\2\u0124\u0125"+
-    "\5\36\20\7\u0125\u0126\b\20\1\2\u0126\u0134\3\2\2\2\u0127\u0128\f\5\2"+
-    "\2\u0128\u0129\7\61\2\2\u0129\u012a\5\36\20\6\u012a\u012b\b\20\1\2\u012b"+
-    "\u0134\3\2\2\2\u012c\u012d\f\4\2\2\u012d\u012e\7\62\2\2\u012e\u012f\5"+
-    "\36\20\2\u012f\u0130\7\63\2\2\u0130\u0131\5\36\20\4\u0131\u0132\b\20\1"+
-    "\2\u0132\u0134\3\2\2\2\u0133\u00f5\3\2\2\2\u0133\u00fa\3\2\2\2\u0133\u00ff"+
-    "\3\2\2\2\u0133\u0104\3\2\2\2\u0133\u0109\3\2\2\2\u0133\u010e\3\2\2\2\u0133"+
-    "\u0113\3\2\2\2\u0133\u0118\3\2\2\2\u0133\u011d\3\2\2\2\u0133\u0122\3\2"+
-    "\2\2\u0133\u0127\3\2\2\2\u0133\u012c\3\2\2\2\u0134\u0137\3\2\2\2\u0135"+
-    "\u0133\3\2\2\2\u0135\u0136\3\2\2\2\u0136\37\3\2\2\2\u0137\u0135\3\2\2"+
-    "\2\u0138\u0139\6\21\17\3\u0139\u013a\t\t\2\2\u013a\u0156\5\"\22\2\u013b"+
-    "\u013c\6\21\20\3\u013c\u013d\5\"\22\2\u013d\u013e\t\t\2\2\u013e\u0156"+
-    "\3\2\2\2\u013f\u0140\6\21\21\3\u0140\u0156\5\"\22\2\u0141\u0142\6\21\22"+
-    "\3\u0142\u0143\t\n\2\2\u0143\u0156\b\21\1\2\u0144\u0145\6\21\23\3\u0145"+
-    "\u0146\7L\2\2\u0146\u0156\b\21\1\2\u0147\u0148\6\21\24\3\u0148\u0149\7"+
-    "M\2\2\u0149\u0156\b\21\1\2\u014a\u014b\6\21\25\3\u014b\u014c\7N\2\2\u014c"+
-    "\u0156\b\21\1\2\u014d\u014e\6\21\26\3\u014e\u014f\t\13\2\2\u014f\u0156"+
-    "\5 \21\2\u0150\u0151\7\t\2\2\u0151\u0152\5\26\f\2\u0152\u0153\7\n\2\2"+
-    "\u0153\u0154\5 \21\2\u0154\u0156\3\2\2\2\u0155\u0138\3\2\2\2\u0155\u013b"+
-    "\3\2\2\2\u0155\u013f\3\2\2\2\u0155\u0141\3\2\2\2\u0155\u0144\3\2\2\2\u0155"+
-    "\u0147\3\2\2\2\u0155\u014a\3\2\2\2\u0155\u014d\3\2\2\2\u0155\u0150\3\2"+
-    "\2\2\u0156!\3\2\2\2\u0157\u015b\5$\23\2\u0158\u015a\5&\24\2\u0159\u0158"+
-    "\3\2\2\2\u015a\u015d\3\2\2\2\u015b\u0159\3\2\2\2\u015b\u015c\3\2\2\2\u015c"+
-    "\u017a\3\2\2\2\u015d\u015b\3\2\2\2\u015e\u015f\5\26\f\2\u015f\u0163\5"+
-    "(\25\2\u0160\u0162\5&\24\2\u0161\u0160\3\2\2\2\u0162\u0165\3\2\2\2\u0163"+
-    "\u0161\3\2\2\2\u0163\u0164\3\2\2\2\u0164\u017a\3\2\2\2\u0165\u0163\3\2"+
-    "\2\2\u0166\u0167\7\26\2\2\u0167\u016c\7O\2\2\u0168\u0169\7\7\2\2\u0169"+
-    "\u016a\5\36\20\2\u016a\u016b\7\b\2\2\u016b\u016d\3\2\2\2\u016c\u0168\3"+
-    "\2\2\2\u016d\u016e\3\2\2\2\u016e\u016c\3\2\2\2\u016e\u016f\3\2\2\2\u016f"+
-    "\u0177\3\2\2\2\u0170\u0174\5(\25\2\u0171\u0173\5&\24\2\u0172\u0171\3\2"+
-    "\2\2\u0173\u0176\3\2\2\2\u0174\u0172\3\2\2\2\u0174\u0175\3\2\2\2\u0175"+
-    "\u0178\3\2\2\2\u0176\u0174\3\2\2\2\u0177\u0170\3\2\2\2\u0177\u0178\3\2"+
-    "\2\2\u0178\u017a\3\2\2\2\u0179\u0157\3\2\2\2\u0179\u015e\3\2\2\2\u0179"+
-    "\u0166\3\2\2\2\u017a#\3\2\2\2\u017b\u017c\6\23\27\3\u017c\u017d\7\t\2"+
-    "\2\u017d\u017e\5\36\20\2\u017e\u017f\7\n\2\2\u017f\u0180\b\23\1\2\u0180"+
-    "\u018f\3\2\2\2\u0181\u0182\6\23\30\3\u0182\u0183\7\t\2\2\u0183\u0184\5"+
-    " \21\2\u0184\u0185\7\n\2\2\u0185\u018f\3\2\2\2\u0186\u018f\7J\2\2\u0187"+
-    "\u018f\7K\2\2\u0188\u018f\7P\2\2\u0189\u018a\7P\2\2\u018a\u018f\5,\27"+
-    "\2\u018b\u018c\7\26\2\2\u018c\u018d\7O\2\2\u018d\u018f\5,\27\2\u018e\u017b"+
-    "\3\2\2\2\u018e\u0181\3\2\2\2\u018e\u0186\3\2\2\2\u018e\u0187\3\2\2\2\u018e"+
-    "\u0188\3\2\2\2\u018e\u0189\3\2\2\2\u018e\u018b\3\2\2\2\u018f%\3\2\2\2"+
-    "\u0190\u0191\6\24\31\3\u0191\u0195\5(\25\2\u0192\u0193\6\24\32\3\u0193"+
-    "\u0195\5*\26\2\u0194\u0190\3\2\2\2\u0194\u0192\3\2\2\2\u0195\'\3\2\2\2"+
-    "\u0196\u0197\7\13\2\2\u0197\u0198\7R\2\2\u0198\u019c\5,\27\2\u0199\u019a"+
-    "\7\13\2\2\u019a\u019c\t\f\2\2\u019b\u0196\3\2\2\2\u019b\u0199\3\2\2\2"+
-    "\u019c)\3\2\2\2\u019d\u019e\7\7\2\2\u019e\u019f\5\36\20\2\u019f\u01a0"+
-    "\7\b\2\2\u01a0+\3\2\2\2\u01a1\u01aa\7\t\2\2\u01a2\u01a7\5.\30\2\u01a3"+
-    "\u01a4\7\f\2\2\u01a4\u01a6\5.\30\2\u01a5\u01a3\3\2\2\2\u01a6\u01a9\3\2"+
-    "\2\2\u01a7\u01a5\3\2\2\2\u01a7\u01a8\3\2\2\2\u01a8\u01ab\3\2\2\2\u01a9"+
-    "\u01a7\3\2\2\2\u01aa\u01a2\3\2\2\2\u01aa\u01ab\3\2\2\2\u01ab\u01ac\3\2"+
-    "\2\2\u01ac\u01ad\7\n\2\2\u01ad-\3\2\2\2\u01ae\u01b2\5\36\20\2\u01af\u01b2"+
-    "\5\60\31\2\u01b0\u01b2\5\64\33\2\u01b1\u01ae\3\2\2\2\u01b1\u01af\3\2\2"+
-    "\2\u01b1\u01b0\3\2\2\2\u01b2/\3\2\2\2\u01b3\u01c1\5\62\32\2\u01b4\u01bd"+
-    "\7\t\2\2\u01b5\u01ba\5\62\32\2\u01b6\u01b7\7\f\2\2\u01b7\u01b9\5\62\32"+
-    "\2\u01b8\u01b6\3\2\2\2\u01b9\u01bc\3\2\2\2\u01ba\u01b8\3\2\2\2\u01ba\u01bb"+
-    "\3\2\2\2\u01bb\u01be\3\2\2\2\u01bc\u01ba\3\2\2\2\u01bd\u01b5\3\2\2\2\u01bd"+
-    "\u01be\3\2\2\2\u01be\u01bf\3\2\2\2\u01bf\u01c1\7\n\2\2\u01c0\u01b3\3\2"+
-    "\2\2\u01c0\u01b4\3\2\2\2\u01c1\u01c2\3\2\2\2\u01c2\u01c5\7\65\2\2\u01c3"+
-    "\u01c6\5\f\7\2\u01c4\u01c6\5\36\20\2\u01c5\u01c3\3\2\2\2\u01c5\u01c4\3"+
-    "\2\2\2\u01c6\61\3\2\2\2\u01c7\u01c9\5\26\f\2\u01c8\u01c7\3\2\2\2\u01c8"+
-    "\u01c9\3\2\2\2\u01c9\u01ca\3\2\2\2\u01ca\u01cb\7P\2\2\u01cb\63\3\2\2\2"+
-    "\u01cc\u01d1\5\66\34\2\u01cd\u01d1\58\35\2\u01ce\u01d1\5:\36\2\u01cf\u01d1"+
-    "\5<\37\2\u01d0\u01cc\3\2\2\2\u01d0\u01cd\3\2\2\2\u01d0\u01ce\3\2\2\2\u01d0"+
-    "\u01cf\3\2\2\2\u01d1\65\3\2\2\2\u01d2\u01d3\7O\2\2\u01d3\u01d4\7\64\2"+
-    "\2\u01d4\u01d5\7P\2\2\u01d5\67\3\2\2\2\u01d6\u01d7\5\26\f\2\u01d7\u01d8"+
-    "\7\64\2\2\u01d8\u01d9\7\26\2\2\u01d99\3\2\2\2\u01da\u01db\7P\2\2\u01db"+
-    "\u01dc\7\64\2\2\u01dc\u01dd\7P\2\2\u01dd;\3\2\2\2\u01de\u01df\7\32\2\2"+
-    "\u01df\u01e0\7\64\2\2\u01e0\u01e1\7P\2\2\u01e1=\3\2\2\2+AGZ]iq~\u0082"+
-    "\u0086\u008b\u00a6\u00af\u00b3\u00b9\u00c2\u00cc\u00d4\u00da\u00e8\u00f3"+
-    "\u0133\u0135\u0155\u015b\u0163\u016e\u0174\u0177\u0179\u018e\u0194\u019b"+
-    "\u01a7\u01aa\u01b1\u01ba\u01bd\u01c0\u01c5\u01c8\u01d0";
+    "\3\21\3\21\3\21\3\21\5\21\u0151\n\21\3\22\3\22\7\22\u0155\n\22\f\22\16"+
+    "\22\u0158\13\22\3\22\3\22\3\22\7\22\u015d\n\22\f\22\16\22\u0160\13\22"+
+    "\3\22\3\22\3\22\3\22\3\22\3\22\6\22\u0168\n\22\r\22\16\22\u0169\3\22\3"+
+    "\22\7\22\u016e\n\22\f\22\16\22\u0171\13\22\5\22\u0173\n\22\5\22\u0175"+
+    "\n\22\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23"+
+    "\3\23\3\23\3\23\3\23\3\23\3\23\5\23\u018a\n\23\3\24\3\24\3\24\3\24\5\24"+
+    "\u0190\n\24\3\25\3\25\3\25\3\25\3\25\5\25\u0197\n\25\3\26\3\26\3\26\3"+
+    "\26\3\27\3\27\3\27\3\27\7\27\u01a1\n\27\f\27\16\27\u01a4\13\27\5\27\u01a6"+
+    "\n\27\3\27\3\27\3\30\3\30\3\30\5\30\u01ad\n\30\3\31\3\31\3\31\3\31\3\31"+
+    "\7\31\u01b4\n\31\f\31\16\31\u01b7\13\31\5\31\u01b9\n\31\3\31\5\31\u01bc"+
+    "\n\31\3\31\3\31\3\31\5\31\u01c1\n\31\3\32\5\32\u01c4\n\32\3\32\3\32\3"+
+    "\33\3\33\3\33\3\33\5\33\u01cc\n\33\3\34\3\34\3\34\3\34\3\35\3\35\3\35"+
+    "\3\35\3\36\3\36\3\36\3\36\3\37\3\37\3\37\3\37\3\37\2\3\36 \2\4\6\b\n\f"+
+    "\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62\64\668:<\2\16\3\3\r\r\3\2:"+
+    "E\3\2\35\37\3\2 !\3\2\66\67\3\2\"$\3\2%(\3\2),\3\289\3\2FI\4\2\33\34 "+
+    "!\3\2QR\u020b\2A\3\2\2\2\4L\3\2\2\2\6Q\3\2\2\2\b\u00af\3\2\2\2\n\u00b3"+
+    "\3\2\2\2\f\u00b5\3\2\2\2\16\u00be\3\2\2\2\20\u00c2\3\2\2\2\22\u00c4\3"+
+    "\2\2\2\24\u00c6\3\2\2\2\26\u00cf\3\2\2\2\30\u00d7\3\2\2\2\32\u00dc\3\2"+
+    "\2\2\34\u00e3\3\2\2\2\36\u00ee\3\2\2\2 \u0150\3\2\2\2\"\u0174\3\2\2\2"+
+    "$\u0189\3\2\2\2&\u018f\3\2\2\2(\u0196\3\2\2\2*\u0198\3\2\2\2,\u019c\3"+
+    "\2\2\2.\u01ac\3\2\2\2\60\u01bb\3\2\2\2\62\u01c3\3\2\2\2\64\u01cb\3\2\2"+
+    "\2\66\u01cd\3\2\2\28\u01d1\3\2\2\2:\u01d5\3\2\2\2<\u01d9\3\2\2\2>@\5\4"+
+    "\3\2?>\3\2\2\2@C\3\2\2\2A?\3\2\2\2AB\3\2\2\2BG\3\2\2\2CA\3\2\2\2DF\5\b"+
+    "\5\2ED\3\2\2\2FI\3\2\2\2GE\3\2\2\2GH\3\2\2\2HJ\3\2\2\2IG\3\2\2\2JK\7\2"+
+    "\2\3K\3\3\2\2\2LM\5\26\f\2MN\7P\2\2NO\5\6\4\2OP\5\f\7\2P\5\3\2\2\2Q]\7"+
+    "\t\2\2RS\5\26\f\2SZ\7P\2\2TU\7\f\2\2UV\5\26\f\2VW\7P\2\2WY\3\2\2\2XT\3"+
+    "\2\2\2Y\\\3\2\2\2ZX\3\2\2\2Z[\3\2\2\2[^\3\2\2\2\\Z\3\2\2\2]R\3\2\2\2]"+
+    "^\3\2\2\2^_\3\2\2\2_`\7\n\2\2`\7\3\2\2\2ab\7\16\2\2bc\7\t\2\2cd\5\36\20"+
+    "\2de\7\n\2\2ei\5\n\6\2fg\7\17\2\2gj\5\n\6\2hj\6\5\2\2if\3\2\2\2ih\3\2"+
+    "\2\2j\u00b0\3\2\2\2kl\7\20\2\2lm\7\t\2\2mn\5\36\20\2nq\7\n\2\2or\5\n\6"+
+    "\2pr\5\16\b\2qo\3\2\2\2qp\3\2\2\2r\u00b0\3\2\2\2st\7\21\2\2tu\5\f\7\2"+
+    "uv\7\20\2\2vw\7\t\2\2wx\5\36\20\2xy\7\n\2\2yz\5\34\17\2z\u00b0\3\2\2\2"+
+    "{|\7\22\2\2|~\7\t\2\2}\177\5\20\t\2~}\3\2\2\2~\177\3\2\2\2\177\u0080\3"+
+    "\2\2\2\u0080\u0082\7\r\2\2\u0081\u0083\5\36\20\2\u0082\u0081\3\2\2\2\u0082"+
+    "\u0083\3\2\2\2\u0083\u0084\3\2\2\2\u0084\u0086\7\r\2\2\u0085\u0087\5\22"+
+    "\n\2\u0086\u0085\3\2\2\2\u0086\u0087\3\2\2\2\u0087\u0088\3\2\2\2\u0088"+
+    "\u008b\7\n\2\2\u0089\u008c\5\n\6\2\u008a\u008c\5\16\b\2\u008b\u0089\3"+
+    "\2\2\2\u008b\u008a\3\2\2\2\u008c\u00b0\3\2\2\2\u008d\u008e\7\22\2\2\u008e"+
+    "\u008f\7\t\2\2\u008f\u0090\5\26\f\2\u0090\u0091\7P\2\2\u0091\u0092\7\63"+
+    "\2\2\u0092\u0093\5\36\20\2\u0093\u0094\7\n\2\2\u0094\u0095\5\n\6\2\u0095"+
+    "\u00b0\3\2\2\2\u0096\u0097\5\24\13\2\u0097\u0098\5\34\17\2\u0098\u00b0"+
+    "\3\2\2\2\u0099\u009a\7\23\2\2\u009a\u00b0\5\34\17\2\u009b\u009c\7\24\2"+
+    "\2\u009c\u00b0\5\34\17\2\u009d\u009e\7\25\2\2\u009e\u009f\5\36\20\2\u009f"+
+    "\u00a0\5\34\17\2\u00a0\u00b0\3\2\2\2\u00a1\u00a2\7\27\2\2\u00a2\u00a4"+
+    "\5\f\7\2\u00a3\u00a5\5\32\16\2\u00a4\u00a3\3\2\2\2\u00a5\u00a6\3\2\2\2"+
+    "\u00a6\u00a4\3\2\2\2\u00a6\u00a7\3\2\2\2\u00a7\u00b0\3\2\2\2\u00a8\u00a9"+
+    "\7\31\2\2\u00a9\u00aa\5\36\20\2\u00aa\u00ab\5\34\17\2\u00ab\u00b0\3\2"+
+    "\2\2\u00ac\u00ad\5\36\20\2\u00ad\u00ae\5\34\17\2\u00ae\u00b0\3\2\2\2\u00af"+
+    "a\3\2\2\2\u00afk\3\2\2\2\u00afs\3\2\2\2\u00af{\3\2\2\2\u00af\u008d\3\2"+
+    "\2\2\u00af\u0096\3\2\2\2\u00af\u0099\3\2\2\2\u00af\u009b\3\2\2\2\u00af"+
+    "\u009d\3\2\2\2\u00af\u00a1\3\2\2\2\u00af\u00a8\3\2\2\2\u00af\u00ac\3\2"+
+    "\2\2\u00b0\t\3\2\2\2\u00b1\u00b4\5\f\7\2\u00b2\u00b4\5\b\5\2\u00b3\u00b1"+
+    "\3\2\2\2\u00b3\u00b2\3\2\2\2\u00b4\13\3\2\2\2\u00b5\u00b9\7\5\2\2\u00b6"+
+    "\u00b8\5\b\5\2\u00b7\u00b6\3\2\2\2\u00b8\u00bb\3\2\2\2\u00b9\u00b7\3\2"+
+    "\2\2\u00b9\u00ba\3\2\2\2\u00ba\u00bc\3\2\2\2\u00bb\u00b9\3\2\2\2\u00bc"+
+    "\u00bd\7\6\2\2\u00bd\r\3\2\2\2\u00be\u00bf\7\r\2\2\u00bf\17\3\2\2\2\u00c0"+
+    "\u00c3\5\24\13\2\u00c1\u00c3\5\36\20\2\u00c2\u00c0\3\2\2\2\u00c2\u00c1"+
+    "\3\2\2\2\u00c3\21\3\2\2\2\u00c4\u00c5\5\36\20\2\u00c5\23\3\2\2\2\u00c6"+
+    "\u00c7\5\26\f\2\u00c7\u00cc\5\30\r\2\u00c8\u00c9\7\f\2\2\u00c9\u00cb\5"+
+    "\30\r\2\u00ca\u00c8\3\2\2\2\u00cb\u00ce\3\2\2\2\u00cc\u00ca\3\2\2\2\u00cc"+
+    "\u00cd\3\2\2\2\u00cd\25\3\2\2\2\u00ce\u00cc\3\2\2\2\u00cf\u00d4\7O\2\2"+
+    "\u00d0\u00d1\7\7\2\2\u00d1\u00d3\7\b\2\2\u00d2\u00d0\3\2\2\2\u00d3\u00d6"+
+    "\3\2\2\2\u00d4\u00d2\3\2\2\2\u00d4\u00d5\3\2\2\2\u00d5\27\3\2\2\2\u00d6"+
+    "\u00d4\3\2\2\2\u00d7\u00da\7P\2\2\u00d8\u00d9\7:\2\2\u00d9\u00db\5\36"+
+    "\20\2\u00da\u00d8\3\2\2\2\u00da\u00db\3\2\2\2\u00db\31\3\2\2\2\u00dc\u00dd"+
+    "\7\30\2\2\u00dd\u00de\7\t\2\2\u00de\u00df\7O\2\2\u00df\u00e0\7P\2\2\u00e0"+
+    "\u00e1\7\n\2\2\u00e1\u00e2\5\f\7\2\u00e2\33\3\2\2\2\u00e3\u00e4\t\2\2"+
+    "\2\u00e4\35\3\2\2\2\u00e5\u00e6\b\20\1\2\u00e6\u00e7\5\"\22\2\u00e7\u00e8"+
+    "\t\3\2\2\u00e8\u00e9\5\36\20\3\u00e9\u00ea\b\20\1\2\u00ea\u00ef\3\2\2"+
+    "\2\u00eb\u00ec\5 \21\2\u00ec\u00ed\b\20\1\2\u00ed\u00ef\3\2\2\2\u00ee"+
+    "\u00e5\3\2\2\2\u00ee\u00eb\3\2\2\2\u00ef\u0130\3\2\2\2\u00f0\u00f1\f\17"+
+    "\2\2\u00f1\u00f2\t\4\2\2\u00f2\u00f3\5\36\20\20\u00f3\u00f4\b\20\1\2\u00f4"+
+    "\u012f\3\2\2\2\u00f5\u00f6\f\16\2\2\u00f6\u00f7\t\5\2\2\u00f7\u00f8\5"+
+    "\36\20\17\u00f8\u00f9\b\20\1\2\u00f9\u012f\3\2\2\2\u00fa\u00fb\f\r\2\2"+
+    "\u00fb\u00fc\t\6\2\2\u00fc\u00fd\5\36\20\16\u00fd\u00fe\b\20\1\2\u00fe"+
+    "\u012f\3\2\2\2\u00ff\u0100\f\f\2\2\u0100\u0101\t\7\2\2\u0101\u0102\5\36"+
+    "\20\r\u0102\u0103\b\20\1\2\u0103\u012f\3\2\2\2\u0104\u0105\f\13\2\2\u0105"+
+    "\u0106\t\b\2\2\u0106\u0107\5\36\20\f\u0107\u0108\b\20\1\2\u0108\u012f"+
+    "\3\2\2\2\u0109\u010a\f\n\2\2\u010a\u010b\t\t\2\2\u010b\u010c\5\36\20\13"+
+    "\u010c\u010d\b\20\1\2\u010d\u012f\3\2\2\2\u010e\u010f\f\t\2\2\u010f\u0110"+
+    "\7-\2\2\u0110\u0111\5\36\20\n\u0111\u0112\b\20\1\2\u0112\u012f\3\2\2\2"+
+    "\u0113\u0114\f\b\2\2\u0114\u0115\7.\2\2\u0115\u0116\5\36\20\t\u0116\u0117"+
+    "\b\20\1\2\u0117\u012f\3\2\2\2\u0118\u0119\f\7\2\2\u0119\u011a\7/\2\2\u011a"+
+    "\u011b\5\36\20\b\u011b\u011c\b\20\1\2\u011c\u012f\3\2\2\2\u011d\u011e"+
+    "\f\6\2\2\u011e\u011f\7\60\2\2\u011f\u0120\5\36\20\7\u0120\u0121\b\20\1"+
+    "\2\u0121\u012f\3\2\2\2\u0122\u0123\f\5\2\2\u0123\u0124\7\61\2\2\u0124"+
+    "\u0125\5\36\20\6\u0125\u0126\b\20\1\2\u0126\u012f\3\2\2\2\u0127\u0128"+
+    "\f\4\2\2\u0128\u0129\7\62\2\2\u0129\u012a\5\36\20\2\u012a\u012b\7\63\2"+
+    "\2\u012b\u012c\5\36\20\4\u012c\u012d\b\20\1\2\u012d\u012f\3\2\2\2\u012e"+
+    "\u00f0\3\2\2\2\u012e\u00f5\3\2\2\2\u012e\u00fa\3\2\2\2\u012e\u00ff\3\2"+
+    "\2\2\u012e\u0104\3\2\2\2\u012e\u0109\3\2\2\2\u012e\u010e\3\2\2\2\u012e"+
+    "\u0113\3\2\2\2\u012e\u0118\3\2\2\2\u012e\u011d\3\2\2\2\u012e\u0122\3\2"+
+    "\2\2\u012e\u0127\3\2\2\2\u012f\u0132\3\2\2\2\u0130\u012e\3\2\2\2\u0130"+
+    "\u0131\3\2\2\2\u0131\37\3\2\2\2\u0132\u0130\3\2\2\2\u0133\u0134\6\21\17"+
+    "\3\u0134\u0135\t\n\2\2\u0135\u0151\5\"\22\2\u0136\u0137\6\21\20\3\u0137"+
+    "\u0138\5\"\22\2\u0138\u0139\t\n\2\2\u0139\u0151\3\2\2\2\u013a\u013b\6"+
+    "\21\21\3\u013b\u0151\5\"\22\2\u013c\u013d\6\21\22\3\u013d\u013e\t\13\2"+
+    "\2\u013e\u0151\b\21\1\2\u013f\u0140\6\21\23\3\u0140\u0141\7L\2\2\u0141"+
+    "\u0151\b\21\1\2\u0142\u0143\6\21\24\3\u0143\u0144\7M\2\2\u0144\u0151\b"+
+    "\21\1\2\u0145\u0146\6\21\25\3\u0146\u0147\7N\2\2\u0147\u0151\b\21\1\2"+
+    "\u0148\u0149\6\21\26\3\u0149\u014a\t\f\2\2\u014a\u0151\5 \21\2\u014b\u014c"+
+    "\7\t\2\2\u014c\u014d\5\26\f\2\u014d\u014e\7\n\2\2\u014e\u014f\5 \21\2"+
+    "\u014f\u0151\3\2\2\2\u0150\u0133\3\2\2\2\u0150\u0136\3\2\2\2\u0150\u013a"+
+    "\3\2\2\2\u0150\u013c\3\2\2\2\u0150\u013f\3\2\2\2\u0150\u0142\3\2\2\2\u0150"+
+    "\u0145\3\2\2\2\u0150\u0148\3\2\2\2\u0150\u014b\3\2\2\2\u0151!\3\2\2\2"+
+    "\u0152\u0156\5$\23\2\u0153\u0155\5&\24\2\u0154\u0153\3\2\2\2\u0155\u0158"+
+    "\3\2\2\2\u0156\u0154\3\2\2\2\u0156\u0157\3\2\2\2\u0157\u0175\3\2\2\2\u0158"+
+    "\u0156\3\2\2\2\u0159\u015a\5\26\f\2\u015a\u015e\5(\25\2\u015b\u015d\5"+
+    "&\24\2\u015c\u015b\3\2\2\2\u015d\u0160\3\2\2\2\u015e\u015c\3\2\2\2\u015e"+
+    "\u015f\3\2\2\2\u015f\u0175\3\2\2\2\u0160\u015e\3\2\2\2\u0161\u0162\7\26"+
+    "\2\2\u0162\u0167\7O\2\2\u0163\u0164\7\7\2\2\u0164\u0165\5\36\20\2\u0165"+
+    "\u0166\7\b\2\2\u0166\u0168\3\2\2\2\u0167\u0163\3\2\2\2\u0168\u0169\3\2"+
+    "\2\2\u0169\u0167\3\2\2\2\u0169\u016a\3\2\2\2\u016a\u0172\3\2\2\2\u016b"+
+    "\u016f\5(\25\2\u016c\u016e\5&\24\2\u016d\u016c\3\2\2\2\u016e\u0171\3\2"+
+    "\2\2\u016f\u016d\3\2\2\2\u016f\u0170\3\2\2\2\u0170\u0173\3\2\2\2\u0171"+
+    "\u016f\3\2\2\2\u0172\u016b\3\2\2\2\u0172\u0173\3\2\2\2\u0173\u0175\3\2"+
+    "\2\2\u0174\u0152\3\2\2\2\u0174\u0159\3\2\2\2\u0174\u0161\3\2\2\2\u0175"+
+    "#\3\2\2\2\u0176\u0177\6\23\27\3\u0177\u0178\7\t\2\2\u0178\u0179\5\36\20"+
+    "\2\u0179\u017a\7\n\2\2\u017a\u017b\b\23\1\2\u017b\u018a\3\2\2\2\u017c"+
+    "\u017d\6\23\30\3\u017d\u017e\7\t\2\2\u017e\u017f\5 \21\2\u017f\u0180\7"+
+    "\n\2\2\u0180\u018a\3\2\2\2\u0181\u018a\7J\2\2\u0182\u018a\7K\2\2\u0183"+
+    "\u018a\7P\2\2\u0184\u0185\7P\2\2\u0185\u018a\5,\27\2\u0186\u0187\7\26"+
+    "\2\2\u0187\u0188\7O\2\2\u0188\u018a\5,\27\2\u0189\u0176\3\2\2\2\u0189"+
+    "\u017c\3\2\2\2\u0189\u0181\3\2\2\2\u0189\u0182\3\2\2\2\u0189\u0183\3\2"+
+    "\2\2\u0189\u0184\3\2\2\2\u0189\u0186\3\2\2\2\u018a%\3\2\2\2\u018b\u018c"+
+    "\6\24\31\3\u018c\u0190\5(\25\2\u018d\u018e\6\24\32\3\u018e\u0190\5*\26"+
+    "\2\u018f\u018b\3\2\2\2\u018f\u018d\3\2\2\2\u0190\'\3\2\2\2\u0191\u0192"+
+    "\7\13\2\2\u0192\u0193\7R\2\2\u0193\u0197\5,\27\2\u0194\u0195\7\13\2\2"+
+    "\u0195\u0197\t\r\2\2\u0196\u0191\3\2\2\2\u0196\u0194\3\2\2\2\u0197)\3"+
+    "\2\2\2\u0198\u0199\7\7\2\2\u0199\u019a\5\36\20\2\u019a\u019b\7\b\2\2\u019b"+
+    "+\3\2\2\2\u019c\u01a5\7\t\2\2\u019d\u01a2\5.\30\2\u019e\u019f\7\f\2\2"+
+    "\u019f\u01a1\5.\30\2\u01a0\u019e\3\2\2\2\u01a1\u01a4\3\2\2\2\u01a2\u01a0"+
+    "\3\2\2\2\u01a2\u01a3\3\2\2\2\u01a3\u01a6\3\2\2\2\u01a4\u01a2\3\2\2\2\u01a5"+
+    "\u019d\3\2\2\2\u01a5\u01a6\3\2\2\2\u01a6\u01a7\3\2\2\2\u01a7\u01a8\7\n"+
+    "\2\2\u01a8-\3\2\2\2\u01a9\u01ad\5\36\20\2\u01aa\u01ad\5\60\31\2\u01ab"+
+    "\u01ad\5\64\33\2\u01ac\u01a9\3\2\2\2\u01ac\u01aa\3\2\2\2\u01ac\u01ab\3"+
+    "\2\2\2\u01ad/\3\2\2\2\u01ae\u01bc\5\62\32\2\u01af\u01b8\7\t\2\2\u01b0"+
+    "\u01b5\5\62\32\2\u01b1\u01b2\7\f\2\2\u01b2\u01b4\5\62\32\2\u01b3\u01b1"+
+    "\3\2\2\2\u01b4\u01b7\3\2\2\2\u01b5\u01b3\3\2\2\2\u01b5\u01b6\3\2\2\2\u01b6"+
+    "\u01b9\3\2\2\2\u01b7\u01b5\3\2\2\2\u01b8\u01b0\3\2\2\2\u01b8\u01b9\3\2"+
+    "\2\2\u01b9\u01ba\3\2\2\2\u01ba\u01bc\7\n\2\2\u01bb\u01ae\3\2\2\2\u01bb"+
+    "\u01af\3\2\2\2\u01bc\u01bd\3\2\2\2\u01bd\u01c0\7\65\2\2\u01be\u01c1\5"+
+    "\f\7\2\u01bf\u01c1\5\36\20\2\u01c0\u01be\3\2\2\2\u01c0\u01bf\3\2\2\2\u01c1"+
+    "\61\3\2\2\2\u01c2\u01c4\5\26\f\2\u01c3\u01c2\3\2\2\2\u01c3\u01c4\3\2\2"+
+    "\2\u01c4\u01c5\3\2\2\2\u01c5\u01c6\7P\2\2\u01c6\63\3\2\2\2\u01c7\u01cc"+
+    "\5\66\34\2\u01c8\u01cc\58\35\2\u01c9\u01cc\5:\36\2\u01ca\u01cc\5<\37\2"+
+    "\u01cb\u01c7\3\2\2\2\u01cb\u01c8\3\2\2\2\u01cb\u01c9\3\2\2\2\u01cb\u01ca"+
+    "\3\2\2\2\u01cc\65\3\2\2\2\u01cd\u01ce\7O\2\2\u01ce\u01cf\7\64\2\2\u01cf"+
+    "\u01d0\7P\2\2\u01d0\67\3\2\2\2\u01d1\u01d2\5\26\f\2\u01d2\u01d3\7\64\2"+
+    "\2\u01d3\u01d4\7\26\2\2\u01d49\3\2\2\2\u01d5\u01d6\7P\2\2\u01d6\u01d7"+
+    "\7\64\2\2\u01d7\u01d8\7P\2\2\u01d8;\3\2\2\2\u01d9\u01da\7\32\2\2\u01da"+
+    "\u01db\7\64\2\2\u01db\u01dc\7P\2\2\u01dc=\3\2\2\2*AGZ]iq~\u0082\u0086"+
+    "\u008b\u00a6\u00af\u00b3\u00b9\u00c2\u00cc\u00d4\u00da\u00ee\u012e\u0130"+
+    "\u0150\u0156\u015e\u0169\u016f\u0172\u0174\u0189\u018f\u0196\u01a2\u01a5"+
+    "\u01ac\u01b5\u01b8\u01bb\u01c0\u01c3\u01cb";
   public static final ATN _ATN =
     new ATNDeserializer().deserialize(_serializedATN.toCharArray());
   static {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/SlashStrategy.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/SlashStrategy.java
@@ -20,15 +20,14 @@
 package org.elasticsearch.painless.antlr;
 
 import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.TokenFactory;
 
 /**
  * Utility to figure out if a {@code /} is division or the start of a regex literal.
  */
 public class SlashStrategy {
-    public static boolean slashIsRegex(TokenFactory<?> factory) {
-        StashingTokenFactory<?> stashingFactory = (StashingTokenFactory<?>) factory;
-        Token lastToken = stashingFactory.getLastToken();
+    public static boolean slashIsRegex(PainlessLexer lexer) {
+        EnhancedPainlessLexer realLexer = (EnhancedPainlessLexer) lexer;
+        Token lastToken = realLexer.getPreviousToken();
         if (lastToken == null) {
             return true;
         }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/Walker.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/Walker.java
@@ -183,7 +183,7 @@ public final class Walker extends PainlessParserBaseVisitor<Object> {
 
     private SourceContext buildAntlrTree(String source) {
         ANTLRInputStream stream = new ANTLRInputStream(source);
-        PainlessLexer lexer = new ErrorHandlingLexer(stream, sourceName);
+        PainlessLexer lexer = new EnhancedPainlessLexer(stream, sourceName);
         PainlessParser parser = new PainlessParser(new CommonTokenStream(lexer));
         ParserErrorStrategy strategy = new ParserErrorStrategy(sourceName);
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/LambdaTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/LambdaTests.java
@@ -79,7 +79,11 @@ public class LambdaTests extends ScriptTestCase {
     }
 
     public void testMultipleStatements() {
-        assertEquals(2, exec("int applyOne(IntFunction arg) { arg.apply(1) } applyOne(x -> { x = x + 1; return x;})"));
+        assertEquals(2, exec("int applyOne(IntFunction arg) { arg.apply(1) } applyOne(x -> { x = x + 1; return x })"));
+    }
+
+    public void testUnneededCurlyStatements() {
+        assertEquals(2, exec("int applyOne(IntFunction arg) { arg.apply(1) } applyOne(x -> { x + 1 })"));
     }
 
     public void testTwoLambdas() {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/RegexTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/RegexTests.java
@@ -201,6 +201,6 @@ public class RegexTests extends ScriptTestCase {
         IllegalArgumentException e = expectScriptThrows(IllegalArgumentException.class, () -> {
             exec("/asdf/b", emptyMap(), emptyMap(), null); // Not picky so we get a non-assertion error
         });
-        assertEquals("invalid sequence of tokens near ['b'].", e.getMessage());
+        assertEquals("unexpected token ['b'] was expecting one of [{<EOF>, ';'}].", e.getMessage());
     }
 }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/antlr/ParserTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/antlr/ParserTests.java
@@ -40,7 +40,7 @@ public class ParserTests extends ScriptTestCase {
 
     private SourceContext buildAntlrTree(String source) {
         ANTLRInputStream stream = new ANTLRInputStream(source);
-        PainlessLexer lexer = new ErrorHandlingLexer(stream, "testing");
+        PainlessLexer lexer = new EnhancedPainlessLexer(stream, "testing");
         PainlessParser parser = new PainlessParser(new CommonTokenStream(lexer));
         ParserErrorStrategy strategy = new ParserErrorStrategy("testing");
 


### PR DESCRIPTION
Perviously we used token level lookbehind in the parser. That worked,
but only if the parser didn't have any ambiguity _at all_. Since the
parser has ambiguity it didn't work everywhere. In particular it failed
when parsing blocks in lambdas like `a -> {int b = a + 2; b * b}`.

This moves the hack from the parser into the lexer. There we can use
token lookbehind (same trick) to _insert_ semicolons into the token
stream. This works much better for antlr because antlr's prediction
code can work with real tokens.

Also, the lexer is simpler than the parser, so if there is a place
to introduce a hack, that is a better place.
