### PR TITLE
[TEST] fix vagrant tests for seed with format ABC:DEF

### DIFF
--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -64,7 +64,8 @@ String upgradeFromVersion
 
 String maybeTestsSeed = System.getProperty("tests.seed", null);
 if (maybeTestsSeed != null) {
-  seed = new BigInteger(maybeTestsSeed, 16).longValue()
+  def (masterSeed, testSeed) = maybeTestsSeed.tokenize(':')
+  seed = new BigInteger(masterSeed, masterSeed.size()).longValue()
   formattedSeed = maybeTestsSeed
 } else {
   seed = new Random().nextLong()

--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -67,7 +67,7 @@ if (maybeTestsSeed != null) {
   List<String> seeds = maybeTestsSeed.tokenize(':')
   if (seeds.size() != 0) {
     String masterSeed = seeds.get(0)
-    seed = new BigInteger(masterSeed, masterSeed.length()).longValue()
+    seed = new BigInteger(masterSeed, 16).longValue()
     formattedSeed = maybeTestsSeed
   }
 }

--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -58,16 +58,20 @@ for (String box : vagrantBoxes.split(',')) {
 }
 
 long seed
-String formattedSeed
+String formattedSeed = null
 String[] upgradeFromVersions
 String upgradeFromVersion
 
 String maybeTestsSeed = System.getProperty("tests.seed", null);
 if (maybeTestsSeed != null) {
-  def (masterSeed, testSeed) = maybeTestsSeed.tokenize(':')
-  seed = new BigInteger(masterSeed, masterSeed.size()).longValue()
-  formattedSeed = maybeTestsSeed
-} else {
+  List<String> seeds = maybeTestsSeed.tokenize(':')
+  if (seeds.size() != 0) {
+    String masterSeed = seeds.get(0)
+    seed = new BigInteger(masterSeed, masterSeed.length()).longValue()
+    formattedSeed = maybeTestsSeed
+  }
+}
+if (formattedSeed == null) {
   seed = new Random().nextLong()
   formattedSeed = String.format("%016X", seed)
 }


### PR DESCRIPTION
Otherwise one gets an error message when passing
-Dtests.seed=ABC:DEF
to any test run.
