### PR TITLE
Update forbiddenapis to 2.2

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -84,7 +84,7 @@ dependencies {
   compile 'com.netflix.nebula:gradle-info-plugin:3.0.3'
   compile 'org.eclipse.jgit:org.eclipse.jgit:3.2.0.201312181205-r'
   compile 'com.perforce:p4java:2012.3.551082' // THIS IS SUPPOSED TO BE OPTIONAL IN THE FUTURE....
-  compile 'de.thetaphi:forbiddenapis:2.1'
+  compile 'de.thetaphi:forbiddenapis:2.2'
   compile 'com.bmuschko:gradle-nexus-plugin:2.3.1'
   compile 'org.apache.rat:apache-rat:0.11'
 }

--- a/buildSrc/src/main/resources/forbidden/es-all-signatures.txt
+++ b/buildSrc/src/main/resources/forbidden/es-all-signatures.txt
@@ -32,7 +32,7 @@ org.apache.lucene.index.IndexReader#getCombinedCoreAndDeletesKey()
 @defaultMessage Soon to be removed
 org.apache.lucene.document.FieldType#numericType()
 
-@defaultMessage Don't use MethodHandles in slow ways, dont be lenient in tests.
-# unfortunately, invoke() cannot be banned, because forbidden apis does not support signature polymorphic methods
+@defaultMessage Don't use MethodHandles in slow ways, don't be lenient in tests.
+java.lang.invoke.MethodHandle#invoke(java.lang.Object[])
 java.lang.invoke.MethodHandle#invokeWithArguments(java.lang.Object[])
 java.lang.invoke.MethodHandle#invokeWithArguments(java.util.List)

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ArrayTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ArrayTests.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.painless;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+
 /** Tests for or operator across all types */
 public class ArrayTests extends ScriptTestCase {
 
@@ -36,7 +39,10 @@ public class ArrayTests extends ScriptTestCase {
     }
 
     private void assertArrayLength(int length, Object array) throws Throwable {
-        assertEquals(length, (int) Def.arrayLengthGetter(array.getClass()).invoke(array));
+        final MethodHandle mh = Def.arrayLengthGetter(array.getClass());
+        assertSame(array.getClass(), mh.type().parameterType(0));
+        assertEquals(length, (int) mh.asType(MethodType.methodType(int.class, Object.class))
+                .invokeExact(array));
     }
 
     public void testArrayLoadStoreInt() {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/DefBootstrapTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/DefBootstrapTests.java
@@ -139,7 +139,7 @@ public class DefBootstrapTests extends ESTestCase {
                                                                DefBootstrap.BINARY_OPERATOR, DefBootstrap.OPERATOR_ALLOWS_NULL);
         MethodHandle handle = site.dynamicInvoker();
         assertEquals(2, (Object)handle.invokeExact((Object)1, (Object)1));
-        assertEquals("nulltest", (Object)handle.invoke((Object)null, (Object)"test"));
+        assertEquals("nulltest", (Object)handle.invokeExact((Object)null, (Object)"test"));
     }
     
     public void testNullGuardEq() throws Throwable {


### PR DESCRIPTION
Forbidden-Apis 2.2 was released an hour ago.

This version supports/fixes the following important stuff:
- allows to forbid signature polymorphic methods (e.g., slow `MethodHandle.invoke(...)` when used instead of `MethodHandle.invokeExact(...)`
- Works around a bug in Gradle's Spyware Daemon
- commons-io signatures for 2.5; also update/review older commons-io signatures

I only updated the version numbers in the build. I did not reenable the Gradle Daemon, this is something separate. Forbiddenapis now detects automatically if the Gradle Daemon is used to build and switches to slow, non-caching mode :-)

I also added `MethodHandle.invoke(...)` to the forbidden signatures. I had to fix 2 tests that used the slow method.
