### PR TITLE
`index.checksum_on_merge` should default to `true`

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -60,7 +60,7 @@ public final class EngineConfig {
     private volatile boolean enableGcDeletes = true;
     private final String codecName;
     private final boolean optimizeAutoGenerateId;
-    private volatile boolean checksumOnMerge;
+    private volatile boolean checksumOnMerge = true;
     private final ThreadPool threadPool;
     private final ShardIndexingService indexingService;
     private final IndexSettingsService indexSettingsService;

--- a/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -1749,4 +1749,12 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
             });
         }
     }
+
+    public void testEngineDefaults() {
+        IndexSettingsService indexSettingsService = new IndexSettingsService(shardId.index(),
+                ImmutableSettings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build());
+        EngineConfig config = config(indexSettingsService, engine.store, engine.config().getTranslog(),
+                engine.config().getMergeScheduler());
+        assertTrue(config.isChecksumOnMerge());
+    }
 }


### PR DESCRIPTION
This was lost in a refactoring and should default to true to ensure we catch corruptions
where they happen.

Note this only applies to the 1.7 branch
