### PR TITLE
Add support for extracting ranges from percolator queries

### DIFF
--- a/docs/reference/mapping/types/percolator.asciidoc
+++ b/docs/reference/mapping/types/percolator.asciidoc
@@ -71,10 +71,13 @@ a percolator query does not exist, it will be handled as a default string field 
 fail.
 
 [float]
-==== Important Notes
+==== Limitations
 
 Because the `percolate` query is processing one document at a time, it doesn't support queries and filters that run
 against child documents such as `has_child` and `has_parent`.
+
+The percolator doesn't accepts percolator queries containing `range` queries with ranges that are based on current
+time (using `now`).
 
 There are a number of queries that fetch data via a get call during query parsing. For example the `terms` query when
 using terms lookup, `template` query when using indexed scripts and `geo_shape` when using pre-indexed shapes. When these

--- a/docs/reference/migration/migrate_5_0/percolator.asciidoc
+++ b/docs/reference/migration/migrate_5_0/percolator.asciidoc
@@ -48,6 +48,11 @@ the existing document.
 
 The percolate stats have been removed. This is because the percolator no longer caches the percolator queries.
 
+==== Percolator queries containing range queries with now ranges
+
+The percolator no longer accepts percolator queries containing `range` queries with ranges that are based on current
+time (using `now`).
+
 ==== Java client
 
 The percolator is no longer part of the core elasticsearch dependency. It has moved to the percolator module.

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/MultiPercolateAction.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/MultiPercolateAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.percolator;
 import org.elasticsearch.action.Action;
 import org.elasticsearch.client.ElasticsearchClient;
 
+@Deprecated
 public class MultiPercolateAction extends Action<MultiPercolateRequest, MultiPercolateResponse, MultiPercolateRequestBuilder> {
 
     public static final MultiPercolateAction INSTANCE = new MultiPercolateAction();

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateAction.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.percolator;
 import org.elasticsearch.action.Action;
 import org.elasticsearch.client.ElasticsearchClient;
 
+@Deprecated
 public class PercolateAction extends Action<PercolateRequest, PercolateResponse, PercolateRequestBuilder> {
 
     public static final PercolateAction INSTANCE = new PercolateAction();

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQuery.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQuery.java
@@ -22,13 +22,11 @@ package org.elasticsearch.percolator;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorer;
-import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
@@ -36,115 +34,39 @@ import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Bits;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.common.lucene.search.MatchNoDocsQuery;
 
 import java.io.IOException;
 import java.util.Objects;
 import java.util.Set;
 
-import static org.apache.lucene.search.BooleanClause.Occur.FILTER;
-
-public final class PercolateQuery extends Query implements Accountable {
+final class PercolateQuery extends Query implements Accountable {
 
     // cost of matching the query against the document, arbitrary as it would be really complex to estimate
     public static final float MATCH_COST = 1000;
 
-    public static class Builder {
-
-        private final String docType;
-        private final QueryStore queryStore;
-        private final BytesReference documentSource;
-        private final IndexSearcher percolatorIndexSearcher;
-
-        private Query queriesMetaDataQuery;
-        private Query verifiedQueriesQuery = new MatchNoDocsQuery("");
-        private Query percolateTypeQuery;
-
-        /**
-         * @param docType                   The type of the document being percolated
-         * @param queryStore                The lookup holding all the percolator queries as Lucene queries.
-         * @param documentSource            The source of the document being percolated
-         * @param percolatorIndexSearcher   The index searcher on top of the in-memory index that holds the document being percolated
-         */
-        public Builder(String docType, QueryStore queryStore, BytesReference documentSource, IndexSearcher percolatorIndexSearcher) {
-            this.docType = Objects.requireNonNull(docType);
-            this.queryStore = Objects.requireNonNull(queryStore);
-            this.documentSource = Objects.requireNonNull(documentSource);
-            this.percolatorIndexSearcher = Objects.requireNonNull(percolatorIndexSearcher);
-        }
-
-        /**
-         * Optionally sets a query that reduces the number of queries to percolate based on extracted terms from
-         * the document to be percolated.
-         * @param extractedTermsFieldName   The name of the field to get the extracted terms from
-         * @param extractionResultField     The field to indicate for a document whether query term extraction was complete,
-         *                                  partial or failed. If query extraction was complete, the MemoryIndex doesn't
-         */
-        public void extractQueryTermsQuery(String extractedTermsFieldName, String extractionResultField) throws IOException {
-            // We can only skip the MemoryIndex verification when percolating a single document.
-            // When the document being percolated contains a nested object field then the MemoryIndex contains multiple
-            // documents. In this case the term query that indicates whether memory index verification can be skipped
-            // can incorrectly indicate that non nested queries would match, while their nested variants would not.
-            if (percolatorIndexSearcher.getIndexReader().maxDoc() == 1) {
-                this.verifiedQueriesQuery = new TermQuery(new Term(extractionResultField, ExtractQueryTermsService.EXTRACTION_COMPLETE));
-            }
-            this.queriesMetaDataQuery = ExtractQueryTermsService.createQueryTermsQuery(
-                    percolatorIndexSearcher.getIndexReader(), extractedTermsFieldName,
-                    // include extractionResultField:failed, because docs with this term have no extractedTermsField
-                    // and otherwise we would fail to return these docs. Docs that failed query term extraction
-                    // always need to be verified by MemoryIndex:
-                    new Term(extractionResultField, ExtractQueryTermsService.EXTRACTION_FAILED)
-            );
-        }
-
-        /**
-         * @param percolateTypeQuery    A query that identifies all document containing percolator queries
-         */
-        public void setPercolateTypeQuery(Query percolateTypeQuery) {
-            this.percolateTypeQuery = Objects.requireNonNull(percolateTypeQuery);
-        }
-
-        public PercolateQuery build() {
-            if (percolateTypeQuery != null && queriesMetaDataQuery != null) {
-                throw new IllegalStateException("Either filter by deprecated percolator type or by query metadata");
-            }
-            // The query that selects which percolator queries will be evaluated by MemoryIndex:
-            BooleanQuery.Builder queriesQuery = new BooleanQuery.Builder();
-            if (percolateTypeQuery != null) {
-                queriesQuery.add(percolateTypeQuery, FILTER);
-            }
-            if (queriesMetaDataQuery != null) {
-                queriesQuery.add(queriesMetaDataQuery, FILTER);
-            }
-            return new PercolateQuery(docType, queryStore, documentSource, queriesQuery.build(), percolatorIndexSearcher,
-                    verifiedQueriesQuery);
-        }
-
-    }
-
     private final String documentType;
     private final QueryStore queryStore;
     private final BytesReference documentSource;
-    private final Query percolatorQueriesQuery;
-    private final Query verifiedQueriesQuery;
+    private final Query candidateMatchesQuery;
+    private final Query verifiedMatchesQuery;
     private final IndexSearcher percolatorIndexSearcher;
 
-    private PercolateQuery(String documentType, QueryStore queryStore, BytesReference documentSource,
-                           Query percolatorQueriesQuery, IndexSearcher percolatorIndexSearcher, Query verifiedQueriesQuery) {
-        this.documentType = documentType;
-        this.documentSource = documentSource;
-        this.percolatorQueriesQuery = percolatorQueriesQuery;
-        this.queryStore = queryStore;
-        this.percolatorIndexSearcher = percolatorIndexSearcher;
-        this.verifiedQueriesQuery = verifiedQueriesQuery;
+    PercolateQuery(String documentType, QueryStore queryStore, BytesReference documentSource,
+                          Query candidateMatchesQuery, IndexSearcher percolatorIndexSearcher, Query verifiedMatchesQuery) {
+        this.documentType = Objects.requireNonNull(documentType);
+        this.documentSource = Objects.requireNonNull(documentSource);
+        this.candidateMatchesQuery = Objects.requireNonNull(candidateMatchesQuery);
+        this.queryStore = Objects.requireNonNull(queryStore);
+        this.percolatorIndexSearcher = Objects.requireNonNull(percolatorIndexSearcher);
+        this.verifiedMatchesQuery = Objects.requireNonNull(verifiedMatchesQuery);
     }
 
     @Override
     public Query rewrite(IndexReader reader) throws IOException {
-        Query rewritten = percolatorQueriesQuery.rewrite(reader);
-        if (rewritten != percolatorQueriesQuery) {
+        Query rewritten = candidateMatchesQuery.rewrite(reader);
+        if (rewritten != candidateMatchesQuery) {
             return new PercolateQuery(documentType, queryStore, documentSource, rewritten, percolatorIndexSearcher,
-                    verifiedQueriesQuery);
+                    verifiedMatchesQuery);
         } else {
             return this;
         }
@@ -152,8 +74,8 @@ public final class PercolateQuery extends Query implements Accountable {
 
     @Override
     public Weight createWeight(IndexSearcher searcher, boolean needsScores) throws IOException {
-        final Weight verifiedQueriesQueryWeight = verifiedQueriesQuery.createWeight(searcher, false);
-        final Weight innerWeight = percolatorQueriesQuery.createWeight(searcher, needsScores);
+        final Weight verifiedMatchesWeight = verifiedMatchesQuery.createWeight(searcher, false);
+        final Weight candidateMatchesWeight = candidateMatchesQuery.createWeight(searcher, false);
         return new Weight(this) {
             @Override
             public void extractTerms(Set<Term> set) {
@@ -183,17 +105,17 @@ public final class PercolateQuery extends Query implements Accountable {
 
             @Override
             public float getValueForNormalization() throws IOException {
-                return innerWeight.getValueForNormalization();
+                return candidateMatchesWeight.getValueForNormalization();
             }
 
             @Override
             public void normalize(float v, float v1) {
-                innerWeight.normalize(v, v1);
+                candidateMatchesWeight.normalize(v, v1);
             }
 
             @Override
             public Scorer scorer(LeafReaderContext leafReaderContext) throws IOException {
-                final Scorer approximation = innerWeight.scorer(leafReaderContext);
+                final Scorer approximation = candidateMatchesWeight.scorer(leafReaderContext);
                 if (approximation == null) {
                     return null;
                 }
@@ -226,7 +148,7 @@ public final class PercolateQuery extends Query implements Accountable {
                         }
                     };
                 } else {
-                    Scorer verifiedDocsScorer = verifiedQueriesQueryWeight.scorer(leafReaderContext);
+                    Scorer verifiedDocsScorer = verifiedMatchesWeight.scorer(leafReaderContext);
                     Bits verifiedDocsBits = Lucene.asSequentialAccessBits(leafReaderContext.reader().maxDoc(), verifiedDocsScorer);
                     return new BaseScorer(this, approximation, queries, percolatorIndexSearcher) {
 
@@ -293,7 +215,7 @@ public final class PercolateQuery extends Query implements Accountable {
     @Override
     public String toString(String s) {
         return "PercolateQuery{document_type={" + documentType + "},document_source={" + documentSource.utf8ToString() +
-                "},inner={" + percolatorQueriesQuery.toString(s)  + "}}";
+                "},inner={" + candidateMatchesQuery.toString(s)  + "}}";
     }
 
     @Override

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -20,10 +20,26 @@ package org.elasticsearch.percolator;
 
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.queries.TermsQuery;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.lucene.search.MatchNoDocsQuery;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -31,6 +47,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
@@ -38,17 +55,30 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.core.BinaryFieldMapper;
 import org.elasticsearch.index.mapper.core.KeywordFieldMapper;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper.NumberType;
+import org.elasticsearch.index.mapper.ip.IpFieldMapper;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.BoostingQueryBuilder;
+import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.QueryShardException;
+import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
+import org.elasticsearch.percolator.QueryExtractService.RangeType;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import static org.apache.lucene.search.BooleanClause.Occur.MUST;
 
 public class PercolatorFieldMapper extends FieldMapper {
 
@@ -56,11 +86,29 @@ public class PercolatorFieldMapper extends FieldMapper {
     public static final Setting<Boolean> INDEX_MAP_UNMAPPED_FIELDS_AS_STRING_SETTING =
             Setting.boolSetting("index.percolator.map_unmapped_fields_as_string", false, Setting.Property.IndexScope);
     public static final String CONTENT_TYPE = "percolator";
-    private static final PercolatorFieldType FIELD_TYPE = new PercolatorFieldType();
+    private static final FieldType FIELD_TYPE = new FieldType();
+
+    static final byte FIELD_VALUE_SEPARATOR = 0;  // nul code point
+    static final String EXTRACTION_COMPLETE = "complete";
+    static final String EXTRACTION_PARTIAL = "partial";
+    static final String EXTRACTION_FAILED = "failed";
 
     public static final String EXTRACTED_TERMS_FIELD_NAME = "extracted_terms";
     public static final String EXTRACTION_RESULT_FIELD_NAME = "extraction_result";
     public static final String QUERY_BUILDER_FIELD_NAME = "query_builder_field";
+
+    public static final String INT_FROM_FIELD = "extracted_int_from";
+    public static final String INT_TO_FIELD = "extracted_int_to";
+    public static final String LONG_FROM_FIELD = "extracted_long_from";
+    public static final String LONG_TO_FIELD = "extracted_to_from";
+    public static final String HALF_FLOAT_FROM_FIELD = "extracted_half_float_from";
+    public static final String HALF_FLOAT_TO_FIELD = "extracted_half_float_to";
+    public static final String FLOAT_FROM_FIELD = "extracted_float_from";
+    public static final String FLOAT_TO_FIELD = "extracted_float_to";
+    public static final String DOUBLE_FROM_FIELD = "extracted_double_from";
+    public static final String DOUBLE_TO_FIELD = "extracted_double_to";
+    public static final String IP_FROM_FIELD = "extracted_ip_from";
+    public static final String IP_TO_FIELD = "extracted_ip_to";
 
     public static class Builder extends FieldMapper.Builder<Builder, PercolatorFieldMapper> {
 
@@ -74,17 +122,49 @@ public class PercolatorFieldMapper extends FieldMapper {
         @Override
         public PercolatorFieldMapper build(BuilderContext context) {
             context.path().add(name());
+            FieldType fieldType = (FieldType) this.fieldType;
             KeywordFieldMapper extractedTermsField = createExtractQueryFieldBuilder(EXTRACTED_TERMS_FIELD_NAME, context);
-            ((PercolatorFieldType) fieldType).queryTermsField = extractedTermsField.fieldType();
+            fieldType.queryTermsField = extractedTermsField.fieldType();
             KeywordFieldMapper extractionResultField = createExtractQueryFieldBuilder(EXTRACTION_RESULT_FIELD_NAME, context);
-            ((PercolatorFieldType) fieldType).extractionResultField = extractionResultField.fieldType();
+            fieldType.extractionResultField = extractionResultField.fieldType();
             BinaryFieldMapper queryBuilderField = createQueryBuilderFieldBuilder(context);
-            ((PercolatorFieldType) fieldType).queryBuilderField = queryBuilderField.fieldType();
+            fieldType.queryBuilderField = queryBuilderField.fieldType();
+
+            NumberFieldMapper intFromField = createExtractedRangeFieldBuilder(INT_FROM_FIELD, NumberType.INTEGER, context);
+            NumberFieldMapper intToField = createExtractedRangeFieldBuilder(INT_TO_FIELD, NumberType.INTEGER, context);
+            MappedRange intRange  = new MappedRange(RangeType.INT, intFromField.fieldType(), intToField.fieldType());
+            fieldType.ranges.put("byte", intRange);
+            fieldType.ranges.put("short", intRange);
+            fieldType.ranges.put("integer", intRange);
+
+            NumberFieldMapper longFromField = createExtractedRangeFieldBuilder(LONG_FROM_FIELD, NumberType.LONG, context);
+            NumberFieldMapper longToField = createExtractedRangeFieldBuilder(LONG_TO_FIELD, NumberType.LONG, context);
+            fieldType.ranges.put("long", new MappedRange(RangeType.LONG, longFromField.fieldType(), longToField.fieldType()));
+
+            NumberFieldMapper halfFloatFromField = createExtractedRangeFieldBuilder(HALF_FLOAT_FROM_FIELD, NumberType.HALF_FLOAT, context);
+            NumberFieldMapper halfFloatToField = createExtractedRangeFieldBuilder(HALF_FLOAT_TO_FIELD, NumberType.HALF_FLOAT, context);
+            fieldType.ranges.put("half_float", new MappedRange(RangeType.HALF_FLOAT, halfFloatFromField.fieldType(),
+                    halfFloatToField.fieldType()));
+
+            NumberFieldMapper floatFromField = createExtractedRangeFieldBuilder(FLOAT_FROM_FIELD, NumberType.FLOAT, context);
+            NumberFieldMapper floatToField = createExtractedRangeFieldBuilder(FLOAT_TO_FIELD, NumberType.FLOAT, context);
+            fieldType.ranges.put("float", new MappedRange(RangeType.FLOAT, floatFromField.fieldType(), floatToField.fieldType()));
+
+            NumberFieldMapper doubleFromField = createExtractedRangeFieldBuilder(DOUBLE_FROM_FIELD, NumberType.DOUBLE, context);
+            NumberFieldMapper doubleToField = createExtractedRangeFieldBuilder(DOUBLE_TO_FIELD, NumberType.DOUBLE, context);
+            fieldType.ranges.put("double", new MappedRange(RangeType.DOUBLE, doubleFromField.fieldType(), doubleToField.fieldType()));
+
+            IpFieldMapper ipFromField = createExtractedIpFieldBuilder(IP_FROM_FIELD, context);
+            IpFieldMapper ipToField = createExtractedIpFieldBuilder(IP_TO_FIELD, context);
+            fieldType.ranges.put(IpFieldMapper.CONTENT_TYPE, new MappedRange(RangeType.IP, ipFromField.fieldType(), ipToField.fieldType()));
+
             context.path().remove();
             setupFieldType(context);
             return new PercolatorFieldMapper(name(), fieldType, defaultFieldType, context.indexSettings(),
                     multiFieldsBuilder.build(this, context), copyTo, queryShardContext, extractedTermsField,
-                    extractionResultField, queryBuilderField);
+                    extractionResultField, queryBuilderField, intFromField, intToField, longFromField, longToField,
+                    halfFloatFromField, halfFloatToField, floatFromField, floatToField, doubleFromField, doubleToField,
+                    ipFromField, ipToField);
         }
 
         static KeywordFieldMapper createExtractQueryFieldBuilder(String name, BuilderContext context) {
@@ -104,6 +184,20 @@ public class PercolatorFieldMapper extends FieldMapper {
             return builder.build(context);
         }
 
+        static NumberFieldMapper createExtractedRangeFieldBuilder(String name, NumberType numberType, BuilderContext context) {
+            NumberFieldMapper.Builder builder = new NumberFieldMapper.Builder(name, numberType);
+            builder.docValues(false);
+            builder.store(false);
+            return builder.build(context);
+        }
+
+        static IpFieldMapper createExtractedIpFieldBuilder(String name, BuilderContext context) {
+            IpFieldMapper.Builder builder = new IpFieldMapper.Builder(name);
+            builder.docValues(false);
+            builder.store(false);
+            return builder.build(context);
+        }
+
     }
 
     public static class TypeParser implements FieldMapper.TypeParser {
@@ -114,40 +208,31 @@ public class PercolatorFieldMapper extends FieldMapper {
         }
     }
 
-    public static class PercolatorFieldType extends MappedFieldType {
+    public static class FieldType extends MappedFieldType {
 
-        private MappedFieldType queryTermsField;
-        private MappedFieldType extractionResultField;
-        private MappedFieldType queryBuilderField;
+        MappedFieldType queryTermsField;
+        MappedFieldType extractionResultField;
+        MappedFieldType queryBuilderField;
+        Map<String, MappedRange> ranges;
 
-        public PercolatorFieldType() {
+        public FieldType() {
             setIndexOptions(IndexOptions.NONE);
             setDocValuesType(DocValuesType.NONE);
             setStored(false);
+            this.ranges = new HashMap<>();
         }
 
-        public PercolatorFieldType(PercolatorFieldType ref) {
+        public FieldType(FieldType ref) {
             super(ref);
             queryTermsField = ref.queryTermsField;
             extractionResultField = ref.extractionResultField;
             queryBuilderField = ref.queryBuilderField;
-        }
-
-        public String getExtractedTermsField() {
-            return queryTermsField.name();
-        }
-
-        public String getExtractionResultFieldName() {
-            return extractionResultField.name();
-        }
-
-        public String getQueryBuilderFieldName() {
-            return queryBuilderField.name();
+            ranges = ref.ranges;
         }
 
         @Override
         public MappedFieldType clone() {
-            return new PercolatorFieldType(this);
+            return new FieldType(this);
         }
 
         @Override
@@ -159,6 +244,103 @@ public class PercolatorFieldMapper extends FieldMapper {
         public Query termQuery(Object value, QueryShardContext context) {
             throw new QueryShardException(context, "Percolator fields are not searchable directly, use a percolate query instead");
         }
+
+        public Query percolateQuery(String documentType, PercolateQuery.QueryStore queryStore, BytesReference documentSource,
+                                    IndexSearcher searcher, DocumentMapper documentMapper) throws IOException {
+            IndexReader indexReader = searcher.getIndexReader();
+            Query candidateMatchesQuery = createCandidateQuery(indexReader, documentMapper);
+            Query verifiedMatchesQuery;
+            // We can only skip the MemoryIndex verification when percolating a single document.
+            // When the document being percolated contains a nested object field then the MemoryIndex contains multiple
+            // documents. In this case the term query that indicates whether memory index verification can be skipped
+            // can incorrectly indicate that non nested queries would match, while their nested variants would not.
+            if (indexReader.maxDoc() == 1) {
+                verifiedMatchesQuery = new TermQuery(new Term(extractionResultField.name(), EXTRACTION_COMPLETE));
+            } else {
+                verifiedMatchesQuery = new MatchNoDocsQuery("nested docs, no verified matches");
+            }
+            return new PercolateQuery(documentType, queryStore, documentSource, candidateMatchesQuery, searcher, verifiedMatchesQuery);
+        }
+
+        Query createCandidateQuery(IndexReader indexReader, DocumentMapper documentMapper) throws IOException {
+            List<Term> extractedTerms = new ArrayList<>();
+            // include extractionResultField:failed, because docs with this term have no extractedTermsField
+            // and otherwise we would fail to return these docs. Docs that failed query term extraction
+            // always need to be verified by MemoryIndex:
+            extractedTerms.add(new Term(extractionResultField.name(), EXTRACTION_FAILED));
+
+            BooleanQuery.Builder bq = new BooleanQuery.Builder();
+            LeafReader reader = indexReader.leaves().get(0).reader();
+            Fields fields = reader.fields();
+            for (String field : fields) {
+                Terms terms = fields.terms(field);
+                if (terms == null) {
+                    continue;
+                }
+
+                BytesRef fieldBr = new BytesRef(field);
+                TermsEnum tenum = terms.iterator();
+                for (BytesRef term = tenum.next(); term != null; term = tenum.next()) {
+                    BytesRefBuilder builder = new BytesRefBuilder();
+                    builder.append(fieldBr);
+                    builder.append(FIELD_VALUE_SEPARATOR);
+                    builder.append(term);
+                    extractedTerms.add(new Term(queryTermsField.name(), builder.toBytesRef()));
+                }
+            }
+
+            if (extractedTerms.size() != 0) {
+                bq.add(new TermsQuery(extractedTerms), BooleanClause.Occur.SHOULD);
+            }
+
+            for (FieldInfo info : reader.getFieldInfos()) {
+                if (info == null || info.getPointDimensionCount() == 0) {
+                    continue;
+                }
+
+                FieldMapper fieldMapper = documentMapper.mappers().getMapper(info.name);
+                if (fieldMapper == null) {
+                    continue;
+                }
+
+                MappedFieldType fieldType = fieldMapper.fieldType();
+                PointValues values = reader.getPointValues();
+                if (values == null) {
+                    continue;
+                }
+                MappedRange mappedRange = ranges.get(fieldType.typeName());
+                byte[] packedValue = values.getMinPackedValue(info.name);
+                Object value = mappedRange.rangeType.decodePackedValue(packedValue);
+                BooleanQuery.Builder rangeBq = new BooleanQuery.Builder();
+                rangeBq.add(mappedRange.fromField.rangeQuery(null, value, true, true), MUST);
+                rangeBq.add(mappedRange.toField.rangeQuery(value, null, true, true), MUST);
+                bq.add(rangeBq.build(), BooleanClause.Occur.SHOULD);
+            }
+            return bq.build();
+        }
+
+    }
+
+    static class MappedRange {
+
+        final RangeType rangeType;
+        final MappedFieldType fromField;
+        final MappedFieldType toField;
+
+        MappedRange(RangeType rangeType, MappedFieldType fromField, MappedFieldType toField) {
+            this.rangeType = rangeType;
+            this.fromField = fromField;
+            this.toField = toField;
+        }
+
+        Field createFromField(byte[] value) {
+            return rangeType.createField(fromField.name(), value);
+        }
+
+        Field createToField(byte[] value) {
+            return rangeType.createField(toField.name(), value);
+        }
+
     }
 
     private final boolean mapUnmappedFieldAsString;
@@ -167,16 +349,46 @@ public class PercolatorFieldMapper extends FieldMapper {
     private KeywordFieldMapper extractionResultField;
     private BinaryFieldMapper queryBuilderField;
 
+    private NumberFieldMapper intFromField;
+    private NumberFieldMapper intToField;
+    private NumberFieldMapper longFromField;
+    private NumberFieldMapper longToField;
+    private NumberFieldMapper halfFloatFromField;
+    private NumberFieldMapper halfFloatToField;
+    private NumberFieldMapper floatFromField;
+    private NumberFieldMapper floatToField;
+    private NumberFieldMapper doubleFromField;
+    private NumberFieldMapper doubleToField;
+    private IpFieldMapper ipFromField;
+    private IpFieldMapper ipToField;
+
     public PercolatorFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
                                  Settings indexSettings, MultiFields multiFields, CopyTo copyTo, QueryShardContext queryShardContext,
                                  KeywordFieldMapper queryTermsField, KeywordFieldMapper extractionResultField,
-                                 BinaryFieldMapper queryBuilderField) {
+                                 BinaryFieldMapper queryBuilderField, NumberFieldMapper intFromField, NumberFieldMapper intToField,
+                                 NumberFieldMapper longFromField, NumberFieldMapper longToField, NumberFieldMapper halfFloatFromField,
+                                 NumberFieldMapper halfFloatToField, NumberFieldMapper floatFromField, NumberFieldMapper floatToField,
+                                 NumberFieldMapper doubleFromField, NumberFieldMapper doubleToField, IpFieldMapper ipFromField,
+                                 IpFieldMapper ipToField) {
         super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
         this.queryShardContext = queryShardContext;
         this.queryTermsField = queryTermsField;
         this.extractionResultField = extractionResultField;
         this.queryBuilderField = queryBuilderField;
         this.mapUnmappedFieldAsString = INDEX_MAP_UNMAPPED_FIELDS_AS_STRING_SETTING.get(indexSettings);
+
+        this.intFromField = intFromField;
+        this.intToField = intToField;
+        this.longFromField = longFromField;
+        this.longToField = longToField;
+        this.halfFloatFromField = halfFloatFromField;
+        this.halfFloatToField = halfFloatToField;
+        this.floatFromField = floatFromField;
+        this.floatToField = floatToField;
+        this.doubleFromField = doubleFromField;
+        this.doubleToField = doubleToField;
+        this.ipFromField = ipFromField;
+        this.ipToField = ipToField;
     }
 
     @Override
@@ -186,8 +398,26 @@ public class PercolatorFieldMapper extends FieldMapper {
         KeywordFieldMapper extractionResultUpdated = (KeywordFieldMapper) extractionResultField.updateFieldType(fullNameToFieldType);
         BinaryFieldMapper queryBuilderUpdated = (BinaryFieldMapper) queryBuilderField.updateFieldType(fullNameToFieldType);
 
+        NumberFieldMapper intFromFieldUpdated = (NumberFieldMapper) intFromField.updateFieldType(fullNameToFieldType);
+        NumberFieldMapper intToFieldUpdated = (NumberFieldMapper) intToField.updateFieldType(fullNameToFieldType);
+        NumberFieldMapper longFromFieldUpdated = (NumberFieldMapper) longFromField.updateFieldType(fullNameToFieldType);
+        NumberFieldMapper longToFieldUpdated = (NumberFieldMapper) longToField.updateFieldType(fullNameToFieldType);
+        NumberFieldMapper halfFloatFromFieldUpdated = (NumberFieldMapper) halfFloatFromField.updateFieldType(fullNameToFieldType);
+        NumberFieldMapper halfFloatToFieldUpdated = (NumberFieldMapper) halfFloatToField.updateFieldType(fullNameToFieldType);
+        NumberFieldMapper floatFromFieldUpdated = (NumberFieldMapper) floatFromField.updateFieldType(fullNameToFieldType);
+        NumberFieldMapper floatToFieldUpdated = (NumberFieldMapper) floatToField.updateFieldType(fullNameToFieldType);
+        NumberFieldMapper doubleFromFieldUpdated = (NumberFieldMapper) doubleFromField.updateFieldType(fullNameToFieldType);
+        NumberFieldMapper doubleToFieldUpdated = (NumberFieldMapper) doubleToField.updateFieldType(fullNameToFieldType);
+        IpFieldMapper ipFromFieldUpdated = (IpFieldMapper) ipFromField.updateFieldType(fullNameToFieldType);
+        IpFieldMapper ipToFieldUpdated = (IpFieldMapper) ipToField.updateFieldType(fullNameToFieldType);
+
         if (updated == this && queryTermsUpdated == queryTermsField && extractionResultUpdated == extractionResultField
-                && queryBuilderUpdated == queryBuilderField) {
+                && queryBuilderUpdated == queryBuilderField && intFromFieldUpdated == intFromField && intToFieldUpdated == intToField &&
+                longFromFieldUpdated == longFromField && longToFieldUpdated == longToField &&
+                halfFloatFromFieldUpdated == halfFloatFromField && halfFloatToFieldUpdated == halfFloatToField &&
+                floatFromFieldUpdated == floatFromField && floatToFieldUpdated == floatToField &&
+                doubleFromFieldUpdated == doubleFromField && doubleToFieldUpdated == doubleToField && ipFromFieldUpdated == ipFromField &&
+                ipToFieldUpdated == ipToField) {
             return this;
         }
         if (updated == this) {
@@ -196,6 +426,18 @@ public class PercolatorFieldMapper extends FieldMapper {
         updated.queryTermsField = queryTermsUpdated;
         updated.extractionResultField = extractionResultUpdated;
         updated.queryBuilderField = queryBuilderUpdated;
+        updated.intFromField = intFromFieldUpdated;
+        updated.intToField = intToFieldUpdated;
+        updated.longFromField = longFromFieldUpdated;
+        updated.longToField = longToFieldUpdated;
+        updated.halfFloatFromField= halfFloatFromFieldUpdated;
+        updated.halfFloatToField= halfFloatToFieldUpdated;
+        updated.floatFromField= floatFromFieldUpdated;
+        updated.floatToField= floatToFieldUpdated;
+        updated.doubleFromField= doubleFromFieldUpdated;
+        updated.doubleToField= doubleToFieldUpdated;
+        updated.ipFromField= ipFromFieldUpdated;
+        updated.ipToField= ipToFieldUpdated;
         return updated;
     }
 
@@ -211,6 +453,7 @@ public class PercolatorFieldMapper extends FieldMapper {
 
         XContentParser parser = context.parser();
         QueryBuilder queryBuilder = parseQueryBuilder(queryShardContext.newParseContext(parser), parser.getTokenLocation());
+        verifyRangeQueries(queryBuilder);
         // Fetching of terms, shapes and indexed scripts happen during this rewrite:
         queryBuilder = queryBuilder.rewrite(queryShardContext);
 
@@ -222,9 +465,38 @@ public class PercolatorFieldMapper extends FieldMapper {
         }
 
         Query query = toQuery(queryShardContext, mapUnmappedFieldAsString, queryBuilder);
-        ExtractQueryTermsService.extractQueryTerms(query, context.doc(), queryTermsField.name(), extractionResultField.name(),
-                queryTermsField.fieldType());
+        extractTermsAndRanges(context, query);
         return null;
+    }
+
+    void extractTermsAndRanges(ParseContext context, Query query) {
+        ParseContext.Document doc = context.doc();
+        FieldType pft = (FieldType) this.fieldType();
+        QueryExtractService.Result result;
+        try {
+            result = QueryExtractService.extractQueryTerms(query);
+        } catch (QueryExtractService.UnsupportedQueryException e) {
+            doc.add(new Field(pft.extractionResultField.name(), EXTRACTION_FAILED, extractionResultField.fieldType()));
+            return;
+        }
+        for (Term term : result.terms) {
+            BytesRefBuilder builder = new BytesRefBuilder();
+            builder.append(new BytesRef(term.field()));
+            builder.append(FIELD_VALUE_SEPARATOR);
+            builder.append(term.bytes());
+            doc.add(new Field(queryTermsField.name(), builder.toBytesRef(), queryTermsField.fieldType()));
+        }
+        for (QueryExtractService.Range range : result.ranges) {
+            MappedFieldType rangeFieldType = context.mapperService().fullName(range.fieldName);
+            MappedRange mappedRange = pft.ranges.get(rangeFieldType.typeName());
+            doc.add(mappedRange.createFromField(range.lowerPoint));
+            doc.add(mappedRange.createToField(range.upperPoint));
+        }
+        if (result.verified) {
+            doc.add(new Field(extractionResultField.name(), EXTRACTION_COMPLETE, extractionResultField.fieldType()));
+        } else {
+            doc.add(new Field(extractionResultField.name(), EXTRACTION_PARTIAL, extractionResultField.fieldType()));
+        }
     }
 
     public static Query parseQuery(QueryShardContext context, boolean mapUnmappedFieldsAsString, XContentParser parser) throws IOException {
@@ -260,7 +532,11 @@ public class PercolatorFieldMapper extends FieldMapper {
 
     @Override
     public Iterator<Mapper> iterator() {
-        return Arrays.<Mapper>asList(queryTermsField, extractionResultField, queryBuilderField).iterator();
+        return Arrays.<Mapper>asList(
+                queryTermsField, extractionResultField, queryBuilderField, intFromField, intToField, longFromField,
+                longToField, halfFloatFromField, halfFloatToField, floatFromField, floatToField, doubleFromField,
+                doubleToField, ipFromField, ipToField
+        ).iterator();
     }
 
     @Override
@@ -271,6 +547,40 @@ public class PercolatorFieldMapper extends FieldMapper {
     @Override
     protected String contentType() {
         return CONTENT_TYPE;
+    }
+
+    /**
+     * Fails if a range query with a date range is found based on current time
+     */
+    static void verifyRangeQueries(QueryBuilder queryBuilder) {
+        if (queryBuilder instanceof RangeQueryBuilder) {
+            RangeQueryBuilder rangeQueryBuilder = (RangeQueryBuilder) queryBuilder;
+            if (rangeQueryBuilder.from() instanceof String) {
+                String from = (String) rangeQueryBuilder.from();
+                String to = (String) rangeQueryBuilder.to();
+                if (from.contains("now") || to.contains("now")) {
+                    throw new IllegalArgumentException("Percolator queries containing time range queries based on the " +
+                            "current time are forbidden");
+                }
+            }
+        } else if (queryBuilder instanceof BoolQueryBuilder) {
+            BoolQueryBuilder boolQueryBuilder = (BoolQueryBuilder) queryBuilder;
+            List<QueryBuilder> clauses = new ArrayList<>();
+            clauses.addAll(boolQueryBuilder.filter());
+            clauses.addAll(boolQueryBuilder.must());
+            clauses.addAll(boolQueryBuilder.mustNot());
+            clauses.addAll(boolQueryBuilder.should());
+            for (QueryBuilder clause : clauses) {
+                verifyRangeQueries(clause);
+            }
+        } else if (queryBuilder instanceof ConstantScoreQueryBuilder) {
+            verifyRangeQueries(((ConstantScoreQueryBuilder) queryBuilder).innerQuery());
+        } else if (queryBuilder instanceof FunctionScoreQueryBuilder) {
+            verifyRangeQueries(((FunctionScoreQueryBuilder) queryBuilder).query());
+        } else if (queryBuilder instanceof BoostingQueryBuilder) {
+            verifyRangeQueries(((BoostingQueryBuilder) queryBuilder).negativeQuery());
+            verifyRangeQueries(((BoostingQueryBuilder) queryBuilder).positiveQuery());
+        }
     }
 
 }

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/RestMultiPercolateAction.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/RestMultiPercolateAction.java
@@ -33,6 +33,7 @@ import org.elasticsearch.rest.action.support.RestToXContentListener;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
+@Deprecated
 public class RestMultiPercolateAction extends BaseRestHandler {
 
     private final boolean allowExplicitIndex;

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/RestPercolateAction.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/RestPercolateAction.java
@@ -35,6 +35,7 @@ import org.elasticsearch.rest.action.support.RestToXContentListener;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
+@Deprecated
 public class RestPercolateAction extends BaseRestHandler {
     @Inject
     public RestPercolateAction(Settings settings, RestController controller) {

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/TransportMultiPercolateAction.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/TransportMultiPercolateAction.java
@@ -49,6 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@Deprecated
 public class TransportMultiPercolateAction extends HandledTransportAction<MultiPercolateRequest, MultiPercolateResponse> {
 
     private final Client client;

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/TransportPercolateAction.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/TransportPercolateAction.java
@@ -57,6 +57,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+@Deprecated
 public class TransportPercolateAction extends HandledTransportAction<PercolateRequest, PercolateResponse> {
 
     private final Client client;

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
@@ -1,0 +1,613 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.percolator;
+
+import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.DoublePoint;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FloatPoint;
+import org.apache.lucene.document.HalfFloatPoint;
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.memory.MemoryIndex;
+import org.apache.lucene.queries.BlendedTermQuery;
+import org.apache.lucene.queries.CommonTermsQuery;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.FilterScorer;
+import org.apache.lucene.search.FilteredDocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.PrefixQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.search.spans.SpanNearQuery;
+import org.apache.lucene.search.spans.SpanNotQuery;
+import org.apache.lucene.search.spans.SpanOrQuery;
+import org.apache.lucene.search.spans.SpanTermQuery;
+import org.apache.lucene.store.Directory;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.lucene.search.MatchNoDocsQuery;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.elasticsearch.common.network.InetAddresses.forString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class CandidateQueryTests extends ESSingleNodeTestCase {
+
+    private Directory directory;
+    private IndexWriter indexWriter;
+    private DocumentMapper documentMapper;
+    private DirectoryReader directoryReader;
+    private MapperService mapperService;
+
+    private PercolatorFieldMapper fieldMapper;
+    private PercolatorFieldMapper.FieldType fieldType;
+
+    private List<Query> queries;
+    private PercolateQuery.QueryStore queryStore;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Collections.singleton(PercolatorPlugin.class);
+    }
+
+    @Before
+    public void init() throws Exception {
+        directory = newDirectory();
+        IndexWriterConfig config = new IndexWriterConfig(new WhitespaceAnalyzer());
+        config.setMergePolicy(NoMergePolicy.INSTANCE);
+        indexWriter = new IndexWriter(directory, config);
+
+        String indexName = "test";
+        IndexService indexService = createIndex(indexName, Settings.EMPTY);
+        mapperService = indexService.mapperService();
+
+        String mapper = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties")
+                .startObject("int_field").field("type", "integer").endObject()
+                .startObject("long_field").field("type", "long").endObject()
+                .startObject("half_float_field").field("type", "half_float").endObject()
+                .startObject("float_field").field("type", "float").endObject()
+                .startObject("double_field").field("type", "double").endObject()
+                .startObject("ip_field").field("type", "ip").endObject()
+                .startObject("field").field("type", "keyword").endObject()
+                .endObject().endObject().endObject().string();
+        documentMapper = mapperService.merge("type", new CompressedXContent(mapper), MapperService.MergeReason.MAPPING_UPDATE, true);
+
+        String queryField = "query_field";
+        String mappingType = "query";
+        String percolatorMapper = XContentFactory.jsonBuilder().startObject().startObject(mappingType)
+                .startObject("properties").startObject(queryField).field("type", "percolator").endObject().endObject()
+                .endObject().endObject().string();
+        mapperService.merge(mappingType, new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE, true);
+        fieldMapper = (PercolatorFieldMapper) mapperService.documentMapper(mappingType).mappers().getMapper(queryField);
+        fieldType = (PercolatorFieldMapper.FieldType) fieldMapper.fieldType();
+
+        queries = new ArrayList<>();
+        queryStore = ctx -> docId -> this.queries.get(docId);
+    }
+
+    @After
+    public void deinit() throws Exception {
+        directoryReader.close();
+        directory.close();
+    }
+
+    public void testRangeQueries() throws Exception {
+        List<ParseContext.Document> docs = new ArrayList<>();
+        addQuery(IntPoint.newRangeQuery("int_field", 0, 5), docs);
+        addQuery(LongPoint.newRangeQuery("long_field", 5L, 10L), docs);
+        addQuery(HalfFloatPoint.newRangeQuery("half_float_field", 10, 15), docs);
+        addQuery(FloatPoint.newRangeQuery("float_field", 15, 20), docs);
+        addQuery(DoublePoint.newRangeQuery("double_field", 20, 25), docs);
+        addQuery(InetAddressPoint.newRangeQuery("ip_field", forString("192.168.0.1"), forString("192.168.0.10")), docs);
+        indexWriter.addDocuments(docs);
+        indexWriter.close();
+        directoryReader = DirectoryReader.open(directory);
+        IndexSearcher shardSearcher = newSearcher(directoryReader);
+        shardSearcher.setQueryCache(null);
+
+        MemoryIndex memoryIndex =  MemoryIndex.fromDocument(Collections.singleton(new IntPoint("int_field", 3)), new WhitespaceAnalyzer());
+        IndexSearcher percolateSearcher = memoryIndex.createSearcher();
+        Query query = fieldType.percolateQuery("type", queryStore, new BytesArray("{}"), percolateSearcher, documentMapper);
+        TopDocs topDocs = shardSearcher.search(query, 1);
+        assertThat(topDocs.totalHits, equalTo(1));
+        assertThat(topDocs.scoreDocs.length, equalTo(1));
+        assertThat(topDocs.scoreDocs[0].doc, equalTo(0));
+
+        memoryIndex =  MemoryIndex.fromDocument(Collections.singleton(new LongPoint("long_field", 7L)), new WhitespaceAnalyzer());
+        percolateSearcher = memoryIndex.createSearcher();
+        query = fieldType.percolateQuery("type", queryStore, new BytesArray("{}"), percolateSearcher, documentMapper);
+        topDocs = shardSearcher.search(query, 1);
+        assertThat(topDocs.totalHits, equalTo(1));
+        assertThat(topDocs.scoreDocs.length, equalTo(1));
+        assertThat(topDocs.scoreDocs[0].doc, equalTo(1));
+
+        memoryIndex =  MemoryIndex.fromDocument(Collections.singleton(new HalfFloatPoint("half_float_field", 12)),
+                new WhitespaceAnalyzer());
+        percolateSearcher = memoryIndex.createSearcher();
+        query = fieldType.percolateQuery("type", queryStore, new BytesArray("{}"), percolateSearcher,
+                documentMapper);
+        topDocs = shardSearcher.search(query, 1);
+        assertThat(topDocs.totalHits, equalTo(1));
+        assertThat(topDocs.scoreDocs.length, equalTo(1));
+        assertThat(topDocs.scoreDocs[0].doc, equalTo(2));
+
+        memoryIndex =  MemoryIndex.fromDocument(Collections.singleton(new FloatPoint("float_field", 17)), new WhitespaceAnalyzer());
+        percolateSearcher = memoryIndex.createSearcher();
+        query = fieldType.percolateQuery("type", queryStore, new BytesArray("{}"), percolateSearcher, documentMapper);
+        topDocs = shardSearcher.search(query, 1);
+        assertThat(topDocs.totalHits, equalTo(1));
+        assertThat(topDocs.scoreDocs.length, equalTo(1));
+        assertThat(topDocs.scoreDocs[0].doc, equalTo(3));
+
+        memoryIndex =  MemoryIndex.fromDocument(Collections.singleton(new DoublePoint("double_field", 21)), new WhitespaceAnalyzer());
+        percolateSearcher = memoryIndex.createSearcher();
+        query = fieldType.percolateQuery("type", queryStore, new BytesArray("{}"), percolateSearcher, documentMapper);
+        topDocs = shardSearcher.search(query, 1);
+        assertThat(topDocs.totalHits, equalTo(1));
+        assertThat(topDocs.scoreDocs.length, equalTo(1));
+        assertThat(topDocs.scoreDocs[0].doc, equalTo(4));
+
+        memoryIndex =  MemoryIndex.fromDocument(Collections.singleton(new InetAddressPoint("ip_field",
+                forString("192.168.0.4"))), new WhitespaceAnalyzer());
+        percolateSearcher = memoryIndex.createSearcher();
+        query = fieldType.percolateQuery("type", queryStore, new BytesArray("{}"), percolateSearcher, documentMapper);
+        topDocs = shardSearcher.search(query, 1);
+        assertThat(topDocs.totalHits, equalTo(1));
+        assertThat(topDocs.scoreDocs.length, equalTo(1));
+        assertThat(topDocs.scoreDocs[0].doc, equalTo(5));
+    }
+
+    public void testDuelRangeQueries() throws Exception {
+        List<ParseContext.Document> documents = new ArrayList<>();
+
+        int lowerInt = randomIntBetween(0, 256);
+        int upperInt = lowerInt + randomIntBetween(0, 32);
+        addQuery(IntPoint.newRangeQuery("int_field", lowerInt, upperInt), documents);
+
+        long lowerLong = randomIntBetween(0, 256);
+        long upperLong = lowerLong + randomIntBetween(0, 32);
+        addQuery(LongPoint.newRangeQuery("long_field", lowerLong, upperLong), documents);
+
+        float lowerHalfFloat = randomIntBetween(0, 256);
+        float upperHalfFloat = lowerHalfFloat + randomIntBetween(0, 32);
+        addQuery(HalfFloatPoint.newRangeQuery("half_float_field", lowerHalfFloat, upperHalfFloat), documents);
+
+        float lowerFloat = randomIntBetween(0, 256);
+        float upperFloat = lowerFloat + randomIntBetween(0, 32);
+        addQuery(FloatPoint.newRangeQuery("float_field", lowerFloat, upperFloat), documents);
+
+        double lowerDouble = randomDoubleBetween(0, 256, true);
+        double upperDouble = lowerDouble + randomDoubleBetween(0, 32, true);
+        addQuery(DoublePoint.newRangeQuery("double_field", lowerDouble, upperDouble), documents);
+
+        int lowerIpPart = randomIntBetween(0, 255);
+        int upperIpPart = randomIntBetween(lowerIpPart, 255);
+        addQuery(InetAddressPoint.newRangeQuery("ip_field", forString("192.168.1." + lowerIpPart),
+                forString("192.168.1." + upperIpPart)), documents);
+
+
+        indexWriter.addDocuments(documents);
+        indexWriter.close();
+        directoryReader = DirectoryReader.open(directory);
+        IndexSearcher shardSearcher = newSearcher(directoryReader);
+        // Disable query cache, because ControlQuery cannot be cached...
+        shardSearcher.setQueryCache(null);
+
+        int randomInt = randomIntBetween(lowerInt, upperInt);
+        Iterable<? extends IndexableField> doc = Collections.singleton(new IntPoint("int_field", randomInt));
+        MemoryIndex memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        TopDocs result = executeQuery(queryStore, memoryIndex, shardSearcher);
+        assertThat(result.scoreDocs.length, equalTo(1));
+        assertThat(result.scoreDocs[0].doc, equalTo(0));
+        duelRun(queryStore, memoryIndex, shardSearcher);
+        doc = Collections.singleton(new IntPoint("int_field", randomInt()));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        duelRun(queryStore, memoryIndex, shardSearcher);
+
+        long randomLong = randomIntBetween((int) lowerLong, (int) upperLong);
+        doc = Collections.singleton(new LongPoint("long_field", randomLong));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        result = executeQuery(queryStore, memoryIndex, shardSearcher);
+        assertThat(result.scoreDocs.length, equalTo(1));
+        assertThat(result.scoreDocs[0].doc, equalTo(1));
+        duelRun(queryStore, memoryIndex, shardSearcher);
+        doc = Collections.singleton(new LongPoint("long_field", randomLong()));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        duelRun(queryStore, memoryIndex, shardSearcher);
+
+        float randomHalfFloat = randomIntBetween((int) lowerHalfFloat, (int) upperHalfFloat);
+        doc = Collections.singleton(new HalfFloatPoint("half_float_field", randomHalfFloat));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        result = executeQuery(queryStore, memoryIndex, shardSearcher);
+        assertThat(result.scoreDocs.length, equalTo(1));
+        assertThat(result.scoreDocs[0].doc, equalTo(2));
+        duelRun(queryStore, memoryIndex, shardSearcher);
+        doc = Collections.singleton(new HalfFloatPoint("half_float_field", randomFloat()));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        duelRun(queryStore, memoryIndex, shardSearcher);
+
+        float randomFloat = randomIntBetween((int) lowerFloat, (int) upperFloat);
+        doc = Collections.singleton(new FloatPoint("float_field", randomFloat));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        result = executeQuery(queryStore, memoryIndex, shardSearcher);
+        assertThat(result.scoreDocs.length, equalTo(1));
+        assertThat(result.scoreDocs[0].doc, equalTo(3));
+        duelRun(queryStore, memoryIndex, shardSearcher);
+        doc = Collections.singleton(new FloatPoint("float_field", randomFloat()));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        duelRun(queryStore, memoryIndex, shardSearcher);
+
+        double randomDouble = randomDoubleBetween(lowerDouble, upperDouble, true);
+        doc = Collections.singleton(new DoublePoint("double_field", randomDouble));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        result = executeQuery(queryStore, memoryIndex, shardSearcher);
+        assertThat(result.scoreDocs.length, equalTo(1));
+        assertThat(result.scoreDocs[0].doc, equalTo(4));
+        duelRun(queryStore, memoryIndex, shardSearcher);
+        doc = Collections.singleton(new DoublePoint("double_field", randomFloat()));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        duelRun(queryStore, memoryIndex, shardSearcher);
+
+        doc = Collections.singleton(new InetAddressPoint("ip_field",
+                forString("192.168.1." + randomIntBetween(lowerIpPart, upperIpPart))));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        result = executeQuery(queryStore, memoryIndex, shardSearcher);
+        assertThat(result.scoreDocs.length, equalTo(1));
+        assertThat(result.scoreDocs[0].doc, equalTo(5));
+        duelRun(queryStore, memoryIndex, shardSearcher);
+        doc = Collections.singleton(new InetAddressPoint("ip_field",
+                forString("192.168.1." + randomIntBetween(0, 255))));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        duelRun(queryStore, memoryIndex, shardSearcher);
+    }
+
+    public void testDuel() throws Exception {
+        List<Function<String, Query>> queryFunctions = new ArrayList<>();
+        queryFunctions.add((id) -> new PrefixQuery(new Term("field", id)));
+        queryFunctions.add((id) -> new WildcardQuery(new Term("field", id + "*")));
+        queryFunctions.add((id) -> new CustomQuery(new Term("field", id)));
+        queryFunctions.add((id) -> new SpanTermQuery(new Term("field", id)));
+        queryFunctions.add((id) -> new TermQuery(new Term("field", id)));
+        queryFunctions.add((id) -> {
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            return builder.build();
+        });
+        queryFunctions.add((id) -> {
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            builder.add(new TermQuery(new Term("field", id)), BooleanClause.Occur.MUST);
+            if (randomBoolean()) {
+                builder.add(new MatchNoDocsQuery("no reason"), BooleanClause.Occur.MUST_NOT);
+            }
+            if (randomBoolean()) {
+                builder.add(new CustomQuery(new Term("field", id)), BooleanClause.Occur.MUST);
+            }
+            return builder.build();
+        });
+        queryFunctions.add((id) -> {
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            builder.add(new TermQuery(new Term("field", id)), BooleanClause.Occur.SHOULD);
+            if (randomBoolean()) {
+                builder.add(new MatchNoDocsQuery("no reason"), BooleanClause.Occur.MUST_NOT);
+            }
+            if (randomBoolean()) {
+                builder.add(new CustomQuery(new Term("field", id)), BooleanClause.Occur.SHOULD);
+            }
+            return builder.build();
+        });
+        queryFunctions.add((id) -> {
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            builder.add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST);
+            builder.add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST);
+            if (randomBoolean()) {
+                builder.add(new MatchNoDocsQuery("no reason"), BooleanClause.Occur.MUST_NOT);
+            }
+            return builder.build();
+        });
+        queryFunctions.add((id) -> {
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            builder.add(new MatchAllDocsQuery(), BooleanClause.Occur.SHOULD);
+            builder.add(new MatchAllDocsQuery(), BooleanClause.Occur.SHOULD);
+            if (randomBoolean()) {
+                builder.add(new MatchNoDocsQuery("no reason"), BooleanClause.Occur.MUST_NOT);
+            }
+            return builder.build();
+        });
+        queryFunctions.add((id) -> {
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            builder.setMinimumNumberShouldMatch(randomIntBetween(0, 4));
+            builder.add(new TermQuery(new Term("field", id)), BooleanClause.Occur.SHOULD);
+            builder.add(new CustomQuery(new Term("field", id)), BooleanClause.Occur.SHOULD);
+            return builder.build();
+        });
+        queryFunctions.add((id) -> new MatchAllDocsQuery());
+        queryFunctions.add((id) -> new MatchNoDocsQuery("no reason at all"));
+
+        int numDocs = randomIntBetween(queryFunctions.size(), queryFunctions.size() * 3);
+        List<ParseContext.Document> documents = new ArrayList<>();
+        for (int i = 0; i < numDocs; i++) {
+            String id = Integer.toString(i);
+            Query query = queryFunctions.get(i % queryFunctions.size()).apply(id);
+            addQuery(query, documents);
+        }
+
+        indexWriter.addDocuments(documents);
+        indexWriter.close();
+        directoryReader = DirectoryReader.open(directory);
+        IndexSearcher shardSearcher = newSearcher(directoryReader);
+        // Disable query cache, because ControlQuery cannot be cached...
+        shardSearcher.setQueryCache(null);
+
+        for (int i = 0; i < numDocs; i++) {
+            String id = Integer.toString(i);
+            Iterable<? extends IndexableField> doc = Collections.singleton(new StringField("field", id, Field.Store.NO));
+            MemoryIndex memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+            duelRun(queryStore, memoryIndex, shardSearcher);
+        }
+
+        Iterable<? extends IndexableField> doc = Collections.singleton(new StringField("field", "value", Field.Store.NO));
+        MemoryIndex memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        duelRun(queryStore, memoryIndex, shardSearcher);
+        // Empty percolator doc:
+        memoryIndex = new MemoryIndex();
+        duelRun(queryStore, memoryIndex, shardSearcher);
+    }
+
+    public void testDuelSpecificQueries() throws Exception {
+        List<ParseContext.Document> documents = new ArrayList<>();
+
+        CommonTermsQuery commonTermsQuery = new CommonTermsQuery(BooleanClause.Occur.SHOULD, BooleanClause.Occur.SHOULD, 128);
+        commonTermsQuery.add(new Term("field", "quick"));
+        commonTermsQuery.add(new Term("field", "brown"));
+        commonTermsQuery.add(new Term("field", "fox"));
+        addQuery(commonTermsQuery, documents);
+
+        BlendedTermQuery blendedTermQuery = BlendedTermQuery.booleanBlendedQuery(new Term[]{new Term("field", "quick"),
+                new Term("field", "brown"), new Term("field", "fox")}, false);
+        addQuery(blendedTermQuery, documents);
+
+        SpanNearQuery spanNearQuery = new SpanNearQuery.Builder("field", true)
+                .addClause(new SpanTermQuery(new Term("field", "quick")))
+                .addClause(new SpanTermQuery(new Term("field", "brown")))
+                .addClause(new SpanTermQuery(new Term("field", "fox")))
+                .build();
+        addQuery(spanNearQuery, documents);
+
+        SpanNearQuery spanNearQuery2 = new SpanNearQuery.Builder("field", true)
+                .addClause(new SpanTermQuery(new Term("field", "the")))
+                .addClause(new SpanTermQuery(new Term("field", "lazy")))
+                .addClause(new SpanTermQuery(new Term("field", "doc")))
+                .build();
+        SpanOrQuery spanOrQuery = new SpanOrQuery(
+                spanNearQuery,
+                spanNearQuery2
+        );
+        addQuery(spanOrQuery, documents);
+
+        SpanNotQuery spanNotQuery = new SpanNotQuery(spanNearQuery, spanNearQuery);
+        addQuery(spanNotQuery, documents);
+
+        indexWriter.addDocuments(documents);
+        indexWriter.close();
+        directoryReader = DirectoryReader.open(directory);
+        IndexSearcher shardSearcher = newSearcher(directoryReader);
+        // Disable query cache, because ControlQuery cannot be cached...
+        shardSearcher.setQueryCache(null);
+
+        Document document = new Document();
+        document.add(new TextField("field", "the quick brown fox jumps over the lazy dog", Field.Store.NO));
+        MemoryIndex memoryIndex = MemoryIndex.fromDocument(document, new WhitespaceAnalyzer());
+        duelRun(queryStore, memoryIndex, shardSearcher);
+    }
+
+    private void duelRun(PercolateQuery.QueryStore queryStore, MemoryIndex memoryIndex, IndexSearcher shardSearcher) throws IOException {
+        boolean requireScore = randomBoolean();
+        IndexSearcher percolateSearcher = memoryIndex.createSearcher();
+        Query percolateQuery = fieldType.percolateQuery("type", queryStore, new BytesArray("{}"), percolateSearcher, documentMapper);
+        Query query = requireScore ? percolateQuery : new ConstantScoreQuery(percolateQuery);
+        TopDocs topDocs = shardSearcher.search(query, 10);
+
+        Query controlQuery = new ControlQuery(memoryIndex, queryStore);
+        controlQuery = requireScore ? controlQuery : new ConstantScoreQuery(controlQuery);
+        TopDocs controlTopDocs = shardSearcher.search(controlQuery, 10);
+        assertThat(topDocs.totalHits, equalTo(controlTopDocs.totalHits));
+        assertThat(topDocs.scoreDocs.length, equalTo(controlTopDocs.scoreDocs.length));
+        for (int j = 0; j < topDocs.scoreDocs.length; j++) {
+            assertThat(topDocs.scoreDocs[j].doc, equalTo(controlTopDocs.scoreDocs[j].doc));
+            assertThat(topDocs.scoreDocs[j].score, equalTo(controlTopDocs.scoreDocs[j].score));
+            if (requireScore) {
+                Explanation explain1 = shardSearcher.explain(query, topDocs.scoreDocs[j].doc);
+                Explanation explain2 = shardSearcher.explain(controlQuery, controlTopDocs.scoreDocs[j].doc);
+                assertThat(explain1.isMatch(), equalTo(explain2.isMatch()));
+                assertThat(explain1.getValue(), equalTo(explain2.getValue()));
+            }
+        }
+    }
+
+    private TopDocs executeQuery(PercolateQuery.QueryStore queryStore, MemoryIndex memoryIndex,
+                                 IndexSearcher shardSearcher) throws IOException {
+        IndexSearcher percolateSearcher = memoryIndex.createSearcher();
+        Query percolateQuery = fieldType.percolateQuery("type", queryStore, new BytesArray("{}"), percolateSearcher, documentMapper);
+        return shardSearcher.search(percolateQuery, 10);
+    }
+
+    private void addQuery(Query query, List<ParseContext.Document> docs) throws IOException {
+        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(Settings.EMPTY,
+                mapperService.documentMapperParser(), documentMapper, null, null);
+        fieldMapper.extractTermsAndRanges(parseContext, query);
+        docs.add(parseContext.doc());
+        queries.add(query);
+    }
+
+    private static final class CustomQuery extends Query {
+
+        private final Term term;
+
+        private CustomQuery(Term term) {
+            this.term = term;
+        }
+
+        @Override
+        public Query rewrite(IndexReader reader) throws IOException {
+            return new TermQuery(term);
+        }
+
+        @Override
+        public String toString(String field) {
+            return "custom{" + field + "}";
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return sameClassAs(obj);
+        }
+
+        @Override
+        public int hashCode() {
+            return classHash();
+        }
+    }
+
+    private static final class ControlQuery extends Query {
+
+        private final MemoryIndex memoryIndex;
+        private final PercolateQuery.QueryStore queryStore;
+
+        private ControlQuery(MemoryIndex memoryIndex, PercolateQuery.QueryStore queryStore) {
+            this.memoryIndex = memoryIndex;
+            this.queryStore = queryStore;
+        }
+
+        @Override
+        public Weight createWeight(IndexSearcher searcher, boolean needsScores) {
+            return new ConstantScoreWeight(this) {
+
+                float _score;
+
+                @Override
+                public Explanation explain(LeafReaderContext context, int doc) throws IOException {
+                    Scorer scorer = scorer(context);
+                    if (scorer != null) {
+                        int result = scorer.iterator().advance(doc);
+                        if (result == doc) {
+                            return Explanation.match(scorer.score(), "ControlQuery");
+                        }
+                    }
+                    return Explanation.noMatch("ControlQuery");
+                }
+
+                @Override
+                public String toString() {
+                    return "weight(" + ControlQuery.this + ")";
+                }
+
+                @Override
+                public Scorer scorer(LeafReaderContext context) throws IOException {
+                    DocIdSetIterator allDocs = DocIdSetIterator.all(context.reader().maxDoc());
+                    PercolateQuery.QueryStore.Leaf leaf = queryStore.getQueries(context);
+                    FilteredDocIdSetIterator memoryIndexIterator = new FilteredDocIdSetIterator(allDocs) {
+
+                        @Override
+                        protected boolean match(int doc) {
+                            try {
+                                Query query = leaf.getQuery(doc);
+                                float score = memoryIndex.search(query);
+                                if (score != 0f) {
+                                    if (needsScores) {
+                                        _score = score;
+                                    }
+                                    return true;
+                                } else {
+                                    return false;
+                                }
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }
+                    };
+                    return new FilterScorer(new ConstantScoreScorer(this, score(), memoryIndexIterator)) {
+
+                        @Override
+                        public float score() throws IOException {
+                            return _score;
+                        }
+                    };
+                }
+            };
+        }
+
+        @Override
+        public String toString(String field) {
+            return "control{" + field + "}";
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return sameClassAs(obj);
+        }
+
+        @Override
+        public int hashCode() {
+            return classHash();
+        }
+
+    }
+
+}

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryTests.java
@@ -21,60 +21,36 @@ package org.elasticsearch.percolator;
 
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.FieldType;
-import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexOptions;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.memory.MemoryIndex;
-import org.apache.lucene.queries.BlendedTermQuery;
-import org.apache.lucene.queries.CommonTermsQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
-import org.apache.lucene.search.ConstantScoreScorer;
-import org.apache.lucene.search.ConstantScoreWeight;
-import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
-import org.apache.lucene.search.FilterScorer;
-import org.apache.lucene.search.FilteredDocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.PhraseQuery;
-import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.Weight;
-import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.search.spans.SpanNearQuery;
-import org.apache.lucene.search.spans.SpanNotQuery;
-import org.apache.lucene.search.spans.SpanOrQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.lucene.search.MatchNoDocsQuery;
-import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.mapper.Uid;
-import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 import org.junit.Before;
 
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.equalTo;
@@ -82,34 +58,13 @@ import static org.hamcrest.Matchers.is;
 
 public class PercolateQueryTests extends ESTestCase {
 
-    public static final String EXTRACTED_TERMS_FIELD_NAME = "extracted_terms";
-    public static final String UNKNOWN_QUERY_FIELD_NAME = "unknown_query";
-    public static final FieldType EXTRACTED_TERMS_FIELD_TYPE = new FieldType();
-
-    static {
-        EXTRACTED_TERMS_FIELD_TYPE.setTokenized(false);
-        EXTRACTED_TERMS_FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
-        EXTRACTED_TERMS_FIELD_TYPE.freeze();
-    }
-
     private Directory directory;
     private IndexWriter indexWriter;
-    private Map<String, Query> queries;
-    private PercolateQuery.QueryStore queryStore;
     private DirectoryReader directoryReader;
 
     @Before
     public void init() throws Exception {
         directory = newDirectory();
-        queries = new HashMap<>();
-        queryStore = ctx -> docId -> {
-            try {
-                String val = ctx.reader().document(docId).get(UidFieldMapper.NAME);
-                return queries.get(Uid.createUid(val).id());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        };
         IndexWriterConfig config = new IndexWriterConfig(new WhitespaceAnalyzer());
         config.setMergePolicy(NoMergePolicy.INSTANCE);
         indexWriter = new IndexWriter(directory, config);
@@ -121,31 +76,38 @@ public class PercolateQueryTests extends ESTestCase {
         directory.close();
     }
 
-    public void testVariousQueries() throws Exception {
-        addPercolatorQuery("1", new TermQuery(new Term("field", "brown")));
-        addPercolatorQuery("2", new TermQuery(new Term("field", "monkey")));
-        addPercolatorQuery("3", new TermQuery(new Term("field", "fox")));
-        BooleanQuery.Builder bq1 = new BooleanQuery.Builder();
-        bq1.add(new TermQuery(new Term("field", "fox")), BooleanClause.Occur.SHOULD);
-        bq1.add(new TermQuery(new Term("field", "monkey")), BooleanClause.Occur.SHOULD);
-        addPercolatorQuery("4", bq1.build());
-        BooleanQuery.Builder bq2 = new BooleanQuery.Builder();
-        bq2.add(new TermQuery(new Term("field", "fox")), BooleanClause.Occur.MUST);
-        bq2.add(new TermQuery(new Term("field", "monkey")), BooleanClause.Occur.MUST);
-        addPercolatorQuery("5", bq2.build());
-        BooleanQuery.Builder bq3 = new BooleanQuery.Builder();
-        bq3.add(new TermQuery(new Term("field", "fox")), BooleanClause.Occur.MUST);
-        bq3.add(new TermQuery(new Term("field", "apes")), BooleanClause.Occur.MUST_NOT);
-        addPercolatorQuery("6", bq3.build());
-        BooleanQuery.Builder bq4 = new BooleanQuery.Builder();
-        bq4.add(new TermQuery(new Term("field", "fox")), BooleanClause.Occur.MUST_NOT);
-        bq4.add(new TermQuery(new Term("field", "apes")), BooleanClause.Occur.MUST);
-        addPercolatorQuery("7", bq4.build());
-        PhraseQuery.Builder pq1 = new PhraseQuery.Builder();
-        pq1.add(new Term("field", "lazy"));
-        pq1.add(new Term("field", "dog"));
-        addPercolatorQuery("8", pq1.build());
+    public void testPercolateQuery() throws Exception {
+        List<Iterable<? extends IndexableField>> docs = new ArrayList<>();
+        List<Query> queries = new ArrayList<>();
+        PercolateQuery.QueryStore queryStore = ctx -> queries::get;
 
+        queries.add(new TermQuery(new Term("field", "fox")));
+        docs.add(Collections.singleton(new StringField("select", "a", Field.Store.NO)));
+
+        SpanNearQuery.Builder snp = new SpanNearQuery.Builder("field", true);
+        snp.addClause(new SpanTermQuery(new Term("field", "jumps")));
+        snp.addClause(new SpanTermQuery(new Term("field", "lazy")));
+        snp.addClause(new SpanTermQuery(new Term("field", "dog")));
+        snp.setSlop(2);
+        queries.add(snp.build());
+        docs.add(Collections.singleton(new StringField("select", "b", Field.Store.NO)));
+
+        PhraseQuery.Builder pq1 = new PhraseQuery.Builder();
+        pq1.add(new Term("field", "quick"));
+        pq1.add(new Term("field", "brown"));
+        pq1.add(new Term("field", "jumps"));
+        pq1.setSlop(1);
+        queries.add(pq1.build());
+        docs.add(Collections.singleton(new StringField("select", "b", Field.Store.NO)));
+
+        BooleanQuery.Builder bq1 = new BooleanQuery.Builder();
+        bq1.add(new TermQuery(new Term("field", "quick")), BooleanClause.Occur.MUST);
+        bq1.add(new TermQuery(new Term("field", "brown")), BooleanClause.Occur.MUST);
+        bq1.add(new TermQuery(new Term("field", "fox")), BooleanClause.Occur.MUST);
+        queries.add(bq1.build());
+        docs.add(Collections.singleton(new StringField("select", "b", Field.Store.NO)));
+
+        indexWriter.addDocuments(docs);
         indexWriter.close();
         directoryReader = DirectoryReader.open(directory);
         IndexSearcher shardSearcher = newSearcher(directoryReader);
@@ -153,26 +115,26 @@ public class PercolateQueryTests extends ESTestCase {
         MemoryIndex memoryIndex = new MemoryIndex();
         memoryIndex.addField("field", "the quick brown fox jumps over the lazy dog", new WhitespaceAnalyzer());
         IndexSearcher percolateSearcher = memoryIndex.createSearcher();
-
-        PercolateQuery.Builder builder = new PercolateQuery.Builder(
-                "docType",
-                queryStore,
-                new BytesArray("{}"),
-                percolateSearcher
-        );
-        builder.extractQueryTermsQuery(EXTRACTED_TERMS_FIELD_NAME, UNKNOWN_QUERY_FIELD_NAME);
         // no scoring, wrapping it in a constant score query:
-        Query query = new ConstantScoreQuery(builder.build());
+        Query query = new ConstantScoreQuery(new PercolateQuery("type", queryStore, new BytesArray("a"),
+                new TermQuery(new Term("select", "a")), percolateSearcher, new MatchNoDocsQuery("")));
         TopDocs topDocs = shardSearcher.search(query, 10);
-        assertThat(topDocs.totalHits, equalTo(5));
-        assertThat(topDocs.scoreDocs.length, equalTo(5));
+        assertThat(topDocs.totalHits, equalTo(1));
+        assertThat(topDocs.scoreDocs.length, equalTo(1));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(0));
         Explanation explanation = shardSearcher.explain(query, 0);
         assertThat(explanation.isMatch(), is(true));
         assertThat(explanation.getValue(), equalTo(topDocs.scoreDocs[0].score));
 
+        query = new ConstantScoreQuery(new PercolateQuery("type", queryStore, new BytesArray("b"),
+                new TermQuery(new Term("select", "b")), percolateSearcher, new MatchNoDocsQuery("")));
+        topDocs = shardSearcher.search(query, 10);
+        assertThat(topDocs.totalHits, equalTo(3));
+        assertThat(topDocs.scoreDocs.length, equalTo(3));
+        assertThat(topDocs.scoreDocs[0].doc, equalTo(1));
         explanation = shardSearcher.explain(query, 1);
-        assertThat(explanation.isMatch(), is(false));
+        assertThat(explanation.isMatch(), is(true));
+        assertThat(explanation.getValue(), equalTo(topDocs.scoreDocs[0].score));
 
         assertThat(topDocs.scoreDocs[1].doc, equalTo(2));
         explanation = shardSearcher.explain(query, 2);
@@ -180,371 +142,37 @@ public class PercolateQueryTests extends ESTestCase {
         assertThat(explanation.getValue(), equalTo(topDocs.scoreDocs[1].score));
 
         assertThat(topDocs.scoreDocs[2].doc, equalTo(3));
-        explanation = shardSearcher.explain(query, 3);
+        explanation = shardSearcher.explain(query, 2);
         assertThat(explanation.isMatch(), is(true));
         assertThat(explanation.getValue(), equalTo(topDocs.scoreDocs[2].score));
 
-        explanation = shardSearcher.explain(query, 4);
-        assertThat(explanation.isMatch(), is(false));
+        query = new ConstantScoreQuery(new PercolateQuery("type", queryStore, new BytesArray("c"),
+                new MatchAllDocsQuery(), percolateSearcher, new MatchAllDocsQuery()));
+        topDocs = shardSearcher.search(query, 10);
+        assertThat(topDocs.totalHits, equalTo(4));
 
-        assertThat(topDocs.scoreDocs[3].doc, equalTo(5));
-        explanation = shardSearcher.explain(query, 5);
-        assertThat(explanation.isMatch(), is(true));
-        assertThat(explanation.getValue(), equalTo(topDocs.scoreDocs[3].score));
-
-        explanation = shardSearcher.explain(query, 6);
-        assertThat(explanation.isMatch(), is(false));
-
-        assertThat(topDocs.scoreDocs[4].doc, equalTo(7));
-        explanation = shardSearcher.explain(query, 7);
-        assertThat(explanation.isMatch(), is(true));
-        assertThat(explanation.getValue(), equalTo(topDocs.scoreDocs[4].score));
-    }
-
-    public void testVariousQueries_withScoring() throws Exception {
-        SpanNearQuery.Builder snp = new SpanNearQuery.Builder("field", true);
-        snp.addClause(new SpanTermQuery(new Term("field", "jumps")));
-        snp.addClause(new SpanTermQuery(new Term("field", "lazy")));
-        snp.addClause(new SpanTermQuery(new Term("field", "dog")));
-        snp.setSlop(2);
-        addPercolatorQuery("1", snp.build());
-        PhraseQuery.Builder pq1 = new PhraseQuery.Builder();
-        pq1.add(new Term("field", "quick"));
-        pq1.add(new Term("field", "brown"));
-        pq1.add(new Term("field", "jumps"));
-        pq1.setSlop(1);
-        addPercolatorQuery("2", pq1.build());
-        BooleanQuery.Builder bq1 = new BooleanQuery.Builder();
-        bq1.add(new TermQuery(new Term("field", "quick")), BooleanClause.Occur.MUST);
-        bq1.add(new TermQuery(new Term("field", "brown")), BooleanClause.Occur.MUST);
-        bq1.add(new TermQuery(new Term("field", "fox")), BooleanClause.Occur.MUST);
-        addPercolatorQuery("3", bq1.build());
-
-        indexWriter.close();
-        directoryReader = DirectoryReader.open(directory);
-        IndexSearcher shardSearcher = newSearcher(directoryReader);
-
-        MemoryIndex memoryIndex = new MemoryIndex();
-        memoryIndex.addField("field", "the quick brown fox jumps over the lazy dog", new WhitespaceAnalyzer());
-        IndexSearcher percolateSearcher = memoryIndex.createSearcher();
-
-        PercolateQuery.Builder builder = new PercolateQuery.Builder(
-                "docType",
-                queryStore,
-                new BytesArray("{}"),
-                percolateSearcher
-        );
-        builder.extractQueryTermsQuery(EXTRACTED_TERMS_FIELD_NAME, UNKNOWN_QUERY_FIELD_NAME);
-        Query query = builder.build();
-        TopDocs topDocs = shardSearcher.search(query, 10);
+        query = new PercolateQuery("type", queryStore, new BytesArray("{}"), new TermQuery(new Term("select", "b")),
+                percolateSearcher, new MatchNoDocsQuery(""));
+        topDocs = shardSearcher.search(query, 10);
         assertThat(topDocs.totalHits, equalTo(3));
-
-        assertThat(topDocs.scoreDocs[0].doc, equalTo(2));
-        Explanation explanation = shardSearcher.explain(query, 2);
+        assertThat(topDocs.scoreDocs.length, equalTo(3));
+        assertThat(topDocs.scoreDocs[0].doc, equalTo(3));
+        explanation = shardSearcher.explain(query, 3);
         assertThat(explanation.isMatch(), is(true));
         assertThat(explanation.getValue(), equalTo(topDocs.scoreDocs[0].score));
         assertThat(explanation.getDetails(), arrayWithSize(1));
 
-        assertThat(topDocs.scoreDocs[1].doc, equalTo(1));
-        explanation = shardSearcher.explain(query, 1);
+        assertThat(topDocs.scoreDocs[1].doc, equalTo(2));
+        explanation = shardSearcher.explain(query, 2);
         assertThat(explanation.isMatch(), is(true));
         assertThat(explanation.getValue(), equalTo(topDocs.scoreDocs[1].score));
         assertThat(explanation.getDetails(), arrayWithSize(1));
 
-        assertThat(topDocs.scoreDocs[2].doc, equalTo(0));
-        explanation = shardSearcher.explain(query, 0);
+        assertThat(topDocs.scoreDocs[2].doc, equalTo(1));
+        explanation = shardSearcher.explain(query, 1);
         assertThat(explanation.isMatch(), is(true));
         assertThat(explanation.getValue(), equalTo(topDocs.scoreDocs[2].score));
         assertThat(explanation.getDetails(), arrayWithSize(1));
-    }
-
-    public void testDuel() throws Exception {
-        List<Function<String, Query>> queries = new ArrayList<>();
-        queries.add((id) -> new PrefixQuery(new Term("field", id)));
-        queries.add((id) -> new WildcardQuery(new Term("field", id + "*")));
-        queries.add((id) -> new CustomQuery(new Term("field", id)));
-        queries.add((id) -> new SpanTermQuery(new Term("field", id)));
-        queries.add((id) -> new TermQuery(new Term("field", id)));
-        queries.add((id) -> {
-            BooleanQuery.Builder builder = new BooleanQuery.Builder();
-            return builder.build();
-        });
-        queries.add((id) -> {
-            BooleanQuery.Builder builder = new BooleanQuery.Builder();
-            builder.add(new TermQuery(new Term("field", id)), BooleanClause.Occur.MUST);
-            if (randomBoolean()) {
-                builder.add(new MatchNoDocsQuery("no reason"), BooleanClause.Occur.MUST_NOT);
-            }
-            if (randomBoolean()) {
-                builder.add(new CustomQuery(new Term("field", id)), BooleanClause.Occur.MUST);
-            }
-            return builder.build();
-        });
-        queries.add((id) -> {
-            BooleanQuery.Builder builder = new BooleanQuery.Builder();
-            builder.add(new TermQuery(new Term("field", id)), BooleanClause.Occur.SHOULD);
-            if (randomBoolean()) {
-                builder.add(new MatchNoDocsQuery("no reason"), BooleanClause.Occur.MUST_NOT);
-            }
-            if (randomBoolean()) {
-                builder.add(new CustomQuery(new Term("field", id)), BooleanClause.Occur.SHOULD);
-            }
-            return builder.build();
-        });
-        queries.add((id) -> {
-            BooleanQuery.Builder builder = new BooleanQuery.Builder();
-            builder.add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST);
-            builder.add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST);
-            if (randomBoolean()) {
-                builder.add(new MatchNoDocsQuery("no reason"), BooleanClause.Occur.MUST_NOT);
-            }
-            return builder.build();
-        });
-        queries.add((id) -> {
-            BooleanQuery.Builder builder = new BooleanQuery.Builder();
-            builder.add(new MatchAllDocsQuery(), BooleanClause.Occur.SHOULD);
-            builder.add(new MatchAllDocsQuery(), BooleanClause.Occur.SHOULD);
-            if (randomBoolean()) {
-                builder.add(new MatchNoDocsQuery("no reason"), BooleanClause.Occur.MUST_NOT);
-            }
-            return builder.build();
-        });
-        queries.add((id) -> {
-            BooleanQuery.Builder builder = new BooleanQuery.Builder();
-            builder.setMinimumNumberShouldMatch(randomIntBetween(0, 4));
-            builder.add(new TermQuery(new Term("field", id)), BooleanClause.Occur.SHOULD);
-            builder.add(new CustomQuery(new Term("field", id)), BooleanClause.Occur.SHOULD);
-            return builder.build();
-        });
-        queries.add((id) -> new MatchAllDocsQuery());
-        queries.add((id) -> new MatchNoDocsQuery("no reason at all"));
-
-        int numDocs = randomIntBetween(queries.size(), queries.size() * 3);
-        for (int i = 0; i < numDocs; i++) {
-            String id = Integer.toString(i);
-            addPercolatorQuery(id, queries.get(i % queries.size()).apply(id));
-        }
-
-        indexWriter.close();
-        directoryReader = DirectoryReader.open(directory);
-        IndexSearcher shardSearcher = newSearcher(directoryReader);
-        // Disable query cache, because ControlQuery cannot be cached...
-        shardSearcher.setQueryCache(null);
-
-        for (int i = 0; i < numDocs; i++) {
-            String id = Integer.toString(i);
-            MemoryIndex memoryIndex = new MemoryIndex();
-            memoryIndex.addField("field", id, new WhitespaceAnalyzer());
-            duelRun(memoryIndex, shardSearcher);
-        }
-
-        MemoryIndex memoryIndex = new MemoryIndex();
-        memoryIndex.addField("field", "value", new WhitespaceAnalyzer());
-        duelRun(memoryIndex, shardSearcher);
-        // Empty percolator doc:
-        memoryIndex = new MemoryIndex();
-        duelRun(memoryIndex, shardSearcher);
-    }
-
-    public void testDuelSpecificQueries() throws Exception {
-        CommonTermsQuery commonTermsQuery = new CommonTermsQuery(BooleanClause.Occur.SHOULD, BooleanClause.Occur.SHOULD, 128);
-        commonTermsQuery.add(new Term("field", "quick"));
-        commonTermsQuery.add(new Term("field", "brown"));
-        commonTermsQuery.add(new Term("field", "fox"));
-        addPercolatorQuery("_id1", commonTermsQuery);
-
-        BlendedTermQuery blendedTermQuery = BlendedTermQuery.booleanBlendedQuery(new Term[]{new Term("field", "quick"),
-                new Term("field", "brown"), new Term("field", "fox")}, false);
-        addPercolatorQuery("_id2", blendedTermQuery);
-
-        SpanNearQuery spanNearQuery = new SpanNearQuery.Builder("field", true)
-                .addClause(new SpanTermQuery(new Term("field", "quick")))
-                .addClause(new SpanTermQuery(new Term("field", "brown")))
-                .addClause(new SpanTermQuery(new Term("field", "fox")))
-                .build();
-        addPercolatorQuery("_id3", spanNearQuery);
-
-        SpanNearQuery spanNearQuery2 = new SpanNearQuery.Builder("field", true)
-                .addClause(new SpanTermQuery(new Term("field", "the")))
-                .addClause(new SpanTermQuery(new Term("field", "lazy")))
-                .addClause(new SpanTermQuery(new Term("field", "doc")))
-                .build();
-        SpanOrQuery spanOrQuery = new SpanOrQuery(
-                spanNearQuery,
-                spanNearQuery2
-        );
-        addPercolatorQuery("_id4", spanOrQuery);
-
-        SpanNotQuery spanNotQuery = new SpanNotQuery(spanNearQuery, spanNearQuery);
-        addPercolatorQuery("_id5", spanNotQuery);
-
-        indexWriter.close();
-        directoryReader = DirectoryReader.open(directory);
-        IndexSearcher shardSearcher = newSearcher(directoryReader);
-        // Disable query cache, because ControlQuery cannot be cached...
-        shardSearcher.setQueryCache(null);
-
-        MemoryIndex memoryIndex = new MemoryIndex();
-        memoryIndex.addField("field", "the quick brown fox jumps over the lazy dog", new WhitespaceAnalyzer());
-        duelRun(memoryIndex, shardSearcher);
-    }
-
-    void addPercolatorQuery(String id, Query query, String... extraFields) throws IOException {
-        queries.put(id, query);
-        ParseContext.Document document = new ParseContext.Document();
-        ExtractQueryTermsService.extractQueryTerms(query, document, EXTRACTED_TERMS_FIELD_NAME, UNKNOWN_QUERY_FIELD_NAME,
-                EXTRACTED_TERMS_FIELD_TYPE);
-        document.add(new StoredField(UidFieldMapper.NAME, Uid.createUid(MapperService.PERCOLATOR_LEGACY_TYPE_NAME, id)));
-        assert extraFields.length % 2 == 0;
-        for (int i = 0; i < extraFields.length; i++) {
-            document.add(new StringField(extraFields[i], extraFields[++i], Field.Store.NO));
-        }
-        indexWriter.addDocument(document);
-    }
-
-    private void duelRun(MemoryIndex memoryIndex, IndexSearcher shardSearcher) throws IOException {
-        boolean requireScore = randomBoolean();
-        IndexSearcher percolateSearcher = memoryIndex.createSearcher();
-        PercolateQuery.Builder builder = new PercolateQuery.Builder(
-                "docType",
-                queryStore,
-                new BytesArray("{}"),
-                percolateSearcher
-        );
-        // enables the optimization that prevents queries from being evaluated that don't match
-        builder.extractQueryTermsQuery(EXTRACTED_TERMS_FIELD_NAME, UNKNOWN_QUERY_FIELD_NAME);
-        Query query = requireScore ? builder.build() : new ConstantScoreQuery(builder.build());
-        TopDocs topDocs = shardSearcher.search(query, 10);
-
-        Query controlQuery = new ControlQuery(memoryIndex, queryStore);
-        controlQuery = requireScore ? controlQuery : new ConstantScoreQuery(controlQuery);
-        TopDocs controlTopDocs = shardSearcher.search(controlQuery, 10);
-        assertThat(topDocs.totalHits, equalTo(controlTopDocs.totalHits));
-        assertThat(topDocs.scoreDocs.length, equalTo(controlTopDocs.scoreDocs.length));
-        for (int j = 0; j < topDocs.scoreDocs.length; j++) {
-            assertThat(topDocs.scoreDocs[j].doc, equalTo(controlTopDocs.scoreDocs[j].doc));
-            assertThat(topDocs.scoreDocs[j].score, equalTo(controlTopDocs.scoreDocs[j].score));
-            if (requireScore) {
-                Explanation explain1 = shardSearcher.explain(query, topDocs.scoreDocs[j].doc);
-                Explanation explain2 = shardSearcher.explain(controlQuery, controlTopDocs.scoreDocs[j].doc);
-                assertThat(explain1.isMatch(), equalTo(explain2.isMatch()));
-                assertThat(explain1.getValue(), equalTo(explain2.getValue()));
-            }
-        }
-    }
-
-    private static final class CustomQuery extends Query {
-
-        private final Term term;
-
-        private CustomQuery(Term term) {
-            this.term = term;
-        }
-
-        @Override
-        public Query rewrite(IndexReader reader) throws IOException {
-            return new TermQuery(term);
-        }
-
-        @Override
-        public String toString(String field) {
-            return "custom{" + field + "}";
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            return sameClassAs(obj);
-        }
-
-        @Override
-        public int hashCode() {
-            return classHash();
-        }
-    }
-
-    private static final class ControlQuery extends Query {
-
-        private final MemoryIndex memoryIndex;
-        private final PercolateQuery.QueryStore queryStore;
-
-        private ControlQuery(MemoryIndex memoryIndex, PercolateQuery.QueryStore queryStore) {
-            this.memoryIndex = memoryIndex;
-            this.queryStore = queryStore;
-        }
-
-        @Override
-        public Weight createWeight(IndexSearcher searcher, boolean needsScores) {
-            return new ConstantScoreWeight(this) {
-
-                float _score;
-
-                @Override
-                public Explanation explain(LeafReaderContext context, int doc) throws IOException {
-                    Scorer scorer = scorer(context);
-                    if (scorer != null) {
-                        int result = scorer.iterator().advance(doc);
-                        if (result == doc) {
-                            return Explanation.match(scorer.score(), "ControlQuery");
-                        }
-                    }
-                    return Explanation.noMatch("ControlQuery");
-                }
-
-                @Override
-                public String toString() {
-                    return "weight(" + ControlQuery.this + ")";
-                }
-
-                @Override
-                public Scorer scorer(LeafReaderContext context) throws IOException {
-                    DocIdSetIterator allDocs = DocIdSetIterator.all(context.reader().maxDoc());
-                    PercolateQuery.QueryStore.Leaf leaf = queryStore.getQueries(context);
-                    FilteredDocIdSetIterator memoryIndexIterator = new FilteredDocIdSetIterator(allDocs) {
-
-                        @Override
-                        protected boolean match(int doc) {
-                            try {
-                                Query query = leaf.getQuery(doc);
-                                float score = memoryIndex.search(query);
-                                if (score != 0f) {
-                                    if (needsScores) {
-                                        _score = score;
-                                    }
-                                    return true;
-                                } else {
-                                    return false;
-                                }
-                            } catch (IOException e) {
-                                throw new RuntimeException(e);
-                            }
-                        }
-                    };
-                    return new FilterScorer(new ConstantScoreScorer(this, score(), memoryIndexIterator)) {
-
-                        @Override
-                        public float score() throws IOException {
-                            return _score;
-                        }
-                    };
-                }
-            };
-        }
-
-        @Override
-        public String toString(String field) {
-            return "control{" + field + "}";
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            return sameClassAs(obj);
-        }
-
-        @Override
-        public int hashCode() {
-            return classHash();
-        }
-
     }
 
 }

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -19,26 +19,52 @@
 
 package org.elasticsearch.percolator;
 
+import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.PrefixCodedTerms;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.memory.MemoryIndex;
+import org.apache.lucene.queries.TermsQuery;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.PointRangeQuery;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.BoostingQueryBuilder;
+import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.QueryShardException;
+import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
+import org.elasticsearch.index.query.functionscore.RandomScoreFunctionBuilder;
 import org.elasticsearch.indices.TermsLookup;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
@@ -49,8 +75,9 @@ import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termsLookupQuery;
 import static org.elasticsearch.index.query.QueryBuilders.wildcardQuery;
-import static org.elasticsearch.percolator.ExtractQueryTermsService.EXTRACTION_COMPLETE;
-import static org.elasticsearch.percolator.ExtractQueryTermsService.EXTRACTION_FAILED;
+import static org.elasticsearch.percolator.PercolatorFieldMapper.EXTRACTION_COMPLETE;
+import static org.elasticsearch.percolator.PercolatorFieldMapper.EXTRACTION_FAILED;
+import static org.elasticsearch.percolator.PercolatorFieldMapper.EXTRACTION_PARTIAL;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -61,7 +88,8 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
     private String fieldName;
     private IndexService indexService;
     private MapperService mapperService;
-    private PercolatorFieldMapper.PercolatorFieldType fieldType;
+    private DocumentMapper documentMapper;
+    private PercolatorFieldMapper.FieldType fieldType;
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
@@ -77,10 +105,14 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
             .startObject("_field_names").field("enabled", false).endObject() // makes testing easier
             .startObject("properties")
                 .startObject("field").field("type", "text").endObject()
+                .startObject("field1").field("type", "text").endObject()
+                .startObject("field2").field("type", "text").endObject()
+                .startObject("_field3").field("type", "text").endObject()
+                .startObject("field4").field("type", "text").endObject()
                 .startObject("number_field").field("type", "long").endObject()
                 .startObject("date_field").field("type", "date").endObject()
             .endObject().endObject().endObject().string();
-        mapperService.merge("type", new CompressedXContent(mapper), MapperService.MergeReason.MAPPING_UPDATE, true);
+        documentMapper = mapperService.merge("type", new CompressedXContent(mapper), MapperService.MergeReason.MAPPING_UPDATE, true);
     }
 
     private void addQueryMapping() throws Exception {
@@ -90,7 +122,123 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                 .startObject("properties").startObject(fieldName).field("type", "percolator").endObject().endObject()
                 .endObject().endObject().string();
         mapperService.merge(typeName, new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE, true);
-        fieldType = (PercolatorFieldMapper.PercolatorFieldType) mapperService.fullName(fieldName);
+        fieldType = (PercolatorFieldMapper.FieldType) mapperService.fullName(fieldName);
+    }
+
+    public void testExtractTermsAndRanges() throws Exception {
+        addQueryMapping();
+        BooleanQuery.Builder bq = new BooleanQuery.Builder();
+        TermQuery termQuery1 = new TermQuery(new Term("field", "term1"));
+        bq.add(termQuery1, BooleanClause.Occur.SHOULD);
+        TermQuery termQuery2 = new TermQuery(new Term("field", "term2"));
+        bq.add(termQuery2, BooleanClause.Occur.SHOULD);
+        bq.add(LongPoint.newRangeQuery("number_field", 5L, 10L), BooleanClause.Occur.SHOULD);
+
+        DocumentMapper documentMapper = mapperService.documentMapper(typeName);
+        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
+        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(Settings.EMPTY,
+                mapperService.documentMapperParser(), documentMapper, null, null);
+        fieldMapper.extractTermsAndRanges(parseContext, bq.build());
+        ParseContext.Document document = parseContext.doc();
+
+        PercolatorFieldMapper.FieldType fieldType = (PercolatorFieldMapper.FieldType) fieldMapper.fieldType();
+        assertThat(document.getField(fieldType.extractionResultField.name()).stringValue(), equalTo(EXTRACTION_PARTIAL));
+        List<IndexableField> fields = new ArrayList<>(Arrays.asList(document.getFields(fieldType.queryTermsField.name())));
+        Collections.sort(fields, (field1, field2) -> field1.binaryValue().compareTo(field2.binaryValue()));
+        assertThat(fields.size(), equalTo(2));
+        assertThat(fields.get(0).binaryValue().utf8ToString(), equalTo("field\u0000term1"));
+        assertThat(fields.get(1).binaryValue().utf8ToString(), equalTo("field\u0000term2"));
+
+        IndexableField field = document.getField(fieldType.ranges.get("long").fromField.name());
+        assertThat(LongPoint.decodeDimension(field.binaryValue().bytes, 0), equalTo(5L));
+        field = document.getField(fieldType.ranges.get("long").toField.name());
+        assertThat(LongPoint.decodeDimension(field.binaryValue().bytes, 0), equalTo(10L));
+    }
+
+    public void testExtractTermsAndRanges_unsupported() throws Exception {
+        addQueryMapping();
+        TermRangeQuery query = new TermRangeQuery("field1", new BytesRef("a"), new BytesRef("z"), true, true);
+        DocumentMapper documentMapper = mapperService.documentMapper(typeName);
+        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
+        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(Settings.EMPTY,
+                mapperService.documentMapperParser(), documentMapper, null, null);
+        fieldMapper.extractTermsAndRanges(parseContext, query);
+        ParseContext.Document document = parseContext.doc();
+
+        PercolatorFieldMapper.FieldType fieldType = (PercolatorFieldMapper.FieldType) fieldMapper.fieldType();
+        assertThat(document.getFields().size(), equalTo(1));
+        assertThat(document.getField(fieldType.extractionResultField.name()).stringValue(), equalTo(EXTRACTION_FAILED));
+    }
+
+    public void testExtractTermsAndRanges_notVerified() throws Exception {
+        addQueryMapping();
+        PhraseQuery phraseQuery = new PhraseQuery("field", "term");
+        DocumentMapper documentMapper = mapperService.documentMapper(typeName);
+        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
+        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(Settings.EMPTY,
+                mapperService.documentMapperParser(), documentMapper, null, null);
+        fieldMapper.extractTermsAndRanges(parseContext, phraseQuery);
+        ParseContext.Document document = parseContext.doc();
+
+        PercolatorFieldMapper.FieldType fieldType = (PercolatorFieldMapper.FieldType) fieldMapper.fieldType();
+        assertThat(document.getFields().size(), equalTo(2));
+        assertThat(document.getFields().get(0).binaryValue().utf8ToString(), equalTo("field\u0000term"));
+        assertThat(document.getField(fieldType.extractionResultField.name()).stringValue(), equalTo(EXTRACTION_PARTIAL));
+    }
+
+    public void testCreateCandidateQuery() throws Exception {
+        addQueryMapping();
+
+        MemoryIndex memoryIndex = new MemoryIndex(false);
+        memoryIndex.addField("field1", "the quick brown fox jumps over the lazy dog", new WhitespaceAnalyzer());
+        memoryIndex.addField("field2", "some more text", new WhitespaceAnalyzer());
+        memoryIndex.addField("_field3", "unhide me", new WhitespaceAnalyzer());
+        memoryIndex.addField("field4", "123", new WhitespaceAnalyzer());
+        memoryIndex.addField(new LongPoint("number_field", 10L), new WhitespaceAnalyzer());
+
+        IndexReader indexReader = memoryIndex.createSearcher().getIndexReader();
+
+        BooleanQuery bq = (BooleanQuery) fieldType.createCandidateQuery(indexReader, documentMapper);
+        assertThat(bq.clauses().get(0).getOccur(), equalTo(BooleanClause.Occur.SHOULD));
+        TermsQuery termsQuery = (TermsQuery) bq.clauses().get(0).getQuery();
+
+        PrefixCodedTerms terms = termsQuery.getTermData();
+        assertThat(terms.size(), equalTo(15L));
+        PrefixCodedTerms.TermIterator termIterator = terms.iterator();
+        assertTermIterator(termIterator, "_field3\u0000me", fieldType.queryTermsField.name());
+        assertTermIterator(termIterator, "_field3\u0000unhide", fieldType.queryTermsField.name());
+        assertTermIterator(termIterator, "field1\u0000brown", fieldType.queryTermsField.name());
+        assertTermIterator(termIterator, "field1\u0000dog", fieldType.queryTermsField.name());
+        assertTermIterator(termIterator, "field1\u0000fox", fieldType.queryTermsField.name());
+        assertTermIterator(termIterator, "field1\u0000jumps", fieldType.queryTermsField.name());
+        assertTermIterator(termIterator, "field1\u0000lazy", fieldType.queryTermsField.name());
+        assertTermIterator(termIterator, "field1\u0000over", fieldType.queryTermsField.name());
+        assertTermIterator(termIterator, "field1\u0000quick", fieldType.queryTermsField.name());
+        assertTermIterator(termIterator, "field1\u0000the", fieldType.queryTermsField.name());
+        assertTermIterator(termIterator, "field2\u0000more", fieldType.queryTermsField.name());
+        assertTermIterator(termIterator, "field2\u0000some", fieldType.queryTermsField.name());
+        assertTermIterator(termIterator, "field2\u0000text", fieldType.queryTermsField.name());
+        assertTermIterator(termIterator, "field4\u0000123", fieldType.queryTermsField.name());
+        assertTermIterator(termIterator, EXTRACTION_FAILED, fieldType.extractionResultField.name());
+
+        assertThat(bq.clauses().get(1).getOccur(), equalTo(BooleanClause.Occur.SHOULD));
+        BooleanQuery rangeBq = (BooleanQuery) bq.clauses().get(1).getQuery();
+        assertThat(rangeBq.clauses().size(), equalTo(2));
+        assertThat(rangeBq.clauses().get(0).getOccur(), equalTo(BooleanClause.Occur.MUST));
+        PointRangeQuery pointRangeQuery = (PointRangeQuery) rangeBq.clauses().get(0).getQuery();
+        assertThat(pointRangeQuery.getField(), equalTo(fieldType.ranges.get("long").fromField.name()));
+        assertThat(LongPoint.decodeDimension(pointRangeQuery.getLowerPoint(), 0), equalTo(Long.MIN_VALUE));
+        assertThat(LongPoint.decodeDimension(pointRangeQuery.getUpperPoint(), 0), equalTo(10L));
+        assertThat(rangeBq.clauses().get(1).getOccur(), equalTo(BooleanClause.Occur.MUST));
+        pointRangeQuery = (PointRangeQuery) rangeBq.clauses().get(1).getQuery();
+        assertThat(pointRangeQuery.getField(), equalTo(fieldType.ranges.get("long").toField.name()));
+        assertThat(LongPoint.decodeDimension(pointRangeQuery.getLowerPoint(), 0), equalTo(10L));
+        assertThat(LongPoint.decodeDimension(pointRangeQuery.getUpperPoint(), 0), equalTo(Long.MAX_VALUE));
+    }
+
+    private void assertTermIterator(PrefixCodedTerms.TermIterator termIterator, String expectedValue, String expectedField) {
+        assertThat(termIterator.next().utf8ToString(), equalTo(expectedValue));
+        assertThat(termIterator.field(), equalTo(expectedField));
     }
 
     public void testPercolatorFieldMapper() throws Exception {
@@ -100,12 +248,13 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
             .field(fieldName, queryBuilder)
             .endObject().bytes());
 
-        assertThat(doc.rootDoc().getFields(fieldType.getExtractedTermsField()).length, equalTo(1));
-        assertThat(doc.rootDoc().getFields(fieldType.getExtractedTermsField())[0].binaryValue().utf8ToString(), equalTo("field\0value"));
-        assertThat(doc.rootDoc().getFields(fieldType.getQueryBuilderFieldName()).length, equalTo(1));
-        assertThat(doc.rootDoc().getFields(fieldType.getExtractionResultFieldName()).length, equalTo(1));
-        assertThat(doc.rootDoc().getFields(fieldType.getExtractionResultFieldName())[0].stringValue(), equalTo(EXTRACTION_COMPLETE));
-        BytesRef qbSource = doc.rootDoc().getFields(fieldType.getQueryBuilderFieldName())[0].binaryValue();
+        assertThat(doc.rootDoc().getFields(fieldType.queryTermsField.name()).length, equalTo(1));
+        assertThat(doc.rootDoc().getFields(fieldType.queryTermsField.name())[0].binaryValue().utf8ToString(), equalTo("field\0value"));
+        assertThat(doc.rootDoc().getFields(fieldType.queryBuilderField.name()).length, equalTo(1));
+        assertThat(doc.rootDoc().getFields(fieldType.extractionResultField.name()).length, equalTo(1));
+        assertThat(doc.rootDoc().getFields(fieldType.extractionResultField.name())[0].stringValue(),
+                equalTo(EXTRACTION_COMPLETE));
+        BytesRef qbSource = doc.rootDoc().getFields(fieldType.queryBuilderField.name())[0].binaryValue();
         assertQueryBuilder(qbSource, queryBuilder);
 
         // add an query for which we don't extract terms from
@@ -113,11 +262,12 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         doc = mapperService.documentMapper(typeName).parse("test", typeName, "1", XContentFactory.jsonBuilder().startObject()
                 .field(fieldName, queryBuilder)
                 .endObject().bytes());
-        assertThat(doc.rootDoc().getFields(fieldType.getExtractionResultFieldName()).length, equalTo(1));
-        assertThat(doc.rootDoc().getFields(fieldType.getExtractionResultFieldName())[0].stringValue(), equalTo(EXTRACTION_FAILED));
-        assertThat(doc.rootDoc().getFields(fieldType.getExtractedTermsField()).length, equalTo(0));
-        assertThat(doc.rootDoc().getFields(fieldType.getQueryBuilderFieldName()).length, equalTo(1));
-        qbSource = doc.rootDoc().getFields(fieldType.getQueryBuilderFieldName())[0].binaryValue();
+        assertThat(doc.rootDoc().getFields(fieldType.extractionResultField.name()).length, equalTo(1));
+        assertThat(doc.rootDoc().getFields(fieldType.extractionResultField.name())[0].stringValue(),
+                equalTo(EXTRACTION_FAILED));
+        assertThat(doc.rootDoc().getFields(fieldType.queryTermsField.name()).length, equalTo(0));
+        assertThat(doc.rootDoc().getFields(fieldType.queryBuilderField.name()).length, equalTo(1));
+        qbSource = doc.rootDoc().getFields(fieldType.queryBuilderField.name())[0].binaryValue();
         assertQueryBuilder(qbSource, queryBuilder);
     }
 
@@ -136,7 +286,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                     XContentFactory.jsonBuilder().startObject()
                     .field(fieldName, query)
                     .endObject().bytes());
-            BytesRef qbSource = doc.rootDoc().getFields(fieldType.getQueryBuilderFieldName())[0].binaryValue();
+            BytesRef qbSource = doc.rootDoc().getFields(fieldType.queryBuilderField.name())[0].binaryValue();
             assertQueryBuilder(qbSource, query);
         }
     }
@@ -148,7 +298,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         ParsedDocument doc = mapperService.documentMapper(typeName).parse("test", typeName, "1", XContentFactory.jsonBuilder().startObject()
                 .field(fieldName, queryBuilder)
                 .endObject().bytes());
-        BytesRef qbSource = doc.rootDoc().getFields(fieldType.getQueryBuilderFieldName())[0].binaryValue();
+        BytesRef qbSource = doc.rootDoc().getFields(fieldType.queryBuilderField.name())[0].binaryValue();
         assertQueryBuilder(qbSource, queryBuilder.rewrite(indexService.newQueryShardContext()));
     }
 
@@ -169,7 +319,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         addQueryMapping();
         ParsedDocument doc = mapperService.documentMapper(typeName).parse("test", typeName, "1", XContentFactory.jsonBuilder().startObject()
             .endObject().bytes());
-        assertThat(doc.rootDoc().getFields(fieldType.getQueryBuilderFieldName()).length, equalTo(0));
+        assertThat(doc.rootDoc().getFields(fieldType.queryBuilderField.name()).length, equalTo(0));
 
         try {
             mapperService.documentMapper(typeName).parse("test", typeName, "1", XContentFactory.jsonBuilder().startObject()
@@ -273,6 +423,53 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         );
         assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
         assertThat(e.getCause().getMessage(), equalTo("a document can only contain one percolator query"));
+    }
+
+    public void testRangeQueryWithNowRangeIsForbidden() throws Exception {
+        addQueryMapping();
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> {
+            mapperService.documentMapper(typeName).parse("test", typeName, "1",
+                        jsonBuilder().startObject()
+                                .field(fieldName, rangeQuery("date_field").from("2016-01-01||/D").to("now"))
+                                .endObject().bytes());
+            }
+        );
+        assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
+        e = expectThrows(MapperParsingException.class, () -> {
+            mapperService.documentMapper(typeName).parse("test", typeName, "1",
+                        jsonBuilder().startObject()
+                                .field(fieldName, rangeQuery("date_field").from("2016-01-01||/D").to("now/D"))
+                                .endObject().bytes());
+                }
+        );
+        assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
+        e = expectThrows(MapperParsingException.class, () -> {
+            mapperService.documentMapper(typeName).parse("test", typeName, "1",
+                        jsonBuilder().startObject()
+                                .field(fieldName, rangeQuery("date_field").from("now-1d").to("now"))
+                                .endObject().bytes());
+                }
+        );
+        assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
+    }
+
+    public void testVerifyRangeQueries() {
+        RangeQueryBuilder rangeQuery1 = new RangeQueryBuilder("field").from("2016-01-01||/D").to("2017-01-01||/D");
+        RangeQueryBuilder rangeQuery2 = new RangeQueryBuilder("field").from("2016-01-01||/D").to("now");
+        PercolatorFieldMapper.verifyRangeQueries(rangeQuery1);
+        expectThrows(IllegalArgumentException.class, () -> PercolatorFieldMapper.verifyRangeQueries(rangeQuery2));
+        PercolatorFieldMapper.verifyRangeQueries(new BoolQueryBuilder().must(rangeQuery1));
+        expectThrows(IllegalArgumentException.class, () ->
+                PercolatorFieldMapper.verifyRangeQueries(new BoolQueryBuilder().must(rangeQuery2)));
+        PercolatorFieldMapper.verifyRangeQueries(new ConstantScoreQueryBuilder((rangeQuery1)));
+        expectThrows(IllegalArgumentException.class, () ->
+                PercolatorFieldMapper.verifyRangeQueries(new ConstantScoreQueryBuilder(rangeQuery2)));
+        PercolatorFieldMapper.verifyRangeQueries(new BoostingQueryBuilder(rangeQuery1, new MatchAllQueryBuilder()));
+        expectThrows(IllegalArgumentException.class, () ->
+                PercolatorFieldMapper.verifyRangeQueries(new BoostingQueryBuilder(rangeQuery2, new MatchAllQueryBuilder())));
+        PercolatorFieldMapper.verifyRangeQueries(new FunctionScoreQueryBuilder(rangeQuery1, new RandomScoreFunctionBuilder()));
+        expectThrows(IllegalArgumentException.class, () ->
+                PercolatorFieldMapper.verifyRangeQueries(new FunctionScoreQueryBuilder(rangeQuery2, new RandomScoreFunctionBuilder())));
     }
 
     private void assertQueryBuilder(BytesRef actual, QueryBuilder expected) throws IOException {

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhaseTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhaseTests.java
@@ -41,10 +41,9 @@ import static org.hamcrest.Matchers.sameInstance;
 public class PercolatorHighlightSubFetchPhaseTests extends ESTestCase {
 
     public void testHitsExecutionNeeded() {
-        PercolateQuery percolateQuery = new PercolateQuery.Builder("", ctx -> null, new BytesArray("{}"),
-                Mockito.mock(IndexSearcher.class))
-                .build();
-
+        PercolateQuery percolateQuery = new PercolateQuery(
+                "", ctx -> null, new BytesArray("{}"), new MatchAllDocsQuery(), Mockito.mock(IndexSearcher.class), new MatchAllDocsQuery()
+        );
         PercolatorHighlightSubFetchPhase subFetchPhase = new PercolatorHighlightSubFetchPhase(Settings.EMPTY,
             new Highlighters(Settings.EMPTY));
         SearchContext searchContext = Mockito.mock(SearchContext.class);
@@ -57,10 +56,9 @@ public class PercolatorHighlightSubFetchPhaseTests extends ESTestCase {
     }
 
     public void testLocatePercolatorQuery() {
-        PercolateQuery percolateQuery = new PercolateQuery.Builder("", ctx -> null, new BytesArray("{}"),
-                Mockito.mock(IndexSearcher.class))
-                .build();
-
+        PercolateQuery percolateQuery = new PercolateQuery(
+                "", ctx -> null, new BytesArray("{}"), new MatchAllDocsQuery(), Mockito.mock(IndexSearcher.class), new MatchAllDocsQuery()
+        );
         assertThat(PercolatorHighlightSubFetchPhase.locatePercolatorQuery(new MatchAllDocsQuery()), nullValue());
         BooleanQuery.Builder bq = new BooleanQuery.Builder();
         bq.add(new MatchAllDocsQuery(), BooleanClause.Occur.FILTER);


### PR DESCRIPTION
Also stop support percolator queries containing `range` queries with ranges based on `now`.
