### PR TITLE
Make request cache's key generation pluggable

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsAction.java
@@ -195,7 +195,7 @@ public class TransportFieldStatsAction extends
                 fieldNames.addAll(shard.mapperService().simpleMatchToIndexNames(field));
             }
             for (String field : fieldNames) {
-                FieldStats<?> stats = indicesService.getFieldStats(shard, searcher, field, request.shouldUseCache());
+                FieldStats<?> stats = indicesService.getFieldStats(shardId, shard, searcher, field, request.shouldUseCache());
                 if (stats != null) {
                     fieldStats.put(field, stats);
                 }

--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -48,6 +48,7 @@ import org.elasticsearch.node.internal.InternalSettingsPreparer;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsModule;
 import org.elasticsearch.plugins.PluginsService;
+import org.elasticsearch.plugins.ThreadPoolPlugin;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.threadpool.ExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -124,6 +125,9 @@ public class TransportClient extends AbstractClient {
             Version version = Version.CURRENT;
 
             final ThreadPool threadPool = new ThreadPool(settings);
+            for (ThreadPoolPlugin plugin : pluginsService.filterPlugins(ThreadPoolPlugin.class)) {
+                plugin.setThreadPool(threadPool);
+            }
             final NetworkService networkService = new NetworkService(settings);
             NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry();
             boolean success = false;

--- a/core/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -35,10 +35,10 @@ import org.elasticsearch.index.mapper.core.BooleanFieldMapper;
 import org.elasticsearch.index.mapper.core.CompletionFieldMapper;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
 import org.elasticsearch.index.mapper.core.KeywordFieldMapper;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper;
 import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.elasticsearch.index.mapper.core.TextFieldMapper;
 import org.elasticsearch.index.mapper.core.TokenCountFieldMapper;
-import org.elasticsearch.index.mapper.core.NumberFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.internal.AllFieldMapper;
@@ -78,6 +78,7 @@ public class IndicesModule extends AbstractModule {
     // Use a LinkedHashMap for metadataMappers because iteration order matters
     private final Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers
         = new LinkedHashMap<>();
+    private IndicesRequestCacheKeyBuilder indicesRequstCacheKeyBuilder = new IndicesRequestCacheKeyBuilder.Default();
     private final NamedWriteableRegistry namedWritableRegistry;
 
     public IndicesModule(NamedWriteableRegistry namedWriteableRegistry) {
@@ -153,6 +154,20 @@ public class IndicesModule extends AbstractModule {
         metadataMapperParsers.put(name, parser);
     }
 
+    /**
+     * Get the builder for keys into the indices request cache.
+     */
+    public IndicesRequestCacheKeyBuilder getIndicesRequstCacheKeyBuilder() {
+        return indicesRequstCacheKeyBuilder;
+    }
+
+    /**
+     * Set the builder for keys into the indices request cache. This may only be set before {@link #configure()} is called.
+     */
+    public void setIndicesRequstCacheKeyBuilder(IndicesRequestCacheKeyBuilder indicesRequstCacheKeyBuilder) {
+        this.indicesRequstCacheKeyBuilder = indicesRequstCacheKeyBuilder;
+    }
+
     @Override
     protected void configure() {
         bindMapperExtension();
@@ -169,6 +184,7 @@ public class IndicesModule extends AbstractModule {
         bind(UpdateHelper.class).asEagerSingleton();
         bind(MetaDataIndexUpgradeService.class).asEagerSingleton();
         bind(NodeServicesProvider.class).asEagerSingleton();
+        bind(IndicesRequestCacheKeyBuilder.class).toInstance(indicesRequstCacheKeyBuilder);
     }
 
     // public for testing

--- a/core/src/main/java/org/elasticsearch/indices/IndicesRequestCacheKeyBuilder.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesRequestCacheKeyBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices;
+
+import org.elasticsearch.action.fieldstats.FieldStats;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.search.internal.ShardSearchRequest;
+
+import java.io.IOException;
+
+public interface IndicesRequestCacheKeyBuilder {
+    /**
+     * The key into the request cache for a {@link SearchRequest}. This lookup is already scoped to a single shard so it is safe to ignore
+     * that part of the request.
+     */
+    BytesReference searchRequestKey(ShardSearchRequest request) throws IOException;
+
+    /**
+     * The key into the request cache for {@link FieldStats} for a particular field. It is safe to just use the field name as the request
+     * is already scoped to the shard but the shard information is provided in case it is useful.
+     */
+    BytesReference fieldStatsKey(ShardId shardId, String field) throws IOException;
+
+    public class Default implements IndicesRequestCacheKeyBuilder {
+        @Override
+        public BytesReference searchRequestKey(ShardSearchRequest request) throws IOException {
+            return request.cacheKey();
+        }
+
+        @Override
+        public BytesReference fieldStatsKey(ShardId shardId, String field) {
+            return new BytesArray("fieldstats:" + field);
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -92,6 +92,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsModule;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.plugins.ThreadPoolPlugin;
 import org.elasticsearch.repositories.RepositoriesModule;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.script.ScriptModule;
@@ -223,6 +224,9 @@ public class Node implements Closeable {
         try {
             final ThreadPool threadPool = new ThreadPool(settings, executorBuilders.toArray(new ExecutorBuilder[0]));
             resourcesToClose.add(() -> ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS));
+            for (ThreadPoolPlugin plugin : pluginsService.filterPlugins(ThreadPoolPlugin.class)) {
+                plugin.setThreadPool(threadPool);
+            }
             final List<Setting<?>> additionalSettings = new ArrayList<>();
             final List<String> additionalSettingsFilter = new ArrayList<>();
             additionalSettings.addAll(pluginsService.getPluginSettings());

--- a/core/src/main/java/org/elasticsearch/plugins/ThreadPoolPlugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/ThreadPoolPlugin.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import org.elasticsearch.threadpool.ThreadPool;
+
+/**
+ * Interface for plugins that need the ThreadPool.
+ */
+public interface ThreadPoolPlugin {
+    void setThreadPool(ThreadPool threadPool);
+}

--- a/core/src/test/java/org/elasticsearch/plugins/ThreadPoolPluginTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/ThreadPoolPluginTests.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import org.elasticsearch.common.component.LifecycleComponent;
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.threadpool.ExecutorBuilder;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Test that {@link ThreadPoolPlugin}s get the ThreadPool at an appropriate time. 
+ */
+public class ThreadPoolPluginTests extends ESSingleNodeTestCase {
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.getPlugins());
+        plugins.add(TestPlugin.class);
+        return plugins;
+    }
+
+    public void testPluginOk() {
+        assertSame(getInstanceFromNode(ThreadPool.class), TestPlugin.threadPool);
+    }
+
+    public static class TestPlugin extends Plugin implements ThreadPoolPlugin {
+        private static ThreadPool threadPool;
+
+        @Override
+        public void setThreadPool(ThreadPool threadPool) {
+            TestPlugin.threadPool = threadPool;
+        }
+
+        @Override
+        public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
+            assertNull("setThreadPool should not have already been called", threadPool);
+            return super.getExecutorBuilders(settings);
+        }
+
+        @Override
+        public Collection<Module> nodeModules() {
+            assertNotNull("setThreadPool should have already been called", threadPool);
+            return super.nodeModules();
+        }
+
+        @Override
+        @SuppressWarnings("rawtypes")
+        public Collection<Class<? extends LifecycleComponent>> nodeServices() {
+            assertNotNull("setThreadPool should have already been called", threadPool);
+            return super.nodeServices();
+        }
+    }
+}


### PR DESCRIPTION
Also adds ThreadPoolPlugin for plugins that need access to the node's ThreadPool. Together, these allow plugins that hijack the search process to avoid poisoning the cache because they have control over the key. Now they can alter the key to keep the cache healthy.
