### PR TITLE
Testing infra - stablize data folder usage and clean up

### DIFF
--- a/core/src/main/java/org/elasticsearch/gateway/Gateway.java
+++ b/core/src/main/java/org/elasticsearch/gateway/Gateway.java
@@ -21,7 +21,6 @@ package org.elasticsearch.gateway;
 
 import com.carrotsearch.hppc.ObjectFloatHashMap;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
@@ -38,7 +37,6 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.NodeServicesProvider;
 import org.elasticsearch.indices.IndicesService;
 
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.function.Supplier;
 
@@ -158,15 +156,6 @@ public class Gateway extends AbstractComponent implements ClusterStateListener {
         ClusterState.Builder builder = ClusterState.builder(clusterService.getClusterName());
         builder.metaData(metaDataBuilder);
         listener.onSuccess(builder.build());
-    }
-    public void reset() throws Exception {
-        try {
-            Path[] dataPaths = nodeEnv.nodeDataPaths();
-            logger.trace("removing node data paths: [{}]", (Object)dataPaths);
-            IOUtils.rm(dataPaths);
-        } catch (Exception ex) {
-            logger.debug("failed to delete shard locations", ex);
-        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -163,6 +163,7 @@ public class Node implements Closeable {
     private final Injector injector;
     private final Settings settings;
     private final Environment environment;
+    private final NodeEnvironment nodeEnvironment;
     private final PluginsService pluginsService;
     private final Client client;
 
@@ -236,7 +237,6 @@ public class Node implements Closeable {
             // this is as early as we can validate settings at this point. we already pass them to ScriptModule as well as ThreadPool
             // so we might be late here already
             final SettingsModule settingsModule = new SettingsModule(this.settings, additionalSettings, additionalSettingsFilter);
-            final NodeEnvironment nodeEnvironment;
             try {
                 nodeEnvironment = new NodeEnvironment(this.settings, this.environment);
                 resourcesToClose.add(nodeEnvironment);
@@ -323,6 +323,14 @@ public class Node implements Closeable {
     public Environment getEnvironment() {
         return environment;
     }
+
+    /**
+     * Returns the {@link NodeEnvironment} instance of this node
+     */
+    public NodeEnvironment getNodeEnvironment() {
+        return nodeEnvironment;
+    }
+
 
     /**
      * Start the node. If the node is already started, this method is no-op.

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryIT.java
@@ -297,7 +297,7 @@ public class ZenDiscoveryIT extends ESIntegTestCase {
         Settings nodeSettings = Settings.builder()
                 .put("discovery.type", "zen") // <-- To override the local setting if set externally
                 .build();
-        String nodeName = internalCluster().startNode(nodeSettings, Version.CURRENT);
+        String nodeName = internalCluster().startNode(nodeSettings);
         ZenDiscovery zenDiscovery = (ZenDiscovery) internalCluster().getInstance(Discovery.class, nodeName);
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class, nodeName);
         DiscoveryNode node = new DiscoveryNode("_node_id", new InetSocketTransportAddress(InetAddress.getByName("0.0.0.0"), 0),

--- a/core/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/core/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -298,15 +298,10 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         assertThat(client().prepareGet("test", "type1", "1").execute().actionGet().isExists(), equalTo(true));
 
         logger.info("--> restarting the nodes");
-        final Gateway gateway1 = internalCluster().getInstance(GatewayService.class, node_1).getGateway();
         internalCluster().fullRestart(new RestartCallback() {
             @Override
-            public Settings onNodeStopped(String nodeName) throws Exception {
-                if (node_1.equals(nodeName)) {
-                    logger.info("--> deleting the data for the first node");
-                    gateway1.reset();
-                }
-                return null;
+            public boolean clearData(String nodeName) {
+                return node_1.equals(nodeName);
             }
         });
 

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -887,7 +887,7 @@ public final class InternalTestCluster extends TestCluster {
 
         private void clearDataIfNeeded(RestartCallback callback) throws IOException {
             if (callback.clearData(name)) {
-                NodeEnvironment nodeEnv = getInstanceFromNode(NodeEnvironment.class, node);
+                NodeEnvironment nodeEnv = node.getNodeEnvironment();
                 if (nodeEnv.hasNodeFile()) {
                     final Path[] locations = nodeEnv.nodeDataPaths();
                     logger.debug("removing node data paths: [{}]", (Object[]) locations);
@@ -1130,7 +1130,7 @@ public final class InternalTestCluster extends TestCluster {
 
     private void markNodeDataDirsAsPendingForWipe(Node node) {
         assert Thread.holdsLock(this);
-        NodeEnvironment nodeEnv = getInstanceFromNode(NodeEnvironment.class, node);
+        NodeEnvironment nodeEnv = node.getNodeEnvironment();
         if (nodeEnv.hasNodeFile()) {
             dataDirToClean.addAll(Arrays.asList(nodeEnv.nodeDataPaths()));
         }
@@ -1138,7 +1138,7 @@ public final class InternalTestCluster extends TestCluster {
 
     private void markNodeDataDirsAsNotEligableForWipe(Node node) {
         assert Thread.holdsLock(this);
-        NodeEnvironment nodeEnv = getInstanceFromNode(NodeEnvironment.class, node);
+        NodeEnvironment nodeEnv = node.getNodeEnvironment();
         if (nodeEnv.hasNodeFile()) {
             dataDirToClean.removeAll(Arrays.asList(nodeEnv.nodeDataPaths()));
         }
@@ -1952,7 +1952,8 @@ public final class InternalTestCluster extends TestCluster {
     public void assertAfterTest() throws IOException {
         super.assertAfterTest();
         assertRequestsFinished();
-        for (NodeEnvironment env : this.getInstances(NodeEnvironment.class)) {
+        for (NodeAndClient nodeAndClient : nodes.values()) {
+            NodeEnvironment env = nodeAndClient.node().getNodeEnvironment();
             Set<ShardId> shardIds = env.lockedShards();
             for (ShardId id : shardIds) {
                 try {

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -369,15 +369,6 @@ public final class InternalTestCluster extends TestCluster {
     private Settings getSettings(int nodeOrdinal, long nodeSeed, Settings others) {
         Builder builder = Settings.builder().put(defaultSettings)
             .put(getRandomNodeSettings(nodeSeed));
-        Settings interimSettings = builder.build();
-        final String dataSuffix = getRoleSuffix(interimSettings);
-        if (dataSuffix.isEmpty() == false) {
-            // to make sure that a master node will not pick up on the data folder of a data only node
-            // once restarted we append the role suffix to each path.
-            String[] dataPath = Environment.PATH_DATA_SETTING.get(interimSettings).stream()
-                .map(path -> path + dataSuffix).toArray(String[]::new);
-            builder.putArray(Environment.PATH_DATA_SETTING.getKey(), dataPath);
-        }
         Settings settings = nodeConfigurationSource.nodeSettings(nodeOrdinal);
         if (settings != null) {
             if (settings.get(ClusterName.CLUSTER_NAME_SETTING.getKey()) != null) {

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -579,17 +579,17 @@ public final class InternalTestCluster extends TestCluster {
         }
     }
 
-    private NodeAndClient buildNode(Settings settings, Version version) {
+    private NodeAndClient buildNode(Settings settings) {
         int ord = nextNodeId.getAndIncrement();
-        return buildNode(ord, random.nextLong(), settings, version, false);
+        return buildNode(ord, random.nextLong(), settings, false);
     }
 
     private NodeAndClient buildNode() {
         int ord = nextNodeId.getAndIncrement();
-        return buildNode(ord, random.nextLong(), null, Version.CURRENT, false);
+        return buildNode(ord, random.nextLong(), null, false);
     }
 
-    private NodeAndClient buildNode(int nodeId, long seed, Settings settings, Version version, boolean reuseExisting) {
+    private NodeAndClient buildNode(int nodeId, long seed, Settings settings, boolean reuseExisting) {
         assert Thread.holdsLock(this);
         ensureOpen();
         settings = getSettings(nodeId, seed, settings);
@@ -1009,7 +1009,7 @@ public final class InternalTestCluster extends TestCluster {
             final Settings.Builder settings = Settings.builder();
             settings.put(Node.NODE_MASTER_SETTING.getKey(), true).build();
             settings.put(Node.NODE_DATA_SETTING.getKey(), false).build();
-            NodeAndClient nodeAndClient = buildNode(i, sharedNodesSeeds[i], settings.build(), Version.CURRENT, true);
+            NodeAndClient nodeAndClient = buildNode(i, sharedNodesSeeds[i], settings.build(), true);
             nodeAndClient.startNode();
             publishNode(nodeAndClient);
         }
@@ -1020,7 +1020,7 @@ public final class InternalTestCluster extends TestCluster {
                 settings.put(Node.NODE_MASTER_SETTING.getKey(), false).build();
                 settings.put(Node.NODE_DATA_SETTING.getKey(), true).build();
             }
-            NodeAndClient nodeAndClient = buildNode(i, sharedNodesSeeds[i], settings.build(), Version.CURRENT, true);
+            NodeAndClient nodeAndClient = buildNode(i, sharedNodesSeeds[i], settings.build(), true);
             nodeAndClient.startNode();
             publishNode(nodeAndClient);
         }
@@ -1028,7 +1028,7 @@ public final class InternalTestCluster extends TestCluster {
              i < numSharedDedicatedMasterNodes + numSharedDataNodes + numSharedCoordOnlyNodes; i++) {
             final Builder settings = Settings.builder().put(Node.NODE_MASTER_SETTING.getKey(), false)
                 .put(Node.NODE_DATA_SETTING.getKey(), false).put(Node.NODE_INGEST_SETTING.getKey(), false);
-            NodeAndClient nodeAndClient = buildNode(i, sharedNodesSeeds[i], settings.build(), Version.CURRENT, true);
+            NodeAndClient nodeAndClient = buildNode(i, sharedNodesSeeds[i], settings.build(), true);
             nodeAndClient.startNode();
             publishNode(nodeAndClient);
         }
@@ -1530,35 +1530,21 @@ public final class InternalTestCluster extends TestCluster {
      * Starts a node with default settings and returns it's name.
      */
     public synchronized String startNode() {
-        return startNode(Settings.EMPTY, Version.CURRENT);
-    }
-
-    /**
-     * Starts a node with default settings ad the specified version and returns it's name.
-     */
-    public synchronized String startNode(Version version) {
-        return startNode(Settings.EMPTY, version);
+        return startNode(Settings.EMPTY);
     }
 
     /**
      * Starts a node with the given settings builder and returns it's name.
      */
     public synchronized String startNode(Settings.Builder settings) {
-        return startNode(settings.build(), Version.CURRENT);
+        return startNode(settings.build());
     }
 
     /**
      * Starts a node with the given settings and returns it's name.
      */
     public synchronized String startNode(Settings settings) {
-        return startNode(settings, Version.CURRENT);
-    }
-
-    /**
-     * Starts a node with the given settings and version and returns it's name.
-     */
-    public synchronized String startNode(Settings settings, Version version) {
-        NodeAndClient buildNode = buildNode(settings, version);
+        NodeAndClient buildNode = buildNode(settings);
         buildNode.startNode();
         publishNode(buildNode);
         return buildNode.name;
@@ -1593,7 +1579,7 @@ public final class InternalTestCluster extends TestCluster {
 
     public synchronized String startMasterOnlyNode(Settings settings) {
         Settings settings1 = Settings.builder().put(settings).put(Node.NODE_MASTER_SETTING.getKey(), true).put(Node.NODE_DATA_SETTING.getKey(), false).build();
-        return startNode(settings1, Version.CURRENT);
+        return startNode(settings1);
     }
 
     public synchronized Async<String> startDataOnlyNodeAsync() {
@@ -1607,7 +1593,7 @@ public final class InternalTestCluster extends TestCluster {
 
     public synchronized String startDataOnlyNode(Settings settings) {
         Settings settings1 = Settings.builder().put(settings).put(Node.NODE_MASTER_SETTING.getKey(), false).put(Node.NODE_DATA_SETTING.getKey(), true).build();
-        return startNode(settings1, Version.CURRENT);
+        return startNode(settings1);
     }
 
     /**
@@ -1628,7 +1614,7 @@ public final class InternalTestCluster extends TestCluster {
      * Starts a node in an async manner with the given settings and version and returns future with its name.
      */
     public synchronized Async<String> startNodeAsync(final Settings settings, final Version version) {
-        final NodeAndClient buildNode = buildNode(settings, version);
+        final NodeAndClient buildNode = buildNode(settings);
         final Future<String> submit = executor.submit(() -> {
             buildNode.startNode();
             publishNode(buildNode);

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -28,6 +28,7 @@ import org.apache.lucene.store.StoreRateLimiting;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags.Flag;
@@ -38,6 +39,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNode.Role;
 import org.elasticsearch.cluster.node.DiscoveryNodeService;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.OperationRouting;
@@ -498,7 +500,7 @@ public final class InternalTestCluster extends TestCluster {
             return randomNodeAndClient;
         }
         NodeAndClient buildNode = buildNode();
-        buildNode.node().start();
+        buildNode.startNode();
         publishNode(buildNode);
         return buildNode;
     }
@@ -569,7 +571,7 @@ public final class InternalTestCluster extends TestCluster {
             n == 0 ? nodes.values().stream() : nodes.values().stream().filter(new DataNodePredicate().and(new MasterNodePredicate(getMasterName()).negate()));
         final Iterator<NodeAndClient> values = collection.iterator();
 
-        logger.info("changing cluster size from {} to {}, {} data nodes", size(), n + numSharedCoordOnlyNodes, n);
+        logger.info("changing cluster size from {} data nodes to {}", size, n);
         Set<NodeAndClient> nodesToRemove = new HashSet<>();
         int numNodesAndClients = 0;
         while (values.hasNext() && numNodesAndClients++ < size - n) {
@@ -615,7 +617,7 @@ public final class InternalTestCluster extends TestCluster {
             .put(DiscoveryNodeService.NODE_ID_SEED_SETTING.getKey(), seed)
             .build();
         MockNode node = new MockNode(finalSettings, plugins);
-        return new NodeAndClient(name, node);
+        return new NodeAndClient(name, node, nodeId);
     }
 
     private String buildNodeName(int id, Settings settings) {
@@ -630,10 +632,10 @@ public final class InternalTestCluster extends TestCluster {
     private String getRoleSuffix(Settings settings) {
         String suffix = "";
         if (Node.NODE_MASTER_SETTING.exists(settings) && Node.NODE_MASTER_SETTING.get(settings)) {
-            suffix = suffix + DiscoveryNode.Role.MASTER.getAbbreviation();
+            suffix = suffix + Role.MASTER.getAbbreviation();
         }
         if (Node.NODE_DATA_SETTING.exists(settings) && Node.NODE_DATA_SETTING.get(settings)) {
-            suffix = suffix + DiscoveryNode.Role.DATA.getAbbreviation();
+            suffix = suffix + Role.DATA.getAbbreviation();
         }
         if (Node.NODE_MASTER_SETTING.exists(settings) && Node.NODE_MASTER_SETTING.get(settings) == false &&
             Node.NODE_DATA_SETTING.exists(settings) && Node.NODE_DATA_SETTING.get(settings) == false
@@ -709,7 +711,7 @@ public final class InternalTestCluster extends TestCluster {
         return getRandomNodeAndClient(new NoDataNoMasterNodePredicate()).client(random);
     }
 
-    public synchronized Client startCoordinatingOnlyNode(Settings settings) {
+    public synchronized String startCoordinatingOnlyNode(Settings settings) {
         ensureOpen(); // currently unused
         Builder builder = Settings.builder().put(settings).put(Node.NODE_MASTER_SETTING.getKey(), false)
             .put(Node.NODE_DATA_SETTING.getKey(), false).put(Node.NODE_INGEST_SETTING.getKey(), false);
@@ -717,8 +719,7 @@ public final class InternalTestCluster extends TestCluster {
             // if we are the first node - don't wait for a state
             builder.put(DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), 0);
         }
-        String name = startNode(builder);
-        return nodes.get(name).nodeClient();
+        return startNode(builder);
     }
 
     /**
@@ -771,7 +772,7 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
         if (this.open.compareAndSet(true, false)) {
             if (activeDisruptionScheme != null) {
                 activeDisruptionScheme.testClusterClosed();
@@ -793,10 +794,13 @@ public final class InternalTestCluster extends TestCluster {
         private Client transportClient;
         private final AtomicBoolean closed = new AtomicBoolean(false);
         private final String name;
+        private final int nodeAndClientId;
 
-        NodeAndClient(String name, MockNode node) {
+        NodeAndClient(String name, MockNode node, int nodeAndClientId) {
             this.node = node;
             this.name = name;
+            this.nodeAndClientId = nodeAndClientId;
+            markNodeDataDirsAsNotEligableForWipe(node);
         }
 
         Node node() {
@@ -804,6 +808,10 @@ public final class InternalTestCluster extends TestCluster {
                 throw new RuntimeException("already closed");
             }
             return node;
+        }
+
+        public int nodeAndClientId() {
+            return nodeAndClientId;
         }
 
         Client client(Random random) {
@@ -860,12 +868,16 @@ public final class InternalTestCluster extends TestCluster {
             }
         }
 
+        void startNode() {
+            node.start();
+        }
+
         void closeNode() throws IOException {
-            registerDataPath();
+            markNodeDataDirsAsPendingForWipe(node);
             node.close();
         }
 
-        void restart(RestartCallback callback) throws Exception {
+        void restart(RestartCallback callback, boolean clearDataIfNeeded) throws Exception {
             assert callback != null;
             resetClient();
             if (!node.isClosed()) {
@@ -875,30 +887,31 @@ public final class InternalTestCluster extends TestCluster {
             if (newSettings == null) {
                 newSettings = Settings.EMPTY;
             }
+            if (clearDataIfNeeded) {
+                clearDataIfNeeded(callback);
+            }
+            createNewNode(newSettings);
+            startNode();
+        }
+
+        private void clearDataIfNeeded(RestartCallback callback) throws IOException {
             if (callback.clearData(name)) {
                 NodeEnvironment nodeEnv = getInstanceFromNode(NodeEnvironment.class, node);
                 if (nodeEnv.hasNodeFile()) {
-                    IOUtils.rm(nodeEnv.nodeDataPaths());
+                    final Path[] locations = nodeEnv.nodeDataPaths();
+                    logger.debug("removing node data paths: [{}]", (Object[]) locations);
+                    IOUtils.rm(locations);
                 }
             }
-            startNewNode(newSettings);
         }
 
-        private void startNewNode(final Settings newSettings) {
+        private void createNewNode(final Settings newSettings) {
             final long newIdSeed = DiscoveryNodeService.NODE_ID_SEED_SETTING.get(node.settings()) + 1; // use a new seed to make sure we have new node id
             Settings finalSettings = Settings.builder().put(node.settings()).put(newSettings).put(DiscoveryNodeService.NODE_ID_SEED_SETTING.getKey(), newIdSeed).build();
             Collection<Class<? extends Plugin>> plugins = node.getPlugins();
             node = new MockNode(finalSettings, plugins);
-            node.start();
+            markNodeDataDirsAsNotEligableForWipe(node);
         }
-
-        void registerDataPath() {
-            NodeEnvironment nodeEnv = getInstanceFromNode(NodeEnvironment.class, node);
-            if (nodeEnv.hasNodeFile()) {
-                dataDirToClean.addAll(Arrays.asList(nodeEnv.nodeDataPaths()));
-            }
-        }
-
 
         @Override
         public void close() throws IOException {
@@ -972,25 +985,42 @@ public final class InternalTestCluster extends TestCluster {
             }
         }
         randomlyResetClients();
-        if (wipeData) {
-            wipeDataDirectories();
-        }
-        if (nextNodeId.get() == sharedNodesSeeds.length && nodes.size() == sharedNodesSeeds.length) {
-            logger.debug("Cluster hasn't changed - moving out - nodes: [{}] nextNodeId: [{}] numSharedNodes: [{}]", nodes.keySet(), nextNodeId.get(), sharedNodesSeeds.length);
+        final int newSize = sharedNodesSeeds.length;
+        if (nextNodeId.get() == newSize && nodes.size() == newSize) {
+            if (wipeData) {
+                wipePendingDataDirectories();
+            }
+            logger.debug("Cluster hasn't changed - moving out - nodes: [{}] nextNodeId: [{}] numSharedNodes: [{}]", nodes.keySet(), nextNodeId.get(), newSize);
             return;
         }
-        logger.debug("Cluster is NOT consistent - restarting shared nodes - nodes: [{}] nextNodeId: [{}] numSharedNodes: [{}]", nodes.keySet(), nextNodeId.get(), sharedNodesSeeds.length);
+        logger.debug("Cluster is NOT consistent - restarting shared nodes - nodes: [{}] nextNodeId: [{}] numSharedNodes: [{}]", nodes.keySet(), nextNodeId.get(), newSize);
+
+        // trash all nodes with id >= sharedNodesSeeds.length - they are non shared
 
 
-        Set<NodeAndClient> sharedNodes = new HashSet<>();
-        assert sharedNodesSeeds.length == numSharedDedicatedMasterNodes + numSharedDataNodes + numSharedCoordOnlyNodes;
+        for (Iterator<NodeAndClient> iterator = nodes.values().iterator(); iterator.hasNext();) {
+            NodeAndClient nodeAndClient = iterator.next();
+            if (nodeAndClient.nodeAndClientId() >= sharedNodesSeeds.length) {
+                logger.debug("Close Node [{}] not shared", nodeAndClient.name);
+                nodeAndClient.close();
+                iterator.remove();
+            }
+        }
+
+        // clean up what the nodes left that is unused
+        if (wipeData) {
+            wipePendingDataDirectories();
+        }
+
+        // start any missing node
+        assert newSize == numSharedDedicatedMasterNodes + numSharedDataNodes + numSharedCoordOnlyNodes;
         for (int i = 0; i < numSharedDedicatedMasterNodes; i++) {
             final Settings.Builder settings = Settings.builder();
             settings.put(Node.NODE_MASTER_SETTING.getKey(), true).build();
             settings.put(Node.NODE_DATA_SETTING.getKey(), false).build();
             NodeAndClient nodeAndClient = buildNode(i, sharedNodesSeeds[i], settings.build(), Version.CURRENT, true);
-            nodeAndClient.node().start();
-            sharedNodes.add(nodeAndClient);
+            nodeAndClient.startNode();
+            publishNode(nodeAndClient);
         }
         for (int i = numSharedDedicatedMasterNodes; i < numSharedDedicatedMasterNodes + numSharedDataNodes; i++) {
             final Settings.Builder settings = Settings.builder();
@@ -1000,43 +1030,34 @@ public final class InternalTestCluster extends TestCluster {
                 settings.put(Node.NODE_DATA_SETTING.getKey(), true).build();
             }
             NodeAndClient nodeAndClient = buildNode(i, sharedNodesSeeds[i], settings.build(), Version.CURRENT, true);
-            nodeAndClient.node().start();
-            sharedNodes.add(nodeAndClient);
+            nodeAndClient.startNode();
+            publishNode(nodeAndClient);
         }
         for (int i = numSharedDedicatedMasterNodes + numSharedDataNodes;
              i < numSharedDedicatedMasterNodes + numSharedDataNodes + numSharedCoordOnlyNodes; i++) {
             final Builder settings = Settings.builder().put(Node.NODE_MASTER_SETTING.getKey(), false)
                 .put(Node.NODE_DATA_SETTING.getKey(), false).put(Node.NODE_INGEST_SETTING.getKey(), false);
             NodeAndClient nodeAndClient = buildNode(i, sharedNodesSeeds[i], settings.build(), Version.CURRENT, true);
-            nodeAndClient.node().start();
-            sharedNodes.add(nodeAndClient);
-        }
-
-        for (NodeAndClient nodeAndClient : sharedNodes) {
-            nodes.remove(nodeAndClient.name);
-        }
-
-        // trash the remaining nodes
-        final Collection<NodeAndClient> toShutDown = nodes.values();
-        for (NodeAndClient nodeAndClient : toShutDown) {
-            logger.debug("Close Node [{}] not shared", nodeAndClient.name);
-            nodeAndClient.close();
-        }
-        nodes.clear();
-        for (NodeAndClient nodeAndClient : sharedNodes) {
+            nodeAndClient.startNode();
             publishNode(nodeAndClient);
         }
-        nextNodeId.set(sharedNodesSeeds.length);
-        assert size() == sharedNodesSeeds.length;
-        if (size() > 0) {
-            client().admin().cluster().prepareHealth().setWaitForNodes(Integer.toString(sharedNodesSeeds.length)).get();
+
+        nextNodeId.set(newSize);
+        assert size() == newSize;
+        if (newSize > 0) {
+            ClusterHealthResponse response = client().admin().cluster().prepareHealth()
+                .setWaitForNodes(Integer.toString(newSize)).get();
+            if (response.isTimedOut()) {
+                logger.warn("failed to wait for a cluster of size [{}], got", newSize, response);
+                throw new IllegalStateException("cluster failed to reach the expected size of [" + newSize + "]");
+            }
         }
-        logger.debug("Cluster is consistent again - nodes: [{}] nextNodeId: [{}] numSharedNodes: [{}]", nodes.keySet(), nextNodeId.get(), sharedNodesSeeds.length);
+        logger.debug("Cluster is consistent again - nodes: [{}] nextNodeId: [{}] numSharedNodes: [{}]", nodes.keySet(), nextNodeId.get(), newSize);
     }
 
     @Override
     public synchronized void afterTest() throws IOException {
-        wipeDataDirectories();
+        wipePendingDataDirectories();
         randomlyResetClients(); /* reset all clients - each test gets its own client based on the Random instance created above. */
     }
 
@@ -1098,7 +1119,8 @@ public final class InternalTestCluster extends TestCluster {
         }
     }
 
-    private void wipeDataDirectories() {
+    private void wipePendingDataDirectories() {
+        assert Thread.holdsLock(this);
         if (!dataDirToClean.isEmpty()) {
             try {
                 for (Path path : dataDirToClean) {
@@ -1112,6 +1134,22 @@ public final class InternalTestCluster extends TestCluster {
             } finally {
                 dataDirToClean.clear();
             }
+        }
+    }
+
+    private void markNodeDataDirsAsPendingForWipe(Node node) {
+        assert Thread.holdsLock(this);
+        NodeEnvironment nodeEnv = getInstanceFromNode(NodeEnvironment.class, node);
+        if (nodeEnv.hasNodeFile()) {
+            dataDirToClean.addAll(Arrays.asList(nodeEnv.nodeDataPaths()));
+        }
+    }
+
+    private void markNodeDataDirsAsNotEligableForWipe(Node node) {
+        assert Thread.holdsLock(this);
+        NodeEnvironment nodeEnv = getInstanceFromNode(NodeEnvironment.class, node);
+        if (nodeEnv.hasNodeFile()) {
+            dataDirToClean.removeAll(Arrays.asList(nodeEnv.nodeDataPaths()));
         }
     }
 
@@ -1254,7 +1292,7 @@ public final class InternalTestCluster extends TestCluster {
     /**
      * Stops any of the current nodes but not the master node.
      */
-    public void stopRandomNonMasterNode() throws IOException {
+    public synchronized void stopRandomNonMasterNode() throws IOException {
         NodeAndClient nodeAndClient = getRandomNodeAndClient(new MasterNodePredicate(getMasterName()).negate());
         if (nodeAndClient != null) {
             logger.info("Closing random non master node [{}] current master [{}] ", nodeAndClient.name, getMasterName());
@@ -1295,28 +1333,28 @@ public final class InternalTestCluster extends TestCluster {
     /**
      * Restarts a random node in the cluster and calls the callback during restart.
      */
-    private void restartRandomNode(Predicate<NodeAndClient> predicate, RestartCallback callback) throws Exception {
+    private synchronized void restartRandomNode(Predicate<NodeAndClient> predicate, RestartCallback callback) throws Exception {
         ensureOpen();
         NodeAndClient nodeAndClient = getRandomNodeAndClient(predicate);
         if (nodeAndClient != null) {
             logger.info("Restarting random node [{}] ", nodeAndClient.name);
-            nodeAndClient.restart(callback);
+            nodeAndClient.restart(callback, true);
         }
     }
 
     /**
      * Restarts a node and calls the callback during restart.
      */
-    public void restartNode(String nodeName, RestartCallback callback) throws Exception {
+    synchronized public void restartNode(String nodeName, RestartCallback callback) throws Exception {
         ensureOpen();
         NodeAndClient nodeAndClient = nodes.get(nodeName);
         if (nodeAndClient != null) {
             logger.info("Restarting node [{}] ", nodeAndClient.name);
-            nodeAndClient.restart(callback);
+            nodeAndClient.restart(callback, true);
         }
     }
 
-    private void restartAllNodes(boolean rollingRestart, RestartCallback callback) throws Exception {
+    synchronized private void restartAllNodes(boolean rollingRestart, RestartCallback callback) throws Exception {
         ensureOpen();
         List<NodeAndClient> toRemove = new ArrayList<>();
         try {
@@ -1344,13 +1382,15 @@ public final class InternalTestCluster extends TestCluster {
                 if (activeDisruptionScheme != null) {
                     activeDisruptionScheme.removeFromNode(nodeAndClient.name, this);
                 }
-                nodeAndClient.restart(callback);
+                nodeAndClient.restart(callback, true);
                 if (activeDisruptionScheme != null) {
                     activeDisruptionScheme.applyToNode(nodeAndClient.name, this);
                 }
             }
         } else {
             int numNodesRestarted = 0;
+            Set[] nodesRoleOrder = new Set[nextNodeId.get()];
+            Map<Set<Role>, List<NodeAndClient>> nodesByRoles = new HashMap<>();
             for (NodeAndClient nodeAndClient : nodes.values()) {
                 callback.doAfterNodes(numNodesRestarted++, nodeAndClient.nodeClient());
                 logger.info("Stopping node [{}] ", nodeAndClient.name);
@@ -1358,25 +1398,37 @@ public final class InternalTestCluster extends TestCluster {
                     activeDisruptionScheme.removeFromNode(nodeAndClient.name, this);
                 }
                 nodeAndClient.closeNode();
+                // delete data folders now, before we start other nodes that may claim it
+                nodeAndClient.clearDataIfNeeded(callback);
+
+
+                DiscoveryNode discoveryNode = getInstanceFromNode(ClusterService.class, nodeAndClient.node()).localNode();
+                nodesRoleOrder[nodeAndClient.nodeAndClientId()] = discoveryNode.getRoles();
+                nodesByRoles.computeIfAbsent(discoveryNode.getRoles(), k -> new ArrayList<>()).add(nodeAndClient);
             }
 
-            // starting master nodes first, for now so restart will be quick. If we'll start
-            // the data nodes first, they will wait for 30s for a master
-            List<DiscoveryNode> discoveryNodes = new ArrayList<>();
-            for (ClusterService clusterService : getInstances(ClusterService.class)) {
-                discoveryNodes.add(clusterService.localNode());
+            assert nodesByRoles.values().stream().collect(Collectors.summingInt(List::size)) == nodes.size();
+
+            // randomize start up order, but making sure that:
+            // 1) A data folder that was assigned to a data node will stay so
+            // 2) Data nodes will get the same node lock ordinal range, so custom index paths (where the ordinal is used)
+            //    will still belong to data nodes
+            for (List<NodeAndClient> sameRoleNodes : nodesByRoles.values()) {
+                Collections.shuffle(sameRoleNodes, random);
             }
 
-            discoveryNodes.sort((n1, n2) -> Boolean.compare(n1.isMasterNode() == false, n2.isMasterNode() == false));
-
-
-            for (DiscoveryNode node : discoveryNodes) {
-                NodeAndClient nodeAndClient = nodes.get(node.getName());
+            for (Set roles : nodesRoleOrder) {
+                if (roles == null) {
+                    // if some nodes were stopped, we want have a role for them
+                    continue;
+                }
+                NodeAndClient nodeAndClient = nodesByRoles.get(roles).remove(0);
                 logger.info("Starting node [{}] ", nodeAndClient.name);
                 if (activeDisruptionScheme != null) {
                     activeDisruptionScheme.removeFromNode(nodeAndClient.name, this);
                 }
-                nodeAndClient.restart(callback);
+                // we already cleared data folders, before starting nodes up
+                nodeAndClient.restart(callback, false);
                 if (activeDisruptionScheme != null) {
                     activeDisruptionScheme.applyToNode(nodeAndClient.name, this);
                 }
@@ -1516,7 +1568,7 @@ public final class InternalTestCluster extends TestCluster {
      */
     public synchronized String startNode(Settings settings, Version version) {
         NodeAndClient buildNode = buildNode(settings, version);
-        buildNode.node().start();
+        buildNode.startNode();
         publishNode(buildNode);
         return buildNode.name;
     }
@@ -1587,7 +1639,7 @@ public final class InternalTestCluster extends TestCluster {
     public synchronized Async<String> startNodeAsync(final Settings settings, final Version version) {
         final NodeAndClient buildNode = buildNode(settings, version);
         final Future<String> submit = executor.submit(() -> {
-            buildNode.node().start();
+            buildNode.startNode();
             publishNode(buildNode);
             return buildNode.name;
         });
@@ -1646,10 +1698,6 @@ public final class InternalTestCluster extends TestCluster {
 
     private synchronized void publishNode(NodeAndClient nodeAndClient) {
         assert !nodeAndClient.node().isClosed();
-        NodeEnvironment nodeEnv = getInstanceFromNode(NodeEnvironment.class, nodeAndClient.node);
-        if (nodeEnv.hasNodeFile()) {
-            dataDirToClean.addAll(Arrays.asList(nodeEnv.nodeDataPaths()));
-        }
         nodes.put(nodeAndClient.name, nodeAndClient);
         applyDisruptionSchemeToNode(nodeAndClient);
     }

--- a/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -22,23 +22,39 @@ import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.discovery.DiscoverySettings;
+import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.NodeConfigurationSource;
 import org.elasticsearch.transport.TransportSettings;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import static org.elasticsearch.cluster.node.DiscoveryNode.Role.DATA;
+import static org.elasticsearch.cluster.node.DiscoveryNode.Role.INGEST;
+import static org.elasticsearch.cluster.node.DiscoveryNode.Role.MASTER;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFileExists;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFileNotExists;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.not;
 
 /**
  * Basic test that ensure that the internal cluster reproduces the same
@@ -152,5 +168,141 @@ public class InternalTestClusterTests extends ESTestCase {
         } finally {
             IOUtils.close(cluster0, cluster1);
         }
+    }
+
+    public void testDataFolderAssignmentAndCleaning() throws IOException, InterruptedException {
+        long clusterSeed = randomLong();
+        boolean masterNodes = randomBoolean();
+        // we need one stable node
+        int minNumDataNodes = 2;
+        int maxNumDataNodes = 2;
+        final String clusterName1 = "shared1";
+        NodeConfigurationSource nodeConfigurationSource = NodeConfigurationSource.EMPTY;
+        int numClientNodes = 0;
+        boolean enableHttpPipelining = randomBoolean();
+        String nodePrefix = "test";
+        Path baseDir = createTempDir();
+        InternalTestCluster cluster = new InternalTestCluster("local", clusterSeed, baseDir, masterNodes,
+            minNumDataNodes, maxNumDataNodes, clusterName1, nodeConfigurationSource, numClientNodes,
+            enableHttpPipelining, nodePrefix, Collections.emptyList(), Function.identity());
+        try {
+            cluster.beforeTest(random(), 0.0);
+            final Map<String,Path[]> shardNodePaths = new HashMap<>();
+            for (String name: cluster.getNodeNames()) {
+                shardNodePaths.put(name, getNodePaths(cluster, name));
+            }
+            String poorNode = randomFrom(cluster.getNodeNames());
+            Path dataPath = getNodePaths(cluster, poorNode)[0];
+            final Path testMarker = dataPath.resolve("testMarker");
+            Files.createDirectories(testMarker);
+            cluster.stopRandomNode(InternalTestCluster.nameFilter(poorNode));
+            assertFileExists(testMarker); // stopping a node half way shouldn't clean data
+
+            final String stableNode = randomFrom(cluster.getNodeNames());
+            final Path stableDataPath = getNodePaths(cluster, stableNode)[0];
+            final Path stableTestMarker = stableDataPath.resolve("stableTestMarker");
+            assertThat(stableDataPath, not(dataPath));
+            Files.createDirectories(stableTestMarker);
+
+            final String newNode1 =  cluster.startNode();
+            assertThat(getNodePaths(cluster, newNode1)[0], equalTo(dataPath));
+            assertFileExists(testMarker); // starting a node should re-use data folders and not clean it
+
+            final String newNode2 =  cluster.startNode();
+            final Path newDataPath = getNodePaths(cluster, newNode2)[0];
+            final Path newTestMarker = newDataPath.resolve("newTestMarker");
+            assertThat(newDataPath, not(dataPath));
+            Files.createDirectories(newTestMarker);
+            cluster.beforeTest(random(), 0.0);
+            assertFileNotExists(newTestMarker); // the cluster should be reset for a new test, cleaning up the extra path we made
+            assertFileNotExists(testMarker); // a new unknown node used this path, it should be cleaned
+            assertFileExists(stableTestMarker); // but leaving the structure of existing, reused nodes
+            for (String name: cluster.getNodeNames()) {
+                assertThat("data paths for " + name + " changed", getNodePaths(cluster, name),
+                    equalTo(shardNodePaths.get(name)));
+            }
+
+            cluster.beforeTest(random(), 0.0);
+            assertFileExists(stableTestMarker); // but leaving the structure of existing, reused nodes
+            for (String name: cluster.getNodeNames()) {
+                assertThat("data paths for " + name + " changed", getNodePaths(cluster, name),
+                    equalTo(shardNodePaths.get(name)));
+            }
+
+        } finally {
+            cluster.close();
+        }
+    }
+
+    private Path[] getNodePaths(InternalTestCluster cluster, String name) {
+        final NodeEnvironment nodeEnvironment = cluster.getInstance(NodeEnvironment.class, name);
+        if (nodeEnvironment.hasNodeFile()) {
+            return nodeEnvironment.nodeDataPaths();
+        } else {
+            return new Path[0];
+        }
+    }
+
+    public void testDifferentRolesMaintainPathOnRestart() throws Exception {
+        final Path baseDir = createTempDir();
+        InternalTestCluster cluster = new InternalTestCluster("local", randomLong(), baseDir, true, 0, 0, "test",
+            new NodeConfigurationSource() {
+                @Override
+                public Settings nodeSettings(int nodeOrdinal) {
+                    return Settings.builder().put(DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), 0).build();
+                }
+
+                @Override
+                public Settings transportClientSettings() {
+                    return Settings.EMPTY;
+                }
+            }, 0, randomBoolean(), "", Collections.emptyList(), Function.identity());
+        cluster.beforeTest(random(), 0.0);
+        try {
+            Map<DiscoveryNode.Role, Set<String>> pathsPerRole = new HashMap<>();
+            for (int i = 0; i < 5; i++) {
+                final DiscoveryNode.Role role = randomFrom(MASTER, DiscoveryNode.Role.DATA, DiscoveryNode.Role.INGEST);
+                final String node;
+                switch (role) {
+                    case MASTER:
+                        node = cluster.startMasterOnlyNode(Settings.EMPTY);
+                        break;
+                    case DATA:
+                        node = cluster.startDataOnlyNode(Settings.EMPTY);
+                        break;
+                    case INGEST:
+                        node = cluster.startCoordinatingOnlyNode(Settings.EMPTY);
+                        break;
+                    default:
+                        throw new IllegalStateException("get your story straight");
+                }
+                Set<String> rolePaths = pathsPerRole.computeIfAbsent(role, k -> new HashSet<>());
+                for (Path path : getNodePaths(cluster, node)) {
+                    assertTrue(rolePaths.add(path.toString()));
+                }
+            }
+            cluster.fullRestart();
+
+            Map<DiscoveryNode.Role, Set<String>> result = new HashMap<>();
+            for (String name : cluster.getNodeNames()) {
+                DiscoveryNode node = cluster.getInstance(ClusterService.class, name).localNode();
+                List<String> paths = Arrays.stream(getNodePaths(cluster, name)).map(Path::toString).collect(Collectors.toList());
+                if (node.isMasterNode()) {
+                    result.computeIfAbsent(MASTER, k -> new HashSet<>()).addAll(paths);
+                } else if (node.isDataNode()) {
+                    result.computeIfAbsent(DATA, k -> new HashSet<>()).addAll(paths);
+                } else {
+                    result.computeIfAbsent(INGEST, k -> new HashSet<>()).addAll(paths);
+                }
+            }
+
+            assertThat(result.size(), equalTo(pathsPerRole.size()));
+            for (DiscoveryNode.Role role : result.keySet()) {
+                assertThat("path are not the same for " + role, result.get(role), equalTo(pathsPerRole.get(role)));
+            }
+        } finally {
+            cluster.close();
+        }
+
     }
 }


### PR DESCRIPTION
The plan for persistent node ids ( #17811 ) is to tie the node identity to a file stored in it's data folders. As such it becomes important that nodes in our testing infra have better affinity with their data folders and that their data folders are not cleaned underneath them. The first is important because we fix the random seed used for node id generation (for reproducibility) and allowing the same node to use two different data folders causes two separate nodes to have the same id, which prevents the cluster from forming. The second is important, for example, where a full cluster restart / single node restart need to maintain node identity and wiping the data folders at the wrong moment prevents this.

Concretely this PR does the following:
1) Remove previous attempts to have data folder per role using a prefix. This wasn't effective as it was using the data paths settings which are only used for part of the runs. An attempt to completely separate the paths via the home dir failed due to assumptions made by index custom path about node data folder ordinal uniqueness  (see #19076)
2) Change full cluster restarts to start up nodes in the same order their were first created in, only randomly swapping nodes with the same roles.
3) Change test cluster reset methods to first shutdown the unneeded nodes and then re-start the shared nodes that were shut down, so they'll reclaim their data folders.
4) Improve data folder wiping logic and make sure it wipes only folders of "offline" nodes.
5) Add some very basic tests
