### PR TITLE
Bump version to 5.0.0-alpha5.

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,4 +1,4 @@
-elasticsearch     = 5.0.0-alpha4
+elasticsearch     = 5.0.0-alpha5
 lucene            = 6.1.0
 
 # optional dependencies

--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -77,7 +77,9 @@ public class Version {
     public static final Version V_5_0_0_alpha3 = new Version(V_5_0_0_alpha3_ID, org.apache.lucene.util.Version.LUCENE_6_0_0);
     public static final int V_5_0_0_alpha4_ID = 5000004;
     public static final Version V_5_0_0_alpha4 = new Version(V_5_0_0_alpha4_ID, org.apache.lucene.util.Version.LUCENE_6_1_0);
-    public static final Version CURRENT = V_5_0_0_alpha4;
+    public static final int V_5_0_0_alpha5_ID = 5000005;
+    public static final Version V_5_0_0_alpha5 = new Version(V_5_0_0_alpha5_ID, org.apache.lucene.util.Version.LUCENE_6_1_0);
+    public static final Version CURRENT = V_5_0_0_alpha5;
 
     static {
         assert CURRENT.luceneVersion.equals(org.apache.lucene.util.Version.LATEST) : "Version must be upgraded to ["
@@ -90,6 +92,8 @@ public class Version {
 
     public static Version fromId(int id) {
         switch (id) {
+            case V_5_0_0_alpha5_ID:
+                return V_5_0_0_alpha5;
             case V_5_0_0_alpha4_ID:
                 return V_5_0_0_alpha4;
             case V_5_0_0_alpha3_ID:

--- a/qa/backwards-5.0/build.gradle
+++ b/qa/backwards-5.0/build.gradle
@@ -18,6 +18,6 @@ integTest {
   cluster {
     numNodes = 2
     numBwcNodes = 1
-    bwcVersion = "5.0.0-alpha4-SNAPSHOT" // this is the same as the current version until we released the first RC
+    bwcVersion = "5.0.0-alpha5-SNAPSHOT" // this is the same as the current version until we released the first RC
   }
 }


### PR DESCRIPTION
This way we can start adding backward-compatibility logic again using `Version.onOrAfter`.
