### PR TITLE
Add the ability to dynamically update similarity options

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -963,7 +963,6 @@
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]shard[/\\]IndexShardTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]shard[/\\]IndexingOperationListenerTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]shard[/\\]ShardPathTests.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]similarity[/\\]SimilarityTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]snapshots[/\\]blobstore[/\\]FileInfoTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]store[/\\]CorruptedFileIT.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]store[/\\]CorruptedTranslogIT.java" checks="LineLength" />
@@ -1096,7 +1095,6 @@
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]suggest[/\\]completion[/\\]CategoryContextMappingTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]suggest[/\\]completion[/\\]GeoContextMappingTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]suggest[/\\]phrase[/\\]NoisyChannelSpellCheckerTests.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]similarity[/\\]SimilarityIT.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]snapshots[/\\]AbstractSnapshotIntegTestCase.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]snapshots[/\\]BlobStoreFormatIT.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]snapshots[/\\]DedicatedClusterSnapshotRestoreIT.java" checks="LineLength" />

--- a/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -140,18 +140,8 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         PrimaryShardAllocator.INDEX_RECOVERY_INITIAL_SHARDS_SETTING,
         FsDirectoryService.INDEX_LOCK_FACTOR_SETTING,
         EngineConfig.INDEX_CODEC_SETTING,
-        // validate that built-in similarities don't get redefined
-        Setting.groupSetting("index.similarity.", (s) -> {
-            Map<String, Settings> groups = s.getAsGroups();
-            for (String key : SimilarityService.BUILT_IN.keySet()) {
-                if (groups.containsKey(key)) {
-                    throw new IllegalArgumentException("illegal value for [index.similarity." + key +
-                            "] cannot redefine built-in similarity");
-                }
-            }
-        }, Property.IndexScope), // this allows similarity settings to be passed
+        SimilarityService.SIMILARITY_SETTINGS,
         Setting.groupSetting("index.analysis.", Property.IndexScope) // this allows analysis settings to be passed
-
     )));
 
     public static final IndexScopedSettings DEFAULT_SCOPED_SETTINGS = new IndexScopedSettings(Settings.EMPTY,

--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -486,6 +486,19 @@ public class Setting<T> extends ToXContentToBytes {
         }, properties);
     }
 
+    public static Setting<Float> floatSetting(String key, float defaultValue, float minValue, float maxValue, Property... properties) {
+        return new Setting<>(key, (s) -> Float.toString(defaultValue), (s) -> {
+            float value = Float.parseFloat(s);
+            if (value < minValue) {
+                throw new IllegalArgumentException("Failed to parse value [" + s + "] for setting [" + key + "] must be >= " + minValue);
+            }
+            if (value > maxValue) {
+                throw new IllegalArgumentException("Failed to parse value [" + s + "] for setting [" + key + "] must be <= " + maxValue);
+            }
+            return value;
+        }, properties);
+    }
+
     public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, int maxValue, Property... properties) {
         return new Setting<>(key, (s) -> Integer.toString(defaultValue), (s) -> parseInt(s, minValue, maxValue, key), properties);
     }

--- a/core/src/main/java/org/elasticsearch/index/similarity/ClassicSimilarityProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/similarity/ClassicSimilarityProvider.java
@@ -31,13 +31,11 @@ import org.elasticsearch.common.settings.Settings;
  * </ul>
  * @see ClassicSimilarity For more information about configuration
  */
-public class ClassicSimilarityProvider extends AbstractSimilarityProvider {
-
+public class ClassicSimilarityProvider extends BaseSimilarityProvider {
     private final ClassicSimilarity similarity = new ClassicSimilarity();
 
     public ClassicSimilarityProvider(String name, Settings settings) {
-        super(name);
-        boolean discountOverlaps = settings.getAsBoolean("discount_overlaps", true);
+        super(name, settings);
         this.similarity.setDiscountOverlaps(discountOverlaps);
     }
 
@@ -45,7 +43,11 @@ public class ClassicSimilarityProvider extends AbstractSimilarityProvider {
      * {@inheritDoc}
      */
     @Override
-    public ClassicSimilarity get() {
+    protected ClassicSimilarity doGet() {
         return similarity;
+    }
+
+    @Override
+    protected void doUpdateSettings(Settings settings) {
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/similarity/SimilarityProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/similarity/SimilarityProvider.java
@@ -20,23 +20,138 @@
 package org.elasticsearch.index.similarity;
 
 import org.apache.lucene.search.similarities.Similarity;
+import org.apache.lucene.search.spell.LevensteinDistance;
+import org.apache.lucene.util.CollectionUtil;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Provider for {@link Similarity} instances
  */
-public interface SimilarityProvider {
+public abstract class SimilarityProvider {
+    protected static final Setting<String> TYPE_SETTING = Setting.simpleString("type");
+
+    private final String name;
+    private final Map<String, Setting<?> > settingMap;
+    private Settings currentSettings;
+
+    /**
+     *
+     * @param name The name associated with the Provider
+     * @param settings The settings for this similarity provider
+     */
+    public SimilarityProvider(String name, Settings settings) {
+        this.name = name;
+        this.settingMap = getSettings().stream().collect(Collectors.toMap(Setting::getKey, setting -> setting));
+        this.settingMap.put(TYPE_SETTING.getKey(), TYPE_SETTING);
+        validateSettings(settings);
+        this.currentSettings = settings;
+    }
 
     /**
      * Returns the name associated with the Provider
      *
      * @return Name of the Provider
      */
-    String name();
+    public final String name() {
+        return name;
+    }
+
+    /**
+     * Returns a list of additional {@link Setting} definitions for this Provider.
+     */
+    public List<Setting<?>> getSettings() { return Collections.emptyList(); }
+
 
     /**
      * Returns the {@link Similarity} the Provider is for
      *
+     * This method is always invoked from a synchronized context
      * @return Provided {@link Similarity}
      */
-    Similarity get();
+    protected abstract Similarity doGet();
+
+    public final synchronized Similarity get() {
+        return doGet();
+    }
+
+    /**
+     * Called before {@link SimilarityProvider#doUpdateSettings(Settings)}
+     *
+     * @param newSettings The settings to validate for this similarity provider
+     */
+    protected void doValidateUpdateSettings(Settings newSettings) {}
+
+    /**
+     * Called when the {@link Settings} are updated.
+     *
+     * This method is always invoked from a synchronized context
+     * @param settings The updated settings for this similarity provider
+     */
+    protected abstract void doUpdateSettings(Settings settings);
+
+    final synchronized void updateSettings(Settings settings) {
+        if (settings.equals(currentSettings)) {
+            this.currentSettings = settings;
+            return ;
+        }
+        doUpdateSettings(settings);
+        this.currentSettings = settings;
+    }
+
+    final void validateUpdateSettings(Settings newSettings) {
+        if (newSettings.equals(currentSettings)) {
+            return ;
+        }
+        validateSettings(newSettings);
+        settingMap.forEach((k, v) -> {
+            Setting<?> setting = settingMap.get(k);
+            if (setting.isDynamic() == false) {
+                Object obj1 = setting.get(newSettings);
+                Object obj2 = setting.get(currentSettings);
+                boolean hasChanged = (Objects.equals(obj1, obj2) == false);
+                if (hasChanged) {
+                    throw new IllegalArgumentException("setting [" + setting.getKey() + "] " +
+                        "for similarity [" + name() + "], not dynamically updateable");
+                }
+            }
+        });
+        doValidateUpdateSettings(newSettings);
+    }
+
+    final void validateSettings(Settings settings) {
+        settings.getAsMap().forEach((k, v) -> {
+            Setting<?> setting = settingMap.get(k);
+            if (setting == null) {
+                LevensteinDistance ld = new LevensteinDistance();
+                List<Tuple<Float, String>> scoredKeys = new ArrayList<>();
+                for (String key : settingMap.keySet()) {
+                    float distance = ld.getDistance(k, key);
+                    if (distance > 0.7f) {
+                        scoredKeys.add(new Tuple<>(distance, key));
+                    }
+                }
+                CollectionUtil.timSort(scoredKeys, (a, b) -> b.v1().compareTo(a.v1()));
+                String msg = "unknown setting [" + k + "] for similarity [" + name() + "]";
+                List<String> keys = scoredKeys.stream().map((a) -> a.v2()).collect(Collectors.toList());
+                if (keys.isEmpty() == false) {
+                    msg += " did you mean " +
+                        (keys.size() == 1 ? "[" + keys.get(0) + "]": "any of " + keys.toString()) + "?";
+                } else {
+                    msg += " please check that any required plugins are installed, " +
+                        "or check the breaking changes documentation for removed settings";
+                }
+                throw new IllegalArgumentException(msg);
+            }
+            setting.get(settings);
+        });
+    }
 }

--- a/core/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/core/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -22,9 +22,10 @@ package org.elasticsearch.index.similarity;
 import org.apache.lucene.search.similarities.PerFieldSimilarityWrapper;
 import org.apache.lucene.search.similarities.Similarity;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.AbstractIndexComponent;
-import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
@@ -35,11 +36,11 @@ import java.util.Map;
 import java.util.function.BiFunction;
 
 public final class SimilarityService extends AbstractIndexComponent {
-
     public static final String DEFAULT_SIMILARITY = "BM25";
-    private final Similarity defaultSimilarity;
-    private final Similarity baseSimilarity;
-    private final Map<String, SimilarityProvider> similarities;
+
+    public static final Setting<Settings> SIMILARITY_SETTINGS = Setting.groupSetting("index.similarity.",
+        Setting.Property.IndexScope, Setting.Property.Dynamic);
+
     static final Map<String, BiFunction<String, Settings, SimilarityProvider>> DEFAULTS;
     public static final Map<String, BiFunction<String, Settings, SimilarityProvider>> BUILT_IN;
     static {
@@ -58,99 +59,140 @@ public final class SimilarityService extends AbstractIndexComponent {
         BUILT_IN = Collections.unmodifiableMap(buildIn);
     }
 
-    public SimilarityService(IndexSettings indexSettings, Map<String, BiFunction<String, Settings, SimilarityProvider>> similarities) {
+    private final Map<String, BiFunction<String, Settings, SimilarityProvider> > customProviders;
+    private final Map<String, SimilarityProvider> similarities =
+        Collections.synchronizedMap(new HashMap<> ());
+
+    private final SimilarityProvider defaultSimilarityProvider;
+    private final SimilarityProvider baseSimilarityProvider;
+
+    public SimilarityService(IndexSettings indexSettings,
+                             Map<String, BiFunction<String, Settings, SimilarityProvider>> customProviders) {
         super(indexSettings);
-        Map<String, SimilarityProvider> providers = new HashMap<>(similarities.size());
-        Map<String, Settings> similaritySettings = this.indexSettings.getSettings().getGroups(IndexModule.SIMILARITY_SETTINGS_PREFIX);
-        for (Map.Entry<String, Settings> entry : similaritySettings.entrySet()) {
+        this.customProviders = customProviders;
+        Map<String, Settings> groupSettings =
+            new HashMap<> (indexSettings.getSettings().getGroups(SIMILARITY_SETTINGS.getKey()));
+
+        // Add default similarity (BM25 and classic)
+        for (Map.Entry<String, BiFunction<String, Settings, SimilarityProvider>> entry : DEFAULTS.entrySet()) {
             String name = entry.getKey();
-            // Starting with v5.0 indices, it should no longer be possible to redefine built-in similarities
-            if(BUILT_IN.containsKey(name) && indexSettings.getIndexVersionCreated().onOrAfter(Version.V_5_0_0_alpha1)) {
-                throw new IllegalArgumentException("Cannot redefine built-in Similarity [" + name + "]");
-            }
-            Settings settings = entry.getValue();
-            String typeName = settings.get("type");
-            if (typeName == null) {
-                throw new IllegalArgumentException("Similarity [" + name + "] must have an associated type");
-            } else if ((similarities.containsKey(typeName) || BUILT_IN.containsKey(typeName)) == false) {
-                throw new IllegalArgumentException("Unknown Similarity type [" + typeName + "] for [" + name + "]");
-            }
-            BiFunction<String, Settings, SimilarityProvider> factory = similarities.getOrDefault(typeName, BUILT_IN.get(typeName));
+            Settings settings = groupSettings.get(name);
             if (settings == null) {
                 settings = Settings.Builder.EMPTY_SETTINGS;
             }
-            providers.put(name, factory.apply(name, settings));
-        }
-        for (Map.Entry<String, SimilarityProvider> entry : addSimilarities(similaritySettings, DEFAULTS).entrySet()) {
-            // Avoid overwriting custom providers for indices older that v5.0
-            if (providers.containsKey(entry.getKey()) && indexSettings.getIndexVersionCreated().before(Version.V_5_0_0_alpha1)) {
-                continue;
+            String type = settings.get("type");
+            BiFunction<String, Settings, SimilarityProvider> factory;
+            if (type != null) {
+                if (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_5_0_0_alpha1)) {
+                    throw new IllegalArgumentException("Cannot redefine built-in Similarity [" + entry.getKey() + "]");
+                }
+                if (BUILT_IN.containsKey(type) == false && customProviders.containsKey(type) == false) {
+                    throw new IllegalArgumentException("Unknown Similarity type [" + type + "] for [" +
+                        entry.getKey() + "]");
+                }
+                factory = customProviders.getOrDefault(type, BUILT_IN.get(type));
+            } else {
+                factory = entry.getValue();
             }
-            providers.put(entry.getKey(), entry.getValue());
+            SimilarityProvider provider = factory.apply(name, settings);
+            similarities.put(name, provider);
+            groupSettings.remove(name);
         }
-        this.similarities = providers;
-        defaultSimilarity = (providers.get("default") != null) ? providers.get("default").get()
-                                                              : providers.get(SimilarityService.DEFAULT_SIMILARITY).get();
+        addOrUpdateSimilarities(groupSettings, false);
+
+        defaultSimilarityProvider = similarities.containsKey("default") ? similarities.get("default")
+            : similarities.get(SimilarityService.DEFAULT_SIMILARITY);
         // Expert users can configure the base type as being different to default, but out-of-box we use default.
-        baseSimilarity = (providers.get("base") != null) ? providers.get("base").get() :
-                defaultSimilarity;
-    }
-
-    public Similarity similarity(MapperService mapperService) {
-        // TODO we can maybe factor out MapperService here entirely by introducing an interface for the lookup?
-        return (mapperService != null) ? new PerFieldSimilarity(defaultSimilarity, baseSimilarity, mapperService) :
-                defaultSimilarity;
-    }
-
-    private Map<String, SimilarityProvider> addSimilarities(Map<String, Settings>  similaritySettings,
-                                 Map<String, BiFunction<String, Settings, SimilarityProvider>> similarities)  {
-        Map<String, SimilarityProvider> providers = new HashMap<>(similarities.size());
-        for (Map.Entry<String, BiFunction<String, Settings, SimilarityProvider>> entry : similarities.entrySet()) {
-            String name = entry.getKey();
-            BiFunction<String, Settings, SimilarityProvider> factory = entry.getValue();
-            Settings settings = similaritySettings.get(name);
-            if (settings == null) {
-                settings = Settings.Builder.EMPTY_SETTINGS;
-            }
-            providers.put(name, factory.apply(name, settings));
-        }
-        return providers;
+        baseSimilarityProvider = similarities.containsKey("base") ? similarities.get("base") :
+            defaultSimilarityProvider;
+        similarities.put("default", defaultSimilarityProvider);
+        similarities.put("base", baseSimilarityProvider);
     }
 
     public SimilarityProvider getSimilarity(String name) {
         return similarities.get(name);
     }
 
-    Similarity getDefaultSimilarity() {
-        return defaultSimilarity;
+    public Similarity similarity(MapperService mapperService) {
+        // TODO we can maybe factor out MapperService here entirely by introducing an interface for the lookup?
+        return new PerFieldSimilarity(mapperService);
     }
 
-    static class PerFieldSimilarity extends PerFieldSimilarityWrapper {
+    public void addSettingsUpdateConsumer(IndexScopedSettings settings) {
+        settings.addSettingsUpdateConsumer(SIMILARITY_SETTINGS, this::updateSettings, this::validateSettings);
+    }
 
-        private final Similarity defaultSimilarity;
-        private final Similarity baseSimilarity;
-        private final MapperService mapperService;
+    /**
+     * validates that the updated settings are valid.
+     **/
+    void validateSettings(Settings settings) {
+        Map<String, Settings> groupSettings = settings.getAsGroups();
+        addOrUpdateSimilarities(groupSettings, true);
+    }
 
-        PerFieldSimilarity(Similarity defaultSimilarity, Similarity baseSimilarity, MapperService mapperService) {
-            this.defaultSimilarity = defaultSimilarity;
-            this.baseSimilarity = baseSimilarity;
+    /**
+     * update in place the similarity provider with the new settings
+     */
+    void updateSettings(Settings settings) {
+        Map<String, Settings> groupSettings = settings.getAsGroups();
+        addOrUpdateSimilarities(groupSettings, false);
+    }
+
+    private void addOrUpdateSimilarities(Map<String, Settings> groupSettings, boolean dryRun) {
+        for (Map.Entry<String, Settings> entry : groupSettings.entrySet()) {
+            final String name = entry.getKey();
+            final Settings settings = entry.getValue();
+            SimilarityProvider provider = similarities.get(name);
+            if (provider != null) {
+                provider.validateUpdateSettings(settings);
+                if (dryRun == false) {
+                    provider.updateSettings(settings);
+                }
+            } else {
+                String type = settings.get("type");
+                if (type == null) {
+                    throw new IllegalArgumentException("Similarity [" + name +
+                        "] must have an associated type");
+                }
+                if (BUILT_IN.containsKey(type) == false && customProviders.containsKey(type) == false) {
+                    throw new IllegalArgumentException("Unknown Similarity type [" + type + "] for [" +
+                        name + "]");
+                }
+                BiFunction<String, Settings, SimilarityProvider> factory =
+                    customProviders.getOrDefault(type, BUILT_IN.get(type));
+                provider = factory.apply(name, settings);
+                if (dryRun == false) {
+                    similarities.put(name, provider);
+                }
+            }
+        }
+    }
+
+    class PerFieldSimilarity extends PerFieldSimilarityWrapper {
+        final MapperService mapperService;
+
+        PerFieldSimilarity(MapperService mapperService) {
             this.mapperService = mapperService;
         }
 
         @Override
         public float coord(int overlap, int maxOverlap) {
-            return baseSimilarity.coord(overlap, maxOverlap);
+            return baseSimilarityProvider.get().coord(overlap, maxOverlap);
         }
 
         @Override
         public float queryNorm(float valueForNormalization) {
-            return baseSimilarity.queryNorm(valueForNormalization);
+            return baseSimilarityProvider.get().queryNorm(valueForNormalization);
         }
 
         @Override
         public Similarity get(String name) {
+            if (mapperService == null) {
+                return defaultSimilarityProvider.get();
+            }
             MappedFieldType fieldType = mapperService.fullName(name);
-            return (fieldType != null && fieldType.similarity() != null) ? fieldType.similarity().get() : defaultSimilarity;
+            return (fieldType != null && fieldType.similarity() != null) ?
+                fieldType.similarity().get() : defaultSimilarityProvider.get();
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -233,15 +233,7 @@ public class ScopedSettingsTests extends ESTestCase {
         } catch (IllegalArgumentException e) {
             assertEquals("Failed to parse value [true] for setting [index.number_of_replicas]", e.getMessage());
         }
-
-        try {
-            settings.validate("index.similarity.classic.type", Settings.builder().put("index.similarity.classic.type", "mine").build());
-            fail();
-        } catch (IllegalArgumentException e) {
-            assertEquals("illegal value for [index.similarity.classic] cannot redefine built-in similarity", e.getMessage());
-        }
     }
-
 
     public static IndexMetaData newIndexMeta(String name, Settings indexSettings) {
         Settings build = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)

--- a/core/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/core/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -434,7 +434,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         ensureGreen(metaData.getIndex().getName());
         state = client().admin().cluster().prepareState().get().getState();
         assertEquals(IndexMetaData.State.CLOSE, state.getMetaData().index(metaData.getIndex()).getState());
-        assertEquals("classic", state.getMetaData().index(metaData.getIndex()).getSettings().get("archived.index.similarity.BM25.type"));
+        assertEquals("classic", state.getMetaData().index(metaData.getIndex()).getSettings().get("index.similarity.BM25.type"));
         // try to open it with the broken setting - fail again!
         ElasticsearchException ex = expectThrows(ElasticsearchException.class, () -> client().admin().indices().prepareOpen("test").get());
         assertEquals(ex.getMessage(), "Failed to verify index " + metaData.getIndex());

--- a/core/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
+++ b/core/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
@@ -50,8 +50,10 @@ import org.elasticsearch.test.VersionUtils;
 import java.io.IOException;
 import java.util.Collection;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.startsWith;
 
 public class SimilarityTests extends ESSingleNodeTestCase {
 
@@ -64,7 +66,7 @@ public class SimilarityTests extends ESSingleNodeTestCase {
         SimilarityService similarityService = createIndex("foo").similarityService();
         assertThat(similarityService.getSimilarity("classic").get(), instanceOf(ClassicSimilarity.class));
         assertThat(similarityService.getSimilarity("BM25").get(), instanceOf(BM25Similarity.class));
-        assertThat(similarityService.getSimilarity("default"), equalTo(null));
+        assertThat(similarityService.getSimilarity("default").get(), instanceOf(BM25Similarity.class));
     }
 
     public void testResolveSimilaritiesFromMapping_classic() throws IOException {
@@ -79,10 +81,13 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .put("index.similarity.my_similarity.discount_overlaps", false)
             .build();
         IndexService indexService = createIndex("foo", indexSettings);
-        DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
-        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(), instanceOf(ClassicSimilarityProvider.class));
+        DocumentMapper documentMapper = indexService.mapperService()
+            .documentMapperParser().parse("type", new CompressedXContent(mapping));
+        assertThat(documentMapper.mappers().getMapper("field1")
+            .fieldType().similarity(), instanceOf(ClassicSimilarityProvider.class));
 
-        ClassicSimilarity similarity = (ClassicSimilarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
+        ClassicSimilarity similarity = (ClassicSimilarity) documentMapper.mappers()
+            .getMapper("field1").fieldType().similarity().get();
         assertThat(similarity.getDiscountOverlaps(), equalTo(false));
     }
 
@@ -100,10 +105,13 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .put("index.similarity.my_similarity.discount_overlaps", false)
             .build();
         IndexService indexService = createIndex("foo", indexSettings);
-        DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
-        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(), instanceOf(BM25SimilarityProvider.class));
+        DocumentMapper documentMapper = indexService.mapperService()
+            .documentMapperParser().parse("type", new CompressedXContent(mapping));
+        assertThat(documentMapper.mappers().getMapper("field1")
+            .fieldType().similarity(), instanceOf(BM25SimilarityProvider.class));
 
-        BM25Similarity similarity = (BM25Similarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
+        BM25Similarity similarity = (BM25Similarity) documentMapper.mappers()
+            .getMapper("field1").fieldType().similarity().get();
         assertThat(similarity.getK1(), equalTo(2.0f));
         assertThat(similarity.getB(), equalTo(0.5f));
         assertThat(similarity.getDiscountOverlaps(), equalTo(false));
@@ -124,10 +132,13 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .put("index.similarity.my_similarity.normalization.h2.c", 3f)
             .build();
         IndexService indexService = createIndex("foo", indexSettings);
-        DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
-        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(), instanceOf(DFRSimilarityProvider.class));
+        DocumentMapper documentMapper = indexService.mapperService()
+            .documentMapperParser().parse("type", new CompressedXContent(mapping));
+        assertThat(documentMapper.mappers().getMapper("field1")
+            .fieldType().similarity(), instanceOf(DFRSimilarityProvider.class));
 
-        DFRSimilarity similarity = (DFRSimilarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
+        DFRSimilarity similarity = (DFRSimilarity) documentMapper.mappers()
+            .getMapper("field1").fieldType().similarity().get();
         assertThat(similarity.getBasicModel(), instanceOf(BasicModelG.class));
         assertThat(similarity.getAfterEffect(), instanceOf(AfterEffectL.class));
         assertThat(similarity.getNormalization(), instanceOf(NormalizationH2.class));
@@ -149,10 +160,13 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .put("index.similarity.my_similarity.normalization.h2.c", 3f)
             .build();
         IndexService indexService = createIndex("foo", indexSettings);
-        DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
-        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(), instanceOf(IBSimilarityProvider.class));
+        DocumentMapper documentMapper = indexService.mapperService()
+            .documentMapperParser().parse("type", new CompressedXContent(mapping));
+        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(),
+            instanceOf(IBSimilarityProvider.class));
 
-        IBSimilarity similarity = (IBSimilarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
+        IBSimilarity similarity = (IBSimilarity) documentMapper.mappers().getMapper("field1")
+            .fieldType().similarity().get();
         assertThat(similarity.getDistribution(), instanceOf(DistributionSPL.class));
         assertThat(similarity.getLambda(), instanceOf(LambdaTTF.class));
         assertThat(similarity.getNormalization(), instanceOf(NormalizationH2.class));
@@ -171,7 +185,8 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .put("index.similarity.my_similarity.independence_measure", "chisquared")
             .build();
         IndexService indexService = createIndex("foo", indexSettings);
-        DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
+        DocumentMapper documentMapper = indexService.mapperService()
+            .documentMapperParser().parse("type", new CompressedXContent(mapping));
         MappedFieldType fieldType = documentMapper.mappers().getMapper("field1").fieldType();
         assertThat(fieldType.similarity(), instanceOf(DFISimilarityProvider.class));
         DFISimilarity similarity = (DFISimilarity) fieldType.similarity().get();
@@ -190,10 +205,13 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .put("index.similarity.my_similarity.mu", 3000f)
             .build();
         IndexService indexService = createIndex("foo", indexSettings);
-        DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
-        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(), instanceOf(LMDirichletSimilarityProvider.class));
+        DocumentMapper documentMapper = indexService.mapperService()
+            .documentMapperParser().parse("type", new CompressedXContent(mapping));
+        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(),
+            instanceOf(LMDirichletSimilarityProvider.class));
 
-        LMDirichletSimilarity similarity = (LMDirichletSimilarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
+        LMDirichletSimilarity similarity = (LMDirichletSimilarity) documentMapper.mappers()
+            .getMapper("field1").fieldType().similarity().get();
         assertThat(similarity.getMu(), equalTo(3000f));
     }
 
@@ -209,10 +227,13 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .put("index.similarity.my_similarity.lambda", 0.7f)
             .build();
         IndexService indexService = createIndex("foo", indexSettings);
-        DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
-        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(), instanceOf(LMJelinekMercerSimilarityProvider.class));
+        DocumentMapper documentMapper = indexService.mapperService()
+            .documentMapperParser().parse("type", new CompressedXContent(mapping));
+        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(),
+            instanceOf(LMJelinekMercerSimilarityProvider.class));
 
-        LMJelinekMercerSimilarity similarity = (LMJelinekMercerSimilarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
+        LMJelinekMercerSimilarity similarity = (LMJelinekMercerSimilarity) documentMapper.mappers()
+            .getMapper("field1").fieldType().similarity().get();
         assertThat(similarity.getLambda(), equalTo(0.7f));
     }
 
@@ -243,20 +264,210 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .endObject()
             .endObject().string();
         Settings settings = Settings.builder()
-            .put(IndexMetaData.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.V_2_2_0))
+            .put(IndexMetaData.SETTING_VERSION_CREATED,
+                VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.V_2_2_0))
             .build();
 
         DocumentMapperParser parser = createIndex("test_v2.x", settings).mapperService().documentMapperParser();
         DocumentMapper documentMapper = parser.parse("type", new CompressedXContent(mapping));
-        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(), instanceOf(ClassicSimilarityProvider.class));
-        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity().name(), equalTo("classic"));
+        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(),
+            instanceOf(ClassicSimilarityProvider.class));
+        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity().name(),
+            equalTo("classic"));
 
         parser = createIndex("test_v3.x").mapperService().documentMapperParser();
-        try {
-            parser.parse("type", new CompressedXContent(mapping));
-            fail("Expected MappingParsingException");
-        } catch (MapperParsingException e) {
-            assertThat(e.getMessage(), equalTo("Unknown Similarity type [default] for field [field1]"));
+        documentMapper = parser.parse("type", new CompressedXContent(mapping));
+        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(),
+            instanceOf(BM25SimilarityProvider.class));
+        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity().name(), equalTo("BM25"));
+    }
+
+    public void testSimilarityUpdate() throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties")
+            .startObject("field1").field("type", "text").field("similarity", "my_similarity").endObject()
+            .endObject()
+            .endObject().endObject().string();
+
+        Settings indexSettings = Settings.builder()
+            .put("index.similarity.my_similarity.type", "BM25")
+            .put("index.similarity.my_similarity.discount_overlaps", false)
+            .build();
+        IndexService indexService = createIndex("foo", indexSettings);
+        DocumentMapper documentMapper = indexService.mapperService().documentMapperParser()
+            .parse("type", new CompressedXContent(mapping));
+        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(),
+            instanceOf(BM25SimilarityProvider.class));
+
+        BM25Similarity similarity = (BM25Similarity) documentMapper.mappers()
+            .getMapper("field1").fieldType().similarity().get();
+        assertThat(similarity.getDiscountOverlaps(), equalTo(false));
+
+        Settings newSettings = Settings.builder()
+            .put("index.similarity.my_similarity.k1", 2.0f)
+            .put("index.similarity.my_similarity.b", 0.5f)
+            .build();
+        client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet();
+        similarity = (BM25Similarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
+        assertThat(similarity.getK1(), equalTo(2.0f));
+        assertThat(similarity.getB(), equalTo(0.5f));
+        assertThat(similarity.getDiscountOverlaps(), equalTo(false));
+    }
+
+    public void testInvalidSimilarity() {
+        final Settings.Builder builder = Settings.builder()
+            .put("index.similarity.my_similarity.type", "BM25")
+            .put("index.similarity.my_similarity.discount_overlaps", false)
+            .put("index.similarity.my_similarity.b", 0.5f)
+            .put("index.similarity.my_similarity.invalid", "boom");
+        IllegalArgumentException exc =
+            expectThrows(IllegalArgumentException.class, () -> createIndex("foo", builder.build()));
+        assertThat(exc.getMessage(),
+            containsString("unknown setting [invalid] for similarity [my_similarity] please check "));
+        builder.remove("index.similarity.my_similarity.discount_overlaps");
+        builder.remove("index.similarity.my_similarity.invalid");
+        builder.put("index.similarity.my_similarity.discount-overlap", false);
+        exc =
+            expectThrows(IllegalArgumentException.class, () -> createIndex("foo", builder.build()));
+        assertThat(exc.getMessage(),
+            containsString("unknown setting [discount-overlap] for similarity [my_similarity] " +
+                "did you mean [discount_overlaps]?"));
+    }
+
+    public void testInvalidSimilarityUpdate() throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties")
+            .startObject("field1").field("type", "text").field("similarity", "my_similarity").endObject()
+            .endObject()
+            .endObject().endObject().string();
+
+        Settings indexSettings = Settings.builder()
+            .put("index.similarity.my_similarity.type", "BM25")
+            .put("index.similarity.my_similarity.discount_overlaps", false)
+            .put("index.similarity.my_similarity.b", 0.5f)
+            .build();
+        IndexService indexService = createIndex("foo", indexSettings);
+        DocumentMapper documentMapper = indexService.mapperService()
+            .documentMapperParser().parse("type", new CompressedXContent(mapping));
+        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(),
+            instanceOf(BM25SimilarityProvider.class));
+
+        BM25Similarity similarity = (BM25Similarity) documentMapper.mappers()
+            .getMapper("field1").fieldType().similarity().get();
+        assertThat(similarity.getDiscountOverlaps(), equalTo(false));
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.discount_overlaps", true)
+                .put("index.similarity.my_similarity.b", 0.8f)
+                .build();
+            IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo")
+                    .setSettings(newSettings).execute().actionGet());
+            assertThat(exc.getCause(), instanceOf(IllegalArgumentException.class));
+            assertThat(exc.getCause().getMessage(),
+                equalTo("setting [discount_overlaps] for similarity [my_similarity], not dynamically updateable"));
+            similarity = (BM25Similarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
+            assertThat(similarity.getB(), equalTo(0.5f));
+            assertThat(similarity.getDiscountOverlaps(), equalTo(false));
         }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.type", "classic")
+                .build();
+            IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo")
+                    .setSettings(newSettings).execute().actionGet());
+            assertThat(exc.getCause(), instanceOf(IllegalArgumentException.class));
+            assertThat(exc.getCause().getMessage(),
+                equalTo("setting [type] for similarity [my_similarity], not dynamically updateable"));
+        }
+        // should also fail on closed indices
+        client().admin().indices().prepareClose("foo").execute().actionGet();
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.discount_overlaps", true)
+                .put("index.similarity.my_similarity.b", 0.8f)
+                .build();
+            IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo")
+                    .setSettings(newSettings).execute().actionGet());
+            assertThat(exc.getCause(), instanceOf(IllegalArgumentException.class));
+            assertThat(exc.getCause().getMessage(),
+                equalTo("setting [discount_overlaps] for similarity [my_similarity], not dynamically updateable"));
+            IndexMetaData indexMetaData =
+                client().admin().cluster().prepareState().execute().actionGet().getState().metaData().index("foo");
+            assertEquals(indexMetaData.getSettings().get("index.similarity.my_similarity.discount_overlaps"), "false");
+        }
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.type", "classic")
+                .build();
+            IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo")
+                    .setSettings(newSettings).execute().actionGet());
+            assertThat(exc.getCause(), instanceOf(IllegalArgumentException.class));
+            assertThat(exc.getCause().getMessage(),
+                equalTo("setting [type] for similarity [my_similarity], not dynamically updateable"));
+        }
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.discount-overlap", false)
+                .build();
+            IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo")
+                    .setSettings(newSettings).execute().actionGet());
+            assertThat(exc.getCause(), instanceOf(IllegalArgumentException.class));
+            assertThat(exc.getCause().getMessage(),
+                equalTo("unknown setting [discount-overlap] for similarity [my_similarity] " +
+                    "did you mean [discount_overlaps]?"));
+        }
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.invalid", "boom")
+                .build();
+            IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo")
+                    .setSettings(newSettings).execute().actionGet());
+            assertThat(exc.getCause(), instanceOf(IllegalArgumentException.class));
+            assertThat(exc.getCause().getMessage(),
+                startsWith("unknown setting [invalid] for similarity [my_similarity] please check"));
+        }
+    }
+
+    public void testAddDynamicSimilarity() throws IOException {
+        IndexService indexService = createIndex("foo");
+
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties")
+            .startObject("field1").field("type", "text").field("similarity", "my_similarity").endObject()
+            .endObject()
+            .endObject().endObject().string();
+
+        Settings indexSettings = Settings.builder()
+            .put("index.similarity.my_similarity.type", "BM25")
+            .put("index.similarity.my_similarity.k1", 0.5f)
+            .put("index.similarity.my_similarity.b", 0.9f)
+            .build();
+
+        client().admin().indices().prepareUpdateSettings("foo").setSettings(indexSettings).execute().actionGet();
+        DocumentMapper documentMapper = indexService.mapperService()
+            .documentMapperParser().parse("type", new CompressedXContent(mapping));
+        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(),
+            instanceOf(BM25SimilarityProvider.class));
+        BM25Similarity sim = (BM25Similarity) documentMapper.mappers().getMapper("field1")
+            .fieldType().similarity().get();
+        assertThat(sim.getK1(), equalTo(0.5f));
+        assertThat(sim.getB(), equalTo(0.9f));
+
+        Settings newSettings = Settings.builder()
+            .put("index.similarity.another_similarity.k1", "0.5f")
+            .build();
+        IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
+            () -> client().admin().indices().prepareUpdateSettings("foo")
+                .setSettings(newSettings).execute().actionGet());
+        assertThat(exc.getCause(), instanceOf(IllegalArgumentException.class));
+        assertThat(exc.getCause().getMessage(),
+            equalTo("Similarity [another_similarity] must have an associated type"));
     }
 }

--- a/core/src/test/java/org/elasticsearch/similarity/SimilarityIT.java
+++ b/core/src/test/java/org/elasticsearch/similarity/SimilarityIT.java
@@ -64,11 +64,13 @@ public class SimilarityIT extends ESIntegTestCase {
                                                             "field2", "the quick brown fox jumped over the lazy dog")
                 .setRefreshPolicy(IMMEDIATE).execute().actionGet();
 
-        SearchResponse bm25SearchResponse = client().prepareSearch().setQuery(matchQuery("field1", "quick brown fox")).execute().actionGet();
+        SearchResponse bm25SearchResponse =
+            client().prepareSearch().setQuery(matchQuery("field1", "quick brown fox")).execute().actionGet();
         assertThat(bm25SearchResponse.getHits().totalHits(), equalTo(1L));
         float bm25Score = bm25SearchResponse.getHits().hits()[0].score();
 
-        SearchResponse defaultSearchResponse = client().prepareSearch().setQuery(matchQuery("field2", "quick brown fox")).execute().actionGet();
+        SearchResponse defaultSearchResponse =
+            client().prepareSearch().setQuery(matchQuery("field2", "quick brown fox")).execute().actionGet();
         assertThat(defaultSearchResponse.getHits().totalHits(), equalTo(1L));
         float defaultScore = defaultSearchResponse.getHits().hits()[0].score();
 

--- a/docs/reference/index-modules/similarity.asciidoc
+++ b/docs/reference/index-modules/similarity.asciidoc
@@ -47,6 +47,20 @@ Here we configure the DFRSimilarity so it can be referenced as
 [float]
 === Available similarities
 
+Similarity options marked with *dynamic* are dynamically updatable.
+Here we update the option `normalization.h2.c` of the similarity `my_similarity`:
+
+[source,js]
+--------------------------------------------------
+"similarity" : {
+  "my_similarity" : {
+    "normalization.h2.c" : "4.0"
+  }
+}
+--------------------------------------------------
+
+Note that it is not possible to update the type of an already defined similarity.
+
 [float]
 [[bm25]]
 ==== BM25 similarity (*default*)
@@ -57,11 +71,11 @@ http://en.wikipedia.org/wiki/Okapi_BM25[Okapi_BM25] for more details.
 This similarity has the following options:
 
 [horizontal]
-`k1`::
+`k1` (*dynamic*)::
     Controls non-linear term frequency normalization
     (saturation). The default value is `1.2`.
 
-`b`::
+`b` (*dynamic*)::
     Controls to what degree document length normalizes tf values.
     The default value is `0.75`.
 
@@ -95,14 +109,19 @@ http://lucene.apache.org/core/5_2_1/core/org/apache/lucene/search/similarities/D
 from randomness] framework. This similarity has the following options:
 
 [horizontal]
-`basic_model`::
+`basic_model` (*dynamic*)::
     Possible values: `be`, `d`, `g`, `if`, `in`, `ine` and `p`.
 
-`after_effect`::
+`after_effect` (*dynamic*)::
     Possible values: `no`, `b` and `l`.
 
-`normalization`::
+`normalization` (*dynamic*)::
     Possible values: `no`, `h1`, `h2`, `h3` and `z`.
+
+`discount_overlaps`::
+    Determines whether overlap tokens (Tokens with
+    0 position increment) are ignored when computing norm. By default this
+    is true, meaning overlap tokens do not count when computing norms.
 
 All options but the first option need a normalization value.
 
@@ -117,7 +136,12 @@ model.
 This similarity has the following options:
 
 [horizontal]
-`independence_measure`:: Possible values `standardized`, `saturated`, `chisquared`.
+`independence_measure` (*dynamic*):: Possible values `standardized`, `saturated`, `chisquared`.
+
+`discount_overlaps`::
+    Determines whether overlap tokens (Tokens with
+    0 position increment) are ignored when computing norm. By default this
+    is true, meaning overlap tokens do not count when computing norms.
 
 Type name: `DFI`
 
@@ -132,9 +156,19 @@ For written texts this challenge would correspond to comparing the writing style
 This similarity has the following options:
 
 [horizontal]
-`distribution`::  Possible values: `ll` and `spl`.
-`lambda`::        Possible values: `df` and `ttf`.
-`normalization`:: Same as in `DFR` similarity.
+`distribution` (*dynamic*)::
+    Possible values: `ll` and `spl`.
+
+`lambda` (*dynamic*)::
+    Possible values: `df` and `ttf`.
+
+`normalization` (*dynamic*)::
+    Same as in `DFR` similarity.
+
+`discount_overlaps`::
+    Determines whether overlap tokens (Tokens with
+    0 position increment) are ignored when computing norm. By default this
+    is true, meaning overlap tokens do not count when computing norms.
 
 Type name: `IB`
 
@@ -146,7 +180,13 @@ http://lucene.apache.org/core/5_2_1/core/org/apache/lucene/search/similarities/L
 Dirichlet similarity] . This similarity has the following options:
 
 [horizontal]
-`mu`::  Default to `2000`.
+`mu` (*dynamic*)::
+    Default to `2000`.
+
+`discount_overlaps`::
+    Determines whether overlap tokens (Tokens with
+    0 position increment) are ignored when computing norm. By default this
+    is true, meaning overlap tokens do not count when computing norms.
 
 Type name: `LMDirichlet`
 
@@ -158,8 +198,13 @@ http://lucene.apache.org/core/5_2_1/core/org/apache/lucene/search/similarities/L
 Jelinek Mercer similarity] . The algorithm attempts to capture important patterns in the text, while leaving out noise. This similarity has the following options:
 
 [horizontal]
-`lambda`::  The optimal value depends on both the collection and the query. The optimal value is around `0.1`
+`lambda` (*dynamic*)::  The optimal value depends on both the collection and the query. The optimal value is around `0.1`
 for title queries and `0.7` for long queries. Default to `0.1`. When value approaches `0`, documents that match more query terms will be ranked higher than those that match fewer terms.
+
+`discount_overlaps`::
+    Determines whether overlap tokens (Tokens with
+    0 position increment) are ignored when computing norm. By default this
+    is true, meaning overlap tokens do not count when computing norms.
 
 Type name: `LMJelinekMercer`
 


### PR DESCRIPTION
This change allows to dynamically change options for any existing similarities on an open index.
This change also adds the ability to create a new similarity directly on an existing index.
It does not allow to change the type of an existing similarity or to change the similarity of a field.
Options are updatable only if they don't change the way the similarity encodes the norm on disk.
The non-updatable options can't be changed if the index is opened nor closed.
This change adds validation to the similarity settings and throws an exception with a detailed message if a setting is unknown.

Relates #6727
