### PR TITLE
Fixing typo for path.conf location

### DIFF
--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -26,7 +26,7 @@ setting, as follows:
 
 [source,sh]
 -------------------------------
-./bin/elasticsearch -Ees.path.conf=/path/to/my/config/
+./bin/elasticsearch -Epath.conf=/path/to/my/config/
 -------------------------------
 
 [float]


### PR DESCRIPTION
Changing -Ees.path.conf to -Epath.conf
