### PR TITLE
[TEST] Move back some messy tests from Groovy plugin to core

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -1125,12 +1125,9 @@
   <suppress files="modules[/\\]lang-expression[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]script[/\\]expression[/\\]MoreExpressionTests.java" checks="LineLength" />
   <suppress files="modules[/\\]lang-groovy[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]script[/\\]groovy[/\\]GroovyPlugin.java" checks="LineLength" />
   <suppress files="modules[/\\]lang-groovy[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]script[/\\]groovy[/\\]GroovyScriptEngineService.java" checks="LineLength" />
-  <suppress files="modules[/\\]lang-groovy[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]messy[/\\]tests[/\\]BucketScriptTests.java" checks="LineLength" />
   <suppress files="modules[/\\]lang-groovy[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]messy[/\\]tests[/\\]BulkTests.java" checks="LineLength" />
   <suppress files="modules[/\\]lang-groovy[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]messy[/\\]tests[/\\]DoubleTermsTests.java" checks="LineLength" />
   <suppress files="modules[/\\]lang-groovy[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]messy[/\\]tests[/\\]EquivalenceTests.java" checks="LineLength" />
-  <suppress files="modules[/\\]lang-groovy[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]messy[/\\]tests[/\\]HDRPercentileRanksTests.java" checks="LineLength" />
-  <suppress files="modules[/\\]lang-groovy[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]messy[/\\]tests[/\\]HDRPercentilesTests.java" checks="LineLength" />
   <suppress files="modules[/\\]lang-groovy[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]messy[/\\]tests[/\\]HistogramTests.java" checks="LineLength" />
   <suppress files="modules[/\\]lang-groovy[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]messy[/\\]tests[/\\]IPv4RangeTests.java" checks="LineLength" />
   <suppress files="modules[/\\]lang-groovy[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]messy[/\\]tests[/\\]IndexLookupTests.java" checks="LineLength" />

--- a/core/src/test/java/org/elasticsearch/script/FileScriptTests.java
+++ b/core/src/test/java/org/elasticsearch/script/FileScriptTests.java
@@ -58,7 +58,7 @@ public class FileScriptTests extends ESTestCase {
         CompiledScript compiledScript = scriptService.compile(script, ScriptContext.Standard.SEARCH, Collections.emptyMap());
         assertNotNull(compiledScript);
         MockCompiledScript executable = (MockCompiledScript) compiledScript.compiled();
-        assertEquals("script1.mockscript", executable.name);
+        assertEquals("script1.mockscript", executable.getName());
     }
 
     public void testAllOpsDisabled() throws Exception {

--- a/core/src/test/java/org/elasticsearch/script/StoredScriptsIT.java
+++ b/core/src/test/java/org/elasticsearch/script/StoredScriptsIT.java
@@ -24,6 +24,9 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 
@@ -41,7 +44,7 @@ public class StoredScriptsIT extends ESIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(MockScriptEngine.TestPlugin.class);
+        return pluginList(CustomScriptPlugin.class);
     }
 
     public void testBasics() {
@@ -79,4 +82,11 @@ public class StoredScriptsIT extends ESIntegTestCase {
         assertEquals("Limit of script size in bytes [64] has been exceeded for script [foobar] with size [65]", e.getMessage());
     }
 
+    public static class CustomScriptPlugin extends MockScriptPlugin {
+
+        @Override
+        protected Map<String, Function<Map<String, Object>, Object>> pluginScripts() {
+            return Collections.emptyMap();
+        }
+    }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/AggregationTestScriptsPlugin.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/AggregationTestScriptsPlugin.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations;
+
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.script.MockScriptPlugin;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * This class contains various mocked scripts that are used in aggregations integration tests.
+ */
+public class AggregationTestScriptsPlugin extends MockScriptPlugin {
+
+    @Override
+    protected Map<String, Function<Map<String, Object>, Object>> pluginScripts() {
+        Map<String, Function<Map<String, Object>, Object>> scripts = new HashMap<>();
+
+        scripts.put("20 - _value", vars -> {
+            double value = (double) vars.get("_value");
+            return 20.0d - value;
+        });
+
+        scripts.put("_value - 1", vars -> {
+            double value = (double) vars.get("_value");
+            return value - 1.0d;
+        });
+
+        scripts.put("_value - dec", vars -> {
+            double value = (double) vars.get("_value");
+            int dec = (int) vars.get("dec");
+            return value - dec;
+        });
+
+        scripts.put("doc['value'].value", vars -> {
+            Map<?, ?> doc = (Map) vars.get("doc");
+            return doc.get("value");
+        });
+
+        scripts.put("doc['value'].value - dec", vars -> {
+            int dec = (int) vars.get("dec");
+            Map<?, ?> doc = (Map) vars.get("doc");
+            ScriptDocValues.Longs value = (ScriptDocValues.Longs) doc.get("value");
+            return value.getValue() - dec;
+        });
+
+        scripts.put("doc['values'].values", vars -> {
+            Map<?, ?> doc = (Map) vars.get("doc");
+            return doc.get("values");
+        });
+
+        scripts.put("decrement all values", vars -> {
+            int dec = (int) vars.get("dec");
+            Map<?, ?> doc = (Map) vars.get("doc");
+            ScriptDocValues.Longs values = (ScriptDocValues.Longs) doc.get("values");
+
+            double[] res = new double[values.size()];
+            for (int i = 0; i < res.length; i++) {
+                res[i] = values.get(i) - dec;
+            }
+            return res;
+        });
+
+        return scripts;
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksIT.java
@@ -16,20 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.messy.tests;
+package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService.ScriptType;
-import org.elasticsearch.script.groovy.GroovyPlugin;
+import org.elasticsearch.search.aggregations.AggregationTestScriptsPlugin;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Order;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.search.aggregations.metrics.AbstractNumericTestCase;
 import org.elasticsearch.search.aggregations.metrics.percentiles.Percentile;
 import org.elasticsearch.search.aggregations.metrics.percentiles.PercentileRanks;
 import org.elasticsearch.search.aggregations.metrics.percentiles.PercentilesMethod;
@@ -41,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.emptyMap;
 import static org.elasticsearch.common.util.CollectionUtils.iterableAsArrayList;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
@@ -56,13 +56,11 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
-/**
- *
- */
-public class HDRPercentileRanksTests extends AbstractNumericTestCase {
+public class HDRPercentileRanksIT extends AbstractNumericTestCase {
+
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Collections.singleton(GroovyPlugin.class);
+        return Collections.singleton(AggregationTestScriptsPlugin.class);
     }
 
     private static double[] randomPercents(long minValue, long maxValue) {
@@ -82,7 +80,7 @@ public class HDRPercentileRanksTests extends AbstractNumericTestCase {
             }
         }
         Arrays.sort(percents);
-        Loggers.getLogger(HDRPercentileRanksTests.class).info("Using values={}", Arrays.toString(percents));
+        Loggers.getLogger(HDRPercentileRanksIT.class).info("Using values={}", Arrays.toString(percents));
         return percents;
     }
 
@@ -208,7 +206,7 @@ public class HDRPercentileRanksTests extends AbstractNumericTestCase {
         PercentileRanks values = global.getAggregations().get("percentile_ranks");
         assertThat(values, notNullValue());
         assertThat(values.getName(), equalTo("percentile_ranks"));
-        assertThat((PercentileRanks) global.getProperty("percentile_ranks"), sameInstance(values));
+        assertThat(global.getProperty("percentile_ranks"), sameInstance(values));
 
     }
 
@@ -255,8 +253,12 @@ public class HDRPercentileRanksTests extends AbstractNumericTestCase {
                 .prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(
-                        percentileRanks("percentile_ranks").method(PercentilesMethod.HDR).numberOfSignificantValueDigits(sigDigits)
-                        .field("value").script(new Script("_value - 1")).values(pcts))
+                        percentileRanks("percentile_ranks")
+                                .method(PercentilesMethod.HDR)
+                                .numberOfSignificantValueDigits(sigDigits)
+                                .field("value")
+                                .script(new Script("_value - 1", ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, emptyMap()))
+                                .values(pcts))
                 .execute().actionGet();
 
         assertHitCount(searchResponse, 10);
@@ -275,8 +277,12 @@ public class HDRPercentileRanksTests extends AbstractNumericTestCase {
                 .prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(
-                        percentileRanks("percentile_ranks").method(PercentilesMethod.HDR).numberOfSignificantValueDigits(sigDigits)
-                        .field("value").script(new Script("_value - dec", ScriptType.INLINE, null, params)).values(pcts))
+                        percentileRanks("percentile_ranks")
+                                .method(PercentilesMethod.HDR)
+                                .numberOfSignificantValueDigits(sigDigits)
+                                .field("value")
+                                .script(new Script("_value - dec", ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, params))
+                                .values(pcts))
                 .execute().actionGet();
 
         assertHitCount(searchResponse, 10);
@@ -311,8 +317,12 @@ public class HDRPercentileRanksTests extends AbstractNumericTestCase {
                 .prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(
-                        percentileRanks("percentile_ranks").method(PercentilesMethod.HDR).numberOfSignificantValueDigits(sigDigits)
-                        .field("values").script(new Script("_value - 1")).values(pcts))
+                        percentileRanks("percentile_ranks")
+                                .method(PercentilesMethod.HDR)
+                                .numberOfSignificantValueDigits(sigDigits)
+                                .field("values")
+                                .script(new Script("_value - 1", ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, emptyMap()))
+                                .values(pcts))
                 .execute().actionGet();
 
         assertHitCount(searchResponse, 10);
@@ -328,8 +338,12 @@ public class HDRPercentileRanksTests extends AbstractNumericTestCase {
                 .prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(
-                        percentileRanks("percentile_ranks").method(PercentilesMethod.HDR).numberOfSignificantValueDigits(sigDigits)
-                        .field("values").script(new Script("20 - _value")).values(pcts))
+                        percentileRanks("percentile_ranks")
+                                .method(PercentilesMethod.HDR)
+                                .numberOfSignificantValueDigits(sigDigits)
+                                .field("values")
+                                .script(new Script("20 - _value", ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, emptyMap()))
+                                .values(pcts))
                 .execute().actionGet();
 
         assertHitCount(searchResponse, 10);
@@ -348,8 +362,12 @@ public class HDRPercentileRanksTests extends AbstractNumericTestCase {
                 .prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(
-                        percentileRanks("percentile_ranks").method(PercentilesMethod.HDR).numberOfSignificantValueDigits(sigDigits)
-                        .field("values").script(new Script("_value - dec", ScriptType.INLINE, null, params)).values(pcts))
+                        percentileRanks("percentile_ranks")
+                                .method(PercentilesMethod.HDR)
+                                .numberOfSignificantValueDigits(sigDigits)
+                                .field("values")
+                                .script(new Script("_value - dec", ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, params))
+                                .values(pcts))
                 .execute().actionGet();
 
         assertHitCount(searchResponse, 10);
@@ -366,8 +384,11 @@ public class HDRPercentileRanksTests extends AbstractNumericTestCase {
                 .prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(
-                        percentileRanks("percentile_ranks").method(PercentilesMethod.HDR).numberOfSignificantValueDigits(sigDigits)
-                        .script(new Script("doc['value'].value")).values(pcts))
+                        percentileRanks("percentile_ranks")
+                                .method(PercentilesMethod.HDR)
+                                .numberOfSignificantValueDigits(sigDigits)
+                                .script(new Script("doc['value'].value", ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, emptyMap()))
+                                .values(pcts))
                 .execute().actionGet();
 
         assertHitCount(searchResponse, 10);
@@ -381,13 +402,19 @@ public class HDRPercentileRanksTests extends AbstractNumericTestCase {
         int sigDigits = randomSignificantDigits();
         Map<String, Object> params = new HashMap<>();
         params.put("dec", 1);
+
+        Script script = new Script("doc['value'].value - dec", ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, params);
+
         final double[] pcts = randomPercents(minValue - 1, maxValue - 1);
         SearchResponse searchResponse = client()
                 .prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(
-                        percentileRanks("percentile_ranks").method(PercentilesMethod.HDR).numberOfSignificantValueDigits(sigDigits)
-                        .script(new Script("doc['value'].value - dec", ScriptType.INLINE, null, params)).values(pcts))
+                        percentileRanks("percentile_ranks")
+                                .method(PercentilesMethod.HDR)
+                                .numberOfSignificantValueDigits(sigDigits)
+                                .script(script)
+                                .values(pcts))
                 .execute().actionGet();
 
         assertHitCount(searchResponse, 10);
@@ -400,12 +427,18 @@ public class HDRPercentileRanksTests extends AbstractNumericTestCase {
     public void testScriptMultiValued() throws Exception {
         int sigDigits = randomSignificantDigits();
         final double[] pcts = randomPercents(minValues, maxValues);
+
+        Script script = new Script("doc['values'].values", ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, emptyMap());
+
         SearchResponse searchResponse = client()
                 .prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(
-                        percentileRanks("percentile_ranks").method(PercentilesMethod.HDR).numberOfSignificantValueDigits(sigDigits)
-                        .script(new Script("doc['values'].values")).values(pcts))
+                        percentileRanks("percentile_ranks")
+                                .method(PercentilesMethod.HDR)
+                                .numberOfSignificantValueDigits(sigDigits)
+                                .script(script)
+                                .values(pcts))
                 .execute().actionGet();
 
         assertHitCount(searchResponse, 10);
@@ -419,6 +452,17 @@ public class HDRPercentileRanksTests extends AbstractNumericTestCase {
         int sigDigits = randomSignificantDigits();
         Map<String, Object> params = new HashMap<>();
         params.put("dec", 1);
+
+        // Equivalent to:
+        //
+        // List values = doc['values'].values;
+        // double[] res = new double[values.size()];
+        // for (int i = 0; i < res.length; i++) {
+        //      res[i] = values.get(i) - dec;
+        // };
+        // return res;
+        Script script = new Script("decrement all values", ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, params);
+
         final double[] pcts = randomPercents(minValues - 1, maxValues - 1);
         SearchResponse searchResponse = client()
                 .prepareSearch("idx")
@@ -427,10 +471,8 @@ public class HDRPercentileRanksTests extends AbstractNumericTestCase {
                         percentileRanks("percentile_ranks")
                                 .method(PercentilesMethod.HDR)
                                 .numberOfSignificantValueDigits(sigDigits)
-                                .script(new Script(
-                                        "List values = doc['values'].values; double[] res = new double[values.size()]; for (int i = 0; i < res.length; i++) { res[i] = values.get(i) - dec; }; return res;",
-                                ScriptType.INLINE, null, params))
-                        .values(pcts))
+                                .script(script)
+                                .values(pcts))
                 .execute().actionGet();
 
         assertHitCount(searchResponse, 10);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.MockScriptEngine;
+import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchHit;
@@ -54,6 +55,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.smileBuilder;
@@ -92,7 +95,14 @@ public class TopHitsIT extends ESIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Collections.singleton(MockScriptEngine.TestPlugin.class);
+        return Collections.singleton(CustomScriptPlugin.class);
+    }
+
+    public static class CustomScriptPlugin extends MockScriptPlugin {
+        @Override
+        protected Map<String, Function<Map<String, Object>, Object>> pluginScripts() {
+            return Collections.emptyMap();
+        }
     }
 
     public static String randomExecutionHint() {

--- a/core/src/test/java/org/elasticsearch/search/innerhits/InnerHitsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/innerhits/InnerHitsIT.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.InnerHitBuilder;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.MockScriptEngine;
+import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchHit;
@@ -47,6 +48,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -71,9 +74,17 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 public class InnerHitsIT extends ESIntegTestCase {
+
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(MockScriptEngine.TestPlugin.class);
+        return Collections.singleton(CustomScriptPlugin.class);
+    }
+
+    public static class CustomScriptPlugin extends MockScriptPlugin {
+        @Override
+        protected Map<String, Function<Map<String, Object>, Object>> pluginScripts() {
+            return Collections.emptyMap();
+        }
     }
 
     public void testSimpleNested() throws Exception {

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/package-info.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/package-info.java
@@ -36,8 +36,6 @@
  */
 /* List of renames that took place:
   renamed:    core/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/AvgTests.java
-  renamed:    core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/BucketScriptTests.java
-  renamed:    core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketSelectorIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/BucketSelectorTests.java
   renamed:    core/src/test/java/org/elasticsearch/document/BulkIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/BulkTests.java
   renamed:    core/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/CardinalityTests.java
   renamed:    core/src/test/java/org/elasticsearch/search/child/ChildQuerySearchIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/ChildQuerySearchTests.java
@@ -50,8 +48,6 @@
   renamed:    core/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/ExtendedStatsTests.java
   renamed:    core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/FunctionScoreTests.java
   renamed:    core/src/test/java/org/elasticsearch/search/geo/GeoDistanceIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/GeoDistanceTests.java
-  renamed:    core/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/HDRPercentileRanksTests.java
-  renamed:    core/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/HDRPercentilesTests.java
   renamed:    core/src/test/java/org/elasticsearch/search/aggregations/bucket/HistogramIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/HistogramTests.java
   renamed:    core/src/test/java/org/elasticsearch/search/aggregations/bucket/IPv4RangeIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/IPv4RangeTests.java
   renamed:    core/src/test/java/org/elasticsearch/script/IndexLookupIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/IndexLookupTests.java

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -22,92 +22,60 @@ package org.elasticsearch.script;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.search.lookup.LeafSearchLookup;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
- * A dummy script engine used for testing. Scripts must be a number. Many
- * tests rely on the fact this thing returns a String as its compiled form.
- * they even try to serialize it over the network!
+ * A mocked script engine that can be used for testing purpose.
  */
 public class MockScriptEngine implements ScriptEngineService {
 
     public static final String NAME = "mockscript";
 
-    /** A compiled script, just holds the scripts name, source, and params that were passed in */
-    public static class MockCompiledScript {
-        public final String name;
-        public final String source;
-        public final Map<String,String> params;
+    private final String type;
+    private final Map<String, Function<Map<String, Object>, Object>> scripts;
 
-        MockCompiledScript(String name, String source, Map<String,String> params) {
-            this.name = name;
-            this.source = source;
-            this.params = params;
-        }
+    public MockScriptEngine(String type, Map<String, Function<Map<String, Object>, Object>> scripts) {
+        this.type = type;
+        this.scripts = Collections.unmodifiableMap(scripts);
     }
 
-    public static class TestPlugin extends Plugin implements ScriptPlugin {
-        @Override
-        public ScriptEngineService getScriptEngineService(Settings settings) {
-            return new MockScriptEngine();
-        }
+    public MockScriptEngine() {
+        this(NAME, Collections.emptyMap());
     }
 
     @Override
     public String getType() {
-        return NAME;
+        return type;
     }
 
     @Override
     public String getExtension() {
-        return NAME;
+        return getType();
     }
 
     @Override
-    public Object compile(String scriptName, String scriptSource, Map<String, String> params) {
-        return new MockCompiledScript(scriptName, scriptSource, params);
+    public Object compile(String name, String source, Map<String, String> params) {
+        Function<Map<String, Object>, Object> script = scripts.get(source);
+        return new MockCompiledScript(name, params, source, script);
     }
 
     @Override
     public ExecutableScript executable(CompiledScript compiledScript, @Nullable Map<String, Object> vars) {
-        assert compiledScript.compiled() instanceof MockCompiledScript
-          : "do NOT pass compiled scripts from other engines to me, I will fail your test, got: " + compiledScript;
-        return new AbstractExecutableScript() {
-            @Override
-            public Object run() {
-                return new BytesArray(((MockCompiledScript)compiledScript.compiled()).source);
-            }
-        };
+        MockCompiledScript compiled = (MockCompiledScript) compiledScript.compiled();
+        return compiled.createExecutableScript(vars);
     }
 
     @Override
     public SearchScript search(CompiledScript compiledScript, SearchLookup lookup, @Nullable Map<String, Object> vars) {
-        return new SearchScript() {
-            @Override
-            public LeafSearchScript getLeafSearchScript(LeafReaderContext context) throws IOException {
-                AbstractSearchScript leafSearchScript = new AbstractSearchScript() {
-
-                    @Override
-                    public Object run() {
-                        return ((MockCompiledScript)compiledScript.compiled()).source;
-                    }
-
-                };
-                leafSearchScript.setLookup(lookup.getLeafSearchLookup(context));
-                return leafSearchScript;
-            }
-
-            @Override
-            public boolean needsScores() {
-                return false;
-            }
-        };
+        MockCompiledScript compiled = (MockCompiledScript) compiledScript.compiled();
+        return compiled.createSearchScript(vars, lookup);
     }
 
     @Override
@@ -117,5 +85,112 @@ public class MockScriptEngine implements ScriptEngineService {
     @Override
     public boolean isInlineScriptEnabled() {
         return true;
+    }
+
+
+    public class MockCompiledScript {
+
+        private final String name;
+        private final String source;
+        private final Map<String, String> params;
+        private final Function<Map<String, Object>, Object> script;
+
+        public MockCompiledScript(String name, Map<String, String> params, String source, Function<Map<String, Object>, Object> script) {
+            this.name = name;
+            this.source = source;
+            this.params = params;
+            this.script = script;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public ExecutableScript createExecutableScript(Map<String, Object> vars) {
+            Map<String, Object> context = new HashMap<>();
+            if (params != null) {
+                context.putAll(params);
+            }
+            if (vars != null) {
+                context.putAll(vars);
+            }
+            return new MockExecutableScript(context, script != null ? script : ctx -> new BytesArray(source));
+        }
+
+        public SearchScript createSearchScript(Map<String, Object> vars, SearchLookup lookup) {
+            Map<String, Object> context = new HashMap<>();
+            if (params != null) {
+                context.putAll(params);
+            }
+            if (vars != null) {
+                context.putAll(vars);
+            }
+            return new MockSearchScript(lookup, context, script != null ? script : ctx -> source);
+        }
+    }
+
+    public class MockExecutableScript implements ExecutableScript {
+
+        private final Function<Map<String, Object>, Object> script;
+        private final Map<String, Object> vars;
+
+        public MockExecutableScript(Map<String, Object> vars, Function<Map<String, Object>, Object> script) {
+            this.vars = vars;
+            this.script = script;
+        }
+
+        @Override
+        public void setNextVar(String name, Object value) {
+            vars.put(name, value);
+        }
+
+        @Override
+        public Object run() {
+            return script.apply(vars);
+        }
+    }
+
+    public class MockSearchScript implements SearchScript {
+
+        private final Function<Map<String, Object>, Object> script;
+        private final Map<String, Object> vars;
+        private final SearchLookup lookup;
+
+        public MockSearchScript(SearchLookup lookup, Map<String, Object> vars, Function<Map<String, Object>, Object> script) {
+            this.lookup = lookup;
+            this.vars = vars;
+            this.script = script;
+        }
+
+        @Override
+        public LeafSearchScript getLeafSearchScript(LeafReaderContext context) throws IOException {
+            LeafSearchLookup leafLookup = lookup.getLeafSearchLookup(context);
+
+            Map<String, Object> ctx = new HashMap<>();
+            ctx.putAll(leafLookup.asMap());
+            if (vars != null) {
+                ctx.putAll(vars);
+            }
+
+            AbstractSearchScript leafSearchScript = new AbstractSearchScript() {
+
+                @Override
+                public Object run() {
+                    return script.apply(ctx);
+                }
+
+                @Override
+                public void setNextVar(String name, Object value) {
+                    ctx.put(name, value);
+                }
+            };
+            leafSearchScript.setLookup(leafLookup);
+            return leafSearchScript;
+        }
+
+        @Override
+        public boolean needsScores() {
+            return false;
+        }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptPlugin.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptPlugin.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.script;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.ScriptPlugin;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * A script plugin that uses {@link MockScriptEngine} as the script engine for tests.
+ */
+public abstract class MockScriptPlugin extends Plugin implements ScriptPlugin {
+
+    public static final String NAME = MockScriptEngine.NAME;
+
+    @Override
+    public ScriptEngineService getScriptEngineService(Settings settings) {
+        return new MockScriptEngine(pluginScriptLang(), pluginScripts());
+    }
+
+    protected abstract Map<String, Function<Map<String, Object>, Object>> pluginScripts();
+
+    public String pluginScriptLang() {
+        return NAME;
+    }
+}


### PR DESCRIPTION
After #13834 many tests that used Groovy scripts (for good or bad reason) in their tests have been moved in the `lang-groovy` module and the issue #13837 has been created to track these messy tests in order to clean them up.

This PR moves `BucketSelectorIT`, `BucketScriptIT`, `HDRPercentileRanksIT` and `HDRPercentilesIT` back at their original place in core, removes the dependency on Groovy, changes the scripts in order to use the mocked script engine `MockScriptEngine` instead, and change them back to integration tests.

This PR also changes `MockScriptEngine` and `MockScriptPlugin` so that it is easier, I hope, to mock scripts.
