### PR TITLE
Cleanup some things after removal of joda-time hack

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -64,8 +64,6 @@ dependencies {
 
   // time handling, remove with java 8 time
   compile 'joda-time:joda-time:2.9.4'
-  // joda 2.0 moved to using volatile fields for datetime
-  // When updating to a new version, make sure to update our copy of BaseDateTime
   compile 'org.joda:joda-convert:1.2'
 
   // json and yaml

--- a/core/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java
@@ -31,6 +31,7 @@ import java.security.PermissionCollection;
 import java.security.Permissions;
 import java.security.Policy;
 import java.security.ProtectionDomain;
+import java.util.Collections;
 import java.util.Map;
 
 /** custom policy for union of static and dynamic permissions */
@@ -49,7 +50,7 @@ final class ESPolicy extends Policy {
 
     public ESPolicy(PermissionCollection dynamic, Map<String,Policy> plugins, boolean filterBadDefaults) {
         this.template = Security.readPolicy(getClass().getResource(POLICY_RESOURCE), JarHell.parseClassPath());
-        this.untrusted = Security.readPolicy(getClass().getResource(UNTRUSTED_RESOURCE), new URL[0]);
+        this.untrusted = Security.readPolicy(getClass().getResource(UNTRUSTED_RESOURCE), Collections.emptySet());
         if (filterBadDefaults) {
             this.system = new SystemPolicy(Policy.getPolicy());
         } else {

--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -45,11 +45,11 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Permissions;
 import java.security.Policy;
 import java.security.URIParameter;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Initializes SecurityManager with necessary permissions.
@@ -133,19 +133,23 @@ final class Security {
     @SuppressForbidden(reason = "proper use of URL")
     static Map<String,Policy> getPluginPermissions(Environment environment) throws IOException, NoSuchAlgorithmException {
         Map<String,Policy> map = new HashMap<>();
-        // collect up lists of plugins and modules
-        List<Path> pluginsAndModules = new ArrayList<>();
+        // collect up set of plugins and modules by listing directories.
+        Set<Path> pluginsAndModules = new LinkedHashSet<>(); // order is already lost, but some filesystems have it
         if (Files.exists(environment.pluginsFile())) {
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(environment.pluginsFile())) {
                 for (Path plugin : stream) {
-                    pluginsAndModules.add(plugin);
+                    if (pluginsAndModules.add(plugin) == false) {
+                        throw new IllegalStateException("duplicate plugin: " + plugin);
+                    }
                 }
             }
         }
         if (Files.exists(environment.modulesFile())) {
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(environment.modulesFile())) {
-                for (Path plugin : stream) {
-                    pluginsAndModules.add(plugin);
+                for (Path module : stream) {
+                    if (pluginsAndModules.add(module) == false) {
+                        throw new IllegalStateException("duplicate module: " + module);
+                    }
                 }
             }
         }
@@ -155,15 +159,18 @@ final class Security {
             if (Files.exists(policyFile)) {
                 // first get a list of URLs for the plugins' jars:
                 // we resolve symlinks so map is keyed on the normalize codebase name
-                List<URL> codebases = new ArrayList<>();
+                Set<URL> codebases = new LinkedHashSet<>(); // order is already lost, but some filesystems have it
                 try (DirectoryStream<Path> jarStream = Files.newDirectoryStream(plugin, "*.jar")) {
                     for (Path jar : jarStream) {
-                        codebases.add(jar.toRealPath().toUri().toURL());
+                        URL url = jar.toRealPath().toUri().toURL();
+                        if (codebases.add(url) == false) {
+                            throw new IllegalStateException("duplicate module/plugin: " + url);
+                        }
                     }
                 }
 
                 // parse the plugin's policy file into a set of permissions
-                Policy policy = readPolicy(policyFile.toUri().toURL(), codebases.toArray(new URL[codebases.size()]));
+                Policy policy = readPolicy(policyFile.toUri().toURL(), codebases);
 
                 // consult this policy for each of the plugin's jars:
                 for (URL url : codebases) {
@@ -181,24 +188,33 @@ final class Security {
     /**
      * Reads and returns the specified {@code policyFile}.
      * <p>
-     * Resources (e.g. jar files and directories) listed in {@code codebases} location
+     * Jar files listed in {@code codebases} location
      * will be provided to the policy file via a system property of the short name:
      * e.g. <code>${codebase.joda-convert-1.2.jar}</code> would map to full URL.
      */
     @SuppressForbidden(reason = "accesses fully qualified URLs to configure security")
-    static Policy readPolicy(URL policyFile, URL codebases[]) {
+    static Policy readPolicy(URL policyFile, Set<URL> codebases) {
         try {
             try {
                 // set codebase properties
                 for (URL url : codebases) {
                     String shortName = PathUtils.get(url.toURI()).getFileName().toString();
-                    System.setProperty("codebase." + shortName, url.toString());
+                    if (shortName.endsWith(".jar") == false) {
+                        continue; // tests :(
+                    }
+                    String previous = System.setProperty("codebase." + shortName, url.toString());
+                    if (previous != null) {
+                        throw new IllegalStateException("codebase properly already set: " + shortName + "->" + previous);
+                    }
                 }
                 return Policy.getInstance("JavaPolicy", new URIParameter(policyFile.toURI()));
             } finally {
                 // clear codebase properties
                 for (URL url : codebases) {
                     String shortName = PathUtils.get(url.toURI()).getFileName().toString();
+                    if (shortName.endsWith(".jar") == false) {
+                        continue; // tests :(
+                    }
                     System.clearProperty("codebase." + shortName);
                 }
             }

--- a/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -406,8 +406,7 @@ class InstallPluginCommand extends SettingCommand {
     /** check a candidate plugin for jar hell before installing it */
     void jarHellCheck(Path candidate, Path pluginsDir) throws Exception {
         // create list of current jars in classpath
-        final List<URL> jars = new ArrayList<>();
-        jars.addAll(Arrays.asList(JarHell.parseClassPath()));
+        final Set<URL> jars = new HashSet<>(JarHell.parseClassPath());
 
         // read existing bundles. this does some checks on the installation too.
         PluginsService.getPluginBundles(pluginsDir);
@@ -415,13 +414,15 @@ class InstallPluginCommand extends SettingCommand {
         // add plugin jars to the list
         Path pluginJars[] = FileSystemUtils.files(candidate, "*.jar");
         for (Path jar : pluginJars) {
-            jars.add(jar.toUri().toURL());
+            if (jars.add(jar.toUri().toURL()) == false) {
+                throw new IllegalStateException("jar hell! duplicate plugin jar: " + jar);
+            }
         }
         // TODO: no jars should be an error
         // TODO: verify the classname exists in one of the jars!
 
         // check combined (current classpath + new jars to-be-added)
-        JarHell.checkJarHell(jars.toArray(new URL[jars.size()]));
+        JarHell.checkJarHell(jars);
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/bootstrap/JarHellTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/JarHellTests.java
@@ -30,7 +30,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
@@ -62,7 +64,8 @@ public class JarHellTests extends ESTestCase {
 
     public void testDifferentJars() throws Exception {
         Path dir = createTempDir();
-        URL[] jars = {makeJar(dir, "foo.jar", null, "DuplicateClass.class"), makeJar(dir, "bar.jar", null, "DuplicateClass.class")};
+        Set<URL> jars = asSet(makeJar(dir, "foo.jar", null, "DuplicateClass.class"),
+                              makeJar(dir, "bar.jar", null, "DuplicateClass.class"));
         try {
             JarHell.checkJarHell(jars);
             fail("did not get expected exception");
@@ -74,17 +77,11 @@ public class JarHellTests extends ESTestCase {
         }
     }
 
-    public void testDuplicateClasspathLeniency() throws Exception {
-        Path dir = createTempDir();
-        URL jar = makeJar(dir, "foo.jar", null, "Foo.class");
-        URL[] jars = {jar, jar};
-        JarHell.checkJarHell(jars);
-    }
-
     public void testDirsOnClasspath() throws Exception {
         Path dir1 = createTempDir();
         Path dir2 = createTempDir();
-        URL[] dirs = {makeFile(dir1, "DuplicateClass.class"), makeFile(dir2, "DuplicateClass.class")};
+        Set<URL> dirs = asSet(makeFile(dir1, "DuplicateClass.class"), 
+                              makeFile(dir2, "DuplicateClass.class"));
         try {
             JarHell.checkJarHell(dirs);
             fail("did not get expected exception");
@@ -99,7 +96,8 @@ public class JarHellTests extends ESTestCase {
     public void testDirAndJar() throws Exception {
         Path dir1 = createTempDir();
         Path dir2 = createTempDir();
-        URL[] dirs = {makeJar(dir1, "foo.jar", null, "DuplicateClass.class"), makeFile(dir2, "DuplicateClass.class")};
+        Set<URL> dirs = asSet(makeJar(dir1, "foo.jar", null, "DuplicateClass.class"), 
+                              makeFile(dir2, "DuplicateClass.class"));
         try {
             JarHell.checkJarHell(dirs);
             fail("did not get expected exception");
@@ -111,22 +109,24 @@ public class JarHellTests extends ESTestCase {
         }
     }
 
-    public void testLog4jLeniency() throws Exception {
+    public void testModuleInfoException() throws Exception {
         Path dir = createTempDir();
-        URL[] jars = {makeJar(dir, "foo.jar", null, "org/apache/log4j/DuplicateClass.class"), makeJar(dir, "bar.jar", null, "org/apache/log4j/DuplicateClass.class")};
+        Set<URL> jars = asSet(makeJar(dir, "foo.jar", null, "module-info.class"), 
+                              makeJar(dir, "bar.jar", null, "module-info.class"));
         JarHell.checkJarHell(jars);
     }
 
-    public void testBaseDateTimeLeniency() throws Exception {
+    public void testLog4jLeniency() throws Exception {
         Path dir = createTempDir();
-        URL[] jars = {makeJar(dir, "foo.jar", null, "org/joda/time/base/BaseDateTime.class"), makeJar(dir, "bar.jar", null, "org/joda/time/base/BaseDateTime.class")};
+        Set<URL> jars = asSet(makeJar(dir, "foo.jar", null, "org/apache/log4j/DuplicateClass.class"),
+                              makeJar(dir, "bar.jar", null, "org/apache/log4j/DuplicateClass.class"));
         JarHell.checkJarHell(jars);
     }
 
     public void testWithinSingleJar() throws Exception {
         // the java api for zip file does not allow creating duplicate entries (good!) so
         // this bogus jar had to be constructed with ant
-        URL[] jars = {JarHellTests.class.getResource("duplicate-classes.jar")};
+        Set<URL> jars = Collections.singleton(JarHellTests.class.getResource("duplicate-classes.jar"));
         try {
             JarHell.checkJarHell(jars);
             fail("did not get expected exception");
@@ -139,7 +139,7 @@ public class JarHellTests extends ESTestCase {
     }
 
     public void testXmlBeansLeniency() throws Exception {
-        URL[] jars = {JarHellTests.class.getResource("duplicate-xmlbeans-classes.jar")};
+        Set<URL> jars = Collections.singleton(JarHellTests.class.getResource("duplicate-xmlbeans-classes.jar"));
         JarHell.checkJarHell(jars);
     }
 
@@ -157,7 +157,7 @@ public class JarHellTests extends ESTestCase {
         Attributes attributes = manifest.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0.0");
         attributes.put(new Attributes.Name("X-Compile-Target-JDK"), targetVersion.toString());
-        URL[] jars = {makeJar(dir, "foo.jar", manifest, "Foo.class")};
+        Set<URL> jars = Collections.singleton(makeJar(dir, "foo.jar", manifest, "Foo.class"));
         try {
             JarHell.checkJarHell(jars);
             fail("did not get expected exception");
@@ -173,7 +173,7 @@ public class JarHellTests extends ESTestCase {
         Attributes attributes = manifest.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0.0");
         attributes.put(new Attributes.Name("X-Compile-Target-JDK"), "bogus");
-        URL[] jars = {makeJar(dir, "foo.jar", manifest, "Foo.class")};
+        Set<URL> jars = Collections.singleton(makeJar(dir, "foo.jar", manifest, "Foo.class"));
         try {
             JarHell.checkJarHell(jars);
             fail("did not get expected exception");
@@ -188,7 +188,7 @@ public class JarHellTests extends ESTestCase {
         Attributes attributes = manifest.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0.0");
         attributes.put(new Attributes.Name("X-Compile-Target-JDK"), "1.7");
-        URL[] jars = {makeJar(dir, "foo.jar", manifest, "Foo.class")};
+        Set<URL> jars = Collections.singleton(makeJar(dir, "foo.jar", manifest, "Foo.class"));
 
         JarHell.checkJarHell(jars);
     }
@@ -200,7 +200,7 @@ public class JarHellTests extends ESTestCase {
         Attributes attributes = manifest.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0.0");
         attributes.put(new Attributes.Name("X-Compile-Elasticsearch-Version"), Version.CURRENT.toString());
-        URL[] jars = {makeJar(dir, "foo.jar", manifest, "Foo.class")};
+        Set<URL> jars = Collections.singleton(makeJar(dir, "foo.jar", manifest, "Foo.class"));
         JarHell.checkJarHell(jars);
     }
 
@@ -211,7 +211,7 @@ public class JarHellTests extends ESTestCase {
         Attributes attributes = manifest.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0.0");
         attributes.put(new Attributes.Name("X-Compile-Elasticsearch-Version"), "1.0-bogus");
-        URL[] jars = {makeJar(dir, "foo.jar", manifest, "Foo.class")};
+        Set<URL> jars = Collections.singleton(makeJar(dir, "foo.jar", manifest, "Foo.class"));
         try {
             JarHell.checkJarHell(jars);
             fail("did not get expected exception");
@@ -254,8 +254,8 @@ public class JarHellTests extends ESTestCase {
         Path element1 = createTempDir();
         Path element2 = createTempDir();
 
-        URL expected[] = { element1.toUri().toURL(), element2.toUri().toURL() };
-        assertArrayEquals(expected, JarHell.parseClassPath(element1.toString() + ":" + element2.toString()));
+        Set<URL> expected = asSet(element1.toUri().toURL(), element2.toUri().toURL());
+        assertEquals(expected, JarHell.parseClassPath(element1.toString() + ":" + element2.toString()));
     }
 
     /**
@@ -283,8 +283,8 @@ public class JarHellTests extends ESTestCase {
         Path element1 = createTempDir();
         Path element2 = createTempDir();
 
-        URL expected[] = { element1.toUri().toURL(), element2.toUri().toURL() };
-        assertArrayEquals(expected, JarHell.parseClassPath(element1.toString() + ";" + element2.toString()));
+        Set<URL> expected = asSet(element1.toUri().toURL(), element2.toUri().toURL());
+        assertEquals(expected, JarHell.parseClassPath(element1.toString() + ";" + element2.toString()));
     }
 
     /**
@@ -310,13 +310,13 @@ public class JarHellTests extends ESTestCase {
         assumeTrue("test is designed for windows-like systems only", ";".equals(System.getProperty("path.separator")));
         assumeTrue("test is designed for windows-like systems only", "\\".equals(System.getProperty("file.separator")));
 
-        URL expected[] = {
+        Set<URL> expected = asSet(
             PathUtils.get("c:\\element1").toUri().toURL(),
             PathUtils.get("c:\\element2").toUri().toURL(),
             PathUtils.get("c:\\element3").toUri().toURL(),
-            PathUtils.get("c:\\element 4").toUri().toURL(),
-        };
-        URL actual[] = JarHell.parseClassPath("c:\\element1;c:\\element2;/c:/element3;/c:/element 4");
-        assertArrayEquals(expected, actual);
+            PathUtils.get("c:\\element 4").toUri().toURL()
+        );
+        Set<URL> actual = JarHell.parseClassPath("c:\\element1;c:\\element2;/c:/element3;/c:/element 4");
+        assertEquals(expected, actual);
     }
 }

--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -15,7 +15,7 @@ for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
 
 REM check in case a user was using this mechanism
 if "%ES_CLASSPATH%" == "" (
-set ES_CLASSPATH=!ES_HOME!/lib/elasticsearch-${project.version}.jar;!ES_HOME!/lib/*
+set ES_CLASSPATH=!ES_HOME!/lib/*
 ) else (
 ECHO Error: Don't modify the classpath with ES_CLASSPATH, Best is to add 1>&2
 ECHO additional elements via the plugin mechanism, or if code must really be 1>&2

--- a/distribution/src/main/resources/bin/elasticsearch.in.sh
+++ b/distribution/src/main/resources/bin/elasticsearch.in.sh
@@ -10,4 +10,4 @@ EOF
     exit 1
 fi
 
-ES_CLASSPATH="$ES_HOME/lib/elasticsearch-${project.version}.jar:$ES_HOME/lib/*"
+ES_CLASSPATH="$ES_HOME/lib/*"

--- a/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/TikaImpl.java
+++ b/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/TikaImpl.java
@@ -45,7 +45,10 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.security.ProtectionDomain;
 import java.security.SecurityPermission;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.PropertyPermission;
+import java.util.Set;
 
 /**
  * Runs tika with limited parsers and limited permissions.
@@ -128,7 +131,12 @@ final class TikaImpl {
         addReadPermissions(perms, JarHell.parseClassPath());
         // plugin jars
         if (TikaImpl.class.getClassLoader() instanceof URLClassLoader) {
-            addReadPermissions(perms, ((URLClassLoader)TikaImpl.class.getClassLoader()).getURLs());
+            URL[] urls = ((URLClassLoader)TikaImpl.class.getClassLoader()).getURLs();
+            Set<URL> set = new LinkedHashSet<>(Arrays.asList(urls));
+            if (set.size() != urls.length) {
+                throw new AssertionError("duplicate jars: " + Arrays.toString(urls));
+            }
+            addReadPermissions(perms, set);
         }
         // jvm's java.io.tmpdir (needs read/write)
         perms.add(new FilePermission(System.getProperty("java.io.tmpdir") + System.getProperty("file.separator") + "-",
@@ -145,7 +153,7 @@ final class TikaImpl {
 
     // add resources to (what is typically) a jar, but might not be (e.g. in tests/IDE)
     @SuppressForbidden(reason = "adds access to jar resources")
-    static void addReadPermissions(Permissions perms, URL resources[]) {
+    static void addReadPermissions(Permissions perms, Set<URL> resources) {
         try {
             for (URL url : resources) {
                 Path path = PathUtils.get(url.toURI());

--- a/plugins/mapper-attachments/src/main/java/org/elasticsearch/mapper/attachments/TikaImpl.java
+++ b/plugins/mapper-attachments/src/main/java/org/elasticsearch/mapper/attachments/TikaImpl.java
@@ -45,7 +45,10 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.security.ProtectionDomain;
 import java.security.SecurityPermission;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.PropertyPermission;
+import java.util.Set;
 
 /**
  * Runs tika with limited parsers and limited permissions.
@@ -128,7 +131,12 @@ final class TikaImpl {
         addReadPermissions(perms, JarHell.parseClassPath());
         // plugin jars
         if (TikaImpl.class.getClassLoader() instanceof URLClassLoader) {
-            addReadPermissions(perms, ((URLClassLoader)TikaImpl.class.getClassLoader()).getURLs());
+            URL[] urls = ((URLClassLoader)TikaImpl.class.getClassLoader()).getURLs();
+            Set<URL> set = new LinkedHashSet<>(Arrays.asList(urls));
+            if (set.size() != urls.length) {
+                throw new AssertionError("duplicate jars: " + Arrays.toString(urls));
+            }
+            addReadPermissions(perms, set);
         }
         // jvm's java.io.tmpdir (needs read/write)
         perms.add(new FilePermission(System.getProperty("java.io.tmpdir") + System.getProperty("file.separator") + "-",
@@ -145,7 +153,7 @@ final class TikaImpl {
 
     // add resources to (what is typically) a jar, but might not be (e.g. in tests/IDE)
     @SuppressForbidden(reason = "adds access to jar resources")
-    static void addReadPermissions(Permissions perms, URL resources[]) {
+    static void addReadPermissions(Permissions perms, Set<URL> resources) {
         try {
             for (URL url : resources) {
                 Path path = PathUtils.get(url.toURI());

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -183,7 +183,7 @@ public class BootstrapForTesting {
         }
 
         // compute classpath minus obvious places, all other jars will get the permission.
-        Set<URL> codebases = new HashSet<>(Arrays.asList(parseClassPathWithSymlinks()));
+        Set<URL> codebases = new HashSet<>(parseClassPathWithSymlinks());
         Set<URL> excluded = new HashSet<>(Arrays.asList(
                 // es core
                 Bootstrap.class.getProtectionDomain().getCodeSource().getLocation(),
@@ -201,7 +201,7 @@ public class BootstrapForTesting {
         // parse each policy file, with codebase substitution from the classpath
         final List<Policy> policies = new ArrayList<>();
         for (URL policyFile : pluginPolicies) {
-            policies.add(Security.readPolicy(policyFile, codebases.toArray(new URL[codebases.size()])));
+            policies.add(Security.readPolicy(policyFile, codebases));
         }
 
         // consult each policy file for those codebases
@@ -228,10 +228,14 @@ public class BootstrapForTesting {
      * this is for matching the toRealPath() in the code where we have a proper plugin structure
      */
     @SuppressForbidden(reason = "does evil stuff with paths and urls because devs and jenkins do evil stuff with paths and urls")
-    static URL[] parseClassPathWithSymlinks() throws Exception {
-        URL raw[] = JarHell.parseClassPath();
-        for (int i = 0; i < raw.length; i++) {
-            raw[i] = PathUtils.get(raw[i].toURI()).toRealPath().toUri().toURL();
+    static Set<URL> parseClassPathWithSymlinks() throws Exception {
+        Set<URL> raw = JarHell.parseClassPath();
+        Set<URL> cooked = new HashSet<>(raw.size());
+        for (URL url : raw) {
+            boolean added = cooked.add(PathUtils.get(url.toURI()).toRealPath().toUri().toURL());
+            if (added == false) {
+                throw new IllegalStateException("Duplicate in classpath after resolving symlinks: " + url);
+            }
         }
         return raw;
     }


### PR DESCRIPTION
After removing this hack, we can cleanup a bit. Particularly important is to be able to treat codebases as a unique thing (since ES jar is no longer duplicated on the classpath to be "in front of" joda-time). This gives a lot of internal checks in case something goes wrong.

I know the other day i accidentally installed groovy as a plugin (its already a module), and the error was strange. So using Set and checking the return values is an easy improvement.
