### PR TITLE
Fixed typo 'if' -> 'is' in Scripted Metric Aggregation docs

### DIFF
--- a/docs/reference/aggregations/metrics/scripted-metric-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/scripted-metric-aggregation.asciidoc
@@ -101,7 +101,7 @@ In the above example, the `init_script` creates an array `transactions` in the `
 map_script::        Executed once per document collected. This is the only required script. If no combine_script is specified, the resulting state 
                     needs to be stored in an object named `_agg`.
 +
-In the above example, the `map_script` checks the value of the type field. If the value if 'sale' the value of the amount field 
+In the above example, the `map_script` checks the value of the type field. If the value is 'sale' the value of the amount field 
 is added to the transactions array. If the value of the type field is not 'sale' the negated value of the amount field is added 
 to transactions.
 


### PR DESCRIPTION
- I believe this should be "is" or some similar wording
