### PR TITLE
Show ignored errors in verbose simulate result

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ingest/TrackingResultProcessor.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/TrackingResultProcessor.java
@@ -24,7 +24,6 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -49,7 +48,7 @@ public final class TrackingResultProcessor implements Processor {
             processorResultList.add(new SimulateProcessorResult(actualProcessor.getTag(), new IngestDocument(ingestDocument)));
         } catch (Exception e) {
             if (ignoreFailure) {
-                processorResultList.add(new SimulateProcessorResult(actualProcessor.getTag(), new IngestDocument(ingestDocument)));
+                processorResultList.add(new SimulateProcessorResult(actualProcessor.getTag(), new IngestDocument(ingestDocument), e));
             } else {
                 processorResultList.add(new SimulateProcessorResult(actualProcessor.getTag(), e));
             }

--- a/core/src/test/java/org/elasticsearch/action/ingest/SimulateProcessorResultTests.java
+++ b/core/src/test/java/org/elasticsearch/action/ingest/SimulateProcessorResultTests.java
@@ -37,13 +37,18 @@ public class SimulateProcessorResultTests extends ESTestCase {
 
     public void testSerialization() throws IOException {
         String processorTag = randomAsciiOfLengthBetween(1, 10);
-        boolean isFailure = randomBoolean();
+        boolean isSuccessful = randomBoolean();
+        boolean isIgnoredException = randomBoolean();
         SimulateProcessorResult simulateProcessorResult;
-        if (isFailure) {
-            simulateProcessorResult = new SimulateProcessorResult(processorTag, new IllegalArgumentException("test"));
-        } else {
+        if (isSuccessful) {
             IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
-            simulateProcessorResult = new SimulateProcessorResult(processorTag, ingestDocument);
+            if (isIgnoredException) {
+                simulateProcessorResult = new SimulateProcessorResult(processorTag, ingestDocument, new IllegalArgumentException("test"));
+            } else {
+                simulateProcessorResult = new SimulateProcessorResult(processorTag, ingestDocument);
+            }
+        } else {
+            simulateProcessorResult = new SimulateProcessorResult(processorTag, new IllegalArgumentException("test"));
         }
 
         BytesStreamOutput out = new BytesStreamOutput();
@@ -51,13 +56,20 @@ public class SimulateProcessorResultTests extends ESTestCase {
         StreamInput streamInput = out.bytes().streamInput();
         SimulateProcessorResult otherSimulateProcessorResult = new SimulateProcessorResult(streamInput);
         assertThat(otherSimulateProcessorResult.getProcessorTag(), equalTo(simulateProcessorResult.getProcessorTag()));
-        if (isFailure) {
-            assertThat(simulateProcessorResult.getIngestDocument(), is(nullValue()));
+        if (isSuccessful) {
+            assertIngestDocument(otherSimulateProcessorResult.getIngestDocument(), simulateProcessorResult.getIngestDocument());
+            if (isIgnoredException) {
+                assertThat(otherSimulateProcessorResult.getFailure(), instanceOf(IllegalArgumentException.class));
+                IllegalArgumentException e = (IllegalArgumentException) otherSimulateProcessorResult.getFailure();
+                assertThat(e.getMessage(), equalTo("test"));
+            } else {
+                assertThat(otherSimulateProcessorResult.getFailure(), nullValue());
+            }
+        } else {
+            assertThat(otherSimulateProcessorResult.getIngestDocument(), is(nullValue()));
             assertThat(otherSimulateProcessorResult.getFailure(), instanceOf(IllegalArgumentException.class));
             IllegalArgumentException e = (IllegalArgumentException) otherSimulateProcessorResult.getFailure();
             assertThat(e.getMessage(), equalTo("test"));
-        } else {
-            assertIngestDocument(otherSimulateProcessorResult.getIngestDocument(), simulateProcessorResult.getIngestDocument());
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/ingest/TrackingResultProcessorTests.java
+++ b/core/src/test/java/org/elasticsearch/action/ingest/TrackingResultProcessorTests.java
@@ -39,6 +39,7 @@ import static org.elasticsearch.ingest.CompoundProcessor.ON_FAILURE_PROCESSOR_TY
 import static org.elasticsearch.action.ingest.TrackingResultProcessor.decorate;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class TrackingResultProcessorTests extends ESTestCase {
 
@@ -142,7 +143,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
         assertThat(testProcessor.getInvokedCounter(), equalTo(1));
         assertThat(resultList.size(), equalTo(1));
         assertThat(resultList.get(0).getIngestDocument(), equalTo(expectedResult.getIngestDocument()));
-        assertThat(resultList.get(0).getFailure(), nullValue());
+        assertThat(resultList.get(0).getFailure(), sameInstance(exception));
         assertThat(resultList.get(0).getProcessorTag(), equalTo(expectedResult.getProcessorTag()));
     }
 }

--- a/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/90_simulate.yaml
+++ b/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/90_simulate.yaml
@@ -481,7 +481,7 @@
   - match: { docs.0.processor_results.4.doc._source.status: 200 }
 
 ---
-"Test verbose simulate with ignore_failure":
+"Test verbose simulate with ignore_failure and thrown exception":
   - do:
       ingest.simulate:
         verbose: true
@@ -547,5 +547,54 @@
   - match: { docs.0.processor_results.0.doc._source.field1: "123.42 400 <foo>" }
   - match: { docs.0.processor_results.0.doc._source.status: 200 }
   - match: { docs.0.processor_results.1.tag: "rename-1" }
+  - match: { docs.0.processor_results.1.ignored_error.error.type: "illegal_argument_exception" }
+  - match: { docs.0.processor_results.1.ignored_error.error.reason: "field [foofield] doesn't exist" }
   - match: { docs.0.processor_results.1.doc._source.field1: "123.42 400 <foo>" }
   - match: { docs.0.processor_results.1.doc._source.status: 200 }
+
+---
+"Test verbose simulate with ignore_failure and no exception thrown":
+  - do:
+      ingest.simulate:
+        verbose: true
+        body: >
+          {
+            "pipeline" : {
+              "description": "_description",
+              "processors": [
+                {
+                  "set" : {
+                    "tag" : "setstatus-1",
+                    "field" : "status",
+                    "value" : 200
+                  }
+                },
+                {
+                  "rename" : {
+                    "tag" : "rename-1",
+                    "field" : "status",
+                    "target_field" : "new_status",
+                    "ignore_failure": true
+                  }
+                }
+              ]
+            },
+            "docs": [
+              {
+                "_index": "index",
+                "_type": "type",
+                "_id": "id",
+                "_source": {
+                  "field1": "123.42 400 <foo>"
+                }
+              }
+            ]
+          }
+  - length: { docs: 1 }
+  - length: { docs.0.processor_results: 2 }
+  - match: { docs.0.processor_results.0.tag: "setstatus-1" }
+  - match: { docs.0.processor_results.0.doc._source.field1: "123.42 400 <foo>" }
+  - match: { docs.0.processor_results.0.doc._source.status: 200 }
+  - length: { docs.0.processor_results.1: 2 }
+  - match: { docs.0.processor_results.1.tag: "rename-1" }
+  - match: { docs.0.processor_results.1.doc._source.new_status: 200 }


### PR DESCRIPTION
When returning verbose processor responses in ingest simulate responses... 

Exposes any exceptions that were ignored within a processor that has `ignore_failure: true` set. 

Closes #19319
