### PR TITLE
Remove the `lowercase_expanded_terms` and `locale` options from `(simple_)query_string`.

### DIFF
--- a/core/src/main/java/org/apache/lucene/queryparser/classic/QueryParserSettings.java
+++ b/core/src/main/java/org/apache/lucene/queryparser/classic/QueryParserSettings.java
@@ -20,11 +20,13 @@
 package org.apache.lucene.queryparser.classic;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.MultiTermQuery;
+import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.joda.time.DateTimeZone;
 
-import java.util.Locale;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -32,18 +34,15 @@ import java.util.Map;
  */
 public class QueryParserSettings {
 
-    private final String queryString;
-
     private String defaultField;
 
-    private Map<String, Float> fieldsAndWeights;
+    private Map<String, Float> fieldsAndWeights = Collections.emptyMap();
 
     private QueryParser.Operator defaultOperator;
 
     private Analyzer analyzer;
-    private boolean forceAnalyzer;
+    private Analyzer multiTermAnalyzer;
     private Analyzer quoteAnalyzer;
-    private boolean forceQuoteAnalyzer;
 
     private String quoteFieldSuffix;
 
@@ -53,15 +52,11 @@ public class QueryParserSettings {
 
     private boolean analyzeWildcard;
 
-    private boolean lowercaseExpandedTerms;
-
     private boolean enablePositionIncrements;
 
-    private Locale locale;
-
-    private Fuzziness fuzziness;
-    private int fuzzyPrefixLength;
-    private int fuzzyMaxExpansions;
+    private Fuzziness fuzziness = Fuzziness.AUTO;
+    private int fuzzyPrefixLength = FuzzyQuery.defaultPrefixLength;
+    private int fuzzyMaxExpansions = FuzzyQuery.defaultMaxExpansions;
     private MultiTermQuery.RewriteMethod fuzzyRewriteMethod;
 
     private int phraseSlop;
@@ -77,15 +72,7 @@ public class QueryParserSettings {
     private DateTimeZone timeZone;
 
     /** To limit effort spent determinizing regexp queries. */
-    private int maxDeterminizedStates;
-
-    public QueryParserSettings(String queryString) {
-        this.queryString = queryString;
-    }
-
-    public String queryString() {
-        return queryString;
-    }
+    private int maxDeterminizedStates = Operations.DEFAULT_MAX_DETERMINIZED_STATES;
 
     public String defaultField() {
         return defaultField;
@@ -135,14 +122,6 @@ public class QueryParserSettings {
         this.allowLeadingWildcard = allowLeadingWildcard;
     }
 
-    public boolean lowercaseExpandedTerms() {
-        return lowercaseExpandedTerms;
-    }
-
-    public void lowercaseExpandedTerms(boolean lowercaseExpandedTerms) {
-        this.lowercaseExpandedTerms = lowercaseExpandedTerms;
-    }
-
     public boolean enablePositionIncrements() {
         return enablePositionIncrements;
     }
@@ -183,40 +162,25 @@ public class QueryParserSettings {
         this.fuzzyRewriteMethod = fuzzyRewriteMethod;
     }
 
-    public void defaultAnalyzer(Analyzer analyzer) {
+    public void analyzer(Analyzer analyzer, Analyzer multiTermAnalyzer) {
         this.analyzer = analyzer;
-        this.forceAnalyzer = false;
-    }
-
-    public void forceAnalyzer(Analyzer analyzer) {
-        this.analyzer = analyzer;
-        this.forceAnalyzer = true;
+        this.multiTermAnalyzer = multiTermAnalyzer;
     }
 
     public Analyzer analyzer() {
         return analyzer;
     }
 
-    public boolean forceAnalyzer() {
-        return forceAnalyzer;
+    public Analyzer multiTermAnalyzer() {
+        return multiTermAnalyzer;
     }
 
-    public void defaultQuoteAnalyzer(Analyzer quoteAnalyzer) {
+    public void quoteAnalyzer(Analyzer quoteAnalyzer) {
         this.quoteAnalyzer = quoteAnalyzer;
-        this.forceQuoteAnalyzer = false;
-    }
-
-    public void forceQuoteAnalyzer(Analyzer quoteAnalyzer) {
-        this.quoteAnalyzer = quoteAnalyzer;
-        this.forceQuoteAnalyzer = true;
     }
 
     public Analyzer quoteAnalyzer() {
         return quoteAnalyzer;
-    }
-
-    public boolean forceQuoteAnalyzer() {
-        return forceQuoteAnalyzer;
     }
 
     public boolean analyzeWildcard() {
@@ -265,14 +229,6 @@ public class QueryParserSettings {
 
     public void useDisMax(boolean useDisMax) {
         this.useDisMax = useDisMax;
-    }
-
-    public void locale(Locale locale) {
-        this.locale = locale;
-    }
-
-    public Locale locale() {
-        return this.locale;
     }
 
     public void timeZone(DateTimeZone timeZone) {

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
@@ -32,6 +32,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.indices.mapper.MapperRegistry;
 
+import java.io.IOException;
 import java.util.Collections;
 
 import static org.elasticsearch.common.util.set.Sets.newHashSet;
@@ -167,9 +168,12 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
         }
 
         @Override
-        public void close() {
-            fakeAnalyzer.close();
-            super.close();
+        public void close() throws IOException {
+            try {
+                fakeAnalyzer.close();
+            } finally {
+                super.close();
+            }
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
@@ -23,7 +23,6 @@ import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
@@ -396,7 +395,9 @@ public final class AnalysisRegistry implements Closeable {
             // Analyzers
             for (PreBuiltAnalyzers preBuiltAnalyzerEnum : PreBuiltAnalyzers.values()) {
                 String name = preBuiltAnalyzerEnum.name().toLowerCase(Locale.ROOT);
-                analyzerProviderFactories.put(name, new PreBuiltAnalyzerProviderFactory(name, AnalyzerScope.INDICES, preBuiltAnalyzerEnum.getAnalyzer(Version.CURRENT)));
+                analyzerProviderFactories.put(name, new PreBuiltAnalyzerProviderFactory(name, AnalyzerScope.INDICES,
+                        preBuiltAnalyzerEnum.getAnalyzer(Version.CURRENT),
+                        preBuiltAnalyzerEnum.getMultiTermAnalyzer(Version.CURRENT)));
             }
 
             // Tokenizers

--- a/core/src/main/java/org/elasticsearch/index/analysis/AnalysisService.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/AnalysisService.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
@@ -28,8 +29,12 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.core.TextFieldMapper;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Collections.unmodifiableMap;
 
@@ -38,17 +43,34 @@ import static java.util.Collections.unmodifiableMap;
  */
 public class AnalysisService extends AbstractIndexComponent implements Closeable {
 
+    private static NamedAnalyzer buildNamedAnalyzer(String name, AnalyzerProvider analyzerFactory,
+            Analyzer analyzerF, int overridePositionIncrementGap) {
+        if (analyzerF instanceof NamedAnalyzer) {
+            // if we got a named analyzer back, use it...
+            NamedAnalyzer analyzer = (NamedAnalyzer) analyzerF;
+            if (overridePositionIncrementGap >= 0 && analyzer.getPositionIncrementGap(analyzer.name()) != overridePositionIncrementGap) {
+                // unless the positionIncrementGap needs to be overridden
+                analyzer = new NamedAnalyzer(analyzer, overridePositionIncrementGap);
+            }
+            return analyzer;
+        } else {
+            return new NamedAnalyzer(name, analyzerFactory.scope(), analyzerF, overridePositionIncrementGap);
+        }
+    }
+
     private final Map<String, NamedAnalyzer> analyzers;
+    private final Map<String, NamedAnalyzer> multiTermAnalyzers;
     private final Map<String, TokenizerFactory> tokenizers;
     private final Map<String, CharFilterFactory> charFilters;
     private final Map<String, TokenFilterFactory> tokenFilters;
 
     private final NamedAnalyzer defaultIndexAnalyzer;
     private final NamedAnalyzer defaultSearchAnalyzer;
+    private final NamedAnalyzer defaultSearchMultiTermAnalyzer;
     private final NamedAnalyzer defaultSearchQuoteAnalyzer;
 
     public AnalysisService(IndexSettings indexSettings,
-                           Map<String, AnalyzerProvider> analyzerProviders,
+                           Map<String, AnalyzerProvider> analyzerFactories,
                            Map<String, TokenizerFactory> tokenizerFactoryFactories,
                            Map<String, CharFilterFactory> charFilterFactoryFactories,
                            Map<String, TokenFilterFactory> tokenFilterFactoryFactories) {
@@ -56,20 +78,21 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
         this.tokenizers = unmodifiableMap(tokenizerFactoryFactories);
         this.charFilters = unmodifiableMap(charFilterFactoryFactories);
         this.tokenFilters = unmodifiableMap(tokenFilterFactoryFactories);
-        analyzerProviders = new HashMap<>(analyzerProviders);
+        analyzerFactories = new HashMap<>(analyzerFactories);
 
-        if (!analyzerProviders.containsKey("default")) {
-            analyzerProviders.put("default", new StandardAnalyzerProvider(indexSettings, null, "default", Settings.Builder.EMPTY_SETTINGS));
+        if (!analyzerFactories.containsKey("default")) {
+            analyzerFactories.put("default", new StandardAnalyzerProvider(indexSettings, null, "default", Settings.Builder.EMPTY_SETTINGS));
         }
-        if (!analyzerProviders.containsKey("default_search")) {
-            analyzerProviders.put("default_search", analyzerProviders.get("default"));
+        if (!analyzerFactories.containsKey("default_search")) {
+            analyzerFactories.put("default_search", analyzerFactories.get("default"));
         }
-        if (!analyzerProviders.containsKey("default_search_quoted")) {
-            analyzerProviders.put("default_search_quoted", analyzerProviders.get("default_search"));
+        if (!analyzerFactories.containsKey("default_search_quoted")) {
+            analyzerFactories.put("default_search_quoted", analyzerFactories.get("default_search"));
         }
 
         Map<String, NamedAnalyzer> analyzers = new HashMap<>();
-        for (Map.Entry<String, AnalyzerProvider> entry : analyzerProviders.entrySet()) {
+        Map<String, NamedAnalyzer> multiTermAnalyzers = new HashMap<>();
+        for (Map.Entry<String, AnalyzerProvider> entry : analyzerFactories.entrySet()) {
             AnalyzerProvider analyzerFactory = entry.getValue();
             String name = entry.getKey();
             /*
@@ -94,30 +117,25 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
             if (analyzerF == null) {
                 throw new IllegalArgumentException("analyzer [" + analyzerFactory.name() + "] created null analyzer");
             }
-            NamedAnalyzer analyzer;
-            if (analyzerF instanceof NamedAnalyzer) {
-                // if we got a named analyzer back, use it...
-                analyzer = (NamedAnalyzer) analyzerF;
-                if (overridePositionIncrementGap >= 0 && analyzer.getPositionIncrementGap(analyzer.name()) != overridePositionIncrementGap) {
-                    // unless the positionIncrementGap needs to be overridden
-                    analyzer = new NamedAnalyzer(analyzer, overridePositionIncrementGap);
-                }
-            } else {
-                analyzer = new NamedAnalyzer(name, analyzerFactory.scope(), analyzerF, overridePositionIncrementGap);
-            }
+            NamedAnalyzer analyzer = buildNamedAnalyzer(name, analyzerFactory, analyzerF, overridePositionIncrementGap);
+            Analyzer multiTermAnalyzerF = analyzerFactory.getMultiTerm();
+            NamedAnalyzer multiTermAnalyzer = buildNamedAnalyzer(name, analyzerFactory, multiTermAnalyzerF, overridePositionIncrementGap);
             if (analyzers.containsKey(name)) {
                 throw new IllegalStateException("already registered analyzer with name: " + name);
             }
             analyzers.put(name, analyzer);
+            multiTermAnalyzers.put(name, multiTermAnalyzer);
             String strAliases = this.indexSettings.getSettings().get("index.analysis.analyzer." + analyzerFactory.name() + ".alias");
             if (strAliases != null) {
                 for (String alias : Strings.commaDelimitedListToStringArray(strAliases)) {
                     analyzers.put(alias, analyzer);
+                    multiTermAnalyzers.put(alias, multiTermAnalyzer);
                 }
             }
             String[] aliases = this.indexSettings.getSettings().getAsArray("index.analysis.analyzer." + analyzerFactory.name() + ".alias");
             for (String alias : aliases) {
                 analyzers.put(alias, analyzer);
+                multiTermAnalyzers.put(alias, multiTermAnalyzer);
             }
         }
 
@@ -133,36 +151,52 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
                 deprecationLogger.deprecated("setting [index.analysis.analyzer.default_index] is deprecated, use [index.analysis.analyzer.default] instead for index [{}]", index().getName());
             }
         }
-        defaultIndexAnalyzer = analyzers.containsKey("default_index") ? analyzers.get("default_index") : defaultAnalyzer;
-        defaultSearchAnalyzer = analyzers.containsKey("default_search") ? analyzers.get("default_search") : defaultAnalyzer;
-        defaultSearchQuoteAnalyzer = analyzers.containsKey("default_search_quote") ? analyzers.get("default_search_quote") : defaultSearchAnalyzer;
-
+        NamedAnalyzer defaultIndexAnalyzer = analyzers.get("default_index");
+        if (defaultIndexAnalyzer == null) {
+            defaultIndexAnalyzer = defaultAnalyzer;
+        }
+        NamedAnalyzer defaultSearchAnalyzer = analyzers.get("default_search");
+        if (defaultSearchAnalyzer == null) {
+            defaultSearchAnalyzer = defaultAnalyzer;
+        }
+        NamedAnalyzer defaultSearchQuoteAnalyzer = analyzers.get("default_search_quote");
+        if (defaultSearchQuoteAnalyzer == null) {
+            defaultSearchQuoteAnalyzer = defaultSearchAnalyzer;
+        }
+        NamedAnalyzer defaultSearchMultiTermAnalyzer = multiTermAnalyzers.get("default_search");
+        if (defaultSearchMultiTermAnalyzer == null) {
+            defaultSearchMultiTermAnalyzer = multiTermAnalyzers.get("default");
+        }
+        this.defaultIndexAnalyzer = defaultIndexAnalyzer;
+        this.defaultSearchAnalyzer = defaultSearchAnalyzer;
+        this.defaultSearchQuoteAnalyzer = defaultSearchQuoteAnalyzer;
+        this.defaultSearchMultiTermAnalyzer = defaultSearchMultiTermAnalyzer;
         for (Map.Entry<String, NamedAnalyzer> analyzer : analyzers.entrySet()) {
             if (analyzer.getKey().startsWith("_")) {
                 throw new IllegalArgumentException("analyzer name must not start with '_'. got \"" + analyzer.getKey() + "\"");
             }
         }
+        assert analyzers.keySet().equals(multiTermAnalyzers.keySet());
         this.analyzers = unmodifiableMap(analyzers);
+        this.multiTermAnalyzers = unmodifiableMap(multiTermAnalyzers);
     }
 
     @Override
-    public void close() {
-        for (NamedAnalyzer analyzer : analyzers.values()) {
-            if (analyzer.scope() == AnalyzerScope.INDEX) {
-                try {
-                    analyzer.close();
-                } catch (NullPointerException e) {
-                    // because analyzers are aliased, they might be closed several times
-                    // an NPE is thrown in this case, so ignore....
-                } catch (Exception e) {
-                    logger.debug("failed to close analyzer {}", analyzer);
-                }
-            }
-        }
+    public void close() throws IOException {
+        List<NamedAnalyzer> indexAnalyzers = Stream.concat(
+                analyzers.values().stream(),
+                multiTermAnalyzers.values().stream())
+                .filter(analyzer -> analyzer.scope() == AnalyzerScope.INDEX)
+                .collect(Collectors.toList());
+        IOUtils.close(indexAnalyzers);
     }
 
     public NamedAnalyzer analyzer(String name) {
         return analyzers.get(name);
+    }
+
+    public NamedAnalyzer multiTermAnalyzer(String name) {
+        return multiTermAnalyzers.get(name);
     }
 
     public NamedAnalyzer defaultIndexAnalyzer() {
@@ -171,6 +205,10 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
 
     public NamedAnalyzer defaultSearchAnalyzer() {
         return defaultSearchAnalyzer;
+    }
+
+    public NamedAnalyzer defaultSearchMultiTermAnalyzer() {
+        return defaultSearchMultiTermAnalyzer;
     }
 
     public NamedAnalyzer defaultSearchQuoteAnalyzer() {

--- a/core/src/main/java/org/elasticsearch/index/analysis/AnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/AnalyzerProvider.java
@@ -25,12 +25,12 @@ import org.elasticsearch.common.inject.Provider;
 /**
  *
  */
-public interface AnalyzerProvider<T extends Analyzer> extends Provider<T> {
+public interface AnalyzerProvider extends Provider<Analyzer> {
 
     String name();
 
     AnalyzerScope scope();
 
-    @Override
-    T get();
+    /** Get the analyzer that should be used for multi-term queries. */
+    Analyzer getMultiTerm();
 }

--- a/core/src/main/java/org/elasticsearch/index/analysis/ArabicAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/ArabicAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class ArabicAnalyzerProvider extends AbstractIndexAnalyzerProvider<ArabicAnalyzer> {
+public class ArabicAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final ArabicAnalyzer arabicAnalyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/ArmenianAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/ArmenianAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class ArmenianAnalyzerProvider extends AbstractIndexAnalyzerProvider<ArmenianAnalyzer> {
+public class ArmenianAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final ArmenianAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/BasqueAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/BasqueAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class BasqueAnalyzerProvider extends AbstractIndexAnalyzerProvider<BasqueAnalyzer> {
+public class BasqueAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final BasqueAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/BrazilianAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/BrazilianAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class BrazilianAnalyzerProvider extends AbstractIndexAnalyzerProvider<BrazilianAnalyzer> {
+public class BrazilianAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final BrazilianAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/BulgarianAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/BulgarianAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class BulgarianAnalyzerProvider extends AbstractIndexAnalyzerProvider<BulgarianAnalyzer> {
+public class BulgarianAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final BulgarianAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/CatalanAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/CatalanAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class CatalanAnalyzerProvider extends AbstractIndexAnalyzerProvider<CatalanAnalyzer> {
+public class CatalanAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final CatalanAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/ChineseAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/ChineseAnalyzerProvider.java
@@ -27,7 +27,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  * Only for old indexes
  */
-public class ChineseAnalyzerProvider extends AbstractIndexAnalyzerProvider<StandardAnalyzer> {
+public class ChineseAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final StandardAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/CjkAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/CjkAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class CjkAnalyzerProvider extends AbstractIndexAnalyzerProvider<CJKAnalyzer> {
+public class CjkAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final CJKAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/CzechAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/CzechAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class CzechAnalyzerProvider extends AbstractIndexAnalyzerProvider<CzechAnalyzer> {
+public class CzechAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final CzechAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/DanishAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/DanishAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class DanishAnalyzerProvider extends AbstractIndexAnalyzerProvider<DanishAnalyzer> {
+public class DanishAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final DanishAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/DutchAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/DutchAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class DutchAnalyzerProvider extends AbstractIndexAnalyzerProvider<DutchAnalyzer> {
+public class DutchAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final DutchAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/EnglishAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/EnglishAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class EnglishAnalyzerProvider extends AbstractIndexAnalyzerProvider<EnglishAnalyzer> {
+public class EnglishAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final EnglishAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/FingerprintAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/FingerprintAnalyzerProvider.java
@@ -31,7 +31,7 @@ import org.elasticsearch.index.IndexSettings;
  * Builds an OpenRefine Fingerprint analyzer.  Uses the default settings from the various components
  * (Standard Tokenizer and lowercase + stop + fingerprint + ascii-folding filters)
  */
-public class FingerprintAnalyzerProvider extends AbstractIndexAnalyzerProvider<Analyzer> {
+public class FingerprintAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     public static ParseField MAX_OUTPUT_SIZE = FingerprintTokenFilterFactory.MAX_OUTPUT_SIZE;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/FinnishAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/FinnishAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class FinnishAnalyzerProvider extends AbstractIndexAnalyzerProvider<FinnishAnalyzer> {
+public class FinnishAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final FinnishAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/FrenchAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/FrenchAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class FrenchAnalyzerProvider extends AbstractIndexAnalyzerProvider<FrenchAnalyzer> {
+public class FrenchAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final FrenchAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/GalicianAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/GalicianAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class GalicianAnalyzerProvider extends AbstractIndexAnalyzerProvider<GalicianAnalyzer> {
+public class GalicianAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final GalicianAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/GermanAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/GermanAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class GermanAnalyzerProvider extends AbstractIndexAnalyzerProvider<GermanAnalyzer> {
+public class GermanAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final GermanAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/GreekAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/GreekAnalyzerProvider.java
@@ -27,7 +27,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class GreekAnalyzerProvider extends AbstractIndexAnalyzerProvider<GreekAnalyzer> {
+public class GreekAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final GreekAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/HindiAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/HindiAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class HindiAnalyzerProvider extends AbstractIndexAnalyzerProvider<HindiAnalyzer> {
+public class HindiAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final HindiAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/HungarianAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/HungarianAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class HungarianAnalyzerProvider extends AbstractIndexAnalyzerProvider<HungarianAnalyzer> {
+public class HungarianAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final HungarianAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/IndonesianAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/IndonesianAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class IndonesianAnalyzerProvider extends AbstractIndexAnalyzerProvider<IndonesianAnalyzer> {
+public class IndonesianAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final IndonesianAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/IrishAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/IrishAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  * Provider for {@link IrishAnalyzer}
  */
-public class IrishAnalyzerProvider extends AbstractIndexAnalyzerProvider<IrishAnalyzer> {
+public class IrishAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final IrishAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/ItalianAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/ItalianAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class ItalianAnalyzerProvider extends AbstractIndexAnalyzerProvider<ItalianAnalyzer> {
+public class ItalianAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final ItalianAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/KeywordAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/KeywordAnalyzerProvider.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.analysis;
 
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
@@ -27,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class KeywordAnalyzerProvider extends AbstractIndexAnalyzerProvider<KeywordAnalyzer> {
+public class KeywordAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final KeywordAnalyzer keywordAnalyzer;
 
@@ -39,5 +40,10 @@ public class KeywordAnalyzerProvider extends AbstractIndexAnalyzerProvider<Keywo
     @Override
     public KeywordAnalyzer get() {
         return this.keywordAnalyzer;
+    }
+
+    @Override
+    public Analyzer getMultiTerm() {
+        return get();
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/analysis/LatvianAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/LatvianAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class LatvianAnalyzerProvider extends AbstractIndexAnalyzerProvider<LatvianAnalyzer> {
+public class LatvianAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final LatvianAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/LithuanianAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/LithuanianAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  * Provider for {@link LithuanianAnalyzer}
  */
-public class LithuanianAnalyzerProvider extends AbstractIndexAnalyzerProvider<LithuanianAnalyzer> {
+public class LithuanianAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final LithuanianAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/NorwegianAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/NorwegianAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class NorwegianAnalyzerProvider extends AbstractIndexAnalyzerProvider<NorwegianAnalyzer> {
+public class NorwegianAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final NorwegianAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/PatternAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/PatternAnalyzerProvider.java
@@ -33,7 +33,7 @@ import java.util.regex.Pattern;
 /**
  *
  */
-public class PatternAnalyzerProvider extends AbstractIndexAnalyzerProvider<Analyzer> {
+public class PatternAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final PatternAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/PersianAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/PersianAnalyzerProvider.java
@@ -27,7 +27,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class PersianAnalyzerProvider extends AbstractIndexAnalyzerProvider<PersianAnalyzer> {
+public class PersianAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final PersianAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/PortugueseAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/PortugueseAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class PortugueseAnalyzerProvider extends AbstractIndexAnalyzerProvider<PortugueseAnalyzer> {
+public class PortugueseAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final PortugueseAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerProvider.java
@@ -24,15 +24,17 @@ import org.apache.lucene.analysis.Analyzer;
 /**
  *
  */
-public class PreBuiltAnalyzerProvider implements AnalyzerProvider<NamedAnalyzer> {
+public class PreBuiltAnalyzerProvider implements AnalyzerProvider {
 
     private final NamedAnalyzer analyzer;
+    private final NamedAnalyzer multiTermAnalyzer;
 
-    public PreBuiltAnalyzerProvider(String name, AnalyzerScope scope, Analyzer analyzer) {
+    public PreBuiltAnalyzerProvider(String name, AnalyzerScope scope, Analyzer analyzer, Analyzer multiTermAnalyzer) {
         // we create the named analyzer here so the resources associated with it will be shared
         // and we won't wrap a shared analyzer with named analyzer each time causing the resources
         // to not be shared...
         this.analyzer = new NamedAnalyzer(name, scope, analyzer);
+        this.multiTermAnalyzer = new NamedAnalyzer(name, scope, multiTermAnalyzer);
     }
 
     @Override
@@ -48,5 +50,10 @@ public class PreBuiltAnalyzerProvider implements AnalyzerProvider<NamedAnalyzer>
     @Override
     public NamedAnalyzer get() {
         return analyzer;
+    }
+
+    @Override
+    public Analyzer getMultiTerm() {
+        return multiTermAnalyzer;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerProviderFactory.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerProviderFactory.java
@@ -36,8 +36,8 @@ public class PreBuiltAnalyzerProviderFactory implements AnalysisModule.AnalysisP
 
     private final PreBuiltAnalyzerProvider analyzerProvider;
 
-    public PreBuiltAnalyzerProviderFactory(String name, AnalyzerScope scope, Analyzer analyzer) {
-        analyzerProvider = new PreBuiltAnalyzerProvider(name, scope, analyzer);
+    public PreBuiltAnalyzerProviderFactory(String name, AnalyzerScope scope, Analyzer analyzer, Analyzer multiTermAnalyzer) {
+        analyzerProvider = new PreBuiltAnalyzerProvider(name, scope, analyzer, multiTermAnalyzer);
     }
 
     public AnalyzerProvider create(String name, Settings settings) {
@@ -46,7 +46,8 @@ public class PreBuiltAnalyzerProviderFactory implements AnalysisModule.AnalysisP
             PreBuiltAnalyzers preBuiltAnalyzers = PreBuiltAnalyzers.getOrDefault(name, null);
             if (preBuiltAnalyzers != null) {
                 Analyzer analyzer = preBuiltAnalyzers.getAnalyzer(indexVersion);
-                return new PreBuiltAnalyzerProvider(name, AnalyzerScope.INDICES, analyzer);
+                Analyzer multiTermAnalyzer = preBuiltAnalyzers.getMultiTermAnalyzer(indexVersion);
+                return new PreBuiltAnalyzerProvider(name, AnalyzerScope.INDICES, analyzer, multiTermAnalyzer);
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/RomanianAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/RomanianAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class RomanianAnalyzerProvider extends AbstractIndexAnalyzerProvider<RomanianAnalyzer> {
+public class RomanianAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final RomanianAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/RussianAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/RussianAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class RussianAnalyzerProvider extends AbstractIndexAnalyzerProvider<RussianAnalyzer> {
+public class RussianAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final RussianAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/SimpleAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/SimpleAnalyzerProvider.java
@@ -27,7 +27,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class SimpleAnalyzerProvider extends AbstractIndexAnalyzerProvider<SimpleAnalyzer> {
+public class SimpleAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final SimpleAnalyzer simpleAnalyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/SnowballAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/SnowballAnalyzerProvider.java
@@ -45,7 +45,7 @@ import static java.util.Collections.unmodifiableMap;
  *
  *
  */
-public class SnowballAnalyzerProvider extends AbstractIndexAnalyzerProvider<SnowballAnalyzer> {
+public class SnowballAnalyzerProvider extends AbstractIndexAnalyzerProvider {
     private static final Map<String, CharArraySet> DEFAULT_LANGUAGE_STOPWORDS;
 
     static {

--- a/core/src/main/java/org/elasticsearch/index/analysis/SoraniAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/SoraniAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  * Provider for {@link SoraniAnalyzer}
  */
-public class SoraniAnalyzerProvider extends AbstractIndexAnalyzerProvider<SoraniAnalyzer> {
+public class SoraniAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final SoraniAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/SpanishAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/SpanishAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class SpanishAnalyzerProvider extends AbstractIndexAnalyzerProvider<SpanishAnalyzer> {
+public class SpanishAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final SpanishAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/StandardAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/StandardAnalyzerProvider.java
@@ -19,10 +19,8 @@
 
 package org.elasticsearch.index.analysis;
 
-import org.apache.lucene.analysis.core.StopAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.util.CharArraySet;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
@@ -30,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class StandardAnalyzerProvider extends AbstractIndexAnalyzerProvider<StandardAnalyzer> {
+public class StandardAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final StandardAnalyzer standardAnalyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/StandardHtmlStripAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/StandardHtmlStripAnalyzerProvider.java
@@ -19,9 +19,7 @@
 
 package org.elasticsearch.index.analysis;
 
-import org.apache.lucene.analysis.core.StopAnalyzer;
 import org.apache.lucene.analysis.util.CharArraySet;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
@@ -29,7 +27,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class StandardHtmlStripAnalyzerProvider extends AbstractIndexAnalyzerProvider<StandardHtmlStripAnalyzer> {
+public class StandardHtmlStripAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final StandardHtmlStripAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/StopAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/StopAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class StopAnalyzerProvider extends AbstractIndexAnalyzerProvider<StopAnalyzer> {
+public class StopAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final StopAnalyzer stopAnalyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/SwedishAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/SwedishAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class SwedishAnalyzerProvider extends AbstractIndexAnalyzerProvider<SwedishAnalyzer> {
+public class SwedishAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final SwedishAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/ThaiAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/ThaiAnalyzerProvider.java
@@ -27,7 +27,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class ThaiAnalyzerProvider extends AbstractIndexAnalyzerProvider<ThaiAnalyzer> {
+public class ThaiAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final ThaiAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/TurkishAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/TurkishAnalyzerProvider.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class TurkishAnalyzerProvider extends AbstractIndexAnalyzerProvider<TurkishAnalyzer> {
+public class TurkishAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final TurkishAnalyzer analyzer;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/WhitespaceAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/WhitespaceAnalyzerProvider.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.analysis;
 
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
@@ -27,18 +29,26 @@ import org.elasticsearch.index.IndexSettings;
 /**
  *
  */
-public class WhitespaceAnalyzerProvider extends AbstractIndexAnalyzerProvider<WhitespaceAnalyzer> {
+public class WhitespaceAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final WhitespaceAnalyzer analyzer;
+    private final KeywordAnalyzer multiTermAnalyzer;
 
     public WhitespaceAnalyzerProvider(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
         super(indexSettings, name, settings);
         this.analyzer = new WhitespaceAnalyzer();
         this.analyzer.setVersion(version);
+        this.multiTermAnalyzer = new KeywordAnalyzer();
+        this.multiTermAnalyzer.setVersion(version);
     }
 
     @Override
     public WhitespaceAnalyzer get() {
         return this.analyzer;
+    }
+
+    @Override
+    public synchronized Analyzer getMultiTerm() {
+        return multiTermAnalyzer;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -173,8 +173,8 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             return builder;
         }
 
-        public T searchAnalyzer(NamedAnalyzer searchAnalyzer) {
-            this.fieldType.setSearchAnalyzer(searchAnalyzer);
+        public T searchAnalyzer(NamedAnalyzer searchAnalyzer, NamedAnalyzer searchMultiTermAnalyzer) {
+            this.fieldType.setSearchAnalyzer(searchAnalyzer, searchMultiTermAnalyzer);
             return builder;
         }
 
@@ -228,7 +228,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             }
             if (fieldType.indexAnalyzer() == null && fieldType.tokenized() == false && fieldType.indexOptions() != IndexOptions.NONE) {
                 fieldType.setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
-                fieldType.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
+                fieldType.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER);
             }
             boolean defaultDocValues = defaultDocValues(context.indexCreatedVersion());
             defaultFieldType.setHasDocValues(defaultDocValues);

--- a/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -59,6 +59,7 @@ public abstract class MappedFieldType extends FieldType {
     private boolean docValues;
     private NamedAnalyzer indexAnalyzer;
     private NamedAnalyzer searchAnalyzer;
+    private NamedAnalyzer searchMultiTermAnalyzer;
     private NamedAnalyzer searchQuoteAnalyzer;
     private SimilarityProvider similarity;
     private Object nullValue;
@@ -72,6 +73,7 @@ public abstract class MappedFieldType extends FieldType {
         this.docValues = ref.hasDocValues();
         this.indexAnalyzer = ref.indexAnalyzer();
         this.searchAnalyzer = ref.searchAnalyzer();
+        this.searchMultiTermAnalyzer = ref.searchMultiTermAnalyzer;
         this.searchQuoteAnalyzer = ref.searchQuoteAnalyzer();
         this.similarity = ref.similarity();
         this.nullValue = ref.nullValue();
@@ -121,6 +123,7 @@ public abstract class MappedFieldType extends FieldType {
             Objects.equals(name, fieldType.name) &&
             Objects.equals(indexAnalyzer, fieldType.indexAnalyzer) &&
             Objects.equals(searchAnalyzer, fieldType.searchAnalyzer) &&
+            Objects.equals(searchMultiTermAnalyzer, fieldType.searchMultiTermAnalyzer) &&
             Objects.equals(searchQuoteAnalyzer(), fieldType.searchQuoteAnalyzer()) &&
             Objects.equals(eagerGlobalOrdinals, fieldType.eagerGlobalOrdinals) &&
             Objects.equals(nullValue, fieldType.nullValue) &&
@@ -130,7 +133,7 @@ public abstract class MappedFieldType extends FieldType {
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), name, boost, docValues, indexAnalyzer, searchAnalyzer, searchQuoteAnalyzer,
-            eagerGlobalOrdinals, similarity == null ? null : similarity.name(), nullValue, nullValueAsString);
+            searchMultiTermAnalyzer, eagerGlobalOrdinals, similarity == null ? null : similarity.name(), nullValue, nullValueAsString);
     }
 
     // norelease: we need to override freeze() and add safety checks that all settings are actually set
@@ -260,9 +263,14 @@ public abstract class MappedFieldType extends FieldType {
         return searchAnalyzer;
     }
 
-    public void setSearchAnalyzer(NamedAnalyzer analyzer) {
+    public void setSearchAnalyzer(NamedAnalyzer analyzer, NamedAnalyzer multiTermAnalyzer) {
         checkIfFrozen();
         this.searchAnalyzer = analyzer;
+        this.searchMultiTermAnalyzer = multiTermAnalyzer;
+    }
+
+    public NamedAnalyzer searchMultiTermAnalyzer() {
+        return searchMultiTermAnalyzer;
     }
 
     public NamedAnalyzer searchQuoteAnalyzer() {

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -35,7 +35,6 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.AbstractIndexComponent;
-import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.mapper.Mapper.BuilderContext;
@@ -121,6 +120,7 @@ public class MapperService extends AbstractIndexComponent {
 
     private final MapperAnalyzerWrapper indexAnalyzer;
     private final MapperAnalyzerWrapper searchAnalyzer;
+    private final MapperAnalyzerWrapper searchMultiTermAnalyzer;
     private final MapperAnalyzerWrapper searchQuoteAnalyzer;
 
     private volatile Map<String, MappedFieldType> unmappedFieldTypes = emptyMap();
@@ -138,6 +138,7 @@ public class MapperService extends AbstractIndexComponent {
         this.documentParser = new DocumentMapperParser(indexSettings, this, analysisService, similarityService, mapperRegistry, queryShardContextSupplier);
         this.indexAnalyzer = new MapperAnalyzerWrapper(analysisService.defaultIndexAnalyzer(), p -> p.indexAnalyzer());
         this.searchAnalyzer = new MapperAnalyzerWrapper(analysisService.defaultSearchAnalyzer(), p -> p.searchAnalyzer());
+        this.searchMultiTermAnalyzer = new MapperAnalyzerWrapper(analysisService.defaultSearchMultiTermAnalyzer(), p -> p.searchMultiTermAnalyzer());
         this.searchQuoteAnalyzer = new MapperAnalyzerWrapper(analysisService.defaultSearchQuoteAnalyzer(), p -> p.searchQuoteAnalyzer());
         this.mapperRegistry = mapperRegistry;
 
@@ -606,6 +607,10 @@ public class MapperService extends AbstractIndexComponent {
 
     public Analyzer searchAnalyzer() {
         return this.searchAnalyzer;
+    }
+
+    public Analyzer searchMultiTermAnalyzer() {
+        return searchMultiTermAnalyzer;
     }
 
     public Analyzer searchQuoteAnalyzer() {

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
@@ -65,8 +65,6 @@ public class BooleanFieldMapper extends FieldMapper {
             FIELD_TYPE.setOmitNorms(true);
             FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
             FIELD_TYPE.setTokenized(false);
-            FIELD_TYPE.setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
-            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
             FIELD_TYPE.freeze();
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -126,6 +126,8 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
             CompletionFieldMapper.Builder builder = new CompletionFieldMapper.Builder(name);
             NamedAnalyzer indexAnalyzer = null;
             NamedAnalyzer searchAnalyzer = null;
+            NamedAnalyzer searchMultiTermAnalyzer = null;
+            
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();
                 String fieldName = entry.getKey();
@@ -138,6 +140,7 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
                     iterator.remove();
                 } else if (parserContext.parseFieldMatcher().match(fieldName, Fields.SEARCH_ANALYZER)) {
                     searchAnalyzer = getNamedAnalyzer(parserContext, fieldNode.toString());
+                    searchMultiTermAnalyzer = parserContext.analysisService().multiTermAnalyzer(name);
                     iterator.remove();
                 } else if (parserContext.parseFieldMatcher().match(fieldName, Fields.PRESERVE_SEPARATORS)) {
                     builder.preserveSeparators(Boolean.parseBoolean(fieldNode.toString()));
@@ -166,7 +169,7 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
             }
 
             builder.indexAnalyzer(indexAnalyzer);
-            builder.searchAnalyzer(searchAnalyzer);
+            builder.searchAnalyzer(searchAnalyzer, searchMultiTermAnalyzer);
             return builder;
         }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper2x.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper2x.java
@@ -173,6 +173,7 @@ public class CompletionFieldMapper2x extends FieldMapper {
             CompletionFieldMapper2x.Builder builder = new Builder(name);
             NamedAnalyzer indexAnalyzer = null;
             NamedAnalyzer searchAnalyzer = null;
+            NamedAnalyzer searchMultiTermAnalyzer = null;
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext(); ) {
                 Map.Entry<String, Object> entry = iterator.next();
                 String fieldName = entry.getKey();
@@ -187,6 +188,7 @@ public class CompletionFieldMapper2x extends FieldMapper {
                     iterator.remove();
                 } else if (parserContext.parseFieldMatcher().match(fieldName, Fields.SEARCH_ANALYZER)) {
                     searchAnalyzer = getNamedAnalyzer(parserContext, fieldNode.toString());
+                    searchMultiTermAnalyzer = parserContext.analysisService().multiTermAnalyzer(name);
                     iterator.remove();
                 } else if (fieldName.equals(Fields.PAYLOADS)) {
                     builder.payloads(Boolean.parseBoolean(fieldNode.toString()));
@@ -218,7 +220,7 @@ public class CompletionFieldMapper2x extends FieldMapper {
                 searchAnalyzer = indexAnalyzer;
             }
             builder.indexAnalyzer(indexAnalyzer);
-            builder.searchAnalyzer(searchAnalyzer);
+            builder.searchAnalyzer(searchAnalyzer, searchMultiTermAnalyzer);
 
             return builder;
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/TextFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/TextFieldMapper.java
@@ -120,8 +120,6 @@ public class TextFieldMapper extends FieldMapper implements AllFieldMapper.Inclu
         public TextFieldMapper build(BuilderContext context) {
             if (positionIncrementGap != POSITION_INCREMENT_GAP_USE_ANALYZER) {
                 fieldType.setIndexAnalyzer(new NamedAnalyzer(fieldType.indexAnalyzer(), positionIncrementGap));
-                fieldType.setSearchAnalyzer(new NamedAnalyzer(fieldType.searchAnalyzer(), positionIncrementGap));
-                fieldType.setSearchQuoteAnalyzer(new NamedAnalyzer(fieldType.searchQuoteAnalyzer(), positionIncrementGap));
             }
             setupFieldType(context);
             TextFieldMapper fieldMapper = new TextFieldMapper(
@@ -136,7 +134,9 @@ public class TextFieldMapper extends FieldMapper implements AllFieldMapper.Inclu
         public Mapper.Builder parse(String fieldName, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             TextFieldMapper.Builder builder = new TextFieldMapper.Builder(fieldName);
             builder.fieldType().setIndexAnalyzer(parserContext.analysisService().defaultIndexAnalyzer());
-            builder.fieldType().setSearchAnalyzer(parserContext.analysisService().defaultSearchAnalyzer());
+            builder.fieldType().setSearchAnalyzer(
+                    parserContext.analysisService().defaultSearchAnalyzer(),
+                    parserContext.analysisService().defaultSearchMultiTermAnalyzer());
             builder.fieldType().setSearchQuoteAnalyzer(parserContext.analysisService().defaultSearchQuoteAnalyzer());
             parseTextField(builder, fieldName, node, parserContext);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
@@ -118,10 +118,6 @@ public class AllFieldMapper extends MetadataFieldMapper {
             } else {
                 fieldType.setIndexAnalyzer(new NamedAnalyzer(fieldType.indexAnalyzer(),
                     Defaults.POSITION_INCREMENT_GAP));
-                fieldType.setSearchAnalyzer(new NamedAnalyzer(fieldType.searchAnalyzer(),
-                    Defaults.POSITION_INCREMENT_GAP));
-                fieldType.setSearchQuoteAnalyzer(new NamedAnalyzer(fieldType.searchQuoteAnalyzer(),
-                    Defaults.POSITION_INCREMENT_GAP));
             }
             fieldType.setTokenized(true);
 
@@ -135,7 +131,9 @@ public class AllFieldMapper extends MetadataFieldMapper {
                                                  ParserContext parserContext) throws MapperParsingException {
             Builder builder = new Builder(parserContext.mapperService().fullName(NAME));
             builder.fieldType().setIndexAnalyzer(parserContext.analysisService().defaultIndexAnalyzer());
-            builder.fieldType().setSearchAnalyzer(parserContext.analysisService().defaultSearchAnalyzer());
+            builder.fieldType().setSearchAnalyzer(
+                    parserContext.analysisService().defaultSearchAnalyzer(),
+                    parserContext.analysisService().defaultSearchMultiTermAnalyzer());
             builder.fieldType().setSearchQuoteAnalyzer(parserContext.analysisService().defaultSearchQuoteAnalyzer());
 
             // parseField below will happily parse the doc_values setting, but it is then never passed to

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
@@ -67,7 +67,7 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
             FIELD_TYPE.setStored(false);
             FIELD_TYPE.setOmitNorms(true);
             FIELD_TYPE.setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
-            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
+            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER);
             FIELD_TYPE.setName(NAME);
             FIELD_TYPE.freeze();
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
@@ -72,7 +72,7 @@ public class IdFieldMapper extends MetadataFieldMapper {
             FIELD_TYPE.setStored(false);
             FIELD_TYPE.setOmitNorms(true);
             FIELD_TYPE.setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
-            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
+            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER);
             FIELD_TYPE.setName(NAME);
             FIELD_TYPE.freeze();
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
@@ -63,7 +63,7 @@ public class IndexFieldMapper extends MetadataFieldMapper {
             FIELD_TYPE.setStored(false);
             FIELD_TYPE.setOmitNorms(true);
             FIELD_TYPE.setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
-            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
+            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER);
             FIELD_TYPE.setName(NAME);
             FIELD_TYPE.freeze();
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
@@ -57,7 +57,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
             FIELD_TYPE.setStored(true);
             FIELD_TYPE.setOmitNorms(true);
             FIELD_TYPE.setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
-            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
+            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER);
             FIELD_TYPE.setName(NAME);
             FIELD_TYPE.freeze();
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
@@ -72,7 +72,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
             FIELD_TYPE.setStored(true);
             FIELD_TYPE.setOmitNorms(true);
             FIELD_TYPE.setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
-            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
+            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER);
             FIELD_TYPE.setName(NAME);
             FIELD_TYPE.freeze();
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
@@ -63,7 +63,7 @@ public class TTLFieldMapper extends MetadataFieldMapper {
             TTL_FIELD_TYPE.setNumericPrecisionStep(Defaults.PRECISION_STEP_64_BIT);
             TTL_FIELD_TYPE.setName(NAME);
             TTL_FIELD_TYPE.setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
-            TTL_FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
+            TTL_FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER);
             TTL_FIELD_TYPE.freeze();
         }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -67,7 +67,7 @@ public class TimestampFieldMapper extends MetadataFieldMapper {
             FIELD_TYPE.setName(NAME);
             FIELD_TYPE.setDateTimeFormatter(DATE_TIME_FORMATTER);
             FIELD_TYPE.setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
-            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
+            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER);
             FIELD_TYPE.setHasDocValues(true);
             FIELD_TYPE.freeze();
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
@@ -72,7 +72,7 @@ public class TypeFieldMapper extends MetadataFieldMapper {
             FIELD_TYPE.setStored(false);
             FIELD_TYPE.setOmitNorms(true);
             FIELD_TYPE.setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
-            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
+            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER);
             FIELD_TYPE.setName(NAME);
             FIELD_TYPE.freeze();
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
@@ -62,7 +62,7 @@ public class UidFieldMapper extends MetadataFieldMapper {
             FIELD_TYPE.setStored(true);
             FIELD_TYPE.setOmitNorms(true);
             FIELD_TYPE.setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
-            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
+            FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER);
             FIELD_TYPE.setName(NAME);
             FIELD_TYPE.freeze();
 

--- a/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
@@ -382,11 +382,7 @@ public class CommonTermsQueryBuilder extends AbstractQueryBuilder<CommonTermsQue
 
         Analyzer analyzerObj;
         if (analyzer == null) {
-            if (fieldType != null) {
-                analyzerObj = context.getSearchAnalyzer(fieldType);
-            } else {
-                analyzerObj = context.getMapperService().searchAnalyzer();
-            }
+            analyzerObj = context.getMapperService().searchAnalyzer();
         } else {
             analyzerObj = context.getMapperService().analysisService().analyzer(analyzer);
             if (analyzerObj == null) {

--- a/core/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.queryparser.classic.MapperQueryParser;
 import org.apache.lucene.queryparser.classic.QueryParserSettings;
@@ -190,28 +189,6 @@ public class QueryShardContext extends QueryRewriteContext {
 
     public ObjectMapper getObjectMapper(String name) {
         return mapperService.getObjectMapper(name);
-    }
-
-    /**
-     * Gets the search analyzer for the given field, or the default if there is none present for the field
-     * TODO: remove this by moving defaults into mappers themselves
-     */
-    public Analyzer getSearchAnalyzer(MappedFieldType fieldType) {
-        if (fieldType.searchAnalyzer() != null) {
-            return fieldType.searchAnalyzer();
-        }
-        return getMapperService().searchAnalyzer();
-    }
-
-    /**
-     * Gets the search quote analyzer for the given field, or the default if there is none present for the field
-     * TODO: remove this by moving defaults into mappers themselves
-     */
-    public Analyzer getSearchQuoteAnalyzer(MappedFieldType fieldType) {
-        if (fieldType.searchQuoteAnalyzer() != null) {
-            return fieldType.searchQuoteAnalyzer();
-        }
-        return getMapperService().searchQuoteAnalyzer();
     }
 
     public void setAllowUnmappedFields(boolean allowUnmappedFields) {

--- a/core/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -199,8 +199,8 @@ public class MatchQuery {
 
     protected Analyzer getAnalyzer(MappedFieldType fieldType) {
         if (this.analyzer == null) {
-            if (fieldType != null) {
-                return context.getSearchAnalyzer(fieldType);
+            if (fieldType != null && fieldType.searchAnalyzer() != null) {
+                return fieldType.searchAnalyzer();
             }
             return context.getMapperService().searchAnalyzer();
         } else {

--- a/core/src/main/java/org/elasticsearch/indices/analysis/PreBuiltTokenFilters.java
+++ b/core/src/main/java/org/elasticsearch/indices/analysis/PreBuiltTokenFilters.java
@@ -65,6 +65,7 @@ import org.apache.lucene.analysis.util.ElisionFilter;
 import org.elasticsearch.Version;
 import org.elasticsearch.index.analysis.DelimitedPayloadTokenFilterFactory;
 import org.elasticsearch.index.analysis.LimitTokenCountFilterFactory;
+import org.elasticsearch.index.analysis.MultiTermAwareComponent;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.indices.analysis.PreBuiltCacheFactory.CachingStrategy;
 import org.tartarus.snowball.ext.DutchStemmer;
@@ -77,7 +78,7 @@ import java.util.Locale;
  */
 public enum PreBuiltTokenFilters {
 
-    WORD_DELIMITER(CachingStrategy.ONE) {
+    WORD_DELIMITER(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new WordDelimiterFilter(tokenStream,
@@ -89,112 +90,112 @@ public enum PreBuiltTokenFilters {
         }
     },
 
-    STOP(CachingStrategy.LUCENE) {
+    STOP(CachingStrategy.LUCENE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new StopFilter(tokenStream, StopAnalyzer.ENGLISH_STOP_WORDS_SET);
         }
     },
 
-    TRIM(CachingStrategy.LUCENE) {
+    TRIM(CachingStrategy.LUCENE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new TrimFilter(tokenStream);
         }
     },
 
-    REVERSE(CachingStrategy.LUCENE) {
+    REVERSE(CachingStrategy.LUCENE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new ReverseStringFilter(tokenStream);
         }
     },
 
-    ASCIIFOLDING(CachingStrategy.ONE) {
+    ASCIIFOLDING(CachingStrategy.ONE, true) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new ASCIIFoldingFilter(tokenStream);
         }
     },
 
-    LENGTH(CachingStrategy.LUCENE) {
+    LENGTH(CachingStrategy.LUCENE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new LengthFilter(tokenStream, 0, Integer.MAX_VALUE);
         }
     },
 
-    COMMON_GRAMS(CachingStrategy.LUCENE) {
+    COMMON_GRAMS(CachingStrategy.LUCENE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new CommonGramsFilter(tokenStream, CharArraySet.EMPTY_SET);
         }
     },
 
-    LOWERCASE(CachingStrategy.LUCENE) {
+    LOWERCASE(CachingStrategy.LUCENE, true) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new LowerCaseFilter(tokenStream);
         }
     },
 
-    UPPERCASE(CachingStrategy.LUCENE) {
+    UPPERCASE(CachingStrategy.LUCENE, true) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new UpperCaseFilter(tokenStream);
         }
     },
 
-    KSTEM(CachingStrategy.ONE) {
+    KSTEM(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new KStemFilter(tokenStream);
         }
     },
 
-    PORTER_STEM(CachingStrategy.ONE) {
+    PORTER_STEM(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new PorterStemFilter(tokenStream);
         }
     },
 
-    STANDARD(CachingStrategy.LUCENE) {
+    STANDARD(CachingStrategy.LUCENE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new StandardFilter(tokenStream);
         }
     },
 
-    CLASSIC(CachingStrategy.ONE) {
+    CLASSIC(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new ClassicFilter(tokenStream);
         }
     },
 
-    NGRAM(CachingStrategy.LUCENE) {
+    NGRAM(CachingStrategy.LUCENE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new NGramTokenFilter(tokenStream);
         }
     },
 
-    EDGE_NGRAM(CachingStrategy.LUCENE) {
+    EDGE_NGRAM(CachingStrategy.LUCENE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new EdgeNGramTokenFilter(tokenStream, EdgeNGramTokenFilter.DEFAULT_MIN_GRAM_SIZE, EdgeNGramTokenFilter.DEFAULT_MAX_GRAM_SIZE);
         }
     },
 
-    UNIQUE(CachingStrategy.ONE) {
+    UNIQUE(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new UniqueTokenFilter(tokenStream);
         }
     },
 
-    TRUNCATE(CachingStrategy.ONE) {
+    TRUNCATE(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new TruncateTokenFilter(tokenStream, 10);
@@ -202,189 +203,189 @@ public enum PreBuiltTokenFilters {
     },
 
     // Extended Token Filters
-    SNOWBALL(CachingStrategy.ONE) {
+    SNOWBALL(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new SnowballFilter(tokenStream, "English");
         }
     },
 
-    STEMMER(CachingStrategy.ONE) {
+    STEMMER(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new PorterStemFilter(tokenStream);
         }
     },
 
-    ELISION(CachingStrategy.ONE) {
+    ELISION(CachingStrategy.ONE, true) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new ElisionFilter(tokenStream, FrenchAnalyzer.DEFAULT_ARTICLES);
         }
     },
 
-    ARABIC_STEM(CachingStrategy.ONE) {
+    ARABIC_STEM(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new ArabicStemFilter(tokenStream);
         }
     },
 
-    BRAZILIAN_STEM(CachingStrategy.ONE) {
+    BRAZILIAN_STEM(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new BrazilianStemFilter(tokenStream);
         }
     },
 
-    CZECH_STEM(CachingStrategy.ONE) {
+    CZECH_STEM(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new CzechStemFilter(tokenStream);
         }
     },
 
-    DUTCH_STEM(CachingStrategy.ONE) {
+    DUTCH_STEM(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new SnowballFilter(tokenStream, new DutchStemmer());
         }
     },
 
-    FRENCH_STEM(CachingStrategy.ONE) {
+    FRENCH_STEM(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new SnowballFilter(tokenStream, new FrenchStemmer());
         }
     },
 
-    GERMAN_STEM(CachingStrategy.ONE) {
+    GERMAN_STEM(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new GermanStemFilter(tokenStream);
         }
     },
 
-    RUSSIAN_STEM(CachingStrategy.ONE) {
+    RUSSIAN_STEM(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new SnowballFilter(tokenStream, "Russian");
         }
     },
 
-    KEYWORD_REPEAT(CachingStrategy.ONE) {
+    KEYWORD_REPEAT(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new KeywordRepeatFilter(tokenStream);
         }
     },
 
-    ARABIC_NORMALIZATION(CachingStrategy.ONE) {
+    ARABIC_NORMALIZATION(CachingStrategy.ONE, true) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new ArabicNormalizationFilter(tokenStream);
         }
     },
 
-    PERSIAN_NORMALIZATION(CachingStrategy.ONE) {
+    PERSIAN_NORMALIZATION(CachingStrategy.ONE, true) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new PersianNormalizationFilter(tokenStream);
         }
     },
 
-    TYPE_AS_PAYLOAD(CachingStrategy.ONE) {
+    TYPE_AS_PAYLOAD(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new TypeAsPayloadTokenFilter(tokenStream);
         }
     },
 
-    SHINGLE(CachingStrategy.ONE) {
+    SHINGLE(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new ShingleFilter(tokenStream);
         }
     },
 
-    GERMAN_NORMALIZATION(CachingStrategy.ONE) {
+    GERMAN_NORMALIZATION(CachingStrategy.ONE, true) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new GermanNormalizationFilter(tokenStream);
         }
     },
 
-    HINDI_NORMALIZATION(CachingStrategy.ONE) {
+    HINDI_NORMALIZATION(CachingStrategy.ONE, true) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new HindiNormalizationFilter(tokenStream);
         }
     },
 
-    INDIC_NORMALIZATION(CachingStrategy.ONE) {
+    INDIC_NORMALIZATION(CachingStrategy.ONE, true) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new IndicNormalizationFilter(tokenStream);
         }
     },
 
-    SORANI_NORMALIZATION(CachingStrategy.ONE) {
+    SORANI_NORMALIZATION(CachingStrategy.ONE, true) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new SoraniNormalizationFilter(tokenStream);
         }
     },
 
-    SCANDINAVIAN_NORMALIZATION(CachingStrategy.ONE) {
+    SCANDINAVIAN_NORMALIZATION(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new ScandinavianNormalizationFilter(tokenStream);
         }
     },
 
-    SCANDINAVIAN_FOLDING(CachingStrategy.ONE) {
+    SCANDINAVIAN_FOLDING(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new ScandinavianFoldingFilter(tokenStream);
         }
     },
 
-    APOSTROPHE(CachingStrategy.ONE) {
+    APOSTROPHE(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new ApostropheFilter(tokenStream);
         }
     },
 
-    CJK_WIDTH(CachingStrategy.ONE) {
+    CJK_WIDTH(CachingStrategy.ONE, true) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new CJKWidthFilter(tokenStream);
         }
     },
 
-    DECIMAL_DIGIT(CachingStrategy.ONE) {
+    DECIMAL_DIGIT(CachingStrategy.ONE, true) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new DecimalDigitFilter(tokenStream);
         }
     },
 
-    CJK_BIGRAM(CachingStrategy.ONE) {
+    CJK_BIGRAM(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new CJKBigramFilter(tokenStream);
         }
     },
 
-    DELIMITED_PAYLOAD_FILTER(CachingStrategy.ONE) {
+    DELIMITED_PAYLOAD_FILTER(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new DelimitedPayloadTokenFilter(tokenStream, DelimitedPayloadTokenFilterFactory.DEFAULT_DELIMITER, DelimitedPayloadTokenFilterFactory.DEFAULT_ENCODER);
         }
     },
 
-    LIMIT(CachingStrategy.ONE) {
+    LIMIT(CachingStrategy.ONE, false) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new LimitTokenCountFilter(tokenStream, LimitTokenCountFilterFactory.DEFAULT_MAX_TOKEN_COUNT, LimitTokenCountFilterFactory.DEFAULT_CONSUME_ALL_TOKENS);
@@ -396,31 +397,52 @@ public enum PreBuiltTokenFilters {
     abstract public TokenStream create(TokenStream tokenStream, Version version);
 
     protected final PreBuiltCacheFactory.PreBuiltCache<TokenFilterFactory> cache;
+    private final boolean multiTermAware;
 
-
-    PreBuiltTokenFilters(CachingStrategy cachingStrategy) {
+    PreBuiltTokenFilters(CachingStrategy cachingStrategy, boolean multiTermAware) {
         cache = PreBuiltCacheFactory.getCache(cachingStrategy);
+        this.multiTermAware = multiTermAware;
     }
 
     public synchronized TokenFilterFactory getTokenFilterFactory(final Version version) {
         TokenFilterFactory factory = cache.get(version);
         if (factory == null) {
-            final String finalName = name();
-            factory = new TokenFilterFactory() {
-                @Override
-                public String name() {
-                    return finalName.toLowerCase(Locale.ROOT);
-                }
-
-                @Override
-                public TokenStream create(TokenStream tokenStream) {
-                    return valueOf(finalName).create(tokenStream, version);
-                }
-            };
+            if (multiTermAware) {
+                factory = new MultiTermAwareTokenFilterFactory() {
+                    @Override
+                    public String name() {
+                        return PreBuiltTokenFilters.this.name().toLowerCase(Locale.ROOT);
+                    }
+    
+                    @Override
+                    public TokenStream create(TokenStream tokenStream) {
+                        return PreBuiltTokenFilters.this.create(tokenStream, version);
+                    }
+                };
+            } else {
+                factory = new TokenFilterFactory() {
+                    @Override
+                    public String name() {
+                        return PreBuiltTokenFilters.this.name().toLowerCase(Locale.ROOT);
+                    }
+    
+                    @Override
+                    public TokenStream create(TokenStream tokenStream) {
+                        return PreBuiltTokenFilters.this.create(tokenStream, version);
+                    }
+                };
+            }
             cache.put(version, factory);
         }
 
         return factory;
+    }
+
+    private static abstract class MultiTermAwareTokenFilterFactory implements TokenFilterFactory, MultiTermAwareComponent {
+        @Override
+            public Object getMultiTermComponent() {
+                return this;
+            }
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/rest/action/support/RestActions.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/support/RestActions.java
@@ -195,7 +195,6 @@ public class RestActions {
         queryBuilder.defaultField(request.param("df"));
         queryBuilder.analyzer(request.param("analyzer"));
         queryBuilder.analyzeWildcard(request.paramAsBoolean("analyze_wildcard", false));
-        queryBuilder.lowercaseExpandedTerms(request.paramAsBoolean("lowercase_expanded_terms", true));
         queryBuilder.lenient(request.paramAsBoolean("lenient", null));
         String defaultOperator = request.param("default_operator");
         if (defaultOperator != null) {

--- a/core/src/test/java/org/apache/lucene/queryparser/classic/MapperQueryParserTests.java
+++ b/core/src/test/java/org/apache/lucene/queryparser/classic/MapperQueryParserTests.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.queryparser.classic;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.PrefixQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TermRangeQuery;
+import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+public class MapperQueryParserTests extends ESSingleNodeTestCase {
+
+    public void testTermQuery() throws ParseException {
+        IndexService index = createIndex("index", Settings.EMPTY, "type", "field", "type=text,analyzer=english");
+        QueryShardContext context = index.newQueryShardContext();
+        MapperQueryParser parser = new MapperQueryParser(context);
+        QueryParserSettings settings = new QueryParserSettings();
+        settings.defaultField("field");
+        parser.reset(settings);
+        Query query = parser.parse("Foxes");
+        assertEquals(new TermQuery(new Term("field", "fox")), query); // the whole chain was applied
+    }
+
+    public void testPhraseQuery() throws ParseException {
+        IndexService index = createIndex("index", Settings.EMPTY, "type", "field", "type=text,analyzer=english");
+        QueryShardContext context = index.newQueryShardContext();
+        MapperQueryParser parser = new MapperQueryParser(context);
+        QueryParserSettings settings = new QueryParserSettings();
+        settings.defaultField("field");
+        parser.reset(settings);
+        Query query = parser.parse("\"Quick Foxes\"");
+        assertEquals(new BooleanQuery.Builder()
+                .setDisableCoord(true)
+                .add(new PhraseQuery("field", "quick", "fox"), Occur.SHOULD) // the whole chain was applied
+                .build(),
+                query);
+    }
+
+    public void testPrefixQuery() throws ParseException {
+        IndexService index = createIndex("index", Settings.EMPTY, "type", "field", "type=text,analyzer=english");
+        QueryShardContext context = index.newQueryShardContext();
+        MapperQueryParser parser = new MapperQueryParser(context);
+        QueryParserSettings settings = new QueryParserSettings();
+        settings.defaultField("field");
+        parser.reset(settings);
+        Query query = parser.parse("Tables*");
+        assertEquals(new PrefixQuery(new Term("field", "tables")), query); // lowercase was applied but not stemming
+
+        settings.analyzeWildcard(true);
+        parser.reset(settings);
+        query = parser.parse("Tables*");
+        assertEquals(new PrefixQuery(new Term("field", "tabl")), query);
+    }
+
+    public void testWildcardQuery() throws ParseException {
+        IndexService index = createIndex("index", Settings.EMPTY, "type", "field", "type=text,analyzer=english");
+        QueryShardContext context = index.newQueryShardContext();
+        MapperQueryParser parser = new MapperQueryParser(context);
+        QueryParserSettings settings = new QueryParserSettings();
+        settings.defaultField("field");
+        parser.reset(settings);
+        Query query = parser.parse("Fr*days");
+        assertEquals(new WildcardQuery(new Term("field", "fr*days")), query); // lowercase was applied but not stemming
+
+        settings.analyzeWildcard(true);
+        parser.reset(settings);
+        query = parser.parse("Fr*days");
+        assertEquals(new WildcardQuery(new Term("field", "fr*dai")), query);
+    }
+
+    public void testFuzzyQuery() throws ParseException {
+        IndexService index = createIndex("index", Settings.EMPTY, "type", "field", "type=text,analyzer=english");
+        QueryShardContext context = index.newQueryShardContext();
+        MapperQueryParser parser = new MapperQueryParser(context);
+        QueryParserSettings settings = new QueryParserSettings();
+        settings.defaultField("field");
+        parser.reset(settings);
+        Query query = parser.parse("Toys~1");
+        assertEquals(new FuzzyQuery(new Term("field", "toys"), 1), query); // lowercase was applied but not stemming
+    }
+
+    public void testRangeQuery() throws ParseException {
+        IndexService index = createIndex("index", Settings.EMPTY, "type", "field", "type=text,analyzer=english");
+        QueryShardContext context = index.newQueryShardContext();
+        MapperQueryParser parser = new MapperQueryParser(context);
+        QueryParserSettings settings = new QueryParserSettings();
+        settings.defaultField("field");
+        parser.reset(settings);
+        Query query = parser.parse("[A TO B]");
+        assertEquals(new TermRangeQuery("field", new BytesRef("a"), new BytesRef("b"),
+                true, true), query); // lowercase was applied but not stemming
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/index/analysis/AnalysisFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/AnalysisFactoryTests.java
@@ -19,8 +19,182 @@
 
 package org.elasticsearch.index.analysis;
 
+import org.apache.lucene.analysis.ar.ArabicNormalizationFilterFactory;
+import org.apache.lucene.analysis.ar.ArabicStemFilterFactory;
+import org.apache.lucene.analysis.br.BrazilianStemFilterFactory;
+import org.apache.lucene.analysis.charfilter.HTMLStripCharFilterFactory;
+import org.apache.lucene.analysis.cjk.CJKWidthFilterFactory;
+import org.apache.lucene.analysis.ckb.SoraniNormalizationFilterFactory;
+import org.apache.lucene.analysis.commongrams.CommonGramsFilterFactory;
+import org.apache.lucene.analysis.core.DecimalDigitFilterFactory;
+import org.apache.lucene.analysis.core.LetterTokenizerFactory;
+import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
+import org.apache.lucene.analysis.core.StopFilterFactory;
+import org.apache.lucene.analysis.core.UpperCaseFilterFactory;
+import org.apache.lucene.analysis.core.WhitespaceTokenizerFactory;
+import org.apache.lucene.analysis.cz.CzechStemFilterFactory;
+import org.apache.lucene.analysis.de.GermanNormalizationFilterFactory;
+import org.apache.lucene.analysis.en.KStemFilterFactory;
+import org.apache.lucene.analysis.en.PorterStemFilterFactory;
+import org.apache.lucene.analysis.fa.PersianNormalizationFilterFactory;
+import org.apache.lucene.analysis.hi.HindiNormalizationFilterFactory;
+import org.apache.lucene.analysis.in.IndicNormalizationFilterFactory;
+import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilterFactory;
+import org.apache.lucene.analysis.miscellaneous.KeywordRepeatFilterFactory;
+import org.apache.lucene.analysis.miscellaneous.LengthFilterFactory;
+import org.apache.lucene.analysis.miscellaneous.LimitTokenCountFilterFactory;
+import org.apache.lucene.analysis.miscellaneous.ScandinavianFoldingFilterFactory;
+import org.apache.lucene.analysis.miscellaneous.ScandinavianNormalizationFilterFactory;
+import org.apache.lucene.analysis.miscellaneous.TrimFilterFactory;
+import org.apache.lucene.analysis.miscellaneous.TruncateTokenFilterFactory;
+import org.apache.lucene.analysis.miscellaneous.WordDelimiterFilterFactory;
+import org.apache.lucene.analysis.ngram.EdgeNGramFilterFactory;
+import org.apache.lucene.analysis.ngram.EdgeNGramTokenizerFactory;
+import org.apache.lucene.analysis.ngram.NGramFilterFactory;
+import org.apache.lucene.analysis.ngram.NGramTokenizerFactory;
+import org.apache.lucene.analysis.path.PathHierarchyTokenizerFactory;
+import org.apache.lucene.analysis.pattern.PatternTokenizerFactory;
+import org.apache.lucene.analysis.payloads.DelimitedPayloadTokenFilterFactory;
+import org.apache.lucene.analysis.payloads.TypeAsPayloadTokenFilterFactory;
+import org.apache.lucene.analysis.reverse.ReverseStringFilterFactory;
+import org.apache.lucene.analysis.shingle.ShingleFilterFactory;
+import org.apache.lucene.analysis.standard.ClassicFilterFactory;
+import org.apache.lucene.analysis.standard.ClassicTokenizerFactory;
+import org.apache.lucene.analysis.standard.StandardFilterFactory;
+import org.apache.lucene.analysis.standard.StandardTokenizerFactory;
+import org.apache.lucene.analysis.standard.UAX29URLEmailTokenizerFactory;
+import org.apache.lucene.analysis.th.ThaiTokenizerFactory;
+import org.apache.lucene.analysis.tr.ApostropheFilterFactory;
+import org.apache.lucene.analysis.util.ElisionFilterFactory;
 import org.elasticsearch.AnalysisFactoryTestCase;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.indices.analysis.PreBuiltCharFilters;
+import org.elasticsearch.indices.analysis.PreBuiltTokenFilters;
+import org.elasticsearch.indices.analysis.PreBuiltTokenizers;
+
+import java.util.Map;
 
 public class AnalysisFactoryTests extends AnalysisFactoryTestCase {
-    // tests are inherited
+
+    static final Map<PreBuiltTokenizers,Class<?>> KNOWN_TOKENIZERS
+        = new MapBuilder<PreBuiltTokenizers,Class<?>>()
+            .put(PreBuiltTokenizers.CLASSIC, ClassicTokenizerFactory.class)
+            .put(PreBuiltTokenizers.EDGE_NGRAM, EdgeNGramTokenizerFactory.class)
+            .put(PreBuiltTokenizers.KEYWORD, org.apache.lucene.analysis.core.KeywordTokenizerFactory.class)
+            .put(PreBuiltTokenizers.LETTER, LetterTokenizerFactory.class)
+            .put(PreBuiltTokenizers.LOWERCASE, Void.class)
+            .put(PreBuiltTokenizers.NGRAM, NGramTokenizerFactory.class)
+            .put(PreBuiltTokenizers.PATH_HIERARCHY, PathHierarchyTokenizerFactory.class)
+            .put(PreBuiltTokenizers.PATTERN, PatternTokenizerFactory.class)
+            .put(PreBuiltTokenizers.STANDARD, StandardTokenizerFactory.class)
+            .put(PreBuiltTokenizers.THAI, ThaiTokenizerFactory.class)
+            .put(PreBuiltTokenizers.UAX_URL_EMAIL, UAX29URLEmailTokenizerFactory.class)
+            .put(PreBuiltTokenizers.WHITESPACE, WhitespaceTokenizerFactory.class)
+            .immutableMap();
+
+    static final Map<PreBuiltCharFilters,Class<?>> KNOWN_CHAR_FILTERS
+        = new MapBuilder<PreBuiltCharFilters,Class<?>>()
+            .put(PreBuiltCharFilters.HTML_STRIP, HTMLStripCharFilterFactory.class)
+            .immutableMap();
+
+    static final Map<PreBuiltTokenFilters,Class<?>> KNOWN_TOKEN_FILTERS
+        = new MapBuilder<PreBuiltTokenFilters,Class<?>>()
+            .put(PreBuiltTokenFilters.APOSTROPHE, ApostropheFilterFactory.class)
+            .put(PreBuiltTokenFilters.ARABIC_NORMALIZATION, ArabicNormalizationFilterFactory.class)
+            .put(PreBuiltTokenFilters.ARABIC_STEM, ArabicStemFilterFactory.class)
+            .put(PreBuiltTokenFilters.ASCIIFOLDING, ASCIIFoldingFilterFactory.class)
+            .put(PreBuiltTokenFilters.BRAZILIAN_STEM, BrazilianStemFilterFactory.class)
+            .put(PreBuiltTokenFilters.CJK_BIGRAM, org.apache.lucene.analysis.cjk.CJKBigramFilterFactory.class)
+            .put(PreBuiltTokenFilters.CJK_WIDTH, CJKWidthFilterFactory.class)
+            .put(PreBuiltTokenFilters.CLASSIC, ClassicFilterFactory.class)
+            .put(PreBuiltTokenFilters.COMMON_GRAMS, CommonGramsFilterFactory.class)
+            .put(PreBuiltTokenFilters.CZECH_STEM, CzechStemFilterFactory.class)
+            .put(PreBuiltTokenFilters.DECIMAL_DIGIT, DecimalDigitFilterFactory.class)
+            .put(PreBuiltTokenFilters.DELIMITED_PAYLOAD_FILTER, DelimitedPayloadTokenFilterFactory.class)
+            .put(PreBuiltTokenFilters.DUTCH_STEM, Void.class) // no Lucene factory
+            .put(PreBuiltTokenFilters.EDGE_NGRAM, EdgeNGramFilterFactory.class)
+            .put(PreBuiltTokenFilters.ELISION, ElisionFilterFactory.class)
+            .put(PreBuiltTokenFilters.FRENCH_STEM, Void.class) // no Lucene factory
+            .put(PreBuiltTokenFilters.GERMAN_NORMALIZATION, GermanNormalizationFilterFactory.class)
+            .put(PreBuiltTokenFilters.GERMAN_STEM, Void.class) // no Lucene factory
+            .put(PreBuiltTokenFilters.HINDI_NORMALIZATION, HindiNormalizationFilterFactory.class)
+            .put(PreBuiltTokenFilters.INDIC_NORMALIZATION, IndicNormalizationFilterFactory.class)
+            .put(PreBuiltTokenFilters.KEYWORD_REPEAT, KeywordRepeatFilterFactory.class)
+            .put(PreBuiltTokenFilters.KSTEM, KStemFilterFactory.class)
+            .put(PreBuiltTokenFilters.LENGTH, LengthFilterFactory.class)
+            .put(PreBuiltTokenFilters.LIMIT, LimitTokenCountFilterFactory.class)
+            .put(PreBuiltTokenFilters.LOWERCASE, LowerCaseFilterFactory.class)
+            .put(PreBuiltTokenFilters.NGRAM, NGramFilterFactory.class)
+            .put(PreBuiltTokenFilters.PERSIAN_NORMALIZATION, PersianNormalizationFilterFactory.class)
+            .put(PreBuiltTokenFilters.PORTER_STEM, PorterStemFilterFactory.class)
+            .put(PreBuiltTokenFilters.REVERSE, ReverseStringFilterFactory.class)
+            .put(PreBuiltTokenFilters.RUSSIAN_STEM, Void.class)
+            .put(PreBuiltTokenFilters.SCANDINAVIAN_FOLDING, ScandinavianFoldingFilterFactory.class)
+            .put(PreBuiltTokenFilters.SCANDINAVIAN_NORMALIZATION, ScandinavianNormalizationFilterFactory.class)
+            .put(PreBuiltTokenFilters.SHINGLE, ShingleFilterFactory.class)
+            .put(PreBuiltTokenFilters.SNOWBALL, Void.class) // no Lucene factory
+            .put(PreBuiltTokenFilters.SORANI_NORMALIZATION, SoraniNormalizationFilterFactory.class)
+            .put(PreBuiltTokenFilters.STANDARD, StandardFilterFactory.class)
+            .put(PreBuiltTokenFilters.STEMMER, PorterStemFilterFactory.class)
+            .put(PreBuiltTokenFilters.STOP, StopFilterFactory.class)
+            .put(PreBuiltTokenFilters.TRIM, TrimFilterFactory.class)
+            .put(PreBuiltTokenFilters.TRUNCATE, TruncateTokenFilterFactory.class)
+            .put(PreBuiltTokenFilters.TYPE_AS_PAYLOAD, TypeAsPayloadTokenFilterFactory.class)
+            .put(PreBuiltTokenFilters.UNIQUE, Void.class) // no Lucene factory
+            .put(PreBuiltTokenFilters.UPPERCASE, UpperCaseFilterFactory.class)
+            .put(PreBuiltTokenFilters.WORD_DELIMITER, WordDelimiterFilterFactory.class)
+            .immutableMap();
+
+    public void testPrebuiltTokenizers() {
+        for (PreBuiltTokenizers tokenizer : PreBuiltTokenizers.values()) {
+            Class<?> luceneFactory = KNOWN_TOKENIZERS.get(tokenizer);
+            assertNotNull("Add " + tokenizer + " to KNOWN_TOKENIZERS", luceneFactory);
+            if (Void.class.equals(luceneFactory)) {
+                continue;
+            }
+            assertTrue(
+                    "Not a Lucene factory for " + tokenizer,
+                    org.apache.lucene.analysis.util.TokenizerFactory.class.isAssignableFrom(luceneFactory));
+            TokenizerFactory factory = tokenizer.getTokenizerFactory(Version.CURRENT);
+            assertEquals("Wrong multi-term behaviour for " + tokenizer,
+                    org.apache.lucene.analysis.util.MultiTermAwareComponent.class.isAssignableFrom(luceneFactory),
+                    factory instanceof MultiTermAwareComponent);
+        }
+    }
+
+    public void testPrebuiltCharFilters() {
+        for (PreBuiltCharFilters charFilter : PreBuiltCharFilters.values()) {
+            Class<?> luceneFactory = KNOWN_CHAR_FILTERS.get(charFilter);
+            assertNotNull("Add " + charFilter + " to KNOWN_CHAR_FILTERS", luceneFactory);
+            if (Void.class.equals(luceneFactory)) {
+                continue;
+            }
+            assertTrue(
+                    "Not a Lucene factory for " + charFilter,
+                    org.apache.lucene.analysis.util.CharFilterFactory.class.isAssignableFrom(luceneFactory));
+            CharFilterFactory factory = charFilter.getCharFilterFactory(Version.CURRENT);
+            assertEquals("Wrong multi-term behaviour for " + charFilter,
+                    org.apache.lucene.analysis.util.MultiTermAwareComponent.class.isAssignableFrom(luceneFactory),
+                    factory instanceof MultiTermAwareComponent);
+        }
+    }
+
+    public void testPrebuiltTokenFilterFactories() {
+        for (PreBuiltTokenFilters tokenFilter : PreBuiltTokenFilters.values()) {
+            Class<?> luceneFactory = KNOWN_TOKEN_FILTERS.get(tokenFilter);
+            assertNotNull("Add " + tokenFilter + " to KNOWN_TOKEN_FILTERS", luceneFactory);
+            if (Void.class.equals(luceneFactory)) {
+                continue;
+            }
+            assertTrue(
+                    "Not a Lucene factory for " + tokenFilter,
+                    org.apache.lucene.analysis.util.TokenFilterFactory.class.isAssignableFrom(luceneFactory));
+            TokenFilterFactory factory = tokenFilter.getTokenFilterFactory(Version.CURRENT);
+            assertEquals("Wrong multi-term behaviour for " + tokenFilter,
+                    org.apache.lucene.analysis.util.MultiTermAwareComponent.class.isAssignableFrom(luceneFactory),
+                    factory instanceof MultiTermAwareComponent);
+        }
+    }
+
 }

--- a/core/src/test/java/org/elasticsearch/index/analysis/AnalysisServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/AnalysisServiceTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.analysis;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
@@ -47,7 +48,7 @@ import static org.hamcrest.Matchers.instanceOf;
 public class AnalysisServiceTests extends ESTestCase {
 
     private static AnalyzerProvider analyzerProvider(final String name) {
-        return new PreBuiltAnalyzerProvider(name, AnalyzerScope.INDEX, new EnglishAnalyzer());
+        return new PreBuiltAnalyzerProvider(name, AnalyzerScope.INDEX, new EnglishAnalyzer(), new KeywordAnalyzer());
     }
 
     public void testDefaultAnalyzers() throws IOException {
@@ -80,7 +81,8 @@ public class AnalysisServiceTests extends ESTestCase {
         Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, version).build();
         try {
             AnalysisService analysisService = new AnalysisService(IndexSettingsModule.newIndexSettings("index", settings),
-                    Collections.singletonMap("default_index", new PreBuiltAnalyzerProvider("default_index", AnalyzerScope.INDEX, new EnglishAnalyzer())),
+                    Collections.singletonMap("default_index", new PreBuiltAnalyzerProvider("default_index", AnalyzerScope.INDEX,
+                            new EnglishAnalyzer(), new KeywordAnalyzer())),
                     Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
             fail("Expected ISE");
         } catch (IllegalArgumentException e) {

--- a/core/src/test/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerTests.java
@@ -81,7 +81,8 @@ public class PreBuiltAnalyzerTests extends ESSingleNodeTestCase {
         Version randomVersion = randomVersion(random());
         Settings indexSettings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, randomVersion).build();
 
-        NamedAnalyzer namedAnalyzer = new PreBuiltAnalyzerProvider(analyzerName, AnalyzerScope.INDEX, randomPreBuiltAnalyzer.getAnalyzer(randomVersion)).get();
+        NamedAnalyzer namedAnalyzer = new PreBuiltAnalyzerProvider(analyzerName, AnalyzerScope.INDEX,
+                randomPreBuiltAnalyzer.getAnalyzer(randomVersion), randomPreBuiltAnalyzer.getAnalyzer(randomVersion)).get();
 
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("properties").startObject("field").field("type", "text").field("analyzer", analyzerName).endObject().endObject()

--- a/core/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
@@ -111,7 +111,9 @@ public class DocumentFieldMapperTests extends LuceneTestCase {
         FakeFieldType fieldType1 = new FakeFieldType();
         fieldType1.setName("field1");
         fieldType1.setIndexAnalyzer(new NamedAnalyzer("foo", new FakeAnalyzer("index")));
-        fieldType1.setSearchAnalyzer(new NamedAnalyzer("bar", new FakeAnalyzer("search")));
+        fieldType1.setSearchAnalyzer(
+                new NamedAnalyzer("bar", new FakeAnalyzer("search")),
+                new NamedAnalyzer("bar", new FakeAnalyzer("search")));
         fieldType1.setSearchQuoteAnalyzer(new NamedAnalyzer("baz", new FakeAnalyzer("search_quote")));
         FieldMapper fieldMapper1 = new FakeFieldMapper("field1", fieldType1);
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
@@ -84,17 +85,23 @@ public abstract class FieldTypeTestCase extends ESTestCase {
         new Modifier("search_analyzer", true) {
             @Override
             public void modify(MappedFieldType ft) {
-                ft.setSearchAnalyzer(new NamedAnalyzer("bar", new StandardAnalyzer()));
+                ft.setSearchAnalyzer(
+                        new NamedAnalyzer("bar", new StandardAnalyzer()),
+                        new NamedAnalyzer("bar", new KeywordAnalyzer()));
             }
         },
         new Modifier("search_analyzer", true) {
             @Override
             public void modify(MappedFieldType ft) {
-                ft.setSearchAnalyzer(new NamedAnalyzer("bar", new StandardAnalyzer()));
+                ft.setSearchAnalyzer(
+                        new NamedAnalyzer("bar", new StandardAnalyzer()),
+                        new NamedAnalyzer("bar", new KeywordAnalyzer()));
             }
             @Override
             public void normalizeOther(MappedFieldType other) {
-                other.setSearchAnalyzer(new NamedAnalyzer("foo", new StandardAnalyzer()));
+                other.setSearchAnalyzer(
+                        new NamedAnalyzer("foo", new StandardAnalyzer()),
+                        new NamedAnalyzer("foo", new KeywordAnalyzer()));
             }
         },
         new Modifier("search_quote_analyzer", true) {

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -102,9 +102,6 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             queryStringQueryBuilder.maxDeterminizedStates(randomIntBetween(1, 100));
         }
         if (randomBoolean()) {
-            queryStringQueryBuilder.lowercaseExpandedTerms(randomBoolean());
-        }
-        if (randomBoolean()) {
             queryStringQueryBuilder.autoGeneratePhraseQueries(randomBoolean());
         }
         if (randomBoolean()) {
@@ -142,9 +139,6 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         }
         if (randomBoolean()) {
             queryStringQueryBuilder.useDisMax(randomBoolean());
-        }
-        if (randomBoolean()) {
-            queryStringQueryBuilder.locale(randomLocale(random()));
         }
         if (randomBoolean()) {
             queryStringQueryBuilder.timeZone(randomDateTimeZone().getID());
@@ -308,7 +302,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         for (Operator op : Operator.values()) {
             BooleanClause.Occur defaultOp = op.toBooleanClauseOccur();
             MapperQueryParser queryParser = new MapperQueryParser(createShardContext());
-            QueryParserSettings settings = new QueryParserSettings("first foo-bar-foobar* last");
+            QueryParserSettings settings = new QueryParserSettings();
             settings.defaultField(STRING_FIELD_NAME);
             settings.fieldsAndWeights(Collections.emptyMap());
             settings.analyzeWildcard(true);
@@ -336,14 +330,14 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         for (Operator op : Operator.values()) {
             BooleanClause.Occur defaultOp = op.toBooleanClauseOccur();
             MapperQueryParser queryParser = new MapperQueryParser(createShardContext());
-            QueryParserSettings settings = new QueryParserSettings("first foo-bar-foobar* last");
+            QueryParserSettings settings = new QueryParserSettings();
             settings.defaultField(STRING_FIELD_NAME);
             settings.fieldsAndWeights(Collections.emptyMap());
             settings.analyzeWildcard(true);
             settings.fuzziness(Fuzziness.AUTO);
             settings.rewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
             settings.defaultOperator(op.toQueryParserOperator());
-            settings.forceAnalyzer(new MockRepeatAnalyzer());
+            settings.analyzer(new MockRepeatAnalyzer(), new MockRepeatAnalyzer());
             queryParser.reset(settings);
             Query query = queryParser.parse("first foo-bar-foobar* last");
 
@@ -522,13 +516,11 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                 "    \"default_operator\" : \"or\",\n" +
                 "    \"auto_generated_phrase_queries\" : false,\n" +
                 "    \"max_determined_states\" : 10000,\n" +
-                "    \"lowercase_expanded_terms\" : true,\n" +
                 "    \"enable_position_increment\" : true,\n" +
                 "    \"fuzziness\" : \"AUTO\",\n" +
                 "    \"fuzzy_prefix_length\" : 0,\n" +
                 "    \"fuzzy_max_expansions\" : 50,\n" +
                 "    \"phrase_slop\" : 0,\n" +
-                "    \"locale\" : \"und\",\n" +
                 "    \"escape\" : false,\n" +
                 "    \"boost\" : 1.0\n" +
                 "  }\n" +

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -56,12 +56,6 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
             result.lenient(randomBoolean());
         }
         if (randomBoolean()) {
-            result.lowercaseExpandedTerms(randomBoolean());
-        }
-        if (randomBoolean()) {
-            result.locale(randomLocale(random()));
-        }
-        if (randomBoolean()) {
             result.minimumShouldMatch(randomMinimumShouldMatch());
         }
         if (randomBoolean()) {
@@ -109,26 +103,22 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
         assertEquals("Wrong default default operator field.", Operator.OR, SimpleQueryStringBuilder.DEFAULT_OPERATOR);
 
         assertEquals("Wrong default default locale.", Locale.ROOT, qb.locale());
-        assertEquals("Wrong default default locale field.", Locale.ROOT, SimpleQueryStringBuilder.DEFAULT_LOCALE);
 
         assertEquals("Wrong default default analyze_wildcard.", false, qb.analyzeWildcard());
         assertEquals("Wrong default default analyze_wildcard field.", false, SimpleQueryStringBuilder.DEFAULT_ANALYZE_WILDCARD);
 
         assertEquals("Wrong default default lowercase_expanded_terms.", true, qb.lowercaseExpandedTerms());
-        assertEquals("Wrong default default lowercase_expanded_terms field.", true,
-                SimpleQueryStringBuilder.DEFAULT_LOWERCASE_EXPANDED_TERMS);
 
         assertEquals("Wrong default default lenient.", false, qb.lenient());
         assertEquals("Wrong default default lenient field.", false, SimpleQueryStringBuilder.DEFAULT_LENIENT);
 
         assertEquals("Wrong default default locale.", Locale.ROOT, qb.locale());
-        assertEquals("Wrong default default locale field.", Locale.ROOT, SimpleQueryStringBuilder.DEFAULT_LOCALE);
     }
 
     public void testDefaultNullLocale() {
         SimpleQueryStringBuilder qb = new SimpleQueryStringBuilder("The quick brown fox.");
         qb.locale(null);
-        assertEquals("Setting locale to null should result in returning to default value.", SimpleQueryStringBuilder.DEFAULT_LOCALE,
+        assertEquals("Setting locale to null should result in returning to default value.", Locale.ROOT,
                 qb.locale());
     }
 
@@ -349,10 +339,8 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
                 "    \"analyzer\" : \"snowball\",\n" +
                 "    \"flags\" : -1,\n" +
                 "    \"default_operator\" : \"and\",\n" +
-                "    \"lowercase_expanded_terms\" : true,\n" +
                 "    \"lenient\" : false,\n" +
                 "    \"analyze_wildcard\" : false,\n" +
-                "    \"locale\" : \"und\",\n" +
                 "    \"boost\" : 1.0\n" +
                 "  }\n" +
                 "}";

--- a/core/src/test/java/org/elasticsearch/indices/analysis/DummyAnalyzerProvider.java
+++ b/core/src/test/java/org/elasticsearch/indices/analysis/DummyAnalyzerProvider.java
@@ -19,10 +19,11 @@
 
 package org.elasticsearch.indices.analysis;
 
+import org.apache.lucene.analysis.Analyzer;
 import org.elasticsearch.index.analysis.AnalyzerProvider;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 
-public class DummyAnalyzerProvider implements AnalyzerProvider<DummyAnalyzer> {
+public class DummyAnalyzerProvider implements AnalyzerProvider {
     @Override
     public String name() {
         return "dummy";
@@ -36,5 +37,10 @@ public class DummyAnalyzerProvider implements AnalyzerProvider<DummyAnalyzer> {
     @Override
     public DummyAnalyzer get() {
         return new DummyAnalyzer();
+    }
+
+    @Override
+    public Analyzer getMultiTerm() {
+        return get();
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
@@ -30,12 +30,10 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.io.IOException;
-import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 import static org.elasticsearch.index.query.QueryBuilders.simpleQueryStringQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -168,35 +166,7 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         assertSearchHits(searchResponse, "1");
 
         searchResponse = client().prepareSearch().setQuery(
-                simpleQueryStringQuery("Professio*").lowercaseExpandedTerms(false)).get();
-        assertHitCount(searchResponse, 0L);
-
-        searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("Professionan~1")).get();
-        assertHitCount(searchResponse, 1L);
-        assertSearchHits(searchResponse, "1");
-
-        searchResponse = client().prepareSearch().setQuery(
-                simpleQueryStringQuery("Professionan~1").lowercaseExpandedTerms(false)).get();
-        assertHitCount(searchResponse, 0L);
-    }
-
-    public void testQueryStringLocale() {
-        createIndex("test");
-        client().prepareIndex("test", "type1", "1").setSource("body", "bılly").get();
-        refresh();
-
-        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("BILL*")).get();
-        assertHitCount(searchResponse, 0L);
-        searchResponse = client().prepareSearch().setQuery(queryStringQuery("body:BILL*")).get();
-        assertHitCount(searchResponse, 0L);
-
-        searchResponse = client().prepareSearch().setQuery(
-                simpleQueryStringQuery("BILL*").locale(new Locale("tr", "TR"))).get();
-        assertHitCount(searchResponse, 1L);
-        assertSearchHits(searchResponse, "1");
-        searchResponse = client().prepareSearch().setQuery(
-                queryStringQuery("body:BILL*").locale(new Locale("tr", "TR"))).get();
         assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
     }
@@ -342,7 +312,7 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch()
-                .setQuery(simpleQueryStringQuery("Köln*").analyzeWildcard(true).field("location")).get();
+                .setQuery(simpleQueryStringQuery("Köln*").field("location")).get();
         assertNoFailures(searchResponse);
         assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");

--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -40,10 +40,6 @@ with default operator of `AND`, the same query is translated to
 |`allow_leading_wildcard` |When set, `*` or `?` are allowed as the first
 character. Defaults to `true`.
 
-|`lowercase_expanded_terms` |Whether terms of wildcard, prefix, fuzzy,
-and range queries are to be automatically lower-cased or not (since they
-are not analyzed). Default it `true`.
-
 |`enable_position_increments` |Set to `true` to enable position
 increments in result queries. Defaults to `true`.
 
@@ -61,9 +57,9 @@ phrase matches are required. Default value is `0`.
 
 |`boost` |Sets the boost value of the query. Defaults to `1.0`.
 
-|`analyze_wildcard` |By default, wildcards terms in a query string are
-not analyzed. By setting this value to `true`, a best effort will be
-made to analyze those as well.
+|`analyze_wildcard` |By default, only the char filters and token filters that
+make sense ape applied to wildcarded terms (eg. `lowercase` but not stemmers).
+By setting this value to `true`, the whole analysis chain will be applied.
 
 |`auto_generate_phrase_queries` |Defaults to `false`.
 
@@ -79,9 +75,6 @@ both>>.
 
 |`lenient` |If set to `true` will cause format based failures (like
 providing text to a numeric field) to be ignored.
-
-|`locale` | Locale that should be used for string conversions.
-Defaults to `ROOT`.
 
 |`time_zone` | Time Zone to be applied to any range query related to dates. See also
 http://www.joda.org/joda-time/apidocs/org/joda/time/DateTimeZone.html[JODA timezone].

--- a/docs/reference/query-dsl/query-string-syntax.asciidoc
+++ b/docs/reference/query-dsl/query-string-syntax.asciidoc
@@ -65,12 +65,10 @@ they match.  Leading wildcards can be disabled by setting
 `allow_leading_wildcard` to `false`.
 =======
 
-Wildcarded terms are not analyzed by default -- they are lowercased
-(`lowercase_expanded_terms` defaults to `true`) but no further analysis
-is done, mainly because it is impossible to accurately analyze a word that
-is missing some of its letters.  However, by setting `analyze_wildcard` to
-`true`, an attempt will be made to analyze wildcarded words before searching
-the term list for matching terms.
+By default, only the char filters and token filters that make sense are
+applied to wildcarded terms (eg. `lowercase` but not stemmers). It is
+possible to apply the whole analysis chain by setting `analyze_wildcard` to
+`true`.
 
 ===== Regular expressions
 

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -44,17 +44,10 @@ creating composite queries.
 |`flags` |Flags specifying which features of the `simple_query_string` to
 enable. Defaults to `ALL`.
 
-|`lowercase_expanded_terms` | Whether terms of prefix and fuzzy queries should
-be automatically lower-cased or not (since they are not analyzed). Defaults to
-`true`.
-
-|`analyze_wildcard` | Whether terms of prefix queries should be automatically
-analyzed or not. If `true` a best effort will be made to analyze the prefix. However,
-some analyzers will be not able to provide a meaningful results
-based just on the prefix of a term. Defaults to `false`.
-
-|`locale` | Locale that should be used for string conversions.
-Defaults to `ROOT`.
+|`analyze_wildcard` | Whether terms of prefix queries should be tokenized
+or not. If `false` (default), only the char filters and token filters that
+make sense (eg. `lowercase` but not stemmers) will be applied. It is possible
+to set it to `true` in order to apply the whole analysis chain.
 
 |`lenient` | If set to `true` will cause format based failures
 (like providing text to a numeric field) to be ignored.

--- a/docs/reference/search/count.asciidoc
+++ b/docs/reference/search/count.asciidoc
@@ -74,10 +74,7 @@ query.
 |`lenient` |If set to true will cause format based failures (like
 providing text to a numeric field) to be ignored. Defaults to false.
 
-|`lowercase_expanded_terms` |Should terms be automatically lowercased or
-not. Defaults to `true`.
-
-|`analyze_wildcard` |Should wildcard and prefix queries be analyzed or
+|`analyze_wildcard` |Should wildcard and prefix queries be tokenized or
 not. Defaults to `false`.
 
 |`terminate_after` |The maximum count for each shard, upon

--- a/docs/reference/search/explain.asciidoc
+++ b/docs/reference/search/explain.asciidoc
@@ -96,12 +96,8 @@ This will yield the same result as the previous request.
     string. Defaults to the analyzer of the _all field.
 
 `analyze_wildcard`::
-    Should wildcard and prefix queries be analyzed or
+    Should wildcard and prefix queries be tokenized or
     not. Defaults to false.
-
-`lowercase_expanded_terms`::
-    Should terms be automatically lowercased
-    or not. Defaults to true.
 
 `lenient`::
     If set to true will cause format based failures (like

--- a/docs/reference/search/uri-request.asciidoc
+++ b/docs/reference/search/uri-request.asciidoc
@@ -64,10 +64,7 @@ query.
 
 |`analyzer` |The analyzer name to be used when analyzing the query string.
 
-|`lowercase_expanded_terms` |Should terms be automatically lowercased or
-not. Defaults to `true`.
-
-|`analyze_wildcard` |Should wildcard and prefix queries be analyzed or
+|`analyze_wildcard` |Should wildcard and prefix queries be tokenized or
 not. Defaults to `false`.
 
 |`default_operator` |The default operator to be used, can be `AND` or

--- a/docs/reference/search/validate.asciidoc
+++ b/docs/reference/search/validate.asciidoc
@@ -52,10 +52,7 @@ query.
 |`lenient` |If set to true will cause format based failures (like
 providing text to a numeric field) to be ignored. Defaults to false.
 
-|`lowercase_expanded_terms` |Should terms be automatically lowercased or
-not. Defaults to `true`.
-
-|`analyze_wildcard` |Should wildcard and prefix queries be analyzed or
+|`analyze_wildcard` |Should wildcard and prefix queries be tokenized or
 not. Defaults to `false`.
 |=======================================================================
 

--- a/plugins/analysis-kuromoji/src/main/java/org/elasticsearch/index/analysis/KuromojiAnalyzerProvider.java
+++ b/plugins/analysis-kuromoji/src/main/java/org/elasticsearch/index/analysis/KuromojiAnalyzerProvider.java
@@ -31,7 +31,7 @@ import java.util.Set;
 
 /**
  */
-public class KuromojiAnalyzerProvider extends AbstractIndexAnalyzerProvider<JapaneseAnalyzer> {
+public class KuromojiAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final JapaneseAnalyzer analyzer;
 

--- a/plugins/analysis-smartcn/src/main/java/org/elasticsearch/index/analysis/SmartChineseAnalyzerProvider.java
+++ b/plugins/analysis-smartcn/src/main/java/org/elasticsearch/index/analysis/SmartChineseAnalyzerProvider.java
@@ -26,7 +26,7 @@ import org.elasticsearch.index.IndexSettings;
 
 /**
  */
-public class SmartChineseAnalyzerProvider extends AbstractIndexAnalyzerProvider<SmartChineseAnalyzer> {
+public class SmartChineseAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final SmartChineseAnalyzer analyzer;
 

--- a/plugins/analysis-stempel/src/main/java/org/elasticsearch/index/analysis/pl/PolishAnalyzerProvider.java
+++ b/plugins/analysis-stempel/src/main/java/org/elasticsearch/index/analysis/pl/PolishAnalyzerProvider.java
@@ -27,7 +27,7 @@ import org.elasticsearch.index.analysis.AbstractIndexAnalyzerProvider;
 
 /**
  */
-public class PolishAnalyzerProvider extends AbstractIndexAnalyzerProvider<PolishAnalyzer> {
+public class PolishAnalyzerProvider extends AbstractIndexAnalyzerProvider {
 
     private final PolishAnalyzer analyzer;
 

--- a/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/SizeFieldMapper.java
+++ b/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/SizeFieldMapper.java
@@ -55,15 +55,13 @@ public class SizeFieldMapper extends MetadataFieldMapper {
         static {
             SIZE_FIELD_TYPE.setStored(true);
             SIZE_FIELD_TYPE.setName(NAME);
-            SIZE_FIELD_TYPE.setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
-            SIZE_FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
             SIZE_FIELD_TYPE.freeze();
 
             LEGACY_SIZE_FIELD_TYPE.setStored(true);
             LEGACY_SIZE_FIELD_TYPE.setNumericPrecisionStep(LegacyIntegerFieldMapper.Defaults.PRECISION_STEP_32_BIT);
             LEGACY_SIZE_FIELD_TYPE.setName(NAME);
             LEGACY_SIZE_FIELD_TYPE.setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
-            LEGACY_SIZE_FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
+            LEGACY_SIZE_FIELD_TYPE.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER);
             LEGACY_SIZE_FIELD_TYPE.freeze();
         }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/count/20_query_string.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/count/20_query_string.yaml
@@ -58,15 +58,6 @@
       count:
         index: test
         q: field:BA*
-        lowercase_expanded_terms: false
-
-  - match: {count : 0}
-
-  - do:
-      count:
-        index: test
-        q: field:BA*
-        analyze_wildcard: true
 
   - match: {count : 1}
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/explain/30_query_string.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/explain/30_query_string.yaml
@@ -68,17 +68,6 @@
         type:   test
         id:     1
         q: field:BA*
-        lowercase_expanded_terms: false
-
-  - is_false: matched
-
-  - do:
-      explain:
-        index:  test
-        type:   test
-        id:     1
-        q: field:BA*
-        analyze_wildcard: true
 
   - is_true: matched
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/60_query_string.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/60_query_string.yaml
@@ -58,15 +58,6 @@
       search:
         index: test
         q: field:BA*
-        lowercase_expanded_terms: false
-
-  - match: {hits.total: 0}
-
-  - do:
-      search:
-        index: test
-        q: field:BA*
-        analyze_wildcard: true
 
   - match: {hits.total: 1}
 


### PR DESCRIPTION
This pull request uses the `MultiTermAwareComponent` interface in order to
figure out how to deal with queries that match partial strings. This provides a
better out-of-the-box experience and allows to remove the
`lowercase_expanded_terms` and `locale` (which was only used for lowercasing)
options.

Things are expected to work well for custom analyzers. However, built-in
analyzers make it challenging to know which components should be kept for
multi-term analysis. The way it is implemented today is thet there is a default
implementation that returns a lowercasing analyzer, which should be fine for
most language analyzers for european languages. I did not want to go crazy
with configuring the correct multi-term analyzer for those until we have a way
to test that we are sync'ed with what happens in Lucene like we do for testing
which factories need to implement `MultiTermAwareComponent`.

In the future we could consider removing `analyze_wildcards` as well, but the
query parser currently has the ability to tokenize it and generate a term query
for the n-1 first tokens and a wildcard query on the last token. I suspect some
users are relying on this behaviour so I think this should be explored in a
separate change.

Closes #9978
