### PR TITLE
Wrong name for values field

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -882,7 +882,7 @@ Assume the following document:
 [source,js]
 --------------------------------------------------
 {
-  "value" : ["foo", "bar", "baz"]
+  "values" : ["foo", "bar", "baz"]
 }
 --------------------------------------------------
 
@@ -909,7 +909,7 @@ Then the document will look like this after preprocessing:
 [source,js]
 --------------------------------------------------
 {
-  "value" : ["FOO", "BAR", "BAZ"]
+  "values" : ["FOO", "BAR", "BAZ"]
 }
 --------------------------------------------------
 


### PR DESCRIPTION
We wrote that the document is:

``` json
{
  "value" : ["foo", "bar", "baz"]
}
```

But the processor is using a `values` field:

``` json
{
  "foreach" : {
    "field" : "values",
    "processors" : [
      // ...
    ]
  }
}
```

It should be `values`.
