### PR TITLE
Limit batch size when scrolling

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -192,19 +192,23 @@ public class DefaultSearchContext extends SearchContext {
         if (hasOnlySuggest() ) {
             return;
         }
-        if (scrollContext == null) {
-            long from = from() == -1 ? 0 : from();
-            long size = size() == -1 ? 10 : size();
-            long resultWindow = from + size;
-            int maxResultWindow = indexService.getIndexSettings().getMaxResultWindow();
+        long from = from() == -1 ? 0 : from();
+        long size = size() == -1 ? 10 : size();
+        long resultWindow = from + size;
+        int maxResultWindow = indexService.getIndexSettings().getMaxResultWindow();
 
-            if (resultWindow > maxResultWindow) {
+        if (resultWindow > maxResultWindow) {
+            if (scrollContext == null) {
                 throw new QueryPhaseExecutionException(this,
                         "Result window is too large, from + size must be less than or equal to: [" + maxResultWindow + "] but was ["
                                 + resultWindow + "]. See the scroll api for a more efficient way to request large data sets. "
                                 + "This limit can be set by changing the [" + IndexSettings.MAX_RESULT_WINDOW_SETTING.getKey()
                                 + "] index level setting.");
             }
+            throw new QueryPhaseExecutionException(this,
+                    "Batch size is too large, size must be less than or equal to: [" + maxResultWindow + "] but was [" + resultWindow
+                            + "]. Scroll batch sizes cost as much memory as result windows so they are controlled by the ["
+                            + IndexSettings.MAX_RESULT_WINDOW_SETTING.getKey() + "] index level setting.");
         }
         if (rescore != null) {
             int maxWindow = indexService.getIndexSettings().getMaxRescoreWindow();

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/30_limits.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/30_limits.yaml
@@ -10,11 +10,20 @@ setup:
       indices.refresh: {}
 
 ---
-"Request window limits":
+"Request window limits without scroll":
   - do:
-      catch:      /Result window is too large, from \+ size must be less than or equal to[:] \[10000\] but was \[10010\]/
+      catch:      /Result window is too large, from \+ size must be less than or equal to[:] \[10000\] but was \[10010\]\. See the scroll api for a more efficient way to request large data sets\./
       search:
         index: test_1
+        from: 10000
+
+---
+"Request window limits with scroll":
+  - do:
+      catch:      /Batch size is too large, size must be less than or equal to[:] \[10000\] but was \[10010\]\. Scroll batch sizes cost as much memory as result windows so they are controlled by the \[index.max_result_window\] index level setting\./
+      search:
+        index: test_1
+        scroll: 5m
         from: 10000
 
 ---


### PR DESCRIPTION
Limits the batch size from scrolling using the same setting as interactive
search: `index.max_result_window`.

Closes #19249
