### PR TITLE
Use a static default precision for the cardinality aggregation.

### DIFF
--- a/docs/reference/aggregations/metrics/cardinality-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/cardinality-aggregation.asciidoc
@@ -45,9 +45,7 @@ experimental[The `precision_threshold` option is specific to the current interna
 defines a unique count below which counts are expected to be close to
 accurate. Above this value, counts might become a bit more fuzzy. The maximum
 supported value is 40000, thresholds above this number will have the same
-effect as a threshold of 40000.
-Default value depends on the number of parent aggregations that multiple
-create buckets (such as terms or histograms).
+effect as a threshold of 40000. The default values is +3000+.
 
 ==== Counts are approximate
 


### PR DESCRIPTION
Today the default precision for the cardinality aggregation depends on how many
parent bucket aggregations it had. The reasoning was that the more parent bucket
aggregations, the more buckets the cardinality had to be computed on. And this
number could be huge depending on what the parent aggregations actually are.

However now that we run terms aggregations in breadth-first mode by default when
there are sub aggregations, it is less likely that we have to run the cardinality
aggregation on kagilions of buckets. So we could use a static default, which will
be less confusing to users.
