### PR TITLE
Also support query term extract for queries wrapped inside a FunctionScoreQuery

### DIFF
--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/ExtractQueryTermsService.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/ExtractQueryTermsService.java
@@ -49,6 +49,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.lucene.search.MatchNoDocsQuery;
+import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
 import org.elasticsearch.index.mapper.ParseContext;
 
 import java.io.IOException;
@@ -75,7 +76,7 @@ public final class ExtractQueryTermsService {
     static final Map<Class<? extends Query>, Function<Query, Result>> queryProcessors;
 
     static {
-        Map<Class<? extends Query>, Function<Query, Result>> map = new HashMap<>(16);
+        Map<Class<? extends Query>, Function<Query, Result>> map = new HashMap<>(17);
         map.put(MatchNoDocsQuery.class, matchNoDocsQuery());
         map.put(ConstantScoreQuery.class, constantScoreQuery());
         map.put(BoostQuery.class, boostQuery());
@@ -92,6 +93,7 @@ public final class ExtractQueryTermsService {
         map.put(BooleanQuery.class, booleanQuery());
         map.put(DisjunctionMaxQuery.class, disjunctionMaxQuery());
         map.put(SynonymQuery.class, synonymQuery());
+        map.put(FunctionScoreQuery.class, functionScoreQuery());
         queryProcessors = Collections.unmodifiableMap(map);
     }
 
@@ -373,6 +375,16 @@ public final class ExtractQueryTermsService {
         return query -> {
             List<Query> disjuncts = ((DisjunctionMaxQuery) query).getDisjuncts();
             return handleDisjunction(disjuncts, 1, false);
+        };
+    }
+
+    static Function<Query, Result> functionScoreQuery() {
+        return query -> {
+            Result result = extractQueryTerms(((FunctionScoreQuery) query).getSubQuery());
+            // If min_score is specified we can't guarantee upfront that this percolator query always matches
+            // if it matches with the percolator document matches with the extracted terms.
+            // Min score filters out docs, which is different than the functions, which just influences the score.
+            return new Result(false, result.terms);
         };
     }
 

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
@@ -25,9 +25,11 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.query.ParsedQuery;
@@ -110,10 +112,19 @@ public final class PercolatorHighlightSubFetchPhase extends HighlightPhase {
                     return result;
                 }
             }
+        } else if (query instanceof DisjunctionMaxQuery) {
+            for (Query disjunct : ((DisjunctionMaxQuery) query).getDisjuncts()) {
+                PercolateQuery result = locatePercolatorQuery(disjunct);
+                if (result != null) {
+                    return result;
+                }
+            }
         } else if (query instanceof ConstantScoreQuery) {
             return locatePercolatorQuery(((ConstantScoreQuery) query).getQuery());
         } else if (query instanceof BoostQuery) {
             return locatePercolatorQuery(((BoostQuery) query).getQuery());
+        } else if (query instanceof FunctionScoreQuery) {
+            return locatePercolatorQuery(((FunctionScoreQuery) query).getSubQuery());
         }
 
         return null;

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/ExtractQueryTermsServiceTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/ExtractQueryTermsServiceTests.java
@@ -46,6 +46,8 @@ import org.apache.lucene.search.spans.SpanOrQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.search.MatchNoDocsQuery;
+import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
+import org.elasticsearch.common.lucene.search.function.RandomScoreFunction;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.percolator.ExtractQueryTermsService.Result;
 import org.elasticsearch.test.ESTestCase;
@@ -569,6 +571,14 @@ public class ExtractQueryTermsServiceTests extends ESTestCase {
         result = extractQueryTerms(query);
         assertThat(result.verified, is(true));
         assertTermsEqual(result.terms, new Term("_field", "_value1"), new Term("_field", "_value2"));
+    }
+
+    public void testFunctionScoreQuery() {
+        TermQuery termQuery = new TermQuery(new Term("_field", "_value"));
+        FunctionScoreQuery functionScoreQuery = new FunctionScoreQuery(termQuery, new RandomScoreFunction());
+        Result result = extractQueryTerms(functionScoreQuery);
+        assertThat(result.verified, is(false));
+        assertTermsEqual(result.terms, new Term("_field", "_value"));
     }
 
     public void testCreateQueryMetadataQuery() throws Exception {


### PR DESCRIPTION
Additionally for highlighting percolator hits, also extract percolator query from FunctionScoreQuery and DisjunctionMaxQuery
