### PR TITLE
Catch assertion errors on commit and turn it into a real exception

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/core/src/main/java/org/elasticsearch/index/store/Store.java
@@ -846,14 +846,14 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
                     logger.warn("failed to build store metadata. checking segment info integrity (with commit [{}])",
                             ex, commit == null ? "no" : "yes");
                     Lucene.checkSegmentInfoIntegrity(directory);
-                    throw ex;
                 } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException cex) {
                     cex.addSuppressed(ex);
                     throw cex;
                 } catch (Exception inner) {
-                    ex.addSuppressed(inner);
-                    throw ex;
+                    inner.addSuppressed(ex);
+                    throw inner;
                 }
+                throw ex;
             }
             return new LoadedMetadata(unmodifiableMap(builder), unmodifiableMap(commitUserDataBuilder), numDocs);
         }


### PR DESCRIPTION
Lucene IndexWriter asserts on files existing on the filesystem but
some tests throw IOException explicitly on those operatiosn such that
some tests trip asserts. We had this before on InternalEngine#ctor
and added some logic there to catch only a specific assertions based
on some excepition stack analysis. This change applies the same logic
to the IndexWriter#commit part of the engine since it can hit the same
issue.
This also fixes a self-suppression issue in Store.java.

Closes #19356
