### PR TITLE
Fix ignore_failure behavior in _simulate?verbose and more cleanup

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ingest/TrackingResultProcessor.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/TrackingResultProcessor.java
@@ -24,6 +24,7 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -33,15 +34,12 @@ public final class TrackingResultProcessor implements Processor {
 
     private final Processor actualProcessor;
     private final List<SimulateProcessorResult> processorResultList;
+    private final boolean ignoreFailure;
 
-    public TrackingResultProcessor(Processor actualProcessor, List<SimulateProcessorResult> processorResultList) {
+    public TrackingResultProcessor(boolean ignoreFailure, Processor actualProcessor, List<SimulateProcessorResult> processorResultList) {
+        this.ignoreFailure = ignoreFailure;
         this.processorResultList = processorResultList;
-        if (actualProcessor instanceof CompoundProcessor) {
-            CompoundProcessor trackedCompoundProcessor = decorate((CompoundProcessor) actualProcessor, processorResultList);
-            this.actualProcessor = trackedCompoundProcessor;
-        } else {
-            this.actualProcessor = actualProcessor;
-        }
+        this.actualProcessor = actualProcessor;
     }
 
     @Override
@@ -50,7 +48,11 @@ public final class TrackingResultProcessor implements Processor {
             actualProcessor.execute(ingestDocument);
             processorResultList.add(new SimulateProcessorResult(actualProcessor.getTag(), new IngestDocument(ingestDocument)));
         } catch (Exception e) {
-            processorResultList.add(new SimulateProcessorResult(actualProcessor.getTag(), e));
+            if (ignoreFailure) {
+                processorResultList.add(new SimulateProcessorResult(actualProcessor.getTag(), new IngestDocument(ingestDocument)));
+            } else {
+                processorResultList.add(new SimulateProcessorResult(actualProcessor.getTag(), e));
+            }
             throw e;
         }
     }
@@ -71,7 +73,7 @@ public final class TrackingResultProcessor implements Processor {
             if (processor instanceof CompoundProcessor) {
                 processors.add(decorate((CompoundProcessor) processor, processorResultList));
             } else {
-                processors.add(new TrackingResultProcessor(processor, processorResultList));
+                processors.add(new TrackingResultProcessor(compoundProcessor.isIgnoreFailure(), processor, processorResultList));
             }
         }
         List<Processor> onFailureProcessors = new ArrayList<>(compoundProcessor.getProcessors().size());
@@ -79,10 +81,10 @@ public final class TrackingResultProcessor implements Processor {
             if (processor instanceof CompoundProcessor) {
                 onFailureProcessors.add(decorate((CompoundProcessor) processor, processorResultList));
             } else {
-                onFailureProcessors.add(new TrackingResultProcessor(processor, processorResultList));
+                onFailureProcessors.add(new TrackingResultProcessor(compoundProcessor.isIgnoreFailure(), processor, processorResultList));
             }
         }
-        return new CompoundProcessor(false, processors, onFailureProcessors);
+        return new CompoundProcessor(compoundProcessor.isIgnoreFailure(), processors, onFailureProcessors);
     }
 }
 

--- a/core/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
+++ b/core/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
@@ -243,6 +243,7 @@ public final class ConfigurationUtils {
                 }
             }
         }
+
         return processors;
     }
 
@@ -256,7 +257,12 @@ public final class ConfigurationUtils {
             List<Processor> onFailureProcessors = readProcessorConfigs(onFailureProcessorConfigs, processorRegistry);
             Processor processor;
             processor = factory.create(config);
-            if (!config.isEmpty()) {
+
+            if (onFailureProcessorConfigs != null && onFailureProcessors.isEmpty()) {
+                throw newConfigurationException(processor.getType(), processor.getTag(), Pipeline.ON_FAILURE_KEY,
+                    "processors list cannot be empty");
+            }
+            if (config.isEmpty() == false) {
                 throw new ElasticsearchParseException("processor [{}] doesn't support one or more provided configuration parameters {}",
                     type, Arrays.toString(config.keySet().toArray()));
             }

--- a/core/src/main/java/org/elasticsearch/ingest/Pipeline.java
+++ b/core/src/main/java/org/elasticsearch/ingest/Pipeline.java
@@ -109,6 +109,9 @@ public final class Pipeline {
                 throw new ElasticsearchParseException("pipeline [" + id +
                         "] doesn't support one or more provided configuration parameters " + Arrays.toString(config.keySet().toArray()));
             }
+            if (onFailureProcessorConfigs != null && onFailureProcessors.isEmpty()) {
+                throw new ElasticsearchParseException("pipeline [" + id + "] cannot have an empty on_failure option defined");
+            }
             CompoundProcessor compoundProcessor = new CompoundProcessor(false, Collections.unmodifiableList(processors),
                     Collections.unmodifiableList(onFailureProcessors));
             return new Pipeline(id, description, compoundProcessor);

--- a/core/src/test/java/org/elasticsearch/action/ingest/SimulateExecutionServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/action/ingest/SimulateExecutionServiceTests.java
@@ -159,6 +159,22 @@ public class SimulateExecutionServiceTests extends ESTestCase {
         assertThat(simulateDocumentVerboseResult.getProcessorResults().get(2).getFailure(), nullValue());
     }
 
+    public void testExecuteVerboseItemExceptionWithIgnoreFailure() throws Exception {
+        TestProcessor testProcessor = new TestProcessor("processor_0", "mock", ingestDocument -> { throw new RuntimeException("processor failed"); });
+        CompoundProcessor processor = new CompoundProcessor(true, Collections.singletonList(testProcessor), Collections.emptyList());
+        Pipeline pipeline = new Pipeline("_id", "_description", new CompoundProcessor(processor));
+        SimulateDocumentResult actualItemResponse = executionService.executeDocument(pipeline, ingestDocument, true);
+        assertThat(testProcessor.getInvokedCounter(), equalTo(1));
+        assertThat(actualItemResponse, instanceOf(SimulateDocumentVerboseResult.class));
+        SimulateDocumentVerboseResult simulateDocumentVerboseResult = (SimulateDocumentVerboseResult) actualItemResponse;
+        assertThat(simulateDocumentVerboseResult.getProcessorResults().size(), equalTo(1));
+        assertThat(simulateDocumentVerboseResult.getProcessorResults().get(0).getProcessorTag(), equalTo("processor_0"));
+        assertThat(simulateDocumentVerboseResult.getProcessorResults().get(0).getFailure(), nullValue());
+        assertThat(simulateDocumentVerboseResult.getProcessorResults().get(0).getIngestDocument(), not(sameInstance(ingestDocument)));
+        assertIngestDocument(simulateDocumentVerboseResult.getProcessorResults().get(0).getIngestDocument(), ingestDocument);
+        assertThat(simulateDocumentVerboseResult.getProcessorResults().get(0).getIngestDocument().getSourceAndMetadata(), not(sameInstance(ingestDocument.getSourceAndMetadata())));
+    }
+
     public void testExecuteItemWithFailure() throws Exception {
         TestProcessor processor = new TestProcessor(ingestDocument -> { throw new RuntimeException("processor failed"); });
         Pipeline pipeline = new Pipeline("_id", "_description", new CompoundProcessor(processor, processor));

--- a/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/50_on_failure.yaml
+++ b/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/50_on_failure.yaml
@@ -108,6 +108,61 @@
   - match: { _source.foofield2: "ran" }
 
 ---
+"Test pipeline with empty on_failure in a processor":
+  - do:
+      catch: request
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "fail" : {
+                  "tag" : "emptyfail",
+                  "message" : "_message",
+                  "on_failure": []
+                }
+              }
+            ],
+            "on_failure": [
+              {
+                "set" : {
+                  "field": "on_failure_executed",
+                  "value": true
+                }
+              }
+            ]
+          }
+  - match: { error.root_cause.0.type: "parse_exception" }
+  - match: { error.root_cause.0.reason: "[on_failure] processors list cannot be empty" }
+  - match: { error.root_cause.0.header.processor_type: "fail" }
+  - match: { error.root_cause.0.header.processor_tag: "emptyfail" }
+  - match: { error.root_cause.0.header.property_name: "on_failure" }
+
+---
+"Test pipeline with empty on_failure in pipeline":
+  - do:
+      catch: request
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "set" : {
+                  "field" : "foo",
+                  "value" : "_message"
+                }
+              }
+            ],
+            "on_failure": []
+          }
+  - match: { error.root_cause.0.type: "parse_exception" }
+  - match: { error.root_cause.0.reason: "pipeline [my_pipeline] cannot have an empty on_failure option defined" }
+
+---
 "Test pipeline with ignore_failure in a processor":
   - do:
       ingest.put_pipeline:

--- a/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/90_simulate.yaml
+++ b/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/90_simulate.yaml
@@ -479,3 +479,73 @@
   - match: { docs.0.processor_results.4.doc._source.foofield2: "ran" }
   - match: { docs.0.processor_results.4.doc._source.field1: "123.42 400 <foo>" }
   - match: { docs.0.processor_results.4.doc._source.status: 200 }
+
+---
+"Test verbose simulate with ignore_failure":
+  - do:
+      ingest.simulate:
+        verbose: true
+        body: >
+          {
+            "pipeline" : {
+              "description": "_description",
+              "processors": [
+                {
+                  "set" : {
+                    "tag" : "setstatus-1",
+                    "field" : "status",
+                    "value" : 200
+                  }
+                },
+                {
+                  "rename" : {
+                    "tag" : "rename-1",
+                    "field" : "foofield",
+                    "target_field" : "field1",
+                    "ignore_failure": true,
+                    "on_failure" : [
+                      {
+                        "set" : {
+                          "tag" : "set on_failure rename",
+                          "field" : "foofield",
+                          "value" : "exists"
+                        }
+                      },
+                      {
+                        "rename" : {
+                          "field" : "foofield2",
+                          "target_field" : "field1",
+                          "on_failure" : [
+                            {
+                              "set" : {
+                                "field" : "foofield2",
+                                "value" : "ran"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "docs": [
+              {
+                "_index": "index",
+                "_type": "type",
+                "_id": "id",
+                "_source": {
+                  "field1": "123.42 400 <foo>"
+                }
+              }
+            ]
+          }
+  - length: { docs: 1 }
+  - length: { docs.0.processor_results: 2 }
+  - match: { docs.0.processor_results.0.tag: "setstatus-1" }
+  - match: { docs.0.processor_results.0.doc._source.field1: "123.42 400 <foo>" }
+  - match: { docs.0.processor_results.0.doc._source.status: 200 }
+  - match: { docs.0.processor_results.1.tag: "rename-1" }
+  - match: { docs.0.processor_results.1.doc._source.field1: "123.42 400 <foo>" }
+  - match: { docs.0.processor_results.1.doc._source.status: 200 }


### PR DESCRIPTION
- fix it so that processors with the `ignore_failure` option do not
  record their exception in the response
- add more tests to make empty `on_failure` block behavior more explicit

🎩  tip to @BigFunger for reporting these issues!
