### PR TITLE
Fix JarHell errors when running tests in Eclipse

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -32,16 +32,31 @@ dependencies {
   compile "commons-codec:commons-codec:${versions.commonscodec}"
   compile "commons-logging:commons-logging:${versions.commonslogging}"
 
-  testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  testCompile "junit:junit:${versions.junit}"
-  testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
-  //we use the last lucene-test version that is compatible with java 1.7
-  testCompile "org.apache.lucene:lucene-test-framework:5.5.1"
-  testCompile "org.apache.lucene:lucene-core:5.5.1"
-  testCompile "org.apache.lucene:lucene-codecs:5.5.1"
-  testCompile "org.elasticsearch:securemock:${versions.securemock}"
-  testCompile "org.codehaus.mojo:animal-sniffer-annotations:1.15"
+  if (isEclipse == false || project.path == ":client-tests") {
+    testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+    testCompile "junit:junit:${versions.junit}"
+    testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
+    //we use the last lucene-test version that is compatible with java 1.7
+    testCompile "org.apache.lucene:lucene-test-framework:5.5.1"
+    testCompile "org.apache.lucene:lucene-core:5.5.1"
+    testCompile "org.apache.lucene:lucene-codecs:5.5.1"
+    testCompile "org.elasticsearch:securemock:${versions.securemock}"
+    testCompile "org.codehaus.mojo:animal-sniffer-annotations:1.15"
+  }
   signature "org.codehaus.mojo.signature:java17:1.0@signature"
+}
+
+if (isEclipse) {
+  // in eclipse the project is under a fake root, we need to change around the source sets
+  sourceSets {
+    if (project.path == ":client") {
+      main.java.srcDirs = ['java']
+      main.resources.srcDirs = ['resources']
+    } else {
+      test.java.srcDirs = ['java']
+      test.resources.srcDirs = ['resources']
+    }
+  }
 }
 
 forbiddenApisMain {

--- a/client/src/main/eclipse-build.gradle
+++ b/client/src/main/eclipse-build.gradle
@@ -1,0 +1,3 @@
+
+// this is just shell gradle file for eclipse to have separate projects for core src and tests
+apply from: '../../build.gradle'

--- a/client/src/test/eclipse-build.gradle
+++ b/client/src/test/eclipse-build.gradle
@@ -1,0 +1,7 @@
+
+// this is just shell gradle file for eclipse to have separate projects for core src and tests
+apply from: '../../build.gradle'
+
+dependencies {
+  testCompile project(':client')
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -57,11 +57,16 @@ List projects = [
   'qa:vagrant',
 ]
 
-boolean isEclipse = System.getProperty("eclipse.launcher") != null || gradle.startParameter.taskNames.contains('eclipse') || gradle.startParameter.taskNames.contains('cleanEclipse')
+boolean isEclipse = System.getProperty("eclipse.launcher") != null ||
+    gradle.startParameter.taskNames.contains('eclipse') ||
+    gradle.startParameter.taskNames.contains('cleanEclipse')
 if (isEclipse) {
-  // eclipse cannot handle an intermediate dependency between main and test, so we must create separate projects
-  // for core-src and core-tests
+  /* eclipse cannot handle an intermediate dependency between main and test so
+   * we must create separate projects for core-src and core-tests */
   projects << 'core-tests'
+  /* Eclipse squashes tests and main dependencies so client's tests cause
+   * JarHell with all other tests */
+  projects << 'client-tests'
 }
 
 include projects.toArray(new String[0])
@@ -73,6 +78,10 @@ if (isEclipse) {
   project(":core").buildFileName = 'eclipse-build.gradle'
   project(":core-tests").projectDir = new File(rootProject.projectDir, 'core/src/test')
   project(":core-tests").buildFileName = 'eclipse-build.gradle'
+  project(":client").projectDir = new File(rootProject.projectDir, 'client/src/main')
+  project(":client").buildFileName = 'eclipse-build.gradle'
+  project(":client-tests").projectDir = new File(rootProject.projectDir, 'client/src/test')
+  project(":client-tests").buildFileName = 'eclipse-build.gradle'
 }
 
 /**


### PR DESCRIPTION
Eclipse merges the test and main dependencies of all project because it
is silly. This isn't a problem most of the time but it became a problem
when core's tests started to depend on the client. That caused Eclipse
to add the client's test dependencies to core's test's classpath. That
is a problem because the client's test dependencies use an older version
of Lucene so they can be Java 1.7 compatible. So we end up with two
copies of LuceneTestCase on the classpath when running core's tests.
Which causes JarHell.

This fixes the problem by breaking the client into two projects when
importing it into Eclipse - one for main code and one for tests. Now
client's test dependencies no longer blead into core in Eclipse.
