### PR TITLE
Remove extra brace from rollover rest api spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
@@ -3,7 +3,7 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html",
     "methods": ["POST"],
     "url": {
-      "path": "/{alias}/_rollover}",
+      "path": "/{alias}/_rollover",
       "paths": ["/{alias}/_rollover", "/{alias}/_rollover/{new_index}"],
       "parts": {
         "alias": {


### PR DESCRIPTION
As pointed out by @karmi, there was an extra brace in the rest-api-spec for rollover API.
