### PR TITLE
Make parsing of bool queries stricter

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -340,6 +340,10 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
                 default:
                     throw new ParsingException(parser.getTokenLocation(), "[bool] query does not support [" + currentFieldName + "]");
                 }
+                if (parser.currentToken() != XContentParser.Token.END_OBJECT) {
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "expected [END_OBJECT] but got [{}], possibly too many query clauses", parser.currentToken());
+                }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                     switch (currentFieldName) {


### PR DESCRIPTION
Currently we don't throw an error when there is more than one query clause specified in a must/must_not/should/filter object of the bool query without
using array notation, e.g.: 

```
 {
    "bool": {
        "must": {
            "match" : { ... },
            "match" : { ... }
        }
    }
}
```

In these cases, only the first query will be parsed correctly, possibly leading to silently ignoring the rest of the query.
Instead we should throw a ParsingException if we don't encounter an END_OBJECT token after having parsed the query clause.

Closes #19034
