### PR TITLE
Don't recursively count children profile timings

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/profile/AbstractInternalProfileTree.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/AbstractInternalProfileTree.java
@@ -162,7 +162,7 @@ public abstract class AbstractInternalProfileTree<PB extends AbstractProfileBrea
 
         // TODO this would be better done bottom-up instead of top-down to avoid
         // calculating the same times over and over...but worth the effort?
-        long nodeTime = getNodeTime(timings, childrenProfileResults);
+        long nodeTime = getNodeTime(timings);
         String type = getTypeFromElement(element);
         String description = getDescriptionFromElement(element);
         return new ProfileResult(type, description, timings, childrenProfileResults, nodeTime);
@@ -189,19 +189,12 @@ public abstract class AbstractInternalProfileTree<PB extends AbstractProfileBrea
      *
      * @param timings
      *            A map of breakdown timing for the node
-     * @param children
-     *            All children profile results at this node
      * @return The total time at this node, inclusive of children
      */
-    private static long getNodeTime(Map<String, Long> timings, List<ProfileResult> children) {
+    private static long getNodeTime(Map<String, Long> timings) {
         long nodeTime = 0;
         for (long time : timings.values()) {
             nodeTime += time;
-        }
-
-        // Then add up our children
-        for (ProfileResult child : children) {
-            nodeTime += getNodeTime(child.getTimeBreakdown(), child.getProfiledChildren());
         }
         return nodeTime;
     }

--- a/core/src/test/java/org/elasticsearch/search/profile/query/QueryProfilerTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/query/QueryProfilerTests.java
@@ -38,8 +38,6 @@ import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.profile.ProfileResult;
-import org.elasticsearch.search.profile.query.QueryProfiler;
-import org.elasticsearch.search.profile.query.QueryTimingType;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;


### PR DESCRIPTION
The breakdown is already inclusive of children timing. Including the child times will double-count and inflate the final time.

@jpountz mind taking a quick look when you have a sec?

Closes #18693
