### PR TITLE
Rest Client: add slash to log line when missing between host and uri

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/RequestLogger.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RequestLogger.java
@@ -26,6 +26,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
+import org.apache.http.RequestLine;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.BufferedHttpEntity;
 import org.apache.http.entity.ContentType;
@@ -55,7 +56,7 @@ final class RequestLogger {
      */
     static void logResponse(Log logger, HttpUriRequest request, HttpHost host, HttpResponse httpResponse) {
         if (logger.isDebugEnabled()) {
-            logger.debug("request [" + request.getMethod() + " " + host + request.getRequestLine().getUri() +
+            logger.debug("request [" + request.getMethod() + " " + host + getUri(request.getRequestLine()) +
                     "] returned [" + httpResponse.getStatusLine() + "]");
         }
         if (tracer.isTraceEnabled()) {
@@ -81,7 +82,7 @@ final class RequestLogger {
      * Logs a request that failed
      */
     static void logFailedRequest(Log logger, HttpUriRequest request, HttpHost host, IOException e) {
-        logger.debug("request [" + request.getMethod() + " " + host + request.getRequestLine().getUri() + "] failed", e);
+        logger.debug("request [" + request.getMethod() + " " + host + getUri(request.getRequestLine()) + "] failed", e);
         if (logger.isTraceEnabled()) {
             String traceRequest;
             try {
@@ -98,7 +99,7 @@ final class RequestLogger {
      * Creates curl output for given request
      */
     static String buildTraceRequest(HttpUriRequest request, HttpHost host) throws IOException {
-        String requestLine = "curl -iX " + request.getMethod() + " '" + host + request.getRequestLine().getUri() + "'";
+        String requestLine = "curl -iX " + request.getMethod() + " '" + host + getUri(request.getRequestLine()) + "'";
         if (request instanceof  HttpEntityEnclosingRequest) {
             HttpEntityEnclosingRequest enclosingRequest = (HttpEntityEnclosingRequest) request;
             if (enclosingRequest.getEntity() != null) {
@@ -142,5 +143,12 @@ final class RequestLogger {
             }
         }
         return responseLine;
+    }
+
+    private static String getUri(RequestLine requestLine) {
+        if (requestLine.getUri().charAt(0) != '/') {
+            return "/" + requestLine.getUri();
+        }
+        return requestLine.getUri();
     }
 }

--- a/client/rest/src/test/java/org/elasticsearch/client/RequestLoggerTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RequestLoggerTests.java
@@ -50,7 +50,14 @@ public class RequestLoggerTests extends RestClientTestCase {
 
     public void testTraceRequest() throws IOException, URISyntaxException {
         HttpHost host = new HttpHost("localhost", 9200, getRandom().nextBoolean() ? "http" : "https");
-        URI uri = new URI("/index/type/_api");
+
+        String expectedEndpoint = "/index/type/_api";
+        URI uri;
+        if (randomBoolean()) {
+            uri = new URI(expectedEndpoint);
+        } else {
+            uri = new URI("index/type/_api");
+        }
 
         HttpRequestBase request;
         int requestType = RandomInts.randomIntBetween(getRandom(), 0, 7);
@@ -83,7 +90,7 @@ public class RequestLoggerTests extends RestClientTestCase {
                 throw new UnsupportedOperationException();
         }
 
-        String expected = "curl -iX " + request.getMethod() + " '" + host + uri + "'";
+        String expected = "curl -iX " + request.getMethod() + " '" + host + expectedEndpoint + "'";
         boolean hasBody = request instanceof HttpEntityEnclosingRequest && getRandom().nextBoolean();
         String requestBody = "{ \"field\": \"value\" }";
         if (hasBody) {


### PR DESCRIPTION
Rest Client: add slash to log line when missing between host and uri

Closes #19314
