### PR TITLE
Support new Asia Pacific (Mumbai) ap-south-1 AWS region

### DIFF
--- a/docs/plugins/discovery-ec2.asciidoc
+++ b/docs/plugins/discovery-ec2.asciidoc
@@ -105,19 +105,18 @@ cloud:
 The `cloud.aws.region` can be set to a region and will automatically use the relevant settings for both `ec2` and `s3`.
 The available values are:
 
-* `us-east` (`us-east-1`)
-* `us-west` (`us-west-1`)
-* `us-west-1`
-* `us-west-2`
-* `ap-southeast` (`ap-southeast-1`)
-* `ap-southeast-1`
-* `ap-southeast-2`
-* `ap-northeast` (`ap-northeast-1`)
-* `ap-northeast-2` (`ap-northeast-2`)
-* `eu-west` (`eu-west-1`)
-* `eu-central` (`eu-central-1`)
-* `sa-east` (`sa-east-1`)
-* `cn-north` (`cn-north-1`)
+* `us-east` (`us-east-1`) for US East (N. Virginia)
+* `us-west` (`us-west-1`) for US West (N. California)
+* `us-west-2` for US West (Oregon)
+* `ap-south-1` for Asia Pacific (Mumbai)
+* `ap-southeast` (`ap-southeast-1`) for Asia Pacific (Singapore)
+* `ap-southeast-2` for Asia Pacific (Sydney)
+* `ap-northeast` (`ap-northeast-1`) for Asia Pacific (Tokyo)
+* `ap-northeast-2` (`ap-northeast-2`) for Asia Pacific (Seoul)
+* `eu-west` (`eu-west-1`) for EU (Ireland)
+* `eu-central` (`eu-central-1`) for EU (Frankfurt)
+* `sa-east` (`sa-east-1`) for South America (São Paulo)
+* `cn-north` (`cn-north-1`) for China (Beijing)
 
 [[discovery-ec2-usage-signer]]
 ===== EC2 Signer API

--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -110,19 +110,18 @@ The `cloud.aws.region` can be set to a region and will automatically use the rel
 You can specifically set it for s3 only using `cloud.aws.s3.region`.
 The available values are:
 
-* `us-east` (`us-east-1`)
-* `us-west` (`us-west-1`)
-* `us-west-1`
-* `us-west-2`
-* `ap-southeast` (`ap-southeast-1`)
-* `ap-southeast-1`
-* `ap-southeast-2`
-* `ap-northeast` (`ap-northeast-1`)
-* `ap-northeast-2` (`ap-northeast-2`)
-* `eu-west` (`eu-west-1`)
-* `eu-central` (`eu-central-1`)
-* `sa-east` (`sa-east-1`)
-* `cn-north` (`cn-north-1`)
+* `us-east` (`us-east-1`) for US East (N. Virginia)
+* `us-west` (`us-west-1`) for US West (N. California)
+* `us-west-2` for US West (Oregon)
+* `ap-south-1` for Asia Pacific (Mumbai)
+* `ap-southeast` (`ap-southeast-1`) for Asia Pacific (Singapore)
+* `ap-southeast-2` for Asia Pacific (Sydney)
+* `ap-northeast` (`ap-northeast-1`) for Asia Pacific (Tokyo)
+* `ap-northeast-2` (`ap-northeast-2`) for Asia Pacific (Seoul)
+* `eu-west` (`eu-west-1`) for EU (Ireland)
+* `eu-central` (`eu-central-1`) for EU (Frankfurt)
+* `sa-east` (`sa-east-1`) for South America (São Paulo)
+* `cn-north` (`cn-north-1`) for China (Beijing)
 
 [[repository-s3-usage-signer]]
 ===== S3 Signer API

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2ServiceImpl.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2ServiceImpl.java
@@ -148,6 +148,8 @@ public class AwsEc2ServiceImpl extends AbstractLifecycleComponent<AwsEc2Service>
                 endpoint = "ec2.ap-southeast-1.amazonaws.com";
             } else if (region.equals("us-gov-west") || region.equals("us-gov-west-1")) {
                 endpoint = "ec2.us-gov-west-1.amazonaws.com";
+            } else if (region.equals("ap-south-1")) {
+                endpoint = "ec2.ap-south-1.amazonaws.com";
             } else if (region.equals("ap-southeast-2")) {
                 endpoint = "ec2.ap-southeast-2.amazonaws.com";
             } else if (region.equals("ap-northeast") || region.equals("ap-northeast-1")) {

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -155,6 +155,8 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent<AwsS3Servic
             return "s3-us-west-1.amazonaws.com";
         } else if ("us-west-2".equals(region)) {
             return "s3-us-west-2.amazonaws.com";
+        } else if (region.equals("ap-south-1")) {
+            return "s3-ap-south-1.amazonaws.com";
         } else if ("ap-southeast".equals(region) || "ap-southeast-1".equals(region)) {
             return "s3-ap-southeast-1.amazonaws.com";
         } else if ("ap-southeast-2".equals(region)) {


### PR DESCRIPTION
AWS [announced](http://www.allthingsdistributed.com/2016/06/introducing-aws-asia-pacific-mumbai-region.html) a new region: Asia Pacific (Mumbai)    `ap-south-1`.

We need to support it for:
- repository-s3: s3.ap-south-1.amazonaws.com or s3-ap-south-1.amazonaws.com
- discovery-ec2: ec2.ap-south-1.amazonaws.com

For reference: http://docs.aws.amazon.com/general/latest/gr/rande.html

Closes #19110.
