### PR TITLE
Add callback to customize http client settings

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -37,8 +37,6 @@ import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpTrace;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.config.Registry;
-import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -91,7 +89,7 @@ public final class RestClient implements Closeable {
     private final ConcurrentMap<HttpHost, DeadHostState> blacklist = new ConcurrentHashMap<>();
     private final FailureListener failureListener;
 
-    private RestClient(CloseableHttpClient client, long maxRetryTimeoutMillis, Header[] defaultHeaders,
+    RestClient(CloseableHttpClient client, long maxRetryTimeoutMillis, Header[] defaultHeaders,
                        HttpHost[] hosts, FailureListener failureListener) {
         this.client = client;
         this.maxRetryTimeoutMillis = maxRetryTimeoutMillis;
@@ -393,10 +391,10 @@ public final class RestClient implements Closeable {
         private static final Header[] EMPTY_HEADERS = new Header[0];
 
         private final HttpHost[] hosts;
-        private CloseableHttpClient httpClient;
         private int maxRetryTimeout = DEFAULT_MAX_RETRY_TIMEOUT_MILLIS;
         private Header[] defaultHeaders = EMPTY_HEADERS;
         private FailureListener failureListener;
+        private HttpClientConfigCallback httpClientConfigCallback;
 
         /**
          * Creates a new builder instance and sets the hosts that the client will send requests to.
@@ -406,17 +404,6 @@ public final class RestClient implements Closeable {
                 throw new IllegalArgumentException("no hosts provided");
             }
             this.hosts = hosts;
-        }
-
-        /**
-         * Sets the http client. A new default one will be created if not
-         * specified, by calling {@link #createDefaultHttpClient(Registry)})}.
-         *
-         * @see CloseableHttpClient
-         */
-        public Builder setHttpClient(CloseableHttpClient httpClient) {
-            this.httpClient = httpClient;
-            return this;
         }
 
         /**
@@ -434,12 +421,10 @@ public final class RestClient implements Closeable {
         }
 
         /**
-         * Sets the default request headers, to be used when creating the default http client instance.
-         * In case the http client is set through {@link #setHttpClient(CloseableHttpClient)}, the default headers need to be
-         * set to it externally during http client construction.
+         * Sets the default request headers, to be used sent with every request unless overridden on a per request basis
          */
         public Builder setDefaultHeaders(Header[] defaultHeaders) {
-            Objects.requireNonNull(defaultHeaders, "default headers must not be null");
+            Objects.requireNonNull(defaultHeaders, "defaultHeaders must not be null");
             for (Header defaultHeader : defaultHeaders) {
                 Objects.requireNonNull(defaultHeader, "default header must not be null");
             }
@@ -451,8 +436,17 @@ public final class RestClient implements Closeable {
          * Sets the {@link FailureListener} to be notified for each request failure
          */
         public Builder setFailureListener(FailureListener failureListener) {
-            Objects.requireNonNull(failureListener, "failure listener must not be null");
+            Objects.requireNonNull(failureListener, "failureListener must not be null");
             this.failureListener = failureListener;
+            return this;
+        }
+
+        /**
+         * Sets the {@link HttpClientConfigCallback} to be used to customize http client configuration
+         */
+        public Builder setHttpClientConfigCallback(HttpClientConfigCallback httpClientConfigCallback) {
+            Objects.requireNonNull(httpClientConfigCallback, "httpClientConfigCallback must not be null");
+            this.httpClientConfigCallback = httpClientConfigCallback;
             return this;
         }
 
@@ -460,37 +454,59 @@ public final class RestClient implements Closeable {
          * Creates a new {@link RestClient} based on the provided configuration.
          */
         public RestClient build() {
-            if (httpClient == null) {
-                httpClient = createDefaultHttpClient(null);
-            }
             if (failureListener == null) {
                 failureListener = new FailureListener();
             }
+            CloseableHttpClient httpClient = createHttpClient();
             return new RestClient(httpClient, maxRetryTimeout, defaultHeaders, hosts, failureListener);
         }
 
-        /**
-         * Creates a {@link CloseableHttpClient} with default settings. Used when the http client instance is not provided.
-         *
-         * @see CloseableHttpClient
-         */
-        public static CloseableHttpClient createDefaultHttpClient(Registry<ConnectionSocketFactory> socketFactoryRegistry) {
-            PoolingHttpClientConnectionManager connectionManager;
-            if (socketFactoryRegistry == null) {
-                connectionManager = new PoolingHttpClientConnectionManager();
-            } else {
-                connectionManager = new PoolingHttpClientConnectionManager(socketFactoryRegistry);
+        private CloseableHttpClient createHttpClient() {
+            //default timeouts are all infinite
+            RequestConfig.Builder requestConfigBuilder = RequestConfig.custom().setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MILLIS)
+                    .setSocketTimeout(DEFAULT_SOCKET_TIMEOUT_MILLIS)
+                    .setConnectionRequestTimeout(DEFAULT_CONNECTION_REQUEST_TIMEOUT_MILLIS);
+
+            if (httpClientConfigCallback != null) {
+                httpClientConfigCallback.customizeDefaultRequestConfig(requestConfigBuilder);
             }
+            RequestConfig requestConfig = requestConfigBuilder.build();
+
+            PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
             //default settings may be too constraining
             connectionManager.setDefaultMaxPerRoute(10);
             connectionManager.setMaxTotal(30);
 
-            //default timeouts are all infinite
-            RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MILLIS)
-                    .setSocketTimeout(DEFAULT_SOCKET_TIMEOUT_MILLIS)
-                    .setConnectionRequestTimeout(DEFAULT_CONNECTION_REQUEST_TIMEOUT_MILLIS).build();
-            return HttpClientBuilder.create().setConnectionManager(connectionManager).setDefaultRequestConfig(requestConfig).build();
+            HttpClientBuilder httpClientBuilder = HttpClientBuilder.create().setConnectionManager(connectionManager)
+                    .setDefaultRequestConfig(requestConfig);
+
+            if (httpClientConfigCallback != null) {
+                httpClientConfigCallback.customizeHttpClient(httpClientBuilder);
+            }
+            return httpClientBuilder.build();
         }
+    }
+
+    /**
+     * Callback used to customize the {@link CloseableHttpClient} instance used by a {@link RestClient} instance.
+     * Allows to customize default {@link RequestConfig} being set to the client and any parameter that
+     * can be set through {@link HttpClientBuilder}
+     */
+    public interface HttpClientConfigCallback {
+        /**
+         * Allows to customize the {@link RequestConfig} that will be used with each request.
+         * It is common to customize the different timeout values through this method without losing any other useful default
+         * value that the {@link RestClient.Builder} sets internally.
+         */
+        void customizeDefaultRequestConfig(RequestConfig.Builder requestConfigBuilder);
+
+        /**
+         * Allows to customize the {@link CloseableHttpClient} being created and used by the {@link RestClient}.
+         * It is common to customzie the default {@link org.apache.http.client.CredentialsProvider} through this method,
+         * or the {@link org.apache.http.conn.HttpClientConnectionManager} being used without losing any other useful default
+         * value that the {@link RestClient.Builder} sets internally.
+         */
+        void customizeHttpClient(HttpClientBuilder httpClientBuilder);
     }
 
     /**

--- a/client/rest/src/main/java/org/elasticsearch/client/SSLSocketFactoryHttpConfigCallback.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/SSLSocketFactoryHttpConfigCallback.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+
+/**
+ * Helps configuring the http client when needing to communicate over ssl. It effectively replaces the connection manager
+ * with one that has ssl properly configured thanks to the provided {@link SSLConnectionSocketFactory}.
+ */
+public class SSLSocketFactoryHttpConfigCallback implements RestClient.HttpClientConfigCallback {
+
+    private final SSLConnectionSocketFactory sslSocketFactory;
+
+    public SSLSocketFactoryHttpConfigCallback(SSLConnectionSocketFactory sslSocketFactory) {
+        this.sslSocketFactory = sslSocketFactory;
+    }
+
+    @Override
+    public void customizeHttpClient(HttpClientBuilder httpClientBuilder) {
+        Registry<ConnectionSocketFactory> socketFactoryRegistry = RegistryBuilder.<ConnectionSocketFactory>create()
+                .register("http", PlainConnectionSocketFactory.getSocketFactory())
+                .register("https", sslSocketFactory).build();
+        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager(socketFactoryRegistry);
+        //default settings may be too constraining
+        connectionManager.setDefaultMaxPerRoute(10);
+        connectionManager.setMaxTotal(30);
+        httpClientBuilder.setConnectionManager(connectionManager);
+    }
+}

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientBuilderTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientBuilderTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.client;
 import com.carrotsearch.randomizedtesting.generators.RandomInts;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicHeader;
 
@@ -67,7 +68,7 @@ public class RestClientBuilderTests extends RestClientTestCase {
             RestClient.builder(new HttpHost("localhost", 9200)).setDefaultHeaders(null);
             fail("should have failed");
         } catch(NullPointerException e) {
-            assertEquals("default headers must not be null", e.getMessage());
+            assertEquals("defaultHeaders must not be null", e.getMessage());
         }
 
         try {
@@ -81,7 +82,14 @@ public class RestClientBuilderTests extends RestClientTestCase {
             RestClient.builder(new HttpHost("localhost", 9200)).setFailureListener(null);
             fail("should have failed");
         } catch(NullPointerException e) {
-            assertEquals("failure listener must not be null", e.getMessage());
+            assertEquals("failureListener must not be null", e.getMessage());
+        }
+
+        try {
+            RestClient.builder(new HttpHost("localhost", 9200)).setHttpClientConfigCallback(null);
+            fail("should have failed");
+        } catch(NullPointerException e) {
+            assertEquals("httpClientConfigCallback must not be null", e.getMessage());
         }
 
         int numNodes = RandomInts.randomIntBetween(getRandom(), 1, 5);
@@ -91,7 +99,17 @@ public class RestClientBuilderTests extends RestClientTestCase {
         }
         RestClient.Builder builder = RestClient.builder(hosts);
         if (getRandom().nextBoolean()) {
-            builder.setHttpClient(HttpClientBuilder.create().build());
+            builder.setHttpClientConfigCallback(new RestClient.HttpClientConfigCallback() {
+                @Override
+                public void customizeDefaultRequestConfig(RequestConfig.Builder requestConfigBuilder) {
+
+                }
+
+                @Override
+                public void customizeHttpClient(HttpClientBuilder httpClientBuilder) {
+
+                }
+            });
         }
         if (getRandom().nextBoolean()) {
             int numHeaders = RandomInts.randomIntBetween(getRandom(), 1, 5);

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientBuilderTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientBuilderTests.java
@@ -92,6 +92,13 @@ public class RestClientBuilderTests extends RestClientTestCase {
             assertEquals("httpClientConfigCallback must not be null", e.getMessage());
         }
 
+        try {
+            RestClient.builder(new HttpHost("localhost", 9200)).setRequestConfigCallback(null);
+            fail("should have failed");
+        } catch(NullPointerException e) {
+            assertEquals("requestConfigCallback must not be null", e.getMessage());
+        }
+
         int numNodes = RandomInts.randomIntBetween(getRandom(), 1, 5);
         HttpHost[] hosts = new HttpHost[numNodes];
         for (int i = 0; i < numNodes; i++) {
@@ -101,13 +108,14 @@ public class RestClientBuilderTests extends RestClientTestCase {
         if (getRandom().nextBoolean()) {
             builder.setHttpClientConfigCallback(new RestClient.HttpClientConfigCallback() {
                 @Override
-                public void customizeDefaultRequestConfig(RequestConfig.Builder requestConfigBuilder) {
-
-                }
-
-                @Override
                 public void customizeHttpClient(HttpClientBuilder httpClientBuilder) {
-
+                }
+            });
+        }
+        if (getRandom().nextBoolean()) {
+            builder.setRequestConfigCallback(new RestClient.RequestConfigCallback() {
+                @Override
+                public void customizeRequestConfig(RequestConfig.Builder requestConfigBuilder) {
                 }
             });
         }

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientMultipleHostsTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientMultipleHostsTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.client;
 
 import com.carrotsearch.randomizedtesting.generators.RandomInts;
+import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.ProtocolVersion;
@@ -91,7 +92,7 @@ public class RestClientMultipleHostsTests extends RestClientTestCase {
             httpHosts[i] = new HttpHost("localhost", 9200 + i);
         }
         failureListener = new TrackingFailureListener();
-        restClient = RestClient.builder(httpHosts).setHttpClient(httpClient).setFailureListener(failureListener).build();
+        restClient = new RestClient(httpClient, 10000, new Header[0], httpHosts, failureListener);
     }
 
     public void testRoundRobinOkStatusCodes() throws Exception {

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostTests.java
@@ -128,8 +128,7 @@ public class RestClientSingleHostTests extends RestClientTestCase {
         }
         httpHost = new HttpHost("localhost", 9200);
         failureListener = new TrackingFailureListener();
-        restClient = RestClient.builder(httpHost).setHttpClient(httpClient).setDefaultHeaders(defaultHeaders)
-                .setFailureListener(failureListener).build();
+        restClient = new RestClient(httpClient, 10000, defaultHeaders, new HttpHost[]{httpHost}, failureListener);
     }
 
     /**

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/HttpCompressionIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/HttpCompressionIT.java
@@ -22,7 +22,6 @@ import org.apache.http.Header;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponseInterceptor;
-import org.apache.http.client.config.RequestConfig;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicHeader;
@@ -136,10 +135,6 @@ public class HttpCompressionIT extends ESIntegTestCase {
 
         ContentEncodingHeaderExtractorConfigCallback(ContentEncodingHeaderExtractor contentEncodingHeaderExtractor) {
             this.contentEncodingHeaderExtractor = contentEncodingHeaderExtractor;
-        }
-
-        @Override
-        public void customizeDefaultRequestConfig(RequestConfig.Builder requestConfigBuilder) {
         }
 
         @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -23,7 +23,6 @@ import com.carrotsearch.randomizedtesting.annotations.TestGroup;
 import com.carrotsearch.randomizedtesting.generators.RandomInts;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import org.apache.http.HttpHost;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
@@ -2075,11 +2074,11 @@ public abstract class ESIntegTestCase extends ESTestCase {
         return restClient;
     }
 
-    protected static RestClient createRestClient(CloseableHttpClient httpClient) {
-        return createRestClient(httpClient, "http");
+    protected static RestClient createRestClient(RestClient.HttpClientConfigCallback httpClientConfigCallback) {
+        return createRestClient(httpClientConfigCallback, "http");
     }
 
-    protected static RestClient createRestClient(CloseableHttpClient httpClient, String protocol) {
+    protected static RestClient createRestClient(RestClient.HttpClientConfigCallback httpClientConfigCallback, String protocol) {
         final NodesInfoResponse nodeInfos = client().admin().cluster().prepareNodesInfo().get();
         final List<NodeInfo> nodes = nodeInfos.getNodes();
         assertFalse(nodeInfos.hasFailures());
@@ -2093,8 +2092,8 @@ public abstract class ESIntegTestCase extends ESTestCase {
             }
         }
         RestClient.Builder builder = RestClient.builder(hosts.toArray(new HttpHost[hosts.size()]));
-        if (httpClient != null) {
-            builder.setHttpClient(httpClient);
+        if (httpClientConfigCallback != null) {
+            builder.setHttpClientConfigCallback(httpClientConfigCallback);
         }
         return builder.build();
     }


### PR DESCRIPTION
The callback replaces the ability to fully replace the http client instance. By doing that, one used to lose any default that the RestClient had set for the underlying http client. Given that you'd usually override one or two things only, like a couple of timeout values, the ssl factory or the default credentials providers, it is not user friendly if by doing that users end up replacing the whole http client instance and lose any default set by us.
