### PR TITLE
Fix documentation typo in How-To docs

### DIFF
--- a/docs/reference/how-to/indexing-speed.asciidoc
+++ b/docs/reference/how-to/indexing-speed.asciidoc
@@ -28,7 +28,7 @@ help reduce the cost of each fsync.
 Make sure to watch for `TOO_MANY_REQUESTS (429)` response codes
 (`EsRejectedExecutionException` with the Java client), which is the way that
 elasticsearch tells you that it cannot keep up with the current indexing rate.
-When it happens, you should pause ndexing a bit before trying again, ideally
+When it happens, you should pause indexing a bit before trying again, ideally
 with randomized exponential backoff.
 
 Similarly to sizing bulk requests, only testing can tell what the optimal

--- a/docs/reference/how-to/search-speed.asciidoc
+++ b/docs/reference/how-to/search-speed.asciidoc
@@ -190,5 +190,5 @@ depending on the file extension using the <<file-system,`index.store.preload`>>
 setting.
 
 WARNING: Loading data into the filesystem cache eagerly on too many indices or
-too many files will make searh _slower_ if the filesystem cache is not large
+too many files will make search _slower_ if the filesystem cache is not large
 enough to hold all the data. Use with caution.


### PR DESCRIPTION
Fix Typos
