### PR TITLE
Add catchAnalyzer precommit task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,7 @@ subprojects {
     "org.elasticsearch.distribution.rpm:elasticsearch:${version}": ':distribution:rpm',
     "org.elasticsearch.distribution.deb:elasticsearch:${version}": ':distribution:deb',
     "org.elasticsearch.test:logger-usage:${version}": ':test:logger-usage',
+    "org.elasticsearch.test.tools:catch-analyzer:${version}": ':test:tools:catch-analyzer',
   ]
   configurations.all {
     resolutionStrategy.dependencySubstitution { DependencySubstitutions subs ->

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/LoggedExec.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/LoggedExec.groovy
@@ -29,6 +29,10 @@ class LoggedExec extends Exec {
 
     protected ByteArrayOutputStream output = new ByteArrayOutputStream()
 
+    // the failure message to add to a gradle exception the the exec fails
+    // or null to use the default
+    protected String failureMessage
+
     LoggedExec() {
         if (logger.isInfoEnabled() == false) {
             standardOutput = output
@@ -37,7 +41,11 @@ class LoggedExec extends Exec {
             doLast {
                 if (execResult.exitValue != 0) {
                     output.toString('UTF-8').eachLine { line -> logger.error(line) }
-                    throw new GradleException("Process '${executable} ${args.join(' ')}' finished with non-zero exit value ${execResult.exitValue}")
+                    String msg = failureMessage
+                    if (msg == null) {
+                        msg = "Process '${executable} ${args.join(' ')}' finished with non-zero exit value ${execResult.exitValue}"
+                    }
+                    throw new GradleException(msg)
                 }
             }
         }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/CatchAnalyzerTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/CatchAnalyzerTask.groovy
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle.precommit
+
+import org.elasticsearch.gradle.LoggedExec
+import org.elasticsearch.gradle.VersionProperties
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+
+/**
+ * Runs CatchAnalyzer on a set of directories.
+ */
+public class CatchAnalyzerTask extends LoggedExec {
+
+    @OutputFile
+    File successMarker = new File(project.buildDir, 'markers/catchAnalyzer')
+
+    @InputFiles
+    FileCollection classpath
+
+    @InputFiles
+    List<File> classDirectories
+
+    public CatchAnalyzerTask() {
+        Configuration catchAnalyzerConfig = project.configurations.findByName('catchAnalyzerPlugin')
+        if (catchAnalyzerConfig == null) {
+            catchAnalyzerConfig = project.configurations.create('catchAnalyzerPlugin')
+            project.dependencies.add('catchAnalyzerPlugin',
+                    "org.elasticsearch.test.tools:catch-analyzer:${VersionProperties.elasticsearch}")
+        }
+        failureMessage = 'Found swallowed exceptions.'
+        project.afterEvaluate {
+            dependsOn(classpath)
+            executable = new File(project.javaHome, 'bin/java')
+            if (classDirectories == null) {
+                classDirectories = []
+                if (project.sourceSets.findByName("main")) {
+                    classDirectories += [project.sourceSets.main.output.classesDir]
+                    dependsOn project.tasks.classes
+                }
+                /*if (project.sourceSets.findByName("test")) {
+                    classDirectories += [project.sourceSets.test.output.classesDir]
+                    dependsOn project.tasks.testClasses
+                }*/
+            }
+            doFirst({
+                args('-cp', "${catchAnalyzerConfig.asPath}", 'org.elasticsearch.test.CatchAnalyzer', '-classpath', "${classpath.asPath}:${classDirectories.join(':')}")
+                classDirectories.each {
+                    args it.getAbsolutePath()
+                }
+            })
+            doLast({
+                successMarker.parentFile.mkdirs()
+                successMarker.setText("", 'UTF-8')
+            })
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
@@ -19,8 +19,10 @@
 package org.elasticsearch.gradle.precommit
 
 import de.thetaphi.forbiddenapis.gradle.ForbiddenApisPlugin
+import org.elasticsearch.gradle.VersionProperties
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.plugins.JavaBasePlugin
 
 /**
@@ -60,6 +62,10 @@ class PrecommitTasks {
              * here.
              */
             precommitTasks.add(configureLoggerUsage(project))
+            Task catchAnalyzerTask = createCatchAnalyzerTask(project)
+            if (catchAnalyzerTask != null) {
+                precommitTasks.add(catchAnalyzerTask)
+            }
         }
 
 
@@ -171,5 +177,15 @@ class PrecommitTasks {
         }
 
         return loggerUsageTask
+    }
+
+    private static Task createCatchAnalyzerTask(Project project) {
+        // TODO: create two separate tasks for main/test, for now this only tests main
+        if (project.configurations.findByName('runtime') != null) {
+            Task catchAnalyzerTask = project.tasks.create('catchAnalyzer', CatchAnalyzerTask.class)
+            catchAnalyzerTask.classpath = project.configurations.runtime
+            return catchAnalyzerTask
+        }
+        return null
     }
 }

--- a/core/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
+++ b/core/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
@@ -36,6 +36,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SynonymQuery;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -176,6 +177,7 @@ public class MapperQueryParser extends QueryParser {
         }
     }
 
+    @SwallowsExceptions(reason = "?")
     private Query getFieldQuerySingle(String field, String queryText, boolean quoted) throws ParseException {
         if (!quoted && queryText.length() > 1) {
             if (queryText.charAt(0) == '>') {
@@ -326,6 +328,7 @@ public class MapperQueryParser extends QueryParser {
         }
     }
 
+    @SwallowsExceptions(reason = "?")
     private Query getRangeQuerySingle(String field, String part1, String part2,
                                       boolean startInclusive, boolean endInclusive) {
         currentFieldType = context.fieldMapper(field);
@@ -395,6 +398,7 @@ public class MapperQueryParser extends QueryParser {
         }
     }
 
+    @SwallowsExceptions(reason = "?")
     private Query getFuzzyQuerySingle(String field, String termStr, String minSimilarity) throws ParseException {
         currentFieldType = context.fieldMapper(field);
         if (currentFieldType != null) {
@@ -461,6 +465,7 @@ public class MapperQueryParser extends QueryParser {
         }
     }
 
+    @SwallowsExceptions(reason = "?")
     private Query getPrefixQuerySingle(String field, String termStr) throws ParseException {
         currentFieldType = null;
         Analyzer oldAnalyzer = getAnalyzer();
@@ -490,6 +495,7 @@ public class MapperQueryParser extends QueryParser {
         }
     }
 
+    @SwallowsExceptions(reason = "?")
     private Query getPossiblyAnalyzedPrefixQuery(String field, String termStr) throws ParseException {
         if (!settings.analyzeWildcard()) {
             return super.getPrefixQuery(field, termStr);
@@ -628,6 +634,7 @@ public class MapperQueryParser extends QueryParser {
         }
     }
 
+    @SwallowsExceptions(reason = "?")
     private Query getWildcardQuerySingle(String field, String termStr) throws ParseException {
         String indexedNameField = field;
         currentFieldType = null;
@@ -652,6 +659,7 @@ public class MapperQueryParser extends QueryParser {
         }
     }
 
+    @SwallowsExceptions(reason = "?")
     private Query getPossiblyAnalyzedWildcardQuery(String field, String termStr) throws ParseException {
         if (!settings.analyzeWildcard()) {
             return super.getWildcardQuery(field, termStr);
@@ -756,6 +764,7 @@ public class MapperQueryParser extends QueryParser {
         }
     }
 
+    @SwallowsExceptions(reason = "?")
     private Query getRegexpQuerySingle(String field, String termStr) throws ParseException {
         currentFieldType = null;
         Analyzer oldAnalyzer = getAnalyzer();

--- a/core/src/main/java/org/apache/lucene/search/XFilteredDocIdSetIterator.java
+++ b/core/src/main/java/org/apache/lucene/search/XFilteredDocIdSetIterator.java
@@ -21,6 +21,8 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 
+import org.elasticsearch.common.SwallowsExceptions;
+
 // this is just one possible solution for "early termination" !
 
 /**
@@ -63,7 +65,7 @@ public abstract class XFilteredDocIdSetIterator extends DocIdSetIterator {
     return doc;
   }
   
-  @Override
+  @Override @SwallowsExceptions(reason = "early termination support")
   public int nextDoc() throws IOException {
     try {
       while ((doc = _innerIter.nextDoc()) != NO_MORE_DOCS) {
@@ -77,7 +79,7 @@ public abstract class XFilteredDocIdSetIterator extends DocIdSetIterator {
     return doc;
   }
   
-  @Override
+  @Override @SwallowsExceptions(reason = "early termination support")
   public int advance(int target) throws IOException {
     doc = _innerIter.advance(target);
     try {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.health.ClusterIndexHealth;
 import org.elasticsearch.cluster.health.ClusterStateHealth;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
@@ -204,7 +205,7 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
     }
 
 
-    @Override
+    @Override @SwallowsExceptions(reason = "?")
     public String toString() {
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -198,6 +199,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
         return response;
     }
 
+    @SwallowsExceptions(reason = "?")
     private boolean prepareResponse(final ClusterHealthRequest request, final ClusterHealthResponse response, ClusterState clusterState, final int waitFor) {
         int waitForCounter = 0;
         if (request.waitForStatus() != null && response.getStatus().value() <= request.waitForStatus().value()) {
@@ -269,7 +271,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
         return waitForCounter == waitFor;
     }
 
-
+    @SwallowsExceptions(reason = "?")
     private ClusterHealthResponse clusterHealth(ClusterHealthRequest request, ClusterState clusterState, int numberOfPendingTasks, int numberOfInFlightFetch,
                                                 TimeValue pendingTaskTimeInQueue) {
         if (logger.isTraceEnabled()) {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -125,7 +126,7 @@ public class NodesInfoResponse extends BaseNodesResponse<NodeInfo> implements To
         return builder;
     }
 
-    @Override
+    @Override @SwallowsExceptions(reason = "?")
     public String toString() {
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.cluster.node.stats;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -68,7 +69,7 @@ public class NodesStatsResponse extends BaseNodesResponse<NodeStats> implements 
         return builder;
     }
 
-    @Override
+    @Override @SwallowsExceptions(reason = "?")
     public String toString() {
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ParseFieldMatcher;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
@@ -203,7 +204,7 @@ public class TransportGetTaskAction extends HandledTransportAction<GetTaskReques
                 request.getTaskId().toString());
         get.setParentTask(clusterService.localNode().getId(), thisTask.getId());
         client.get(get, new ActionListener<GetResponse>() {
-            @Override
+            @Override @SwallowsExceptions(reason = "?")
             public void onResponse(GetResponse getResponse) {
                 try {
                     onGetFinishedTaskFromIndex(getResponse, listener);

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
@@ -74,7 +75,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
     }
 
-    @Override
+    @Override @SwallowsExceptions(reason = "?")
     protected void masterOperation(final GetSnapshotsRequest request, ClusterState state,
                                    final ActionListener<GetSnapshotsResponse> listener) {
         try {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.snapshots.status;
 
 import org.elasticsearch.cluster.SnapshotsInProgress.State;
 import org.elasticsearch.snapshots.Snapshot;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -157,7 +158,7 @@ public class SnapshotStatus implements ToXContent, Streamable {
         return snapshotInfo;
     }
 
-    @Override
+    @Override @SwallowsExceptions(reason = "?")
     public String toString() {
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
@@ -119,7 +120,7 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeAction<Sn
             TransportNodesSnapshotsStatus.Request nodesRequest = new TransportNodesSnapshotsStatus.Request(nodesIds.toArray(new String[nodesIds.size()]))
                     .snapshots(snapshots).timeout(request.masterNodeTimeout());
             transportNodesSnapshotsStatus.execute(nodesRequest, new ActionListener<TransportNodesSnapshotsStatus.NodesSnapshotStatus>() {
-                        @Override
+                        @Override @SwallowsExceptions(reason = "?")
                         public void onResponse(TransportNodesSnapshotsStatus.NodesSnapshotStatus nodeSnapshotStatuses) {
                             try {
                                 List<SnapshotsInProgress.Entry> currentSnapshots =

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -132,7 +133,7 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
         return builder;
     }
 
-    @Override
+    @Override @SwallowsExceptions(reason = "?")
     public String toString() {
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/PutStoredScriptRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/PutStoredScriptRequest.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.storedscripts;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -113,7 +114,7 @@ public class PutStoredScriptRequest extends AcknowledgedRequest<PutStoredScriptR
         out.writeBytesReference(script);
     }
 
-    @Override
+    @Override @SwallowsExceptions(reason = "?")
     public String toString() {
         String sSource = "_na_";
         try {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksResponse.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.tasks;
 
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.cluster.service.PendingClusterTask;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -70,7 +71,7 @@ public class PendingClusterTasksResponse extends ActionResponse implements Itera
         return sb.toString();
     }
 
-    @Override
+    @Override @SwallowsExceptions(reason = "?")
     public String toString() {
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -28,6 +28,7 @@ import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.MapBuilder;
@@ -372,7 +373,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
     /**
      * Sets the settings and mappings as a single source.
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings("unchecked") @SwallowsExceptions(reason = "?")
     public CreateIndexRequest source(Map<String, ?> source) {
         boolean found = false;
         for (Map.Entry<String, ?> entry : source.entrySet()) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/TransportIndicesExistsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/TransportIndicesExistsAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -63,7 +64,7 @@ public class TransportIndicesExistsAction extends TransportMasterNodeReadAction<
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_READ, indexNameExpressionResolver.concreteIndexNames(state, indicesOptions, request.indices()));
     }
 
-    @Override
+    @Override @SwallowsExceptions(reason = "?")
     protected void masterOperation(final IndicesExistsRequest request, final ClusterState state, final ActionListener<IndicesExistsResponse> listener) {
         boolean exists;
         try {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.indices.stats;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -211,7 +212,7 @@ public class IndicesStatsResponse extends BroadcastResponse implements ToXConten
         static final String SHARDS = "shards";
     }
 
-    @Override
+    @Override @SwallowsExceptions(reason = "?")
     public String toString() {
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.MapBuilder;
@@ -269,7 +270,7 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
     /**
      * The template source definition.
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings("unchecked") @SwallowsExceptions(reason = "?")
     public PutIndexTemplateRequest source(Map templateSource) {
         Map<String, Object> source = templateSource;
         for (Map.Entry<String, Object> entry : source.entrySet()) {

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -209,7 +210,7 @@ public class BulkProcessor implements Closeable {
     /**
      * Closes the processor. If flushing by time is enabled, then it's shutdown. Any remaining bulk actions are flushed.
      */
-    @Override
+    @Override @SwallowsExceptions(reason = "?")
     public void close() {
         try {
             awaitClose(0, TimeUnit.NANOSECONDS);

--- a/core/src/main/java/org/elasticsearch/common/SwallowsExceptions.java
+++ b/core/src/main/java/org/elasticsearch/common/SwallowsExceptions.java
@@ -1,0 +1,31 @@
+package org.elasticsearch.common;
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to suppress broken catch-block swallowing for a method or class
+ */
+@Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.TYPE})
+public @interface SwallowsExceptions {
+    String reason();
+}

--- a/core/src/main/java/org/elasticsearch/monitor/Probes.java
+++ b/core/src/main/java/org/elasticsearch/monitor/Probes.java
@@ -19,10 +19,13 @@
 
 package org.elasticsearch.monitor;
 
+import org.elasticsearch.common.SwallowsExceptions;
+
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Method;
 
 public class Probes {
+    @SwallowsExceptions(reason = "?")
     public static short getLoadAndScaleToPercent(Method method, OperatingSystemMXBean osMxBean) {
         if (method != null) {
             try {

--- a/core/src/main/java/org/elasticsearch/monitor/fs/FsProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/fs/FsProbe.java
@@ -21,6 +21,7 @@ package org.elasticsearch.monitor.fs;
 
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.SuppressForbidden;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.io.PathUtils;
@@ -68,6 +69,7 @@ public class FsProbe extends AbstractComponent {
         return new FsInfo(System.currentTimeMillis(), ioStats, paths);
     }
 
+    @SwallowsExceptions(reason = "?")
     final FsInfo.IoStats ioStats(final Set<Tuple<Integer, Integer>> devicesNumbers, final FsInfo previous) {
         try {
             final Map<Tuple<Integer, Integer>, FsInfo.DeviceStats> deviceMap = new HashMap<>();

--- a/core/src/main/java/org/elasticsearch/monitor/fs/FsService.java
+++ b/core/src/main/java/org/elasticsearch/monitor/fs/FsService.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.monitor.fs;
 
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Setting;
@@ -55,6 +56,7 @@ public class FsService extends AbstractComponent {
         return cache.getOrRefresh();
     }
 
+    @SwallowsExceptions(reason = "?")
     private static FsInfo stats(FsProbe probe, FsInfo initialValue, ESLogger logger) {
         try {
             return probe.stats(initialValue);

--- a/core/src/main/java/org/elasticsearch/monitor/jvm/JvmGcMonitorService.java
+++ b/core/src/main/java/org/elasticsearch/monitor/jvm/JvmGcMonitorService.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.monitor.jvm;
 
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Setting;
@@ -385,7 +386,7 @@ public class JvmGcMonitorService extends AbstractLifecycleComponent {
             this.gcOverheadThreshold = Objects.requireNonNull(gcOverheadThreshold);
         }
 
-        @Override
+        @Override @SwallowsExceptions(reason = "?")
         public void run() {
             try {
                 monitorGc();

--- a/core/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/core/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.monitor.jvm;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -44,6 +45,7 @@ import java.util.Map;
 /**
  *
  */
+@SwallowsExceptions(reason = "?")
 public class JvmInfo implements Streamable, ToXContent {
 
     private static JvmInfo INSTANCE;

--- a/core/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/core/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.monitor.jvm;
 
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -60,6 +61,7 @@ public class JvmStats implements Streamable, ToXContent {
         classLoadingMXBean = ManagementFactory.getClassLoadingMXBean();
     }
 
+    @SwallowsExceptions(reason = "?")
     public static JvmStats jvmStats() {
         JvmStats stats = new JvmStats(System.currentTimeMillis(), runtimeMXBean.getUptime());
         stats.mem = new Mem();

--- a/core/src/main/java/org/elasticsearch/transport/local/LocalTransport.java
+++ b/core/src/main/java/org/elasticsearch/transport/local/LocalTransport.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
@@ -248,6 +249,7 @@ public class LocalTransport extends AbstractLifecycleComponent implements Transp
         return circuitBreakerService.getBreaker(CircuitBreaker.IN_FLIGHT_REQUESTS);
     }
 
+    @SwallowsExceptions(reason = "?")
     protected void messageReceived(byte[] data, String action, LocalTransport sourceTransport, Version version,
             @Nullable final Long sendRequestId) {
         Transports.assertTransportThread();
@@ -292,6 +294,7 @@ public class LocalTransport extends AbstractLifecycleComponent implements Transp
         }
     }
 
+    @SwallowsExceptions(reason = "?")
     private void handleRequest(StreamInput stream, long requestId, int messageLengthBytes, LocalTransport sourceTransport,
                                Version version) throws Exception {
         stream = new NamedWriteableAwareStreamInput(stream, namedWriteableRegistry);
@@ -328,7 +331,7 @@ public class LocalTransport extends AbstractLifecycleComponent implements Transp
                         return reg.isForceExecution();
                     }
 
-                    @Override
+                    @Override @SwallowsExceptions(reason = "?")
                     public void onFailure(Exception e) {
                         if (lifecycleState() == Lifecycle.State.STARTED) {
                             // we can only send a response transport is started....
@@ -353,6 +356,7 @@ public class LocalTransport extends AbstractLifecycleComponent implements Transp
         }
     }
 
+    @SwallowsExceptions(reason = "?")
     protected void handleResponse(StreamInput buffer, LocalTransport sourceTransport, final TransportResponseHandler handler) {
         buffer = new NamedWriteableAwareStreamInput(buffer, namedWriteableRegistry);
         final TransportResponse response = handler.newInstance();
@@ -377,6 +381,7 @@ public class LocalTransport extends AbstractLifecycleComponent implements Transp
         });
     }
 
+    @SwallowsExceptions(reason = "?")
     private void handleResponseError(StreamInput buffer, final TransportResponseHandler handler) {
         Exception exception;
         try {
@@ -387,6 +392,7 @@ public class LocalTransport extends AbstractLifecycleComponent implements Transp
         handleException(handler, exception);
     }
 
+    @SwallowsExceptions(reason = "?")
     private void handleException(final TransportResponseHandler handler, Exception exception) {
         if (!(exception instanceof RemoteTransportException)) {
             exception = new RemoteTransportException("None remote transport exception", null, null, exception);

--- a/core/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
+++ b/core/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
@@ -22,6 +22,7 @@ package org.elasticsearch.transport.netty;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Booleans;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -497,7 +498,7 @@ public class NettyTransport extends TcpTransport<Channel> {
         }
     }
 
-    @Override
+    @Override @SwallowsExceptions(reason = "?")
     protected void closeChannels(List<Channel> channels) {
         List<ChannelFuture> futures = new ArrayList<>();
 
@@ -534,7 +535,7 @@ public class NettyTransport extends TcpTransport<Channel> {
         return channel.isOpen();
     }
 
-    @Override
+    @Override @SwallowsExceptions(reason = "?")
     protected void stopInternal() {
         Releasables.close(serverOpenChannels, () ->{
             for (Map.Entry<String, ServerBootstrap> entry : serverBootstraps.entrySet()) {

--- a/core/src/main/java/org/elasticsearch/transport/netty/SizeHeaderFrameDecoder.java
+++ b/core/src/main/java/org/elasticsearch/transport/netty/SizeHeaderFrameDecoder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.transport.netty;
 
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.transport.TcpHeader;
 import org.elasticsearch.transport.TcpTransport;
 import org.jboss.netty.buffer.ChannelBuffer;
@@ -31,7 +32,7 @@ import org.jboss.netty.handler.codec.frame.TooLongFrameException;
  */
 final class SizeHeaderFrameDecoder extends FrameDecoder {
 
-    @Override
+    @Override @SwallowsExceptions(reason = "?")
     protected Object decode(ChannelHandlerContext ctx, Channel channel, ChannelBuffer buffer) throws Exception {
         try {
             boolean continueProcessing = TcpTransport.validateMessageHeader(NettyUtils.toBytesReference(buffer));

--- a/core/src/main/java/org/elasticsearch/tribe/TribeService.java
+++ b/core/src/main/java/org/elasticsearch/tribe/TribeService.java
@@ -39,6 +39,7 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.hash.MurmurHash3;
@@ -287,7 +288,7 @@ public class TribeService extends AbstractLifecycleComponent {
         doClose();
     }
 
-    @Override
+    @Override @SwallowsExceptions(reason = "?")
     protected void doClose() {
         for (Node node : nodes) {
             try {
@@ -338,7 +339,7 @@ public class TribeService extends AbstractLifecycleComponent {
             return tasks.stream().map(ClusterChangedEvent::source).reduce((s1, s2) -> s1 + ", " + s2).orElse("");
         }
 
-        @Override
+        @Override @SwallowsExceptions(reason = "?")
         public BatchResult<ClusterChangedEvent> execute(ClusterState currentState, List<ClusterChangedEvent> tasks) throws Exception {
             ClusterState accumulator = ClusterState.builder(currentState).build();
             BatchResult.Builder<ClusterChangedEvent> builder = BatchResult.builder();

--- a/core/src/main/java/org/elasticsearch/watcher/FileWatcher.java
+++ b/core/src/main/java/org/elasticsearch/watcher/FileWatcher.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.watcher;
 
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
@@ -51,6 +52,7 @@ public class FileWatcher extends AbstractResourceWatcher<FileChangesListener> {
     /**
      * Clears any state with the FileWatcher, making all files show up as new
      */
+    @SwallowsExceptions(reason = "?")
     public void clearState() {
         rootFileObserver = new FileObserver(file);
         try {
@@ -249,6 +251,7 @@ public class FileWatcher extends AbstractResourceWatcher<FileChangesListener> {
             }
         }
 
+        @SwallowsExceptions(reason = "?")
         private void onFileCreated(boolean initial) {
             for (FileChangesListener listener : listeners()) {
                 try {
@@ -263,6 +266,7 @@ public class FileWatcher extends AbstractResourceWatcher<FileChangesListener> {
             }
         }
 
+        @SwallowsExceptions(reason = "?")
         private void onFileDeleted() {
             for (FileChangesListener listener : listeners()) {
                 try {
@@ -273,6 +277,7 @@ public class FileWatcher extends AbstractResourceWatcher<FileChangesListener> {
             }
         }
 
+        @SwallowsExceptions(reason = "?")
         private void onFileChanged() {
             for (FileChangesListener listener : listeners()) {
                 try {
@@ -284,6 +289,7 @@ public class FileWatcher extends AbstractResourceWatcher<FileChangesListener> {
             }
         }
 
+        @SwallowsExceptions(reason = "?")
         private void onDirectoryCreated(boolean initial) throws IOException {
             for (FileChangesListener listener : listeners()) {
                 try {
@@ -299,6 +305,7 @@ public class FileWatcher extends AbstractResourceWatcher<FileChangesListener> {
             children = listChildren(initial);
         }
 
+        @SwallowsExceptions(reason = "?")
         private void onDirectoryDeleted() {
             // First delete all children
             for (int child = 0; child < children.length; child++) {

--- a/core/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
+++ b/core/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.watcher;
 
+import org.elasticsearch.common.SwallowsExceptions;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Setting;
@@ -190,7 +191,7 @@ public class ResourceWatcherService extends AbstractLifecycleComponent {
             return new WatcherHandle<>(this, watcher);
         }
 
-        @Override
+        @Override @SwallowsExceptions(reason = "?")
         public synchronized void run() {
             for(ResourceWatcher watcher : watchers) {
                 try {

--- a/core/src/main/java/org/joda/time/format/StrictISODateTimeFormat.java
+++ b/core/src/main/java/org/joda/time/format/StrictISODateTimeFormat.java
@@ -1,5 +1,7 @@
 package org.joda.time.format;
 
+import org.elasticsearch.common.SwallowsExceptions;
+
 /*
  *  Copyright 2001-2009 Stephen Colebourne
  *
@@ -161,6 +163,7 @@ public class StrictISODateTimeFormat {
      * @throws IllegalArgumentException if there is no format for the fields
      * @since 1.1
      */
+    @SwallowsExceptions(reason = "?")
     public static DateTimeFormatter forFields(
             Collection<DateTimeFieldType> fields,
             boolean extended,

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,7 @@ List projects = [
   'test:fixtures:example-fixture',
   'test:fixtures:hdfs-fixture',
   'test:logger-usage',
+  'test:tools:catch-analyzer',
   'modules:aggs-matrix-stats',
   'modules:ingest-common',
   'modules:lang-expression',

--- a/test/tools/catch-analyzer/build.gradle
+++ b/test/tools/catch-analyzer/build.gradle
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.elasticsearch.gradle.precommit.PrecommitTasks
+
+dependencies {
+  compile 'org.ow2.asm:asm-debug-all:6.0_ALPHA' // use asm-debug-all because WE LIKE LINE NUMBERS!
+  testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+  testCompile "junit:junit:${versions.junit}"
+  testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}" // hamcrest is evil, but randomized runner no worky without
+}
+
+// some things are disabled as they only work if you have es/lucene
+loggerUsageCheck.enabled = false
+namingConventions.enabled = false
+
+// dies on asm Frame with some java 8 versions, not my problem
+javadoc.enabled = false
+
+forbiddenApisMain {
+  signaturesURLs = [PrecommitTasks.getResource('/forbidden/jdk-signatures.txt')] // does not depend on core, only jdk signatures
+}
+forbiddenApisTest {
+  signaturesURLs = [PrecommitTasks.getResource('/forbidden/jdk-signatures.txt')] // does not depend on core, only jdk signatures
+}

--- a/test/tools/catch-analyzer/src/main/java/org/elasticsearch/test/CatchAnalyzer.java
+++ b/test/tools/catch-analyzer/src/main/java/org/elasticsearch/test/CatchAnalyzer.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Analyzes methods for broken catch blocks. These are catch blocks that somehow
+ * drop the original exception (via any possible codepath). It is ok to wrap the exception
+ * with another one, e.g.:
+ * <ul>
+ *   <li>new OtherException(..., original, ...)
+ *   <li>otherException.initCause(original)
+ *   <li>otherException.addSuppressed(original)
+ * </ul>
+ */
+public class CatchAnalyzer {
+ 
+    /** Exception thrown when some exceptions are swallowed */
+    @SuppressWarnings("serial")
+    public static class SwallowedException extends RuntimeException {
+        public SwallowedException(String message) {
+            super(message);
+        }
+    }
+    
+    static final int ASM_API_VERSION = Opcodes.ASM6;
+    
+    /** Main method, takes directories as parameter. These must also be on classpath!!!! */
+    public static void main(String args[]) throws Exception {
+        long violationCount = 0;
+        long scannedCount = 0;
+        long startTime = System.currentTimeMillis();
+        List<Path> files = new ArrayList<>();
+        if (args.length < 3) {
+            throw new IllegalArgumentException("CatchAnalyzer -classpath <path> <dirs>");
+        }
+        if (args[0].equals("-classpath") == false) {
+            throw new IllegalArgumentException("CatchAnalyzer -classpath <path> <dirs>");
+        }
+        
+        ClassLoader loader = createLoader(args[1]);
+
+        // step 1: collect files
+        for (int i = 2; i < args.length; i++) {
+            String arg = args[i];
+            Path dir = Paths.get(arg);
+            Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    if (file.toString().endsWith(".class")) {
+                        files.add(file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        // step 2: sort
+        files.sort((x,y) -> x.toAbsolutePath().toString().compareTo(y.toAbsolutePath().toString()));
+        // step 3: process
+        for (Path file : files) {
+            byte bytes[] = Files.readAllBytes(file);
+            ClassReader reader = new ClassReader(bytes);
+            // entirely synthetic class, e.g. enum switch table, which always masks NoSuchFieldError!!!!!
+            if ((reader.getAccess() & Opcodes.ACC_SYNTHETIC) != 0) {
+                continue;
+            }
+            ClassAnalyzer analyzer = new ClassAnalyzer(reader.getClassName(), loader);
+            reader.accept(analyzer, 0);
+            scannedCount++;
+            
+            violationCount += analyzer.logViolations(System.out);
+        }
+        long endTime = System.currentTimeMillis();
+        // step 4: print        
+        
+        System.out.println("Scanned " + scannedCount + " classes in " + (endTime - startTime) + " ms");
+        if (violationCount > 0) {
+            throw new SwallowedException(violationCount + " violations were found, see log for more details");
+        }
+    }
+    
+    /**
+     * Creates a classloader for the provided classpath
+     */
+    static ClassLoader createLoader(String classPath) {
+        String pathSeparator = System.getProperty("path.separator");
+        String fileSeparator = System.getProperty("file.separator");
+        String elements[] = classPath.split(pathSeparator);
+        URL urlElements[] = new URL[elements.length];
+        for (int i = 0; i < elements.length; i++) {
+            String element = elements[i];
+            if (element.isEmpty()) {
+                element = System.getProperty("user.dir");
+            }
+            // we should be able to just Paths.get() each element, but unfortunately this is not the
+            // whole story on how classpath parsing works: if you want to know, start at sun.misc.Launcher,
+            // be sure to stop before you tear out your eyes. we just handle the "alternative" filename
+            // specification which java seems to allow, explicitly, right here...
+            if (element.startsWith("/") && "\\".equals(fileSeparator)) {
+                // "correct" the entry to become a normal entry
+                // change to correct file separators
+                element = element.replace("/", "\\");
+                // if there is a drive letter, nuke the leading separator
+                if (element.length() >= 3 && element.charAt(2) == ':') {
+                    element = element.substring(1);
+                }
+            }
+            // now just parse as ordinary file
+            try {
+                urlElements[i] = Paths.get(element).toUri().toURL();
+            } catch (MalformedURLException e) {
+                // should not happen, as we use the filesystem API
+                throw new RuntimeException(e);
+            }
+        }
+        // set up a parallel loader
+        ClassLoader parent = ClassLoader.getSystemClassLoader().getParent();
+        if (parent == null) {
+            throw new UnsupportedOperationException("we can't safely scan for you, sorry");
+        }
+        return URLClassLoader.newInstance(urlElements, parent);
+    }
+}

--- a/test/tools/catch-analyzer/src/main/java/org/elasticsearch/test/ClassAnalyzer.java
+++ b/test/tools/catch-analyzer/src/main/java/org/elasticsearch/test/ClassAnalyzer.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+import org.elasticsearch.test.Violation.Kind;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.commons.Method;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** class-level analyzer */
+class ClassAnalyzer extends ClassVisitor {
+    final String className;
+    final ClassLoader loader;
+    final Map<Method,MethodAnalyzer> analyses = new LinkedHashMap<>();
+    boolean suppressed;
+    String source;
+    String superName;
+
+    ClassAnalyzer(String className, ClassLoader loader) {
+        super(CatchAnalyzer.ASM_API_VERSION);
+        this.className = className;
+        this.loader = loader;
+    }
+    
+    @Override
+    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+        this.superName = superName;
+    }
+
+    @Override
+    public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+        if (desc.contains("SwallowsExceptions")) {
+            suppressed = true;
+        }
+        return null;
+    }
+    
+    @Override
+    public void visitSource(String source, String debug) {
+        this.source = source;
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+        // don't scan bridge methods: they may have annotations, but we won't find problems!
+        if ((access & Opcodes.ACC_BRIDGE) != 0) {
+            return null;
+        }
+        MethodAnalyzer analyzer = new MethodAnalyzer(loader, className, superName, access, name, desc, signature, exceptions);
+        analyses.put(new Method(name, desc), analyzer);
+        return analyzer;
+    }
+
+    @Override
+    public void visitEnd() {
+        // fold lambdas violations into their parent methods
+        List<Method> lambdas = new ArrayList<>();
+        analyses.forEach((method, analysis) -> {
+            for (Method lambda : analysis.lambdas) {
+                MethodAnalyzer lambdaAnalysis = analyses.get(lambda);
+                if (lambdaAnalysis != null) {
+                    analysis.violations.addAll(lambdaAnalysis.violations);
+                    lambdas.add(lambda);
+                } else {
+                    throw new AssertionError("where in the world is lambda " + lambda);
+                }
+            }
+        });
+        // now nuke them
+        analyses.keySet().removeAll(lambdas);
+    }
+    
+    /** log violations, grouping them by catch block entry line number for the method */
+    long logViolations(PrintStream stream) {
+        long violationCount = 0;
+        if (suppressed) {
+            long violations = 0;
+            for (MethodAnalyzer analysis : analyses.values()) {
+                violations += analysis.violations.size();
+            }
+            if (violations == 0) {
+                StringBuilder sb = createMessage("Wrong class annotation", null, -1);
+                addDetails(sb, new Violation(Kind.ANNOTATED_AS_SWALLOWER_BUT_HAS_NO_PROBLEMS, -1, -1));
+                stream.println(sb.toString());
+                violationCount++;
+            }
+        } else {
+            for (Map.Entry<Method,MethodAnalyzer> entry : analyses.entrySet()) {
+                Method method = entry.getKey();
+                MethodAnalyzer analysis = entry.getValue();
+                if (analysis.suppressed) {
+                    if (analysis.violations.isEmpty()) {
+                        StringBuilder sb = createMessage("Wrong method annotation", method, -1);
+                        addDetails(sb, new Violation(Kind.ANNOTATED_AS_SWALLOWER_BUT_HAS_NO_PROBLEMS, -1, -1));
+                        stream.println(sb.toString());
+                        violationCount++;
+                    }
+                } else {
+                    Map<Integer,List<Violation>> report = analysis.violations.stream()
+                                                          .collect(Collectors.groupingBy(Violation::getLineNumber));
+                    for (Map.Entry<Integer,List<Violation>> group : report.entrySet()) {
+                        StringBuilder sb = createMessage("Broken catch block", method, group.getKey());
+                        for (Violation violation : group.getValue()) {
+                            addDetails(sb, violation);
+                        }
+                        stream.println(sb.toString());
+                        violationCount++;
+                    }
+                }
+            }
+        }
+        return violationCount;
+    }
+    
+    private StringBuilder createMessage(String problem, Method method, int lineNumber) {
+        StringBuilder message = new StringBuilder();
+        message.append(problem);
+        message.append(" at ");
+        message.append(className.replace('/', '.'));
+        if (method != null) {
+            message.append(".");
+            message.append(method.getName());
+            message.append("(");
+            if (source == null) {
+                message.append("Unknown Source");
+            } else {
+                message.append(source);
+            }
+            if (lineNumber > 0) {
+                message.append(":" + lineNumber);
+            }
+            message.append(")");
+        }
+        return message;
+    }
+    
+    private void addDetails(StringBuilder message, Violation violation) {
+        message.append(System.lineSeparator());
+        message.append("\t* ");
+        message.append(violation.kind.description);
+        if (violation.secondaryLineNumber != -1) {
+            message.append(" at line ");
+            message.append(violation.secondaryLineNumber);
+        }
+    }
+}

--- a/test/tools/catch-analyzer/src/main/java/org/elasticsearch/test/MethodAnalyzer.java
+++ b/test/tools/catch-analyzer/src/main/java/org/elasticsearch/test/MethodAnalyzer.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.Method;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.LineNumberNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TryCatchBlockNode;
+import org.objectweb.asm.tree.analysis.Analyzer;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.Frame;
+
+import java.lang.invoke.LambdaMetafactory;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+/** Scans a single method for violations */
+class MethodAnalyzer extends MethodVisitor {
+    /** classloader (for type resolution) */
+    final ClassLoader loader;
+    /** method name */
+    final String name;
+    /** parent class name */
+    final String owner;
+    /** parent class's superclass */
+    final String superName;
+    /** any violations we found for this method */
+    final Set<Violation> violations = new TreeSet<>();
+    /** any lambda invocations we found for this method (we'll apply suppression to them, if needed) */
+    final List<Method> lambdas = new ArrayList<>();
+    /** true if we found a suppression annotation for this method */
+    boolean suppressed;
+    
+    MethodAnalyzer(ClassLoader loader, String owner, String superName, 
+                   int access, String name, String desc, String signature, String[] exceptions) {
+        super(CatchAnalyzer.ASM_API_VERSION, new MethodNode(access, name, desc, signature, exceptions));
+        this.loader = loader;
+        this.name = name;
+        this.owner = owner;
+        this.superName = superName;
+    }
+    
+    @Override
+    public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+        if (desc.contains("SwallowsExceptions")) {
+            suppressed = true;
+        }
+        return null;
+    }
+    
+    private static final String LAMBDA_META_FACTORY_INTERNAL_NAME = Type.getInternalName(LambdaMetafactory.class);
+
+    @Override
+    public void visitInvokeDynamicInsn(String name, String desc, Handle bsm, Object... bsmArgs) {
+        // if we see calls to LambdaMetaFactory, remember them, and later we will fold analysis
+        // of the desugared method back into this method
+        if (LAMBDA_META_FACTORY_INTERNAL_NAME.equals(bsm.getOwner())) {
+            Handle implMethod = (Handle) bsmArgs[1];
+            if (implMethod.getOwner().equals(owner) && implMethod.getName().startsWith("lambda$")) {
+                lambdas.add(new Method(implMethod.getName(), implMethod.getDesc()));
+            }
+        }
+        super.visitInvokeDynamicInsn(name, desc, bsm, bsmArgs);
+    }
+
+    @Override
+    public void visitEnd() {
+        MethodNode node = (MethodNode)mv;
+        AbstractInsnNode insns[] = node.instructions.toArray(); // all instructions for the method
+        Set<Integer> handlers = new TreeSet<>(); // entry points of exception handlers found
+
+        Analyzer<BasicValue> a = new Analyzer<BasicValue>(new ThrowableInterpreter(loader)) {
+            @Override
+            protected Frame<BasicValue> newFrame(Frame<? extends BasicValue> src) {
+                return new Node(src, MethodAnalyzer.this);
+            }
+            
+            @Override
+            protected Frame<BasicValue> newFrame(int nLocals, int nStack) {
+                return new Node(nLocals, nStack, MethodAnalyzer.this);
+            }
+            
+            @Override
+            protected void newControlFlowEdge(int insn, int next) {
+                Node s = (Node) getFrames()[insn];
+                s.edges.add(next);
+            }
+            
+            @Override
+            protected boolean newControlFlowExceptionEdge(int insn, TryCatchBlockNode next) {
+                int nextInsn = node.instructions.indexOf(next.handler);
+                newControlFlowEdge(insn, nextInsn);
+                // null type: finally block
+                if (next.type != null) {
+                    handlers.add(nextInsn);
+                }
+                return true;
+            }
+        };
+        try {
+            Frame<BasicValue> frames[] = a.analyze(owner, node);
+            List<Node> nodes = new ArrayList<>();
+            for (Frame<BasicValue> frame : frames) {
+                nodes.add((Node)frame);
+            }
+            // check the destination of every exception edge
+            for (int handler : handlers) {
+                int line = getLineNumberForwards(insns, handler);
+                analyze(line, insns, nodes, handler, new BitSet());
+            }
+        } catch (AnalyzerException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    /**
+     * Analyzes a basic block starting at insn, recursing for all paths in the CFG, until it finds an exit or
+     * throw. records all violations found.
+     */
+    private void analyze(int line, AbstractInsnNode insns[], List<Node> nodes, int insn, BitSet visited) {
+        Node node = nodes.get(insn);
+        while (true) {
+            if (visited.get(insn)) {
+                return;
+            }
+            visited.set(insn);
+            // original exception being added as suppressed exception to another.
+            if (isValidSuppression(insns[insn], node)) {
+                return;
+            }
+            // true if its a throw equivalent, and the original is being passed.
+            Boolean v = isThrowInsn(insns[insn], node);
+            if (v == null) {
+                Violation violation = new Violation(Violation.Kind.THROWS_SOMETHING_ELSE_BUT_LOSES_ORIGINAL, line,
+                                                    getLineNumberBackwards(insns, insn));
+                violations.add(violation);
+                return;
+            } else if (v) {
+                return;
+            }
+            // end of path, you lose
+            if (node.edges.isEmpty()) {
+                Violation violation = new Violation(Violation.Kind.ESCAPES_WITHOUT_THROWING_ANYTHING, line,
+                                                    getLineNumberBackwards(insns, insn));
+                violations.add(violation);
+                return;
+            }
+            // stay within loop instead of recursing for the rest of this block
+            if (node.edges.size() == 1) {
+                insn = node.edges.iterator().next();
+                node = nodes.get(insn);
+            } else {
+                break;
+            }
+        }
+        
+        // recurse: multiple edges
+        for (int edge : node.edges) {
+            analyze(line, insns, nodes, edge, visited);
+        }
+    }
+    
+    /** true if this is a throw, or an equivalent (e.g. rethrow) */
+    private static Boolean isThrowInsn(AbstractInsnNode insn, Node node) {
+        if (insn.getOpcode() == Opcodes.ATHROW) {
+            if (node.getStack(0) != ThrowableInterpreter.ORIGINAL_THROWABLE) {
+                return null;
+            }
+            return true;
+        }
+        if (insn instanceof MethodInsnNode) {
+            MethodInsnNode method = (MethodInsnNode) insn;
+            if (SpecialMethod.isRethrower(method)) {
+                for (int i = 0; i < Type.getArgumentTypes(method.desc).length; i++) {
+                    if (node.getStack(i) == ThrowableInterpreter.ORIGINAL_THROWABLE) {
+                        return true;
+                    }
+                }
+                return null;
+            }
+        }
+        return false;
+    }
+    
+    private boolean isValidSuppression(AbstractInsnNode insn, Node node) {
+        if (insn instanceof MethodInsnNode) {
+            MethodInsnNode methodNode = (MethodInsnNode)insn;
+            if ((methodNode.name.equals("addSuppressed") || methodNode.name.equals("initCause")) &&
+                    ThrowableInterpreter.isThrowable(Type.getObjectType(methodNode.owner), loader)) {
+                // its a suppressor, check our original is passed
+                if (node.getStack(1) == ThrowableInterpreter.ORIGINAL_THROWABLE) {
+                    return true;
+                }
+            }
+            // TODO: remove this (private) method from lucene, its really crappy and lenient
+            if ((methodNode.name.equals("addSuppressed") && methodNode.owner.equals("org/apache/lucene/util/IOUtils"))) {
+                // its a suppressor, check our original is passed
+                if (node.getStack(1) == ThrowableInterpreter.ORIGINAL_THROWABLE) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    
+    private static int getLineNumberForwards(AbstractInsnNode insns[], int insn) {
+        // walk forwards in the line number table
+        int line = -1;
+        for (int i = insn; i < insns.length; i++) {
+            AbstractInsnNode next = insns[i];
+            if (next instanceof LineNumberNode) {
+                line = ((LineNumberNode)next).line;
+                break;
+            }
+        }
+        return line;
+    }
+    
+    private static int getLineNumberBackwards(AbstractInsnNode insns[], int insn) {
+        // walk backwards in the line number table
+        int line = -1;
+        for (int i = insn; i >= 0; i--) {
+            AbstractInsnNode previous = insns[i];
+            if (previous instanceof LineNumberNode) {
+                line = ((LineNumberNode)previous).line;
+                break;
+            }
+        }
+        return line;
+    }
+}

--- a/test/tools/catch-analyzer/src/main/java/org/elasticsearch/test/Node.java
+++ b/test/tools/catch-analyzer/src/main/java/org/elasticsearch/test/Node.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.Frame;
+import org.objectweb.asm.tree.analysis.Interpreter;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/** Node in the flow graph. contains set of outgoing edges for the next instructions possible */
+class Node extends Frame<BasicValue> {
+    Set<Integer> edges = new HashSet<>();
+    MethodAnalyzer parent;
+    
+    Node(int nLocals, int nStack, MethodAnalyzer parent) {
+        super(nLocals, nStack);
+        this.parent = parent;
+    }
+    
+    Node(Frame<? extends BasicValue> src, MethodAnalyzer parent) {
+        super(src);
+        this.parent = parent;
+    }
+    
+    @Override
+    public void execute(AbstractInsnNode insn, Interpreter<BasicValue> interpreter) throws AnalyzerException {
+        // special handling for throwable constructor. if you do new Exception(originalException),
+        // the stack value is replaced with originalException, so it survives.
+        if (insn.getOpcode() == Opcodes.INVOKESPECIAL) {
+            MethodInsnNode node = (MethodInsnNode) insn;
+            Type ownerType = Type.getObjectType(node.owner);
+            // actually calling a throwable ctor
+            if ("<init>".equals(node.name) && ThrowableInterpreter.isThrowable(ownerType, parent.loader)) {
+                // but, not if we are ourselves a throwable ctor invoking another ctor!
+                if ("<init>".equals(parent.name) && 
+                      (ownerType.getInternalName().equals(parent.owner) || 
+                       ownerType.getInternalName().equals(parent.superName))) {
+                    super.execute(insn, interpreter);
+                    return;
+                }
+                // actually creating a throwable
+                List<BasicValue> values = new ArrayList<BasicValue>();
+                String desc = ((MethodInsnNode) insn).desc;
+                // inspect the arguments, see if original exception is being passed
+                boolean sawOriginal = false;
+                for (int i = Type.getArgumentTypes(desc).length; i > 0; --i) {
+                    BasicValue v = pop();
+                    if (v == ThrowableInterpreter.ORIGINAL_THROWABLE) {
+                        sawOriginal = true;
+                    }
+                    values.add(0, v);
+                }
+                values.add(0, pop());
+                interpreter.naryOperation(insn, values);
+                // replace the top stack value (from new), if we saw the original
+                if (sawOriginal) {
+                    pop();
+                    push(ThrowableInterpreter.ORIGINAL_THROWABLE);
+                }
+                return;
+            }
+        }
+        super.execute(insn, interpreter);
+    }
+    
+    // just for debugging
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("edges=" + edges + "\n");
+        sb.append("locals=\n");
+        for (int i = 0; i < getLocals(); i++) {
+            sb.append("\t");
+            sb.append(i + "=" + getLocal(i).getType() + "\n");
+        }
+        sb.append("stack=\n");
+        for (int i = 0; i < getStackSize(); i++) {
+            sb.append("\t");
+            sb.append(i + "=" + getStack(i).getType() + "\n");
+        }
+        return sb.toString();
+    }
+}

--- a/test/tools/catch-analyzer/src/main/java/org/elasticsearch/test/SpecialMethod.java
+++ b/test/tools/catch-analyzer/src/main/java/org/elasticsearch/test/SpecialMethod.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+import org.objectweb.asm.tree.MethodInsnNode;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/** simple whitelist of special helper methods that preserve exceptions */
+class SpecialMethod {
+    private final String owner;
+    private final String name;
+    private final String desc;
+    
+    private SpecialMethod(String owner, String name, String desc) {
+        this.owner = owner;
+        this.name = name;
+        this.desc = desc;
+    }
+    
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((desc == null) ? 0 : desc.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((owner == null) ? 0 : owner.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        SpecialMethod other = (SpecialMethod) obj;
+        if (desc == null) {
+            if (other.desc != null) return false;
+        } else if (!desc.equals(other.desc)) return false;
+        if (name == null) {
+            if (other.name != null) return false;
+        } else if (!name.equals(other.name)) return false;
+        if (owner == null) {
+            if (other.owner != null) return false;
+        } else if (!owner.equals(other.owner)) return false;
+        return true;
+    }
+
+    /** These are "boxers", they return a value that preserves the exception */
+    private static final Set<SpecialMethod> BOXERS = new HashSet<>(Arrays.asList(
+            new SpecialMethod("org/elasticsearch/ExceptionsHelper", 
+                              "convertToElastic", 
+                              "(Ljava/lang/Throwable;)Lorg/elasticsearch/ElasticsearchException;"),
+            new SpecialMethod("org/elasticsearch/ExceptionsHelper", 
+                              "convertToRuntime", 
+                              "(Ljava/lang/Throwable;)Ljava/lang/RuntimeException;"),
+            new SpecialMethod("org/elasticsearch/ExceptionsHelper", 
+                              "useOrSuppress", 
+                              "(Ljava/lang/Throwable;Ljava/lang/Throwable;)Ljava/lang/Throwable;")
+    ));
+    
+    /** These are rethrowers, they actually throw the passed exception (possibly boxing too, but preserve it) */
+    private static final Set<SpecialMethod> RETHROWERS = new HashSet<>(Arrays.asList(
+            new SpecialMethod("org/apache/lucene/util/IOUtils", 
+                              "reThrow", 
+                              "(Ljava/lang/Throwable;)V"),
+            new SpecialMethod("org/apache/lucene/util/IOUtils", 
+                              "reThrowUnchecked", 
+                              "(Ljava/lang/Throwable;)V"),
+            // TODO: not really a rethrower, only rethrows if arg is non-null
+            new SpecialMethod("org/apache/lucene/codecs/CodecUtil", 
+                              "checkFooter", 
+                              "(Lorg/apache/lucene/store/ChecksumIndexInput;Ljava/lang/Throwable;)V")
+    ));
+    
+    /** True if the insn is a call to a boxer (returns the original, or a wrapper) */
+    static boolean isBoxer(MethodInsnNode insn) {
+        return BOXERS.contains(new SpecialMethod(insn.owner, insn.name, insn.desc));
+    }
+    
+    /** True if the insn is a call to an exception rethrower */
+    static boolean isRethrower(MethodInsnNode insn) {
+        return RETHROWERS.contains(new SpecialMethod(insn.owner, insn.name, insn.desc));
+    }
+}

--- a/test/tools/catch-analyzer/src/main/java/org/elasticsearch/test/ThrowableInterpreter.java
+++ b/test/tools/catch-analyzer/src/main/java/org/elasticsearch/test/ThrowableInterpreter.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+import org.objectweb.asm.tree.analysis.BasicInterpreter;
+import org.objectweb.asm.tree.analysis.BasicValue;
+
+import java.util.List;
+
+/**
+ * Tracks "Original throwable". You can assign it to variables and stuff, but otherwise
+ * operations on it convert it into a regular REFERENCE_VALUE. However, new OtherException(ORIGINAL_THROWABLE)
+ * is treated still as ORIGINAL_THROWABLE, as you preserved it.
+ */
+class ThrowableInterpreter extends BasicInterpreter {
+    static final BasicValue ORIGINAL_THROWABLE = new BasicValue(Type.getType(Throwable.class));
+    final ClassLoader loader;
+    
+    ThrowableInterpreter(ClassLoader loader) {
+        super(CatchAnalyzer.ASM_API_VERSION);
+        this.loader = loader;
+    }
+    
+    @Override
+    public BasicValue newValue(Type type) {
+        if (isThrowable(type, loader)) {
+            return ORIGINAL_THROWABLE;
+        }
+        return super.newValue(type);
+    }
+    
+    @Override
+    public BasicValue newOperation(AbstractInsnNode insn) throws AnalyzerException {
+        BasicValue v = super.newOperation(insn);
+        if (v == ORIGINAL_THROWABLE) {
+            // you can't create "new" original throwables. if you make a new exception,
+            // we will replace the stack value only if you pass the original to it.
+            return BasicValue.REFERENCE_VALUE;
+        }
+        return v;
+    }
+
+    @Override
+    public BasicValue naryOperation(AbstractInsnNode insn, List<? extends BasicValue> values) throws AnalyzerException {
+        BasicValue v = super.naryOperation(insn, values);
+        if (v == ORIGINAL_THROWABLE) {
+            // boxer(original-throwable) = original-throwable
+            // these methods preserve
+            if (insn instanceof MethodInsnNode) {
+                MethodInsnNode method = (MethodInsnNode) insn;
+                if (SpecialMethod.isBoxer(method)) {
+                    for (BasicValue arg : values) {
+                        if (arg == ORIGINAL_THROWABLE) {
+                            return ORIGINAL_THROWABLE;
+                        }
+                    }
+                }
+            }
+            return BasicValue.REFERENCE_VALUE;
+        }
+        return v;
+    }
+    
+    /** check if the type is a throwable */
+    static boolean isThrowable(Type type, ClassLoader loader) {
+        if (type != null && type.getSort() == Type.OBJECT && "null".equals(type.getClassName()) == false) {
+            try {
+                Class<?> clazz = Class.forName(type.getClassName(), false, loader);
+                return Throwable.class.isAssignableFrom(clazz);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return false;
+    }
+}

--- a/test/tools/catch-analyzer/src/main/java/org/elasticsearch/test/Violation.java
+++ b/test/tools/catch-analyzer/src/main/java/org/elasticsearch/test/Violation.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+/** some kind of problem with exception handling, with associated line number info */
+class Violation implements Comparable<Violation> {
+    final Kind kind;
+    final int lineNumber;
+    final int secondaryLineNumber;
+    
+    Violation(Kind kind, int lineNumber, int secondaryLineNumber) {
+        this.kind = kind;
+        this.lineNumber = lineNumber;
+        this.secondaryLineNumber = secondaryLineNumber;
+    }
+    
+    int getLineNumber() {
+        return lineNumber;
+    }
+
+    static enum Kind {        
+        ESCAPES_WITHOUT_THROWING_ANYTHING("Control flow escapes with no exception"),
+        THROWS_SOMETHING_ELSE_BUT_LOSES_ORIGINAL("Throws a different exception, losing the original"),
+        ANNOTATED_AS_SWALLOWER_BUT_HAS_NO_PROBLEMS("Annotated with @SwallowsException but has no problems");
+        
+        final String description;
+        Kind(String description) {
+            this.description = description;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + lineNumber;
+        result = prime * result + secondaryLineNumber;
+        result = prime * result + kind.hashCode();
+
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        Violation other = (Violation) obj;
+        if (lineNumber != other.lineNumber) return false;
+        if (secondaryLineNumber != other.secondaryLineNumber) return false;
+        if (kind != other.kind) return false;
+        return true;
+    }
+
+    @Override
+    public int compareTo(Violation other) {
+        int cmp = Integer.compare(lineNumber, other.lineNumber);
+        if (cmp != 0) {
+            return cmp;
+        }
+        cmp = Integer.compare(secondaryLineNumber, other.secondaryLineNumber);
+        if (cmp != 0) {
+            return cmp;
+        }
+        return kind.compareTo(other.kind);
+    }
+}

--- a/test/tools/catch-analyzer/src/test/java/org/elasticsearch/test/BaseTestCase.java
+++ b/test/tools/catch-analyzer/src/test/java/org/elasticsearch/test/BaseTestCase.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+import com.carrotsearch.randomizedtesting.JUnit4MethodProvider;
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
+import com.carrotsearch.randomizedtesting.annotations.TestMethodProviders;
+
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicLong;
+
+@TestMethodProviders({
+    LuceneJUnit3MethodProvider.class,
+    JUnit4MethodProvider.class
+})
+@RunWith(RandomizedRunner.class)
+public class BaseTestCase extends Assert {
+    
+    /** analyzes the method, and returns its analysis */
+    public MethodAnalyzer analyze(Method method) throws Exception {
+        return analyze(method.getDeclaringClass(), method.getName(), Type.getMethodDescriptor(method));
+    }
+    
+    /** analyzes the ctor, and returns its analysis */
+    public MethodAnalyzer analyze(Constructor<?> method) throws Exception {
+        return analyze(method.getDeclaringClass(), "<init>", Type.getConstructorDescriptor(method));
+    }
+    
+    /** analyzes the method, and returns its analysis */
+    private MethodAnalyzer analyze(Class<?> parentClass, String methodName, String methodDesc) throws Exception {
+        ClassReader reader = new ClassReader(parentClass.getName());
+        AtomicLong analyzedMethods = new AtomicLong();
+        MethodAnalyzer analyzer[] = new MethodAnalyzer[1];
+        reader.accept(new ClassVisitor(CatchAnalyzer.ASM_API_VERSION, null) {
+            @Override
+            public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+                if (name.equals(methodName) && desc.equals(methodDesc)) {
+                    analyzedMethods.incrementAndGet();
+                    return analyzer[0] = new MethodAnalyzer(getClass().getClassLoader(), reader.getClassName(), 
+                                                            reader.getSuperName(), access, name, desc, signature, exceptions);
+                }
+                return null;
+            }
+        }, 0);
+        assertNotNull("method not found", analyzer[0]);
+        return analyzer[0];
+    }
+}

--- a/test/tools/catch-analyzer/src/test/java/org/elasticsearch/test/LambdaTests.java
+++ b/test/tools/catch-analyzer/src/test/java/org/elasticsearch/test/LambdaTests.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+import java.util.Optional;
+
+public class LambdaTests extends BaseTestCase {
+    
+    /** drops the exception on the floor */
+    public int escapes() {
+        return Optional.<Integer>empty().orElseGet(() -> {
+            try {
+                return Integer.parseInt("foo");
+            } catch (Exception e) {
+                return 0;
+            }
+        });
+    }
+    
+    public void testEscapes() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("escapes"));
+        assertEquals(1, analyzer.lambdas.size());
+    }
+}

--- a/test/tools/catch-analyzer/src/test/java/org/elasticsearch/test/LuceneJUnit3MethodProvider.java
+++ b/test/tools/catch-analyzer/src/test/java/org/elasticsearch/test/LuceneJUnit3MethodProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.elasticsearch.test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import com.carrotsearch.randomizedtesting.ClassModel;
+import com.carrotsearch.randomizedtesting.ClassModel.MethodModel;
+import com.carrotsearch.randomizedtesting.TestMethodProvider;
+
+/**
+ * Backwards compatible test* method provider (public, non-static).
+ */
+public final class LuceneJUnit3MethodProvider implements TestMethodProvider {
+  @Override
+  public Collection<Method> getTestMethods(Class<?> suiteClass, ClassModel classModel) {
+    Map<Method,MethodModel> methods = classModel.getMethods();
+    ArrayList<Method> result = new ArrayList<>();
+    for (MethodModel mm : methods.values()) {
+      // Skip any methods that have overrieds/ shadows.
+      if (mm.getDown() != null) continue;
+
+      Method m = mm.element;
+      if (m.getName().startsWith("test") &&
+          Modifier.isPublic(m.getModifiers()) &&
+          !Modifier.isStatic(m.getModifiers()) &&
+          m.getParameterTypes().length == 0) {
+        result.add(m);
+      }
+    }
+    return result;
+  }
+}

--- a/test/tools/catch-analyzer/src/test/java/org/elasticsearch/test/SimpleTests.java
+++ b/test/tools/catch-analyzer/src/test/java/org/elasticsearch/test/SimpleTests.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+/** basic tests */
+public class SimpleTests extends BaseTestCase {
+
+    /** drops the exception on the floor */
+    public int escapes() {
+        try {
+            return Integer.parseInt("bogus");
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+    
+    public void testEscapes() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("escapes"));
+        assertEquals(1, analyzer.violations.size());
+        Violation violation = analyzer.violations.iterator().next();
+        assertEquals(Violation.Kind.ESCAPES_WITHOUT_THROWING_ANYTHING, violation.kind);
+    }
+    
+    /** drops the exception on the floor (sometimes) */
+    public int escapesSometimes() {
+        try {
+            return Integer.parseInt("bogus");
+        } catch (RuntimeException e) {
+            if (e.getMessage().equals("ok")) {
+                return 0;
+            } else {
+                throw e;
+            }
+        }
+    }
+    
+    public void testEscapesSometimes() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("escapesSometimes"));
+        assertEquals(1, analyzer.violations.size());
+        Violation violation = analyzer.violations.iterator().next();
+        assertEquals(Violation.Kind.ESCAPES_WITHOUT_THROWING_ANYTHING, violation.kind);
+    }
+    
+    /** drops the exception on the floor (sometimes, with loop) */
+    public int escapesSometimesLoop() {
+        try {
+            return Integer.parseInt("bogus");
+        } catch (RuntimeException e) {
+            while (e != null) {
+              throw e;
+            }
+            return 0;
+        }
+    }
+    
+    public void testEscapesSometimesLoop() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("escapesSometimesLoop"));
+        assertEquals(1, analyzer.violations.size());
+        Violation violation = analyzer.violations.iterator().next();
+        assertEquals(Violation.Kind.ESCAPES_WITHOUT_THROWING_ANYTHING, violation.kind);
+    }
+    
+    /** throws something else (does not pass the exception) */
+    public int throwsSomethingElse() {
+        try {
+            return Integer.parseInt("bogus");
+        } catch (Exception e) {
+            throw new NullPointerException();
+        }
+    }
+    
+    public void testThrowsSomethingElse() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("throwsSomethingElse"));
+        Violation violation = analyzer.violations.iterator().next();
+        assertEquals(Violation.Kind.THROWS_SOMETHING_ELSE_BUT_LOSES_ORIGINAL, violation.kind);
+    }
+    
+    /** throws exception back directly */
+    public int throwsExceptionBack() {
+        try {
+            return Integer.parseInt("bogus");
+        } catch (RuntimeException e) {
+            throw e;
+        }
+    }
+    
+    public void testThrowsExceptionBack() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("throwsExceptionBack"));
+        assertTrue(analyzer.violations.isEmpty());
+    }
+    
+    /** throws exception boxed in another */
+    public int throwsBoxedException() {
+        try {
+            return Integer.parseInt("bogus");
+        } catch (RuntimeException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    public void testThrowsBoxedException() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("throwsBoxedException"));
+        assertTrue(analyzer.violations.isEmpty());
+    }
+    
+    /** throws exception boxed in another (via initCause) */
+    public int throwsBoxedExceptionInitCause() {
+        try {
+            return Integer.parseInt("bogus");
+        } catch (RuntimeException e) {
+            RuntimeException f = new RuntimeException();
+            f.initCause(e);
+            throw f;
+        }
+    }
+    
+    public void testThrowsBoxedExceptionInitCause() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("throwsBoxedExceptionInitCause"));
+        assertTrue(analyzer.violations.isEmpty());
+    }
+    
+    /** throws exception boxed in another (via addSuppressed) */
+    public int throwsBoxedExceptionAddSuppressed() {
+        try {
+            return Integer.parseInt("bogus");
+        } catch (RuntimeException e) {
+            RuntimeException f = new RuntimeException();
+            f.addSuppressed(e);
+            throw f;
+        }
+    }
+    
+    public void testThrowsBoxedExceptionAddSuppressed() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("throwsBoxedExceptionAddSuppressed"));
+        assertTrue(analyzer.violations.isEmpty());
+    }
+}

--- a/test/tools/catch-analyzer/src/test/java/org/elasticsearch/test/SimpleWithResourcesTests.java
+++ b/test/tools/catch-analyzer/src/test/java/org/elasticsearch/test/SimpleWithResourcesTests.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+import java.io.ByteArrayOutputStream;
+
+/** basic tests, using try-with resources */
+public class SimpleWithResourcesTests extends BaseTestCase {
+
+    /** drops the exception on the floor */
+    public int escapes() {
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            assert os != null;
+            return Integer.parseInt("bogus");
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+    
+    public void testEscapes() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("escapes"));
+        assertFalse(analyzer.violations.isEmpty());
+        for (Violation violation : analyzer.violations) {
+            assertEquals(Violation.Kind.ESCAPES_WITHOUT_THROWING_ANYTHING, violation.kind);
+        }
+    }
+    
+    /** drops the exception on the floor (sometimes) */
+    public int escapesSometimes() throws Exception {
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            assert os != null;
+            return Integer.parseInt("bogus");
+        } catch (Exception e) {
+            if (e.getMessage().equals("ok")) {
+                return 0;
+            } else {
+                throw e;
+            }
+        }
+    }
+    
+    public void testEscapesSometimes() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("escapesSometimes"));
+        assertFalse(analyzer.violations.isEmpty());
+        for (Violation violation : analyzer.violations) {
+            assertEquals(Violation.Kind.ESCAPES_WITHOUT_THROWING_ANYTHING, violation.kind);
+        }
+    }
+    
+    /** drops the exception on the floor (sometimes, with loop) */
+    public int escapesSometimesLoop() throws Exception {
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            assert os != null;
+            return Integer.parseInt("bogus");
+        } catch (Exception e) {
+            while (e != null) {
+              throw e;
+            }
+            return 0;
+        }
+    }
+    
+    public void testEscapesSometimesLoop() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("escapesSometimesLoop"));
+        assertFalse(analyzer.violations.isEmpty());
+        for (Violation violation : analyzer.violations) {
+            assertEquals(Violation.Kind.ESCAPES_WITHOUT_THROWING_ANYTHING, violation.kind);
+        }
+    }
+    
+    /** throws something else (does not pass the exception) */
+    public int throwsSomethingElse() {
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            assert os != null;
+            return Integer.parseInt("bogus");
+        } catch (Exception e) {
+            throw new NullPointerException();
+        }
+    }
+    
+    public void testThrowsSomethingElse() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("throwsSomethingElse"));
+        assertFalse(analyzer.violations.isEmpty());
+        for (Violation violation : analyzer.violations) {
+            assertEquals(Violation.Kind.THROWS_SOMETHING_ELSE_BUT_LOSES_ORIGINAL, violation.kind);
+        }
+    }
+    
+    /** throws exception back directly */
+    public int throwsExceptionBack() throws Exception {
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            assert os != null;
+            return Integer.parseInt("bogus");
+        } catch (RuntimeException e) {
+            throw e;
+        }
+    }
+    
+    public void testThrowsExceptionBack() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("throwsExceptionBack"));
+        assertTrue(analyzer.violations.isEmpty());
+    }
+    
+    /** throws exception boxed in another */
+    public int throwsBoxedException() throws Exception {
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            assert os != null;
+            return Integer.parseInt("bogus");
+        } catch (RuntimeException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    public void testThrowsBoxedException() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("throwsBoxedException"));
+        assertTrue(analyzer.violations.isEmpty());
+    }
+    
+    /** throws exception boxed in another (via initCause) */
+    public int throwsBoxedExceptionInitCause() throws Exception {
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            assert os != null;
+            return Integer.parseInt("bogus");
+        } catch (RuntimeException e) {
+            RuntimeException f = new RuntimeException();
+            f.initCause(e);
+            throw f;
+        }
+    }
+    
+    public void testThrowsBoxedExceptionInitCause() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("throwsBoxedExceptionInitCause"));
+        assertTrue(analyzer.violations.isEmpty());
+    }
+    
+    /** throws exception boxed in another (via addSuppressed) */
+    public int throwsBoxedExceptionAddSuppressed() throws Exception {
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            assert os != null;
+            return Integer.parseInt("bogus");
+        } catch (RuntimeException e) {
+            RuntimeException f = new RuntimeException();
+            f.addSuppressed(e);
+            throw f;
+        }
+    }
+    
+    public void testThrowsBoxedExceptionAddSuppressed() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("throwsBoxedExceptionAddSuppressed"));
+        assertTrue(analyzer.violations.isEmpty());
+    }
+}

--- a/test/tools/catch-analyzer/src/test/java/org/elasticsearch/test/SuppressedTests.java
+++ b/test/tools/catch-analyzer/src/test/java/org/elasticsearch/test/SuppressedTests.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+public class SuppressedTests extends BaseTestCase {
+
+    /** drops the exception on the floor */
+    @SwallowsExceptions
+    public int escapes() {
+        try {
+            return Integer.parseInt("bogus");
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+    
+    public void testEscapes() throws Exception {
+        MethodAnalyzer analyzer = analyze(getClass().getMethod("escapes"));
+        assertEquals(1, analyzer.violations.size());
+        assertEquals(true, analyzer.suppressed);
+    }
+}

--- a/test/tools/catch-analyzer/src/test/java/org/elasticsearch/test/SwallowsExceptions.java
+++ b/test/tools/catch-analyzer/src/test/java/org/elasticsearch/test/SwallowsExceptions.java
@@ -1,0 +1,30 @@
+package org.elasticsearch.test;
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to suppress broken catch-block swallowing
+ */
+@Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.TYPE})
+public @interface SwallowsExceptions {
+}


### PR DESCRIPTION
The idea here is to add a simple check to find broken catch blocks. It detects a couple of common problems:
- throwing a different exception, but forgetting to pass the original one to its ctor, or calling initCause/addSuppressed/etc. So information about what originally happened is lost!
- swallowing an exception completely (e.g. just logging it and moving on).

It does some flow analysis (+ hacks) to track the original exception via all possible codepaths. If the method can return without throwing anything, or throws a different exception that doesn't have the original chained to it in some way, it fails.

It also knows about rethrowers that we have, and some helper methods "boxers" that wrap exceptions in other ones.

Scans are true to the bytecode: so don't be surprised by the errors for broken catch blocks with try-with-resources/finally/etc. These aren't duplicates, that's what javac is actually doing with your code.

I think if we really want to swallow an exception, its ok to annotate the method with `@SwallowsException` saying that its intentional. Otherwise in many cases its a bug.

Unfortunately, there are thousands of violations. Even just annotating them all with `@SwallowsException(reason = "?")` takes forever (I did some of them, but quickly gave up). We have to figure out a way to iteratively clean this up...
