### PR TITLE
Adds support for cockroach actions

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -54,6 +54,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocatio
 import org.elasticsearch.cluster.routing.allocation.decider.SnapshotInProgressAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cockroach.CockroachService;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
@@ -163,5 +164,6 @@ public class ClusterModule extends AbstractModule {
         bind(NodeMappingRefreshAction.class).asEagerSingleton();
         bind(MappingUpdatedAction.class).asEagerSingleton();
         bind(TaskPersistenceService.class).asEagerSingleton();
+        bind(CockroachService.class).asEagerSingleton();
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -39,6 +39,7 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cockroach.CockroachTasksInProgress;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
@@ -128,6 +129,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
         // register non plugin custom parts
         registerPrototype(SnapshotsInProgress.TYPE, SnapshotsInProgress.PROTO);
         registerPrototype(RestoreInProgress.TYPE, RestoreInProgress.PROTO);
+        registerPrototype(CockroachTasksInProgress.TYPE, CockroachTasksInProgress.PROTO);
     }
 
     @Nullable

--- a/core/src/main/java/org/elasticsearch/cockroach/CockroachActionCoordinator.java
+++ b/core/src/main/java/org/elasticsearch/cockroach/CockroachActionCoordinator.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cockroach;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cockroach.CockroachTasksInProgress.CockroachTaskInProgress;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.transport.TransportResponse.Empty;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Component that runs only on the master node and is responsible for moving running task from one state to another
+ */
+public class CockroachActionCoordinator extends AbstractComponent implements ClusterStateListener {
+
+    private final ClusterService clusterService;
+    private final CockroachActionRegistry cockroachActionRegistry;
+
+    public CockroachActionCoordinator(Settings settings, ClusterService clusterService, CockroachActionRegistry cockroachActionRegistry) {
+        super(settings);
+        this.clusterService = clusterService;
+        this.cockroachActionRegistry = cockroachActionRegistry;
+    }
+
+    /**
+     * Creates a new cockroach task on master node
+     *
+     * @param callerTaskId task id of the task that started the task and waiting for its response
+     * @param action       the action name
+     * @param callerNodeId the node id of the caller node
+     * @param request      request
+     * @param listener     the listener that will be called when task is started
+     */
+    public <Request extends CockroachRequest<Request>, Response extends CockroachResponse> void createCockroachTask(
+        final TaskId callerTaskId, String action, String callerNodeId, Request request, ActionListener<Empty> listener) {
+
+        clusterService.submitStateUpdateTask("create cockroach task", new ClusterStateUpdateTask() {
+
+            @Override
+            public ClusterState execute(ClusterState currentState) throws Exception {
+                TransportCockroachAction<Request, Response> cockroachAction = cockroachActionRegistry.getCockroachActionSafe(action);
+                cockroachAction.validate(request, currentState);
+                // Pick executor node to execute the request on
+                DiscoveryNode executorNode = cockroachAction.executorNode(request, currentState);
+                if (executorNode == null) {
+                    // TODO: Implement retry machanism that would wait for an executor node to reappear
+                    throw new IllegalStateException("No nodes available to execute the cockroach action [" + action + "], ignoring");
+                }
+                // If the caller node still alive - use it as a response node, otherwise pick another node
+                DiscoveryNode responseNode = currentState.nodes().get(callerNodeId);
+                if (responseNode == null) {
+                    responseNode = cockroachAction.responseNode(request, currentState);
+                    if (responseNode == null) {
+                        throw new IllegalStateException("No nodes available to receive response for the cockroach action [" +
+                            action + "], ignoring");
+                    }
+                }
+
+                CockroachTasksInProgress cockroachTasksInProgress = currentState.custom(CockroachTasksInProgress.TYPE);
+                final List<CockroachTaskInProgress> currentTasks = new ArrayList<>();
+                if (cockroachTasksInProgress != null) {
+                    currentTasks.addAll(cockroachTasksInProgress.entries());
+                }
+                CockroachTaskInProgress<Request, Response> task =
+                    new CockroachTaskInProgress<>(UUIDs.randomBase64UUID(), action, request, executorNode.getId(), responseNode.getId(),
+                        callerTaskId);
+                currentTasks.add(task);
+                ClusterState.Builder builder = ClusterState.builder(currentState);
+                return builder.putCustom(CockroachTasksInProgress.TYPE, new CockroachTasksInProgress(currentTasks)).build();
+            }
+
+            @Override
+            public void onFailure(String source, Exception e) {
+                listener.onFailure(e);
+            }
+
+            @Override
+            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                listener.onResponse(Empty.INSTANCE);
+            }
+        });
+    }
+
+
+    /**
+     * Sets a response or a failure for a running cockroach task
+     *
+     * @param uuid     uuid of the task that should be updated
+     * @param response response for the cockroach task if it finished successfully
+     * @param failure  failure of the cockroach task if it failed
+     * @param listener the listener that will be called when task is updated
+     */
+    @SuppressWarnings("unchecked")
+    public <Response extends CockroachResponse> void finishCockroachTask(String uuid, @Nullable Response response,
+                                                                         @Nullable Exception failure,
+                                                                         ActionListener<Empty> listener) {
+        performOperationOnCockroachTaskInProgress("finish cockroach task", uuid,
+            taskInProgress -> new CockroachTaskInProgress(taskInProgress, response, failure), listener);
+    }
+
+    /**
+     * Changes the caller node for a running cockroach task
+     *
+     * @param uuid       uuid of the task that should be updated
+     * @param callerNode the new caller node id
+     * @param listener   the listener that will be called when task is updated
+     */
+    public void updateCockroachTaskCaller(String uuid, String callerNode, ActionListener<Empty> listener) {
+        performOperationOnCockroachTaskInProgress("update cockroach task caller", uuid,
+            taskInProgress -> new CockroachTaskInProgress<>(taskInProgress, taskInProgress.getExecutorNode(), callerNode),
+            listener);
+    }
+
+    /**
+     * Changes the executor node for a running cockroach task
+     *
+     * @param uuid         uuid of the task that should be updated
+     * @param executorNode the new executor node id
+     * @param listener     the listener that will be called when task is updated
+     */
+    public void updateCockroachTaskExecutor(String uuid, String executorNode, ActionListener<Empty> listener) {
+        performOperationOnCockroachTaskInProgress("update cockroach task executor", uuid,
+            taskInProgress -> new CockroachTaskInProgress<>(taskInProgress, executorNode, taskInProgress.getCallerNode()),
+            listener);
+    }
+
+    private <Request extends CockroachRequest<Request>, Response extends CockroachResponse> void performOperationOnCockroachTaskInProgress(
+        String source, String uuid,
+        Function<CockroachTaskInProgress<Request, Response>, CockroachTaskInProgress<Request, Response>> operation,
+        ActionListener<Empty> listener) {
+
+        clusterService.submitStateUpdateTask(source, new ClusterStateUpdateTask() {
+
+            @Override
+            public ClusterState execute(ClusterState currentState) throws Exception {
+                CockroachTasksInProgress cockroachTasksInProgress = currentState.custom(CockroachTasksInProgress.TYPE);
+                if (cockroachTasksInProgress == null) {
+                    logger.warn("Trying to update cockroach task with id {} that no longer exists, new master?", uuid);
+                    return currentState;
+                }
+                final List<CockroachTaskInProgress> currentTasks = new ArrayList<>();
+                boolean found = false;
+                for (CockroachTaskInProgress taskInProgress : cockroachTasksInProgress.entries()) {
+                    if (found == false && uuid.equals(taskInProgress.getUuid())) {
+                        found = true;
+                        //noinspection unchecked
+                        CockroachTaskInProgress newTask = operation.apply(taskInProgress);
+                        if (newTask != null) {
+                            currentTasks.add(newTask);
+                        }
+                    } else {
+                        currentTasks.add(taskInProgress);
+                    }
+                }
+                if (found) {
+                    ClusterState.Builder builder = ClusterState.builder(currentState);
+                    return builder.putCustom(CockroachTasksInProgress.TYPE, new CockroachTasksInProgress(currentTasks)).build();
+                } else {
+                    logger.warn("Trying to {} cockroach task with id {} that no longer exists", source, uuid);
+                    return currentState;
+                }
+            }
+
+            @Override
+            public void onFailure(String source, Exception e) {
+                if (listener != null) {
+                    listener.onFailure(e);
+                }
+            }
+
+            @Override
+            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                if (listener != null) {
+                    listener.onResponse(Empty.INSTANCE);
+                }
+            }
+
+        });
+
+    }
+
+    /**
+     * Removes a record about a running cockroach task from cluster state
+     *
+     * @param uuid     the uuid of a cockroach task
+     * @param listener the listener that will be called when task is removed
+     */
+    public void removeCockroachTask(String uuid, ActionListener<Empty> listener) {
+        performOperationOnCockroachTaskInProgress("remove cockroach task", uuid, taskInProgress -> null, listener);
+    }
+
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        if (event.localNodeMaster()) {
+            CockroachTasksInProgress tasks = event.state().custom(CockroachTasksInProgress.TYPE);
+            if (tasks != null && event.nodesRemoved()) {
+                // We need to check if removed nodes were running any of the tasks and reassign them
+                Set<String> removedNodes = event.nodesDelta().removedNodes().stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
+                for (CockroachTaskInProgress taskInProgress : tasks.entries()) {
+                    if (removedNodes.contains(taskInProgress.getCallerNode())) {
+                        // The caller node disappeared, we need to assign a new caller node
+                        String action = taskInProgress.getAction();
+                        TransportCockroachAction cockroachAction = cockroachActionRegistry.getCockroachActionSafe(action);
+                        DiscoveryNode node = cockroachAction.responseNode(taskInProgress.getRequest(), event.state());
+                        if (node == null) {
+                            // no nodes are available to receive the response - just remove the task
+                            removeCockroachTask(taskInProgress.getUuid(), null);
+                        } else {
+                            updateCockroachTaskCaller(taskInProgress.getUuid(), node.getId(), null);
+                        }
+                    }
+                    if (taskInProgress.isFinished() == false && removedNodes.contains(taskInProgress.getExecutorNode())) {
+                        // The executor node disappeared before it had a chance to finish the task
+                        // we need to assign it to a new node
+                        String action = taskInProgress.getAction();
+                        TransportCockroachAction cockroachAction = cockroachActionRegistry.getCockroachActionSafe(action);
+                        DiscoveryNode node = cockroachAction.executorNode(taskInProgress.getRequest(), event.state());
+                        if (node == null) {
+                            // no nodes are available to perform the action - just fail it
+                            // TODO: Implement retry mechanism that would wait for an executor node to reappear
+                            finishCockroachTask(taskInProgress.getUuid(), null,
+                                new IllegalStateException("No nodes available to execute the cockroach action [" + action + "]"),
+                                null);
+                        } else {
+                            updateCockroachTaskExecutor(taskInProgress.getUuid(), node.getId(), null);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cockroach/CockroachActionExecutor.java
+++ b/core/src/main/java/org/elasticsearch/cockroach/CockroachActionExecutor.java
@@ -1,0 +1,363 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cockroach;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cockroach.CockroachActionRegistry.CockroachActionHolder;
+import org.elasticsearch.cockroach.CockroachTasksInProgress.CockroachTaskInProgress;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.inject.Provider;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportResponse.Empty;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This component is responsible for execution of cockroach actions on individual nodes. It runs on all
+ * non-transport client nodes in the cluster and monitors cluster state changes to detect started commands.
+ */
+public class CockroachActionExecutor extends AbstractComponent implements ClusterStateListener {
+    private final Map<String, RunningCockroachTask> runningTasks = new HashMap<>();
+    private final CockroachActionRegistry cockroachActionRegistry;
+    private final TaskManager taskManager;
+    private final ThreadPool threadPool;
+    private final CockroachTransportService cockroachTransportService;
+
+
+    public CockroachActionExecutor(final Settings settings, final CockroachActionRegistry cockroachActionRegistry,
+                                   final TaskManager taskManager, final CockroachTransportService cockroachTransportService,
+                                   final ThreadPool threadPool) {
+        super(settings);
+        this.cockroachActionRegistry = cockroachActionRegistry;
+        this.taskManager = taskManager;
+        this.cockroachTransportService = cockroachTransportService;
+        this.threadPool = threadPool;
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        CockroachTasksInProgress tasks = event.state().custom(CockroachTasksInProgress.TYPE);
+        CockroachTasksInProgress previousTasks = event.previousState().custom(CockroachTasksInProgress.TYPE);
+
+        if (Objects.equals(tasks, previousTasks) == false || event.nodesChanged()) {
+            // We have some changes let's check if they are related to our node
+            String localNodeId = event.state().getNodes().getLocalNodeId();
+            Set<String> notVisitedTasks = new HashSet<>(runningTasks.keySet());
+            if (tasks != null) {
+                for (CockroachTaskInProgress taskInProgress : tasks.entries()) {
+                    if (localNodeId.equals(taskInProgress.getExecutorNode())) {
+                        RunningCockroachTask cockroachTask = runningTasks.get(taskInProgress.getUuid());
+                        if (cockroachTask == null) {
+                            // New task - let's start it
+                            startTask(taskInProgress);
+                        } else {
+                            // The task is still running
+                            notVisitedTasks.remove(taskInProgress.getUuid());
+                            if (taskInProgress.isFinished() == false && cockroachTask.getState() == State.FAILED_NOTIFICATION) {
+                                // We tried to notify the master about this task before but the notification failed and
+                                // the master doesn't seem to know about it - retry notification
+                                restartNotification(cockroachTask);
+                            }
+                        }
+                    }
+                }
+            }
+
+            for (String s : notVisitedTasks) {
+                RunningCockroachTask task = runningTasks.get(s);
+                if (task.getState() == State.NOTIFIED || task.getState() == State.DONE) {
+                    // Result was sent to the caller and the caller acknowledged acceptance of the result
+                    finishTask(s);
+                } else if (task.getState() == State.FAILED_NOTIFICATION) {
+                    // We tried to send result to master, but it failed and master doesn't know about this task
+                    logger.warn("failed to notify master about task {}", task.getUuid());
+                    finishTask(s);
+                }
+                // TODO: task is running locally, but master doesn't know about it
+                // We should try cancelling this task when we add cancellation support for cockroach tasks
+            }
+
+        }
+
+    }
+
+    private <Request extends CockroachRequest<Request>, Response extends CockroachResponse> void startTask(
+        CockroachTaskInProgress<Request, Response> taskInProgress) {
+        CockroachActionHolder holder = cockroachActionRegistry.getCockroachActionHolderSafe(taskInProgress.getAction());
+        CockroachTask task = (CockroachTask) taskManager.register("cockroach", taskInProgress.getAction() + "[c]",
+            taskInProgress.getRequest());
+        boolean processed = false;
+        try {
+            RunningCockroachTask<Response> runningCockroachTask = new RunningCockroachTask<>(task, taskInProgress.getUuid());
+            task.setStatusProvider(runningCockroachTask);
+            CockroachTaskListener<Response> listener = new CockroachTaskListener<>(runningCockroachTask);
+            try {
+                runningTasks.put(taskInProgress.getUuid(), runningCockroachTask);
+                threadPool.executor(holder.getExecutor()).execute(new AbstractRunnable() {
+                    @Override
+                    public void onFailure(Exception e) {
+                        listener.onFailure(e);
+                    }
+
+                    @SuppressWarnings("unchecked")
+                    @Override
+                    protected void doRun() throws Exception {
+                        holder.getCockroachAction().executorNodeOperation(task, taskInProgress.getRequest(), listener);
+                    }
+                });
+            } catch (Exception e) {
+                // Submit task failure
+                listener.onFailure(e);
+            }
+            processed = true;
+        } finally {
+            if (processed == false) {
+                // something went wrong - unregistering task
+                taskManager.unregister(task);
+            }
+        }
+    }
+
+    private void finishTask(String uuid) {
+        RunningCockroachTask task = runningTasks.remove(uuid);
+        if (task != null && task.getTask() != null) {
+            taskManager.unregister(task.getTask());
+        }
+    }
+
+
+    private <Response extends CockroachResponse> void restartNotification(RunningCockroachTask<Response> task) {
+        logger.trace("resending notification for task {}", task.getUuid());
+        if (task.restartNotification()) {
+            if (task.getResponse() != null) {
+                cockroachTransportService.sendResponse(
+                    task.getTask(), task.getUuid(), task.getResponse(), new PublishingFailureListener<>(task));
+            } else {
+                cockroachTransportService.sendFailure(
+                    task.getTask(), task.getUuid(), task.getFailure(), new PublishingFailureListener<>(task));
+            }
+        } else {
+            logger.warn("attempt to resend notification for task {} in the {} state", task.getUuid(), task.getState());
+        }
+    }
+
+    private <Response extends CockroachResponse> void startNotification(RunningCockroachTask<Response> task, Exception e) {
+        logger.trace("sending notification for failed task {}", task.getUuid());
+        if (task.startNotification(e)) {
+            cockroachTransportService.sendFailure(task.getTask(), task.getUuid(), e, new PublishingFailureListener<>(task));
+        } else {
+            logger.warn("attempt to send notification for task {} in the {} state", task.getUuid(), task.getState());
+        }
+    }
+
+    private <Response extends CockroachResponse> void startNotification(RunningCockroachTask<Response> task, Response response) {
+        logger.trace("sending notification for finished task {}", task.getUuid());
+        if (task.startNotification(response)) {
+            cockroachTransportService.sendResponse(task.getTask(), task.getUuid(), response, new PublishingFailureListener<>(task));
+        } else {
+            logger.warn("attempt to send notification for task {} in the {} state", task.getUuid(), task.getState());
+        }
+
+    }
+
+    private class CockroachTaskListener<Response extends CockroachResponse> implements ActionListener<Response> {
+        private final RunningCockroachTask<Response> task;
+
+        public CockroachTaskListener(final RunningCockroachTask<Response> task) {
+            this.task = task;
+        }
+
+        @Override
+        public void onResponse(Response response) {
+            startNotification(task, response);
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            startNotification(task, e);
+        }
+    }
+
+    private class PublishingFailureListener<Response extends CockroachResponse> implements ActionListener<Empty> {
+        private final RunningCockroachTask<Response> task;
+
+        public PublishingFailureListener(final RunningCockroachTask<Response> task) {
+            this.task = task;
+        }
+
+
+        @Override
+        public void onResponse(Empty empty) {
+            logger.trace("notification for task {} was successful", task.getUuid());
+            if (task.markAsNotified() == false) {
+                logger.warn("attempt to mark task {} in the {} state as NOTIFIED", task.getUuid(), task.getState());
+            }
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            logger.debug("notification for task {} failed - retrying", e, task.getUuid());
+            if (task.notificationFailed() == false) {
+                logger.warn("attempt to mark restart notification for task {} in the {} state", task.getUuid(), task.getState());
+            }
+        }
+    }
+
+    public enum State {
+        STARTED,  // the task is currently running
+        DONE,     // the task is done running and trying to notify caller
+        FAILED_NOTIFICATION, // the caller notification failed
+        NOTIFIED // the caller was notified, the task can be removed
+    }
+
+    private static class RunningCockroachTask<Response extends CockroachResponse> implements Provider<Task.Status> {
+        private final Task task;
+        private final String uuid;
+        private final AtomicReference<State> state;
+        @Nullable
+        private Response response;
+        @Nullable
+        private Exception failure;
+
+        public RunningCockroachTask(Task task, String uuid) {
+            this(task, uuid, State.STARTED);
+        }
+
+        public RunningCockroachTask(Task task, String uuid, State state) {
+            this.task = task;
+            this.uuid = uuid;
+            this.state = new AtomicReference<>(state);
+        }
+
+        public Task getTask() {
+            return task;
+        }
+
+        public String getUuid() {
+            return uuid;
+        }
+
+        public State getState() {
+            return state.get();
+        }
+
+        public Response getResponse() {
+            return response;
+        }
+
+        public Exception getFailure() {
+            return failure;
+        }
+
+        public boolean startNotification(Response response) {
+            boolean result = state.compareAndSet(State.STARTED, State.DONE);
+            if (result) {
+                this.response = response;
+            }
+            return result;
+        }
+
+
+        public boolean startNotification(Exception failure) {
+            boolean result = state.compareAndSet(State.STARTED, State.DONE);
+            if (result) {
+                this.failure = failure;
+            }
+            return result;
+        }
+
+        public boolean notificationFailed() {
+            return state.compareAndSet(State.DONE, State.FAILED_NOTIFICATION);
+        }
+
+        public boolean restartNotification() {
+            return state.compareAndSet(State.FAILED_NOTIFICATION, State.DONE);
+        }
+
+        public boolean markAsNotified() {
+            return state.compareAndSet(State.DONE, State.NOTIFIED);
+        }
+
+        @Override
+        public Task.Status get() {
+            return new Status(state.get());
+        }
+    }
+
+    public static class Status implements Task.Status {
+        public static final String NAME = "cockroach_executor";
+
+        private final State state;
+
+        public Status(State state) {
+            this.state = requireNonNull(state, "State cannot be null");
+        }
+
+        public Status(StreamInput in) throws IOException {
+            state = State.valueOf(in.readString());
+        }
+
+        @Override
+        public String getWriteableName() {
+            return NAME;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("state", state.toString());
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(state.toString());
+        }
+
+        @Override
+        public String toString() {
+            return Strings.toString(this);
+        }
+
+        public State getState() {
+            return state;
+        }
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/cockroach/CockroachActionRegistry.java
+++ b/core/src/main/java/org/elasticsearch/cockroach/CockroachActionRegistry.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cockroach;
+
+import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Components that registers all cockroach actions
+ */
+public class CockroachActionRegistry extends AbstractComponent {
+
+    private volatile Map<String, CockroachActionHolder> actions = Collections.emptyMap();
+
+    private final Object actionHandlerMutex = new Object();
+
+    public CockroachActionRegistry(Settings settings) {
+        super(settings);
+    }
+
+    public <Request extends CockroachRequest<Request>, Response extends CockroachResponse>
+    void registerCockroachAction(String action,
+                                 TransportCockroachAction<Request, Response> cockroachAction,
+                                 String executor) {
+        registerCockroachAction(new CockroachActionHolder(action, cockroachAction, executor));
+    }
+
+    private <Request extends CockroachRequest<Request>, Response extends CockroachResponse> void registerCockroachAction(
+        CockroachActionHolder<Request, Response> reg) {
+
+        synchronized (actionHandlerMutex) {
+            CockroachActionHolder replaced = actions.get(reg.getAction());
+            actions = MapBuilder.newMapBuilder(actions).put(reg.getAction(), reg).immutableMap();
+            if (replaced != null) {
+                logger.warn("registered two handlers for cockroach action {}, handlers: {}, {}", reg.getAction(), reg, replaced);
+            }
+        }
+    }
+
+    public void removeHandler(String action) {
+        synchronized (actionHandlerMutex) {
+            actions = MapBuilder.newMapBuilder(actions).remove(action).immutableMap();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public <Request extends CockroachRequest<Request>, Response extends CockroachResponse>
+    CockroachActionHolder<Request, Response> getCockroachActionHolderSafe(String action) {
+        CockroachActionHolder holder = actions.get(action);
+        if (holder == null) {
+            throw new IllegalStateException("Unknown cockroach action [" + action + "]");
+        }
+        return holder;
+    }
+
+    public <Request extends CockroachRequest<Request>, Response extends CockroachResponse>
+    TransportCockroachAction<Request, Response> getCockroachActionSafe(String action) {
+        CockroachActionHolder<Request, Response> holder = getCockroachActionHolderSafe(action);
+        return holder.getCockroachAction();
+    }
+
+    public static class CockroachActionHolder<Request extends CockroachRequest<Request>, Response extends CockroachResponse> {
+
+        private final String action;
+        private final TransportCockroachAction<Request, Response> cockroachAction;
+        private final String executor;
+
+
+        public CockroachActionHolder(String action, TransportCockroachAction<Request, Response> cockroachAction, String executor) {
+            this.action = action;
+            this.cockroachAction = cockroachAction;
+            this.executor = executor;
+        }
+
+        public String getAction() {
+            return action;
+        }
+
+        public TransportCockroachAction<Request, Response> getCockroachAction() {
+            return cockroachAction;
+        }
+
+        public String getExecutor() {
+            return executor;
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cockroach/CockroachActionResponseProcessor.java
+++ b/core/src/main/java/org/elasticsearch/cockroach/CockroachActionResponseProcessor.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cockroach;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.inject.Provider;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.common.util.concurrent.ConcurrentMapLong;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportResponse;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Component that is responsible for routing cockroach action responses to registered listeners if they are still available
+ */
+public class CockroachActionResponseProcessor extends AbstractComponent implements ClusterStateListener {
+
+    private final ConcurrentMapLong<ResponseHandlerHolder> responseHandlers =
+        ConcurrentCollections.newConcurrentMapLongWithAggressiveConcurrency();
+    private final Set<String> inFlightNotifications = ConcurrentCollections.newConcurrentSet();
+    private final CockroachTransportService cockroachTransportService;
+    private final CockroachActionRegistry cockroachActionRegistry;
+    private final TaskManager taskManager;
+    private final ThreadPool threadPool;
+
+    public CockroachActionResponseProcessor(final Settings settings, final CockroachTransportService cockroachTransportService,
+                                            final CockroachActionRegistry cockroachActionRegistry,
+                                            final TaskManager taskManager, final ThreadPool threadPool) {
+        super(settings);
+        this.cockroachTransportService = cockroachTransportService;
+        this.cockroachActionRegistry = cockroachActionRegistry;
+        this.taskManager = taskManager;
+        this.threadPool = threadPool;
+    }
+
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        CockroachTasksInProgress tasks = event.state().custom(CockroachTasksInProgress.TYPE);
+        CockroachTasksInProgress previousTasks = event.previousState().custom(CockroachTasksInProgress.TYPE);
+
+        if (Objects.equals(tasks, previousTasks) == false) {
+            // We have some changes let's check if they are related to our node
+            String localNodeId = event.state().getNodes().getLocalNodeId();
+            for (CockroachTasksInProgress.CockroachTaskInProgress taskInProgress : tasks.entries()) {
+                if (localNodeId.equals(taskInProgress.getCallerNode())) {
+                    if (taskInProgress.isFinished() && inFlightNotifications.contains(taskInProgress.getUuid()) == false) {
+                        inFlightNotifications.add(taskInProgress.getUuid());
+                        // Let's find corresponding response handler if it still exists on this node
+                        TaskId taskId = taskInProgress.getCallerTaskId();
+                        ResponseHandlerHolder responseHandlerHolder = null;
+                        if (localNodeId.equals(taskId.getNodeId())) {
+                            // We started this task - so we should have corresponding response handler
+                            responseHandlerHolder = responseHandlers.remove(taskId.getId());
+                            if (responseHandlerHolder == null) {
+                                logger.warn("missing response handler for task id {}, cockroach task uuid {}",
+                                    taskId, taskInProgress.getUuid());
+                            }
+                        }
+                        final Task task;
+                        if (responseHandlerHolder == null) {
+                            // We don't have responseHandlerHolder, let's register a new task and process response in it
+                            task = taskManager.register("cockroach", taskInProgress.getAction() + "[a]", taskInProgress.getRequest());
+                        } else {
+                            task = responseHandlerHolder.getTask();
+                        }
+                        TransportCockroachAction action = cockroachActionRegistry.getCockroachActionSafe(taskInProgress.getAction());
+                        AcknowledgeListener listener = new AcknowledgeListener(task, taskInProgress.getUuid(), responseHandlerHolder);
+                        threadPool.executor(action.getExecutor()).execute(() -> {
+                            try {
+                                if (taskInProgress.getResponse() != null) {
+                                    action.onResponse(task, taskInProgress.getRequest(), taskInProgress.getResponse(), listener);
+                                } else {
+                                    action.onFailure(task, taskInProgress.getRequest(), taskInProgress.getFailure(), listener);
+                                }
+                            } catch (Exception e) {
+                                logger.warn("failed to notify caller for task id {}, cockroach task uuid {}", e,
+                                    taskId, taskInProgress.getUuid());
+                            }
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    private class AcknowledgeListener<Response extends CockroachResponse> implements ActionListener<Response> {
+
+        private final Task task;
+        private final String uuid;
+        private final ResponseHandlerHolder<Response> responseHandlerHolder;
+
+        public AcknowledgeListener(final Task task, final String uuid, final ResponseHandlerHolder<Response> responseHandlerHolder) {
+            this.task = task;
+            this.uuid = uuid;
+            this.responseHandlerHolder = responseHandlerHolder;
+        }
+
+        @Override
+        public void onResponse(Response response) {
+            cockroachTransportService.acknowledgeResponse(task, uuid, new ActionListener<TransportResponse.Empty>() {
+                @Override
+                public void onResponse(TransportResponse.Empty empty) {
+                    cleanup();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    logger.warn("failed to acknowledge cockroach task {}", e, uuid);
+                    cleanup();
+                }
+
+                private void cleanup() {
+                    if (responseHandlerHolder != null) {
+                        responseHandlerHolder.getListener().onResponse(response);
+                    } else {
+                        taskManager.unregister(task);
+                        inFlightNotifications.remove(uuid);
+                    }
+                }
+            });
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            cockroachTransportService.acknowledgeResponse(task, uuid, new ActionListener<TransportResponse.Empty>() {
+                @Override
+                public void onResponse(TransportResponse.Empty empty) {
+                    cleanup(e);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    logger.warn("failed to acknowledge cockroach task {}", e, uuid);
+                    cleanup(e);
+                }
+
+                private void cleanup(Exception e) {
+                    if (responseHandlerHolder != null) {
+                        responseHandlerHolder.getListener().onFailure(e);
+                    } else {
+                        taskManager.unregister(task);
+                        inFlightNotifications.remove(uuid);
+                    }
+                }
+
+            });
+
+        }
+
+    }
+
+    public <Response extends CockroachResponse> Provider<Task.Status> registerResponseListener(Task task, ActionListener<Response>
+        listener) {
+        ResponseHandlerHolder<Response> holder = new ResponseHandlerHolder<>(listener, task);
+        responseHandlers.put(task.getId(), holder);
+        logger.trace("registered listener for task {}", task.getId());
+        return holder;
+    }
+
+    public void markResponseListenerInitialized(Task task) {
+        ResponseHandlerHolder responseHandlerHolder = responseHandlers.get(task.getId());
+        if (responseHandlerHolder != null) {
+            if (responseHandlerHolder.initialize()) {
+                logger.trace("initialized listener for task {}", task.getId());
+            }
+        }
+    }
+
+    public void processFailure(Task task, Exception failure) {
+        ResponseHandlerHolder responseHandlerHolder = responseHandlers.remove(task.getId());
+        if (responseHandlerHolder != null) {
+            responseHandlerHolder.getListener().onFailure(failure);
+            logger.trace("sent failure to listener for task {}", task.getId());
+        } else {
+            logger.warn("failed to unregister listener for task {}", task.getId());
+        }
+    }
+
+    private static class ResponseHandlerHolder<Response extends CockroachResponse> implements Provider<Task.Status> {
+        private final ActionListener<Response> listener;
+        private final Task task;
+        private final AtomicBoolean initialized;
+
+        public ResponseHandlerHolder(ActionListener<Response> listener, Task task) {
+            this.listener = listener;
+            this.task = task;
+            this.initialized = new AtomicBoolean();
+        }
+
+        public ActionListener<Response> getListener() {
+            return listener;
+        }
+
+        public Task getTask() {
+            return task;
+        }
+
+        public boolean getInitialized() {
+            return initialized.get();
+        }
+
+        public boolean initialize() {
+            return initialized.getAndSet(true) == false;
+        }
+
+        @Override
+        public Task.Status get() {
+            return new Status(getInitialized());
+        }
+    }
+
+    public static class Status implements Task.Status {
+        public static final String NAME = "cockroach_caller";
+
+        private final boolean initialized;
+
+        public Status(boolean initialized) {
+            this.initialized = initialized;
+        }
+
+        public Status(StreamInput in) throws IOException {
+            initialized = in.readBoolean();
+        }
+
+        @Override
+        public String getWriteableName() {
+            return NAME;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("initialized", initialized);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeBoolean(initialized);
+        }
+
+        @Override
+        public String toString() {
+            return Strings.toString(this);
+        }
+
+        public boolean isInitialized() {
+            return initialized;
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cockroach/CockroachRequest.java
+++ b/core/src/main/java/org/elasticsearch/cockroach/CockroachRequest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cockroach;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
+
+/**
+ * Base class for a request for a cockroach action
+ */
+public abstract class CockroachRequest<Self extends CockroachRequest<Self>> extends ActionRequest<Self>
+    implements NamedWriteable, ToXContent {
+    @Override
+    public Task createTask(long id, String type, String action, TaskId parentTaskId) {
+        return new CockroachTask(id, type, action, getDescription(), parentTaskId);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cockroach/CockroachResponse.java
+++ b/core/src/main/java/org/elasticsearch/cockroach/CockroachResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cockroach;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.common.xcontent.ToXContent;
+
+/**
+ * Base class for a response for a cockroach action
+ */
+public abstract class CockroachResponse extends ActionResponse implements NamedWriteable, ToXContent {
+}

--- a/core/src/main/java/org/elasticsearch/cockroach/CockroachService.java
+++ b/core/src/main/java/org/elasticsearch/cockroach/CockroachService.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cockroach;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportResponse.Empty;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.function.Supplier;
+
+import static org.elasticsearch.cluster.ClusterState.registerPrototype;
+
+/**
+ * Service responsible for executing restartable actions that can survive disappearance of a coordinating and executor nodes.
+ * <p>
+ * In order to be resilient to node restarts, the cockroach actions are using the cluster state instead of a transport service to send
+ * requests and responses. The execution is done in six phases:
+ * <p>
+ * 1. The coordinating nodes sends an ordinary transport request to the master node to start a new cockroach action. This action is handled
+ * by the {@link CockroachTransportService}.
+ * <p>
+ * 2. The master node updates the {@link CockroachTasksInProgress} in the cluster state to indicate that there is a new cockroach action
+ * running in the system.
+ * <p>
+ * 3. The {@link CockroachActionExecutor} running on every node in the cluster monitors changes in the cluster state and starts execution
+ * of all new actions assigned to the node it is running on.
+ * <p>
+ * 4. When the action finishes on running on the node, the {@link CockroachActionExecutor} uses the {@link CockroachTransportService} to
+ * update the cluster state with the result of the action.
+ * <p>
+ * 5. The {@link CockroachActionResponseProcessor} is running on every node and monitoring changes to the cluster state as well, when
+ * it sees a new action response assigned to the current node that wasn't processed yet, it passes the response to the action caller.
+ * After successful processing of the response, it uses {@link CockroachTransportService} to remove the current cockroach task record from
+ * {@link CockroachTasksInProgress}.
+ * <p>
+ * 6. The {@link CockroachActionExecutor} receives cluster state update with no record of the cockroach action that it was running, which
+ * indicates that the response was successfully processed. It this moment it considers the task completed and removes the result from
+ * memory. However, if connectivity with the master in step 5 fails, the {@link CockroachActionExecutor} would wait for a new master to be
+ * elected in order to repost the result using the new master.
+ * <p>
+ * The {@link CockroachTransportService} is also responsible for running the {@link CockroachActionCoordinator} on the master node. The
+ * coordinator is monitoring  changes in the cluster state and reassigns tasks to different nodes when coordinating or executing nodes
+ * of currently running tasks go down.
+ */
+public class CockroachService extends AbstractLifecycleComponent {
+
+    static {
+        registerPrototype(CockroachTasksInProgress.TYPE, CockroachTasksInProgress.PROTO);
+    }
+
+    private final TaskManager taskManager;
+    private final ClusterService clusterService;
+    private final NamedWriteableRegistry namedWriteableRegistry;
+    private final CockroachActionExecutor cockroachActionExecutor;
+    private final CockroachActionResponseProcessor cockroachActionResponseProcessor;
+    private final CockroachActionRegistry cockroachActionRegistry;
+    private final CockroachTransportService cockroachTransportService;
+
+    @Inject
+    public CockroachService(Settings settings, ClusterService clusterService, TransportService transportService,
+                            NamedWriteableRegistry namedWriteableRegistry, ThreadPool threadPool) {
+        super(settings);
+        this.taskManager = transportService.getTaskManager();
+        this.clusterService = clusterService;
+        this.namedWriteableRegistry = namedWriteableRegistry;
+
+        this.cockroachActionRegistry = new CockroachActionRegistry(settings);
+
+        this.cockroachTransportService =
+            new CockroachTransportService(settings, clusterService, transportService, cockroachActionRegistry);
+
+        this.cockroachActionExecutor =
+            new CockroachActionExecutor(settings, cockroachActionRegistry, taskManager, cockroachTransportService, threadPool);
+        clusterService.addLast(cockroachActionExecutor);
+
+        this.cockroachActionResponseProcessor = new CockroachActionResponseProcessor(settings, cockroachTransportService,
+            cockroachActionRegistry, taskManager, threadPool);
+        clusterService.addLast(cockroachActionResponseProcessor);
+    }
+
+    @Override
+    protected void doStart() {
+        cockroachTransportService.start();
+    }
+
+    @Override
+    protected void doStop() {
+        cockroachTransportService.stop();
+    }
+
+    @Override
+    protected void doClose() {
+        clusterService.remove(cockroachActionResponseProcessor);
+        clusterService.remove(cockroachActionExecutor);
+        cockroachTransportService.close();
+    }
+
+    public <Response extends CockroachResponse, Request extends CockroachRequest<Request>> void sendRequest(
+        final CockroachTask task, final String action, final Request request, ActionListener<Response> listener) {
+        try {
+            task.setStatusProvider(cockroachActionResponseProcessor.registerResponseListener(task, listener));
+            cockroachTransportService.sendRequest(task, action, request, new ActionListener<Empty>() {
+                @Override
+                public void onResponse(Empty empty) {
+                    cockroachActionResponseProcessor.markResponseListenerInitialized(task);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    handleStartException(e, task, request);
+                }
+            });
+        } catch (Exception e) {
+            handleStartException(e, task, request);
+        }
+    }
+
+    private <Request extends CockroachRequest<Request>> void handleStartException(Exception e, Task task, Request request) {
+        logger.warn("[{}] failed to start the cockroach action for [{}]", e, task.getAction(), request);
+        cockroachActionResponseProcessor.processFailure(task, e);
+    }
+
+    /**
+     * Registers a new request handler
+     *
+     * @param action   The action the request handler is associated with
+     * @param executor The executor the request handling will be executed on
+     */
+    public <Request extends CockroachRequest<Request>, Response extends CockroachResponse> void registerRequestHandler(
+        String actionName, TransportCockroachAction<Request, Response> action,
+        Supplier<Request> requestSupplier, Supplier<Response> responseSupplier,
+        String executor) {
+        namedWriteableRegistry.register(CockroachRequest.class, actionName, in -> {
+            Request request = requestSupplier.get();
+            request.readFrom(in);
+            return request;
+        });
+        namedWriteableRegistry.register(CockroachResponse.class, actionName, in -> {
+            Response response = responseSupplier.get();
+            response.readFrom(in);
+            return response;
+        });
+        cockroachActionRegistry.registerCockroachAction(actionName, action, executor);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cockroach/CockroachTask.java
+++ b/core/src/main/java/org/elasticsearch/cockroach/CockroachTask.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cockroach;
+
+import org.elasticsearch.common.inject.Provider;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
+
+/**
+ * Task that returns additional state information
+ */
+public class CockroachTask extends Task {
+    private volatile Provider<Status> statusProvider;
+
+    public CockroachTask(long id, String type, String action, String description, TaskId parentTask) {
+        super(id, type, action, description, parentTask);
+    }
+
+    @Override
+    public Status getStatus() {
+        Provider<Status> statusProvider = this.statusProvider;
+        if (statusProvider != null) {
+            return statusProvider.get();
+        } else {
+            return null;
+        }
+    }
+
+    public void setStatusProvider(Provider<Status> statusProvider) {
+        assert this.statusProvider == null;
+        this.statusProvider = statusProvider;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cockroach/CockroachTasksInProgress.java
+++ b/core/src/main/java/org/elasticsearch/cockroach/CockroachTasksInProgress.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cockroach;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.cluster.AbstractDiffable;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.tasks.TaskId;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A cluster state record that contains a list of all running cockroach tasks
+ */
+public class CockroachTasksInProgress extends AbstractDiffable<ClusterState.Custom> implements ClusterState.Custom {
+    public static final String TYPE = "cockroach_tasks";
+
+    public static final CockroachTasksInProgress PROTO = new CockroachTasksInProgress();
+
+    // TODO: Implement custom Diff for entries
+    private final List<CockroachTaskInProgress> entries;
+
+    public CockroachTasksInProgress(List<CockroachTaskInProgress> entries) {
+        this.entries = entries;
+    }
+
+    public CockroachTasksInProgress(CockroachTaskInProgress... entries) {
+        this.entries = Arrays.asList(entries);
+    }
+
+    public List<CockroachTaskInProgress> entries() {
+        return this.entries;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CockroachTasksInProgress that = (CockroachTasksInProgress) o;
+
+        if (!entries.equals(that.entries)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return entries.hashCode();
+    }
+
+    /**
+     * A record that represents a single running cockroach task
+     */
+    public static class CockroachTaskInProgress<Request extends CockroachRequest<Request>, Response extends CockroachResponse> {
+        private final String uuid;
+        private final String action;
+        private final Request request;
+        @Nullable
+        private final Response response;
+        @Nullable
+        private final Exception failure;
+        @Nullable
+        private final String executorNode;
+        private final String callerNode;
+        private final TaskId callerTaskId;
+
+
+        public CockroachTaskInProgress(String uuid, String action, Request request, Response response, Exception failure,
+                                       String executorNode, String callerNode, TaskId callerTaskId) {
+            this.uuid = uuid;
+            this.action = action;
+            this.request = request;
+            this.response = response;
+            this.failure = failure;
+            this.executorNode = executorNode;
+            this.callerNode = callerNode;
+            this.callerTaskId = callerTaskId;
+        }
+
+        public CockroachTaskInProgress(String uuid, String action, Request request, String executorNode, String callerNode,
+                                       TaskId callerTaskId) {
+            this(uuid, action, request, null, null, executorNode, callerNode, callerTaskId);
+        }
+
+
+        public CockroachTaskInProgress(CockroachTaskInProgress<Request, Response> task, Response response, Exception failure) {
+            this(task.uuid, task.action, task.request, response, failure, task.executorNode, task.callerNode, task.callerTaskId);
+        }
+
+        public CockroachTaskInProgress(CockroachTaskInProgress<Request, Response> task, String executorNode, String callerNode) {
+            this(task.uuid, task.action, task.request, task.response, task.failure, executorNode, callerNode, task.callerTaskId);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            CockroachTaskInProgress<?, ?> that = (CockroachTaskInProgress<?, ?>) o;
+            return Objects.equals(uuid, that.uuid) &&
+                Objects.equals(action, that.action) &&
+                Objects.equals(request, that.request) &&
+                Objects.equals(response, that.response) &&
+                Objects.equals(failure, that.failure) &&
+                Objects.equals(executorNode, that.executorNode) &&
+                Objects.equals(callerNode, that.callerNode) &&
+                Objects.equals(callerTaskId, that.callerTaskId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(uuid, action, request, response, failure, executorNode, callerNode, callerTaskId);
+        }
+
+        public String getUuid() {
+
+            return uuid;
+        }
+
+        public String getAction() {
+            return action;
+        }
+
+        public Request getRequest() {
+            return request;
+        }
+
+        public Response getResponse() {
+            return response;
+        }
+
+        public Exception getFailure() {
+            return failure;
+        }
+
+        public String getExecutorNode() {
+            return executorNode;
+        }
+
+        public String getCallerNode() {
+            return callerNode;
+        }
+
+        public TaskId getCallerTaskId() {
+            return callerTaskId;
+        }
+
+        public boolean isFinished() {
+            return response != null || failure != null;
+        }
+    }
+
+    @Override
+    public String type() {
+        return TYPE;
+    }
+
+    @Override
+    public CockroachTasksInProgress readFrom(StreamInput in) throws IOException {
+        CockroachTaskInProgress[] entries = new CockroachTaskInProgress[in.readVInt()];
+        for (int i = 0; i < entries.length; i++) {
+            final String uuid = in.readString();
+            final String action = in.readString();
+            final CockroachRequest request = in.readNamedWriteable(CockroachRequest.class);
+            final CockroachResponse response = in.readOptionalNamedWriteable(CockroachResponse.class);
+            final Exception failure = in.readException();
+            final String executorNode = in.readString();
+            final String callerNode = in.readString();
+            final TaskId callerTaskId = TaskId.readFromStream(in);
+            entries[i] = new CockroachTaskInProgress(uuid, action, request, response, failure, executorNode, callerNode, callerTaskId);
+        }
+        return new CockroachTasksInProgress(entries);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(entries.size());
+        for (CockroachTaskInProgress entry : entries) {
+            out.writeString(entry.uuid);
+            out.writeString(entry.action);
+            out.writeNamedWriteable(entry.request);
+            out.writeOptionalNamedWriteable(entry.response);
+            out.writeException(entry.failure);
+            out.writeString(entry.executorNode);
+            out.writeString(entry.callerNode);
+            entry.callerTaskId.writeTo(out);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startArray("running_tasks");
+        for (CockroachTaskInProgress entry : entries) {
+            toXContent(entry, builder, params);
+        }
+        builder.endArray();
+        return builder;
+    }
+
+    public void toXContent(CockroachTaskInProgress entry, XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        {
+            builder.field("uuid", entry.uuid);
+            builder.field("action", entry.action);
+            builder.field("request");
+            entry.request.toXContent(builder, params);
+            if (entry.response != null) {
+                builder.field("response");
+                entry.response.toXContent(builder, params);
+            }
+            if (entry.failure != null) {
+                builder.startObject("failure");
+                ElasticsearchException.toXContent(builder, params, entry.failure);
+                builder.endObject();
+            }
+            builder.field("executor_node", entry.executorNode);
+            builder.field("caller_node", entry.callerNode);
+            builder.field("caller_task_id", entry.callerTaskId.toString());
+        }
+        builder.endObject();
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cockroach/CockroachTransportService.java
+++ b/core/src/main/java/org/elasticsearch/cockroach/CockroachTransportService.java
@@ -1,0 +1,404 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cockroach;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.EmptyTransportResponseHandler;
+import org.elasticsearch.transport.TransportChannel;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportRequestHandler;
+import org.elasticsearch.transport.TransportResponse.Empty;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+
+import static org.elasticsearch.cluster.ClusterState.registerPrototype;
+
+/**
+ * Service responsible for executing restartable actions that can survive disappearance of a coordinating and executor nodes.
+ * <p>
+ * In order to be resilient to node restarts, the cockroach actions are using the cluster state instead of a transport service to send
+ * requests and responses.
+ */
+public class CockroachTransportService extends AbstractLifecycleComponent {
+
+    static {
+        registerPrototype(CockroachTasksInProgress.TYPE, CockroachTasksInProgress.PROTO);
+    }
+
+    public static final String START_COCKROACH_ACTION_NAME = "internal:cluster/cockroach/start";
+    public static final String UPDATE_COCKROACH_ACTION_NAME = "internal:cluster/cockroach/update";
+    public static final String REMOVE_COCKROACH_ACTION_NAME = "internal:cluster/cockroach/remove";
+
+    private final ClusterService clusterService;
+    private final TransportService transportService;
+
+    @Nullable // it should only exist on the master-eligible nodes
+    private final CockroachActionCoordinator cockroachActionCoordinator;
+
+    @Inject
+    public CockroachTransportService(Settings settings, ClusterService clusterService, TransportService transportService,
+                                     CockroachActionRegistry cockroachActionRegistry) {
+        super(settings);
+        this.clusterService = clusterService;
+        this.transportService = transportService;
+        if (DiscoveryNode.isMasterNode(settings)) {
+            this.cockroachActionCoordinator = new CockroachActionCoordinator(settings, clusterService, cockroachActionRegistry);
+            this.clusterService.add(this.cockroachActionCoordinator);
+            // This needs to run only on nodes that can become masters
+            transportService.registerRequestHandler(START_COCKROACH_ACTION_NAME, StartCockroachTaskRequest::new, ThreadPool.Names.SAME,
+                new StartCockroachTaskRequestHandler());
+            transportService.registerRequestHandler(UPDATE_COCKROACH_ACTION_NAME, UpdateCockroachTaskRequest::new, ThreadPool.Names.SAME,
+                new UpdateCockroachTaskRequestHandler());
+            transportService.registerRequestHandler(REMOVE_COCKROACH_ACTION_NAME, RemoveCockroachTaskRequest::new, ThreadPool.Names.SAME,
+                new RemoveCockroachTaskRequestHandler());
+        } else {
+            this.cockroachActionCoordinator = null;
+        }
+
+    }
+
+    @Override
+    protected void doStart() {
+
+    }
+
+    @Override
+    protected void doStop() {
+
+    }
+
+    @Override
+    protected void doClose() {
+        clusterService.remove(cockroachActionCoordinator);
+    }
+
+    /**
+     * Sends a request to the master node to register a cockroach task in the cluster state
+     *
+     * @param task     the task id of the caller
+     * @param action   the action name
+     * @param request  cockroach action request
+     * @param listener the listener that will be called when the task is registered
+     */
+    public <Request extends CockroachRequest<Request>> void sendRequest(final Task task, final String action, final Request request,
+                                                                        ActionListener<Empty> listener) {
+        try {
+            String nodeId = clusterService.state().getNodes().getLocalNodeId();
+            if (clusterService.state().nodes().isLocalNodeElectedMaster()) {
+                cockroachActionCoordinator.createCockroachTask(new TaskId(nodeId, task.getId()), action, nodeId, request, listener);
+            } else {
+                StartCockroachTaskRequest<Request> startRequest = new StartCockroachTaskRequest<>(nodeId, action, request);
+                startRequest.setParentTask(nodeId, task.getId());
+                transportService.sendRequest(clusterService.state().nodes().getMasterNode(), START_COCKROACH_ACTION_NAME, startRequest,
+                    new ActionListenerEmptyTransportResponseHandler(ThreadPool.Names.SAME, listener));
+            }
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    /**
+     * Asks the master node to assign a response to the running cockroach task
+     * <p>
+     * This method is used to start a cockroach task.
+     *
+     * @param task     the caller task
+     * @param uuid     the uuid of the running task
+     * @param response response that should be assigned to the task
+     * @param listener the listener that will be called when the task is updated
+     */
+    public <Response extends CockroachResponse> void sendResponse(final Task task, final String uuid, final Response response,
+                                                                  final ActionListener<Empty> listener) {
+        sendResponse(task, uuid, response, null, listener);
+    }
+
+    /**
+     * Asks the master node to assign a failure to the running cockroach task
+     * <p>
+     * This method is used to to indicate that the executor node successfully finished the running task.
+     *
+     * @param task     the caller task
+     * @param uuid     the uuid of the running task
+     * @param failure  failure that should be assigned to the task
+     * @param listener the listener that will be called when the task is updated
+     */
+    public void sendFailure(final Task task, final String uuid, final Exception failure, final ActionListener<Empty> listener) {
+        sendResponse(task, uuid, null, failure, listener);
+    }
+
+    private <Response extends CockroachResponse> void sendResponse(final Task task, final String uuid, final Response response,
+                                                                   final Exception failure, final ActionListener<Empty> listener) {
+        try {
+            String nodeId = clusterService.state().getNodes().getLocalNodeId();
+            if (clusterService.state().nodes().isLocalNodeElectedMaster()) {
+                cockroachActionCoordinator.finishCockroachTask(uuid, response, failure, listener);
+            } else {
+                UpdateCockroachTaskRequest<Response> startRequest = new UpdateCockroachTaskRequest<>(uuid, response, failure);
+                startRequest.setParentTask(nodeId, task.getId());
+                transportService.sendRequest(clusterService.state().nodes().getMasterNode(), UPDATE_COCKROACH_ACTION_NAME, startRequest,
+                    new ActionListenerEmptyTransportResponseHandler(ThreadPool.Names.GENERIC, listener));
+            }
+        } catch (Exception t) {
+            listener.onFailure(t);
+        }
+    }
+
+    /**
+     * Asks the master node to remove the running cockroach task
+     * <p>
+     * This method is called when the caller node has acknowledged the receive the response.
+     *
+     * @param task     the caller task
+     * @param uuid     the uuid of the running task
+     * @param listener the listener that will be called when the task is removed
+     */
+    public void acknowledgeResponse(final Task task, final String uuid, final ActionListener<Empty> listener) {
+        try {
+            String nodeId = clusterService.state().getNodes().getLocalNodeId();
+            if (clusterService.state().nodes().isLocalNodeElectedMaster()) {
+                cockroachActionCoordinator.removeCockroachTask(uuid, listener);
+            } else {
+                RemoveCockroachTaskRequest removeRequest = new RemoveCockroachTaskRequest(uuid);
+                removeRequest.setParentTask(nodeId, task.getId());
+                transportService.sendRequest(clusterService.state().nodes().getMasterNode(), REMOVE_COCKROACH_ACTION_NAME, removeRequest,
+                    new ActionListenerEmptyTransportResponseHandler(ThreadPool.Names.GENERIC, listener));
+            }
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    private static class StartCockroachTaskRequest<Request extends CockroachRequest<Request>>
+        extends TransportRequest {
+        private String action;
+        private String callerNodeId;
+        private Request request;
+
+        private StartCockroachTaskRequest() {
+
+        }
+
+        public StartCockroachTaskRequest(String callerNodeId, String action, Request request) {
+            this.callerNodeId = callerNodeId;
+            this.action = action;
+            this.request = request;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            callerNodeId = in.readString();
+            action = in.readString();
+            request = (Request) in.readNamedWriteable(CockroachRequest.class);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(callerNodeId);
+            out.writeString(action);
+            out.writeNamedWriteable(request);
+        }
+
+        public String getAction() {
+            return action;
+        }
+
+        public Request getRequest() {
+            return request;
+        }
+
+        public String getCallerNodeId() {
+            return callerNodeId;
+        }
+    }
+
+    /**
+     * Transport request handler that is used to send changes in snapshot status to master
+     */
+    class StartCockroachTaskRequestHandler implements TransportRequestHandler<StartCockroachTaskRequest> {
+        @Override
+        public void messageReceived(StartCockroachTaskRequest request, final TransportChannel channel) throws Exception {
+            assert cockroachActionCoordinator != null;
+            cockroachActionCoordinator.createCockroachTask(request.getParentTask(), request.getAction(), request.getCallerNodeId(),
+                request.getRequest(), new EmptyActionListener(channel));
+
+        }
+    }
+
+    private class EmptyActionListener implements ActionListener<Empty> {
+        private final TransportChannel channel;
+
+        public EmptyActionListener(final TransportChannel channel) {
+            this.channel = channel;
+        }
+
+        @Override
+        public void onResponse(final Empty empty) {
+            try {
+                channel.sendResponse(Empty.INSTANCE);
+            } catch (IOException e) {
+                onFailure(e);
+            }
+        }
+
+        @Override
+        public void onFailure(final Exception e) {
+            try {
+                channel.sendResponse(e);
+            } catch (IOException e1) {
+                logger.warn("failed to send response", e);
+            }
+        }
+    }
+
+    private static class UpdateCockroachTaskRequest<Response extends CockroachResponse> extends TransportRequest {
+        private String uuid;
+        @Nullable
+        private Exception failure;
+        @Nullable
+        private Response response;
+
+        private UpdateCockroachTaskRequest() {
+
+        }
+
+        public UpdateCockroachTaskRequest(String uuid, Response response, Exception failure) {
+            this.uuid = uuid;
+            this.response = response;
+            this.failure = failure;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            uuid = in.readString();
+            failure = in.readException();
+            response = (Response) in.readOptionalNamedWriteable(CockroachResponse.class);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(uuid);
+            out.writeException(failure);
+            out.writeOptionalNamedWriteable(response);
+        }
+
+        public String getUuid() {
+            return uuid;
+        }
+
+        public Exception getFailure() {
+            return failure;
+        }
+
+        public Response getResponse() {
+            return response;
+        }
+    }
+
+    /**
+     * Transport request handler that is used to send changes in snapshot status to master
+     */
+    class UpdateCockroachTaskRequestHandler implements TransportRequestHandler<UpdateCockroachTaskRequest> {
+        @Override
+        public void messageReceived(UpdateCockroachTaskRequest request, final TransportChannel channel) throws Exception {
+            assert cockroachActionCoordinator != null;
+            cockroachActionCoordinator.finishCockroachTask(request.getUuid(), request.getResponse(), request.getFailure(),
+                new EmptyActionListener(channel));
+        }
+    }
+
+    private static class RemoveCockroachTaskRequest extends TransportRequest {
+        private String uuid;
+
+        private RemoveCockroachTaskRequest() {
+
+        }
+
+        public RemoveCockroachTaskRequest(String uuid) {
+            this.uuid = uuid;
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            uuid = in.readString();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(uuid);
+        }
+
+        public String getUuid() {
+            return uuid;
+        }
+    }
+
+    /**
+     * Transport request handler that is used to send changes in snapshot status to master
+     */
+    class RemoveCockroachTaskRequestHandler implements TransportRequestHandler<RemoveCockroachTaskRequest> {
+        @Override
+        public void messageReceived(RemoveCockroachTaskRequest request, final TransportChannel channel) throws Exception {
+            assert cockroachActionCoordinator != null;
+            cockroachActionCoordinator.removeCockroachTask(request.getUuid(), new EmptyActionListener(channel));
+        }
+    }
+
+    private static final class ActionListenerEmptyTransportResponseHandler extends EmptyTransportResponseHandler {
+
+        private final ActionListener<Empty> listener;
+
+        public ActionListenerEmptyTransportResponseHandler(final String executor, final ActionListener<Empty> listener) {
+            super(executor);
+            this.listener = listener;
+        }
+
+        @Override
+        public void handleResponse(Empty response) {
+            super.handleResponse(response);
+            listener.onResponse(response);
+        }
+
+        @Override
+        public void handleException(TransportException exp) {
+            super.handleException(exp);
+            listener.onFailure(exp);
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cockroach/TransportCockroachAction.java
+++ b/core/src/main/java/org/elasticsearch/cockroach/TransportCockroachAction.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cockroach;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.function.Supplier;
+
+/**
+ * An action that can survive restart of requesting or executing node.
+ * These actions are using cluster state rather than only transport service to send requests and responses.
+ */
+public abstract class TransportCockroachAction<Request extends CockroachRequest<Request>, Response extends CockroachResponse>
+    extends HandledTransportAction<Request, Response> {
+
+    private final CockroachService cockroachService;
+
+    private final String executor;
+
+    protected TransportCockroachAction(Settings settings, String actionName, boolean canTripCircuitBreaker, ThreadPool threadPool,
+                                       TransportService transportService, CockroachService cockroachService, ActionFilters actionFilters,
+                                       IndexNameExpressionResolver indexNameExpressionResolver,
+                                       Supplier<Request> requestSupplier, Supplier<Response> responseSupplier, String executor) {
+        super(settings, actionName, canTripCircuitBreaker, threadPool, transportService, actionFilters, indexNameExpressionResolver,
+            requestSupplier);
+        this.cockroachService = cockroachService;
+        this.executor = executor;
+        cockroachService.registerRequestHandler(actionName, this, requestSupplier, responseSupplier, executor);
+    }
+
+    /**
+     * Returns the node id where the request has to be executed
+     */
+    public abstract DiscoveryNode executorNode(Request request, ClusterState clusterState);
+
+    /**
+     * Returns the node id where the response should be processed
+     */
+    public abstract DiscoveryNode responseNode(Request request, ClusterState clusterState);
+
+    /**
+     * Checks the current cluster state for compatibility with the request
+     * <p>
+     * Throws an exception if the supplied request cannot be executed on the cluster in the current state.
+     */
+    public void validate(Request request, ClusterState clusterState) {
+
+    }
+
+    @Override
+    protected final void doExecute(Request request, ActionListener<Response> listener) {
+        logger.warn("attempt to execute a cockroach action without a task");
+        throw new UnsupportedOperationException("task parameter is required for this operation");
+    }
+
+    @Override
+    protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
+        cockroachService.sendRequest((CockroachTask) task, actionName, request, listener);
+    }
+
+    /**
+     * This operation will be executed on the caller node.
+     */
+    public abstract void executorNodeOperation(Task task, Request request, ActionListener<Response> listener);
+
+    /**
+     * This operation is called on the caller node if the cockroach task was successful.
+     * <p>
+     * If the original caller node is not available by the time the task finishes, a new node will be elected by calling
+     * {@link #responseNode} method.
+     */
+    public void onResponse(Task task, Request request, Response response, ActionListener<Response> listener) {
+        listener.onResponse(response);
+    }
+
+    /**
+     * This operation is called on the caller node if the cockroach task failed.
+     * <p>
+     * If the original caller node is not available by the time the task finishes, a new node will be elected by calling
+     * {@link #responseNode} method.
+     */
+    public void onFailure(Task task, Request request, Exception failure, ActionListener<Response> listener) {
+        listener.onFailure(failure);
+    }
+
+    public String getExecutor() {
+        return executor;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/common/network/NetworkModule.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkModule.java
@@ -30,6 +30,8 @@ import org.elasticsearch.cluster.routing.allocation.command.AllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.AllocationCommandRegistry;
 import org.elasticsearch.cluster.routing.allocation.command.CancelAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
+import org.elasticsearch.cockroach.CockroachActionExecutor;
+import org.elasticsearch.cockroach.CockroachActionResponseProcessor;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.util.Providers;
@@ -94,6 +96,8 @@ public class NetworkModule extends AbstractModule {
         registerTransport(NETTY_TRANSPORT, NettyTransport.class);
         registerTaskStatus(ReplicationTask.Status.NAME, ReplicationTask.Status::new);
         registerTaskStatus(RawTaskStatus.NAME, RawTaskStatus::new);
+        registerTaskStatus(CockroachActionResponseProcessor.Status.NAME, CockroachActionResponseProcessor.Status::new);
+        registerTaskStatus(CockroachActionExecutor.Status.NAME, CockroachActionResponseProcessor.Status::new);
         registerBuiltinAllocationCommands();
 
         if (transportClient == false) {

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.internal.Nullable;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.logging.ESLogger;
@@ -112,6 +113,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
     public static final String DISCOVERY_REJOIN_ACTION_NAME = "internal:discovery/zen/rejoin";
 
     private final TransportService transportService;
+    private final NamedWriteableRegistry namedWriteableRegistry;
     private final ClusterService clusterService;
     private AllocationService allocationService;
     private final ClusterName clusterName;
@@ -152,11 +154,12 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
     @Inject
     public ZenDiscovery(Settings settings, ThreadPool threadPool,
                         TransportService transportService, final ClusterService clusterService, ClusterSettings clusterSettings,
-                        ZenPingService pingService, ElectMasterService electMasterService) {
+                        NamedWriteableRegistry namedWriteableRegistry, ZenPingService pingService, ElectMasterService electMasterService) {
         super(settings);
         this.clusterService = clusterService;
         this.clusterName = clusterService.getClusterName();
         this.transportService = transportService;
+        this.namedWriteableRegistry = namedWriteableRegistry;
         this.discoverySettings = new DiscoverySettings(settings, clusterSettings);
         this.pingService = pingService;
         this.electMaster = electMasterService;
@@ -192,6 +195,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
                 new PublishClusterStateAction(
                         settings,
                         transportService,
+                        namedWriteableRegistry,
                         clusterService::state,
                         new NewPendingClusterStateListener(),
                         discoverySettings,

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CockroachActionIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CockroachActionIT.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.admin.cluster.node.tasks;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.Collection;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThrows;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, minNumDataNodes = 2)
+public class CockroachActionIT extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return pluginList(TestCockroachActionPlugin.class);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> transportClientPlugins() {
+        return nodePlugins();
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .build();
+    }
+
+    public void testCockroachAction() throws Exception {
+        // Randomly create an empty index to make sure the type is created automatically
+        TestCockroachActionPlugin.TestCockroachAction.INSTANCE.newRequestBuilder(client()).testParam("Blah").get();
+    }
+
+    public void testCockroachFailureToStartAction() throws Exception {
+        // Randomly create an empty index to make sure the type is created automatically
+
+        assertThrows(
+            TestCockroachActionPlugin.TestCockroachAction.INSTANCE.newRequestBuilder(client())
+                .testParam("fail to start")
+                .targetNode("nowhere"),
+            IllegalStateException.class,
+            "No nodes available to execute the cockroach action");
+
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CockroachActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CockroachActionTests.java
@@ -1,0 +1,733 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.admin.cluster.node.tasks;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cockroach.CockroachActionExecutor;
+import org.elasticsearch.cockroach.CockroachActionResponseProcessor;
+import org.elasticsearch.cockroach.CockroachRequest;
+import org.elasticsearch.cockroach.CockroachResponse;
+import org.elasticsearch.cockroach.CockroachService;
+import org.elasticsearch.cockroach.CockroachTasksInProgress;
+import org.elasticsearch.cockroach.TransportCockroachAction;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.AtomicArray;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskInfo;
+import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static org.elasticsearch.common.xcontent.ToXContent.EMPTY_PARAMS;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
+
+public class CockroachActionTests extends TaskManagerTestCase {
+
+    public static class TestRequest extends CockroachRequest<TestRequest> {
+
+        private String testParam;
+
+        private String preferNode;
+
+        public TestRequest() {
+
+        }
+
+        public TestRequest(String testParam) {
+            this.testParam = testParam;
+        }
+
+        public TestRequest(String testParam, String preferNode) {
+            this.testParam = testParam;
+            this.preferNode = preferNode;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TransportTestCockroachAction.NAME;
+        }
+
+        public void setTestParam(String testParam) {
+            this.testParam = testParam;
+        }
+
+        public String getTestParam() {
+            return testParam;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeOptionalString(testParam);
+            out.writeOptionalString(preferNode);
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            testParam = in.readOptionalString();
+            preferNode = in.readOptionalString();
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("param", testParam);
+            builder.endObject();
+            return builder;
+        }
+
+    }
+
+    public static class TestResponse extends CockroachResponse {
+
+        private String response;
+
+        public TestResponse() {
+
+        }
+
+        public TestResponse(String response) {
+            this.response = response;
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TransportTestCockroachAction.NAME;
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            response = in.readOptionalString();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeOptionalString(response);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("text", response);
+            builder.endObject();
+            return builder;
+        }
+
+
+    }
+
+    public static class TransportTestCockroachAction extends TransportCockroachAction<TestRequest, TestResponse> {
+
+        public static final String NAME = "cluster:admin/cockroach/test";
+
+        private final BiFunction<TransportTestCockroachAction, TestRequest, TestResponse> nodeOperation;
+
+        private final BiFunction<TransportTestCockroachAction, TestResponse, TestResponse> callerOperation;
+
+        private final ClusterService clusterService;
+
+        @Inject
+        public TransportTestCockroachAction(Settings settings, ThreadPool threadPool, TransportService transportService,
+                                            ClusterService clusterService,
+                                            CockroachService cockroachService, ActionFilters actionFilters,
+                                            IndexNameExpressionResolver indexNameExpressionResolver,
+                                            BiFunction<TransportTestCockroachAction, TestRequest, TestResponse> nodeOperation,
+                                            BiFunction<TransportTestCockroachAction, TestResponse, TestResponse> callerOperation) {
+            super(settings, NAME, false, threadPool, transportService, cockroachService, actionFilters,
+                indexNameExpressionResolver, TestRequest::new, TestResponse::new, ThreadPool.Names.GENERIC);
+            this.clusterService = clusterService;
+            this.nodeOperation = nodeOperation;
+            this.callerOperation = callerOperation;
+        }
+
+        @Override
+        public DiscoveryNode executorNode(TestRequest request, ClusterState clusterState) {
+            if (request.preferNode != null) {
+                DiscoveryNode executorNode = clusterState.getNodes().get(request.preferNode);
+                if (executorNode != null) {
+                    return executorNode;
+                }
+            }
+            return clusterState.getNodes().getMasterNode();
+        }
+
+        @Override
+        public DiscoveryNode responseNode(TestRequest request, ClusterState clusterState) {
+            return clusterState.getNodes().getMasterNode();
+        }
+
+        @Override
+        public void executorNodeOperation(Task task, TestRequest request, ActionListener<TestResponse> listener) {
+            try {
+                listener.onResponse(nodeOperation.apply(this, request));
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }
+
+        @Override
+        public void onResponse(Task task, TestRequest request, TestResponse response, ActionListener<TestResponse> listener) {
+            if (callerOperation == null) {
+                super.onResponse(task, request, response, listener);
+            } else {
+                listener.onResponse(callerOperation.apply(this, response));
+            }
+        }
+    }
+
+    private void assertCleanClusterState(int node) {
+        CockroachTasksInProgress cockroachTasksInProgresses = testNodes[node].clusterService.state().custom(CockroachTasksInProgress.TYPE);
+        assertTrue(cockroachTasksInProgresses.entries().isEmpty());
+    }
+
+    private void assertNoLeftOverTasks() {
+        boolean found = false;
+        for (int i = 0; i < testNodes.length; i++) {
+            if (testNodes[i].isClosed.get() == false) {
+                TaskManager taskManager = testNodes[i].transportService.getTaskManager();
+                for (Task task : taskManager.getTasks().values()) {
+                    if (task.getAction().startsWith(TransportTestCockroachAction.NAME)) {
+                        found = true;
+                        logger.warn("Found task with id {} for action {} on node {}", task.getId(), task.getAction(), i);
+                    }
+                }
+            }
+        }
+        assertFalse(found);
+    }
+
+    public void testBasicCockroachAction() throws Exception {
+        setupTestNodes(Settings.EMPTY);
+        connectNodes(testNodes);
+        startClusterStatePublishing(0, testNodes);
+        int numberOfRequests = randomIntBetween(1, 100);
+        CountDownLatch responseLatch = new CountDownLatch(numberOfRequests);
+
+        final AtomicArray<TestResponse> responseReference = new AtomicArray<>(numberOfRequests);
+        final AtomicArray<Exception> exceptionReference = new AtomicArray<>(numberOfRequests);
+        boolean[] shouldFail = new boolean[numberOfRequests];
+        for (int i = 0; i < numberOfRequests; i++) {
+            shouldFail[i] = randomBoolean();
+        }
+        TransportTestCockroachAction[] actions = registerTestCockroachAction((transport, request) -> {
+            if ("fail".equals(request.getTestParam())) {
+                throw new RuntimeException("Should fail");
+            } else {
+                return new TestResponse("processed:" + request.getTestParam());
+            }
+        }, null);
+
+        for (int i = 0; i < numberOfRequests; i++) {
+            int coordinatingNode = randomInt(testNodes.length - 1);
+            int executingNode = randomInt(testNodes.length - 1);
+            final int current = i;
+            logger.trace("Coordinating node: {}, executing node: {}, should fail: {}", coordinatingNode, executingNode, shouldFail[i]);
+            TestRequest testRequest = new TestRequest(shouldFail[i] ? "fail" : "work", testNodes[executingNode].getNodeId());
+            actions[coordinatingNode].execute(testRequest,
+                new ActionListener<TestResponse>() {
+                    @Override
+                    public void onResponse(TestResponse listTasksResponse) {
+                        responseReference.set(current, listTasksResponse);
+                        responseLatch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        exceptionReference.set(current, e);
+                        responseLatch.countDown();
+                    }
+                });
+        }
+
+        // Awaiting for the main task to finish
+        responseLatch.await();
+        logger.info("Done with {} requests", numberOfRequests);
+
+        for (int i = 0; i < numberOfRequests; i++) {
+
+            if (shouldFail[i]) {
+                assertNull(responseReference.get(i));
+                assertNotNull(exceptionReference.get(i));
+            } else {
+                assertNotNull(responseReference.get(i));
+                assertNull(exceptionReference.get(i));
+            }
+        }
+        // Make sure there is no leftover junk left in the cluster state and task manager
+        assertCleanClusterState(0);
+        assertNoLeftOverTasks();
+    }
+
+    public void testDeathOfCoordinatingNode() throws Exception {
+        setupTestNodes(Settings.EMPTY);
+        connectNodes(testNodes);
+        startClusterStatePublishing(0, testNodes);
+        CountDownLatch actionStartedLatch = new CountDownLatch(1);
+
+        int node = randomIntBetween(1, testNodes.length - 1);
+        logger.info("Coordinating node: {}", node);
+
+        AtomicBoolean jobIsDone = new AtomicBoolean();
+        AtomicBoolean responseProcessed = new AtomicBoolean();
+        AtomicBoolean shouldNotBeCalled = new AtomicBoolean();
+
+        CountDownLatch blockAction = new CountDownLatch(1);
+
+        Task mainTask = startTestCockroachAction(node, new TestRequest("test"), (transport, request) -> {
+                logger.info("action started");
+                actionStartedLatch.countDown();
+                try {
+                    blockAction.await();
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+                assertFalse(jobIsDone.getAndSet(true));
+                logger.info("processed exec");
+                return new TestResponse("processed:" + request.getTestParam());
+            },
+            (transport, testResponse) -> {
+                logger.info("processed response");
+                assertFalse(responseProcessed.getAndSet(true));
+                return testResponse;
+            },
+            new ActionListener<TestResponse>() {
+                @Override
+                public void onResponse(TestResponse listTasksResponse) {
+                    shouldNotBeCalled.set(true);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+
+                }
+            });
+
+        // Wait for the action to start
+        actionStartedLatch.await();
+
+        // Shut down coordinating node
+        removeNode(0, node, testNodes);
+
+        // Perform action
+        blockAction.countDown();
+
+        // Awaiting for the cockroach task to disappear from the cluster state
+        // There is no other way to wait for it since our coordinating node died
+        assertBusy(() -> assertCleanClusterState(0));
+
+        assertTrue(jobIsDone.get());
+        assertTrue(responseProcessed.get());
+        assertFalse(shouldNotBeCalled.get());
+
+        // Make sure there is no leftover junk left in the task manager
+        // Because our coordinating node died, we have to wait for the tasks to disappear since we have no other way to detect that
+        // all tasks are finished
+        assertBusy(this::assertNoLeftOverTasks);
+    }
+
+    public void testDeathOfExecutorNode() throws Exception {
+        setupTestNodes(Settings.EMPTY);
+        connectNodes(testNodes);
+        startClusterStatePublishing(0, testNodes);
+        CountDownLatch actionStartedLatch = new CountDownLatch(1);
+
+        int executingNode = randomIntBetween(1, testNodes.length - 1);
+        int coordinatingNode = randomIntBetween(0, testNodes.length - 2);
+        if (coordinatingNode >= executingNode) {
+            // the coordinating node and executing nodes should't be the same
+            coordinatingNode++;
+        }
+        boolean shouldFail = randomBoolean();
+
+        logger.info("Executing node: {}, coordinating node:{}, should fail: {}", executingNode, coordinatingNode, shouldFail);
+
+        CountDownLatch responseLatch = new CountDownLatch(1);
+        final AtomicReference<TestResponse> responseReference = new AtomicReference<>();
+        final AtomicReference<Exception> exceptionReference = new AtomicReference<>();
+        final AtomicBoolean triedToExecuteOnNonMaster = new AtomicBoolean();
+
+        CountDownLatch blockAction = new CountDownLatch(1);
+
+        Task mainTask = startTestCockroachAction(coordinatingNode,
+            new TestRequest(shouldFail ? "fail" : "work", testNodes[executingNode].getNodeId()),
+            (transport, request) -> {
+                String nodeId = transport.clusterService.localNode().getId();
+                logger.info("action started on {}", nodeId);
+                // Only block on the first executing node
+                if (nodeId.equals(testNodes[executingNode].getNodeId())) {
+                    triedToExecuteOnNonMaster.set(true);
+                    actionStartedLatch.countDown();
+                    try {
+                        blockAction.await();
+                    } catch (InterruptedException ex) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+                if ("fail".equals(request.getTestParam())) {
+                    throw new RuntimeException("Should fail");
+                } else {
+                    return new TestResponse("processed:" + request.getTestParam() + " on " + nodeId);
+                }
+
+            },
+            null,
+            new ActionListener<TestResponse>() {
+                @Override
+                public void onResponse(TestResponse listTasksResponse) {
+                    responseReference.set(listTasksResponse);
+                    responseLatch.countDown();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    exceptionReference.set(e);
+                    responseLatch.countDown();
+                }
+            });
+
+        // Wait for the action to start
+        actionStartedLatch.await();
+
+        // Shut down coordinating node
+        removeNode(0, executingNode, testNodes);
+
+        // Perform action
+        blockAction.countDown();
+
+        responseLatch.await();
+
+        if (shouldFail) {
+            assertNull(responseReference.get());
+            assertNotNull(exceptionReference.get());
+        } else {
+            assertNotNull(responseReference.get());
+            // Make sure that the work was processed on the master node
+            assertEquals("processed:work on " + testNodes[0].getNodeId(), responseReference.get().response);
+            assertNull(exceptionReference.get());
+        }
+
+        assertTrue(triedToExecuteOnNonMaster.get());
+
+        // Make sure there is no leftover junk left in the cluster state and task manager
+        assertCleanClusterState(0);
+        assertNoLeftOverTasks();
+    }
+
+    public void testMasterRestartDuringNotification() throws Exception {
+        setupTestNodes(Settings.EMPTY);
+        connectNodes(testNodes);
+        startClusterStatePublishing(0, testNodes);
+
+        int executingNode = randomIntBetween(1, testNodes.length - 1);
+        int coordinatingNode = randomIntBetween(1, testNodes.length - 1);
+        int newMaster = randomIntBetween(1, testNodes.length - 1);
+        boolean shouldFail = randomBoolean();
+
+        logger.info("Executing node: {}, coordinating node: {}, new master: {}, should fail: {}", executingNode, coordinatingNode,
+            newMaster, shouldFail);
+
+        CountDownLatch responseLatch = new CountDownLatch(1);
+        final AtomicReference<TestResponse> responseReference = new AtomicReference<>();
+        final AtomicReference<Exception> exceptionReference = new AtomicReference<>();
+
+        CountDownLatch blockAction = new CountDownLatch(1);
+
+        Task callerTask = startTestCockroachAction(coordinatingNode,
+            new TestRequest(shouldFail ? "fail" : "work", testNodes[executingNode].getNodeId()),
+            (transport, request) -> {
+                String nodeId = transport.clusterService.localNode().getId();
+                logger.info("action started on {}", nodeId);
+                // Block on execution so we can restart master before notification is sent
+                try {
+                    assertTrue(blockAction.await(10, TimeUnit.SECONDS));
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+                if ("fail".equals(request.getTestParam())) {
+                    throw new RuntimeException("Should fail");
+                } else {
+                    return new TestResponse("processed:" + request.getTestParam() + " on " + nodeId);
+                }
+            },
+            null,
+            new ActionListener<TestResponse>() {
+                @Override
+                public void onResponse(TestResponse listTasksResponse) {
+                    responseReference.set(listTasksResponse);
+                    responseLatch.countDown();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    exceptionReference.set(e);
+                    responseLatch.countDown();
+                }
+            });
+
+        // Wait for the action to be acknowledged on coordinating node
+        assertBusy(() -> assertTrue(((CockroachActionResponseProcessor.Status) callerTask.getStatus()).isInitialized()));
+
+        // Shut down master
+        removeNode(0, 0, testNodes);
+
+        // Perform action and try to send notification - that should fail because we don't have a master
+        blockAction.countDown();
+
+        // Find the task id that runs on executing node
+        long taskId = findTask(executingNode, task -> task.getAction().equals(TransportTestCockroachAction.NAME + "[c]"));
+        assertNotEquals(-1L, taskId);
+
+        // wait for the notification to fail
+        assertBusy(() -> {
+            TaskManager taskManager = testNodes[executingNode].transportService.getTaskManager();
+            Task task = taskManager.getTask(taskId);
+            assertNotNull(task);
+            assertNotNull(task.getStatus());
+            assertEquals(CockroachActionExecutor.State.FAILED_NOTIFICATION, ((CockroachActionExecutor.Status) task.getStatus()).getState());
+        });
+
+        electMaster(newMaster, testNodes);
+
+        assertTrue(responseLatch.await(10, TimeUnit.SECONDS));
+
+        if (shouldFail) {
+            assertNull(responseReference.get());
+            assertNotNull(exceptionReference.get());
+        } else {
+            assertNotNull(responseReference.get());
+            // Make sure that the work was processed on the original executing node
+            assertEquals("processed:work on " + testNodes[executingNode].getNodeId(), responseReference.get().response);
+            assertNull(exceptionReference.get());
+        }
+
+        // Make sure there is no leftover junk left in the cluster state and task manager
+        assertCleanClusterState(newMaster);
+        assertNoLeftOverTasks();
+    }
+
+
+    public void testClusterStateSerialization() throws Exception {
+        setupTestNodes(Settings.EMPTY);
+        connectNodes(testNodes);
+        startClusterStatePublishing(0, testNodes);
+        int numberOfRequests = randomIntBetween(1, 4); // Cannot have more than 4 requests since they are blocking GENERIC thread pool
+        CountDownLatch actionStartedLatch = new CountDownLatch(numberOfRequests);
+        CountDownLatch responseLatch = new CountDownLatch(numberOfRequests);
+        CountDownLatch acknowledgementLatch = new CountDownLatch(1);
+        CountDownLatch finishResponseLatch = new CountDownLatch(numberOfRequests);
+
+        CountDownLatch blockAction = new CountDownLatch(1);
+
+        TransportTestCockroachAction[] actions = registerTestCockroachAction(
+            (transport, request) -> {
+                actionStartedLatch.countDown();
+                try {
+                    assertTrue(blockAction.await(10, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                if ("fail".equals(request.getTestParam())) {
+                    throw new RuntimeException("Should fail");
+                } else {
+                    return new TestResponse("processed:" + request.getTestParam());
+                }
+            },
+            (transport, response) -> {
+                responseLatch.countDown();
+                try {
+                    assertTrue(acknowledgementLatch.await(10, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return response;
+            });
+
+        for (int i = 0; i < numberOfRequests; i++) {
+            int coordinatingNode = randomInt(testNodes.length - 1);
+            int executingNode = randomInt(testNodes.length - 1);
+            logger.trace("Coordinating node: {}, executing node: {}", coordinatingNode, executingNode);
+            TestRequest testRequest = new TestRequest(randomBoolean() || true ? "work" : "fail", testNodes[executingNode].getNodeId());
+            actions[coordinatingNode].execute(testRequest,
+                new ActionListener<TestResponse>() {
+                    @Override
+                    public void onResponse(TestResponse listTasksResponse) {
+                        finishResponseLatch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        finishResponseLatch.countDown();
+                    }
+                });
+        }
+
+
+        // Wait for the action to start
+        assertTrue(actionStartedLatch.await(10, TimeUnit.SECONDS));
+
+        // Check the cluster state is correctly serialized
+        Map<String, Object> stateMap = xContentToMap(testNodes[0].clusterService.state());
+        Map<String, Object> tasksMap = (Map<String, Object>) stateMap.get("cockroach_tasks");
+        List<Object> tasksList = (List<Object>) tasksMap.get("running_tasks");
+        assertEquals(numberOfRequests, tasksList.size());
+        for (Object task : tasksList) {
+            Map<String, Object> taskMap = (Map<String, Object>) task;
+            assertEquals(TransportTestCockroachAction.NAME, taskMap.get("action"));
+            Map<String, Object> requestMap = (Map<String, Object>) taskMap.get("request");
+            assertThat(requestMap.get("param").toString(), anyOf(equalTo("work"), equalTo("fail")));
+            assertNull(taskMap.get("response"));
+            assertNull(taskMap.get("failure"));
+            assertThat(taskMap.get("caller_task_id").toString(), startsWith(taskMap.get("caller_node") + ":"));
+            assertThat(taskMap.get("executor_node").toString(), startsWith("node"));
+        }
+
+
+        // Perform action and wait for action to finish but block in response so we would have response in the cluster state
+        blockAction.countDown();
+        assertTrue(responseLatch.await(10, TimeUnit.SECONDS));
+
+        stateMap = xContentToMap(testNodes[0].clusterService.state());
+        tasksMap = (Map<String, Object>) stateMap.get("cockroach_tasks");
+        tasksList = (List<Object>) tasksMap.get("running_tasks");
+        assertEquals(numberOfRequests, tasksList.size());
+        for (Object task : tasksList) {
+            Map<String, Object> taskMap = (Map<String, Object>) task;
+            Map<String, Object> requestMap = (Map<String, Object>) taskMap.get("request");
+            if ("work".equals(requestMap.get("param"))) {
+                // Should have response
+                Map<String, Object> responseMap = (Map<String, Object>) taskMap.get("response");
+                assertThat(responseMap.get("text").toString(), startsWith("processed:work"));
+                assertNull(taskMap.get("failure"));
+            } else {
+                // Should have failure
+                assertNull(taskMap.get("response"));
+                assertNotNull(taskMap.get("failure"));
+            }
+        }
+
+        // Verify that we can list cockroach tasks
+        ListTasksRequest listTasksRequest = new ListTasksRequest();
+        listTasksRequest.setActions(TransportTestCockroachAction.NAME + "*");
+        listTasksRequest.setDetailed(true);
+        int randomNode = randomIntBetween(0, testNodes.length - 1);
+        ListTasksResponse response = testNodes[randomNode].transportListTasksAction.execute(listTasksRequest).get();
+        response.setDiscoveryNodes(testNodes[randomNode].clusterService.state().getNodes());
+        // Make sure we can serialize it
+        xContentToMap(response);
+        assertEquals(numberOfRequests * 2, response.getTasks().size());
+        for (TaskInfo taskInfo : response.getTasks()) {
+            if (taskInfo.getAction().equals(TransportTestCockroachAction.NAME)) {
+                CockroachActionResponseProcessor.Status status = (CockroachActionResponseProcessor.Status) taskInfo.getStatus();
+                assertTrue(status.isInitialized());
+            } else if (taskInfo.getAction().equals(TransportTestCockroachAction.NAME + "[c]")) {
+                CockroachActionExecutor.Status status = (CockroachActionExecutor.Status) taskInfo.getStatus();
+                // The status is typically NOTIFIED, but it can be "DONE" as well if a node didn't process the latest
+                // cluster state update yet
+                assertThat(status.getState().toString(), anyOf(equalTo("NOTIFIED"), equalTo("DONE")));
+            } else {
+                fail("Unexpected action " + taskInfo.getAction());
+            }
+        }
+
+        acknowledgementLatch.countDown();
+        assertTrue(finishResponseLatch.await(10, TimeUnit.SECONDS));
+
+        // Make sure there is no leftover junk left in the cluster state and task manager
+        assertCleanClusterState(0);
+        assertNoLeftOverTasks();
+    }
+
+    private static Map<String, Object> xContentToMap(ToXContent content) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        if (randomBoolean()) {
+            builder.humanReadable(true);
+        }
+        builder.startObject();
+        content.toXContent(builder, EMPTY_PARAMS);
+        builder.endObject();
+        return XContentHelper.convertToMap(builder.bytes(), true).v2();
+    }
+
+    private long findTask(int node, Function<Task, Boolean> op) {
+        TaskManager taskManager = testNodes[node].transportService.getTaskManager();
+        for (Map.Entry<Long, Task> entry : taskManager.getTasks().entrySet()) {
+            if (op.apply(entry.getValue())) {
+                return entry.getKey();
+            }
+        }
+        return -1L;
+    }
+
+    private TransportTestCockroachAction[] registerTestCockroachAction(
+        BiFunction<TransportTestCockroachAction, TestRequest, TestResponse> nodeOperation,
+        BiFunction<TransportTestCockroachAction, TestResponse, TestResponse> callerOperation) throws InterruptedException {
+        TransportTestCockroachAction[] actions = new TransportTestCockroachAction[testNodes.length];
+        for (int i = 0; i < testNodes.length; i++) {
+            actions[i] = new TransportTestCockroachAction(Settings.EMPTY, threadPool, testNodes[i].transportService,
+                testNodes[i].clusterService, testNodes[i].cockroachService, testNodes[i].actionFilters,
+                testNodes[i].indexNameExpressionResolver, nodeOperation, callerOperation);
+        }
+        return actions;
+    }
+
+
+    private Task startTestCockroachAction(int coordinatorNode, TestRequest request,
+                                          BiFunction<TransportTestCockroachAction, TestRequest, TestResponse> nodeOperation,
+                                          BiFunction<TransportTestCockroachAction, TestResponse, TestResponse> callerOperation,
+                                          ActionListener<TestResponse> listener) throws InterruptedException {
+        TransportTestCockroachAction[] actions = registerTestCockroachAction(nodeOperation, callerOperation);
+        return actions[coordinatorNode].execute(request, listener);
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestCockroachActionPlugin.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestCockroachActionPlugin.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.admin.cluster.node.tasks;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cockroach.CockroachRequest;
+import org.elasticsearch.cockroach.CockroachResponse;
+import org.elasticsearch.cockroach.CockroachService;
+import org.elasticsearch.cockroach.TransportCockroachAction;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * A plugin that adds a test cockroach task.
+ */
+public class TestCockroachActionPlugin extends Plugin implements ActionPlugin {
+
+    @Override
+    public List<ActionHandler<? extends ActionRequest<?>, ? extends ActionResponse>> getActions() {
+        return singletonList(new ActionHandler<>(TestCockroachAction.INSTANCE, TransportTestCockroachAction.class));
+    }
+
+    public static class TestRequest extends CockroachRequest<TestRequest> {
+
+        private String targetNode = null;
+
+        private String responseNode = null;
+
+        private String testParam = null;
+
+        public TestRequest() {
+
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TestCockroachAction.NAME;
+        }
+
+        public void setTargetNode(String targetNode) {
+            this.targetNode = targetNode;
+        }
+
+        public void setResponseNode(String responseNode) {
+            this.responseNode = responseNode;
+        }
+
+        public void setTestParam(String testParam) {
+            this.testParam = testParam;
+        }
+
+        public String getTargetNode() {
+            return targetNode;
+        }
+
+        public String getResponseNode() {
+            return responseNode;
+        }
+
+        public String getTestParam() {
+            return testParam;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeOptionalString(targetNode);
+            out.writeOptionalString(responseNode);
+            out.writeOptionalString(testParam);
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            targetNode = in.readOptionalString();
+            responseNode = in.readOptionalString();
+            testParam = in.readOptionalString();
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.endObject();
+            return builder;
+        }
+
+    }
+
+    public static class TestResponse extends CockroachResponse {
+
+        public TestResponse() {
+
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TestCockroachAction.NAME;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.endObject();
+            return builder;
+        }
+
+
+    }
+
+    public static class TestCockroachTaskRequestBuilder extends
+        ActionRequestBuilder<TestRequest, TestResponse, TestCockroachTaskRequestBuilder> {
+
+        protected TestCockroachTaskRequestBuilder(ElasticsearchClient client, Action<TestRequest, TestResponse,
+            TestCockroachTaskRequestBuilder> action, TestRequest request) {
+            super(client, action, request);
+        }
+
+        public TestCockroachTaskRequestBuilder testParam(String testParam) {
+            request.setTestParam(testParam);
+            return this;
+        }
+
+        public TestCockroachTaskRequestBuilder responseNode(String responseNode) {
+            request.setResponseNode(responseNode);
+            return this;
+        }
+
+        public TestCockroachTaskRequestBuilder targetNode(String targetNode) {
+            request.setTargetNode(targetNode);
+            return this;
+        }
+
+    }
+
+    public static class TestCockroachAction extends Action<TestRequest, TestResponse, TestCockroachTaskRequestBuilder> {
+
+        public static final TestCockroachAction INSTANCE = new TestCockroachAction();
+        public static final String NAME = "cluster:admin/cockroach/test";
+
+        private TestCockroachAction() {
+            super(NAME);
+        }
+
+        @Override
+        public TestResponse newResponse() {
+            return new TestResponse();
+        }
+
+        @Override
+        public TestCockroachTaskRequestBuilder newRequestBuilder(ElasticsearchClient client) {
+            return new TestCockroachTaskRequestBuilder(client, this, new TestRequest());
+        }
+    }
+
+
+    public static class TransportTestCockroachAction extends TransportCockroachAction<TestRequest, TestResponse> {
+
+        @Inject
+        public TransportTestCockroachAction(Settings settings, ThreadPool threadPool, TransportService transportService,
+                                            CockroachService cockroachService, ActionFilters actionFilters,
+                                            IndexNameExpressionResolver indexNameExpressionResolver) {
+            super(settings, TestCockroachAction.NAME, false, threadPool, transportService, cockroachService, actionFilters,
+                indexNameExpressionResolver, TestRequest::new, TestResponse::new, ThreadPool.Names.MANAGEMENT);
+        }
+
+        @Override
+        public DiscoveryNode executorNode(TestRequest request, ClusterState clusterState) {
+            if (request.getTargetNode() == null) {
+                return clusterState.getNodes().getMasterNode();
+            } else {
+                return clusterState.getNodes().get(request.getTargetNode());
+            }
+        }
+
+        @Override
+        public DiscoveryNode responseNode(TestRequest request, ClusterState clusterState) {
+            if (request.getResponseNode() == null) {
+                return clusterState.getNodes().getMasterNode();
+            } else {
+                return clusterState.getNodes().get(request.getResponseNode());
+            }
+        }
+
+        @Override
+        public void executorNodeOperation(Task task, TestRequest request, ActionListener<TestResponse> listener) {
+            listener.onResponse(new TestResponse());
+        }
+
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -293,8 +293,8 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
 
     private Task startBlockingTestNodesAction(CountDownLatch checkLatch, NodesRequest request, ActionListener<NodesResponse> listener)
             throws InterruptedException {
-        CountDownLatch actionLatch = new CountDownLatch(nodesCount);
-        TestNodesAction[] actions = new TestNodesAction[nodesCount];
+        CountDownLatch actionLatch = new CountDownLatch(testNodes.length);
+        TestNodesAction[] actions = new TestNodesAction[testNodes.length];
         for (int i = 0; i < testNodes.length; i++) {
             final int node = i;
             actions[i] = new TestNodesAction(CLUSTER_SETTINGS, "testAction", threadPool, testNodes[i].clusterService,
@@ -578,7 +578,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         Settings settings = Settings.builder().put(MockTaskManager.USE_MOCK_TASK_MANAGER_SETTING.getKey(), true).build();
         setupTestNodes(settings);
         connectNodes(testNodes);
-        TestNodesAction[] actions = new TestNodesAction[nodesCount];
+        TestNodesAction[] actions = new TestNodesAction[testNodes.length];
         RecordingTaskManagerListener[] listeners = setupListeners(testNodes, "testAction*");
         for (int i = 0; i < testNodes.length; i++) {
             final int node = i;
@@ -597,7 +597,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         }
         NodesRequest request = new NodesRequest("Test Request");
         NodesResponse responses = actions[0].execute(request).get();
-        assertEquals(nodesCount, responses.failureCount());
+        assertEquals(testNodes.length, responses.failureCount());
 
         // Make sure that actions are still registered in the task manager on all nodes
         // Twice on the coordinating node and once on all other nodes.
@@ -617,8 +617,8 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         CountDownLatch checkLatch = new CountDownLatch(1);
         ActionFuture<NodesResponse> future = startBlockingTestNodesAction(checkLatch);
 
-        TestTasksAction[] tasksActions = new TestTasksAction[nodesCount];
-        final int failTaskOnNode = randomIntBetween(1, nodesCount - 1);
+        TestTasksAction[] tasksActions = new TestTasksAction[testNodes.length];
+        final int failTaskOnNode = randomIntBetween(1, testNodes.length - 1);
         for (int i = 0; i < testNodes.length; i++) {
             final int node = i;
             // Simulate task action that fails on one of the tasks on one of the nodes
@@ -675,7 +675,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         Set<String> filterNodes = new HashSet<>(randomSubsetOf(filterNodesSize, allNodes));
         logger.info("Filtering out nodes {} size: {}", filterNodes, filterNodesSize);
 
-        TestTasksAction[] tasksActions = new TestTasksAction[nodesCount];
+        TestTasksAction[] tasksActions = new TestTasksAction[testNodes.length];
         for (int i = 0; i < testNodes.length; i++) {
             final int node = i;
             // Simulate a task action that works on all nodes except nodes listed in filterNodes.
@@ -706,7 +706,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         // should be successful on all nodes except nodes that we filtered out
         TestTasksRequest testTasksRequest = new TestTasksRequest();
         testTasksRequest.setActions("testAction[n]"); // pick all test actions
-        TestTasksResponse response = tasksActions[randomIntBetween(0, nodesCount - 1)].execute(testTasksRequest).get();
+        TestTasksResponse response = tasksActions[randomIntBetween(0, testNodes.length - 1)].execute(testTasksRequest).get();
 
         // Get successful responses from all nodes except nodes that we filtered out
         assertEquals(testNodes.length - filterNodes.size(), response.tasks.size());

--- a/core/src/test/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateActionTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateActionTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -245,9 +246,11 @@ public class PublishClusterStateActionTests extends ESTestCase {
     ) {
         DiscoverySettings discoverySettings =
                 new DiscoverySettings(settings, new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
+        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry();
         return new MockPublishAction(
                 settings,
                 transportService,
+                namedWriteableRegistry,
                 clusterStateSupplier,
                 listener,
                 discoverySettings,
@@ -852,8 +855,8 @@ public class PublishClusterStateActionTests extends ESTestCase {
         AtomicBoolean timeoutOnCommit = new AtomicBoolean();
         AtomicBoolean errorOnCommit = new AtomicBoolean();
 
-        public MockPublishAction(Settings settings, TransportService transportService, Supplier<ClusterState> clusterStateSupplier, NewPendingClusterStateListener listener, DiscoverySettings discoverySettings, ClusterName clusterName) {
-            super(settings, transportService, clusterStateSupplier, listener, discoverySettings, clusterName);
+        public MockPublishAction(Settings settings, TransportService transportService, NamedWriteableRegistry namedWriteableRegistry, Supplier<ClusterState> clusterStateSupplier, NewPendingClusterStateListener listener, DiscoverySettings discoverySettings, ClusterName clusterName) {
+            super(settings, transportService, namedWriteableRegistry, clusterStateSupplier, listener, discoverySettings, clusterName);
         }
 
         @Override


### PR DESCRIPTION
A cockroach action is a transport-like action that is using the cluster state instead of transport to start tasks and send tasks responses. This allows cockroach tasks to survive restart of coordinating and executing nodes. A cockroach action can be implemented by extending TransportCockroachAction. TransportCockroachAction will start the task by using CockroachService, which controls cockroach tasks lifecycle.  See TestCockroachActionPlugin for an example implementing a cockroach action.

This PR just adds an infrastructure for creating cockroach tasks and tests. The first use of the tasks will be to migrate snapshot/restore functionality to it. Since it's a big change, it probably makes more sense to target 6.0.0 with it.
