### PR TITLE
Register group setting for repository-azure accounts

### DIFF
--- a/plugins/repository-azure/build.gradle
+++ b/plugins/repository-azure/build.gradle
@@ -40,3 +40,11 @@ thirdPartyAudit.excludes = [
   'org.slf4j.Logger',
   'org.slf4j.LoggerFactory',
 ]
+
+integTest {
+  cluster {
+    setting 'cloud.azure.storage.my_account_test.account', 'cloudazureresource'
+    setting 'cloud.azure.storage.my_account_test.key', 'abcdefgh'
+    setting 'script.stored', 'true'
+  }
+}

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageService.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageService.java
@@ -25,6 +25,7 @@ import com.microsoft.azure.storage.StorageException;
 import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 
@@ -42,6 +43,9 @@ public interface AzureStorageService {
 
     final class Storage {
         public static final String PREFIX = "cloud.azure.storage.";
+
+        public static final Setting<Settings> STORAGE_ACCOUNTS = Setting.groupSetting(Storage.PREFIX, Setting.Property.NodeScope);
+
         public static final Setting<TimeValue> TIMEOUT_SETTING =
             Setting.timeSetting("cloud.azure.storage.timeout", TimeValue.timeValueMinutes(-1), Property.NodeScope);
         public static final Setting<String> ACCOUNT_SETTING =

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageSettings.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageSettings.java
@@ -112,9 +112,8 @@ public final class AzureStorageSettings {
     }
 
     private static List<AzureStorageSettings> createStorageSettings(Settings settings) {
-        Setting<Settings> storageGroupSetting = Setting.groupSetting(Storage.PREFIX, Setting.Property.NodeScope);
         // ignore global timeout which has the same prefix but does not belong to any group
-        Settings groups = storageGroupSetting.get(settings.filter((k) -> k.equals(Storage.TIMEOUT_SETTING.getKey()) == false));
+        Settings groups = Storage.STORAGE_ACCOUNTS.get(settings.filter((k) -> k.equals(Storage.TIMEOUT_SETTING.getKey()) == false));
         List<AzureStorageSettings> storageSettings = new ArrayList<>();
         for (String groupName : groups.getAsGroups().keySet()) {
             storageSettings.add(

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/plugin/repository/azure/AzureRepositoryPlugin.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/plugin/repository/azure/AzureRepositoryPlugin.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardRepository;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.RepositoriesModule;
@@ -62,13 +61,13 @@ public class AzureRepositoryPlugin extends Plugin {
 
     @Override
     public List<Setting<?>> getSettings() {
-        return Arrays.asList(AzureStorageService.Storage.ACCOUNT_SETTING,
-        AzureStorageService.Storage.COMPRESS_SETTING,
-        AzureStorageService.Storage.CONTAINER_SETTING,
-        AzureStorageService.Storage.BASE_PATH_SETTING,
-        AzureStorageService.Storage.CHUNK_SIZE_SETTING,
-        AzureStorageService.Storage.LOCATION_MODE_SETTING);
-
+        return Arrays.asList(AzureStorageService.Storage.STORAGE_ACCOUNTS,
+                AzureStorageService.Storage.ACCOUNT_SETTING,
+                AzureStorageService.Storage.COMPRESS_SETTING,
+                AzureStorageService.Storage.CONTAINER_SETTING,
+                AzureStorageService.Storage.BASE_PATH_SETTING,
+                AzureStorageService.Storage.CHUNK_SIZE_SETTING,
+                AzureStorageService.Storage.LOCATION_MODE_SETTING);
     }
 
     @Override

--- a/plugins/repository-azure/src/test/resources/rest-api-spec/test/repository_azure/20_repository.yaml
+++ b/plugins/repository-azure/src/test/resources/rest-api-spec/test/repository_azure/20_repository.yaml
@@ -1,0 +1,26 @@
+"Repository can be registered":
+    - do:
+        snapshot.create_repository:
+          repository: test_repo_azure
+          verify: false
+          body:
+            type: azure
+            settings:
+              account   : "my_test_account"
+              container : "backup-container"
+              base_path :  "backups"
+              chunk_size: "32m"
+              compress  : true
+
+    - is_true: acknowledged
+
+    - do:
+        snapshot.get_repository:
+          repository: test_repo_azure
+
+    - is_true : test_repo_azure
+    - match   : { test_repo_azure.settings.account   : "my_test_account" }
+    - match   : { test_repo_azure.settings.container : "backup-container" }
+    - match   : { test_repo_azure.settings.base_path : "backups" }
+    - match   : { test_repo_azure.settings.chunk_size: "32m" }
+    - match   : { test_repo_azure.settings.compress  : "true" }


### PR DESCRIPTION
Since the Settings infrastructure has been improved, a group setting must be registered by the repository-azure plugin to allow settings like `cloud.azure.storage.my_account.account` to be coherent with Azure plugin documentation.

Without this change, a user will hit the following error:

```
[2016-06-27 12:01:15,666][INFO ][plugins                  ] [Darkhawk] modules [], plugins [repository-azure]
|    Exception in thread "main" java.lang.IllegalArgumentException: unknown setting [cloud.azure.storage.my_account_test.account] please check that any required plugins are installed, or check the breaking changes documentation for removed settings
```

This PR also adds a simple integration test for this.
