### PR TITLE
Also do not serialize `_index` key in search response for parent/child inner hits

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsFetchSubPhase.java
@@ -68,7 +68,6 @@ public final class InnerHitsFetchSubPhase implements FetchSubPhase {
             for (int i = 0; i < internalHits.length; i++) {
                 ScoreDoc scoreDoc = topDocs.scoreDocs[i];
                 InternalSearchHit searchHitFields = internalHits[i];
-                searchHitFields.shard(innerHits.shardTarget());
                 searchHitFields.score(scoreDoc.score);
                 if (scoreDoc instanceof FieldDoc) {
                     FieldDoc fieldDoc = (FieldDoc) scoreDoc;

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.inner_hits/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.inner_hits/10_basic.yaml
@@ -78,7 +78,7 @@ setup:
     - match: { hits.hits.0._index: "test" }
     - match: { hits.hits.0._type: "type_2" }
     - match: { hits.hits.0._id: "1" }
-    - match: { hits.hits.0.inner_hits.type_3.hits.hits.0._index: "test" }
+    - is_false: hits.hits.0.inner_hits.type_3.hits.hits.0._index
     - match: { hits.hits.0.inner_hits.type_3.hits.hits.0._type: "type_3" }
     - match: { hits.hits.0.inner_hits.type_3.hits.hits.0._id: "1" }
     - is_false: hits.hits.0.inner_hits.type_3.hits.hits.0._nested


### PR DESCRIPTION
The `_index` key is always the same as the parent search hit.
