### PR TITLE
Add support for `wait_for_events` to the `_cluster/health` REST endpoint

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/Priority.java
+++ b/core/src/main/java/org/elasticsearch/common/Priority.java
@@ -22,6 +22,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
 
 /**
  *
@@ -56,7 +60,7 @@ public final class Priority implements Comparable<Priority> {
     public static final Priority NORMAL = new Priority((byte) 2);
     public static final Priority LOW = new Priority((byte) 3);
     public static final Priority LANGUID = new Priority((byte) 4);
-    private static final Priority[] values = new Priority[] { IMMEDIATE, URGENT, HIGH, NORMAL, LOW, LANGUID };
+    private static final List<Priority> values = Arrays.asList(IMMEDIATE, URGENT, HIGH, NORMAL, LOW, LANGUID);
 
     private final byte value;
 
@@ -65,9 +69,9 @@ public final class Priority implements Comparable<Priority> {
     }
 
     /**
-     * @return an array of all available priorities, sorted from the highest to the lowest.
+     * @return a list of all available priorities, sorted from the highest to the lowest.
      */
-    public static Priority[] values() {
+    public static List<Priority> values() {
         return values;
     }
 
@@ -111,6 +115,25 @@ public final class Priority implements Comparable<Priority> {
             case (byte) 3: return "LOW";
             default:
                 return "LANGUID";
+        }
+    }
+
+    public static Priority valueOf(String value) {
+        switch (value) {
+            case "IMMEDIATE":
+                return IMMEDIATE;
+            case "URGENT":
+                return URGENT;
+            case "HIGH":
+                return HIGH;
+            case "NORMAL":
+                return NORMAL;
+            case "LOW":
+                return LOW;
+            case "LANGUID":
+                return LANGUID;
+            default:
+                throw new IllegalArgumentException("no such priority: " + value);
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/health/RestClusterHealthAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/health/RestClusterHealthAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -62,6 +63,9 @@ public class RestClusterHealthAction extends BaseRestHandler {
         clusterHealthRequest.waitForRelocatingShards(request.paramAsInt("wait_for_relocating_shards", clusterHealthRequest.waitForRelocatingShards()));
         clusterHealthRequest.waitForActiveShards(request.paramAsInt("wait_for_active_shards", clusterHealthRequest.waitForActiveShards()));
         clusterHealthRequest.waitForNodes(request.param("wait_for_nodes", clusterHealthRequest.waitForNodes()));
+        if (request.param("wait_for_events") != null) {
+            clusterHealthRequest.waitForEvents(Priority.valueOf(request.param("wait_for_events").toUpperCase(Locale.ROOT)));
+        }
         client.admin().cluster().health(clusterHealthRequest, new RestStatusToXContentListener<ClusterHealthResponse>(channel));
     }
 

--- a/core/src/test/java/org/elasticsearch/cluster/service/ClusterServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/service/ClusterServiceTests.java
@@ -612,13 +612,12 @@ public class ClusterServiceTests extends ESTestCase {
         BlockingTask block = new BlockingTask(Priority.IMMEDIATE);
         clusterService.submitStateUpdateTask("test", block);
         int taskCount = randomIntBetween(5, 20);
-        Priority[] priorities = Priority.values();
 
         // will hold all the tasks in the order in which they were executed
         List<PrioritizedTask> tasks = new ArrayList<>(taskCount);
         CountDownLatch latch = new CountDownLatch(taskCount);
         for (int i = 0; i < taskCount; i++) {
-            Priority priority = priorities[randomIntBetween(0, priorities.length - 1)];
+            Priority priority = randomFrom(Priority.values());
             clusterService.submitStateUpdateTask("test", new PrioritizedTask(priority, latch, tasks));
         }
 

--- a/core/src/test/java/org/elasticsearch/common/PriorityTests.java
+++ b/core/src/test/java/org/elasticsearch/common/PriorityTests.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class PriorityTests extends ESTestCase {
+
+    public void testValueOf() {
+        for (Priority p : Priority.values()) {
+            assertSame(p, Priority.valueOf(p.toString()));
+        }
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> {
+            Priority.valueOf("foobar");
+        });
+        assertEquals("no such priority: foobar", exception.getMessage());
+    }
+
+    public void testToString() {
+        assertEquals("IMMEDIATE", Priority.IMMEDIATE.toString());
+        assertEquals("HIGH", Priority.HIGH.toString());
+        assertEquals("LANGUID", Priority.LANGUID.toString());
+        assertEquals("LOW", Priority.LOW.toString());
+        assertEquals("URGENT", Priority.URGENT.toString());
+        assertEquals("NORMAL", Priority.NORMAL.toString());
+        assertEquals(6, Priority.values().size());
+    }
+
+    public void testSerialization() throws IOException {
+        for (Priority p : Priority.values()) {
+            BytesStreamOutput out = new BytesStreamOutput();
+            Priority.writeTo(p, out);
+            Priority priority = Priority.readFrom(out.bytes().streamInput());
+            assertSame(p, priority);
+        }
+        assertSame(Priority.IMMEDIATE, Priority.fromByte((byte) -1));
+        assertSame(Priority.HIGH, Priority.fromByte((byte) 1));
+        assertSame(Priority.LANGUID, Priority.fromByte((byte) 4));
+        assertSame(Priority.LOW, Priority.fromByte((byte) 3));
+        assertSame(Priority.NORMAL, Priority.fromByte((byte) 2));
+        assertSame(Priority.URGENT,Priority.fromByte((byte) 0));
+        assertEquals(6, Priority.values().size());
+    }
+
+    public void testCompareTo() {
+        assertTrue(Priority.IMMEDIATE.compareTo(Priority.URGENT) < 0);
+        assertTrue(Priority.URGENT.compareTo(Priority.HIGH) < 0);
+        assertTrue(Priority.HIGH.compareTo(Priority.NORMAL) < 0);
+        assertTrue(Priority.NORMAL.compareTo(Priority.LOW) < 0);
+        assertTrue(Priority.LOW.compareTo(Priority.LANGUID) < 0);
+
+        assertTrue(Priority.URGENT.compareTo(Priority.IMMEDIATE) > 0);
+        assertTrue(Priority.HIGH.compareTo(Priority.URGENT) > 0);
+        assertTrue(Priority.NORMAL.compareTo(Priority.HIGH) > 0);
+        assertTrue(Priority.LOW.compareTo(Priority.NORMAL) > 0);
+        assertTrue(Priority.LANGUID.compareTo(Priority.LOW) > 0);
+
+        for (Priority p : Priority.values()) {
+            assertEquals(0, p.compareTo(p));
+        }
+        List<Priority> shuffeledAndSorted = new ArrayList<>(Priority.values());
+        Collections.shuffle(shuffeledAndSorted, random());
+        Collections.sort(shuffeledAndSorted);
+        for (List<Priority> priorities : Arrays.asList(shuffeledAndSorted,
+            Priority.values())) { // #values() guarantees order!
+            assertSame(Priority.IMMEDIATE, priorities.get(0));
+            assertSame(Priority.URGENT, priorities.get(1));
+            assertSame(Priority.HIGH, priorities.get(2));
+            assertSame(Priority.NORMAL, priorities.get(3));
+            assertSame(Priority.LOW, priorities.get(4));
+            assertSame(Priority.LANGUID, priorities.get(5));
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedExecutorsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedExecutorsTests.java
@@ -50,7 +50,7 @@ public class PrioritizedExecutorsTests extends ESTestCase {
 
     public void testPriorityQueue() throws Exception {
         PriorityBlockingQueue<Priority> queue = new PriorityBlockingQueue<>();
-        List<Priority> priorities = Arrays.asList(Priority.values());
+        List<Priority> priorities = Priority.values();
         Collections.shuffle(priorities, random());
 
         for (Priority priority : priorities) {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
@@ -38,6 +38,11 @@
           "type" : "string",
           "description" : "Wait until the specified number of nodes is available"
         },
+        "wait_for_events": {
+          "type" : "enum",
+          "options" : ["immediate", "urgent", "high", "low", "languid"],
+          "description" : "Wait until all currently queued events with the given priorty are processed"
+        },
         "wait_for_relocating_shards": {
           "type" : "number",
           "description" : "Wait until the specified number of relocating shards is finished"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
@@ -40,7 +40,7 @@
         },
         "wait_for_events": {
           "type" : "enum",
-          "options" : ["immediate", "urgent", "high", "low", "languid"],
+          "options" : ["immediate", "urgent", "high", "normal", "low", "languid"],
           "description" : "Wait until all currently queued events with the given priorty are processed"
         },
         "wait_for_relocating_shards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yaml
@@ -47,6 +47,7 @@
         wait_for_status: green
         index: source
         wait_for_relocating_shards: 0
+        wait_for_events: "languid"
 
   # now we do the actual shrink
   - do:


### PR DESCRIPTION
The Java API supports this while mostly used for tests it can also be useful in
production environments. For instance if something is automated like a settings change
and we execute some health right after it the settings update might have some consequences
like a reroute which hasn't been fully applied since the preconditions are not fulfilled yet.
For instance if not all shards started the settings update is applied but the reroute won't move
currently initializing shards like in the shrink API test. Sure this could be done by waiting for
green before but if the cluster moves shards due to some side-effects waiting for all events is
still useful. I also took the chance to add unittests to Priority.java

Closes #19419
