### PR TITLE
Add some basic services to createComponents for plugins

### DIFF
--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -157,13 +157,11 @@ public class TransportClient extends AbstractClient {
                 resourcesToClose.add(circuitBreakerService);
                 BigArrays bigArrays = new BigArrays(settings, circuitBreakerService);
                 resourcesToClose.add(bigArrays);
-                Collection<Object> pluginComponents = pluginsService.createComponenents();
                 modules.add(settingsModule);
                 modules.add((b -> {
                     b.bind(BigArrays.class).toInstance(bigArrays);
                     b.bind(PluginsService.class).toInstance(pluginsService);
                     b.bind(CircuitBreakerService.class).toInstance(circuitBreakerService);
-                    pluginComponents.stream().forEach(p -> b.bind((Class)p.getClass()).toInstance(p));
                 }));
 
                 Injector injector = modules.createInjector();
@@ -173,9 +171,7 @@ public class TransportClient extends AbstractClient {
                 final TransportProxyClient proxy = new TransportProxyClient(settings, transportService, nodesService,
                     actionModule.getActions().values().stream().map(x -> x.getAction()).collect(Collectors.toList()));
 
-                List<LifecycleComponent> pluginLifecycleComponents = pluginComponents.stream()
-                    .filter(p -> p instanceof LifecycleComponent)
-                    .map(p -> (LifecycleComponent)p).collect(Collectors.toList());
+                List<LifecycleComponent> pluginLifecycleComponents = new ArrayList<>();
                 pluginLifecycleComponents.addAll(pluginsService.getGuiceServiceClasses().stream()
                     .map(injector::getInstance).collect(Collectors.toList()));
                 resourcesToClose.addAll(pluginLifecycleComponents);

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -303,7 +303,9 @@ public class Node implements Closeable {
             resourcesToClose.add(bigArrays);
             modules.add(settingsModule);
             client = new NodeClient(settings, threadPool);
-            Collection<Object> pluginComponents = pluginsService.createComponenents();
+            Collection<Object> pluginComponents = pluginsService.filterPlugins(Plugin.class).stream()
+                .flatMap(p -> p.createComponents(client, clusterService, threadPool).stream())
+                .collect(Collectors.toList());
             modules.add(b -> {
                     b.bind(PluginsService.class).toInstance(pluginsService);
                     b.bind(Client.class).toInstance(client);

--- a/core/src/main/java/org/elasticsearch/plugins/Plugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/Plugin.java
@@ -19,8 +19,13 @@
 
 package org.elasticsearch.plugins;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
 import org.elasticsearch.action.ActionModule;
-import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.settings.Setting;
@@ -30,10 +35,7 @@ import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.threadpool.ExecutorBuilder;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import org.elasticsearch.threadpool.ThreadPool;
 
 /**
  * An extension point allowing to plug in custom functionality.
@@ -65,13 +67,17 @@ public abstract class Plugin {
     }
 
     /**
-     * Returns components maintained by this plugin.
+     * Returns components added by this plugin.
      *
      * Any components returned that implement {@link LifecycleComponent} will have their lifecycle managed.
      * Note: To aid in the migration away from guice, all objects returned as components will be bound in guice
      * to themselves.
+     *
+     * @param client A client to make requests to the system
+     * @param clusterService A service to allow watching and updating cluster state
+     * @param threadPool A service to allow retrieving an executor to run an async action
      */
-    public Collection<Object> createComponents() {
+    public Collection<Object> createComponents(Client client, ClusterService clusterService, ThreadPool threadPool) {
         return Collections.emptyList();
     }
 

--- a/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -19,6 +19,26 @@
 
 package org.elasticsearch.plugins;
 
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import org.apache.lucene.analysis.util.CharFilterFactory;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 import org.apache.lucene.analysis.util.TokenizerFactory;
@@ -41,26 +61,6 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.threadpool.ExecutorBuilder;
-
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.io.FileSystemUtils.isAccessibleDirectory;
 
@@ -291,11 +291,6 @@ public class PluginsService extends AbstractComponent {
             services.addAll(plugin.v2().getGuiceServiceClasses());
         }
         return services;
-    }
-
-    /** Gets components from each plugin. This method should be called exactly once. */
-    public Collection<Object> createComponenents() {
-        return plugins.stream().flatMap(p -> p.v2().createComponents().stream()).collect(Collectors.toList());
     }
 
     public void onIndexModule(IndexModule indexModule) {


### PR DESCRIPTION
This adds the first few basic services needed for any plugin to create
its own components that interact with the rest of the system.

I also removed createComponents from the transport client as this does not make sense now that we are adding actual services in which do not exist in the transport client, like the cluster service.
