### PR TITLE
Remove guice from ScriptService

### DIFF
--- a/core/src/main/java/org/elasticsearch/script/ScriptModule.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptModule.java
@@ -19,12 +19,13 @@
 
 package org.elasticsearch.script;
 
-import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.watcher.ResourceWatcherService;
 
-import java.util.ArrayList;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -34,57 +35,56 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * An {@link org.elasticsearch.common.inject.Module} which manages {@link ScriptEngineService}s, as well
- * as named script
+ * Manages building {@link ScriptService} and {@link ScriptSettings} from a list of plugins.
  */
-public class ScriptModule extends AbstractModule {
-
-    protected final ScriptContextRegistry scriptContextRegistry;
-    protected final ScriptEngineRegistry scriptEngineRegistry;
-    protected final ScriptSettings scriptSettings;
-
-    public ScriptModule(ScriptEngineService... services) {
-        this(Arrays.asList(services), Collections.emptyList());
-    }
-
-    public ScriptModule(List<ScriptEngineService> scriptEngineServices,
-                        List<ScriptContext.Plugin> customScriptContexts) {
-        this.scriptContextRegistry = new ScriptContextRegistry(customScriptContexts);
-        this.scriptEngineRegistry = new ScriptEngineRegistry(scriptEngineServices);
-        this.scriptSettings = new ScriptSettings(scriptEngineRegistry, scriptContextRegistry);
-    }
+public class ScriptModule {
+    private final ScriptSettings scriptSettings;
+    private final ScriptService scriptService;
 
     /**
-     * This method is called after all modules have been processed but before we actually validate all settings. This allows the
-     * script extensions to add all their settings.
+     * Build from {@linkplain ScriptPlugin}s. Convenient for normal use but not great for tests. See
+     * {@link ScriptModule#ScriptModule(Settings, Environment, ResourceWatcherService, List, List)} for easier use in tests.
      */
-    public List<Setting<?>> getSettings() {
-        ArrayList<Setting<?>> settings = new ArrayList<>();
-        scriptSettings.getScriptTypeSettings().forEach(settings::add);
-        scriptSettings.getScriptContextSettings().forEach(settings::add);
-        scriptSettings.getScriptLanguageSettings().forEach(settings::add);
-        settings.add(scriptSettings.getDefaultScriptLanguageSetting());
-        return settings;
-    }
-
-
-    @Override
-    protected void configure() {
-        ScriptSettings scriptSettings = new ScriptSettings(scriptEngineRegistry, scriptContextRegistry);
-        bind(ScriptContextRegistry.class).toInstance(scriptContextRegistry);
-        bind(ScriptEngineRegistry.class).toInstance(scriptEngineRegistry);
-        bind(ScriptSettings.class).toInstance(scriptSettings);
-        bind(ScriptService.class).asEagerSingleton();
-    }
-
-    public static ScriptModule create(Settings settings, List<ScriptPlugin> scriptPlugins) {
+    public static ScriptModule create(Settings settings, Environment environment, ResourceWatcherService resourceWatcherService,
+            List<ScriptPlugin> scriptPlugins) {
         Map<String, NativeScriptFactory> factoryMap = scriptPlugins.stream().flatMap(x -> x.getNativeScripts().stream())
             .collect(Collectors.toMap(NativeScriptFactory::getName, Function.identity()));
         NativeScriptEngineService nativeScriptEngineService = new NativeScriptEngineService(settings, factoryMap);
         List<ScriptEngineService> scriptEngineServices = scriptPlugins.stream().map(x -> x.getScriptEngineService(settings))
             .filter(Objects::nonNull).collect(Collectors.toList());
         scriptEngineServices.add(nativeScriptEngineService);
-        return new ScriptModule(scriptEngineServices, scriptPlugins.stream().map(x -> x.getCustomScriptContexts())
-            .filter(Objects::nonNull).collect(Collectors.toList()));
+        List<ScriptContext.Plugin> plugins = scriptPlugins.stream().map(x -> x.getCustomScriptContexts()).filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        return new ScriptModule(settings, environment, resourceWatcherService, scriptEngineServices, plugins);
+    }
+
+    /**
+     * Build {@linkplain ScriptEngineService} and {@linkplain ScriptContext.Plugin}.
+     */
+    public ScriptModule(Settings settings, Environment environment, ResourceWatcherService resourceWatcherService,
+            List<ScriptEngineService> scriptEngineServices, List<ScriptContext.Plugin> customScriptContexts) {
+        ScriptContextRegistry scriptContextRegistry = new ScriptContextRegistry(customScriptContexts);
+        ScriptEngineRegistry scriptEngineRegistry = new ScriptEngineRegistry(scriptEngineServices);
+        scriptSettings = new ScriptSettings(scriptEngineRegistry, scriptContextRegistry);
+        try {
+            scriptService = new ScriptService(settings, environment, resourceWatcherService, scriptEngineRegistry, scriptContextRegistry,
+                    scriptSettings);
+        } catch (IOException e) {
+            throw new RuntimeException("Couldn't setup ScriptService", e);
+        }
+    }
+
+    /**
+     * Extra settings for scripts.
+     */
+    public List<Setting<?>> getSettings() {
+        return scriptSettings.getSettings();
+    }
+
+    /**
+     * Service responsible for managing scripts.
+     */
+    public ScriptService getScriptService() {
+        return scriptService;
     }
 }

--- a/core/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -41,7 +41,6 @@ import org.elasticsearch.common.cache.RemovalListener;
 import org.elasticsearch.common.cache.RemovalNotification;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -72,7 +71,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
 import static java.util.Collections.unmodifiableMap;
@@ -132,7 +130,6 @@ public class ScriptService extends AbstractComponent implements Closeable {
     @Deprecated
     public static final ParseField SCRIPT_INLINE = new ParseField("script");
 
-    @Inject
     public ScriptService(Settings settings, Environment env,
                          ResourceWatcherService resourceWatcherService, ScriptEngineRegistry scriptEngineRegistry,
                          ScriptContextRegistry scriptContextRegistry, ScriptSettings scriptSettings) throws IOException {

--- a/core/src/main/java/org/elasticsearch/script/ScriptSettings.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptSettings.java
@@ -142,12 +142,13 @@ public class ScriptSettings {
         return scriptModeSettings;
     }
 
-    public Iterable<Setting<Boolean>> getScriptTypeSettings() {
-        return Collections.unmodifiableCollection(SCRIPT_TYPE_SETTING_MAP.values());
-    }
-
-    public Iterable<Setting<Boolean>> getScriptContextSettings() {
-        return Collections.unmodifiableCollection(scriptContextSettingMap.values());
+    public List<Setting<?>> getSettings() {
+        List<Setting<?>> settings = new ArrayList<>();
+        settings.addAll(SCRIPT_TYPE_SETTING_MAP.values());
+        settings.addAll(scriptContextSettingMap.values());
+        settings.addAll(scriptLanguageSettings);
+        settings.add(defaultScriptLanguageSetting);
+        return settings;
     }
 
     public Iterable<Setting<Boolean>> getScriptLanguageSettings() {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/AggregatorParsingTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/AggregatorParsingTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
-import org.elasticsearch.common.inject.util.Providers;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -112,28 +111,29 @@ public class AggregatorParsingTests extends ESTestCase {
             (b) -> {
                 b.bind(Environment.class).toInstance(new Environment(settings));
                 b.bind(ThreadPool.class).toInstance(threadPool);
-            }, settingsModule
-            , scriptModule, new IndicesModule(namedWriteableRegistry) {
+                b.bind(ScriptService.class).toInstance(scriptModule.getScriptService());
+            },
+            settingsModule,
+            new IndicesModule(namedWriteableRegistry) {
+                @Override
+                protected void configure() {
+                    bindMapperExtension();
+                }
+            }, new SearchModule(settings, namedWriteableRegistry) {
+                @Override
+                protected void configureSearch() {
+                    // Skip me
+                }
+            }, new IndexSettingsModule(index, settings),
 
-                    @Override
-                    protected void configure() {
-                        bindMapperExtension();
-                    }
-                }, new SearchModule(settings, namedWriteableRegistry) {
-                    @Override
-                    protected void configureSearch() {
-                        // Skip me
-                    }
-                }, new IndexSettingsModule(index, settings),
-
-                new AbstractModule() {
-                    @Override
-                    protected void configure() {
-                        bind(ClusterService.class).toProvider(Providers.of(clusterService));
-                        bind(CircuitBreakerService.class).to(NoneCircuitBreakerService.class);
-                        bind(NamedWriteableRegistry.class).toInstance(namedWriteableRegistry);
-                    }
-                }).createInjector();
+            new AbstractModule() {
+                @Override
+                protected void configure() {
+                    bind(ClusterService.class).toInstance(clusterService);
+                    bind(CircuitBreakerService.class).toInstance(new NoneCircuitBreakerService());
+                    bind(NamedWriteableRegistry.class).toInstance(namedWriteableRegistry);
+                }
+            }).createInjector();
         aggParsers = injector.getInstance(AggregatorParsers.class);
         // create some random type with some default field, those types will
         // stick around for all of the subclasses

--- a/core/src/test/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
@@ -25,7 +25,6 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ParseFieldMatcher;
-import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.inject.util.Providers;
@@ -140,31 +139,26 @@ public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuil
             (b) -> {
                 b.bind(Environment.class).toInstance(new Environment(settings));
                 b.bind(ThreadPool.class).toInstance(threadPool);
+                b.bind(ScriptService.class).toInstance(scriptModule.getScriptService());
+                b.bind(ClusterService.class).toProvider(Providers.of(clusterService));
+                b.bind(CircuitBreakerService.class).to(NoneCircuitBreakerService.class);
+                b.bind(NamedWriteableRegistry.class).toInstance(namedWriteableRegistry);
             },
             settingsModule,
-            scriptModule,
             new IndicesModule(namedWriteableRegistry) {
 
                 @Override
                 protected void configure() {
                     bindMapperExtension();
                 }
-            }, new SearchModule(settings, namedWriteableRegistry) {
+            },
+            new SearchModule(settings, namedWriteableRegistry) {
                 @Override
                 protected void configureSearch() {
                     // Skip me
                 }
             },
-            new IndexSettingsModule(index, settings),
-
-            new AbstractModule() {
-                @Override
-                protected void configure() {
-                    bind(ClusterService.class).toProvider(Providers.of(clusterService));
-                    bind(CircuitBreakerService.class).to(NoneCircuitBreakerService.class);
-                    bind(NamedWriteableRegistry.class).toInstance(namedWriteableRegistry);
-                }
-            }
+            new IndexSettingsModule(index, settings)
         ).createInjector();
     }
 

--- a/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -134,13 +134,16 @@ public class SearchSourceBuilderTests extends ESTestCase {
                 (b) -> {
                     b.bind(Environment.class).toInstance(new Environment(settings));
                     b.bind(ThreadPool.class).toInstance(threadPool);
-                }, settingsModule,
-                scriptModule, new IndicesModule(namedWriteableRegistry) {
+                    b.bind(ScriptService.class).toInstance(scriptModule.getScriptService());
+                },
+                settingsModule,
+                new IndicesModule(namedWriteableRegistry) {
                     @Override
                     protected void configure() {
                         bindMapperExtension();
                     }
-                }, new SearchModule(settings, namedWriteableRegistry) {
+                },
+                new SearchModule(settings, namedWriteableRegistry) {
                     @Override
                     protected void configureSearch() {
                         // Skip me

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
@@ -901,7 +901,6 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
                             bindMapperExtension();
                         }
                     },
-                    scriptModule,
                     new IndexSettingsModule(index, indexSettings),
                     searchModule,
                     new AbstractModule() {
@@ -919,7 +918,7 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
             IndexScopedSettings indexScopedSettings = injector.getInstance(IndexScopedSettings.class);
             idxSettings = IndexSettingsModule.newIndexSettings(index, indexSettings, indexScopedSettings);
             AnalysisService analysisService = new AnalysisRegistry(null, new Environment(settings)).build(idxSettings);
-            scriptService = injector.getInstance(ScriptService.class);
+            scriptService = scriptModule.getScriptService();
             similarityService = new SimilarityService(idxSettings, Collections.emptyMap());
             MapperRegistry mapperRegistry = injector.getInstance(MapperRegistry.class);
             mapperService = new MapperService(idxSettings, analysisService, similarityService, mapperRegistry,

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -58,11 +58,8 @@ import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.script.MockScriptEngine;
-import org.elasticsearch.script.ScriptContextRegistry;
-import org.elasticsearch.script.ScriptEngineRegistry;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.script.ScriptSettings;
 import org.elasticsearch.search.MockSearchService;
 import org.elasticsearch.test.junit.listeners.LoggingListener;
 import org.elasticsearch.test.junit.listeners.ReproduceInfoPrinter;
@@ -97,6 +94,8 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.elasticsearch.common.util.CollectionUtils.arrayAsArrayList;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -796,25 +795,12 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     public static ScriptModule newTestScriptModule() {
-        return new ScriptModule(new MockScriptEngine()) {
-            @Override
-            protected void configure() {
-                Settings settings = Settings.builder()
-                    .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
-                    // no file watching, so we don't need a ResourceWatcherService
-                    .put(ScriptService.SCRIPT_AUTO_RELOAD_ENABLED_SETTING.getKey(), false)
-                    .build();
-                bind(ScriptEngineRegistry.class).toInstance(scriptEngineRegistry);
-                bind(ScriptContextRegistry.class).toInstance(scriptContextRegistry);
-                bind(ScriptSettings.class).toInstance(scriptSettings);
-                try {
-                    ScriptService scriptService = new ScriptService(settings, new Environment(settings), null,
-                        scriptEngineRegistry, scriptContextRegistry, scriptSettings);
-                    bind(ScriptService.class).toInstance(scriptService);
-                } catch (IOException e) {
-                    throw new IllegalStateException("error while binding ScriptService", e);
-                }
-            }
-        };
+        Settings settings = Settings.builder()
+                .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
+                // no file watching, so we don't need a ResourceWatcherService
+                .put(ScriptService.SCRIPT_AUTO_RELOAD_ENABLED_SETTING.getKey(), false)
+                .build();
+        Environment environment = new Environment(settings);
+        return new ScriptModule(settings, environment, null, singletonList(new MockScriptEngine()), emptyList());
     }
 }


### PR DESCRIPTION
Makes ScriptModule just a plain class that manages building the ScriptSettings and ScriptService from plugins. When we _need_ to bind ScriptService with guice we bind it in a lambda.
