### PR TITLE
Make NotMasterException a first class citizen

### DIFF
--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -692,7 +692,8 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                 org.elasticsearch.index.query.QueryShardException::new, 141),
         NO_LONGER_PRIMARY_SHARD_EXCEPTION(ShardStateAction.NoLongerPrimaryShardException.class,
                 ShardStateAction.NoLongerPrimaryShardException::new, 142),
-        SCRIPT_EXCEPTION(org.elasticsearch.script.ScriptException.class, org.elasticsearch.script.ScriptException::new, 143);
+        SCRIPT_EXCEPTION(org.elasticsearch.script.ScriptException.class, org.elasticsearch.script.ScriptException::new, 143),
+        NOT_MASTER_EXCEPTION(org.elasticsearch.cluster.NotMasterException.class, org.elasticsearch.cluster.NotMasterException::new, 144);
 
 
         final Class<? extends ElasticsearchException> exceptionClass;

--- a/core/src/main/java/org/elasticsearch/cluster/NotMasterException.java
+++ b/core/src/main/java/org/elasticsearch/cluster/NotMasterException.java
@@ -19,16 +19,24 @@
 package org.elasticsearch.cluster;
 
 
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
 
 /**
  * Thrown when a node join request or a master ping reaches a node which is not
  * currently acting as a master or when a cluster state update task is to be executed
  * on a node that is no longer master.
  */
-public class NotMasterException extends IllegalStateException {
+public class NotMasterException extends ElasticsearchException {
 
     public NotMasterException(String msg) {
         super(msg);
+    }
+
+    public NotMasterException(StreamInput in) throws IOException {
+        super(in);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -791,6 +791,7 @@ public class ExceptionSerializationTests extends ESTestCase {
         ids.put(141, org.elasticsearch.index.query.QueryShardException.class);
         ids.put(142, ShardStateAction.NoLongerPrimaryShardException.class);
         ids.put(143, org.elasticsearch.script.ScriptException.class);
+        ids.put(144, org.elasticsearch.cluster.NotMasterException.class);
 
         Map<Class<? extends ElasticsearchException>, Integer> reverse = new HashMap<>();
         for (Map.Entry<Integer, Class<? extends ElasticsearchException>> entry : ids.entrySet()) {


### PR DESCRIPTION
That exception is currently serialized as its current base class IllegalStateException which confuses code supposed to deal with the stepping down of a master. This is an important exception and we should be able to serialize it correctly. This commit fixes it by moving the exception to inherit from ElasticsearchException and properly register it.

As a bonus I adapted CapturingTransport to properly simulate serialized exceptions.

See https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+multijob-os-compatibility/os=debian/751 for an example failure
