### PR TITLE
Fixed incorrect indentation in the YAML integration test for the "Rollover" API

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yaml
@@ -30,11 +30,11 @@
 
   # perform alias rollover
   - do:
-    indices.rollover:
-      alias: "logs_search"
-      body:
-        conditions:
-          max_docs: 1
+      indices.rollover:
+        alias: "logs_search"
+        body:
+          conditions:
+            max_docs: 1
 
   - match: { old_index: logs-1 }
   - match: { new_index: logs-2 }


### PR DESCRIPTION
I got failures for the `indices.rollover/10_basic.yaml` test (_expected "logs-1", got nil_) in the Ruby client. The indentation seems wrong, and the test runner cannot properly evaluate the action then.
