### PR TITLE
Move upgrade test to upgrade from version 2.3.3

### DIFF
--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -58,7 +58,7 @@ for (String box : getProperties().get('vagrant.boxes', 'sample').split(',')) {
 
 /* The version of elasticsearch that we upgrade *from* as part of testing
  * upgrades. */
-String upgradeFromVersion = '2.0.0'
+String upgradeFromVersion = '2.3.3'
 
 configurations {
   test


### PR DESCRIPTION
This commit moves the upgrade test to test upgrading from version 2.3.3
instead of from version 2.0.0.

Closes #19026
