### PR TITLE
Remove guice from transport client helper classes

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -19,6 +19,12 @@
 
 package org.elasticsearch.action;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplainAction;
 import org.elasticsearch.action.admin.cluster.allocation.TransportClusterAllocationExplainAction;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthAction;
@@ -303,12 +309,6 @@ import org.elasticsearch.rest.action.termvectors.RestMultiTermVectorsAction;
 import org.elasticsearch.rest.action.termvectors.RestTermVectorsAction;
 import org.elasticsearch.rest.action.update.RestUpdateAction;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 
@@ -336,6 +336,10 @@ public class ActionModule extends AbstractModule {
         autoCreateIndex = transportClient ? null : new AutoCreateIndex(settings, resolver);
         destructiveOperations = new DestructiveOperations(settings, clusterSettings);
         restController = new RestController(settings);
+    }
+
+    public Map<String, ActionHandler<?, ?>> getActions() {
+        return actions;
     }
 
     static Map<String, ActionHandler<?, ?>> setupActions(List<ActionPlugin> actionPlugins) {
@@ -621,14 +625,6 @@ public class ActionModule extends AbstractModule {
         bind(ActionFilters.class).asEagerSingleton();
         bind(DestructiveOperations.class).toInstance(destructiveOperations);
 
-        // register Name -> GenericAction Map that can be injected to instances.
-        @SuppressWarnings("rawtypes")
-        MapBinder<String, GenericAction> actionsBinder
-                = MapBinder.newMapBinder(binder(), String.class, GenericAction.class);
-
-        for (Map.Entry<String, ActionHandler<?, ?>> entry : actions.entrySet()) {
-            actionsBinder.addBinding(entry.getKey()).toInstance(entry.getValue().getAction());
-        }
         if (false == transportClient) {
             // Supporting classes only used when not a transport client
             bind(AutoCreateIndex.class).toInstance(autoCreateIndex);

--- a/core/src/main/java/org/elasticsearch/action/TransportActionNodeProxy.java
+++ b/core/src/main/java/org/elasticsearch/action/TransportActionNodeProxy.java
@@ -35,7 +35,6 @@ public class TransportActionNodeProxy<Request extends ActionRequest, Response ex
     private final GenericAction<Request, Response> action;
     private final TransportRequestOptions transportOptions;
 
-    @Inject
     public TransportActionNodeProxy(Settings settings, GenericAction<Request, Response> action, TransportService transportService) {
         super(settings);
         this.action = action;

--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -113,7 +113,6 @@ public class TransportClientNodesService extends AbstractComponent implements Cl
     public static final Setting<Boolean> CLIENT_TRANSPORT_SNIFF =
         Setting.boolSetting("client.transport.sniff", false, Property.NodeScope);
 
-    @Inject
     public TransportClientNodesService(Settings settings,TransportService transportService,
                                        ThreadPool threadPool) {
         super(settings);
@@ -282,6 +281,7 @@ public class TransportClientNodesService extends AbstractComponent implements Cl
 
     }
 
+    @Override
     public void close() {
         synchronized (mutex) {
             if (closed) {

--- a/core/src/main/java/org/elasticsearch/common/network/NetworkModule.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkModule.java
@@ -160,10 +160,7 @@ public class NetworkModule extends AbstractModule {
         String defaultTransport = DiscoveryNode.isLocalNode(settings) ? LOCAL_TRANSPORT : NETTY_TRANSPORT;
         transportTypes.bindType(binder(), settings, TRANSPORT_TYPE_KEY, defaultTransport);
 
-        if (transportClient) {
-            bind(TransportProxyClient.class).asEagerSingleton();
-            bind(TransportClientNodesService.class).asEagerSingleton();
-        } else {
+        if (transportClient == false) {
             if (HTTP_ENABLED.get(settings)) {
                 bind(HttpServer.class).asEagerSingleton();
                 httpTransportTypes.bindType(binder(), settings, HTTP_TYPE_SETTING.getKey(), NETTY_TRANSPORT);

--- a/core/src/test/java/org/elasticsearch/client/transport/TransportClientIT.java
+++ b/core/src/test/java/org/elasticsearch/client/transport/TransportClientIT.java
@@ -51,7 +51,6 @@ public class TransportClientIT extends ESIntegTestCase {
 
     public void testNodeVersionIsUpdated() throws IOException {
         TransportClient client = (TransportClient)  internalCluster().client();
-        TransportClientNodesService nodeService = client.nodeService();
         Node node = new Node(Settings.builder()
                 .put(internalCluster().getDefaultSettings())
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
@@ -65,19 +64,19 @@ public class TransportClientIT extends ESIntegTestCase {
             TransportAddress transportAddress = node.injector().getInstance(TransportService.class).boundAddress().publishAddress();
             client.addTransportAddress(transportAddress);
             // since we force transport clients there has to be one node started that we connect to.
-            assertThat(nodeService.connectedNodes().size(), greaterThanOrEqualTo(1));
+            assertThat(client.connectedNodes().size(), greaterThanOrEqualTo(1));
             // connected nodes have updated version
-            for (DiscoveryNode discoveryNode : nodeService.connectedNodes()) {
+            for (DiscoveryNode discoveryNode : client.connectedNodes()) {
                 assertThat(discoveryNode.getVersion(), equalTo(Version.CURRENT));
             }
 
-            for (DiscoveryNode discoveryNode : nodeService.listedNodes()) {
+            for (DiscoveryNode discoveryNode : client.listedNodes()) {
                 assertThat(discoveryNode.getId(), startsWith("#transport#-"));
                 assertThat(discoveryNode.getVersion(), equalTo(Version.CURRENT.minimumCompatibilityVersion()));
             }
 
-            assertThat(nodeService.filteredNodes().size(), equalTo(1));
-            for (DiscoveryNode discoveryNode : nodeService.filteredNodes()) {
+            assertThat(client.filteredNodes().size(), equalTo(1));
+            for (DiscoveryNode discoveryNode : client.filteredNodes()) {
                 assertThat(discoveryNode.getVersion(), equalTo(Version.CURRENT.minimumCompatibilityVersion()));
             }
         } finally {


### PR DESCRIPTION
This change removes injection for constructors of
TransportClientNodesService and TransportProxyClient.
