### PR TITLE
Don't flood the logs when we detect enormous exception in ExceptionHe…

### DIFF
--- a/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -78,7 +78,7 @@ public final class ExceptionsHelper {
             }
             if (counter++ > 10) {
                 // dear god, if we got more than 10 levels down, WTF? just bail
-                logger.warn("Exception cause unwrapping ran for 10 levels...", t);
+                logger.warn("Exception cause unwrapping ran for 10 levels: {}", t.getMessage());
                 return result;
             }
             result = result.getCause();


### PR DESCRIPTION
…lper#unwrapCause

This code seems to be a circuit breaker to prevent digging too deeply in the
exception causes.
If we enter this circuit breaker then it's likely that something very bad is
happening. Unfortunately we ask the logger to log the full stack of all the causes.
It can generate gigs of logs in few minutes and filling up all disk space.
It happened on a cluster affected by what seem to be recursion bug (c.f. #19187)
where it generated 27gig of logs in less than 5 minutes.
While this code is useful to debug problematic exceptions it may generate too
many lines causing "no space left on devices" errors thus making debugging the
root cause even harder.
