### PR TITLE
Persist sequence number checkpoints

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 
 public abstract class FieldStats<T> implements Writeable, ToXContent {
+
     private final byte type;
     private long maxDoc;
     private long docCount;
@@ -628,4 +629,5 @@ public abstract class FieldStats<T> implements Writeable, ToXContent {
         final static String MAX_VALUE = new String("max_value");
         final static String MAX_VALUE_AS_STRING = new String("max_value_as_string");
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -58,7 +58,6 @@ import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.SeqNoFieldMapper;
 import org.elasticsearch.index.merge.MergeStats;
 import org.elasticsearch.index.merge.OnGoingMerge;
-import org.elasticsearch.index.seqno.GlobalCheckpointService;
 import org.elasticsearch.index.seqno.LocalCheckpointService;
 import org.elasticsearch.index.seqno.SequenceNumbersService;
 import org.elasticsearch.index.shard.DocsStats;
@@ -86,6 +85,7 @@ import java.util.function.Function;
  *
  */
 public class InternalEngine extends Engine {
+
     /**
      * When we last pruned expired tombstones from versionMap.deletes:
      */
@@ -115,6 +115,7 @@ public class InternalEngine extends Engine {
     private final IndexThrottle throttle;
 
     private final SequenceNumbersService seqNoService;
+    final static String GLOBAL_CHECKPOINT_KEY = "global_checkpoint";
 
     // How many callers are currently requesting index throttling.  Currently there are only two situations where we do this: when merges
     // are falling behind and when writing indexing buffer to disk is too slow.  When this is 0, there is no throttling, else we throttling
@@ -313,8 +314,8 @@ public class InternalEngine extends Engine {
 
     private long loadGlobalCheckpointFromCommit(IndexWriter writer) {
         final Map<String, String> commitUserData = writer.getCommitData();
-        if (commitUserData.containsKey(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY)) {
-            return Long.parseLong(commitUserData.get(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY));
+        if (commitUserData.containsKey(GLOBAL_CHECKPOINT_KEY)) {
+            return Long.parseLong(commitUserData.get(GLOBAL_CHECKPOINT_KEY));
         } else {
             return SequenceNumbersService.UNASSIGNED_SEQ_NO;
         }
@@ -1182,7 +1183,7 @@ public class InternalEngine extends Engine {
             commitData.put(Translog.TRANSLOG_UUID_KEY, translogGeneration.translogUUID);
 
             commitData.put(LocalCheckpointService.LOCAL_CHECKPOINT_KEY, Long.toString(seqNoService.getLocalCheckpoint()));
-            commitData.put(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY, Long.toString(seqNoService.getGlobalCheckpoint()));
+            commitData.put(GLOBAL_CHECKPOINT_KEY, Long.toString(seqNoService.getGlobalCheckpoint()));
 
             if (syncId != null) {
                 commitData.put(Engine.SYNC_COMMIT_ID, syncId);

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -58,7 +58,6 @@ import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.SeqNoFieldMapper;
 import org.elasticsearch.index.merge.MergeStats;
 import org.elasticsearch.index.merge.OnGoingMerge;
-import org.elasticsearch.index.seqno.LocalCheckpointService;
 import org.elasticsearch.index.seqno.SequenceNumbersService;
 import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.index.shard.ElasticsearchMergePolicy;
@@ -115,6 +114,7 @@ public class InternalEngine extends Engine {
     private final IndexThrottle throttle;
 
     private final SequenceNumbersService seqNoService;
+    final static String LOCAL_CHECKPOINT_KEY = "local_checkpoint";
     final static String GLOBAL_CHECKPOINT_KEY = "global_checkpoint";
 
     // How many callers are currently requesting index throttling.  Currently there are only two situations where we do this: when merges
@@ -305,8 +305,8 @@ public class InternalEngine extends Engine {
 
     private long loadLocalCheckpointFromCommit(IndexWriter writer) {
         final Map<String, String> commitUserData = writer.getCommitData();
-        if (commitUserData.containsKey(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)) {
-            return Long.parseLong(commitUserData.get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY));
+        if (commitUserData.containsKey(LOCAL_CHECKPOINT_KEY)) {
+            return Long.parseLong(commitUserData.get(LOCAL_CHECKPOINT_KEY));
         } else {
             return SequenceNumbersService.NO_OPS_PERFORMED;
         }
@@ -1182,7 +1182,7 @@ public class InternalEngine extends Engine {
             commitData.put(Translog.TRANSLOG_GENERATION_KEY, Long.toString(translogGeneration.translogFileGeneration));
             commitData.put(Translog.TRANSLOG_UUID_KEY, translogGeneration.translogUUID);
 
-            commitData.put(LocalCheckpointService.LOCAL_CHECKPOINT_KEY, Long.toString(seqNoService.getLocalCheckpoint()));
+            commitData.put(LOCAL_CHECKPOINT_KEY, Long.toString(seqNoService.getLocalCheckpoint()));
             commitData.put(GLOBAL_CHECKPOINT_KEY, Long.toString(seqNoService.getGlobalCheckpoint()));
 
             if (syncId != null) {

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1190,8 +1190,8 @@ public class InternalEngine extends Engine {
             commitData.put(Translog.TRANSLOG_GENERATION_KEY, Long.toString(translogGeneration.translogFileGeneration));
             commitData.put(Translog.TRANSLOG_UUID_KEY, translogGeneration.translogUUID);
 
-            commitData.put(LOCAL_CHECKPOINT_KEY, Long.toString(seqNoService.getLocalCheckpoint()));
-            commitData.put(GLOBAL_CHECKPOINT_KEY, Long.toString(seqNoService.getGlobalCheckpoint()));
+            commitData.put(LOCAL_CHECKPOINT_KEY, Long.toString(seqNoService().getLocalCheckpoint()));
+            commitData.put(GLOBAL_CHECKPOINT_KEY, Long.toString(seqNoService().getGlobalCheckpoint()));
 
             if (syncId != null) {
                 commitData.put(Engine.SYNC_COMMIT_ID, syncId);

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/SeqNoFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/SeqNoFieldMapper.java
@@ -116,6 +116,8 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
 
         @Override
         public FieldStats stats(IndexReader reader) throws IOException {
+            // nocommit remove implementation when late-binding commits
+            // are possible
             final List<LeafReaderContext> leaves = reader.leaves();
             if (leaves.isEmpty()) {
                 return null;

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/SeqNoFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/SeqNoFieldMapper.java
@@ -22,7 +22,13 @@ package org.elasticsearch.index.mapper.internal;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.Bits;
+import org.elasticsearch.action.fieldstats.FieldStats;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -108,6 +114,34 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
             throw new QueryShardException(context, "SeqNoField field [" + name() + "] is not searchable");
         }
 
+        @Override
+        public FieldStats stats(IndexReader reader) throws IOException {
+            final List<LeafReaderContext> leaves = reader.leaves();
+            if (leaves.isEmpty()) {
+                return null;
+            }
+
+            long currentMin = Long.MAX_VALUE;
+            long currentMax = Long.MIN_VALUE;
+            boolean found = false;
+            for (int i = 0; i < leaves.size(); i++) {
+                final LeafReader leaf = leaves.get(i).reader();
+                final NumericDocValues values = leaf.getNumericDocValues(name());
+                if (values == null) continue;
+                found = true;
+                final Bits bits = leaf.getLiveDocs();
+                for (int docID = 0; docID < leaf.maxDoc(); docID++) {
+                    if (bits == null || bits.get(docID)) {
+                        final long value = values.get(docID);
+                        currentMin = Math.min(currentMin, value);
+                        currentMax = Math.max(currentMax, value);
+                    }
+                }
+            }
+
+            return found ? new FieldStats.Long(reader.maxDoc(), 0, -1, -1, false, true, currentMin, currentMax) : null;
+        }
+
     }
 
     public SeqNoFieldMapper(Settings indexSettings) {
@@ -129,7 +163,7 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
 
     @Override
     public Mapper parse(ParseContext context) throws IOException {
-        // _seqno added in preparse
+        // _seq_no added in pre-parse
         return null;
     }
 
@@ -157,4 +191,5 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
     protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
         // nothing to do
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/SeqNoFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/SeqNoFieldMapper.java
@@ -130,10 +130,10 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
                 final LeafReader leaf = leaves.get(i).reader();
                 final NumericDocValues values = leaf.getNumericDocValues(name());
                 if (values == null) continue;
-                found = true;
                 final Bits bits = leaf.getLiveDocs();
                 for (int docID = 0; docID < leaf.maxDoc(); docID++) {
                     if (bits == null || bits.get(docID)) {
+                        found = true;
                         final long value = values.get(docID);
                         currentMin = Math.min(currentMin, value);
                         currentMax = Math.max(currentMax, value);

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointService.java
@@ -69,10 +69,6 @@ public class GlobalCheckpointService extends AbstractIndexShardComponent {
 
     private long globalCheckpoint;
 
-    public GlobalCheckpointService(final ShardId shardId, final IndexSettings indexSettings) {
-        this(shardId, indexSettings, SequenceNumbersService.UNASSIGNED_SEQ_NO);
-    }
-
     public GlobalCheckpointService(final ShardId shardId, final IndexSettings indexSettings, final long globalCheckpoint) {
         super(shardId, indexSettings);
         activeLocalCheckpoints = new ObjectLongHashMap<>(1 + indexSettings.getNumberOfReplicas());

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointService.java
@@ -69,6 +69,18 @@ public class GlobalCheckpointService extends AbstractIndexShardComponent {
 
     private long globalCheckpoint;
 
+    /**
+     * Initialize the global checkpoint service. The {@code globalCheckpoint}
+     * should be set to the last known global checkpoint for this shard, or
+     * {@link SequenceNumbersService#NO_OPS_PERFORMED}.
+     *
+     * @param shardId          the shard this service is providing tracking
+     *                         local checkpoints for
+     * @param indexSettings    the index settings
+     * @param globalCheckpoint the last known global checkpoint for this shard,
+     *                         or
+     *                         {@link SequenceNumbersService#UNASSIGNED_SEQ_NO}
+     */
     GlobalCheckpointService(final ShardId shardId, final IndexSettings indexSettings, final long globalCheckpoint) {
         super(shardId, indexSettings);
         activeLocalCheckpoints = new ObjectLongHashMap<>(1 + indexSettings.getNumberOfReplicas());

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointService.java
@@ -69,7 +69,7 @@ public class GlobalCheckpointService extends AbstractIndexShardComponent {
 
     private long globalCheckpoint;
 
-    public GlobalCheckpointService(final ShardId shardId, final IndexSettings indexSettings, final long globalCheckpoint) {
+    GlobalCheckpointService(final ShardId shardId, final IndexSettings indexSettings, final long globalCheckpoint) {
         super(shardId, indexSettings);
         activeLocalCheckpoints = new ObjectLongHashMap<>(1 + indexSettings.getNumberOfReplicas());
         inSyncLocalCheckpoints = new ObjectLongHashMap<>(indexSettings.getNumberOfReplicas());
@@ -124,7 +124,7 @@ public class GlobalCheckpointService extends AbstractIndexShardComponent {
      * @return true if the checkpoint has been updated or if it can not be updated since one of the local checkpoints
      * of one of the active allocations is not known.
      */
-    synchronized public boolean updateCheckpointOnPrimary() {
+    synchronized boolean updateCheckpointOnPrimary() {
         long minCheckpoint = Long.MAX_VALUE;
         if (activeLocalCheckpoints.isEmpty() && inSyncLocalCheckpoints.isEmpty()) {
             return false;
@@ -164,7 +164,7 @@ public class GlobalCheckpointService extends AbstractIndexShardComponent {
     /**
      * updates the global checkpoint on a replica shard (after it has been updated by the primary).
      */
-    synchronized public void updateCheckpointOnReplica(long globalCheckpoint) {
+    synchronized void updateCheckpointOnReplica(long globalCheckpoint) {
         if (this.globalCheckpoint <= globalCheckpoint) {
             this.globalCheckpoint = globalCheckpoint;
             logger.trace("global checkpoint updated from primary to [{}]", globalCheckpoint);

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointService.java
@@ -41,6 +41,8 @@ import java.util.Set;
  */
 public class GlobalCheckpointService extends AbstractIndexShardComponent {
 
+    public static String GLOBAL_CHECKPOINT_KEY = "global_checkpoint";
+
     /**
      * This map holds the last known local checkpoint for every shard copy that's active.
      * All shard copies in this map participate in determining the global checkpoint
@@ -67,15 +69,19 @@ public class GlobalCheckpointService extends AbstractIndexShardComponent {
      */
     final private ObjectLongMap<String> trackingLocalCheckpoint;
 
-    private long globalCheckpoint = SequenceNumbersService.UNASSIGNED_SEQ_NO;
+    private long globalCheckpoint;
 
-    public GlobalCheckpointService(ShardId shardId, IndexSettings indexSettings) {
+    public GlobalCheckpointService(final ShardId shardId, final IndexSettings indexSettings) {
+        this(shardId, indexSettings, SequenceNumbersService.UNASSIGNED_SEQ_NO);
+    }
+
+    public GlobalCheckpointService(final ShardId shardId, final IndexSettings indexSettings, final long globalCheckpoint) {
         super(shardId, indexSettings);
         activeLocalCheckpoints = new ObjectLongHashMap<>(1 + indexSettings.getNumberOfReplicas());
         inSyncLocalCheckpoints = new ObjectLongHashMap<>(indexSettings.getNumberOfReplicas());
         trackingLocalCheckpoint = new ObjectLongHashMap<>(indexSettings.getNumberOfReplicas());
+        this.globalCheckpoint = globalCheckpoint;
     }
-
 
     /**
      * notifies the service of a local checkpoint. if the checkpoint is lower than the currently known one,
@@ -241,4 +247,5 @@ public class GlobalCheckpointService extends AbstractIndexShardComponent {
         }
         return SequenceNumbersService.UNASSIGNED_SEQ_NO;
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointService.java
@@ -41,8 +41,6 @@ import java.util.Set;
  */
 public class GlobalCheckpointService extends AbstractIndexShardComponent {
 
-    public static String GLOBAL_CHECKPOINT_KEY = "global_checkpoint";
-
     /**
      * This map holds the last known local checkpoint for every shard copy that's active.
      * All shard copies in this map participate in determining the global checkpoint

--- a/core/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointService.java
@@ -33,9 +33,6 @@ import java.util.LinkedList;
  */
 public class LocalCheckpointService extends AbstractIndexShardComponent {
 
-    public static String MAX_SEQ_NO = "max_seq_no";
-    public static String LOCAL_CHECKPOINT_KEY = "local_checkpoint";
-
     /**
      * we keep a bit for each seq No that is still pending. to optimize allocation, we do so in multiple arrays
      * allocating them on demand and cleaning up while completed. This setting controls the size of the arrays

--- a/core/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointService.java
@@ -54,10 +54,6 @@ public class LocalCheckpointService extends AbstractIndexShardComponent {
     /** the next available seqNo - used for seqNo generation */
     volatile long nextSeqNo;
 
-    public LocalCheckpointService(final ShardId shardId, final IndexSettings indexSettings) {
-        this(shardId, indexSettings, SequenceNumbersService.NO_OPS_PERFORMED, SequenceNumbersService.NO_OPS_PERFORMED);
-    }
-
     public LocalCheckpointService(final ShardId shardId, final IndexSettings indexSettings, final long maxSeqNo, final long checkpoint) {
         super(shardId, indexSettings);
         bitArraysSize = SETTINGS_BIT_ARRAYS_SIZE.get(indexSettings.getSettings());

--- a/core/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointService.java
@@ -45,16 +45,16 @@ public class LocalCheckpointService extends AbstractIndexShardComponent {
      * which marks the seqNo the fist bit in the first array corresponds to.
      */
     final LinkedList<FixedBitSet> processedSeqNo;
-    final int bitArraysSize;
+    private final int bitArraysSize;
     long firstProcessedSeqNo;
 
     /** the current local checkpoint, i.e., all seqNo lower (&lt;=) than this number have been completed */
     volatile long checkpoint;
 
     /** the next available seqNo - used for seqNo generation */
-    volatile long nextSeqNo;
+    private volatile long nextSeqNo;
 
-    public LocalCheckpointService(final ShardId shardId, final IndexSettings indexSettings, final long maxSeqNo, final long checkpoint) {
+    LocalCheckpointService(final ShardId shardId, final IndexSettings indexSettings, final long maxSeqNo, final long checkpoint) {
         super(shardId, indexSettings);
         bitArraysSize = SETTINGS_BIT_ARRAYS_SIZE.get(indexSettings.getSettings());
         processedSeqNo = new LinkedList<>();
@@ -66,14 +66,14 @@ public class LocalCheckpointService extends AbstractIndexShardComponent {
     /**
      * issue the next sequence number
      **/
-    public synchronized long generateSeqNo() {
+    synchronized long generateSeqNo() {
         return nextSeqNo++;
     }
 
     /**
      * marks the processing of the given seqNo have been completed
      **/
-    public synchronized void markSeqNoAsCompleted(long seqNo) {
+    synchronized void markSeqNoAsCompleted(long seqNo) {
         // make sure we track highest seen seqNo
         if (seqNo >= nextSeqNo) {
             nextSeqNo = seqNo + 1;
@@ -96,7 +96,7 @@ public class LocalCheckpointService extends AbstractIndexShardComponent {
     }
 
     /** gets the maximum seqno seen so far */
-    public long getMaxSeqNo() {
+    long getMaxSeqNo() {
         return nextSeqNo - 1;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointService.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.SnapshotStatus;
 
 import java.util.LinkedList;
 
@@ -32,6 +33,9 @@ import java.util.LinkedList;
  */
 public class LocalCheckpointService extends AbstractIndexShardComponent {
 
+    public static String MAX_SEQ_NO = "max_seq_no";
+    public static String LOCAL_CHECKPOINT_KEY = "local_checkpoint";
+
     /**
      * we keep a bit for each seq No that is still pending. to optimize allocation, we do so in multiple arrays
      * allocating them on demand and cleaning up while completed. This setting controls the size of the arrays
@@ -39,26 +43,31 @@ public class LocalCheckpointService extends AbstractIndexShardComponent {
     public static Setting<Integer> SETTINGS_BIT_ARRAYS_SIZE = Setting.intSetting("index.seq_no.checkpoint.bit_arrays_size", 1024,
         4, Setting.Property.IndexScope);
 
-
     /**
      * an ordered list of bit arrays representing pending seq nos. The list is "anchored" in {@link #firstProcessedSeqNo}
      * which marks the seqNo the fist bit in the first array corresponds to.
      */
     final LinkedList<FixedBitSet> processedSeqNo;
     final int bitArraysSize;
-    long firstProcessedSeqNo = 0;
+    long firstProcessedSeqNo;
 
     /** the current local checkpoint, i.e., all seqNo lower (&lt;=) than this number have been completed */
-    volatile long checkpoint = SequenceNumbersService.NO_OPS_PERFORMED;
+    volatile long checkpoint;
 
     /** the next available seqNo - used for seqNo generation */
-    volatile long nextSeqNo = 0;
+    volatile long nextSeqNo;
 
+    public LocalCheckpointService(final ShardId shardId, final IndexSettings indexSettings) {
+        this(shardId, indexSettings, SequenceNumbersService.NO_OPS_PERFORMED, SequenceNumbersService.NO_OPS_PERFORMED);
+    }
 
-    public LocalCheckpointService(ShardId shardId, IndexSettings indexSettings) {
+    public LocalCheckpointService(final ShardId shardId, final IndexSettings indexSettings, final long maxSeqNo, final long checkpoint) {
         super(shardId, indexSettings);
         bitArraysSize = SETTINGS_BIT_ARRAYS_SIZE.get(indexSettings.getSettings());
         processedSeqNo = new LinkedList<>();
+        firstProcessedSeqNo = checkpoint + 1;
+        this.nextSeqNo = maxSeqNo + 1;
+        this.checkpoint = checkpoint;
     }
 
     /**
@@ -130,7 +139,7 @@ public class LocalCheckpointService extends AbstractIndexShardComponent {
      */
     private FixedBitSet getBitSetForSeqNo(long seqNo) {
         assert Thread.holdsLock(this);
-        assert seqNo >= firstProcessedSeqNo;
+        assert seqNo >= firstProcessedSeqNo : "seqNo: " + seqNo + " firstProcessedSeqNo: " + firstProcessedSeqNo;
         int bitSetOffset = ((int) (seqNo - firstProcessedSeqNo)) / bitArraysSize;
         while (bitSetOffset >= processedSeqNo.size()) {
             processedSeqNo.add(new FixedBitSet(bitArraysSize));
@@ -138,11 +147,11 @@ public class LocalCheckpointService extends AbstractIndexShardComponent {
         return processedSeqNo.get(bitSetOffset);
     }
 
-
     /** maps the given seqNo to a position in the bit set returned by {@link #getBitSetForSeqNo} */
     private int seqNoToBitSetOffset(long seqNo) {
         assert Thread.holdsLock(this);
         assert seqNo >= firstProcessedSeqNo;
         return ((int) (seqNo - firstProcessedSeqNo)) % bitArraysSize;
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
@@ -34,10 +34,15 @@ public class SequenceNumbersService extends AbstractIndexShardComponent {
     final LocalCheckpointService localCheckpointService;
     final GlobalCheckpointService globalCheckpointService;
 
-    public SequenceNumbersService(ShardId shardId, IndexSettings indexSettings) {
+    public SequenceNumbersService(
+        final ShardId shardId,
+        final IndexSettings indexSettings,
+        final long maxSeqNo,
+        final long localCheckpoint,
+        final long globalCheckpoint) {
         super(shardId, indexSettings);
-        localCheckpointService = new LocalCheckpointService(shardId, indexSettings);
-        globalCheckpointService = new GlobalCheckpointService(shardId, indexSettings);
+        localCheckpointService = new LocalCheckpointService(shardId, indexSettings, maxSeqNo, localCheckpoint);
+        globalCheckpointService = new GlobalCheckpointService(shardId, indexSettings, globalCheckpoint);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
@@ -30,10 +30,37 @@ import java.util.Set;
 public class SequenceNumbersService extends AbstractIndexShardComponent {
 
     public final static long UNASSIGNED_SEQ_NO = -2L;
+
+    /**
+     * Represents no operations have been performed on the shard.
+     */
     public final static long NO_OPS_PERFORMED = -1L;
+
     final LocalCheckpointService localCheckpointService;
     final GlobalCheckpointService globalCheckpointService;
 
+    /**
+     * Initialize the sequence number service. The {@code maxSeqNo}
+     * should be set to the last sequence number assigned by this
+     * shard, or {@link SequenceNumbersService#NO_OPS_PERFORMED},
+     * {@code localCheckpoint} should be set to the last known local
+     * checkpoint for this shard, or
+     * {@link SequenceNumbersService#NO_OPS_PERFORMED}, and
+     * {@code globalCheckpoint} should be set to the last known global
+     * checkpoint for this shard, or
+     * {@link SequenceNumbersService#UNASSIGNED_SEQ_NO}.
+     *
+     * @param shardId          the shard this service is providing tracking
+     *                         local checkpoints for
+     * @param indexSettings    the index settings
+     * @param maxSeqNo         the last sequence number assigned by this
+     *                         shard, or
+     *                         {@link SequenceNumbersService#NO_OPS_PERFORMED}
+     * @param localCheckpoint  the last known local checkpoint for this shard,
+     *                         or {@link SequenceNumbersService#NO_OPS_PERFORMED}
+     * @param globalCheckpoint the last known global checkpoint for this shard,
+     *                         or {@link SequenceNumbersService#UNASSIGNED_SEQ_NO}
+     */
     public SequenceNumbersService(
         final ShardId shardId,
         final IndexSettings indexSettings,

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -82,6 +82,8 @@ import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.index.mapper.object.RootObjectMapper;
+import org.elasticsearch.index.seqno.GlobalCheckpointService;
+import org.elasticsearch.index.seqno.LocalCheckpointService;
 import org.elasticsearch.index.seqno.SequenceNumbersService;
 import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.index.shard.IndexSearcherWrapper;
@@ -115,6 +117,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -235,6 +239,7 @@ public class InternalEngineTests extends ESTestCase {
         Field seqNoField = new NumericDocValuesField("_seq_no", 0);
         document.add(uidField);
         document.add(versionField);
+        document.add(seqNoField);
         return new ParsedDocument(versionField, seqNoField, id, type, routing, timestamp, ttl, Arrays.asList(document), source, mappingUpdate);
     }
 
@@ -548,6 +553,14 @@ public class InternalEngineTests extends ESTestCase {
         assertThat(stats1.getGeneration(), greaterThan(0L));
         assertThat(stats1.getId(), notNullValue());
         assertThat(stats1.getUserData(), hasKey(Translog.TRANSLOG_GENERATION_KEY));
+        assertThat(stats1.getUserData(), hasKey(LocalCheckpointService.LOCAL_CHECKPOINT_KEY));
+        assertThat(
+                Long.parseLong(stats1.getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)),
+                equalTo(SequenceNumbersService.NO_OPS_PERFORMED));
+        assertThat(stats1.getUserData(), hasKey(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY));
+        assertThat(
+                Long.parseLong(stats1.getUserData().get(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY)),
+                equalTo(SequenceNumbersService.UNASSIGNED_SEQ_NO));
 
         engine.flush(true, true);
         CommitStats stats2 = engine.commitStats();
@@ -558,6 +571,11 @@ public class InternalEngineTests extends ESTestCase {
         assertThat(stats2.getUserData(), hasKey(Translog.TRANSLOG_UUID_KEY));
         assertThat(stats2.getUserData().get(Translog.TRANSLOG_GENERATION_KEY), not(equalTo(stats1.getUserData().get(Translog.TRANSLOG_GENERATION_KEY))));
         assertThat(stats2.getUserData().get(Translog.TRANSLOG_UUID_KEY), equalTo(stats1.getUserData().get(Translog.TRANSLOG_UUID_KEY)));
+        assertThat(Long.parseLong(stats2.getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)), equalTo(0L));
+        assertThat(stats2.getUserData(), hasKey(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY));
+        assertThat(
+                Long.parseLong(stats2.getUserData().get(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY)),
+                equalTo(SequenceNumbersService.UNASSIGNED_SEQ_NO));
     }
 
     public void testIndexSearcherWrapper() throws Exception {
@@ -655,7 +673,7 @@ public class InternalEngineTests extends ESTestCase {
         Engine recoveringEngine = null;
         try {
             final AtomicBoolean flushed = new AtomicBoolean();
-            recoveringEngine = new InternalEngine(copy(engine.config(), EngineConfig.OpenMode.OPEN_INDEX_AND_TRANSLOG)) {
+            recoveringEngine = new InternalEngine(copy(initialEngine.config(), EngineConfig.OpenMode.OPEN_INDEX_AND_TRANSLOG)) {
                 @Override
                 public CommitId flush(boolean force, boolean waitIfOngoing) throws EngineException {
                     assertThat(getTranslog().totalOperations(), equalTo(docs));
@@ -1558,51 +1576,165 @@ public class InternalEngineTests extends ESTestCase {
         }
     }
 
-    public void testSeqNoAndLocalCheckpoint() {
-        int opCount = randomIntBetween(1, 10);
-        long seqNoCount = -1;
-        for (int op = 0; op < opCount; op++) {
-            final String id = randomFrom("1", "2", "3");
-            ParsedDocument doc = testParsedDocument(id, id, "test", null, -1, -1, testDocumentWithTextField(), B_1, null);
-            if (randomBoolean()) {
-                final Engine.Index index = new Engine.Index(newUid(id), doc,
-                        SequenceNumbersService.UNASSIGNED_SEQ_NO,
-                        rarely() ? 100 : Versions.MATCH_ANY, VersionType.INTERNAL,
-                        PRIMARY, System.currentTimeMillis());
-
-                try {
-                    engine.index(index);
-                } catch (VersionConflictEngineException e) {
-                    // OK
-                }
-                if (index.seqNo() != SequenceNumbersService.UNASSIGNED_SEQ_NO) {
-                    seqNoCount++;
-                    Engine.Index replica = new Engine.Index(index.uid(), index.parsedDoc(), index.seqNo(),
-                            index.version(), VersionType.EXTERNAL, REPLICA, System.currentTimeMillis());
-                    replicaEngine.index(replica);
-                }
-            } else {
-                final Engine.Delete delete = new Engine.Delete("test", id, newUid(id),
-                        SequenceNumbersService.UNASSIGNED_SEQ_NO,
-                        rarely() ? 100 : Versions.MATCH_ANY, VersionType.INTERNAL,
-                        PRIMARY, System.currentTimeMillis(), false);
-                try {
-                    engine.delete(delete);
-                } catch (VersionConflictEngineException e) {
-                    // OK
-                }
-                if (delete.seqNo() != SequenceNumbersService.UNASSIGNED_SEQ_NO) {
-                    seqNoCount++;
-                    Engine.Delete replica = new Engine.Delete(delete.type(), delete.id(), delete.uid(), delete.seqNo(),
-                            delete.version(), VersionType.EXTERNAL, REPLICA, System.currentTimeMillis(), false);
-                    replicaEngine.delete(replica);
+    public void testSeqNoAndCheckpoints() throws IOException {
+        int opCount = randomIntBetween(1, 256);
+        long primarySeqNo = SequenceNumbersService.NO_OPS_PERFORMED;
+        long replicaSeqNo = SequenceNumbersService.NO_OPS_PERFORMED;
+        // we lose deletes when recovering
+        final String[] ids = new String[]{"1", "2", "3"};
+        final Map<String, Long> primaryMaxNoDeleteSeqNo = new HashMap<>();
+        final Map<String, Long> replicaMaxNoDeleteSeqNo = new HashMap<>();
+        long replicaLocalCheckpoint = SequenceNumbersService.NO_OPS_PERFORMED;
+        InternalEngine initialEngine = null;
+        InternalEngine initialReplicaEngine = null;
+        try {
+            initialEngine = engine;
+            initialReplicaEngine = replicaEngine;
+            boolean broken = false;
+            for (int op = 0; op < opCount; op++) {
+                final String id = randomFrom(ids);
+                ParsedDocument doc = testParsedDocument(id, id, "test", null, -1, -1, testDocumentWithTextField(), B_1, null);
+                if (randomBoolean()) {
+                    final Engine.Index index = new Engine.Index(newUid(id), doc,
+                            SequenceNumbersService.UNASSIGNED_SEQ_NO,
+                            rarely() ? 100 : Versions.MATCH_ANY, VersionType.INTERNAL,
+                            PRIMARY, System.currentTimeMillis());
+                    try {
+                        initialEngine.index(index);
+                        primarySeqNo++;
+                    } catch (VersionConflictEngineException e) {
+                        // OK
+                    }
+                    if (index.seqNo() != SequenceNumbersService.UNASSIGNED_SEQ_NO) {
+                        if (rarely()) {
+                            // put a hole in the sequence numbers on the replica
+                            if (!broken) {
+                                broken = true;
+                                replicaLocalCheckpoint = replicaSeqNo;
+                            }
+                        } else {
+                            Engine.Index replica = new Engine.Index(index.uid(), index.parsedDoc(), index.seqNo(),
+                                    index.version(), VersionType.EXTERNAL, REPLICA, System.currentTimeMillis());
+                            initialReplicaEngine.index(replica);
+                            replicaSeqNo = primarySeqNo;
+                            replicaMaxNoDeleteSeqNo.put(id, replicaSeqNo);
+                        }
+                        primaryMaxNoDeleteSeqNo.put(id, primarySeqNo);
+                    }
+                } else {
+                    final Engine.Delete delete = new Engine.Delete("test", id, newUid(id),
+                            SequenceNumbersService.UNASSIGNED_SEQ_NO,
+                            rarely() ? 100 : Versions.MATCH_ANY, VersionType.INTERNAL,
+                            PRIMARY, System.currentTimeMillis(), false);
+                    try {
+                        initialEngine.delete(delete);
+                        primarySeqNo++;
+                    } catch (VersionConflictEngineException e) {
+                        // OK
+                    }
+                    if (delete.seqNo() != SequenceNumbersService.UNASSIGNED_SEQ_NO) {
+                        if (rarely()) {
+                            // put a hole in the sequence numbers on the replica
+                            if (!broken) {
+                                broken = true;
+                                replicaLocalCheckpoint = replicaSeqNo;
+                            }
+                        } else {
+                            Engine.Delete replica = new Engine.Delete(delete.type(), delete.id(), delete.uid(), delete.seqNo(),
+                                    delete.version(), VersionType.EXTERNAL, REPLICA, System.currentTimeMillis(), false);
+                            initialReplicaEngine.delete(replica);
+                            replicaSeqNo = primarySeqNo;
+                            replicaMaxNoDeleteSeqNo.remove(id);
+                        }
+                        primaryMaxNoDeleteSeqNo.remove(id);
+                    }
                 }
             }
+
+            if (!broken) {
+                replicaLocalCheckpoint = primarySeqNo;
+            }
+
+            initialEngine
+                    .seqNoService()
+                    .updateAllocationIdsFromMaster(new HashSet<>(Arrays.asList("primary", "replica")), Collections.emptySet());
+            initialEngine.seqNoService().updateLocalCheckpointForShard("primary", initialEngine.seqNoService().getLocalCheckpoint());
+            initialEngine.seqNoService().updateLocalCheckpointForShard("replica", initialReplicaEngine.seqNoService().getLocalCheckpoint());
+            initialEngine.seqNoService().updateGlobalCheckpointOnPrimary();
+
+            assertThat(initialEngine.seqNoService().stats().getMaxSeqNo(), equalTo(primarySeqNo));
+            assertThat(initialEngine.seqNoService().stats().getLocalCheckpoint(), equalTo(primarySeqNo));
+            assertThat(initialEngine.seqNoService().stats().getGlobalCheckpoint(), equalTo(replicaLocalCheckpoint));
+            assertThat(initialReplicaEngine.seqNoService().stats().getMaxSeqNo(), equalTo(replicaSeqNo));
+            assertThat(initialReplicaEngine.seqNoService().stats().getLocalCheckpoint(), equalTo(replicaLocalCheckpoint));
+            assertThat(
+                    initialReplicaEngine.seqNoService().stats().getGlobalCheckpoint(),
+                    equalTo(SequenceNumbersService.UNASSIGNED_SEQ_NO));
+
+            initialEngine.flush(true, true);
+            assertThat(
+                    Long.parseLong(initialEngine.commitStats().getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)),
+                    equalTo(primarySeqNo));
+            assertThat(
+                    Long.parseLong(initialEngine.commitStats().getUserData().get(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY)),
+                    equalTo(replicaLocalCheckpoint));
+            initialReplicaEngine.flush(true, true);
+            assertThat(
+                    Long.parseLong(initialReplicaEngine.commitStats().getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)),
+                    equalTo(replicaLocalCheckpoint));
+            assertThat(
+                    Long.parseLong(initialReplicaEngine.commitStats().getUserData().get(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY)),
+                    equalTo(SequenceNumbersService.UNASSIGNED_SEQ_NO));
+        } finally {
+            IOUtils.close(initialEngine, initialReplicaEngine);
         }
-        assertThat(engine.seqNoService().stats().getMaxSeqNo(), equalTo(seqNoCount));
-        assertThat(engine.seqNoService().stats().getLocalCheckpoint(), equalTo(seqNoCount));
-        assertThat(replicaEngine.seqNoService().stats().getMaxSeqNo(), equalTo(seqNoCount));
-        assertThat(replicaEngine.seqNoService().stats().getLocalCheckpoint(), equalTo(seqNoCount));
+
+        InternalEngine recoveringEngine = null;
+        InternalEngine recoveringReplicaEngine = null;
+        try {
+            recoveringEngine = new InternalEngine(copy(initialEngine.config(), EngineConfig.OpenMode.OPEN_INDEX_AND_TRANSLOG));
+            recoveringReplicaEngine =
+                    new InternalEngine(copy(initialReplicaEngine.config(), EngineConfig.OpenMode.OPEN_INDEX_AND_TRANSLOG));
+
+            long primaryMaxSeqNo = SequenceNumbersService.NO_OPS_PERFORMED;
+            for (String id : ids) {
+                if (primaryMaxNoDeleteSeqNo.containsKey(id)) {
+                    primaryMaxSeqNo = Math.max(primaryMaxSeqNo, primaryMaxNoDeleteSeqNo.get(id));
+                }
+            }
+
+            long replicaMaxSeqNo = SequenceNumbersService.NO_OPS_PERFORMED;
+            for (String id : ids) {
+                if (replicaMaxNoDeleteSeqNo.containsKey(id)) {
+                    replicaMaxSeqNo = Math.max(replicaMaxSeqNo, replicaMaxNoDeleteSeqNo.get(id));
+                }
+            }
+
+            assertThat(
+                    Long.parseLong(recoveringEngine.commitStats().getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)),
+                    equalTo(primarySeqNo));
+            assertThat(
+                    Long.parseLong(recoveringEngine.commitStats().getUserData().get(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY)),
+                    equalTo(replicaLocalCheckpoint));
+            assertThat(recoveringEngine.seqNoService().stats().getLocalCheckpoint(), equalTo(primarySeqNo));
+            assertThat(recoveringEngine.seqNoService().stats().getGlobalCheckpoint(), equalTo(replicaLocalCheckpoint));
+            assertThat(recoveringEngine.seqNoService().stats().getMaxSeqNo(), equalTo(primaryMaxSeqNo));
+            assertThat(recoveringEngine.seqNoService().generateSeqNo(), equalTo(primaryMaxSeqNo + 1));
+            assertThat(
+                    Long.parseLong(recoveringReplicaEngine.commitStats().getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)),
+                    equalTo(replicaLocalCheckpoint));
+            assertThat(
+                    Long.parseLong(recoveringReplicaEngine.commitStats().getUserData().get(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY)),
+                    equalTo(SequenceNumbersService.UNASSIGNED_SEQ_NO));
+            assertThat(recoveringReplicaEngine.seqNoService().stats().getLocalCheckpoint(), equalTo(replicaLocalCheckpoint));
+            assertThat(
+                    recoveringReplicaEngine.seqNoService().stats().getGlobalCheckpoint(),
+                    equalTo(SequenceNumbersService.UNASSIGNED_SEQ_NO));
+            assertThat(recoveringReplicaEngine.seqNoService().stats().getMaxSeqNo(), equalTo(replicaMaxSeqNo));
+            assertThat(recoveringReplicaEngine.seqNoService().generateSeqNo(), equalTo(replicaMaxSeqNo + 1));
+        } finally {
+            IOUtils.close(recoveringEngine, recoveringReplicaEngine);
+        }
     }
 
     // #8603: make sure we can separately log IFD's messages
@@ -1920,9 +2052,9 @@ public class InternalEngineTests extends ESTestCase {
                     }
                     CommitStats commitStats = engine.commitStats();
                     Map<String, String> userData = commitStats.getUserData();
-                    assertTrue("userdata dosn't contain uuid", userData.containsKey(Translog.TRANSLOG_UUID_KEY));
-                    assertTrue("userdata doesn't contain generation key", userData.containsKey(Translog.TRANSLOG_GENERATION_KEY));
-                    assertFalse("userdata contains legacy marker", userData.containsKey("translog_id"));
+                    assertTrue("user data doesn't contain uuid", userData.containsKey(Translog.TRANSLOG_UUID_KEY));
+                    assertTrue("user data doesn't contain generation key", userData.containsKey(Translog.TRANSLOG_GENERATION_KEY));
+                    assertFalse("user data contains legacy marker", userData.containsKey("translog_id"));
                 }
             }
 

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -82,7 +82,6 @@ import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.index.mapper.object.RootObjectMapper;
-import org.elasticsearch.index.seqno.GlobalCheckpointService;
 import org.elasticsearch.index.seqno.LocalCheckpointService;
 import org.elasticsearch.index.seqno.SequenceNumbersService;
 import org.elasticsearch.index.shard.DocsStats;
@@ -557,9 +556,9 @@ public class InternalEngineTests extends ESTestCase {
         assertThat(
                 Long.parseLong(stats1.getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)),
                 equalTo(SequenceNumbersService.NO_OPS_PERFORMED));
-        assertThat(stats1.getUserData(), hasKey(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY));
+        assertThat(stats1.getUserData(), hasKey(InternalEngine.GLOBAL_CHECKPOINT_KEY));
         assertThat(
-                Long.parseLong(stats1.getUserData().get(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY)),
+                Long.parseLong(stats1.getUserData().get(InternalEngine.GLOBAL_CHECKPOINT_KEY)),
                 equalTo(SequenceNumbersService.UNASSIGNED_SEQ_NO));
 
         engine.flush(true, true);
@@ -572,9 +571,9 @@ public class InternalEngineTests extends ESTestCase {
         assertThat(stats2.getUserData().get(Translog.TRANSLOG_GENERATION_KEY), not(equalTo(stats1.getUserData().get(Translog.TRANSLOG_GENERATION_KEY))));
         assertThat(stats2.getUserData().get(Translog.TRANSLOG_UUID_KEY), equalTo(stats1.getUserData().get(Translog.TRANSLOG_UUID_KEY)));
         assertThat(Long.parseLong(stats2.getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)), equalTo(0L));
-        assertThat(stats2.getUserData(), hasKey(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY));
+        assertThat(stats2.getUserData(), hasKey(InternalEngine.GLOBAL_CHECKPOINT_KEY));
         assertThat(
-                Long.parseLong(stats2.getUserData().get(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY)),
+                Long.parseLong(stats2.getUserData().get(InternalEngine.GLOBAL_CHECKPOINT_KEY)),
                 equalTo(SequenceNumbersService.UNASSIGNED_SEQ_NO));
     }
 
@@ -1676,14 +1675,14 @@ public class InternalEngineTests extends ESTestCase {
                     Long.parseLong(initialEngine.commitStats().getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)),
                     equalTo(primarySeqNo));
             assertThat(
-                    Long.parseLong(initialEngine.commitStats().getUserData().get(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY)),
+                    Long.parseLong(initialEngine.commitStats().getUserData().get(InternalEngine.GLOBAL_CHECKPOINT_KEY)),
                     equalTo(replicaLocalCheckpoint));
             initialReplicaEngine.flush(true, true);
             assertThat(
                     Long.parseLong(initialReplicaEngine.commitStats().getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)),
                     equalTo(replicaLocalCheckpoint));
             assertThat(
-                    Long.parseLong(initialReplicaEngine.commitStats().getUserData().get(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY)),
+                    Long.parseLong(initialReplicaEngine.commitStats().getUserData().get(InternalEngine.GLOBAL_CHECKPOINT_KEY)),
                     equalTo(SequenceNumbersService.UNASSIGNED_SEQ_NO));
         } finally {
             IOUtils.close(initialEngine, initialReplicaEngine);
@@ -1714,7 +1713,7 @@ public class InternalEngineTests extends ESTestCase {
                     Long.parseLong(recoveringEngine.commitStats().getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)),
                     equalTo(primarySeqNo));
             assertThat(
-                    Long.parseLong(recoveringEngine.commitStats().getUserData().get(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY)),
+                    Long.parseLong(recoveringEngine.commitStats().getUserData().get(InternalEngine.GLOBAL_CHECKPOINT_KEY)),
                     equalTo(replicaLocalCheckpoint));
             assertThat(recoveringEngine.seqNoService().stats().getLocalCheckpoint(), equalTo(primarySeqNo));
             assertThat(recoveringEngine.seqNoService().stats().getGlobalCheckpoint(), equalTo(replicaLocalCheckpoint));
@@ -1724,7 +1723,7 @@ public class InternalEngineTests extends ESTestCase {
                     Long.parseLong(recoveringReplicaEngine.commitStats().getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)),
                     equalTo(replicaLocalCheckpoint));
             assertThat(
-                    Long.parseLong(recoveringReplicaEngine.commitStats().getUserData().get(GlobalCheckpointService.GLOBAL_CHECKPOINT_KEY)),
+                    Long.parseLong(recoveringReplicaEngine.commitStats().getUserData().get(InternalEngine.GLOBAL_CHECKPOINT_KEY)),
                     equalTo(SequenceNumbersService.UNASSIGNED_SEQ_NO));
             assertThat(recoveringReplicaEngine.seqNoService().stats().getLocalCheckpoint(), equalTo(replicaLocalCheckpoint));
             assertThat(

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -82,7 +82,6 @@ import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.index.mapper.object.RootObjectMapper;
-import org.elasticsearch.index.seqno.LocalCheckpointService;
 import org.elasticsearch.index.seqno.SequenceNumbersService;
 import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.index.shard.IndexSearcherWrapper;
@@ -552,9 +551,9 @@ public class InternalEngineTests extends ESTestCase {
         assertThat(stats1.getGeneration(), greaterThan(0L));
         assertThat(stats1.getId(), notNullValue());
         assertThat(stats1.getUserData(), hasKey(Translog.TRANSLOG_GENERATION_KEY));
-        assertThat(stats1.getUserData(), hasKey(LocalCheckpointService.LOCAL_CHECKPOINT_KEY));
+        assertThat(stats1.getUserData(), hasKey(InternalEngine.LOCAL_CHECKPOINT_KEY));
         assertThat(
-                Long.parseLong(stats1.getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)),
+                Long.parseLong(stats1.getUserData().get(InternalEngine.LOCAL_CHECKPOINT_KEY)),
                 equalTo(SequenceNumbersService.NO_OPS_PERFORMED));
         assertThat(stats1.getUserData(), hasKey(InternalEngine.GLOBAL_CHECKPOINT_KEY));
         assertThat(
@@ -570,7 +569,7 @@ public class InternalEngineTests extends ESTestCase {
         assertThat(stats2.getUserData(), hasKey(Translog.TRANSLOG_UUID_KEY));
         assertThat(stats2.getUserData().get(Translog.TRANSLOG_GENERATION_KEY), not(equalTo(stats1.getUserData().get(Translog.TRANSLOG_GENERATION_KEY))));
         assertThat(stats2.getUserData().get(Translog.TRANSLOG_UUID_KEY), equalTo(stats1.getUserData().get(Translog.TRANSLOG_UUID_KEY)));
-        assertThat(Long.parseLong(stats2.getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)), equalTo(0L));
+        assertThat(Long.parseLong(stats2.getUserData().get(InternalEngine.LOCAL_CHECKPOINT_KEY)), equalTo(0L));
         assertThat(stats2.getUserData(), hasKey(InternalEngine.GLOBAL_CHECKPOINT_KEY));
         assertThat(
                 Long.parseLong(stats2.getUserData().get(InternalEngine.GLOBAL_CHECKPOINT_KEY)),
@@ -1672,14 +1671,14 @@ public class InternalEngineTests extends ESTestCase {
 
             initialEngine.flush(true, true);
             assertThat(
-                    Long.parseLong(initialEngine.commitStats().getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)),
+                    Long.parseLong(initialEngine.commitStats().getUserData().get(InternalEngine.LOCAL_CHECKPOINT_KEY)),
                     equalTo(primarySeqNo));
             assertThat(
                     Long.parseLong(initialEngine.commitStats().getUserData().get(InternalEngine.GLOBAL_CHECKPOINT_KEY)),
                     equalTo(replicaLocalCheckpoint));
             initialReplicaEngine.flush(true, true);
             assertThat(
-                    Long.parseLong(initialReplicaEngine.commitStats().getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)),
+                    Long.parseLong(initialReplicaEngine.commitStats().getUserData().get(InternalEngine.LOCAL_CHECKPOINT_KEY)),
                     equalTo(replicaLocalCheckpoint));
             assertThat(
                     Long.parseLong(initialReplicaEngine.commitStats().getUserData().get(InternalEngine.GLOBAL_CHECKPOINT_KEY)),
@@ -1710,7 +1709,7 @@ public class InternalEngineTests extends ESTestCase {
             }
 
             assertThat(
-                    Long.parseLong(recoveringEngine.commitStats().getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)),
+                    Long.parseLong(recoveringEngine.commitStats().getUserData().get(InternalEngine.LOCAL_CHECKPOINT_KEY)),
                     equalTo(primarySeqNo));
             assertThat(
                     Long.parseLong(recoveringEngine.commitStats().getUserData().get(InternalEngine.GLOBAL_CHECKPOINT_KEY)),
@@ -1720,7 +1719,7 @@ public class InternalEngineTests extends ESTestCase {
             assertThat(recoveringEngine.seqNoService().stats().getMaxSeqNo(), equalTo(primaryMaxSeqNo));
             assertThat(recoveringEngine.seqNoService().generateSeqNo(), equalTo(primaryMaxSeqNo + 1));
             assertThat(
-                    Long.parseLong(recoveringReplicaEngine.commitStats().getUserData().get(LocalCheckpointService.LOCAL_CHECKPOINT_KEY)),
+                    Long.parseLong(recoveringReplicaEngine.commitStats().getUserData().get(InternalEngine.LOCAL_CHECKPOINT_KEY)),
                     equalTo(replicaLocalCheckpoint));
             assertThat(
                     Long.parseLong(recoveringReplicaEngine.commitStats().getUserData().get(InternalEngine.GLOBAL_CHECKPOINT_KEY)),

--- a/core/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointTests.java
+++ b/core/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointTests.java
@@ -41,7 +41,7 @@ public class GlobalCheckpointTests extends ESTestCase {
     public void setUp() throws Exception {
         super.setUp();
         checkpointService = new GlobalCheckpointService(new ShardId("test", "_na_", 0),
-            IndexSettingsModule.newIndexSettings("test", Settings.EMPTY));
+            IndexSettingsModule.newIndexSettings("test", Settings.EMPTY), SequenceNumbersService.UNASSIGNED_SEQ_NO);
     }
 
     public void testEmptyShards() {

--- a/core/src/test/java/org/elasticsearch/index/seqno/LocalCheckpointServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/seqno/LocalCheckpointServiceTests.java
@@ -53,12 +53,13 @@ public class LocalCheckpointServiceTests extends ESTestCase {
 
     private LocalCheckpointService getCheckpointService() {
         return new LocalCheckpointService(
-            new ShardId("test", "_na_", 0),
-            IndexSettingsModule.newIndexSettings("test",
-                Settings.builder()
-                    .put(LocalCheckpointService.SETTINGS_BIT_ARRAYS_SIZE.getKey(), SMALL_CHUNK_SIZE)
-                    .build()
-            ));
+                new ShardId("test", "_na_", 0),
+                IndexSettingsModule.newIndexSettings("test",
+                        Settings.builder()
+                                .put(LocalCheckpointService.SETTINGS_BIT_ARRAYS_SIZE.getKey(), SMALL_CHUNK_SIZE)
+                                .build()),
+                SequenceNumbersService.NO_OPS_PERFORMED,
+                SequenceNumbersService.NO_OPS_PERFORMED);
     }
 
     public void testSimplePrimary() {


### PR DESCRIPTION
This commit adds persistence for local and global sequence number
checkpoints. We also recover the max sequence number in a shard,
although there will be loss here today from delete operations. This will
be addressed in a follow-up.

Relates #10708
