### PR TITLE
Ensure metadata folder is not resurrected when loading latest state file

### DIFF
--- a/core/src/main/java/org/apache/lucene/store/SimpleReadOnlyFSDirectory.java
+++ b/core/src/main/java/org/apache/lucene/store/SimpleReadOnlyFSDirectory.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.lucene.store;
+
+import java.io.IOException;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Collection;
+
+/**
+ * Similar to {@link SimpleFSDirectory} but only supports reading files from a folder and does not create the directory if it does not
+ * exist. This is useful if we don't want to resurrect a folder that was just deleted before creating the {@link Directory}.
+ *
+ * Only supports the {@link Directory#openInput(String,IOContext)} method.
+ */
+public class SimpleReadOnlyFSDirectory extends BaseDirectory {
+
+    protected final Path directory; // The underlying filesystem directory
+
+    public SimpleReadOnlyFSDirectory(Path path) throws IOException {
+        super(FSLockFactory.getDefault());
+        directory = path.toRealPath();
+    }
+
+    @Override
+    public String[] listAll() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteFile(String name) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long fileLength(String name) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IndexOutput createOutput(String name, IOContext context) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IndexOutput createTempOutput(String prefix, String suffix, IOContext context) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void sync(Collection<String> names) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void renameFile(String source, String dest) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IndexInput openInput(String name, IOContext context) throws IOException {
+        ensureOpen();
+        Path path = directory.resolve(name);
+        SeekableByteChannel channel = Files.newByteChannel(path, StandardOpenOption.READ);
+        return new SimpleFSDirectory.SimpleFSIndexInput("SimpleFSIndexInput(path=\"" + path + "\")", channel, context);
+    }
+
+    @Override
+    public void close() throws IOException {
+        isOpen = false;
+    }
+}

--- a/core/src/main/java/org/apache/lucene/store/SimpleReadOnlyFSDirectory.java
+++ b/core/src/main/java/org/apache/lucene/store/SimpleReadOnlyFSDirectory.java
@@ -18,7 +18,9 @@
  */
 package org.apache.lucene.store;
 
+import java.io.EOFException;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -80,11 +82,136 @@ public class SimpleReadOnlyFSDirectory extends BaseDirectory {
         ensureOpen();
         Path path = directory.resolve(name);
         SeekableByteChannel channel = Files.newByteChannel(path, StandardOpenOption.READ);
-        return new SimpleFSDirectory.SimpleFSIndexInput("SimpleFSIndexInput(path=\"" + path + "\")", channel, context);
+        return new SimpleFSIndexInput("SimpleFSIndexInput(path=\"" + path + "\")", channel, context);
     }
 
     @Override
     public void close() throws IOException {
         isOpen = false;
+    }
+
+    /**
+     * Copy of SimpleFSDirectory.SimpleFSIndexInput which is package-private class.
+     *
+     * Reads bytes with {@link SeekableByteChannel#read(ByteBuffer)}
+     */
+    static final class SimpleFSIndexInput extends BufferedIndexInput {
+        /**
+         * The maximum chunk size for reads of 16384 bytes.
+         */
+        private static final int CHUNK_SIZE = 16384;
+
+        /** the channel we will read from */
+        protected final SeekableByteChannel channel;
+        /** is this instance a clone and hence does not own the file to close it */
+        boolean isClone = false;
+        /** start offset: non-zero in the slice case */
+        protected final long off;
+        /** end offset (start+length) */
+        protected final long end;
+
+        private ByteBuffer byteBuf; // wraps the buffer for NIO
+
+        public SimpleFSIndexInput(String resourceDesc, SeekableByteChannel channel, IOContext context) throws IOException {
+            super(resourceDesc, context);
+            this.channel = channel;
+            this.off = 0L;
+            this.end = channel.size();
+        }
+
+        public SimpleFSIndexInput(String resourceDesc, SeekableByteChannel channel, long off, long length, int bufferSize) {
+            super(resourceDesc, bufferSize);
+            this.channel = channel;
+            this.off = off;
+            this.end = off + length;
+            this.isClone = true;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (!isClone) {
+                channel.close();
+            }
+        }
+
+        @Override
+        public SimpleFSIndexInput clone() {
+            SimpleFSIndexInput clone = (SimpleFSIndexInput)super.clone();
+            clone.isClone = true;
+            return clone;
+        }
+
+        @Override
+        public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+            if (offset < 0 || length < 0 || offset + length > this.length()) {
+                throw new IllegalArgumentException("slice() " + sliceDescription + " out of bounds: offset=" + offset + ",length=" +
+                    length + ",fileLength="  + this.length() + ": "  + this);
+            }
+            return new SimpleFSIndexInput(getFullSliceDescription(sliceDescription), channel, off + offset, length, getBufferSize());
+        }
+
+        @Override
+        public final long length() {
+            return end - off;
+        }
+
+        @Override
+        protected void newBuffer(byte[] newBuffer) {
+            super.newBuffer(newBuffer);
+            byteBuf = ByteBuffer.wrap(newBuffer);
+        }
+
+        @Override
+        protected void readInternal(byte[] b, int offset, int len) throws IOException {
+            final ByteBuffer bb;
+
+            // Determine the ByteBuffer we should use
+            if (b == buffer) {
+                // Use our own pre-wrapped byteBuf:
+                assert byteBuf != null;
+                bb = byteBuf;
+                byteBuf.clear().position(offset);
+            } else {
+                bb = ByteBuffer.wrap(b, offset, len);
+            }
+
+            synchronized(channel) {
+                long pos = getFilePointer() + off;
+
+                if (pos + len > end) {
+                    throw new EOFException("read past EOF: " + this);
+                }
+
+                try {
+                    channel.position(pos);
+
+                    int readLength = len;
+                    while (readLength > 0) {
+                        final int toRead = Math.min(CHUNK_SIZE, readLength);
+                        bb.limit(bb.position() + toRead);
+                        assert bb.remaining() == toRead;
+                        final int i = channel.read(bb);
+                        if (i < 0) { // be defensive here, even though we checked before hand, something could have changed
+                            throw new EOFException("read past EOF: " + this + " off: " + offset + " len: " + len + " pos: " + pos +
+                                " chunkLen: " + toRead + " end: " + end);
+                        }
+                        assert i > 0 : "SeekableByteChannel.read with non zero-length bb.remaining() must always read at least one byte " +
+                            "(Channel is in blocking mode, see spec of ReadableByteChannel)";
+                        pos += i;
+                        readLength -= i;
+                    }
+                    assert readLength == 0;
+                } catch (IOException ioe) {
+                    throw new IOException(ioe.getMessage() + ": " + this, ioe);
+                }
+            }
+        }
+
+        @Override
+        protected void seekInternal(long pos) throws IOException {
+            if (pos > length()) {
+                throw new EOFException("read past EOF: pos=" + pos + " vs length=" + length() + ": " + this);
+            }
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/gateway/MetaDataStateFormat.java
+++ b/core/src/main/java/org/elasticsearch/gateway/MetaDataStateFormat.java
@@ -26,7 +26,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.OutputStreamIndexOutput;
-import org.apache.lucene.store.SimpleFSDirectory;
+import org.apache.lucene.store.SimpleReadOnlyFSDirectory;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -180,7 +180,7 @@ public abstract class MetaDataStateFormat<T> {
      * the state.
      */
     public final T read(Path file) throws IOException {
-        try (Directory dir = newDirectory(file.getParent())) {
+        try (Directory dir = newReadOnlyDirectory(file.getParent())) {
             try (final IndexInput indexInput = dir.openInput(file.getFileName().toString(), IOContext.DEFAULT)) {
                  // We checksum the entire file before we even go and parse it. If it's corrupted we barf right here.
                 CodecUtil.checksumEntireFile(indexInput);
@@ -206,8 +206,8 @@ public abstract class MetaDataStateFormat<T> {
         }
     }
 
-    protected Directory newDirectory(Path dir) throws IOException {
-        return new SimpleFSDirectory(dir);
+    protected Directory newReadOnlyDirectory(Path dir) throws IOException {
+        return new SimpleReadOnlyFSDirectory(dir);
     }
 
     private void cleanupOldFiles(final String prefix, final String currentStateFile, Path[] locations) throws IOException {
@@ -287,8 +287,9 @@ public abstract class MetaDataStateFormat<T> {
                 }
             }
         }
-        final List<Throwable> exceptions = new ArrayList<>();
-        T state = null;
+        if (files.isEmpty()) {
+            return null;
+        }
         // NOTE: we might have multiple version of the latest state if there are multiple data dirs.. for this case
         //       we iterate only over the ones with the max version. If we have at least one state file that uses the
         //       new format (ie. legacy == false) then we know that the latest version state ought to use this new format.
@@ -299,10 +300,13 @@ public abstract class MetaDataStateFormat<T> {
                 .filter(new StateIdAndLegacyPredicate(maxStateId, maxStateIdIsLegacy))
                 .collect(Collectors.toCollection(ArrayList::new));
 
+        final List<Throwable> exceptions = new ArrayList<>();
+        int numFilesDeleted = 0; // number of files that were deleted after being selected above but before reading file content below
         for (PathAndStateId pathAndStateId : pathAndStateIds) {
             try {
                 final Path stateFile = pathAndStateId.file;
                 final long id = pathAndStateId.id;
+                final T state;
                 if (pathAndStateId.legacy) { // read the legacy format -- plain XContent
                     final byte[] data = Files.readAllBytes(stateFile);
                     if (data.length == 0) {
@@ -320,6 +324,10 @@ public abstract class MetaDataStateFormat<T> {
                     logger.trace("state id [{}] read from [{}]", id, stateFile.getFileName());
                 }
                 return state;
+            } catch (NoSuchFileException | FileNotFoundException ex) {
+                // was just deleted on us as we were reading this, ignore
+                numFilesDeleted++;
+                logger.debug("{}: failed to read [{}], ignoring...", ex, pathAndStateId.file.toAbsolutePath(), prefix);
             } catch (Exception e) {
                 exceptions.add(new IOException("failed to read " + pathAndStateId.toString(), e));
                 logger.debug("{}: failed to read [{}], ignoring...", e, pathAndStateId.file.toAbsolutePath(), prefix);
@@ -327,11 +335,11 @@ public abstract class MetaDataStateFormat<T> {
         }
         // if we reach this something went wrong
         ExceptionsHelper.maybeThrowRuntimeAndSuppress(exceptions);
-        if (files.size() > 0) {
+        if (files.size() > numFilesDeleted) {
             // We have some state files but none of them gave us a usable state
             throw new IllegalStateException("Could not find a state file to recover from among " + files);
         }
-        return state;
+        return null;
     }
 
     /**


### PR DESCRIPTION
If `MetaDataStateFormat.loadLatestState()` is called while the folder on which it operates is being deleted, it is possible that this method resurrects the folder. Possibly affects folders for shard state metadata, index metadata or global metadata.

Test failure showing the issue:
https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+multijob-os-compatibility/os=sles/729/console

Log snippets showing issue:

```
java.lang.AssertionError
  2>    at __randomizedtesting.SeedInfo.seed([63923DF9F1B5687D]:0)
  2>    at org.elasticsearch.env.NodeEnvironment.deleteShardDirectoryUnderLock(NodeEnvironment.java:491)
  2>    at org.elasticsearch.indices.IndicesService.deleteShardStore(IndicesService.java:664)
  2>    at org.elasticsearch.index.IndexService.onShardClose(IndexService.java:418)
  2>    at org.elasticsearch.index.IndexService.access$100(IndexService.java:97)
  2>    at org.elasticsearch.index.IndexService$StoreCloseListener.handle(IndexService.java:496)
  2>    at org.elasticsearch.index.IndexService$StoreCloseListener.handle(IndexService.java:481)
  2>    at org.elasticsearch.index.store.Store.closeInternal(Store.java:391)
  2>    at org.elasticsearch.index.store.Store.access$000(Store.java:119)
  2>    at org.elasticsearch.index.store.Store$1.closeInternal(Store.java:140)
  2>    at org.elasticsearch.common.util.concurrent.AbstractRefCounted.decRef(AbstractRefCounted.java:64)
  2>    at org.elasticsearch.index.store.Store.decRef(Store.java:373)
  2>    at org.elasticsearch.index.store.Store.close(Store.java:381)
  2>    at org.elasticsearch.index.IndexService.closeShard(IndexService.java:403)
  2>    at org.elasticsearch.index.IndexService.removeShard(IndexService.java:375)
  2>    at org.elasticsearch.index.IndexService.close(IndexService.java:236)
  2>    at org.elasticsearch.indices.IndicesService.removeIndex(IndicesService.java:504)
  2>    at org.elasticsearch.indices.IndicesService.deleteIndex(IndicesService.java:566)
  2>    at org.elasticsearch.indices.cluster.IndicesClusterStateService.deleteIndices(IndicesClusterStateService.java:244)
  2>    at org.elasticsearch.indices.cluster.IndicesClusterStateService.clusterChanged(IndicesClusterStateService.java:178)
  2>    at org.elasticsearch.cluster.service.ClusterService.runTasksForExecutor(ClusterService.java:691)
  2>    at org.elasticsearch.cluster.service.ClusterService$UpdateTask.run(ClusterService.java:855)
  2>    at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:450)
  2>    at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedEsThreadPoolExecutor.java:237)
  2>    at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:200)
  2>    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
  2>    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
  2>    at java.lang.Thread.run(Thread.java:745)
  2> REPRODUCE WITH: gradle :core:integTest -Dtests.seed=63923DF9F1B5687D -Dtests.class=org.elasticsearch.indices.state.RareClusterStateIT -Dtests.method="testUnassignedShardAndEmptyNodesInRoutingTable" -Dtests.security.manager=true -Dtests.locale=mt-MT -Dtests.timezone=Asia/Brunei
```

and 

```
 1> [2016-07-08 07:33:46,159][DEBUG][org.elasticsearch.gateway] [node_t0] /var/lib/jenkins/workspace/elastic+elasticsearch+master+multijob-os-compatibility/os/sles/core/build/testrun/integTest/J0/temp/org.elasticsearch.indices.state.RareClusterStateIT_63923DF9F1B5687D-001/tempDir-001/d0/nodes/0/indices/CZHA3myYTsCy1yArn911ow/0/_state/state-0.st: failed to read [state-], ignoring...
  1> java.nio.file.NoSuchFileException: /var/lib/jenkins/workspace/elastic+elasticsearch+master+multijob-os-compatibility/os/sles/core/build/testrun/integTest/J0/temp/org.elasticsearch.indices.state.RareClusterStateIT_63923DF9F1B5687D-001/tempDir-001/d0/nodes/0/indices/CZHA3myYTsCy1yArn911ow/0/_state/state-0.st
  1>    at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
  1>    at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
  1>    at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
  1>    at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214)
  1>    at org.apache.lucene.mockfile.FilterFileSystemProvider.newByteChannel(FilterFileSystemProvider.java:212)
  1>    at org.apache.lucene.mockfile.FilterFileSystemProvider.newByteChannel(FilterFileSystemProvider.java:212)
  1>    at org.apache.lucene.mockfile.FilterFileSystemProvider.newByteChannel(FilterFileSystemProvider.java:212)
  1>    at org.apache.lucene.mockfile.HandleTrackingFS.newByteChannel(HandleTrackingFS.java:240)
  1>    at org.apache.lucene.mockfile.FilterFileSystemProvider.newByteChannel(FilterFileSystemProvider.java:212)
  1>    at org.apache.lucene.mockfile.HandleTrackingFS.newByteChannel(HandleTrackingFS.java:240)
  1>    at java.nio.file.Files.newByteChannel(Files.java:361)
  1>    at java.nio.file.Files.newByteChannel(Files.java:407)
  1>    at org.apache.lucene.store.SimpleFSDirectory.openInput(SimpleFSDirectory.java:77)
  1>    at org.elasticsearch.gateway.MetaDataStateFormat.read(MetaDataStateFormat.java:184)
  1>    at org.elasticsearch.gateway.MetaDataStateFormat.loadLatestState(MetaDataStateFormat.java:319)
  1>    at org.elasticsearch.index.shard.ShardPath.loadShardPath(ShardPath.java:115)
  1>    at org.elasticsearch.gateway.TransportNodesListGatewayStartedShards.nodeOperation(TransportNodesListGatewayStartedShards.java:133)
  1>    at org.elasticsearch.gateway.TransportNodesListGatewayStartedShards.nodeOperation(TransportNodesListGatewayStartedShards.java:57)
  1>    at org.elasticsearch.action.support.nodes.TransportNodesAction.nodeOperation(TransportNodesAction.java:143)
  1>    at org.elasticsearch.action.support.nodes.TransportNodesAction$NodeTransportHandler.messageReceived(TransportNodesAction.java:268)
  1>    at org.elasticsearch.action.support.nodes.TransportNodesAction$NodeTransportHandler.messageReceived(TransportNodesAction.java:264)
  1>    at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:69)
  1>    at org.elasticsearch.transport.TransportService$5.doRun(TransportService.java:517)
  1>    at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:510)
  1>    at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
  1>    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
  1>    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
  1>    at java.lang.Thread.run(Thread.java:745)
```

The failing assertion checks after successful shard deletion that the shard folder has gone. It fails as the folder reappears. The reason for this is that there is still a concurrent operation on the node loading shard state metadata (triggered by async fetching).
