### PR TITLE
Add missing permission to repository-s3

### DIFF
--- a/plugins/repository-s3/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/repository-s3/src/main/plugin-metadata/plugin-security.policy
@@ -22,4 +22,16 @@ grant {
   // TODO: get these fixed in aws sdk
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.RuntimePermission "getClassLoader";
+  // Needed because of problems in AmazonS3Client:
+  // When no region is set on a AmazonS3Client instance, the
+  // AWS SDK loads all known partitions from a JSON file and
+  // uses a Jackson's ObjectMapper for that: this one, in
+  // version 2.5.3 with the default binding options, tries
+  // to suppress access checks of ctor/field/method and thus
+  // requires this special permission. AWS must be fixed to
+  // uses Jackson correctly and have the correct modifiers
+  // on binded classes.
+  // TODO: get these fixed in aws sdk
+  // See https://github.com/aws/aws-sdk-java/issues/766
+  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };


### PR DESCRIPTION
Note: PR against master branch, 2.4 is #19121

S3 repository needs a special permission to work because when no region is explicitly set the AWS SDK will load a JSON file that contain all Amazon's endpoints and will map the content of this file to plain old Java objects. To do that, it uses Jackson's databinding and reflection that require the java.lang.reflect.ReflectPermission "suppressAccessChecks" permission.

This issue only occur if no region is set in the repository setting and in the elasticsearch.yml file.

closes #18539
