### PR TITLE
corrected property name for "scripts" folder

### DIFF
--- a/docs/reference/setup/dir-layout.asciidoc
+++ b/docs/reference/setup/dir-layout.asciidoc
@@ -19,7 +19,7 @@ on the node. Can hold multiple locations. | {path.home}/data| path.data
 
 | repo | Shared file system repository locations. Can hold multiple locations. A file system repository can be placed in to any subdirectory of any directory specified here. d| Not configured | path.repo
 
-| script | Location of script files. | {path.conf}/scripts | path.script
+| script | Location of script files. | {path.conf}/scripts | path.scripts
 
 |=======================================================================
 


### PR DESCRIPTION
according to https://github.com/elastic/elasticsearch/pull/12668/commits/d7d25fe6b595422c38426ed1b39ab8f93f5b5919
the property name should be path.scripts, note the extra 's'
