### PR TITLE
InternalTestCluster: Fix data path separation for different node roles

### DIFF
--- a/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryIT.java
@@ -297,7 +297,7 @@ public class ZenDiscoveryIT extends ESIntegTestCase {
         Settings nodeSettings = Settings.builder()
                 .put("discovery.type", "zen") // <-- To override the local setting if set externally
                 .build();
-        String nodeName = internalCluster().startNode(nodeSettings, Version.CURRENT);
+        String nodeName = internalCluster().startNode(nodeSettings);
         ZenDiscovery zenDiscovery = (ZenDiscovery) internalCluster().getInstance(Discovery.class, nodeName);
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class, nodeName);
         DiscoveryNode node = new DiscoveryNode("_node_id", new InetSocketTransportAddress(InetAddress.getByName("0.0.0.0"), 0),

--- a/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
@@ -186,13 +186,14 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
         assertThat(Files.exists(indexDirectory(node_1, index)), equalTo(true));
 
-        final String node_2 = internalCluster().startDataOnlyNode(Settings.builder().build());
+        final String node_2 = internalCluster().startNode(Settings.builder().build());
         assertFalse(client().admin().cluster().prepareHealth().setWaitForNodes("2").get().isTimedOut());
 
-        assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
-        assertThat(Files.exists(indexDirectory(node_1, index)), equalTo(true));
-        assertThat(Files.exists(shardDirectory(node_2, index, 0)), equalTo(false));
-        assertThat(Files.exists(indexDirectory(node_2, index)), equalTo(false));
+        assertThat(shardDirectory(node_1, index, 0) + " should exist", Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
+        assertThat(indexDirectory(node_1, index) + " should exist", Files.exists(indexDirectory(node_1, index)), equalTo(true));
+        assertThat(shardDirectory(node_2, index, 0) + " should not exist", Files.exists(shardDirectory(node_2, index, 0)), equalTo(false));
+        // index meta state is written to disk
+        assertThat(indexDirectory(node_2, index) + " should exist",Files.exists(indexDirectory(node_2, index)), equalTo(true));
 
         // add a transport delegate that will prevent the shard active request to succeed the first time after relocation has finished.
         // node_1 will then wait for the next cluster state change before it tries a next attempt to delete the shard.

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1852,8 +1852,12 @@ public final class InternalTestCluster extends TestCluster {
         }
     }
 
+    /**
+     * returns default settings that can be used as a base to start an independent node.
+     */
     public Settings getDefaultSettings() {
-        return defaultSettings;
+        // we want to return a valid complete settings, meaning we have to add the home settings
+        return Settings.builder().put(defaultSettings).put(Environment.PATH_HOME_SETTING.getKey(), baseDir.toAbsolutePath()).build();
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -604,7 +604,6 @@ public final class InternalTestCluster extends TestCluster {
         // once restarted we append the role suffix to each path.
         final Path finalBaseDir = dataSuffix.isEmpty() ? baseDir : baseDir.resolve(dataSuffix);
 
-
         Settings.Builder finalSettings = Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), finalBaseDir.toAbsolutePath()) // allow overriding path.home
             .put(settings)
@@ -612,13 +611,11 @@ public final class InternalTestCluster extends TestCluster {
             .put(DiscoveryNodeService.NODE_ID_SEED_SETTING.getKey(), seed);
 
         if (Environment.PATH_DATA_SETTING.exists(settings) == false && this.dataPaths != null) {
-            // to make sure that a master node will not pick up on the data folder of a data only node
-            // once restarted we append the role suffix to each path.
-                StringBuilder dataPath = new StringBuilder();
-                for (int i = 0; i < this.dataPaths.length; i++) {
-                    dataPath.append(finalBaseDir.resolve("d" + i).toAbsolutePath()).append(',');
-                }
-                finalSettings.put(Environment.PATH_DATA_SETTING.getKey(), dataPath.toString());
+            StringBuilder dataPath = new StringBuilder();
+            for (int i = 0; i < this.dataPaths.length; i++) {
+                dataPath.append(finalBaseDir.resolve("d" + i).toAbsolutePath()).append(',');
+            }
+            finalSettings.put(Environment.PATH_DATA_SETTING.getKey(), dataPath.toString());
         }
         MockNode node = new MockNode(finalSettings.build(), plugins);
         return new NodeAndClient(name, node);

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -936,7 +936,7 @@ public final class InternalTestCluster extends TestCluster {
             Settings nodeSettings = node.settings();
             Builder builder = Settings.builder()
                 .put("client.transport.nodes_sampler_interval", "1s")
-                .put(Environment.PATH_HOME_SETTING.getKey(), Environment.PATH_HOME_SETTING.get(nodeSettings))
+                .put(Environment.PATH_HOME_SETTING.getKey(), baseDir)
                 .put("node.name", TRANSPORT_CLIENT_PREFIX + node.settings().get("node.name"))
                 .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), clusterName).put("client.transport.sniff", sniff)
                 .put(Node.NODE_MODE_SETTING.getKey(), Node.NODE_MODE_SETTING.exists(nodeSettings) ? Node.NODE_MODE_SETTING.get(nodeSettings) : nodeMode)


### PR DESCRIPTION
#18514 introduced dedicate masters in our testing runs. It also added logic to make sure master and data nodes use different data paths as starting data node on a master path (and vice versa) could lead to tricky to debug failures. Sadly the PR only worked in the case where data paths were explicitly set - which we only do in 20% of the runs. This commit fixes this by working on the base dir level instead. It also adds a test so we know things work :)
