### PR TITLE
Upgrade JNA to 4.2.2 and remove optionality

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -7,8 +7,7 @@ jts               = 1.13
 jackson           = 2.7.1
 log4j             = 1.2.17
 slf4j             = 1.6.2
-jna               = 4.1.0
-
+jna               = 4.2.2
 
 # test dependencies
 randomizedrunner  = 2.3.2

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -89,7 +89,7 @@ dependencies {
   compile "log4j:log4j:${versions.log4j}", optional
   compile "log4j:apache-log4j-extras:${versions.log4j}", optional
 
-  compile "net.java.dev.jna:jna:${versions.jna}", optional
+  compile "net.java.dev.jna:jna:${versions.jna}"
 
   if (isEclipse == false || project.path == ":core-tests") {
     testCompile("org.elasticsearch.test:framework:${version}") {


### PR DESCRIPTION
This commit upgrades JNA from version 4.1.0 to 4.2.2. Additionally, this
dependency is now non-optional as JNA is dual-licensed with Apache
License 2.0 since JNA 4.0.0.

Closes #13245
