### PR TITLE
Rest Client: HostsSniffer to set http as default scheme

### DIFF
--- a/client/sniffer/src/main/java/org/elasticsearch/client/sniff/HostsSniffer.java
+++ b/client/sniffer/src/main/java/org/elasticsearch/client/sniff/HostsSniffer.java
@@ -156,7 +156,7 @@ public class HostsSniffer {
 
         private final RestClient restClient;
         private long sniffRequestTimeoutMillis = DEFAULT_SNIFF_REQUEST_TIMEOUT;
-        private Scheme scheme;
+        private Scheme scheme = Scheme.HTTP;
 
         private Builder(RestClient restClient) {
             Objects.requireNonNull(restClient, "restClient cannot be null");

--- a/client/sniffer/src/test/java/org/elasticsearch/client/sniff/HostsSnifferTests.java
+++ b/client/sniffer/src/test/java/org/elasticsearch/client/sniff/HostsSnifferTests.java
@@ -89,7 +89,11 @@ public class HostsSnifferTests extends RestClientTestCase {
     public void testSniffNodes() throws IOException, URISyntaxException {
         HttpHost httpHost = new HttpHost(httpServer.getAddress().getHostString(), httpServer.getAddress().getPort());
         try (RestClient restClient = RestClient.builder(httpHost).build()) {
-            HostsSniffer sniffer = new HostsSniffer(restClient, sniffRequestTimeout, scheme);
+            HostsSniffer.Builder builder = HostsSniffer.builder(restClient).setSniffRequestTimeoutMillis(sniffRequestTimeout);
+            if (scheme != HostsSniffer.Scheme.HTTP || randomBoolean()) {
+                builder.setScheme(scheme);
+            }
+            HostsSniffer sniffer = builder.build();
             try {
                 List<HttpHost> sniffedHosts = sniffer.sniffHosts();
                 if (sniffResponse.isFailure) {


### PR DESCRIPTION
 The assumption in HostsSniffer is that all of the arguments have been properly provided and validated through HostsSniffer.Builder, except they weren't, as the scheme didn't have a default value and when not set would cause NPEs down the road. Improved tests to catch this also.
