### PR TITLE
Remove settings filtering for service_account in GCS repository

### DIFF
--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
@@ -62,7 +62,7 @@ public class GoogleCloudStorageRepository extends BlobStoreRepository {
     public static final Setting<String> APPLICATION_NAME =
             new Setting<>("application_name", GoogleCloudStoragePlugin.NAME, Function.identity(), Property.NodeScope, Property.Dynamic);
     public static final Setting<String> SERVICE_ACCOUNT =
-            simpleString("service_account", Property.NodeScope, Property.Dynamic, Property.Filtered);
+            simpleString("service_account", Property.NodeScope, Property.Dynamic);
     public static final Setting<TimeValue> HTTP_READ_TIMEOUT =
             timeSetting("http.read_timeout", NO_TIMEOUT, Property.NodeScope, Property.Dynamic);
     public static final Setting<TimeValue> HTTP_CONNECT_TIMEOUT =


### PR DESCRIPTION
Related to #18945 and to this https://github.com/elastic/elasticsearch/commit/35d3bdab84fa05c71e8ae019aaf661759c8b1622#commitcomment-17914150

In GCS Repository plugin we defined a `service_account` setting which is defined as `Property.Filtered`.
It's not needed as it's only a path to a file.

Closes #18946
