### PR TITLE
Fix replica-primary inconsistencies when indexing during primary relocation with ongoing replica recoveries

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -382,8 +382,8 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                         if (recoveryState.getSourceNode().equals(sourceNode) == false) {
                             if (recoveryTargetService.cancelRecoveriesForShard(shardId, "recovery source node changed")) {
                                 // getting here means that the shard was still recovering
-                                logger.debug("{} removing shard (recovery source changed), current [{}], global [{}])",
-                                    shardId, currentRoutingEntry, newShardRouting);
+                                logger.debug("{} removing shard (recovery source changed), current [{}], global [{}], shard [{}])",
+                                    shardId, recoveryState.getSourceNode(), sourceNode, newShardRouting);
                                 indexService.removeShard(shardId.id(), "removing shard (recovery source node changed)");
                             }
                         }

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTargetHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTargetHandler.java
@@ -44,6 +44,11 @@ public interface RecoveryTargetHandler {
     void finalizeRecovery();
 
     /**
+     * Blockingly waits for cluster state with at least clusterStateVersion to be available
+     */
+    void ensureClusterStateVersion(long clusterStateVersion);
+
+    /**
      * Index a set of translog operations on the target
      * @param operations operations to index
      * @param totalTranslogOps current number of total operations expected to be indexed

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTargetService.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTargetService.java
@@ -24,6 +24,7 @@ import org.apache.lucene.store.RateLimiter;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -42,11 +43,11 @@ import org.elasticsearch.index.mapper.MapperException;
 import org.elasticsearch.index.shard.IllegalIndexShardStateException;
 import org.elasticsearch.index.shard.IndexEventListener;
 import org.elasticsearch.index.shard.IndexShard;
-import org.elasticsearch.index.shard.IndexShardClosedException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.index.shard.TranslogRecoveryPerformer;
 import org.elasticsearch.index.store.Store;
+import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.FutureTransportResponseHandler;
@@ -76,6 +77,7 @@ public class RecoveryTargetService extends AbstractComponent implements IndexEve
         public static final String TRANSLOG_OPS = "internal:index/shard/recovery/translog_ops";
         public static final String PREPARE_TRANSLOG = "internal:index/shard/recovery/prepare_translog";
         public static final String FINALIZE = "internal:index/shard/recovery/finalize";
+        public static final String WAIT_CLUSTERSTATE = "internal:index/shard/recovery/wait_clusterstate";
     }
 
     private final ThreadPool threadPool;
@@ -95,7 +97,7 @@ public class RecoveryTargetService extends AbstractComponent implements IndexEve
         this.transportService = transportService;
         this.recoverySettings = recoverySettings;
         this.clusterService = clusterService;
-        this.onGoingRecoveries = new RecoveriesCollection(logger, threadPool);
+        this.onGoingRecoveries = new RecoveriesCollection(logger, threadPool, this::waitForClusterState);
 
         transportService.registerRequestHandler(Actions.FILES_INFO, RecoveryFilesInfoRequest::new, ThreadPool.Names.GENERIC, new
                 FilesInfoRequestHandler());
@@ -109,6 +111,8 @@ public class RecoveryTargetService extends AbstractComponent implements IndexEve
                 new TranslogOperationsRequestHandler());
         transportService.registerRequestHandler(Actions.FINALIZE, RecoveryFinalizeRecoveryRequest::new, ThreadPool.Names.GENERIC, new
                 FinalizeRecoveryRequestHandler());
+        transportService.registerRequestHandler(Actions.WAIT_CLUSTERSTATE, RecoveryWaitForClusterStateRequest::new,
+            ThreadPool.Names.GENERIC, new WaitForClusterStateRequestHandler());
     }
 
     @Override
@@ -301,6 +305,18 @@ public class RecoveryTargetService extends AbstractComponent implements IndexEve
         }
     }
 
+    class WaitForClusterStateRequestHandler implements TransportRequestHandler<RecoveryWaitForClusterStateRequest> {
+
+        @Override
+        public void messageReceived(RecoveryWaitForClusterStateRequest request, TransportChannel channel) throws Exception {
+            try (RecoveriesCollection.RecoveryRef recoveryRef = onGoingRecoveries.getRecoverySafe(request.recoveryId(), request.shardId()
+            )) {
+                recoveryRef.status().ensureClusterStateVersion(request.clusterStateVersion());
+            }
+            channel.sendResponse(TransportResponse.Empty.INSTANCE);
+        }
+    }
+
     class TranslogOperationsRequestHandler implements TransportRequestHandler<RecoveryTranslogOperationsRequest> {
 
         @Override
@@ -358,6 +374,52 @@ public class RecoveryTargetService extends AbstractComponent implements IndexEve
                         }
                     });
                 }
+            }
+        }
+    }
+
+    private void waitForClusterState(long clusterStateVersion) {
+        ClusterStateObserver observer = new ClusterStateObserver(clusterService, TimeValue.timeValueMinutes(5), logger,
+            threadPool.getThreadContext());
+        final ClusterState clusterState = observer.observedState();
+        if (clusterState.getVersion() >= clusterStateVersion) {
+            logger.trace("node has cluster state with version higher than {} (current: {})", clusterStateVersion,
+                clusterState.getVersion());
+            return;
+        } else {
+            logger.trace("waiting for cluster state version {} (current: {})", clusterStateVersion, clusterState.getVersion());
+            final PlainActionFuture<Void> future = new PlainActionFuture<>();
+            observer.waitForNextChange(new ClusterStateObserver.Listener() {
+
+                @Override
+                public void onNewClusterState(ClusterState state) {
+                    future.onResponse(null);
+                }
+
+                @Override
+                public void onClusterServiceClose() {
+                    future.onFailure(new NodeClosedException(clusterService.localNode()));
+                }
+
+                @Override
+                public void onTimeout(TimeValue timeout) {
+                    future.onFailure(new IllegalStateException("cluster state never updated to version " + clusterStateVersion));
+                }
+            }, new ClusterStateObserver.ValidationPredicate() {
+
+                @Override
+                protected boolean validate(ClusterState newState) {
+                    return newState.getVersion() >= clusterStateVersion;
+                }
+            });
+            try {
+                future.get();
+                logger.trace("successfully waited for cluster state with version {} (current: {})", clusterStateVersion,
+                    observer.observedState().getVersion());
+            } catch (Exception e) {
+                logger.debug("failed waiting for cluster state with version {} (current: {})", e, clusterStateVersion,
+                    observer.observedState());
+                throw ExceptionsHelper.convertToRuntime(e);
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryWaitForClusterStateRequest.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryWaitForClusterStateRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.indices.recovery;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.transport.TransportRequest;
+
+import java.io.IOException;
+
+public class RecoveryWaitForClusterStateRequest extends TransportRequest {
+
+    private long recoveryId;
+    private ShardId shardId;
+    private long clusterStateVersion;
+
+    public RecoveryWaitForClusterStateRequest() {
+    }
+
+    RecoveryWaitForClusterStateRequest(long recoveryId, ShardId shardId, long clusterStateVersion) {
+        this.recoveryId = recoveryId;
+        this.shardId = shardId;
+        this.clusterStateVersion = clusterStateVersion;
+    }
+
+    public long recoveryId() {
+        return this.recoveryId;
+    }
+
+    public ShardId shardId() {
+        return shardId;
+    }
+
+    public long clusterStateVersion() {
+        return clusterStateVersion;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        recoveryId = in.readLong();
+        shardId = ShardId.readShardId(in);
+        clusterStateVersion = in.readVLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeLong(recoveryId);
+        shardId.writeTo(out);
+        out.writeVLong(clusterStateVersion);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
@@ -90,6 +90,14 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
     }
 
     @Override
+    public void ensureClusterStateVersion(long clusterStateVersion) {
+        transportService.submitRequest(targetNode, RecoveryTargetService.Actions.WAIT_CLUSTERSTATE,
+            new RecoveryWaitForClusterStateRequest(recoveryId, shardId, clusterStateVersion),
+            TransportRequestOptions.builder().withTimeout(recoverySettings.internalActionLongTimeout()).build(),
+            EmptyTransportResponseHandler.INSTANCE_SAME).txGet();
+    }
+
+    @Override
     public void indexTranslogOperations(List<Translog.Operation> operations, int totalTranslogOps) {
         final RecoveryTranslogOperationsRequest translogOperationsRequest = new RecoveryTranslogOperationsRequest(
                 recoveryId, shardId, operations, totalTranslogOps);

--- a/core/src/main/java/org/elasticsearch/indices/recovery/SharedFSRecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/SharedFSRecoverySourceHandler.java
@@ -19,11 +19,14 @@
 
 package org.elasticsearch.indices.recovery;
 
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.translog.Translog;
 
 import java.io.IOException;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * A recovery handler that skips phase 1 as well as sending the snapshot. During phase 3 the shard is marked
@@ -34,9 +37,10 @@ public class SharedFSRecoverySourceHandler extends RecoverySourceHandler {
     private final IndexShard shard;
     private final StartRecoveryRequest request;
 
-    public SharedFSRecoverySourceHandler(IndexShard shard, RecoveryTargetHandler recoveryTarget, StartRecoveryRequest request, ESLogger
-            logger) {
-        super(shard, recoveryTarget, request, -1, logger);
+    public SharedFSRecoverySourceHandler(IndexShard shard, RecoveryTargetHandler recoveryTarget, StartRecoveryRequest request,
+                                         Supplier<Long> currentClusterStateVersionSupplier,
+                                         Function<String, Releasable> delayNewRecoveries, ESLogger logger) {
+        super(shard, recoveryTarget, request, currentClusterStateVersionSupplier, delayNewRecoveries, -1, logger);
         this.shard = shard;
         this.request = request;
     }

--- a/core/src/test/java/org/elasticsearch/index/replication/RecoveryDuringReplicationTests.java
+++ b/core/src/test/java/org/elasticsearch/index/replication/RecoveryDuringReplicationTests.java
@@ -66,7 +66,7 @@ public class RecoveryDuringReplicationTests extends ESIndexLevelReplicationTestC
 
         BlockingTarget(RecoveryState.Stage stageToBlock, CountDownLatch recoveryBlocked, CountDownLatch releaseRecovery, IndexShard shard,
                        DiscoveryNode sourceNode, RecoveryTargetService.RecoveryListener listener, ESLogger logger) {
-            super(shard, sourceNode, listener);
+            super(shard, sourceNode, listener, version -> {});
             this.recoveryBlocked = recoveryBlocked;
             this.releaseRecovery = releaseRecovery;
             this.stageToBlock = stageToBlock;

--- a/core/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -24,6 +24,7 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.store.BaseDirectoryWrapper;
@@ -35,15 +36,20 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.FileSystemUtils;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lucene.store.IndexOutputOutputStream;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.LocalTransportAddress;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardRelocatedException;
+import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.DirectoryService;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.StoreFileMetaData;
+import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.test.CorruptionUtils;
 import org.elasticsearch.test.DummyShardLock;
 import org.elasticsearch.test.ESTestCase;
@@ -55,9 +61,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class RecoverySourceHandlerTests extends ESTestCase {
     private static final IndexSettings INDEX_SETTINGS = IndexSettingsModule.newIndexSettings("index", Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT).build());
@@ -73,8 +85,8 @@ public class RecoverySourceHandlerTests extends ESTestCase {
                 new DiscoveryNode("b", LocalTransportAddress.buildUnique(), emptyMap(), emptySet(), Version.CURRENT),
             null, RecoveryState.Type.STORE, randomLong());
         Store store = newStore(createTempDir());
-        RecoverySourceHandler handler = new RecoverySourceHandler(null, null, request, recoverySettings.getChunkSize().bytesAsInt(),
-                logger);
+        RecoverySourceHandler handler = new RecoverySourceHandler(null, null, request, () -> 0L, e -> () -> {},
+            recoverySettings.getChunkSize().bytesAsInt(), logger);
         Directory dir = store.directory();
         RandomIndexWriter writer = new RandomIndexWriter(random(), dir, newIndexWriterConfig());
         int numDocs = randomIntBetween(10, 100);
@@ -125,7 +137,8 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         Path tempDir = createTempDir();
         Store store = newStore(tempDir, false);
         AtomicBoolean failedEngine = new AtomicBoolean(false);
-        RecoverySourceHandler handler = new RecoverySourceHandler(null, null, request, recoverySettings.getChunkSize().bytesAsInt(), logger) {
+        RecoverySourceHandler handler = new RecoverySourceHandler(null, null, request, () -> 0L, e -> () -> {},
+            recoverySettings.getChunkSize().bytesAsInt(), logger) {
             @Override
             protected void failEngine(IOException cause) {
                 assertFalse(failedEngine.get());
@@ -188,7 +201,8 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         Path tempDir = createTempDir();
         Store store = newStore(tempDir, false);
         AtomicBoolean failedEngine = new AtomicBoolean(false);
-        RecoverySourceHandler handler = new RecoverySourceHandler(null, null, request, recoverySettings.getChunkSize().bytesAsInt(), logger) {
+        RecoverySourceHandler handler = new RecoverySourceHandler(null, null, request, () -> 0L, e -> () -> {},
+            recoverySettings.getChunkSize().bytesAsInt(), logger) {
             @Override
             protected void failEngine(IOException cause) {
                 assertFalse(failedEngine.get());
@@ -235,6 +249,99 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         }
         assertFalse(failedEngine.get());
         IOUtils.close(store, targetStore);
+    }
+
+    public void testThrowExceptionOnPrimaryRelocatedBeforePhase1Completed() throws IOException {
+        final RecoverySettings recoverySettings = new RecoverySettings(Settings.EMPTY, service);
+        StartRecoveryRequest request = new StartRecoveryRequest(shardId,
+            new DiscoveryNode("b", LocalTransportAddress.buildUnique(), emptyMap(), emptySet(), Version.CURRENT),
+            new DiscoveryNode("b", LocalTransportAddress.buildUnique(), emptyMap(), emptySet(), Version.CURRENT),
+            null, RecoveryState.Type.REPLICA, randomLong());
+        IndexShard shard = mock(IndexShard.class);
+        Translog.View translogView = mock(Translog.View.class);
+        when(shard.acquireTranslogView()).thenReturn(translogView);
+        when(shard.state()).thenReturn(IndexShardState.RELOCATED);
+        AtomicBoolean phase1Called = new AtomicBoolean();
+        AtomicBoolean phase2Called = new AtomicBoolean();
+        RecoverySourceHandler handler = new RecoverySourceHandler(shard, null, request, () -> 0L, e -> () -> {},
+            recoverySettings.getChunkSize().bytesAsInt(), logger) {
+
+            @Override
+            public void phase1(final IndexCommit snapshot, final Translog.View translogView) {
+                phase1Called.set(true);
+            }
+
+            @Override
+            public void phase2(Translog.Snapshot snapshot) {
+                phase2Called.set(true);
+            }
+        };
+        expectThrows(IndexShardRelocatedException.class, () -> handler.recoverToTarget());
+        assertTrue(phase1Called.get());
+        assertFalse(phase2Called.get());
+    }
+
+    public void testWaitForClusterStateOnPrimaryRelocation() throws IOException, InterruptedException {
+        final RecoverySettings recoverySettings = new RecoverySettings(Settings.EMPTY, service);
+        StartRecoveryRequest request = new StartRecoveryRequest(shardId,
+            new DiscoveryNode("b", LocalTransportAddress.buildUnique(), emptyMap(), emptySet(), Version.CURRENT),
+            new DiscoveryNode("b", LocalTransportAddress.buildUnique(), emptyMap(), emptySet(), Version.CURRENT),
+            null, RecoveryState.Type.PRIMARY_RELOCATION, randomLong());
+        AtomicBoolean phase1Called = new AtomicBoolean();
+        AtomicBoolean phase2Called = new AtomicBoolean();
+        AtomicBoolean ensureClusterStateVersionCalled = new AtomicBoolean();
+        AtomicBoolean recoveriesDelayed = new AtomicBoolean();
+        AtomicBoolean relocated = new AtomicBoolean();
+
+        IndexShard shard = mock(IndexShard.class);
+        Translog.View translogView = mock(Translog.View.class);
+        when(shard.acquireTranslogView()).thenReturn(translogView);
+        when(shard.state()).then(i -> relocated.get() ? IndexShardState.RELOCATED : IndexShardState.STARTED);
+        doAnswer(i -> {
+            relocated.set(true);
+            assertTrue(recoveriesDelayed.get());
+            return null;
+        }).when(shard).relocated(any(String.class));
+
+        RecoveryTargetHandler targetHandler = mock(RecoveryTargetHandler.class);
+
+        final Supplier<Long> currentClusterStateVersionSupplier = () -> {
+            assertFalse(ensureClusterStateVersionCalled.get());
+            assertTrue(recoveriesDelayed.get());
+            ensureClusterStateVersionCalled.set(true);
+            return 0L;
+        };
+        final Function<String, Releasable> delayNewRecoveries = s -> {
+            assertTrue(phase1Called.get());
+            assertTrue(phase2Called.get());
+
+            assertFalse(recoveriesDelayed.get());
+            recoveriesDelayed.set(true);
+            return () -> {
+                assertTrue(recoveriesDelayed.get());
+                recoveriesDelayed.set(false);
+            };
+        };
+
+        RecoverySourceHandler handler = new RecoverySourceHandler(shard, targetHandler, request, currentClusterStateVersionSupplier,
+            delayNewRecoveries, recoverySettings.getChunkSize().bytesAsInt(), logger) {
+
+            @Override
+            public void phase1(final IndexCommit snapshot, final Translog.View translogView) {
+                phase1Called.set(true);
+            }
+
+            @Override
+            public void phase2(Translog.Snapshot snapshot) {
+                phase2Called.set(true);
+            }
+        };
+        handler.recoverToTarget();
+        assertTrue(ensureClusterStateVersionCalled.get());
+        assertTrue(phase1Called.get());
+        assertTrue(phase2Called.get());
+        assertTrue(relocated.get());
+        assertFalse(recoveriesDelayed.get());
     }
 
     private Store newStore(Path path) throws IOException {

--- a/core/src/test/java/org/elasticsearch/indices/recovery/RecoveryStatusTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/RecoveryStatusTests.java
@@ -51,7 +51,7 @@ public class RecoveryStatusTests extends ESSingleNodeTestCase {
             @Override
             public void onRecoveryFailure(RecoveryState state, RecoveryFailedException e, boolean sendShardFailure) {
             }
-        });
+        }, version -> {});
         try (IndexOutput indexOutput = status.openAndPutIndexOutput("foo.bar", new StoreFileMetaData("foo.bar", 8 + CodecUtil.footerLength(), "9z51nw"), status.store())) {
             indexOutput.writeInt(1);
             IndexOutput openIndexOutput = status.getOpenIndexOutput("foo.bar");

--- a/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
@@ -444,7 +444,7 @@ public class RelocationIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").setSettings(Settings.builder()
             .put("index.routing.allocation.exclude.color", "blue")
             .put(indexSettings())
-            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0) // NORELEASE: set to randomInt(halfNodes - 1) once replica data loss is fixed
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, randomInt(halfNodes - 1))
         ));
         assertAllShardsOnNodes("test", redFuture.get().toArray(new String[2]));
         int numDocs = randomIntBetween(100, 150);


### PR DESCRIPTION
Primary relocation violates two invariants that ensure proper interaction between document replication and peer recoveries, ultimately leading to documents not being properly replicated (see #19248 for more details).

Closes #19248
