### PR TITLE
[API] separate tasks.list and tasks.get APIs in the json definition

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
@@ -1,5 +1,5 @@
 {
-  "task.get": {
+  "tasks.get": {
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
     "methods": ["GET"],
     "url": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
@@ -4,7 +4,7 @@
     "methods": ["GET"],
     "url": {
       "path": "/_tasks",
-      "paths": ["/_tasks", "/_tasks/{task_id}"],
+      "paths": ["/_tasks"],
       "parts": {},
       "params": {
         "node_id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/tasks.get/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/tasks.get/10_basic.yaml
@@ -6,5 +6,5 @@
 
   - do:
       catch: missing
-      task.get:
+      tasks.get:
         task_id: foo:1


### PR DESCRIPTION
All variable parts of the URL should be documented.
