### PR TITLE
Upgrade `string` fields to `text`/`keyword` even if `include_in_all` is set.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/core/KeywordFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/KeywordFieldMapper.java
@@ -192,6 +192,11 @@ public final class KeywordFieldMapper extends FieldMapper implements AllFieldMap
         return (KeywordFieldMapper) super.clone();
     }
 
+    // pkg-private for testing
+    Boolean includeInAll() {
+        return includeInAll;
+    }
+
     @Override
     public KeywordFieldMapper includeInAll(Boolean includeInAll) {
         if (includeInAll != null) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -73,12 +73,12 @@ public class StringFieldMapper extends FieldMapper implements AllFieldMapper.Inc
             "type",
             // common keyword parameters, for which the upgrade is straightforward
             "index", "store", "doc_values", "omit_norms", "norms", "fields", "copy_to",
-            "fielddata", "ignore_above"));
+            "fielddata", "include_in_all", "ignore_above"));
     private static final Set<String> SUPPORTED_PARAMETERS_FOR_AUTO_UPGRADE_TO_TEXT = new HashSet<>(Arrays.asList(
             "type",
             // common text parameters, for which the upgrade is straightforward
             "index", "store", "doc_values", "omit_norms", "norms", "fields", "copy_to",
-            "fielddata", "analyzer", "search_analyzer", "search_quote_analyzer"));
+            "fielddata", "include_in_all", "analyzer", "search_analyzer", "search_quote_analyzer"));
 
     public static class Defaults {
         public static double FIELDDATA_MIN_FREQUENCY = 0;

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/TextFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/TextFieldMapper.java
@@ -317,6 +317,11 @@ public class TextFieldMapper extends FieldMapper implements AllFieldMapper.Inclu
         return (TextFieldMapper) super.clone();
     }
 
+    // pkg-private for testing
+    Boolean includeInAll() {
+        return includeInAll;
+    }
+
     @Override
     public TextFieldMapper includeInAll(Boolean includeInAll) {
         if (includeInAll != null) {

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/StringMappingUpgradeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/StringMappingUpgradeTests.java
@@ -198,6 +198,32 @@ public class StringMappingUpgradeTests extends ESSingleNodeTestCase {
         assertEquals("keyword", field.fieldType().searchQuoteAnalyzer().name());
     }
 
+    public void testUpgradeTextIncludeInAll() throws IOException {
+        IndexService indexService = createIndex("test");
+        DocumentMapperParser parser = indexService.mapperService().documentMapperParser();
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "string")
+                .field("include_in_all", false).endObject().endObject()
+                .endObject().endObject().string();
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+        FieldMapper field = mapper.mappers().getMapper("field");
+        assertThat(field, instanceOf(TextFieldMapper.class));
+        assertFalse(((TextFieldMapper) field).includeInAll());
+    }
+
+    public void testUpgradeKeywordIncludeInAll() throws IOException {
+        IndexService indexService = createIndex("test");
+        DocumentMapperParser parser = indexService.mapperService().documentMapperParser();
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "string")
+                .field("index", "not_analyzed").field("include_in_all", true).endObject().endObject()
+                .endObject().endObject().string();
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+        FieldMapper field = mapper.mappers().getMapper("field");
+        assertThat(field, instanceOf(KeywordFieldMapper.class));
+        assertTrue(((KeywordFieldMapper) field).includeInAll());
+    }
+
     public void testUpgradeRandomMapping() throws IOException {
         final int iters = 20;
         for (int i = 0; i < iters; ++i) {


### PR DESCRIPTION
Closes #18974
