### PR TITLE
Proof of concept: Build actions "without" guice 

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -233,7 +233,6 @@
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]bootstrap[/\\]Security.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]ElasticsearchClient.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]FilterClient.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]node[/\\]NodeClient.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]support[/\\]AbstractClient.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]transport[/\\]TransportClient.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]transport[/\\]support[/\\]TransportProxyClient.java" checks="LineLength" />

--- a/core/src/main/java/org/elasticsearch/client/node/NodeClient.java
+++ b/core/src/main/java/org/elasticsearch/client/node/NodeClient.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.GenericAction;
 import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.client.support.AbstractClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;

--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -148,7 +148,7 @@ public class TransportClient extends AbstractClient {
                         // noop
                     }
                 });
-                modules.add(new ActionModule(false, true, settings, null, settingsModule.getClusterSettings(),
+                modules.add(new ActionModule(null, false, settings, null, settingsModule.getClusterSettings(),
                         pluginsService.filterPlugins(ActionPlugin.class)));
 
                 pluginsService.processModules(modules);

--- a/core/src/main/java/org/elasticsearch/common/ReflectiveInstantiator.java
+++ b/core/src/main/java/org/elasticsearch/common/ReflectiveInstantiator.java
@@ -35,7 +35,8 @@ import java.util.Set;
  * to be explicit.</li>
  * <li>Only ever instantiate a class once. If you attempt to instantiate a class twice you just get the same instance back.</li>
  * <li>If a constructor argument isn't available on the pool then it is ok to provide it from the instantiated classes but *only* if it has
- * been explicitly permitted</li>
+ * been explicitly permitted. This makes instantiation order dependent but prevents unapproved dependencies from leaking into instantiated
+ * objects.</li>
  * </ul> 
  */
 public class ReflectiveInstantiator {
@@ -86,10 +87,7 @@ public class ReflectiveInstantiator {
                                 "Attempting to reuse a [" + params[p].getTypeName() + "] but that hasn't been explicitly permitted.");
                     }
                 }
-                args[p] = ctorArgs.get(params[p]);
-                if (args[p] == null) {
-                    throw new IllegalArgumentException("Don't have a [" + params[p].getTypeName() + "] available.");
-                }
+                throw new IllegalArgumentException("Don't have a [" + params[p].getTypeName() + "] available.");
             }
             T instantiated = clazz.cast(ctor.newInstance(args));
             built.put(clazz, instantiated);

--- a/core/src/main/java/org/elasticsearch/common/SimpleReflectiveInstantiator.java
+++ b/core/src/main/java/org/elasticsearch/common/SimpleReflectiveInstantiator.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+import org.elasticsearch.common.inject.Inject;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SimpleReflectiveInstantiator {
+    private final Map<Type, Object> ctorArgs = new HashMap<>();
+    private final Map<Class<?>, Object> built = new HashMap<>();
+
+    public void addCtorArg(Object o) {
+        addCtorArg(o.getClass(), o);
+    }
+
+    public void addCtorArg(Type type, Object o) {
+        ctorArgs.put(type, o);
+    }
+
+    public <T> T instantiate(Class<T> clazz) { // TODO set of classes allowed to load from built
+        Object fetched = built.get(clazz);
+        if (fetched != null) {
+            return clazz.cast(fetched);
+        }
+        try {
+            Constructor<?> ctor = pickConstructor(clazz);
+            if (ctor == null) {
+                return clazz.newInstance();
+            }
+            Type[] params = ctor.getGenericParameterTypes();
+            Object[] args = new Object[params.length];
+            for (int p = 0; p < args.length; p++) {
+                args[p] = built.get(params[p]);
+                if (args[p] != null) continue;
+                args[p] = ctorArgs.get(params[p]);
+                if (args[p] == null) {
+                    throw new IllegalArgumentException("Don't have a [" + params[p].getTypeName() + "] available.");
+                }
+            }
+            T instantiated = clazz.cast(ctor.newInstance(args));
+            built.put(clazz, instantiated);
+            return instantiated;
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            throw new RuntimeException("Error building [" + clazz.getName() + "]: " + e.getMessage(), e);
+        }
+    }
+
+    private Constructor<?> pickConstructor(Class<?> clazz) {
+        Constructor<?>[] ctors = (Constructor<?>[]) clazz.getConstructors();
+        if (ctors.length == 0) {
+            return null; // NOCOMMIT is this a thing?
+        }
+        if (ctors.length == 1) {
+            return ctors[0];
+        }
+        for (Constructor<?> ctor : ctors) {
+            if (ctor.getAnnotation(Inject.class) != null) {
+                return ctor;
+            }
+        }
+        throw new IllegalArgumentException("[" + clazz + "] has [" + ctors.length + "] constructors but non are annotated with @Inject");
+    }
+}

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -52,7 +52,7 @@ import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.SimpleReflectiveInstantiator;
+import org.elasticsearch.common.ReflectiveInstantiator;
 import org.elasticsearch.common.StopWatch;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.component.LifecycleComponent;
@@ -316,7 +316,7 @@ public class Node implements Closeable {
             );
             injector = modules.createInjector();
             // Each one of the injector.getInstance calls need individual attention....
-            SimpleReflectiveInstantiator instantiator = new SimpleReflectiveInstantiator();
+            ReflectiveInstantiator instantiator = new ReflectiveInstantiator();
             instantiator.addCtorArg(environment);
             instantiator.addCtorArg(threadPool);
             instantiator.addCtorArg(clusterService);

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -98,6 +98,7 @@ import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.indices.cluster.IndicesClusterStateService;
 import org.elasticsearch.indices.flush.SyncedFlushService;
+import org.elasticsearch.indices.query.IndicesQueriesRegistry;
 import org.elasticsearch.indices.store.IndicesStore;
 import org.elasticsearch.indices.ttl.IndicesTTLService;
 import org.elasticsearch.monitor.MonitorService;
@@ -118,8 +119,10 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.action.SearchTransportService;
+import org.elasticsearch.search.aggregations.AggregatorParsers;
 import org.elasticsearch.search.controller.SearchPhaseController;
 import org.elasticsearch.search.fetch.FetchPhase;
+import org.elasticsearch.search.suggest.Suggesters;
 import org.elasticsearch.snapshots.RestoreService;
 import org.elasticsearch.snapshots.SnapshotShardsService;
 import org.elasticsearch.snapshots.SnapshotsService;
@@ -354,8 +357,11 @@ public class Node implements Closeable {
             instantiator.addCtorArg(injector.getInstance(RestoreService.class));
             instantiator.addCtorArg(injector.getInstance(SettingsFilter.class));
             instantiator.addCtorArg(ClusterInfoService.class, injector.getInstance(ClusterInfoService.class));
+            instantiator.addCtorArg(injector.getInstance(IndicesQueriesRegistry.class));
+            instantiator.addCtorArg(injector.getInstance(AggregatorParsers.class));
+            instantiator.addCtorArg(injector.getInstance(Suggesters.class));
 
-            actionModule.buildActions(instantiator);
+            actionModule.buildActions(instantiator, injector);
             success = true;
         } catch (IOException ex) {
             throw new ElasticsearchException("failed to bind service", ex);

--- a/core/src/main/java/org/elasticsearch/plugins/ActionPlugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/ActionPlugin.java
@@ -25,10 +25,14 @@ import org.elasticsearch.action.GenericAction;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.support.TransportActions;
+import org.elasticsearch.common.inject.Injector;
 
+import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 
 /**
  * An additional extension point for {@link Plugin}s that extends Elasticsearch's scripting functionality. Implement it like this:
@@ -54,6 +58,19 @@ public interface ActionPlugin {
      */
     default List<Class<? extends ActionFilter>> getActionFilters() {
         return emptyList();
+    }
+    /**
+     * Resolve the dependencies needed to build the actions. Called when and if actions are built (so, not for the transport client).
+     */
+    default Map<Type, ? extends Object> getActionDependencies() {
+        return emptyMap();
+    }
+    /**
+     * Resolve the dependencies needed to build the actions from a guice {@link Injector}. Called when and if actions are built (so, not for
+     * the transport client). Prefer {@link #getActionDependencies()} where possible.
+     */
+    default Map<Type, ? extends Object> getActionDependencies(Injector injector) {
+        return getActionDependencies();
     }
 
     public static final class ActionHandler<Request extends ActionRequest<Request>, Response extends ActionResponse> {

--- a/core/src/main/java/org/elasticsearch/plugins/ActionPlugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/ActionPlugin.java
@@ -64,6 +64,10 @@ public interface ActionPlugin {
         /**
          * Create a record of an action, the {@linkplain TransportAction} that handles it, and any supporting {@linkplain TransportActions}
          * that are needed by that {@linkplain TransportAction}.
+         * 
+         * @param supportTransportActions
+         *            array of supporting actions. These are built from back to front so list actions that rely on other actions in the list
+         *            before the actions on which they rely
          */
         public ActionHandler(GenericAction<Request, Response> action, Class<? extends TransportAction<Request, Response>> transportAction,
                 Class<?>... supportTransportActions) {

--- a/core/src/test/java/org/elasticsearch/client/node/NodeClientHeadersTests.java
+++ b/core/src/test/java/org/elasticsearch/client/node/NodeClientHeadersTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.AbstractClientHeadersTestCase;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -46,7 +45,9 @@ public class NodeClientHeadersTests extends AbstractClientHeadersTestCase {
     protected Client buildClient(Settings headersSettings, GenericAction[] testedActions) {
         Settings settings = HEADER_SETTINGS;
         Actions actions = new Actions(settings, threadPool, testedActions);
-        return new NodeClient(settings, threadPool, actions);
+        NodeClient client = new NodeClient(settings, threadPool);
+        client.initialize(actions);
+        return client;
     }
 
     private static class Actions extends HashMap<GenericAction, TransportAction> {

--- a/core/src/test/java/org/elasticsearch/common/ReflectiveInstantiatorTests.java
+++ b/core/src/test/java/org/elasticsearch/common/ReflectiveInstantiatorTests.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.Matchers.startsWith;
+
+public class ReflectiveInstantiatorTests extends ESTestCase {
+    public void testBuildObjectWithoutCtor() {
+        ReflectiveInstantiator ri = new ReflectiveInstantiator();
+        NoCtor noCtor = ri.instantiate(NoCtor.class, emptySet());
+        // Building it twice gets you the same instance
+        assertThat(ri.instantiate(NoCtor.class, emptySet()), sameInstance(noCtor));
+    }
+
+    public void testBuildWithCtorArg() {
+        ReflectiveInstantiator ri = new ReflectiveInstantiator();
+        NoCtor noCtor = new NoCtor();
+        ri.addCtorArg(noCtor);
+        Simple simple = ri.instantiate(Simple.class, emptySet()); 
+        assertThat(simple.noCtor, sameInstance(noCtor));
+    }
+
+    public void testBuildWithPreBuilt() {
+        ReflectiveInstantiator ri = new ReflectiveInstantiator();
+        NoCtor noCtor = ri.instantiate(NoCtor.class, emptySet());
+        Simple simple = ri.instantiate(Simple.class, singleton(NoCtor.class));
+        assertThat(simple.noCtor, sameInstance(noCtor));
+    }
+
+    public void testBuildWithPreBuiltNoAllowed() {
+        ReflectiveInstantiator ri = new ReflectiveInstantiator();
+        ri.instantiate(NoCtor.class, emptySet());
+        Throwable t = expectThrows(RuntimeException.class, () -> ri.instantiate(Simple.class, emptySet()));
+        assertThat(t.getMessage(), startsWith("Error building [org.elasticsearch.common.ReflectiveInstantiatorTests$Simple]:"));
+        assertThat(t.getCause(), instanceOf(IllegalArgumentException.class));
+        t = t.getCause();
+        assertEquals("Attempting to reuse a [org.elasticsearch.common.ReflectiveInstantiatorTests$NoCtor] but that hasn't been "
+                + "explicitly permitted.", t.getMessage());
+    }
+
+    public void testDuplicateCtorArgument() {
+        ReflectiveInstantiator ri = new ReflectiveInstantiator();
+        NoCtor noCtor = new NoCtor();
+        ri.addCtorArg(noCtor);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> ri.addCtorArg(noCtor));
+        assertThat(e.getMessage(), startsWith(
+                "Attempted to register a duplicate ctor argument for [org.elasticsearch.common.ReflectiveInstantiatorTests$NoCtor]."));
+        assertThat(e.getMessage(), containsString("Was [org.elasticsearch.common.ReflectiveInstantiatorTests$NoCtor@"));
+        assertThat(e.getMessage(),
+                containsString("and attempted to register [org.elasticsearch.common.ReflectiveInstantiatorTests$NoCtor@"));
+    }
+
+    public static class NoCtor {}
+    public static class Simple {
+        private final NoCtor noCtor;
+        public Simple(NoCtor noCtor) {
+            this.noCtor = noCtor;
+        }
+    }
+}

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustachePlugin.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustachePlugin.java
@@ -21,6 +21,7 @@ package org.elasticsearch.script.mustache;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.search.template.MultiSearchTemplateAction;
 import org.elasticsearch.action.search.template.SearchTemplateAction;
 import org.elasticsearch.action.search.template.TransportMultiSearchTemplateAction;
@@ -50,8 +51,10 @@ public class MustachePlugin extends Plugin implements ScriptPlugin, ActionPlugin
 
     @Override
     public List<ActionHandler<? extends ActionRequest<?>, ? extends ActionResponse>> getActions() {
-        return Arrays.asList(new ActionHandler<>(SearchTemplateAction.INSTANCE, TransportSearchTemplateAction.class),
-                new ActionHandler<>(MultiSearchTemplateAction.INSTANCE, TransportMultiSearchTemplateAction.class));
+        return Arrays.asList(
+                new ActionHandler<>(SearchTemplateAction.INSTANCE, TransportSearchTemplateAction.class, TransportSearchAction.class),
+                new ActionHandler<>(MultiSearchTemplateAction.INSTANCE, TransportMultiSearchTemplateAction.class,
+                        TransportSearchTemplateAction.class, TransportSearchAction.class));
     }
 
     public void onModule(NetworkModule module) {


### PR DESCRIPTION
Instead of building actions with guice this instead builds them using
a simple helper around reflective constructor invocation. Guice is
still used for resolving services, but those that are available
outside of guice are used instead. This provides a "path away from
guice": we work to resolve all of the services without guice. Once
we've done so we should be 90% of the way to removing guice.
