### PR TITLE
Fix stored_fields message 'is not longer supported'

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
@@ -74,7 +74,7 @@ public final class InnerHitBuilder extends ToXContentToBytes implements Writeabl
         PARSER.declareStringArray(InnerHitBuilder::setStoredFieldNames, SearchSourceBuilder.STORED_FIELDS_FIELD);
         PARSER.declareField((p, i, c) -> {
             throw new ParsingException(p.getTokenLocation(), "The field [" +
-                SearchSourceBuilder.FIELDS_FIELD + "] is not longer supported, please use [" +
+                SearchSourceBuilder.FIELDS_FIELD + "] is no longer supported, please use [" +
                 SearchSourceBuilder.STORED_FIELDS_FIELD + "] to retrieve stored fields or _source filtering " +
                 "if the field is not stored");
         }, SearchSourceBuilder.FIELDS_FIELD, ObjectParser.ValueType.STRING_ARRAY);

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -178,7 +178,7 @@ public class RestSearchAction extends BaseRestHandler {
 
         if (request.param("fields") != null) {
             throw new IllegalArgumentException("The parameter [" +
-                SearchSourceBuilder.FIELDS_FIELD + "] is not longer supported, please use [" +
+                SearchSourceBuilder.FIELDS_FIELD + "] is no longer supported, please use [" +
                 SearchSourceBuilder.STORED_FIELDS_FIELD + "] to retrieve stored fields or _source filtering " +
                 "if the field is not stored");
         }

--- a/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -1073,7 +1073,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
                     searchAfterBuilder = SearchAfterBuilder.fromXContent(parser, context.getParseFieldMatcher());
                 } else if (context.getParseFieldMatcher().match(currentFieldName, FIELDS_FIELD)) {
                     throw new ParsingException(parser.getTokenLocation(), "The field [" +
-                        SearchSourceBuilder.FIELDS_FIELD + "] is not longer supported, please use [" +
+                        SearchSourceBuilder.FIELDS_FIELD + "] is no longer supported, please use [" +
                         SearchSourceBuilder.STORED_FIELDS_FIELD + "] to retrieve stored fields or _source filtering " +
                         "if the field is not stored");
                 } else {


### PR DESCRIPTION
Fix grammar in error message.  I see it in the Kibana console as this;

`Error: [illegal_argument_exception] The parameter [fields] is not longer supported, please use [stored_fields] to retrieve stored fields or _source filtering if the field is not stored`

`is not longer supported` should be either `is not supported` or `is no longer supported`.  This PR changes it to `is no longer supported`.
