### PR TITLE
Add missing permission for S3 repository

### DIFF
--- a/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobContainer.java
+++ b/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobContainer.java
@@ -20,7 +20,13 @@
 package org.elasticsearch.cloud.aws.blobstore;
 
 import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.s3.model.*;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.blobstore.BlobPath;
@@ -33,6 +39,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.util.Map;
 
 /**
@@ -55,10 +64,19 @@ public class S3BlobContainer extends AbstractLegacyBlobContainer {
     }
 
     @Override
-    public boolean blobExists(String blobName) {
+    public boolean blobExists(final String blobName) {
         try {
-            blobStore.client().getObjectMetadata(blobStore.bucket(), buildKey(blobName));
-            return true;
+            return doPrivileged(new PrivilegedExceptionAction<Boolean>() {
+                @Override
+                public Boolean run() throws Exception {
+                    try {
+                        blobStore.client().getObjectMetadata(blobStore.bucket(), buildKey(blobName));
+                        return true;
+                    } catch (AmazonS3Exception e) {
+                        return false;
+                    }
+                }
+            });
         } catch (AmazonS3Exception e) {
             return false;
         } catch (Throwable e) {
@@ -159,4 +177,18 @@ public class S3BlobContainer extends AbstractLegacyBlobContainer {
         return keyPath + blobName;
     }
 
+    /**
+     * Executes a {@link PrivilegedExceptionAction} with privileges enabled.
+     */
+    <T> T doPrivileged(PrivilegedExceptionAction<T> operation) throws IOException {
+        SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPermission(new SpecialPermission());
+        }
+        try {
+            return AccessController.doPrivileged(operation);
+        } catch (PrivilegedActionException e) {
+            throw (IOException) e.getException();
+        }
+    }
 }

--- a/plugins/cloud-aws/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/cloud-aws/src/main/plugin-metadata/plugin-security.policy
@@ -23,4 +23,10 @@ grant {
   // NOTE: no tests fail without this, but we know the problem
   // exists in AWS sdk, and tests here are not thorough
   permission java.lang.RuntimePermission "getClassLoader";
+  // Required by AmazonS3Client because when the region is not
+  // explicitly set the AmazonS3Client.resolveServiceEndpoint()
+  // method tries to load all known regions using PartitionsLoader
+  // and this one uses Jackson databinding and reflections to load
+  // the com/amazonaws/partitions/endpoints.json file.
+  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };

--- a/plugins/cloud-aws/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/cloud-aws/src/main/plugin-metadata/plugin-security.policy
@@ -23,10 +23,14 @@ grant {
   // NOTE: no tests fail without this, but we know the problem
   // exists in AWS sdk, and tests here are not thorough
   permission java.lang.RuntimePermission "getClassLoader";
-  // Required by AmazonS3Client because when the region is not
-  // explicitly set the AmazonS3Client.resolveServiceEndpoint()
-  // method tries to load all known regions using PartitionsLoader
-  // and this one uses Jackson databinding and reflections to load
-  // the com/amazonaws/partitions/endpoints.json file.
+  // Needed because of problems in AmazonS3Client:
+  // When no region is set on a AmazonS3Client instance, the
+  // AWS SDK loads all known partitions from a JSON file and
+  // uses a Jackson's ObjectMapper for that: this one, in
+  // version 2.5.3 with the default binding options, tries
+  // to suppress access checks of ctor/field/method and thus
+  // requires this special permission. AWS must be fixed to
+  // uses Jackson correctly and have the correct modifiers
+  // on binded classes.
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };


### PR DESCRIPTION
Note: PR against 2.4 branch, master will follow.

S3 repository needs a special permission to work because when no region is explicitly set the AWS SDK will load a JSON file that contain all Amazon's endpoints and will map the content of this file to plain old Java objects. To do that, it uses Jackson's databinding and reflection that require the  `java.lang.reflect.ReflectPermission "suppressAccessChecks"` permission.

This issue only occur if no region is set in the repository setting and in the elasticsearch.yml file.

closes #18539
