### PR TITLE
Infer lambda arguments/return type

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Locals.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Locals.java
@@ -69,8 +69,9 @@ public final class Locals {
      * <p>
      * This is just like {@link #newFunctionScope}, except the captured parameters are made read-only.
      */
-    public static Locals newLambdaScope(Locals programScope, List<Parameter> parameters, int captureCount, int maxLoopCounter) {
-        Locals locals = new Locals(programScope, Definition.DEF_TYPE);
+    public static Locals newLambdaScope(Locals programScope, Type returnType, List<Parameter> parameters, 
+                                        int captureCount, int maxLoopCounter) {
+        Locals locals = new Locals(programScope, returnType);
         for (int i = 0; i < parameters.size(); i++) {
             Parameter parameter = parameters.get(i);
             boolean isCapture = i < captureCount;

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -118,5 +117,11 @@ public class BasicAPITests extends ScriptTestCase {
     public void testInterfacesHaveObject() {
         assertEquals("{}", exec("Map map = new HashMap(); return map.toString();"));
         assertEquals("{}", exec("def map = new HashMap(); return map.toString();"));
+    }
+    
+    public void testPrimitivesHaveMethods() {
+        assertEquals(5, exec("int x = 5; return x.intValue();"));
+        assertEquals("5", exec("int x = 5; return x.toString();"));
+        assertEquals(0, exec("int x = 5; return x.compareTo(5);"));
     }
 }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/DefOptimizationTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/DefOptimizationTests.java
@@ -452,4 +452,14 @@ public class DefOptimizationTests extends ScriptTestCase {
         assertBytecodeExists("def x = 1; double y = +x; return y", 
                              "INVOKEDYNAMIC plus(Ljava/lang/Object;)D");
     }
+    
+    public void testLambdaReturnType() {
+        assertBytecodeExists("List l = new ArrayList(); l.removeIf(x -> x < 10)",
+                             "synthetic lambda$0(Ljava/lang/Object;)Z");
+    }
+    
+    public void testLambdaArguments() {
+        assertBytecodeExists("List l = new ArrayList(); l.stream().mapToDouble(Double::valueOf).map(x -> x + 1)",
+                             "synthetic lambda$0(D)D");
+    }
 }


### PR DESCRIPTION
We setup lambdas with optional typing and return value of `def`. But if we know the functional interface, we should use the type info we have, and replace all `def` with the real type.

Today things work, but for example all Predicate's return values are boxed for no good reason.
Of course the worst case is primitive specializations of interfaces:

```
.mapToDouble(Double::valueOf).map(x -> x + 1)
```

Instead of:

```
  private static synthetic lambda$0(Ljava/lang/Object;)Ljava/lang/Object;
    ALOAD 0
    ICONST_1
    INVOKEDYNAMIC add(Ljava/lang/Object;I)Ljava/lang/Object; [
      // handle kind 0x6 : INVOKESTATIC
      org/elasticsearch/painless/DefBootstrap.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;I[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;
      // arguments:
      8, 
      0
    ]
    ARETURN
```

We do:

```
  private static synthetic lambda$0(D)D
    DLOAD 0
    DCONST_1
    DADD
    DRETURN
```

In order for things to be consistent, I added the ability to call methods on primitive types so that we can always replace `def` with its corresponding primitive if needed and it behaves the same. 
