### PR TITLE
Prevent analysis service from eagerly registering default analyzer.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
@@ -262,7 +262,6 @@ public final class AnalysisRegistry implements Closeable {
     }
 
     private void registerBuiltInAnalyzer(Map<String, AnalysisModule.AnalysisProvider<AnalyzerProvider>> analyzers) {
-        analyzers.put("default", StandardAnalyzerProvider::new);
         analyzers.put("standard", StandardAnalyzerProvider::new);
         analyzers.put("standard_html_strip", StandardHtmlStripAnalyzerProvider::new);
         analyzers.put("simple", SimpleAnalyzerProvider::new);

--- a/core/src/main/java/org/elasticsearch/index/analysis/AnalysisService.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/AnalysisService.java
@@ -58,16 +58,6 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
         this.tokenFilters = unmodifiableMap(tokenFilterFactoryFactories);
         analyzerProviders = new HashMap<>(analyzerProviders);
 
-        if (!analyzerProviders.containsKey("default")) {
-            analyzerProviders.put("default", new StandardAnalyzerProvider(indexSettings, null, "default", Settings.Builder.EMPTY_SETTINGS));
-        }
-        if (!analyzerProviders.containsKey("default_search")) {
-            analyzerProviders.put("default_search", analyzerProviders.get("default"));
-        }
-        if (!analyzerProviders.containsKey("default_search_quoted")) {
-            analyzerProviders.put("default_search_quoted", analyzerProviders.get("default_search"));
-        }
-
         Map<String, NamedAnalyzer> analyzers = new HashMap<>();
         for (Map.Entry<String, AnalyzerProvider> entry : analyzerProviders.entrySet()) {
             AnalyzerProvider analyzerFactory = entry.getValue();
@@ -119,6 +109,17 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
             for (String alias : aliases) {
                 analyzers.put(alias, analyzer);
             }
+        }
+
+        if (!analyzerProviders.containsKey("default")) {
+            AnalyzerProvider standardAnalyzerProvider = new StandardAnalyzerProvider(indexSettings, null, "default", Settings.Builder.EMPTY_SETTINGS);
+            analyzers.put("default", new NamedAnalyzer("default", standardAnalyzerProvider.scope(), standardAnalyzerProvider.get(), TextFieldMapper.Defaults.POSITION_INCREMENT_GAP));
+        }
+        if (!analyzerProviders.containsKey("default_search")) {
+            analyzers.put("default_search", analyzers.get("default"));
+        }
+        if (!analyzerProviders.containsKey("default_search_quoted")) {
+            analyzers.put("default_search_quoted", analyzers.get("default_search"));
         }
 
         NamedAnalyzer defaultAnalyzer = analyzers.get("default");
@@ -188,4 +189,5 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
     public TokenFilterFactory tokenFilter(String name) {
         return tokenFilters.get(name);
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzers.java
+++ b/core/src/main/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzers.java
@@ -82,15 +82,6 @@ public enum PreBuiltAnalyzers {
         }
     },
 
-    DEFAULT(CachingStrategy.ELASTICSEARCH){
-        @Override
-        protected Analyzer create(Version version) {
-            // by calling get analyzer we are ensuring reuse of the same STANDARD analyzer for DEFAULT!
-            // this call does not create a new instance
-            return STANDARD.getAnalyzer(version);
-        }
-    },
-
     KEYWORD(CachingStrategy.ONE) {
         @Override
         protected Analyzer create(Version version) {


### PR DESCRIPTION
The tests make references to PrebuiltAnalyzers.DEFAULT so tests fail. @s1monw 
