### PR TITLE
Make Priority an enum

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/Priority.java
+++ b/core/src/main/java/org/elasticsearch/common/Priority.java
@@ -16,28 +16,29 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch.common;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
-/**
- *
- */
-public final class Priority implements Comparable<Priority> {
+public enum Priority {
+
+    IMMEDIATE((byte) -1),
+    URGENT((byte) 0),
+    HIGH((byte) 1),
+    NORMAL((byte) 2),
+    LOW((byte) 3),
+    LANGUID((byte) 4);
 
     public static Priority readFrom(StreamInput input) throws IOException {
         return fromByte(input.readByte());
     }
 
     public static void writeTo(Priority priority, StreamOutput output) throws IOException {
-        byte b = priority.value;
-        output.writeByte(b);
+        output.writeByte(priority.value);
     }
 
     public static Priority fromByte(byte b) {
@@ -53,90 +54,18 @@ public final class Priority implements Comparable<Priority> {
         }
     }
 
-    public static final Priority IMMEDIATE = new Priority((byte) -1);
-    public static final Priority URGENT = new Priority((byte) 0);
-    public static final Priority HIGH = new Priority((byte) 1);
-    public static final Priority NORMAL = new Priority((byte) 2);
-    public static final Priority LOW = new Priority((byte) 3);
-    public static final Priority LANGUID = new Priority((byte) 4);
-    private static final List<Priority> VALUES =
-            Collections.unmodifiableList(Arrays.asList(IMMEDIATE, URGENT, HIGH, NORMAL, LOW, LANGUID));
-
     private final byte value;
 
-    private Priority(byte value) {
+    Priority(byte value) {
         this.value = value;
     }
 
-    /**
-     * All priorities, sorted from highest priority to lowest priority. The returned list is
-     * unmodifiable.
-     *
-     * @return an unmodifiable list of priorities, sorted from highest priority to lowest priority.
-     */
-    public static List<Priority> values() {
-        return VALUES;
-    }
-
-    @Override
-    public int compareTo(Priority p) {
-        return (this.value < p.value) ? -1 : ((this.value > p.value) ? 1 : 0);
-    }
-
     public boolean after(Priority p) {
-        return value > p.value;
+        return this.compareTo(p) > 0;
     }
 
     public boolean sameOrAfter(Priority p) {
-        return value >= p.value;
+        return this.compareTo(p) >= 0;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || Priority.class != o.getClass()) return false;
-
-        Priority priority = (Priority) o;
-
-        if (value != priority.value) return false;
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return (int) value;
-    }
-
-    @Override
-    public String toString() {
-        switch (value) {
-            case (byte) -1: return "IMMEDIATE";
-            case (byte) 0: return "URGENT";
-            case (byte) 1: return "HIGH";
-            case (byte) 2: return "NORMAL";
-            case (byte) 3: return "LOW";
-            default:
-                return "LANGUID";
-        }
-    }
-
-    public static Priority valueOf(String value) {
-        switch (value) {
-            case "IMMEDIATE":
-                return IMMEDIATE;
-            case "URGENT":
-                return URGENT;
-            case "HIGH":
-                return HIGH;
-            case "NORMAL":
-                return NORMAL;
-            case "LOW":
-                return LOW;
-            case "LANGUID":
-                return LANGUID;
-            default:
-                throw new IllegalArgumentException("no such priority: " + value);
-        }
-    }
 }

--- a/core/src/main/java/org/elasticsearch/common/Priority.java
+++ b/core/src/main/java/org/elasticsearch/common/Priority.java
@@ -26,12 +26,12 @@ import java.io.IOException;
 
 public enum Priority {
 
-    IMMEDIATE((byte) -1),
-    URGENT((byte) 0),
-    HIGH((byte) 1),
-    NORMAL((byte) 2),
-    LOW((byte) 3),
-    LANGUID((byte) 4);
+    IMMEDIATE((byte) 0),
+    URGENT((byte) 1),
+    HIGH((byte) 2),
+    NORMAL((byte) 3),
+    LOW((byte) 4),
+    LANGUID((byte) 5);
 
     public static Priority readFrom(StreamInput input) throws IOException {
         return fromByte(input.readByte());
@@ -43,12 +43,12 @@ public enum Priority {
 
     public static Priority fromByte(byte b) {
         switch (b) {
-            case -1: return IMMEDIATE;
-            case 0: return URGENT;
-            case 1: return HIGH;
-            case 2: return NORMAL;
-            case 3: return LOW;
-            case 4: return LANGUID;
+            case 0: return IMMEDIATE;
+            case 1: return URGENT;
+            case 2: return HIGH;
+            case 3: return NORMAL;
+            case 4: return LOW;
+            case 5: return LANGUID;
             default:
                 throw new IllegalArgumentException("can't find priority for [" + b + "]");
         }

--- a/core/src/test/java/org/elasticsearch/common/PriorityTests.java
+++ b/core/src/test/java/org/elasticsearch/common/PriorityTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -37,7 +36,7 @@ public class PriorityTests extends ESTestCase {
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> {
             Priority.valueOf("foobar");
         });
-        assertEquals("no such priority: foobar", exception.getMessage());
+        assertEquals("No enum constant org.elasticsearch.common.Priority.foobar", exception.getMessage());
     }
 
     public void testToString() {
@@ -47,7 +46,7 @@ public class PriorityTests extends ESTestCase {
         assertEquals("LOW", Priority.LOW.toString());
         assertEquals("URGENT", Priority.URGENT.toString());
         assertEquals("NORMAL", Priority.NORMAL.toString());
-        assertEquals(6, Priority.values().size());
+        assertEquals(6, Priority.values().length);
     }
 
     public void testSerialization() throws IOException {
@@ -63,7 +62,7 @@ public class PriorityTests extends ESTestCase {
         assertSame(Priority.LOW, Priority.fromByte((byte) 3));
         assertSame(Priority.NORMAL, Priority.fromByte((byte) 2));
         assertSame(Priority.URGENT,Priority.fromByte((byte) 0));
-        assertEquals(6, Priority.values().size());
+        assertEquals(6, Priority.values().length);
     }
 
     public void testCompareTo() {
@@ -82,11 +81,11 @@ public class PriorityTests extends ESTestCase {
         for (Priority p : Priority.values()) {
             assertEquals(0, p.compareTo(p));
         }
-        List<Priority> shuffeledAndSorted = new ArrayList<>(Priority.values());
+        List<Priority> shuffeledAndSorted = Arrays.asList(Priority.values());
         Collections.shuffle(shuffeledAndSorted, random());
         Collections.sort(shuffeledAndSorted);
         for (List<Priority> priorities : Arrays.asList(shuffeledAndSorted,
-            Priority.values())) { // #values() guarantees order!
+            Arrays.asList(Priority.values()))) { // #values() guarantees order!
             assertSame(Priority.IMMEDIATE, priorities.get(0));
             assertSame(Priority.URGENT, priorities.get(1));
             assertSame(Priority.HIGH, priorities.get(2));

--- a/core/src/test/java/org/elasticsearch/common/PriorityTests.java
+++ b/core/src/test/java/org/elasticsearch/common/PriorityTests.java
@@ -56,12 +56,12 @@ public class PriorityTests extends ESTestCase {
             Priority priority = Priority.readFrom(out.bytes().streamInput());
             assertSame(p, priority);
         }
-        assertSame(Priority.IMMEDIATE, Priority.fromByte((byte) -1));
-        assertSame(Priority.HIGH, Priority.fromByte((byte) 1));
-        assertSame(Priority.LANGUID, Priority.fromByte((byte) 4));
-        assertSame(Priority.LOW, Priority.fromByte((byte) 3));
-        assertSame(Priority.NORMAL, Priority.fromByte((byte) 2));
-        assertSame(Priority.URGENT,Priority.fromByte((byte) 0));
+        assertSame(Priority.IMMEDIATE, Priority.fromByte((byte) 0));
+        assertSame(Priority.HIGH, Priority.fromByte((byte) 2));
+        assertSame(Priority.LANGUID, Priority.fromByte((byte) 5));
+        assertSame(Priority.LOW, Priority.fromByte((byte) 4));
+        assertSame(Priority.NORMAL, Priority.fromByte((byte) 3));
+        assertSame(Priority.URGENT,Priority.fromByte((byte) 1));
         assertEquals(6, Priority.values().length);
     }
 

--- a/core/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedExecutorsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedExecutorsTests.java
@@ -41,16 +41,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-/**
- *
- */
 public class PrioritizedExecutorsTests extends ESTestCase {
 
     private final ThreadContext holder = new ThreadContext(Settings.EMPTY);
 
     public void testPriorityQueue() throws Exception {
         PriorityBlockingQueue<Priority> queue = new PriorityBlockingQueue<>();
-        List<Priority> priorities = new ArrayList<>(Priority.values());
+        List<Priority> priorities = Arrays.asList(Priority.values());
         Collections.shuffle(priorities, random());
 
         for (Priority priority : priorities) {


### PR DESCRIPTION
Today we have an abstraction Priority for representing
priorities. Ideally, these values are a fixed set of constants with a
well-defined ordering which sounds perfect for an enum. This commit
changes Priority so that it is an enum instead of a class.
