### PR TITLE
Move the build vagrant build listener

### DIFF
--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -170,6 +170,16 @@ task prepareTestRoot(type: Copy) {
   from configurations.test
 
   dependsOn createVersionFile, createUpgradeFromFile
+  doFirst {
+    gradle.addBuildListener new BuildAdapter() {
+      @Override
+      void buildFinished(BuildResult result) {
+        if (result.failure) {
+          println "Reproduce with: gradle packagingTest -Pvagrant.boxes=${vagrantBoxes} -Dtests.seed=${formattedSeed} -Dtests.packaging.upgrade.from.versions=${upgradeFromVersions.join(",")}"
+        }
+      }
+    }
+  }
 }
 
 task checkVagrantVersion(type: Exec) {
@@ -196,14 +206,6 @@ task packagingTest {
               "    'sample' can be used to test a single yum and apt box. 'all' can be used to\n" +
               "    test all available boxes. The available boxes are: \n" +
               "    ${availableBoxes}"
-  gradle.addBuildListener new BuildAdapter() {
-    @Override
-    void buildFinished(BuildResult result) {
-      if (result.failure) {
-        println "Reproduce with: gradle packagingTest -Pvagrant.boxes=${vagrantBoxes} -Dtests.seed=${formattedSeed} -Dtests.packaging.upgrade.from.versions=${upgradeFromVersions.join(",")}"
-      }
-    }
-  }
 }
 
 // Each box gets it own set of tasks
@@ -245,7 +247,7 @@ for (String box : availableBoxes) {
     commandLine 'vagrant', 'ssh', box, '--command',
       "set -o pipefail && ${smokeTestCommand} | sed -ue 's/^/    ${box}: /'"
   }
-  vagrantSmokeTest.dependsOn(smoke) 
+  vagrantSmokeTest.dependsOn(smoke)
 
   Task packaging = tasks.create("packagingTest${boxTask}", BatsOverVagrantTask) {
     dependsOn up


### PR DESCRIPTION
That way it doesn't register until we actually try and set up
the vagrant test root. We don't need it all the time.
