### PR TITLE
Add note to issue template regarding supported OS

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,7 +5,7 @@ https://discuss.elastic.co. If you are in fact posting a bug report or
 a feature request, please include one and only one of the below blocks
 in your new issue. Note that whether you're filing a bug report or a
 feature request, ensure that your submission is for an
-[OS that we support](https://www.elastic.co/support/matrix#show_os)?
+[OS that we support](https://www.elastic.co/support/matrix#show_os).
 Bug reports on OS that we do not support or feature requests specific
 to OS that we do not support will be closed.
 -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,11 @@ GitHub is reserved for bug reports and feature requests. The best place
 to ask a general question is at the Elastic Discourse forums at
 https://discuss.elastic.co. If you are in fact posting a bug report or
 a feature request, please include one and only one of the below blocks
-in your new issue.
+in your new issue. Note that whether you're filing a bug report or a
+feature request, ensure that your submission is for an
+[OS that we support](https://www.elastic.co/support/matrix#show_os)?
+Bug reports on OS that we do not support or feature requests specific
+to OS that we do not support will be closed.
 -->
 
 <!--


### PR DESCRIPTION
This commit adds a note to the GitHub issue template noting that bug
reports on OS that we do not support or feature requests for OS that we
do not support will be closed.
