### PR TITLE
Default value of boolean is always false

### DIFF
--- a/core/src/main/java/org/elasticsearch/node/internal/InternalSettingsPreparer.java
+++ b/core/src/main/java/org/elasticsearch/node/internal/InternalSettingsPreparer.java
@@ -97,7 +97,7 @@ public class InternalSettingsPreparer {
         initializeSettings(output, input, true, properties);
         Environment environment = new Environment(output.build());
 
-        boolean settingsFileFound = false;
+        boolean settingsFileFound;
         Set<String> foundSuffixes = new HashSet<>();
         for (String allowedSuffix : ALLOWED_SUFFIXES) {
             Path path = environment.configFile().resolve("elasticsearch" + allowedSuffix);


### PR DESCRIPTION
No need to explicitly specifying boolean settingsFileFound=false; because by default in java boolean value is false
