### PR TITLE
Migrate Vagrant tests for Fedora to Fedora 24

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,8 +60,8 @@ Vagrant.configure(2) do |config|
     config.vm.box = "elastic/oraclelinux-7-x86_64"
     rpm_common config
   end
-  config.vm.define "fedora-22" do |config|
-    config.vm.box = "elastic/fedora-22-x86_64"
+  config.vm.define "fedora-24" do |config|
+    config.vm.box = "elastic/fedora-24-x86_64"
     dnf_common config
   end
   config.vm.define "opensuse-13" do |config|

--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -30,7 +30,7 @@ List<String> availableBoxes = [
     'centos-6',
     'centos-7',
     'debian-8',
-    'fedora-22',
+    'fedora-24',
     'oel-6',
     'oel-7',
     'opensuse-13',


### PR DESCRIPTION
This commit migrates the Vagrant box for Fedora for the packaging tests
from Fedora 22 to Fedora 24 as Fedora 22 reached end-of-line upon the
release of Fedora 24.
