### PR TITLE
Support authentication with reindex-from-remote

### DIFF
--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -692,8 +692,8 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         NO_LONGER_PRIMARY_SHARD_EXCEPTION(ShardStateAction.NoLongerPrimaryShardException.class,
                 ShardStateAction.NoLongerPrimaryShardException::new, 142),
         SCRIPT_EXCEPTION(org.elasticsearch.script.ScriptException.class, org.elasticsearch.script.ScriptException::new, 143),
-        NOT_MASTER_EXCEPTION(org.elasticsearch.cluster.NotMasterException.class, org.elasticsearch.cluster.NotMasterException::new, 144);
-
+        NOT_MASTER_EXCEPTION(org.elasticsearch.cluster.NotMasterException.class, org.elasticsearch.cluster.NotMasterException::new, 144),
+        STATUS_EXCEPTION(org.elasticsearch.ElasticsearchStatusException.class, org.elasticsearch.ElasticsearchStatusException::new, 145);
 
         final Class<? extends ElasticsearchException> exceptionClass;
         final FunctionThatThrowsIOException<StreamInput, ? extends ElasticsearchException> constructor;

--- a/core/src/main/java/org/elasticsearch/ElasticsearchStatusException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchStatusException.java
@@ -16,49 +16,53 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch;
 
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 
 /**
- * Generic security exception
+ * Exception who's {@link RestStatus} is arbitrary rather than derived. Used, for example, by reindex-from-remote to wrap remote exceptions
+ * that contain a status.
  */
-public class ElasticsearchSecurityException extends ElasticsearchStatusException {
+public class ElasticsearchStatusException extends ElasticsearchException {
+    private final RestStatus status;
+
     /**
      * Build the exception with a specific status and cause.
      */
-    public ElasticsearchSecurityException(String msg, RestStatus status, Throwable cause, Object... args) {
-        super(msg, status, cause, args);
-    }
-
-    /**
-     * Build the exception with the status derived from the cause.
-     */
-    public ElasticsearchSecurityException(String msg, Exception cause, Object... args) {
-        this(msg, ExceptionsHelper.status(cause), cause, args);
-    }
-
-    /**
-     * Build the exception with a status of {@link RestStatus#INTERNAL_SERVER_ERROR} without a cause.
-     */
-    public ElasticsearchSecurityException(String msg, Object... args) {
-        this(msg, RestStatus.INTERNAL_SERVER_ERROR, args);
+    public ElasticsearchStatusException(String msg, RestStatus status, Throwable cause, Object... args) {
+        super(msg, cause, args);
+        this.status = status;
     }
 
     /**
      * Build the exception without a cause.
      */
-    public ElasticsearchSecurityException(String msg, RestStatus status, Object... args) {
-        super(msg, status, args);
+    public ElasticsearchStatusException(String msg, RestStatus status, Object... args) {
+        this(msg, status, null, args);
     }
 
     /**
      * Read from a stream.
      */
-    public ElasticsearchSecurityException(StreamInput in) throws IOException {
+    public ElasticsearchStatusException(StreamInput in) throws IOException {
         super(in);
+        status = RestStatus.readFrom(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        RestStatus.writeTo(out, status);
+    }
+
+    @Override
+    public final RestStatus status() {
+        return status;
     }
 }

--- a/core/src/main/java/org/elasticsearch/rest/RestStatus.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestStatus.java
@@ -24,6 +24,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.unmodifiableMap;
 
 public enum RestStatus {
     /**
@@ -477,6 +481,15 @@ public enum RestStatus {
      */
     INSUFFICIENT_STORAGE(506);
 
+    private static final Map<Integer, RestStatus> CODE_TO_STATUS;
+    static {
+        RestStatus[] values = values();
+        Map<Integer, RestStatus> codeToStatus = new HashMap<>(values.length);
+        for (RestStatus value : values) {
+            codeToStatus.put(value.status, value);
+        }
+        CODE_TO_STATUS = unmodifiableMap(codeToStatus);
+    }
 
     private int status;
 
@@ -514,5 +527,12 @@ public enum RestStatus {
             return status;
         }
         return status;
+    }
+
+    /**
+     * Turn a status code into a {@link RestStatus}, returning null if we don't know that status.
+     */
+    public static RestStatus fromCode(int code) {
+        return CODE_TO_STATUS.get(code);
     }
 }

--- a/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -792,6 +792,7 @@ public class ExceptionSerializationTests extends ESTestCase {
         ids.put(142, ShardStateAction.NoLongerPrimaryShardException.class);
         ids.put(143, org.elasticsearch.script.ScriptException.class);
         ids.put(144, org.elasticsearch.cluster.NotMasterException.class);
+        ids.put(145, org.elasticsearch.ElasticsearchStatusException.class);
 
         Map<Class<? extends ElasticsearchException>, Integer> reverse = new HashMap<>();
         for (Map.Entry<Integer, Class<? extends ElasticsearchException>> entry : ids.entrySet()) {
@@ -841,5 +842,12 @@ public class ExceptionSerializationTests extends ESTestCase {
                 assertEquals(serialize.getClass().toString(), "c", serialize.getReason());
             }
         }
+    }
+
+    public void testElasticsearchRemoteException() throws IOException {
+        ElasticsearchStatusException ex = new ElasticsearchStatusException("something", RestStatus.TOO_MANY_REQUESTS);
+        ElasticsearchStatusException e = serialize(ex);
+        assertEquals(ex.status(), e.status());
+        assertEquals(RestStatus.TOO_MANY_REQUESTS, e.status());
     }
 }

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/package-info.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Actions that modify documents based on the results of a scrolling query like {@link ReindexAction}, {@link UpdateByQueryAction}, and
+ * {@link DeleteByQueryAction}.
+ */
+package org.elasticsearch.index.reindex;

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/package-info.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Support for reindexing from a remote Elasticsearch cluster.
+ */
+package org.elasticsearch.index.reindex.remote;

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexFromRemoteWhitelistTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexFromRemoteWhitelistTests.java
@@ -31,6 +31,8 @@ import java.net.UnknownHostException;
 import java.util.HashSet;
 import java.util.Set;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.index.reindex.TransportReindexAction.checkRemoteWhitelist;
 
@@ -58,7 +60,7 @@ public class ReindexFromRemoteWhitelistTests extends ESTestCase {
         String[] inList = whitelist.iterator().next().split(":");
         String host = inList[0];
         int port = Integer.valueOf(inList[1]);
-        checkRemoteWhitelist(whitelist, new RemoteInfo(randomAsciiOfLength(5), host, port, new BytesArray("test"), null, null),
+        checkRemoteWhitelist(whitelist, new RemoteInfo(randomAsciiOfLength(5), host, port, new BytesArray("test"), null, null, emptyMap()),
                 localhostOrNone());
     }
 
@@ -66,14 +68,15 @@ public class ReindexFromRemoteWhitelistTests extends ESTestCase {
         Set<String> whitelist = randomWhitelist();
         whitelist.add("myself");
         TransportAddress publishAddress = new InetSocketTransportAddress(InetAddress.getByAddress(new byte[] {0x7f,0x00,0x00,0x01}), 9200);
-        checkRemoteWhitelist(whitelist, new RemoteInfo(randomAsciiOfLength(5), "127.0.0.1", 9200, new BytesArray("test"), null, null),
-                publishAddress);
+        checkRemoteWhitelist(whitelist,
+                new RemoteInfo(randomAsciiOfLength(5), "127.0.0.1", 9200, new BytesArray("test"), null, null, emptyMap()), publishAddress);
     }
 
     public void testUnwhitelistedRemote() {
         int port = between(1, Integer.MAX_VALUE);
-        Exception e = expectThrows(IllegalArgumentException.class, () -> checkRemoteWhitelist(randomWhitelist(),
-                new RemoteInfo(randomAsciiOfLength(5), "not in list", port, new BytesArray("test"), null, null), localhostOrNone()));
+        RemoteInfo remoteInfo = new RemoteInfo(randomAsciiOfLength(5), "not in list", port, new BytesArray("test"), null, null, emptyMap());
+        Exception e = expectThrows(IllegalArgumentException.class,
+                () -> checkRemoteWhitelist(randomWhitelist(), remoteInfo, localhostOrNone()));
         assertEquals("[not in list:" + port + "] not whitelisted in reindex.remote.whitelist", e.getMessage());
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexFromRemoteWithAuthTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexFromRemoteWithAuthTests.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.reindex;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
+import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.support.ActionFilter;
+import org.elasticsearch.action.support.ActionFilterChain;
+import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.network.NetworkModule;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.index.reindex.remote.RemoteInfo;
+import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.Netty4Plugin;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.elasticsearch.index.reindex.ReindexTestCase.matcher;
+import static org.hamcrest.Matchers.containsString;
+
+public class ReindexFromRemoteWithAuthTests extends ESSingleNodeTestCase {
+    private TransportAddress address;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Arrays.asList(RetryTests.BogusPlugin.class,
+                Netty4Plugin.class,
+                ReindexFromRemoteWithAuthTests.TestPlugin.class,
+                ReindexPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings() {
+        Settings.Builder settings = Settings.builder().put(super.nodeSettings());
+        // Weird incantation required to test with netty
+        settings.put("netty.assert.buglevel", false);
+        settings.put(NetworkModule.HTTP_ENABLED.getKey(), true);
+        // Whitelist reindexing from the http host we're going to use
+        settings.put(TransportReindexAction.REMOTE_CLUSTER_WHITELIST.getKey(), "myself");
+        settings.put(NetworkModule.HTTP_TYPE_KEY, Netty4Plugin.NETTY_HTTP_TRANSPORT_NAME);
+        return settings.build();
+    }
+
+    @Before
+    public void setupSourceIndex() {
+        client().prepareIndex("source", "test").setSource("test", "test").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
+    }
+
+    @Before
+    public void fetchTransportAddress() {
+        NodeInfo nodeInfo = client().admin().cluster().prepareNodesInfo().get().getNodes().get(0);
+        address = nodeInfo.getHttp().getAddress().publishAddress();
+    }
+
+    public void testReindexFromRemoteWithAuthentication() throws Exception {
+        RemoteInfo remote = new RemoteInfo("http", address.getHost(), address.getPort(), new BytesArray("{\"match_all\":{}}"), "Aladdin",
+                "open sesame", emptyMap());
+        ReindexRequestBuilder request = ReindexAction.INSTANCE.newRequestBuilder(client()).source("source").destination("dest")
+                .setRemoteInfo(remote);
+        assertThat(request.get(), matcher().created(1));
+    }
+
+    public void testReindexSendsHeaders() throws Exception {
+        RemoteInfo remote = new RemoteInfo("http", address.getHost(), address.getPort(), new BytesArray("{\"match_all\":{}}"), null, null,
+                singletonMap(TestFilter.EXAMPLE_HEADER, "doesn't matter"));
+        ReindexRequestBuilder request = ReindexAction.INSTANCE.newRequestBuilder(client()).source("source").destination("dest")
+                .setRemoteInfo(remote);
+        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, () -> request.get());
+        assertEquals(RestStatus.BAD_REQUEST, e.status());
+        assertThat(e.getMessage(), containsString("Hurray! Sent the header!"));
+    }
+
+    public void testReindexWithoutAuthenticationWhenRequired() throws Exception {
+        RemoteInfo remote = new RemoteInfo("http", address.getHost(), address.getPort(), new BytesArray("{\"match_all\":{}}"), null, null,
+                emptyMap());
+        ReindexRequestBuilder request = ReindexAction.INSTANCE.newRequestBuilder(client()).source("source").destination("dest")
+                .setRemoteInfo(remote);
+        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, () -> request.get());
+        assertEquals(RestStatus.UNAUTHORIZED, e.status());
+        assertThat(e.getMessage(), containsString("\"reason\":\"Authentication required\""));
+        assertThat(e.getMessage(), containsString("\"WWW-Authenticate\":\"Basic realm=auth-realm\""));
+    }
+
+    public void testReindexWithBadAuthentication() throws Exception {
+        RemoteInfo remote = new RemoteInfo("http", address.getHost(), address.getPort(), new BytesArray("{\"match_all\":{}}"), "junk",
+                "auth", emptyMap());
+        ReindexRequestBuilder request = ReindexAction.INSTANCE.newRequestBuilder(client()).source("source").destination("dest")
+                .setRemoteInfo(remote);
+        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, () -> request.get());
+        assertThat(e.getMessage(), containsString("\"reason\":\"Bad Authorization\""));
+    }
+
+    /**
+     * Plugin that demands authentication.
+     */
+    public static class TestPlugin extends Plugin implements ActionPlugin {
+        @Override
+        public List<Class<? extends ActionFilter>> getActionFilters() {
+            return singletonList(ReindexFromRemoteWithAuthTests.TestFilter.class);
+        }
+
+        @Override
+        public Collection<String> getRestHeaders() {
+            return Arrays.asList(TestFilter.AUTHORIZATION_HEADER, TestFilter.EXAMPLE_HEADER);
+        }
+    }
+
+    /**
+     * Action filter that will reject the request if it isn't authenticated.
+     */
+    public static class TestFilter implements ActionFilter {
+        /**
+         * The authorization required. Corresponds to username="Aladdin" and password="open sesame". It is the example in
+         * <a href="https://tools.ietf.org/html/rfc1945#section-11.1">HTTP/1.0's RFC</a>.
+         */
+        private static final String REQUIRED_AUTH = "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==";
+        private static final String AUTHORIZATION_HEADER = "Authorization";
+        private static final String EXAMPLE_HEADER = "Example-Header";
+        private final ThreadContext context;
+
+        @Inject
+        public TestFilter(ThreadPool threadPool) {
+            context = threadPool.getThreadContext();
+        }
+
+        @Override
+        public int order() {
+            return Integer.MIN_VALUE;
+        }
+
+        @Override
+        public <Request extends ActionRequest<Request>, Response extends ActionResponse> void apply(Task task, String action,
+                Request request, ActionListener<Response> listener, ActionFilterChain<Request, Response> chain) {
+            if (false == action.equals(SearchAction.NAME)) {
+                chain.proceed(task, action, request, listener);
+                return;
+            }
+            if (context.getHeader(EXAMPLE_HEADER) != null) {
+                throw new IllegalArgumentException("Hurray! Sent the header!");
+            }
+            String auth = context.getHeader(AUTHORIZATION_HEADER);
+            if (auth == null) {
+                ElasticsearchSecurityException e = new ElasticsearchSecurityException("Authentication required",
+                        RestStatus.UNAUTHORIZED);
+                e.addHeader("WWW-Authenticate", "Basic realm=auth-realm");
+                throw e;
+            }
+            if (false == REQUIRED_AUTH.equals(auth)) {
+                throw new ElasticsearchSecurityException("Bad Authorization", RestStatus.FORBIDDEN);
+            }
+            chain.proceed(task, action, request, listener);
+        }
+
+        @Override
+        public <Response extends ActionResponse> void apply(String action, Response response, ActionListener<Response> listener,
+                ActionFilterChain<?, Response> chain) {
+            chain.proceed(action, response, listener);
+        }
+    }
+}

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.index.reindex.remote.RemoteInfo;
 import org.elasticsearch.test.ESTestCase;
 
+import static java.util.Collections.emptyMap;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 
 /**
@@ -44,7 +45,7 @@ public class ReindexRequestTests extends ESTestCase {
     public void testReindexFromRemoteDoesNotSupportSearchQuery() {
         ReindexRequest reindex = request();
         reindex.setRemoteInfo(new RemoteInfo(randomAsciiOfLength(5), randomAsciiOfLength(5), between(1, Integer.MAX_VALUE),
-                new BytesArray("real_query"), null, null));
+                new BytesArray("real_query"), null, null, emptyMap()));
         reindex.getSearchRequest().source().query(matchAllQuery()); // Unsupported place to put query
         ActionRequestValidationException e = reindex.validate();
         assertEquals("Validation Failed: 1: reindex from remote sources should use RemoteInfo's query instead of source's query;",

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexSourceTargetValidationTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexSourceTargetValidationTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.reindex.remote.RemoteInfo;
 import org.elasticsearch.test.ESTestCase;
 
+import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.containsString;
 
 /**
@@ -86,9 +87,10 @@ public class ReindexSourceTargetValidationTests extends ESTestCase {
 
     public void testRemoteInfoSkipsValidation() {
         // The index doesn't have to exist
-        succeeds(new RemoteInfo(randomAsciiOfLength(5), "test", 9200, new BytesArray("test"), null, null), "does_not_exist", "target");
+        succeeds(new RemoteInfo(randomAsciiOfLength(5), "test", 9200, new BytesArray("test"), null, null, emptyMap()), "does_not_exist",
+                "target");
         // And it doesn't matter if they are the same index. They are considered to be different because the remote one is, well, remote.
-        succeeds(new RemoteInfo(randomAsciiOfLength(5), "test", 9200, new BytesArray("test"), null, null), "target", "target");
+        succeeds(new RemoteInfo(randomAsciiOfLength(5), "test", 9200, new BytesArray("test"), null, null, emptyMap()), "target", "target");
     }
 
     private void fails(String target, String... sources) {

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RestReindexActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RestReindexActionTests.java
@@ -41,10 +41,16 @@ public class RestReindexActionTests extends ESTestCase {
     }
 
     public void testBuildRemoteInfoFullyLoaded() throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("first", "a");
+        headers.put("second", "b");
+        headers.put("third", "");
+
         Map<String, Object> remote = new HashMap<>();
         remote.put("host", "https://example.com:9200");
         remote.put("username", "testuser");
         remote.put("password", "testpass");
+        remote.put("headers", headers);
 
         Map<String, Object> query = new HashMap<>();
         query.put("a", "b");
@@ -60,6 +66,7 @@ public class RestReindexActionTests extends ESTestCase {
         assertEquals("{\n  \"a\" : \"b\"\n}", remoteInfo.getQuery().utf8ToString());
         assertEquals("testuser", remoteInfo.getUsername());
         assertEquals("testpass", remoteInfo.getPassword());
+        assertEquals(headers, remoteInfo.getHeaders());
     }
 
     public void testBuildRemoteInfoWithoutAllParts() throws IOException {

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RetryTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RetryTests.java
@@ -47,6 +47,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CyclicBarrier;
 
+import static java.util.Collections.emptyMap;
 import static org.elasticsearch.index.reindex.ReindexTestCase.matcher;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
@@ -114,8 +115,8 @@ public class RetryTests extends ESSingleNodeTestCase {
     @Override
     protected Settings nodeSettings() {
         Settings.Builder settings = Settings.builder().put(super.nodeSettings());
-        // Use pools of size 1 so we can block them
         settings.put("netty.assert.buglevel", false);
+        // Use pools of size 1 so we can block them
         settings.put("thread_pool.bulk.size", 1);
         settings.put("thread_pool.search.size", 1);
         // Use queues of size 1 because size 0 is broken and because search requests need the queue to function
@@ -140,7 +141,8 @@ public class RetryTests extends ESSingleNodeTestCase {
     public void testReindexFromRemote() throws Exception {
         NodeInfo nodeInfo = client().admin().cluster().prepareNodesInfo().get().getNodes().get(0);
         TransportAddress address = nodeInfo.getHttp().getAddress().publishAddress();
-        RemoteInfo remote = new RemoteInfo("http", address.getHost(), address.getPort(), new BytesArray("{\"match_all\":{}}"), null, null);
+        RemoteInfo remote = new RemoteInfo("http", address.getHost(), address.getPort(), new BytesArray("{\"match_all\":{}}"), null, null,
+                emptyMap());
         ReindexRequestBuilder request = ReindexAction.INSTANCE.newRequestBuilder(client()).source("source").destination("dest")
                 .setRemoteInfo(remote);
         testCase(ReindexAction.NAME, request, matcher().created(DOC_COUNT));

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RoundTripTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RoundTripTests.java
@@ -38,7 +38,9 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.Math.abs;
 import static java.util.Collections.emptyList;
@@ -62,7 +64,12 @@ public class RoundTripTests extends ESTestCase {
             BytesReference query = new BytesArray(randomAsciiOfLength(5));
             String username = randomBoolean() ? randomAsciiOfLength(5) : null;
             String password = username != null && randomBoolean() ? randomAsciiOfLength(5) : null;
-            reindex.setRemoteInfo(new RemoteInfo(randomAsciiOfLength(5), randomAsciiOfLength(5), port, query, username, password));
+            int headersCount = randomBoolean() ? 0 : between(1, 10);
+            Map<String, String> headers = new HashMap<>(headersCount);
+            while (headers.size() < headersCount) {
+                headers.put(randomAsciiOfLength(5), randomAsciiOfLength(5));
+            }
+            reindex.setRemoteInfo(new RemoteInfo(randomAsciiOfLength(5), randomAsciiOfLength(5), port, query, username, password, headers));
         }
         ReindexRequest tripped = new ReindexRequest();
         roundTrip(reindex, tripped);
@@ -78,6 +85,7 @@ public class RoundTripTests extends ESTestCase {
             assertEquals(reindex.getRemoteInfo().getQuery(), tripped.getRemoteInfo().getQuery());
             assertEquals(reindex.getRemoteInfo().getUsername(), tripped.getRemoteInfo().getUsername());
             assertEquals(reindex.getRemoteInfo().getPassword(), tripped.getRemoteInfo().getPassword());
+            assertEquals(reindex.getRemoteInfo().getHeaders(), tripped.getRemoteInfo().getHeaders());
         }
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteInfoTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteInfoTests.java
@@ -22,15 +22,17 @@ package org.elasticsearch.index.reindex.remote;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.test.ESTestCase;
 
+import static java.util.Collections.emptyMap;
+
 public class RemoteInfoTests extends ESTestCase {
     public void testToString() {
-        RemoteInfo info = new RemoteInfo("http", "testhost", 12344, new BytesArray("testquery"), null, null);
+        RemoteInfo info = new RemoteInfo("http", "testhost", 12344, new BytesArray("testquery"), null, null, emptyMap());
         assertEquals("host=testhost port=12344 query=testquery", info.toString());
-        info = new RemoteInfo("http", "testhost", 12344, new BytesArray("testquery"), "testuser", null);
+        info = new RemoteInfo("http", "testhost", 12344, new BytesArray("testquery"), "testuser", null, emptyMap());
         assertEquals("host=testhost port=12344 query=testquery username=testuser", info.toString());
-        info = new RemoteInfo("http", "testhost", 12344, new BytesArray("testquery"), "testuser", "testpass");
+        info = new RemoteInfo("http", "testhost", 12344, new BytesArray("testquery"), "testuser", "testpass", emptyMap());
         assertEquals("host=testhost port=12344 query=testquery username=testuser password=<<>>", info.toString());
-        info = new RemoteInfo("https", "testhost", 12344, new BytesArray("testquery"), "testuser", "testpass");
+        info = new RemoteInfo("https", "testhost", 12344, new BytesArray("testquery"), "testuser", "testpass", emptyMap());
         assertEquals("scheme=https host=testhost port=12344 query=testquery username=testuser password=<<>>", info.toString());
     }
 }

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -20,7 +20,7 @@
 import org.elasticsearch.gradle.precommit.PrecommitTasks
 
 subprojects {
-  // fixtures is just an intermediate parent project
+  // fixtures is just intermediate parent project
   if (name == 'fixtures') return
 
   group = 'org.elasticsearch.test'
@@ -28,7 +28,7 @@ subprojects {
   apply plugin: 'nebula.maven-base-publish'
   apply plugin: 'nebula.maven-scm'
 
-  
+
   // the main files are actually test files, so use the appropriate forbidden api sigs
   forbiddenApisMain {
     signaturesURLs = [PrecommitTasks.getResource('/forbidden/jdk-signatures.txt'),

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -142,12 +142,17 @@ public class DoSection implements ExecutableSection {
     private static Map<String, Tuple<String, org.hamcrest.Matcher<Integer>>> catches = new HashMap<>();
 
     static {
-        catches.put("missing", tuple("404", equalTo(404)));
-        catches.put("conflict", tuple("409", equalTo(409)));
+        catches.put("unauthorized", tuple("401", equalTo(401)));
         catches.put("forbidden", tuple("403", equalTo(403)));
+        catches.put("missing", tuple("404", equalTo(404)));
         catches.put("request_timeout", tuple("408", equalTo(408)));
+        catches.put("conflict", tuple("409", equalTo(409)));
         catches.put("unavailable", tuple("503", equalTo(503)));
-        catches.put("request", tuple("4xx|5xx",
-                allOf(greaterThanOrEqualTo(400), not(equalTo(404)), not(equalTo(408)), not(equalTo(409)), not(equalTo(403)))));
+        catches.put("request", tuple("4xx|5xx", allOf(greaterThanOrEqualTo(400),
+                not(equalTo(401)),
+                not(equalTo(403)),
+                not(equalTo(404)),
+                not(equalTo(408)),
+                not(equalTo(409)))));
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/support/Features.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/support/Features.java
@@ -35,8 +35,8 @@ import static java.util.Collections.unmodifiableList;
  * and the related skip sections can be removed from the tests as well.
  */
 public final class Features {
-
     private static final List<String> SUPPORTED = unmodifiableList(Arrays.asList(
+            "catch_unauthorized",
             "embedded_stash_key",
             "groovy_scripting",
             "headers",


### PR DESCRIPTION
Without this reindex-from-remote isn't compatible with any sort of security or reverse proxy servers. With this it should be compatible with both. This is how you authenticate:

```
curl -XPOST localhost:9200/_reindex -d'{
  "source": {
    "remote": {
      "host": "https://remoteHost:9200", # http or https are fine
      "username": "Aladdin",
      "password": "open sesame"
    }
    "index": "source",
  }
  "dest": {
    "index": "dest"
  }
}'
```

Optionally, you can also add headers like this:

```
curl -XPOST localhost:9200/_reindex -d'{
  "source": {
    "remote": {
      "host": "https://remoteHost:9200", # http or https are fine
      "headers": {
        "header-1": "value-1",
        "header-2": "value-2"
      }
      "username": "Aladdin",
      "password": "open sesame"
    }
    "index": "source",
  }
  "dest": {
    "index": "dest"
  }
}'
```
