### PR TITLE
Fix typo on analyze.asciidoc

### DIFF
--- a/docs/reference/indices/analyze.asciidoc
+++ b/docs/reference/indices/analyze.asciidoc
@@ -70,7 +70,7 @@ can also be provided to use a different analyzer:
 curl -XGET 'localhost:9200/test/_analyze' -d '
 {
   "analyzer" : "whitespace",
-  "text : "this is a test"
+  "text" : "this is a test"
 }'
 --------------------------------------------------
 


### PR DESCRIPTION
A closing semicolon should be needed, right?
