### PR TITLE
Start migration away from aggregation streams

### DIFF
--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -142,12 +142,7 @@ public class TransportClient extends AbstractClient {
                 }
                 modules.add(new NetworkModule(networkService, settings, true, namedWriteableRegistry));
                 modules.add(b -> b.bind(ThreadPool.class).toInstance(threadPool));
-                modules.add(new SearchModule(settings, namedWriteableRegistry) {
-                    @Override
-                    protected void configure() {
-                        // noop
-                    }
-                });
+                modules.add(new SearchModule(settings, namedWriteableRegistry, true));
                 modules.add(new ActionModule(false, true, settings, null, settingsModule.getClusterSettings(),
                         pluginsService.filterPlugins(ActionPlugin.class)));
 

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -267,7 +267,7 @@ public class Node implements Closeable {
             ClusterModule clusterModule = new ClusterModule(settings, clusterService);
             modules.add(clusterModule);
             modules.add(new IndicesModule(namedWriteableRegistry, pluginsService.filterPlugins(MapperPlugin.class)));
-            modules.add(new SearchModule(settings, namedWriteableRegistry));
+            modules.add(new SearchModule(settings, namedWriteableRegistry, false));
             modules.add(new ActionModule(DiscoveryNode.isIngestNode(settings), false, settings,
                     clusterModule.getIndexNameExpressionResolver(), settingsModule.getClusterSettings(),
                     pluginsService.filterPlugins(ActionPlugin.class)));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMetricsAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMetricsAggregation.java
@@ -19,9 +19,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -32,4 +34,12 @@ public abstract class InternalMetricsAggregation extends InternalAggregation {
     protected InternalMetricsAggregation(String name, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);
     }
+
+    /**
+     * Read from a stream.
+     */
+    protected InternalMetricsAggregation(StreamInput in) throws IOException {
+        super(in);
+    }
+
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
@@ -18,9 +18,11 @@
  */
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -39,6 +41,13 @@ public abstract class InternalNumericMetricsAggregation extends InternalMetricsA
 
         protected SingleValue(String name, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
             super(name, pipelineAggregators, metaData);
+        }
+
+        /**
+         * Read from a stream.
+         */
+        protected SingleValue(StreamInput in) throws IOException {
+            super(in);
         }
 
         @Override
@@ -67,6 +76,13 @@ public abstract class InternalNumericMetricsAggregation extends InternalMetricsA
             super(name, pipelineAggregators, metaData);
         }
 
+        /**
+         * Read from a stream.
+         */
+        protected MultiValue(StreamInput in) throws IOException {
+            super(in);
+        }
+
         public abstract double value(String name);
 
         public String valueAsString(String name) {
@@ -91,4 +107,10 @@ public abstract class InternalNumericMetricsAggregation extends InternalMetricsA
         super(name, pipelineAggregators, metaData);
     }
 
+    /**
+     * Read from a stream.
+     */
+    protected InternalNumericMetricsAggregation(StreamInput in) throws IOException {
+        super(in);
+    }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregationBuilder.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
+import org.elasticsearch.search.aggregations.InternalAggregation.Type;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValueType;
@@ -36,18 +37,19 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import java.io.IOException;
 
 public class AvgAggregationBuilder extends ValuesSourceAggregationBuilder.LeafOnly<ValuesSource.Numeric, AvgAggregationBuilder> {
-    public static final String NAME = InternalAvg.TYPE.name();
+    public static final String NAME = "avg";
+    private final static Type TYPE = new Type(NAME);
     public static final ParseField AGGREGATION_NAME_FIELD = new ParseField(NAME);
 
     public AvgAggregationBuilder(String name) {
-        super(name, InternalAvg.TYPE, ValuesSourceType.NUMERIC, ValueType.NUMERIC);
+        super(name, TYPE, ValuesSourceType.NUMERIC, ValueType.NUMERIC);
     }
 
     /**
      * Read from a stream.
      */
     public AvgAggregationBuilder(StreamInput in) throws IOException {
-        super(in, InternalAvg.TYPE, ValuesSourceType.NUMERIC, ValueType.NUMERIC);
+        super(in, TYPE, ValuesSourceType.NUMERIC, ValueType.NUMERIC);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
@@ -67,7 +67,7 @@ public class InnerHitBuilderTests extends ESTestCase {
     @BeforeClass
     public static void init() {
         namedWriteableRegistry = new NamedWriteableRegistry();
-        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, namedWriteableRegistry).getQueryParserRegistry();
+        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, namedWriteableRegistry, false).getQueryParserRegistry();
     }
 
     @AfterClass

--- a/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -47,7 +47,7 @@ import static org.hamcrest.Matchers.notNullValue;
 public class SearchModuleTests extends ModuleTestCase {
 
    public void testDoubleRegister() {
-       SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry());
+       SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false);
        try {
            module.registerHighlighter("fvh", new PlainHighlighter());
        } catch (IllegalArgumentException e) {
@@ -62,7 +62,7 @@ public class SearchModuleTests extends ModuleTestCase {
    }
 
     public void testRegisterSuggester() {
-        SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry());
+        SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false);
         module.registerSuggester("custom", CustomSuggester.INSTANCE);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> module.registerSuggester("custom", CustomSuggester.INSTANCE));
@@ -70,7 +70,7 @@ public class SearchModuleTests extends ModuleTestCase {
     }
 
     public void testRegisterHighlighter() {
-        SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry());
+        SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false);
         CustomHighlighter customHighlighter = new CustomHighlighter();
         module.registerHighlighter("custom",  customHighlighter);
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
@@ -88,14 +88,14 @@ public class SearchModuleTests extends ModuleTestCase {
     }
 
     public void testRegisterQueryParserDuplicate() {
-        SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry());
+        SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> module
                 .registerQuery(TermQueryBuilder::new, TermQueryBuilder::fromXContent, TermQueryBuilder.QUERY_NAME_FIELD));
         assertThat(e.getMessage(), containsString("] already registered for [query][term] while trying to register [org.elasticsearch."));
     }
 
     public void testRegisteredQueries() throws IOException {
-        SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry());
+        SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false);
         List<String> allSupportedQueries = new ArrayList<>();
         Collections.addAll(allSupportedQueries, NON_DEPRECATED_QUERIES);
         Collections.addAll(allSupportedQueries, DEPRECATED_QUERIES);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/AggregatorParsingTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/AggregatorParsingTests.java
@@ -119,7 +119,7 @@ public class AggregatorParsingTests extends ESTestCase {
                 protected void configure() {
                     bindMapperExtension();
                 }
-            }, new SearchModule(settings, namedWriteableRegistry) {
+            }, new SearchModule(settings, namedWriteableRegistry, false) {
                 @Override
                 protected void configureSearch() {
                     // Skip me

--- a/core/src/test/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
@@ -151,7 +151,7 @@ public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuil
                     bindMapperExtension();
                 }
             },
-            new SearchModule(settings, namedWriteableRegistry) {
+            new SearchModule(settings, namedWriteableRegistry, false) {
                 @Override
                 protected void configureSearch() {
                     // Skip me

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
@@ -106,7 +106,7 @@ public class SignificanceHeuristicTests extends ESTestCase {
         ByteArrayInputStream inBuffer = new ByteArrayInputStream(outBuffer.toByteArray());
         StreamInput in = new InputStreamStreamInput(inBuffer);
         NamedWriteableRegistry registry = new NamedWriteableRegistry();
-        new SearchModule(Settings.EMPTY, registry); // populates the registry through side effects
+        new SearchModule(Settings.EMPTY, registry, false); // populates the registry through side effects
         in = new NamedWriteableAwareStreamInput(in, registry);
         in.setVersion(version);
         sigTerms[1].readFrom(in);
@@ -202,7 +202,7 @@ public class SignificanceHeuristicTests extends ESTestCase {
     // 1. The output of the builders can actually be parsed
     // 2. The parser does not swallow parameters after a significance heuristic was defined
     public void testBuilderAndParser() throws Exception {
-        SearchModule searchModule = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry());
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false);
         ParseFieldRegistry<SignificanceHeuristicParser> heuristicParserMapper = searchModule.getSignificanceHeuristicParserRegistry();
         SearchContext searchContext = new SignificantTermsTestSearchContext();
 

--- a/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -145,7 +145,7 @@ public class SearchSourceBuilderTests extends ESTestCase {
                         bindMapperExtension();
                     }
                 },
-                new SearchModule(settings, namedWriteableRegistry) {
+                new SearchModule(settings, namedWriteableRegistry, false) {
                     @Override
                     protected void configureSearch() {
                         // Skip me

--- a/core/src/test/java/org/elasticsearch/search/highlight/HighlightBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/HighlightBuilderTests.java
@@ -83,7 +83,7 @@ public class HighlightBuilderTests extends ESTestCase {
     @BeforeClass
     public static void init() {
         namedWriteableRegistry = new NamedWriteableRegistry();
-        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, namedWriteableRegistry).getQueryParserRegistry();
+        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, namedWriteableRegistry, false).getQueryParserRegistry();
     }
 
     @AfterClass

--- a/core/src/test/java/org/elasticsearch/search/rescore/QueryRescoreBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/rescore/QueryRescoreBuilderTests.java
@@ -70,7 +70,7 @@ public class QueryRescoreBuilderTests extends ESTestCase {
     @BeforeClass
     public static void init() {
         namedWriteableRegistry = new NamedWriteableRegistry();
-        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, namedWriteableRegistry).getQueryParserRegistry();
+        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, namedWriteableRegistry, false).getQueryParserRegistry();
     }
 
     @AfterClass

--- a/core/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
@@ -106,7 +106,7 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
         };
 
         namedWriteableRegistry = new NamedWriteableRegistry();
-        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, namedWriteableRegistry).getQueryParserRegistry();
+        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, namedWriteableRegistry, false).getQueryParserRegistry();
     }
 
     @AfterClass

--- a/core/src/test/java/org/elasticsearch/search/sort/SortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/SortBuilderTests.java
@@ -52,7 +52,7 @@ public class SortBuilderTests extends ESTestCase {
     @BeforeClass
     public static void init() {
         namedWriteableRegistry = new NamedWriteableRegistry();
-        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, namedWriteableRegistry).getQueryParserRegistry();
+        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, namedWriteableRegistry, false).getQueryParserRegistry();
     }
 
     @AfterClass

--- a/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -56,7 +56,7 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
     @BeforeClass
     public static void init() throws IOException {
         namedWriteableRegistry = new NamedWriteableRegistry();
-        SearchModule searchModule = new SearchModule(Settings.EMPTY, namedWriteableRegistry);
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, namedWriteableRegistry, false);
         queriesRegistry = searchModule.getQueryParserRegistry();
         suggesters = searchModule.getSuggesters();
         parseFieldMatcher = ParseFieldMatcher.STRICT;

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/messy/tests/TemplateQueryParserTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/messy/tests/TemplateQueryParserTests.java
@@ -118,7 +118,7 @@ public class TemplateQueryParserTests extends ESTestCase {
                     b.bind(CircuitBreakerService.class).to(NoneCircuitBreakerService.class);
                 },
                 settingsModule,
-                new SearchModule(settings, new NamedWriteableRegistry()) {
+                new SearchModule(settings, new NamedWriteableRegistry(), false) {
                     @Override
                     protected void configureSearch() {
                         // skip so we don't need transport

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
@@ -880,7 +880,7 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
             scriptSettings.addAll(pluginsService.getPluginSettings());
             scriptSettings.add(InternalSettingsPlugin.VERSION_CREATED);
             SettingsModule settingsModule = new SettingsModule(settings, scriptSettings, pluginsService.getPluginSettingsFilter());
-            searchModule = new SearchModule(settings, namedWriteableRegistry) {
+            searchModule = new SearchModule(settings, namedWriteableRegistry, false) {
                 @Override
                 protected void configureSearch() {
                     // Skip me

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -631,7 +631,7 @@ public class ElasticsearchAssertions {
             registry = ESIntegTestCase.internalCluster().getInstance(NamedWriteableRegistry.class);
         } else {
             registry = new NamedWriteableRegistry();
-            new SearchModule(Settings.EMPTY, registry);
+            new SearchModule(Settings.EMPTY, registry, false);
         }
         assertVersionSerializable(version, streamable, registry);
     }


### PR DESCRIPTION
We'll migrate to NamedWriteable so we can share code with the rest
of the system. So we can work on this in multiple pull requests without
breaking Elasticsearch in between the commits this change supports
_both_ old style `InternalAggregations.stream` serialization and
`NamedWriteable` style serialization. As such it creates about a
half dozen `// NORELEASE` comments that will have to be removed
once the migration is complete.

This also introduces a boolean `transportClient` flag to `SearchModule`
which is used to skip inappropriate registrations for for the
transport client while still registering the things it needs. In
this case that means that the `InternalAggregation` subclasses are
registered with the `NamedWriteableRegistry` but the `AggregationBuilder`
subclasses are not.

Finally, this moves aggregation registration from guice configuration
time to `SearchModule` construction time. This will make it simpler to
work with in the future as we further clean up Elasticsearch's
extension points.
