### PR TITLE
Don't include `_id`, `_type` and `_index` keys in search response for inner hits

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/internal/InternalSearchHit.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/InternalSearchHit.java
@@ -439,13 +439,14 @@ public class InternalSearchHit implements SearchHit {
             builder.field("_shard", shard.shardId());
             builder.field("_node", shard.nodeIdText());
         }
-        if (shard != null) {
-            builder.field(Fields._INDEX, shard.indexText());
-        }
-        builder.field(Fields._TYPE, type);
-        builder.field(Fields._ID, id);
         if (nestedIdentity != null) {
             nestedIdentity.toXContent(builder, params);
+        } else {
+            if (shard != null) {
+                builder.field(Fields._INDEX, shard.indexText());
+            }
+            builder.field(Fields._TYPE, type);
+            builder.field(Fields._ID, id);
         }
         if (version != -1) {
             builder.field(Fields._VERSION, version);

--- a/docs/reference/migration/migrate_5_0/search.asciidoc
+++ b/docs/reference/migration/migrate_5_0/search.asciidoc
@@ -180,6 +180,9 @@ with inner hits defined inside the query dsl.
 * Source filtering for inner hits inside nested queries requires full field names instead of relative field names.
 This is now consistent for source filtering on other places in the search API.
 
+* Nested inner hits will now no longer include `_index`, `_type` and `_id` keys. For nested inner hits these values
+are always the same as the `_index`, `_type` and `_id` keys of the root search hit.
+
 ==== Query Profiler
 
 In the response for profiling queries, the `query_type` has been renamed to `type` and `lucene` has been renamed to

--- a/docs/reference/search/request/inner-hits.asciidoc
+++ b/docs/reference/search/request/inner-hits.asciidoc
@@ -118,8 +118,6 @@ An example of a response snippet that could be generated from the above search r
                  "total": ...,
                  "hits": [
                     {
-                       "_type": "question",
-                       "_id": "1",
                        "_nested": {
                           "field": "comments",
                           "offset": 2

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.inner_hits/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.inner_hits/10_basic.yaml
@@ -1,0 +1,84 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: test
+        body:
+            mappings:
+              type_1: {
+                properties: {
+                  nested_field : {
+                    type: nested
+                  }
+                }
+              }
+              type_2: {}
+              type_3: {
+                _parent: {
+                  type: type_2
+                }
+              }
+
+---
+"Nested inner hits":
+    - do:
+        index:
+          index: test
+          type:  type_1
+          id:    1
+          body:  {
+            "nested_field" : [
+              {
+                "foo": "bar"
+              }
+            ]
+          }
+
+    - do:
+        indices.refresh: {}
+
+    - do:
+        search:
+          body: { "query" : { "nested" : { "path" : "nested_field", "query" : { "match_all" : {} }, "inner_hits" : {} } } }
+    - match: { hits.total: 1 }
+    - match: { hits.hits.0._index: "test" }
+    - match: { hits.hits.0._type: "type_1" }
+    - match: { hits.hits.0._id: "1" }
+    - is_false: hits.hits.0.inner_hits.nested_field.hits.hits.0._index
+    - is_false: hits.hits.0.inner_hits.nested_field.hits.hits.0._type
+    - is_false: hits.hits.0.inner_hits.nested_field.hits.hits.0._id
+    - match: { hits.hits.0.inner_hits.nested_field.hits.hits.0._nested.field: "nested_field" }
+    - match: { hits.hits.0.inner_hits.nested_field.hits.hits.0._nested.offset: 0 }
+    - is_false: hits.hits.0.inner_hits.nested_field.hits.hits.0._nested.child
+
+---
+"Parent/child inner hits":
+    - do:
+        index:
+          index: test
+          type:  type_2
+          id:    1
+          body:  {"foo": "bar"}
+
+    - do:
+        index:
+          index: test
+          type:  type_3
+          id:    1
+          parent: 1
+          body:  {"bar": "baz"}
+
+    - do:
+        indices.refresh: {}
+
+    - do:
+        search:
+          body: { "query" : { "has_child" : { "type" : "type_3", "query" : { "match_all" : {} }, "inner_hits" : {} } } }
+    - match: { hits.total: 1 }
+    - match: { hits.hits.0._index: "test" }
+    - match: { hits.hits.0._type: "type_2" }
+    - match: { hits.hits.0._id: "1" }
+    - match: { hits.hits.0.inner_hits.type_3.hits.hits.0._index: "test" }
+    - match: { hits.hits.0.inner_hits.type_3.hits.hits.0._type: "type_3" }
+    - match: { hits.hits.0.inner_hits.type_3.hits.hits.0._id: "1" }
+    - is_false: hits.hits.0.inner_hits.type_3.hits.hits.0._nested


### PR DESCRIPTION
PR for #18091
