### PR TITLE
Disable service in pre-uninstall

### DIFF
--- a/distribution/src/main/packaging/scripts/postrm
+++ b/distribution/src/main/packaging/scripts/postrm
@@ -13,7 +13,6 @@
 
 SOURCE_ENV_FILE=true
 REMOVE_DIRS=false
-REMOVE_SERVICE=false
 REMOVE_USER_AND_GROUP=false
 
 case "$1" in
@@ -21,7 +20,6 @@ case "$1" in
     # Debian ####################################################
     remove)
         REMOVE_DIRS=true
-        REMOVE_SERVICE=true
     ;;
 
     purge)
@@ -34,7 +32,6 @@ case "$1" in
     # RedHat ####################################################
     0)
         REMOVE_DIRS=true
-        REMOVE_SERVICE=true
         REMOVE_USER_AND_GROUP=true
     ;;
     1)
@@ -62,20 +59,6 @@ if [ "$SOURCE_ENV_FILE" = "true" ]; then
     ES_ENV_FILE="${path.env}"
     if [ -f "$ES_ENV_FILE" ]; then
         . "$ES_ENV_FILE"
-    fi
-fi
-
-if [ "$REMOVE_SERVICE" = "true" ]; then
-    if command -v systemctl >/dev/null; then
-        systemctl disable elasticsearch.service > /dev/null 2>&1 || true
-    fi
-
-    if command -v chkconfig >/dev/null; then
-        chkconfig --del elasticsearch 2> /dev/null || true
-    fi
-
-    if command -v update-rc.d >/dev/null; then
-        update-rc.d elasticsearch remove >/dev/null || true
     fi
 fi
 

--- a/distribution/src/main/packaging/scripts/prerm
+++ b/distribution/src/main/packaging/scripts/prerm
@@ -12,12 +12,14 @@
 
 
 STOP_REQUIRED=false
+REMOVE_SERVICE=false
 
 case "$1" in
 
     # Debian ####################################################
     remove)
         STOP_REQUIRED=true
+        REMOVE_SERVICE=true
     ;;
     upgrade)
         if [ "$RESTART_ON_UPGRADE" = "true" ]; then
@@ -30,6 +32,7 @@ case "$1" in
     # RedHat ####################################################
     0)
         STOP_REQUIRED=true
+        REMOVE_SERVICE=true
     ;;
     1)
         # Dont do anything on upgrade, because the preun script in redhat gets executed after the postinst (madness!)
@@ -62,6 +65,20 @@ if [ "$STOP_REQUIRED" = "true" ]; then
         /etc/rc.d/init.d/elasticsearch stop
     fi
     echo " OK"
+fi
+
+if [ "$REMOVE_SERVICE" = "true" ]; then
+    if command -v systemctl >/dev/null; then
+        systemctl disable elasticsearch.service > /dev/null 2>&1 || true
+    fi
+
+    if command -v chkconfig >/dev/null; then
+        chkconfig --del elasticsearch 2> /dev/null || true
+    fi
+
+    if command -v update-rc.d >/dev/null; then
+        update-rc.d elasticsearch remove >/dev/null || true
+    fi
 fi
 
 SCRIPTS_DIR="/etc/elasticsearch/scripts"


### PR DESCRIPTION
Today in the packaging removal scripts, we disable the service in
post-uninstall. Yet, this happens after service files have been
erased. On some systems, this can cause the service disable to fail
leaving behind state causing the service to be enabled on subsequent
installs. This commit moves the service disabling to the pre-uninstall
script to prevent this issue.
