### PR TITLE
Removes ensureYellow() after index creation in the integration tests

### DIFF
--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainTests.java
@@ -32,7 +32,6 @@ public final class ClusterAllocationExplainTests extends ESSingleNodeTestCase {
     public void testShardExplain() throws Exception {
         client().admin().indices().prepareCreate("test")
                 .setSettings("index.number_of_shards", 1, "index.number_of_replicas", 1).get();
-        client().admin().cluster().health(Requests.clusterHealthRequest("test").waitForYellowStatus()).get();
         ClusterAllocationExplainResponse resp = client().admin().cluster().prepareAllocationExplain()
                 .setIndex("test").setShard(0).setPrimary(false).get();
 

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -120,7 +120,7 @@ public class ClusterStatsIT extends ESIntegTestCase {
         assertThat(response.getStatus(), Matchers.equalTo(ClusterHealthStatus.GREEN));
 
         prepareCreate("test1").setSettings("number_of_shards", 2, "number_of_replicas", 1).get();
-        ensureYellow();
+
         response = client().admin().cluster().prepareClusterStats().get();
         assertThat(response.getStatus(), Matchers.equalTo(ClusterHealthStatus.YELLOW));
         assertThat(response.indicesStats.getDocs().getCount(), Matchers.equalTo(0L));
@@ -161,12 +161,7 @@ public class ClusterStatsIT extends ESIntegTestCase {
     public void testValuesSmokeScreen() throws IOException, ExecutionException, InterruptedException {
         internalCluster().startNodesAsync(randomIntBetween(1, 3)).get();
         index("test1", "type", "1", "f", "f");
-        /*
-         * Ensure at least one shard is allocated otherwise the FS stats might
-         * return 0. This happens if the File#getTotalSpace() and friends is called
-         * on a directory that doesn't exist or has not yet been created.
-         */
-        ensureYellow("test1");
+
         ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
         String msg = response.toString();
         assertThat(msg, response.getTimestamp(), Matchers.greaterThan(946681200000L)); // 1 Jan 2000

--- a/core/src/test/java/org/elasticsearch/action/search/TransportSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/action/search/TransportSearchIT.java
@@ -37,7 +37,6 @@ public class TransportSearchIT extends ESIntegTestCase {
                     .setSettings(IndexMetaData.SETTING_NUMBER_OF_SHARDS, numPrimaries1));
             assertAcked(prepareCreate("test2")
                     .setSettings(IndexMetaData.SETTING_NUMBER_OF_SHARDS, numPrimaries2));
-            ensureYellow("test1", "test2");
 
             // no exception
             client().prepareSearch("test1").get();

--- a/core/src/test/java/org/elasticsearch/action/termvectors/AbstractTermVectorsTestCase.java
+++ b/core/src/test/java/org/elasticsearch/action/termvectors/AbstractTermVectorsTestCase.java
@@ -213,8 +213,6 @@ public abstract class AbstractTermVectorsTestCase extends ESIntegTestCase {
                 .put("index.analysis.analyzer.tv_test.tokenizer", "standard")
                 .putArray("index.analysis.analyzer.tv_test.filter", "type_as_payload", "lowercase");
         assertAcked(prepareCreate(index).addMapping("type1", mappingBuilder).setSettings(settings).addAlias(new Alias(alias)));
-
-        ensureYellow();
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/action/termvectors/GetTermVectorsIT.java
+++ b/core/src/test/java/org/elasticsearch/action/termvectors/GetTermVectorsIT.java
@@ -69,8 +69,6 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
                 .endObject().endObject();
         assertAcked(prepareCreate("test").addAlias(new Alias("alias")).addMapping("type1", mapping));
 
-        ensureYellow();
-
         client().prepareIndex("test", "type1", "666").setSource("field", "foo bar").execute().actionGet();
         refresh();
         for (int i = 0; i < 20; i++) {
@@ -94,8 +92,6 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
                 .endObject()
                 .endObject().endObject();
         assertAcked(prepareCreate("test").addAlias(new Alias("alias")).addMapping("type1", mapping));
-
-        ensureYellow();
 
         // when indexing a field that simply has a question mark, the term vectors will be null
         client().prepareIndex("test", "type1", "0").setSource("existingfield", "?").execute().actionGet();
@@ -121,8 +117,6 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
                 .endObject()
                 .endObject().endObject();
         assertAcked(prepareCreate("test").addAlias(new Alias("alias")).addMapping("type1", mapping));
-
-        ensureYellow();
 
         // when indexing a field that simply has a question mark, the term vectors will be null
         client().prepareIndex("test", "type1", "0").setSource("anotherexistingfield", 1).execute().actionGet();
@@ -151,8 +145,6 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
                         "field3", "type=text,index=false,term_vector=yes", // no tvs
                         "field4", "type=keyword", // yes tvs
                         "field5", "type=text,index=true")); // yes tvs
-
-        ensureYellow();
 
         List<IndexRequestBuilder> indexBuilders = new ArrayList<>();
         for (int i = 0; i < 6; i++) {
@@ -198,7 +190,6 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
                         .put(indexSettings())
                         .put("index.analysis.analyzer.tv_test.tokenizer", "whitespace")
                         .putArray("index.analysis.analyzer.tv_test.filter", "type_as_payload", "lowercase")));
-        ensureYellow();
         for (int i = 0; i < 10; i++) {
             client().prepareIndex("test", "type1", Integer.toString(i))
                     .setSource(jsonBuilder().startObject().field("field", "the quick brown fox jumps over the lazy dog")
@@ -284,7 +275,6 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
                 .setSettings(Settings.builder()
                         .put("index.analysis.analyzer.tv_test.tokenizer", "whitespace")
                         .putArray("index.analysis.analyzer.tv_test.filter", "type_as_payload", "lowercase")));
-        ensureYellow();
         for (int i = 0; i < 10; i++) {
             client().prepareIndex("test", "type1", Integer.toString(i))
                     .setSource(jsonBuilder().startObject().field("field", "the quick brown fox jumps over the lazy dog")
@@ -430,7 +420,6 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
                         .put("index.analysis.filter.my_delimited_payload_filter.delimiter", delimiter)
                         .put("index.analysis.filter.my_delimited_payload_filter.encoding", encodingString)
                         .put("index.analysis.filter.my_delimited_payload_filter.type", "delimited_payload_filter")));
-        ensureYellow();
 
         client().prepareIndex("test", "type1", Integer.toString(1))
                 .setSource(jsonBuilder().startObject().field("field", queryString).endObject()).execute().actionGet();
@@ -1068,7 +1057,6 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         assertAcked(prepareCreate("test")
                 .setSettings(settings)
                 .addMapping("type1", "tags", "type=text"));
-        ensureYellow();
 
         int numTerms = scaledRandomIntBetween(10, 50);
         logger.info("Indexing one document with tags of increasing length ...");
@@ -1106,7 +1094,6 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         assertAcked(prepareCreate("test")
                 .setSettings(settings)
                 .addMapping("type1", "tags", "type=text"));
-        ensureYellow();
 
         logger.info("Indexing one document with tags of increasing frequencies ...");
         int numTerms = scaledRandomIntBetween(10, 50);
@@ -1147,7 +1134,6 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         assertAcked(prepareCreate("test")
                 .setSettings(settings)
                 .addMapping("type1", "tags", "type=text"));
-        ensureYellow();
 
         int numDocs = scaledRandomIntBetween(10, 50); // as many terms as there are docs
         logger.info("Indexing {} documents with tags of increasing dfs ...", numDocs);

--- a/core/src/test/java/org/elasticsearch/aliases/IndexAliasesIT.java
+++ b/core/src/test/java/org/elasticsearch/aliases/IndexAliasesIT.java
@@ -951,8 +951,6 @@ public class IndexAliasesIT extends ESIntegTestCase {
         createIndex("index1");
         createIndex("index2");
 
-        ensureYellow();
-
         assertAcked(admin().indices().prepareAliases().addAlias("index1", "alias1").addAlias("index2", "alias2"));
 
         GetAliasesResponse response = admin().indices().prepareGetAliases().get();

--- a/core/src/test/java/org/elasticsearch/broadcast/BroadcastActionsIT.java
+++ b/core/src/test/java/org/elasticsearch/broadcast/BroadcastActionsIT.java
@@ -44,8 +44,6 @@ public class BroadcastActionsIT extends ESIntegTestCase {
         NumShards numShards = getNumShards("test");
 
         logger.info("Running Cluster Health");
-        ensureYellow();
-
         client().index(indexRequest("test").type("type1").id("1").source(source("1", "test"))).actionGet();
         flush();
         client().index(indexRequest("test").type("type1").id("2").source(source("2", "test"))).actionGet();

--- a/core/src/test/java/org/elasticsearch/bwcompat/BasicAnalysisBackwardCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/BasicAnalysisBackwardCompatibilityIT.java
@@ -59,7 +59,6 @@ public class BasicAnalysisBackwardCompatibilityIT extends ESBackcompatTestCase {
         assertAcked(prepareCreate("test")
                 .addMapping("type", (Object[])fields)
                 .setSettings(indexSettings()));
-        ensureYellow();
         InputOutput[] inout = new InputOutput[numFields];
         for (int i = 0; i < numFields; i++) {
             String input;

--- a/core/src/test/java/org/elasticsearch/bwcompat/BasicBackwardsCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/BasicBackwardsCompatibilityIT.java
@@ -155,7 +155,6 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
             backwardsCluster().startNewNode();
         }
         assertAcked(prepareCreate("test").setSettings(Settings.builder().put("index.routing.allocation.exclude._name", backwardsCluster().newNodePattern()).put(indexSettings())));
-        ensureYellow();
         assertAllShardsOnNodes("test", backwardsCluster().backwardsNodePattern());
         int numDocs = randomIntBetween(100, 150);
         ArrayList<String> ids = new ArrayList<>();
@@ -271,7 +270,6 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
      */
     public void testIndexUpgradeSingleNode() throws Exception {
         assertAcked(prepareCreate("test").setSettings(Settings.builder().put("index.routing.allocation.exclude._name", backwardsCluster().newNodePattern()).put(indexSettings())));
-        ensureYellow();
         int numDocs = randomIntBetween(100, 150);
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
@@ -403,7 +401,6 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
         for (; ; ) {
             indexName = "test_"+indexId++;
             createIndex(indexName);
-            ensureYellow();
             indexRandom(true,
                     client().prepareIndex(indexName, "type1", "1").setSource(jsonBuilder().startObject().startObject("obj1").field("obj1_val", "1").endObject().field("x1", "x_1").field("field1", "value1_1").field("field2", "value2_1").endObject()),
                     client().prepareIndex(indexName, "type1", "2").setSource(jsonBuilder().startObject().startObject("obj1").field("obj1_val", "1").endObject().field("x2", "x_2").field("field1", "value1_2").endObject()),
@@ -490,7 +487,6 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
 
     public void testIndexGetAndDelete() throws ExecutionException, InterruptedException {
         createIndexWithAlias();
-        ensureYellow("test");
 
         int numDocs = iterations(10, 50);
         for (int i = 0; i < numDocs; i++) {
@@ -526,7 +522,6 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
 
     public void testUpdate() {
         createIndexWithAlias();
-        ensureYellow("test");
 
         UpdateRequestBuilder updateRequestBuilder = client().prepareUpdate(indexOrAlias(), "type1", "1")
                 .setUpsert("field1", "value1").setDoc("field2", "value2");
@@ -557,7 +552,6 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
     public void testAnalyze() {
         createIndexWithAlias();
         assertAcked(client().admin().indices().preparePutMapping("test").setType("test").setSource("field", "type=text,analyzer=keyword"));
-        ensureYellow("test");
         AnalyzeResponse analyzeResponse = client().admin().indices().prepareAnalyze("this is a test").setIndex(indexOrAlias()).setField("field").get();
         assertThat(analyzeResponse.getTokens().size(), equalTo(1));
         assertThat(analyzeResponse.getTokens().get(0).getTerm(), equalTo("this is a test"));
@@ -565,7 +559,6 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
 
     public void testExplain() {
         createIndexWithAlias();
-        ensureYellow("test");
 
         client().prepareIndex(indexOrAlias(), "test", "1").setSource("field", "value1").get();
         refresh();
@@ -582,7 +575,6 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
     public void testGetTermVector() throws IOException {
         createIndexWithAlias();
         assertAcked(client().admin().indices().preparePutMapping("test").setType("type1").setSource("field", "type=text,term_vector=with_positions_offsets_payloads").get());
-        ensureYellow("test");
 
         client().prepareIndex(indexOrAlias(), "type1", "1")
                 .setSource("field", "the quick brown fox jumps over the lazy dog").get();
@@ -598,7 +590,6 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
 
     public void testIndicesStats() {
         createIndex("test");
-        ensureYellow("test");
 
         IndicesStatsResponse indicesStatsResponse = client().admin().indices().prepareStats().all().get();
         assertThat(indicesStatsResponse.getIndices().size(), equalTo(1));
@@ -607,7 +598,6 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
 
     public void testMultiGet() throws ExecutionException, InterruptedException {
         createIndexWithAlias();
-        ensureYellow("test");
 
         int numDocs = iterations(10, 50);
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[numDocs];
@@ -639,7 +629,6 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
 
     public void testScroll() throws ExecutionException, InterruptedException {
         createIndex("test");
-        ensureYellow("test");
 
         int numDocs = iterations(10, 100);
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[numDocs];

--- a/core/src/test/java/org/elasticsearch/bwcompat/TransportClientBackwardsCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/TransportClientBackwardsCompatibilityIT.java
@@ -49,7 +49,6 @@ public class TransportClientBackwardsCompatibilityIT extends ESBackcompatTestCas
             client.addTransportAddress(transportAddress);
 
             assertAcked(client.admin().indices().prepareCreate("test"));
-            ensureYellow("test");
 
             int numDocs = iterations(10, 100);
             IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[numDocs];

--- a/core/src/test/java/org/elasticsearch/consistencylevel/WriteConsistencyLevelIT.java
+++ b/core/src/test/java/org/elasticsearch/consistencylevel/WriteConsistencyLevelIT.java
@@ -22,6 +22,7 @@ package org.elasticsearch.consistencylevel;
 import org.elasticsearch.action.UnavailableShardsException;
 import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
@@ -30,6 +31,7 @@ import org.elasticsearch.test.ESIntegTestCase;
 
 import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
 import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -37,12 +39,11 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class WriteConsistencyLevelIT extends ESIntegTestCase {
     public void testWriteConsistencyLevelReplication2() throws Exception {
-        prepareCreate("test", 1, Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 2)).execute().actionGet();
+        CreateIndexResponse createIndexResponse =
+            prepareCreate("test", 1, Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 2))
+                .get();
 
-        ClusterHealthResponse clusterHealth = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForActiveShards(1).setWaitForYellowStatus().execute().actionGet();
-        logger.info("Done Cluster Health, status {}", clusterHealth.getStatus());
-        assertThat(clusterHealth.isTimedOut(), equalTo(false));
-        assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
+        assertAcked(createIndexResponse);
 
         // indexing, by default, will work (ONE consistency level)
         client().prepareIndex("test", "type1", "1").setSource(source("1", "test")).setConsistencyLevel(WriteConsistencyLevel.ONE).execute().actionGet();
@@ -59,7 +60,13 @@ public class WriteConsistencyLevelIT extends ESIntegTestCase {
 
         allowNodes("test", 2);
 
-        clusterHealth = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForActiveShards(2).setWaitForYellowStatus().execute().actionGet();
+        ClusterHealthResponse clusterHealth =
+            client().admin().cluster().prepareHealth()
+                .setWaitForEvents(Priority.LANGUID)
+                .setWaitForActiveShards(2)
+                .setWaitForYellowStatus()
+                .execute()
+                .actionGet();
         logger.info("Done Cluster Health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.YELLOW));

--- a/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
@@ -1132,7 +1132,6 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
         final List<String> allMasterEligibleNodes = masterNodes.get();
         ensureStableCluster(3);
         assertAcked(prepareCreate("test"));
-        ensureYellow();
 
         final String masterNode1 = internalCluster().getMasterName();
         NetworkPartition networkPartition = new NetworkUnresponsivePartition(masterNode1, dataNode.get(), random());

--- a/core/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/core/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -77,9 +77,6 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
                     .field("required", true).endObject().endObject().endObject())
                 .execute().actionGet();
 
-        logger.info("--> waiting for yellow status");
-        ensureYellow();
-
         logger.info("--> verify meta _routing required exists");
         MappingMetaData mappingMd = client().admin().cluster().prepareState().execute().actionGet().getState().metaData()
             .index("test").mapping("type1");
@@ -233,9 +230,6 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
 
         logger.info("--> create an index");
         client().admin().indices().prepareCreate("test").execute().actionGet();
-
-        logger.info("--> waiting for test index to be created");
-        ensureYellow();
 
         client().prepareIndex("test", "type1").setSource("field1", "value1").setTimeout("100ms").execute().actionGet();
     }

--- a/core/src/test/java/org/elasticsearch/index/IndexRequestBuilderIT.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexRequestBuilderIT.java
@@ -36,7 +36,6 @@ import static org.hamcrest.Matchers.containsString;
 public class IndexRequestBuilderIT extends ESIntegTestCase {
     public void testSetSource() throws InterruptedException, ExecutionException {
         createIndex("test");
-        ensureYellow();
         Map<String, Object> map = new HashMap<>();
         map.put("test_field", "foobar");
         IndexRequestBuilder[] builders = new IndexRequestBuilder[] {

--- a/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasIT.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasIT.java
@@ -277,7 +277,6 @@ public class IndexWithShadowReplicasIT extends ESIntegTestCase {
                 .build();
 
         prepareCreate(IDX).setSettings(idxSettings).addMapping("doc", "foo", "type=text").get();
-        ensureYellow(IDX);
         client().prepareIndex(IDX, "doc", "1").setSource("foo", "bar").get();
         client().prepareIndex(IDX, "doc", "2").setSource("foo", "bar").get();
 
@@ -335,7 +334,6 @@ public class IndexWithShadowReplicasIT extends ESIntegTestCase {
                 .build();
 
         prepareCreate(IDX).setSettings(idxSettings).addMapping("doc", "foo", "type=text").get();
-        ensureYellow(IDX);
         client().prepareIndex(IDX, "doc", "1").setSource("foo", "bar").get();
         client().prepareIndex(IDX, "doc", "2").setSource("foo", "bar").get();
 
@@ -395,7 +393,6 @@ public class IndexWithShadowReplicasIT extends ESIntegTestCase {
                 .build();
 
         prepareCreate(IDX).setSettings(idxSettings).addMapping("doc", "foo", "type=text").get();
-        ensureYellow(IDX);
         // Node1 has the primary, now node2 has the replica
         String node2 = internalCluster().startNode(nodeSettings);
         ensureGreen(IDX);
@@ -470,7 +467,6 @@ public class IndexWithShadowReplicasIT extends ESIntegTestCase {
                 .build();
 
         prepareCreate(IDX).setSettings(idxSettings).addMapping("doc", "foo", "type=text").get();
-        ensureYellow(IDX);
         // Node1 has the primary, now node2 has the replica
         String node2 = internalCluster().startNode(nodeSettings);
         ensureGreen(IDX);
@@ -859,7 +855,6 @@ public class IndexWithShadowReplicasIT extends ESIntegTestCase {
                                        .build();
 
         prepareCreate(IDX).setSettings(idxSettings).addMapping("doc", "foo", "type=text").get();
-        ensureYellow(IDX);
 
         client().prepareIndex(IDX, "doc", "1").setSource("foo", "bar").get();
         client().prepareIndex(IDX, "doc", "2").setSource("foo", "bar").get();

--- a/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalValuesMapperIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalValuesMapperIntegrationIT.java
@@ -46,7 +46,6 @@ public class ExternalValuesMapperIntegrationIT extends ESIntegTestCase {
                 .startObject("field").field("type", FakeStringFieldMapper.CONTENT_TYPE).endObject()
                 .endObject()
                 .endObject().endObject()).execute().get();
-        ensureYellow("test-idx");
 
         index("test-idx", "type", "1", XContentFactory.jsonBuilder()
             .startObject()
@@ -96,7 +95,6 @@ public class ExternalValuesMapperIntegrationIT extends ESIntegTestCase {
                     .startObject("field").field("type", ExternalMapperPlugin.EXTERNAL).endObject()
                 .endObject()
             .endObject().endObject()).execute().get();
-        ensureYellow("test-idx");
 
         index("test-idx", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
@@ -150,7 +148,6 @@ public class ExternalValuesMapperIntegrationIT extends ESIntegTestCase {
                     .endObject()
                 .endObject()
                 .endObject().endObject().endObject()).execute().get();
-        ensureYellow("test-idx");
 
         index("test-idx", "doc", "1", "f", "This is my text");
         refresh();

--- a/core/src/test/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
+++ b/core/src/test/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
@@ -80,7 +80,6 @@ public class CorruptedTranslogIT extends ESIntegTestCase {
                 .put("index.refresh_interval", "-1")
                 .put(MockEngineSupport.DISABLE_FLUSH_ON_CLOSE.getKey(), true) // never flush - always recover from translog
         ));
-        ensureYellow();
 
         // Index some documents
         int numDocs = scaledRandomIntBetween(100, 1000);

--- a/core/src/test/java/org/elasticsearch/indexing/IndexActionIT.java
+++ b/core/src/test/java/org/elasticsearch/indexing/IndexActionIT.java
@@ -59,7 +59,6 @@ public class IndexActionIT extends ESIntegTestCase {
                 builders.add(client().prepareIndex("test", "type").setSource("field", "value"));
             }
             indexRandom(true, builders);
-            ensureYellow("test");
             logger.info("verifying indexed content");
             int numOfChecks = randomIntBetween(8, 12);
             for (int j = 0; j < numOfChecks; j++) {

--- a/core/src/test/java/org/elasticsearch/indexlifecycle/IndexLifecycleActionIT.java
+++ b/core/src/test/java/org/elasticsearch/indexlifecycle/IndexLifecycleActionIT.java
@@ -26,7 +26,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
-import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -45,6 +44,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
 import static org.elasticsearch.cluster.routing.ShardRoutingState.RELOCATING;
 import static org.elasticsearch.cluster.routing.ShardRoutingState.STARTED;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -71,13 +71,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
 
         logger.info("Creating index [test]");
         CreateIndexResponse createIndexResponse = client().admin().indices().create(createIndexRequest("test").settings(settings)).actionGet();
-        assertThat(createIndexResponse.isAcknowledged(), equalTo(true));
-
-        logger.info("Running Cluster Health");
-        ClusterHealthResponse clusterHealth = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
-        logger.info("Done Cluster Health, status {}", clusterHealth.getStatus());
-        assertThat(clusterHealth.isTimedOut(), equalTo(false));
-        assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
+        assertAcked(createIndexResponse);
 
         ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
         RoutingNode routingNodeEntry1 = clusterState.getRoutingNodes().node(node1);
@@ -88,8 +82,9 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
         String server_2 = internalCluster().startNode();
 
         // first wait for 2 nodes in the cluster
-        logger.info("Running Cluster Health");
-        clusterHealth = client().admin().cluster().health(clusterHealthRequest().waitForGreenStatus().waitForNodes("2")).actionGet();
+        logger.info("Waiting for replicas to be assigned");
+        ClusterHealthResponse clusterHealth =
+            client().admin().cluster().health(clusterHealthRequest().waitForGreenStatus().waitForNodes("2")).actionGet();
         logger.info("Done Cluster Health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -123,6 +118,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
         String server_3 = internalCluster().startNode();
 
         // first wait for 3 nodes in the cluster
+        logger.info("Waiting for replicas to be assigned");
         clusterHealth = client().admin().cluster().health(clusterHealthRequest().waitForGreenStatus().waitForNodes("3")).actionGet();
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));

--- a/core/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
@@ -74,7 +74,6 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
 
     public void testSpecifiedIndexUnavailableMultipleIndices() throws Exception {
         assertAcked(prepareCreate("test1"));
-        ensureYellow();
 
         // Verify defaults
         verify(search("test1", "test2"), true);
@@ -129,7 +128,6 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
 
         options = IndicesOptions.strictExpandOpen();
         assertAcked(prepareCreate("test2"));
-        ensureYellow();
         verify(search("test1", "test2").setIndicesOptions(options), false);
         verify(msearch(options, "test1", "test2").setIndicesOptions(options), false);
         verify(clearCache("test1", "test2").setIndicesOptions(options), false);
@@ -247,7 +245,6 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         verify(getSettings("test1").setIndicesOptions(options), false);
 
         assertAcked(prepareCreate("test1"));
-        ensureYellow();
 
         options = IndicesOptions.strictExpandOpenAndForbidClosed();
         verify(search("test1").setIndicesOptions(options), false);
@@ -447,7 +444,6 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
 
     public void testAllMissingStrict() throws Exception {
         createIndex("test1");
-        ensureYellow();
         try {
             client().prepareSearch("test2")
                     .setQuery(matchAllQuery())
@@ -503,7 +499,6 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
 
     public void testDeleteIndex() throws Exception {
         createIndex("foobar");
-        ensureYellow();
 
         verify(client().admin().indices().prepareDelete("foo"), true);
         assertThat(client().admin().indices().prepareExists("foobar").get().isExists(), equalTo(true));
@@ -515,7 +510,6 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         verify(client().admin().indices().prepareDelete("_all"), false);
 
         createIndex("foo", "foobar", "bar", "barbaz");
-        ensureYellow();
 
         verify(client().admin().indices().prepareDelete("foo*"), false);
         assertThat(client().admin().indices().prepareExists("foo").get().isExists(), equalTo(false));
@@ -534,7 +528,6 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
 
     public void testPutAlias() throws Exception {
         createIndex("foobar");
-        ensureYellow();
         verify(client().admin().indices().prepareAliases().addAlias("foobar", "foobar_alias"), false);
         assertThat(client().admin().indices().prepareAliasesExist("foobar_alias").setIndices("foobar").get().exists(), equalTo(true));
 
@@ -542,7 +535,6 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
 
     public void testPutAliasWildcard() throws Exception {
         createIndex("foo", "foobar", "bar", "barbaz");
-        ensureYellow();
 
         verify(client().admin().indices().prepareAliases().addAlias("foo*", "foobar_alias"), false);
         assertThat(client().admin().indices().prepareAliasesExist("foobar_alias").setIndices("foo").get().exists(), equalTo(true));
@@ -563,7 +555,6 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         verify(client().admin().indices().preparePutMapping("_all").setType("type1").setSource("field", "type=text"), true);
 
         createIndex("foo", "foobar", "bar", "barbaz");
-        ensureYellow();
 
         verify(client().admin().indices().preparePutMapping("foo").setType("type1").setSource("field", "type=text"), false);
         assertThat(client().admin().indices().prepareGetMappings("foo").get().mappings().get("foo").get("type1"), notNullValue());

--- a/core/src/test/java/org/elasticsearch/indices/exists/indices/IndicesExistsIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/exists/indices/IndicesExistsIT.java
@@ -41,7 +41,6 @@ public class IndicesExistsIT extends ESIntegTestCase {
         assertThat(client().admin().indices().prepareExists("_all").get().isExists(), equalTo(false));
 
         createIndex("foo", "foobar", "bar", "barbaz");
-        ensureYellow();
 
         assertThat(client().admin().indices().prepareExists("foo*").get().isExists(), equalTo(true));
         assertThat(client().admin().indices().prepareExists("foobar").get().isExists(), equalTo(true));
@@ -52,7 +51,6 @@ public class IndicesExistsIT extends ESIntegTestCase {
 
     public void testIndicesExistsWithBlocks() {
         createIndex("ro");
-        ensureYellow();
 
         // Request is not blocked
         for (String blockSetting : Arrays.asList(SETTING_BLOCKS_READ, SETTING_BLOCKS_WRITE, SETTING_READ_ONLY)) {

--- a/core/src/test/java/org/elasticsearch/indices/exists/types/TypesExistsIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/exists/types/TypesExistsIT.java
@@ -18,7 +18,7 @@
  */
 package org.elasticsearch.indices.exists.types;
 
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.exists.types.TypesExistsResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -39,17 +39,16 @@ import static org.hamcrest.Matchers.equalTo;
 public class TypesExistsIT extends ESIntegTestCase {
     public void testSimple() throws Exception {
         Client client = client();
-        client.admin().indices().prepareCreate("test1")
+        CreateIndexResponse response1 = client.admin().indices().prepareCreate("test1")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").endObject().endObject())
                 .addMapping("type2", jsonBuilder().startObject().startObject("type2").endObject().endObject())
                 .execute().actionGet();
-        client.admin().indices().prepareCreate("test2")
+        CreateIndexResponse response2 = client.admin().indices().prepareCreate("test2")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").endObject().endObject())
                 .execute().actionGet();
         client.admin().indices().prepareAliases().addAlias("test1", "alias1").execute().actionGet();
-        ClusterHealthResponse healthResponse = client.admin().cluster()
-                .prepareHealth("test1", "test2").setWaitForYellowStatus().execute().actionGet();
-        assertThat(healthResponse.isTimedOut(), equalTo(false));
+        assertAcked(response1);
+        assertAcked(response2);
 
         TypesExistsResponse response = client.admin().indices().prepareTypesExists("test1").setTypes("type1").execute().actionGet();
         assertThat(response.isExists(), equalTo(true));

--- a/core/src/test/java/org/elasticsearch/indices/mapping/ConcurrentDynamicTemplateIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/mapping/ConcurrentDynamicTemplateIT.java
@@ -54,7 +54,6 @@ public class ConcurrentDynamicTemplateIT extends ESIntegTestCase {
             cluster().wipeIndices("test");
             assertAcked(prepareCreate("test")
                     .addMapping(mappingType, mapping));
-            ensureYellow();
             int numDocs = scaledRandomIntBetween(10, 100);
             final CountDownLatch latch = new CountDownLatch(numDocs);
             final List<Throwable> throwable = new CopyOnWriteArrayList<>();

--- a/core/src/test/java/org/elasticsearch/indices/mapping/SimpleGetFieldMappingsIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/mapping/SimpleGetFieldMappingsIT.java
@@ -46,10 +46,9 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 public class SimpleGetFieldMappingsIT extends ESIntegTestCase {
-    
+
     public void testGetMappingsWhereThereAreNone() {
         createIndex("index");
-        ensureYellow();
         GetFieldMappingsResponse response = client().admin().indices().prepareGetFieldMappings().get();
         assertThat(response.mappings().size(), equalTo(1));
         assertThat(response.mappings().get("index").size(), equalTo(0));
@@ -63,7 +62,7 @@ public class SimpleGetFieldMappingsIT extends ESIntegTestCase {
                 .startObject("obj").startObject("properties").startObject("subfield").field("type", "keyword").endObject().endObject().endObject()
                 .endObject().endObject().endObject();
     }
-    
+
     public void testSimpleGetFieldMappings() throws Exception {
 
         assertAcked(prepareCreate("indexa")
@@ -73,7 +72,6 @@ public class SimpleGetFieldMappingsIT extends ESIntegTestCase {
                 .addMapping("typeA", getMappingForType("typeA"))
                 .addMapping("typeB", getMappingForType("typeB")));
 
-        ensureYellow();
 
         // Get mappings by full name
         GetFieldMappingsResponse response = client().admin().indices().prepareGetFieldMappings("indexa").setTypes("typeA").setFields("field1", "obj.subfield").get();
@@ -139,7 +137,6 @@ public class SimpleGetFieldMappingsIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").addMapping("type", getMappingForType("type")));
 
         client().prepareIndex("test", "type", "1").setSource("num", 1).get();
-        ensureYellow();
 
         GetFieldMappingsResponse response = client().admin().indices().prepareGetFieldMappings().setFields("num", "field1", "obj.subfield").includeDefaults(true).get();
 
@@ -157,7 +154,6 @@ public class SimpleGetFieldMappingsIT extends ESIntegTestCase {
         assertAcked(prepareCreate("index").addMapping("type", getMappingForType("type")));
         Map<String, String> params = new HashMap<>();
         params.put("pretty", "true");
-        ensureYellow();
         GetFieldMappingsResponse response = client().admin().indices().prepareGetFieldMappings("index").setTypes("type").setFields("field1", "obj.subfield").get();
         XContentBuilder responseBuilder = XContentFactory.jsonBuilder().prettyPrint();
         responseBuilder.startObject();
@@ -189,7 +185,6 @@ public class SimpleGetFieldMappingsIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test")
                 .addMapping("typeA", getMappingForType("typeA"))
                 .addMapping("typeB", getMappingForType("typeB")));
-        ensureYellow();
 
         for (String block : Arrays.asList(SETTING_BLOCKS_READ, SETTING_BLOCKS_WRITE, SETTING_READ_ONLY)) {
             try {

--- a/core/src/test/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
@@ -255,10 +255,6 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
     public void testUpdateMappingConcurrently() throws Throwable {
         createIndex("test1", "test2");
 
-        // This is important. The test assumes all nodes are aware of all indices. Due to initializing shard throttling
-        // not all shards are allocated with the initial create index. Wait for it..
-        ensureYellow();
-
         final AtomicReference<Exception> threadException = new AtomicReference<>();
         final AtomicBoolean stop = new AtomicBoolean(false);
         Thread[] threads = new Thread[3];

--- a/core/src/test/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
@@ -22,18 +22,16 @@ package org.elasticsearch.indices.memory.breaker;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.LeafReader;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.MockEngineFactoryPlugin;
@@ -114,18 +112,20 @@ public class RandomExceptionCircuitBreakerIT extends ESIntegTestCase {
                 .put(EXCEPTION_LOW_LEVEL_RATIO_KEY, lowLevelRate)
                 .put(MockEngineSupport.WRAP_READER_RATIO.getKey(), 1.0d);
         logger.info("creating index: [test] using settings: [{}]", settings.build().getAsMap());
-        client().admin().indices().prepareCreate("test")
+        CreateIndexResponse response = client().admin().indices().prepareCreate("test")
                 .setSettings(settings)
                 .addMapping("type", mapping).execute().actionGet();
-        ClusterHealthResponse clusterHealthResponse = client().admin().cluster()
-                .health(Requests.clusterHealthRequest().waitForYellowStatus().timeout(TimeValue.timeValueSeconds(5))).get(); // it's OK to timeout here
         final int numDocs;
-        if (clusterHealthResponse.isTimedOut()) {
+        if (response.isShardsAcked() == false) {
             /* some seeds just won't let you create the index at all and we enter a ping-pong mode
              * trying one node after another etc. that is ok but we need to make sure we don't wait
              * forever when indexing documents so we set numDocs = 1 and expect all shards to fail
              * when we search below.*/
-            logger.info("ClusterHealth timed out - only index one doc and expect searches to fail");
+            if (response.isAcknowledged()) {
+                logger.info("Index creation timed out waiting for primaries to start - only index one doc and expect searches to fail");
+            } else {
+                logger.info("Index creation failed - only index one doc and expect searches to fail");
+            }
             numDocs = 1;
         } else {
             numDocs = between(10, 100);

--- a/core/src/test/java/org/elasticsearch/mget/SimpleMgetIT.java
+++ b/core/src/test/java/org/elasticsearch/mget/SimpleMgetIT.java
@@ -44,7 +44,6 @@ import static org.hamcrest.Matchers.nullValue;
 public class SimpleMgetIT extends ESIntegTestCase {
     public void testThatMgetShouldWorkWithOneIndexMissing() throws IOException {
         createIndex("test");
-        ensureYellow();
 
         client().prepareIndex("test", "test", "1").setSource(jsonBuilder().startObject().field("foo", "bar").endObject())
                 .setRefreshPolicy(IMMEDIATE).get();
@@ -86,7 +85,6 @@ public class SimpleMgetIT extends ESIntegTestCase {
                         .endObject()
                         .endObject()
                         .endObject()));
-        ensureYellow();
 
         client().prepareIndex("test", "test", "1").setParent("4").setRefreshPolicy(IMMEDIATE)
                 .setSource(jsonBuilder().startObject().field("foo", "bar").endObject())
@@ -109,7 +107,6 @@ public class SimpleMgetIT extends ESIntegTestCase {
     @SuppressWarnings("unchecked")
     public void testThatSourceFilteringIsSupported() throws Exception {
         assertAcked(prepareCreate("test").addAlias(new Alias("alias")));
-        ensureYellow();
         BytesReference sourceBytesRef = jsonBuilder().startObject()
                 .field("field", "1", "2")
                 .startObject("included").field("field", "should be seen").field("hidden_field", "should not be seen").endObject()
@@ -151,7 +148,6 @@ public class SimpleMgetIT extends ESIntegTestCase {
                 .setSettings(Settings.builder()
                         .put(indexSettings())
                         .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, between(2, DEFAULT_MAX_NUM_SHARDS))));
-        ensureYellow();
 
         final String id = routingKeyForShard("test", 0);
         final String routingOtherShard = routingKeyForShard("test", 1);

--- a/core/src/test/java/org/elasticsearch/operateAllIndices/DestructiveOperationsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/operateAllIndices/DestructiveOperationsIntegrationIT.java
@@ -74,7 +74,6 @@ public class DestructiveOperationsIntegrationIT extends ESIntegTestCase {
 
         assertAcked(client().admin().indices().prepareCreate("index1").get());
         assertAcked(client().admin().indices().prepareCreate("1index").get());
-        ensureYellow();// wait for primaries to be allocated
         // Should succeed, since no wildcards
         assertAcked(client().admin().indices().prepareClose("1index").get());
 

--- a/core/src/test/java/org/elasticsearch/recovery/FullRollingRestartIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/FullRollingRestartIT.java
@@ -121,7 +121,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         setMinimumMasterNodes(1);
         internalCluster().stopRandomDataNode();
 
-        // make sure the cluster state is green, and all has been recovered
+        // make sure the cluster state is yellow, and all has been recovered
         assertTimeout(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout(healthTimeout).setWaitForYellowStatus().setWaitForRelocatingShards(0).setWaitForNodes("1"));
 
         logger.info("--> one node left, verifying data");

--- a/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
@@ -273,9 +273,6 @@ public class RelocationIT extends ESIntegTestCase {
                         .put("index.refresh_interval", -1) // we want to control refreshes c
                 ).execute().actionGet();
 
-        // make sure the first shard is started.
-        ensureYellow();
-
         for (int i = 1; i < numberOfNodes; i++) {
             logger.info("--> starting [node_{}] ...", i);
             nodes[i] = internalCluster().startNode();
@@ -449,7 +446,6 @@ public class RelocationIT extends ESIntegTestCase {
             .put(indexSettings())
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0) // NORELEASE: set to randomInt(halfNodes - 1) once replica data loss is fixed
         ));
-        ensureYellow();
         assertAllShardsOnNodes("test", redFuture.get().toArray(new String[2]));
         int numDocs = randomIntBetween(100, 150);
         ArrayList<String> ids = new ArrayList<>();

--- a/core/src/test/java/org/elasticsearch/recovery/SimpleRecoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/SimpleRecoveryIT.java
@@ -52,9 +52,6 @@ public class SimpleRecoveryIT extends ESIntegTestCase {
 
         NumShards numShards = getNumShards("test");
 
-        logger.info("Running Cluster Health");
-        ensureYellow();
-
         client().index(indexRequest("test").type("type1").id("1").source(source("1", "test"))).actionGet();
         FlushResponse flushResponse = client().admin().indices().flush(flushRequest("test")).actionGet();
         assertThat(flushResponse.getTotalShards(), equalTo(numShards.totalNumShards));

--- a/core/src/test/java/org/elasticsearch/search/StressSearchServiceReaperIT.java
+++ b/core/src/test/java/org/elasticsearch/search/StressSearchServiceReaperIT.java
@@ -52,7 +52,6 @@ public class StressSearchServiceReaperIT extends ESIntegTestCase {
         }
         createIndex("test");
         indexRandom(true, builders);
-        ensureYellow();
         final int iterations = scaledRandomIntBetween(500, 1000);
         for (int i = 0; i < iterations; i++) {
             SearchResponse searchResponse = client().prepareSearch("test").setQuery(matchAllQuery()).setSize(num).get();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/AggregationsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/AggregationsIntegrationIT.java
@@ -41,7 +41,6 @@ public class AggregationsIntegrationIT extends ESIntegTestCase {
     @Override
     public void setupSuiteScopeCluster() throws Exception {
         assertAcked(prepareCreate("index").addMapping("type", "f", "type=keyword").get());
-        ensureYellow("index");
         numDocs = randomIntBetween(1, 20);
         List<IndexRequestBuilder> docs = new ArrayList<>();
         for (int i = 0; i < numDocs; ++i) {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/EquivalenceIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/EquivalenceIT.java
@@ -409,7 +409,6 @@ public class EquivalenceIT extends ESIntegTestCase {
         createIndex("idx");
         final int value = randomIntBetween(0, 10);
         indexRandom(true, client().prepareIndex("idx", "type").setSource("f", value));
-        ensureYellow("idx"); // only one document let's make sure all shards have an active primary
         SearchResponse response = client().prepareSearch("idx")
                 .addAggregation(filter("filter", QueryBuilders.matchAllQuery())
                 .subAggregation(range("range")

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
@@ -451,7 +451,6 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
     public void testScriptScore() throws ExecutionException, InterruptedException, IOException {
         indexRandomFrequencies01(randomBoolean() ? "text" : "long");
         ScriptHeuristic scriptHeuristic = getScriptSignificanceHeuristic();
-        ensureYellow();
         SearchResponse response = client().prepareSearch(INDEX_NAME)
                 .addAggregation(terms("class").field(CLASS_FIELD)
                         .subAggregation(significantTerms("mySignificantTerms")

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsShardMinDocCountIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsShardMinDocCountIT.java
@@ -59,7 +59,6 @@ public class TermsShardMinDocCountIT extends ESIntegTestCase {
         }
         assertAcked(prepareCreate(index).setSettings(SETTING_NUMBER_OF_SHARDS, 1, SETTING_NUMBER_OF_REPLICAS, 0)
                 .addMapping(type, "text", textMappings));
-        ensureYellow(index);
         List<IndexRequestBuilder> indexBuilders = new ArrayList<>();
 
         addTermsDocs("1", 1, 0, indexBuilders);//high score but low doc freq
@@ -119,7 +118,6 @@ public class TermsShardMinDocCountIT extends ESIntegTestCase {
             termMappings += ",fielddata=true";
         }
         assertAcked(prepareCreate(index).setSettings(SETTING_NUMBER_OF_SHARDS, 1, SETTING_NUMBER_OF_REPLICAS, 0).addMapping(type, "text", termMappings));
-        ensureYellow(index);
         List<IndexRequestBuilder> indexBuilders = new ArrayList<>();
 
         addTermsDocs("1", 1, indexBuilders);//low doc freq but high score

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/DerivativeIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/DerivativeIT.java
@@ -619,7 +619,6 @@ public class DerivativeIT extends ESIntegTestCase {
 
     public void testAvgMovavgDerivNPE() throws Exception {
         createIndex("movavg_npe");
-        ensureYellow("movavg_npe");
 
         for (int i = 0; i < 10; i++) {
             Integer value = i;

--- a/core/src/test/java/org/elasticsearch/search/basic/TransportSearchFailuresIT.java
+++ b/core/src/test/java/org/elasticsearch/search/basic/TransportSearchFailuresIT.java
@@ -54,7 +54,6 @@ public class TransportSearchFailuresIT extends ESIntegTestCase {
     public void testFailedSearchWithWrongQuery() throws Exception {
         logger.info("Start Testing failed search with wrong query");
         assertAcked(prepareCreate("test", 1));
-        ensureYellow();
 
         NumShards test = getNumShards("test");
 

--- a/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginIT.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginIT.java
@@ -80,7 +80,6 @@ public class FetchSubPhasePluginIT extends ESIntegTestCase {
                                 .endObject()
                                 .endObject()
                                 .endObject().endObject()).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
 
         client().index(
                 indexRequest("test").type("type1").id("1")

--- a/core/src/test/java/org/elasticsearch/search/functionscore/DecayFunctionScoreIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/DecayFunctionScoreIT.java
@@ -86,7 +86,6 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
                 "type1",
                 jsonBuilder().startObject().startObject("type1").startObject("properties").startObject("test").field("type", "text")
                         .endObject().startObject("loc").field("type", "geo_point").endObject().endObject().endObject().endObject()));
-        ensureYellow();
 
         List<IndexRequestBuilder> indexBuilders = new ArrayList<>();
         indexBuilders.add(client().prepareIndex()
@@ -184,7 +183,6 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
                 "type1",
                 jsonBuilder().startObject().startObject("type1").startObject("properties").startObject("test").field("type", "text")
                         .endObject().startObject("num").field("type", "double").endObject().endObject().endObject().endObject()));
-        ensureYellow();
 
         // add tw docs within offset
         List<IndexRequestBuilder> indexBuilders = new ArrayList<>();
@@ -267,7 +265,6 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
                             .endObject()
                         .endObject()
                     .endObject()));
-        ensureYellow();
 
         List<IndexRequestBuilder> indexBuilders = new ArrayList<>();
         indexBuilders.add(client().prepareIndex()
@@ -321,7 +318,6 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
                 "type1",
                 jsonBuilder().startObject().startObject("type1").startObject("properties").startObject("test").field("type", "text")
                         .endObject().startObject("loc").field("type", "geo_point").endObject().endObject().endObject().endObject()));
-        ensureYellow();
 
         client().prepareIndex()
                 .setType("type1")
@@ -367,7 +363,6 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
                 "type1",
                 jsonBuilder().startObject().startObject("type1").startObject("properties").startObject("test").field("type", "text")
                         .endObject().startObject("num").field("type", "double").endObject().endObject().endObject().endObject()));
-        ensureYellow();
 
         client().prepareIndex().setType("type1").setId("1").setIndex("test").setRefreshPolicy(IMMEDIATE)
                 .setSource(jsonBuilder().startObject().field("test", "value value").field("num", 1.0).endObject()).get();
@@ -448,7 +443,6 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
                 "type1",
                 jsonBuilder().startObject().startObject("type1").startObject("properties").startObject("test").field("type", "text")
                         .endObject().startObject("num1").field("type", "date").endObject().endObject().endObject().endObject()));
-        ensureYellow();
         client().index(
                 indexRequest("test").type("type1").id("1")
                         .source(jsonBuilder().startObject().field("test", "value").field("num1", "2013-05-27").endObject())).actionGet();
@@ -485,7 +479,6 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
                         .endObject()
                     .endObject()
                 .endObject()));
-        ensureYellow();
         client().index(indexRequest("test").type("type1").id("1")
                 .source(jsonBuilder().startObject().field("test", "value").field("num1", System.currentTimeMillis()).endObject()))
                 .actionGet();
@@ -519,7 +512,6 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
                         .endObject().endObject().endObject().endObject())
         );
 
-        ensureYellow();
 
         client().index(
                 indexRequest("test").type("type1").id("1")
@@ -567,7 +559,6 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
                 "type1",
                 jsonBuilder().startObject().startObject("type1").startObject("properties").startObject("test").field("type", "text")
                         .endObject().startObject("num1").field("type", "date").endObject().endObject().endObject().endObject()));
-        ensureYellow();
 
         DateTime docDate = dt.minusDays(1);
         String docDateString = docDate.getYear() + "-" + String.format(Locale.ROOT, "%02d", docDate.getMonthOfYear()) + "-"
@@ -625,7 +616,6 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
         }
         xContentBuilder.endObject().endObject().endObject().endObject();
         assertAcked(prepareCreate("test").setSettings(settings).addMapping("type", xContentBuilder.string()));
-        ensureYellow();
         int numDocs = 200;
         List<IndexRequestBuilder> indexBuilders = new ArrayList<>();
 
@@ -675,7 +665,6 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
                 "type",
                 jsonBuilder().startObject().startObject("type").startObject("properties").startObject("test").field("type", "text")
                         .endObject().startObject("geo").field("type", "geo_point").endObject().endObject().endObject().endObject()));
-        ensureYellow();
         int numDocs = 2;
         client().index(
                 indexRequest("test").type("type").source(
@@ -704,7 +693,6 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
                 "type",
                 jsonBuilder().startObject().startObject("type").startObject("properties").startObject("test").field("type", "text")
                         .endObject().startObject("num").field("type", "text").endObject().endObject().endObject().endObject()));
-        ensureYellow();
         client().index(
                 indexRequest("test").type("type").source(
                         jsonBuilder().startObject().field("test", "value").field("num", Integer.toString(1)).endObject())).actionGet();
@@ -726,7 +714,6 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
                 "type",
                 jsonBuilder().startObject().startObject("type").startObject("properties").startObject("test").field("type", "text")
                         .endObject().startObject("num").field("type", "double").endObject().endObject().endObject().endObject()));
-        ensureYellow();
         client().index(
                 indexRequest("test").type("type").source(jsonBuilder().startObject().field("test", "value").field("num", 1.0).endObject()))
                 .actionGet();
@@ -752,7 +739,6 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
                         .endObject()
                     .endObject()
                 .endObject()));
-        ensureYellow();
 
         // Index for testing MIN and MAX
         IndexRequestBuilder doc1 = client().prepareIndex().setType("type1").setId("1").setIndex("test")

--- a/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreBackwardCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreBackwardCompatibilityIT.java
@@ -64,7 +64,6 @@ public class FunctionScoreBackwardCompatibilityIT extends ESBackcompatTestCase {
                         .endObject()
                         .endObject()
                         .endObject()));
-        ensureYellow();
 
         int numDocs = 10;
         String[] ids = new String[numDocs];

--- a/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueIT.java
@@ -55,7 +55,6 @@ public class FunctionScoreFieldValueIT extends ESIntegTestCase {
                         .endObject()
                         .endObject()
                         .endObject()).get());
-        ensureYellow();
 
         client().prepareIndex("test", "type1", "1").setSource("test", 5, "body", "foo").get();
         client().prepareIndex("test", "type1", "2").setSource("test", 17, "body", "foo").get();

--- a/core/src/test/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
@@ -80,7 +80,6 @@ public class QueryRescorerIT extends ESIntegTestCase {
         for (int i = 0; i < iters; i ++) {
             client().prepareIndex("test", "type", Integer.toString(i)).setSource("f", Integer.toString(i)).execute().actionGet();
         }
-        ensureYellow();
         refresh();
 
         int numShards = getNumShards("test").numPrimaries;
@@ -118,7 +117,6 @@ public class QueryRescorerIT extends ESIntegTestCase {
         client().prepareIndex("test", "type1", "2").setSource("field1", "the quick lazy huge brown fox jumps over the tree ").get();
         client().prepareIndex("test", "type1", "3")
                 .setSource("field1", "quick huge brown", "field2", "the quick lazy huge brown fox jumps over the tree").get();
-        ensureYellow();
         refresh();
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
@@ -182,7 +180,6 @@ public class QueryRescorerIT extends ESIntegTestCase {
         client().admin().indices().prepareRefresh("test").execute().actionGet();
         client().prepareIndex("test", "type1", "11").setSource("field1", "2st street boston massachusetts").execute().actionGet();
         client().prepareIndex("test", "type1", "12").setSource("field1", "3st street boston massachusetts").execute().actionGet();
-        ensureYellow();
         client().admin().indices().prepareRefresh("test").execute().actionGet();
         SearchResponse searchResponse = client()
                 .prepareSearch()
@@ -249,7 +246,6 @@ public class QueryRescorerIT extends ESIntegTestCase {
         client().admin().indices().prepareRefresh("test").execute().actionGet();
         client().prepareIndex("test", "type1", "1").setSource("field1", "lexington massachusetts avenue").execute().actionGet();
         client().prepareIndex("test", "type1", "2").setSource("field1", "lexington avenue boston massachusetts road").execute().actionGet();
-        ensureYellow();
         client().admin().indices().prepareRefresh("test").execute().actionGet();
 
         SearchResponse searchResponse = client()
@@ -319,7 +315,6 @@ public class QueryRescorerIT extends ESIntegTestCase {
         client().admin().indices().prepareRefresh("test").execute().actionGet();
         client().prepareIndex("test", "type1", "1").setSource("field1", "lexington massachusetts avenue").execute().actionGet();
         client().prepareIndex("test", "type1", "2").setSource("field1", "lexington avenue boston massachusetts road").execute().actionGet();
-        ensureYellow();
         client().admin().indices().prepareRefresh("test").execute().actionGet();
 
         SearchResponse searchResponse = client()
@@ -487,7 +482,6 @@ public class QueryRescorerIT extends ESIntegTestCase {
         client().prepareIndex("test", "type1", "3")
                 .setSource("field1", "quick huge brown", "field2", "the quick lazy huge brown fox jumps over the tree").execute()
                 .actionGet();
-        ensureYellow();
         refresh();
 
         {

--- a/core/src/test/java/org/elasticsearch/search/highlight/CustomHighlighterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/CustomHighlighterSearchIT.java
@@ -52,7 +52,6 @@ public class CustomHighlighterSearchIT extends ESIntegTestCase {
                         "name", "arbitrary content", "other_name", "foo", "other_other_name", "bar"),
                 client().prepareIndex("test", "test", "2").setSource(
                         "other_name", "foo", "other_other_name", "bar"));
-        ensureYellow();
     }
 
     public void testThatCustomHighlightersAreSupported() throws IOException {

--- a/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchIT.java
@@ -115,7 +115,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         mappings.endObject();
         assertAcked(prepareCreate("test")
                 .addMapping("type", mappings));
-        ensureYellow();
         client().prepareIndex("test", "type", "1")
                 .setSource(jsonBuilder().startObject().field("text", "text").endObject())
                 .get();
@@ -151,7 +150,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         mappings.endObject();
         assertAcked(prepareCreate("test")
                 .addMapping("type", mappings));
-        ensureYellow();
         client().prepareIndex("test", "type", "1")
                 .setSource(jsonBuilder().startObject().field("unstored_text", "text").field("text", "text").endObject())
                 .get();
@@ -170,7 +168,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
     public void testHighTermFrequencyDoc() throws IOException {
         assertAcked(prepareCreate("test")
                 .addMapping("test", "name", "type=text,term_vector=with_positions_offsets,store=" + randomBoolean()));
-        ensureYellow();
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < 6000; i++) {
             builder.append("abc").append(" ");
@@ -229,7 +226,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                         .putArray("analysis.analyzer.autocomplete.filter", "lowercase", "wordDelimiter")
                         .put("analysis.analyzer.search_autocomplete.tokenizer", "whitespace")
                         .putArray("analysis.analyzer.search_autocomplete.filter", "lowercase", "wordDelimiter")));
-        ensureYellow();
         client().prepareIndex("test", "test", "1")
             .setSource("name", "ARCOTEL Hotels Deutschland").get();
         refresh();
@@ -332,7 +328,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .addMapping("type1",
                         "no_long_term", "type=text,term_vector=with_positions_offsets",
                         "long_term", "type=text,term_vector=with_positions_offsets"));
-        ensureYellow();
 
         client().prepareIndex("test", "type1", "1")
                 .setSource("no_long_term", "This is a test where foo is highlighed and should be highlighted",
@@ -367,7 +362,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                         .startObject("title").field("type", "text").field("store", false).field("term_vector", "no").endObject()
                         .startObject("attachments").startObject("properties").startObject("body").field("type", "text").field("store", false).field("term_vector", "no").endObject().endObject().endObject()
                         .endObject().endObject().endObject()));
-        ensureYellow();
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < indexRequestBuilders.length; i++) {
@@ -406,7 +400,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                         .startObject("title").field("type", "text").field("store", false).field("term_vector", "with_positions_offsets").endObject()
                         .startObject("attachments").startObject("properties").startObject("body").field("type", "text").field("store", false).field("term_vector", "with_positions_offsets").endObject().endObject().endObject()
                         .endObject().endObject().endObject()));
-        ensureYellow();
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < indexRequestBuilders.length; i++) {
@@ -445,7 +438,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                         .startObject("title").field("type", "text").field("store", false).field("index_options", "offsets").endObject()
                         .startObject("attachments").startObject("properties").startObject("body").field("type", "text").field("store", false).field("index_options", "offsets").endObject().endObject().endObject()
                         .endObject().endObject().endObject()));
-        ensureYellow();
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < indexRequestBuilders.length; i++) {
@@ -492,7 +484,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
     public void testHighlightIssue1994() throws Exception {
         assertAcked(prepareCreate("test")
                 .addMapping("type1", "title", "type=text,store=false", "titleTV", "type=text,store=false,term_vector=with_positions_offsets"));
-        ensureYellow();
 
         indexRandom(false, client().prepareIndex("test", "type1", "1")
                 .setSource("title", new String[]{"This is a test on the highlighting bug present in elasticsearch", "The bug is bugging us"},
@@ -1006,7 +997,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
     public void testSameContent() throws Exception {
         assertAcked(prepareCreate("test")
                 .addMapping("type1", "title", "type=text,store=true,term_vector=with_positions_offsets"));
-        ensureYellow();
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
@@ -1028,7 +1018,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
     public void testFastVectorHighlighterOffsetParameter() throws Exception {
         assertAcked(prepareCreate("test")
                 .addMapping("type1", "title", "type=text,store=true,term_vector=with_positions_offsets").get());
-        ensureYellow();
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
@@ -1051,7 +1040,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
     public void testEscapeHtml() throws Exception {
         assertAcked(prepareCreate("test")
                 .addMapping("type1", "title", "type=text,store=true"));
-        ensureYellow();
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < indexRequestBuilders.length; i++) {
@@ -1073,7 +1061,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
     public void testEscapeHtmlVector() throws Exception {
         assertAcked(prepareCreate("test")
                 .addMapping("type1", "title", "type=text,store=true,term_vector=with_positions_offsets"));
-        ensureYellow();
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
@@ -2098,7 +2085,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
     public void testPostingsHighlighterEscapeHtml() throws Exception {
         assertAcked(prepareCreate("test")
                 .addMapping("type1", "title", "type=text," + randomStoreField() + "index_options=offsets"));
-        ensureYellow();
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
@@ -2578,7 +2564,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         mappings.endObject();
         assertAcked(prepareCreate("test")
             .addMapping("type", mappings));
-        ensureYellow();
 
         client().prepareIndex("test", "type", "1")
             .setSource(jsonBuilder().startObject().field("text", "Arbitrary text field which will should not cause a failure").endObject())
@@ -2610,7 +2595,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         mappings.endObject();
         assertAcked(prepareCreate("test")
             .addMapping("type", mappings));
-        ensureYellow();
 
         client().prepareIndex("test", "type", "1")
             .setSource(jsonBuilder().startObject().field("keyword_field", "some text").endObject())
@@ -2639,7 +2623,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test")
             .addMapping("type", mappings)
         .setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_2_3_2)));
-        ensureYellow();
 
         client().prepareIndex("test", "type", "1")
             .setSource(jsonBuilder().startObject().field("string_field", "some text").endObject())

--- a/core/src/test/java/org/elasticsearch/search/query/ExistsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/ExistsIT.java
@@ -47,7 +47,6 @@ public class ExistsIT extends ESIntegTestCase {
     // TODO: move this to a unit test somewhere...
     public void testEmptyIndex() throws Exception {
         createIndex("test");
-        ensureYellow("test");
         SearchResponse resp = client().prepareSearch("test").setQuery(QueryBuilders.existsQuery("foo")).execute().actionGet();
         assertSearchResponse(resp);
         resp = client().prepareSearch("test").setQuery(QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery("foo"))).execute().actionGet();
@@ -118,7 +117,6 @@ public class ExistsIT extends ESIntegTestCase {
         expected.put("bar.bar.bar", 1);
         expected.put("foobar", 0);
 
-        ensureYellow("idx");
         final long numDocs = sources.length;
         SearchResponse allDocs = client().prepareSearch("idx").setSize(sources.length).get();
         assertSearchResponse(allDocs);

--- a/core/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -94,7 +94,6 @@ public class FieldSortIT extends ESIntegTestCase {
                 client().prepareIndex("test_" + i, "foo", "" + i).setSource("{\"entry\": " + i + "}").get();
             }
         }
-        ensureYellow();
         refresh();
         // sort DESC
         SearchResponse searchResponse = client().prepareSearch()
@@ -146,7 +145,6 @@ public class FieldSortIT extends ESIntegTestCase {
         }
         int docs = builders.size();
         indexRandom(true, builders);
-        ensureYellow();
         SearchResponse allDocsResponse = client().prepareSearch().setQuery(
                 QueryBuilders.boolQuery().must(QueryBuilders.termQuery("foo", "bar")).must(
                         QueryBuilders.rangeQuery("timeUpdated").gte("2014/0" + randomIntBetween(1, 7) + "/01")))
@@ -858,7 +856,6 @@ public class FieldSortIT extends ESIntegTestCase {
 
     public void testIgnoreUnmapped() throws Exception {
         createIndex("test");
-        ensureYellow();
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .field("id", "1")
@@ -889,7 +886,7 @@ public class FieldSortIT extends ESIntegTestCase {
 
     public void testSortMVField() throws Exception {
         assertAcked(prepareCreate("test")
-.addMapping("type1",
+                        .addMapping("type1",
                 XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties").startObject("long_values")
                         .field("type", "long").endObject().startObject("int_values").field("type", "integer").endObject()
                         .startObject("short_values").field("type", "short").endObject().startObject("byte_values")

--- a/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderIT.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderIT.java
@@ -86,7 +86,6 @@ public class GeoDistanceSortBuilderIT extends ESIntegTestCase {
         indexRandom(true,
                 client().prepareIndex("index", "type", "d1").setSource(d1Builder),
                 client().prepareIndex("index", "type", "d2").setSource(d2Builder));
-        ensureYellow();
         GeoPoint[] q = new GeoPoint[2];
         if (randomBoolean()) {
             q[0] = new GeoPoint(2, 1);
@@ -152,7 +151,6 @@ public class GeoDistanceSortBuilderIT extends ESIntegTestCase {
         indexRandom(true,
                 client().prepareIndex("index", "type", "d1").setSource(d1Builder),
                 client().prepareIndex("index", "type", "d2").setSource(d2Builder));
-        ensureYellow();
         GeoPoint q = new GeoPoint(0,0);
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -211,7 +209,6 @@ public class GeoDistanceSortBuilderIT extends ESIntegTestCase {
         indexRandom(true,
                 client().prepareIndex("index", "type", "d1").setSource(d1Builder),
                 client().prepareIndex("index", "type", "d2").setSource(d2Builder));
-        ensureYellow();
 
         List<String> qHashes = new ArrayList<>();
         List<GeoPoint> qPoints = new ArrayList<>();
@@ -260,7 +257,6 @@ public class GeoDistanceSortBuilderIT extends ESIntegTestCase {
         indexRandom(true,
                 client().prepareIndex("index", "type", "d1").setSource(jsonBuilder().startObject().startObject(LOCATION_FIELD).field("lat", 1).field("lon", 1).endObject().endObject()),
                 client().prepareIndex("index", "type", "d2").setSource(jsonBuilder().startObject().startObject(LOCATION_FIELD).field("lat", 1).field("lon", 2).endObject().endObject()));
-        ensureYellow();
 
         String hashPoint = "s037ms06g7h0";
 
@@ -341,8 +337,6 @@ public class GeoDistanceSortBuilderIT extends ESIntegTestCase {
         indexRandom(true,
                 client().prepareIndex("test1", "type").setSource("str_field", "bcd", "long_field", 3, "double_field", 0.65),
                 client().prepareIndex("test2", "type").setSource());
-
-        ensureYellow("test1", "test2");
 
         SearchResponse resp = client().prepareSearch("test1", "test2")
                 .addSort(fieldSort("str_field").order(SortOrder.ASC).unmappedType("keyword"))

--- a/core/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearch2xIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearch2xIT.java
@@ -923,7 +923,6 @@ public class CompletionSuggestSearch2xIT extends ESIntegTestCase {
                 .endObject().endObject()
                 .endObject())
             .get());
-        ensureYellow();
     }
 
     private void createIndexAndMapping(CompletionMappingBuilder completionMappingBuilder) throws IOException {
@@ -1067,7 +1066,6 @@ public class CompletionSuggestSearch2xIT extends ESIntegTestCase {
                 .endObject()
                 .endObject().endObject()
                 .endObject()).get());
-        ensureYellow();
         // can cause stack overflow without the default max_input_length
         String longString = replaceReservedChars(randomRealisticUnicodeOfLength(randomIntBetween(5000, 10000)), (char) 0x01);
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
@@ -1088,7 +1086,6 @@ public class CompletionSuggestSearch2xIT extends ESIntegTestCase {
             .endObject()
             .endObject().endObject()
             .endObject()).get());
-        ensureYellow();
         // can cause stack overflow without the default max_input_length
         String string = "foo" + (char) 0x00 + "bar";
         try {
@@ -1111,7 +1108,6 @@ public class CompletionSuggestSearch2xIT extends ESIntegTestCase {
             .endObject()
             .endObject().endObject()
             .endObject()).get());
-        ensureYellow();
         String string = "foo bar";
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
             .startObject()

--- a/core/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
@@ -1032,7 +1032,6 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
                 .setSettings(Settings.builder().put(indexSettings()).put(settings))
                 .addMapping(TYPE, mapping)
                 .get());
-        ensureYellow();
     }
 
     private void createIndexAndMapping(CompletionMappingBuilder completionMappingBuilder) throws IOException {
@@ -1085,7 +1084,6 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
                 .endObject()
                 .endObject().endObject()
                 .endObject()).get());
-        ensureYellow();
         // can cause stack overflow without the default max_input_length
         String longString = replaceReservedChars(randomRealisticUnicodeOfLength(randomIntBetween(5000, 10000)), (char) 0x01);
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
@@ -1105,7 +1103,6 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
                 .endObject()
                 .endObject().endObject()
                 .endObject()).get());
-        ensureYellow();
         // can cause stack overflow without the default max_input_length
         String string = "foo" + (char) 0x00 + "bar";
         try {
@@ -1130,7 +1127,6 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
                 .endObject()
                 .endObject().endObject()
                 .endObject()).get());
-        ensureYellow();
         String string = "foo bar";
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                         .startObject()

--- a/core/src/test/java/org/elasticsearch/search/suggest/ContextCompletionSuggestSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/ContextCompletionSuggestSearchIT.java
@@ -91,7 +91,6 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
                     .setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
-        ensureYellow(INDEX);
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD).prefix("sugg");
         assertSuggestions("foo", prefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
     }
@@ -123,7 +122,6 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
                     .setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
-        ensureYellow(INDEX);
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD).regex("sugg.*es");
         assertSuggestions("foo", prefix, "sugg9estion", "sugg8estion", "sugg7estion", "sugg6estion", "sugg5estion");
     }
@@ -155,7 +153,6 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
                     .setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
-        ensureYellow(INDEX);
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD).prefix("sugg", Fuzziness.ONE);
         assertSuggestions("foo", prefix, "sugxgestion9", "sugxgestion8", "sugxgestion7", "sugxgestion6", "sugxgestion5");
     }
@@ -180,7 +177,6 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
                     ));
         }
         indexRandom(true, indexRequestBuilders);
-        ensureYellow(INDEX);
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD).prefix("sugg")
                 .contexts(Collections.singletonMap("cat", Collections.singletonList(CategoryQueryContext.builder().setCategory("cat0").build())));
 
@@ -207,7 +203,6 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
                     ));
         }
         indexRandom(true, indexRequestBuilders);
-        ensureYellow(INDEX);
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD).prefix("sugg")
                 .contexts(Collections.singletonMap("cat",
                         Arrays.asList(CategoryQueryContext.builder().setCategory("cat0").setBoost(3).build(),
@@ -237,7 +232,6 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
                     .setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
-        ensureYellow(INDEX);
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD).prefix("sugg");
 
         assertSuggestions("foo", prefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
@@ -265,7 +259,6 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
                     .setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
-        ensureYellow(INDEX);
 
         // filter only on context cat
         CompletionSuggestionBuilder catFilterSuggest = SuggestBuilders.completionSuggestion(FIELD).prefix("sugg");
@@ -310,7 +303,6 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
                     .setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
-        ensureYellow(INDEX);
 
         // boost only on context cat
         CompletionSuggestionBuilder catBoostSuggest = SuggestBuilders.completionSuggestion(FIELD).prefix("sugg");
@@ -370,7 +362,6 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
                     .setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
-        ensureYellow(INDEX);
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD).prefix("sugg");
         assertSuggestions("foo", prefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
     }
@@ -400,7 +391,6 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
                     .setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
-        ensureYellow(INDEX);
 
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD).prefix("sugg");
         assertSuggestions("foo", prefix, "suggestion0", "suggestion1", "suggestion2", "suggestion3", "suggestion4");
@@ -427,7 +417,6 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
                     .setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
-        ensureYellow(INDEX);
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD).prefix("sugg");
         assertSuggestions("foo", prefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
     }
@@ -454,7 +443,6 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
                     .setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
-        ensureYellow(INDEX);
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD).prefix("sugg");
         assertSuggestions("foo", prefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
 
@@ -487,7 +475,6 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
                     .setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
-        ensureYellow(INDEX);
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD).prefix("sugg");
         assertSuggestions("foo", prefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
 
@@ -523,7 +510,6 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
                     .setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
-        ensureYellow(INDEX);
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD).prefix("sugg")
                 .contexts(Collections.singletonMap("geo", Collections.singletonList(GeoQueryContext.builder().setGeoPoint(new GeoPoint(52.2263, 4.543)).build())));
         assertSuggestions("foo", prefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
@@ -561,7 +547,6 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
                     .setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
-        ensureYellow(INDEX);
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD).prefix("sugg");
         assertSuggestions("foo", prefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
 
@@ -599,7 +584,6 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         mapping.endObject();
 
         assertAcked(prepareCreate(INDEX).addMapping(TYPE, mapping));
-        ensureYellow();
 
         XContentBuilder source1 = jsonBuilder()
                 .startObject()
@@ -686,6 +670,5 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
                 .setSettings(Settings.builder().put(indexSettings()).put(settings))
                 .addMapping(TYPE, mapping)
                 .get());
-        ensureYellow();
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/suggest/ContextSuggestSearch2xIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/ContextSuggestSearch2xIT.java
@@ -96,7 +96,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
         assertAcked(prepareCreate(INDEX)
             .setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id))
             .addMapping(TYPE, createMapping(TYPE, ContextBuilder.location("st").precision("5km").neighbors(true))));
-        ensureYellow();
 
         XContentBuilder source1 = jsonBuilder()
             .startObject()
@@ -148,7 +147,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
                 .precision(11)
                 .precision(12)
                 .neighbors(true))));
-        ensureYellow();
 
         XContentBuilder source1 = jsonBuilder()
             .startObject()
@@ -200,7 +198,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
 
         assertAcked(prepareCreate(INDEX).setSettings(
             Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id)).addMapping(TYPE, mapping.string()));
-        ensureYellow();
 
         Collections.shuffle(precisions, getRandom());
         for (int i = 0; i < precision.length; i++) {
@@ -247,7 +244,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
             Settings.builder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id)
         ).addMapping(TYPE, mapping));
-        ensureYellow();
 
         XContentBuilder source1 = jsonBuilder()
             .startObject()
@@ -304,7 +300,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
         assertAcked(prepareCreate(INDEX)
             .setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id))
             .addMapping(TYPE, createMapping(TYPE, ContextBuilder.location("st").precision(precision).neighbors(true))));
-        ensureYellow();
 
         String[] locations = { reinickendorf, pankow, koepenick, bernau, berlin, mitte, steglitz, wilmersdorf, spandau, tempelhof,
             schoeneberg, treptow };
@@ -346,7 +341,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
         assertAcked(prepareCreate(INDEX)
             .setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id))
             .addMapping(TYPE, createMapping(TYPE, ContextBuilder.category("st"))));
-        ensureYellow();
 
         for (int i = 0; i < HEROS.length; i++) {
             XContentBuilder source = jsonBuilder().startObject().startObject(FIELD).field("input", HEROS[i])
@@ -379,7 +373,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
         assertAcked(prepareCreate(INDEX)
             .setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id))
             .addMapping(TYPE, mapping));
-        ensureYellow();
         XContentBuilder doc1 = jsonBuilder();
         doc1.startObject().startObject("suggest_field")
             .field("input", "backpack_red")
@@ -435,7 +428,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
             setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id))
             .addMapping(TYPE, createMapping(TYPE, false, ContextBuilder.reference("st", "_type"),
                 ContextBuilder.reference("nd", "_type"))));
-        ensureYellow();
 
         client().prepareIndex(INDEX, TYPE, "1")
             .setSource(
@@ -454,7 +446,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
         assertAcked(prepareCreate(INDEX)
             .setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id))
             .addMapping(TYPE, createMapping(TYPE, ContextBuilder.reference("st", "category"))));
-        ensureYellow();
 
         for (int i = 0; i < HEROS.length; i++) {
             client().prepareIndex(INDEX, TYPE, "" + i)
@@ -512,7 +503,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
     public void testMultiValueField() throws Exception {
         assertAcked(prepareCreate(INDEX).setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id))
             .addMapping(TYPE, createMapping(TYPE, ContextBuilder.reference("st", "category"))));
-        ensureYellow();
 
         for (int i = 0; i < HEROS.length; i++) {
             client().prepareIndex(INDEX, TYPE, "" + i)
@@ -540,7 +530,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
             .setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id))
             .addMapping(TYPE, createMapping(TYPE, ContextBuilder.reference("st", "categoryA"),
                 ContextBuilder.reference("nd", "categoryB"))));
-        ensureYellow();
 
         for (int i = 0; i < HEROS.length; i++) {
             client().prepareIndex(INDEX, TYPE, "" + i)
@@ -569,7 +558,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
             .setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id))
             .addMapping(TYPE,
                 createMapping(TYPE, ContextBuilder.reference("st", "categoryA"), ContextBuilder.reference("nd", "categoryB"))));
-        ensureYellow();
 
         for (int i = 0; i < HEROS.length; i++) {
             String source = jsonBuilder().startObject().field("categoryA", "" + (char) ('0' + (i % 3)))
@@ -606,7 +594,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
             createIndexRequestBuilder.addMapping(type, createMapping(type, ContextBuilder.reference("st", "_type")));
         }
         assertAcked(createIndexRequestBuilder);
-        ensureYellow();
 
         for (int i = 0; i < HEROS.length; i++) {
             String type = types[i % types.length];
@@ -647,7 +634,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
         assertAcked(prepareCreate(INDEX)
             .setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id))
             .addMapping("poi", xContentBuilder));
-        ensureYellow();
 
         index(INDEX, "poi", "1", jsonBuilder().startObject()
             .startObject("suggest").field("input", "Berlin Alexanderplatz").endObject().endObject());
@@ -677,7 +663,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
         assertAcked(prepareCreate(INDEX)
             .setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id))
             .addMapping("service", xContentBuilder));
-        ensureYellow();
 
         // now index a document with color field
         index(INDEX, "service", "1", jsonBuilder().startObject()
@@ -706,7 +691,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
         assertAcked(prepareCreate(INDEX)
             .setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id))
             .addMapping("item", xContentBuilder));
-        ensureYellow();
 
         index(INDEX, "item", "1", jsonBuilder().startObject()
             .startObject("suggest").field("input", "Hoodie red").endObject().endObject());
@@ -738,7 +722,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
         assertAcked(prepareCreate(INDEX)
             .setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id))
             .addMapping("item", xContentBuilder));
-        ensureYellow();
 
         index(INDEX, "item", "1", jsonBuilder().startObject()
             .startObject("suggest").field("input", "Hoodie red").endObject().endObject());
@@ -768,7 +751,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
         assertAcked(prepareCreate(INDEX)
             .setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id))
             .addMapping("item", xContentBuilder));
-        ensureYellow();
 
         // lets create some locations by geohashes in different cells with the precision 4
         // this means, that poelchaustr is not a neighour to alexanderplatz, but they share the same prefix until the fourth char!
@@ -817,7 +799,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
         assertAcked(prepareCreate(INDEX)
             .setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id))
             .addMapping("item", xContentBuilder));
-        ensureYellow();
 
         GeoPoint alexanderplatz = GeoPoint.fromGeohash("u33dc1");
         // does not look like it, but is a direct neighbor
@@ -860,7 +841,6 @@ public class ContextSuggestSearch2xIT extends ESIntegTestCase {
         assertAcked(prepareCreate(INDEX)
             .setSettings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, PRE2X_VERSION.id))
             .addMapping("item", xContentBuilder));
-        ensureYellow();
 
         GeoPoint alexanderplatz = GeoPoint.fromGeohash("u33dc1");
         index(INDEX, "item", "1", jsonBuilder().startObject()

--- a/core/src/test/java/org/elasticsearch/search/suggest/CustomSuggesterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/CustomSuggesterSearchIT.java
@@ -72,7 +72,6 @@ public class CustomSuggesterSearchIT extends ESIntegTestCase {
                 .field("name", "arbitrary content")
                 .endObject())
                 .setRefreshPolicy(IMMEDIATE).get();
-        ensureYellow();
 
         String randomText = randomAsciiOfLength(10);
         String randomField = randomAsciiOfLength(10);

--- a/core/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -170,7 +170,6 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         internalCluster().startNode();
         Client client = client();
         createIndex("test-idx");
-        ensureYellow();
         logger.info("--> add custom persistent metadata");
         updateClusterState(new ClusterStateUpdater() {
             @Override
@@ -887,8 +886,6 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
     private void createTestIndex(String name) {
         assertAcked(prepareCreate(name, 0, Settings.builder().put("number_of_shards", between(1, 6))
                 .put("number_of_replicas", between(1, 6))));
-
-        ensureYellow(name);
 
         logger.info("--> indexing some data into {}", name);
         for (int i = 0; i < between(10, 500); i++) {

--- a/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -836,7 +836,6 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                         .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)));
 
         createIndex("test-idx-1", "test-idx-2");
-        ensureYellow();
         logger.info("--> indexing some data");
         indexRandom(true,
                 client().prepareIndex("test-idx-1", "doc").setSource("foo", "bar"),
@@ -874,7 +873,6 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                         .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)));
 
         createIndex("test-idx-1", "test-idx-2");
-        ensureYellow();
         logger.info("--> indexing some data");
         indexRandom(true,
                 client().prepareIndex("test-idx-1", "doc").setSource("foo", "bar"),
@@ -908,7 +906,6 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                         .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)));
 
         createIndex("test-idx-1", "test-idx-2");
-        ensureYellow();
         logger.info("--> indexing some data");
         indexRandom(true,
                 client().prepareIndex("test-idx-1", "doc").setSource("foo", "bar"),
@@ -2176,7 +2173,6 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                         .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)));
 
         createIndex("test-idx-1", "test-idx-2", "test-idx-3");
-        ensureYellow();
         logger.info("--> indexing some data");
         indexRandom(true,
                 client().prepareIndex("test-idx-1", "doc").setSource("foo", "bar"),

--- a/core/src/test/java/org/elasticsearch/snapshots/SnapshotBackwardsCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SnapshotBackwardsCompatibilityIT.java
@@ -68,7 +68,6 @@ public class SnapshotBackwardsCompatibilityIT extends ESBackcompatTestCase {
         String[] indices = new String[indicesBefore.length + indicesAfter.length];
         System.arraycopy(indicesBefore, 0, indices, 0, indicesBefore.length);
         System.arraycopy(indicesAfter, 0, indices, indicesBefore.length, indicesAfter.length);
-        ensureYellow();
         logger.info("--> indexing some data");
         IndexRequestBuilder[] buildersBefore = new IndexRequestBuilder[randomIntBetween(10, 200)];
         for (int i = 0; i < buildersBefore.length; i++) {
@@ -171,7 +170,6 @@ public class SnapshotBackwardsCompatibilityIT extends ESBackcompatTestCase {
                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
         ));
-        ensureYellow();
         logger.info("-->  indexing");
 
         final int numDocs = randomIntBetween(10, 100);

--- a/core/src/test/java/org/elasticsearch/ttl/SimpleTTLIT.java
+++ b/core/src/test/java/org/elasticsearch/ttl/SimpleTTLIT.java
@@ -96,7 +96,6 @@ public class SimpleTTLIT extends ESIntegTestCase {
                         .startObject("_ttl").field("enabled", true).field("default", "1d").endObject()
                         .endObject()
                         .endObject()));
-        ensureYellow("test");
 
         final NumShards test = getNumShards("test");
 
@@ -252,7 +251,6 @@ public class SimpleTTLIT extends ESIntegTestCase {
                         .startObject("_ttl").field("enabled", true).endObject()
                         .endObject()
                         .endObject()));
-        ensureYellow("test");
 
         long aLongTime = 10000000;
         long firstTtl = aLongTime * 3;

--- a/core/src/test/java/org/elasticsearch/update/UpdateByNativeScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateByNativeScriptIT.java
@@ -54,7 +54,6 @@ public class UpdateByNativeScriptIT extends ESIntegTestCase {
 
     public void testThatUpdateUsingNativeScriptWorks() throws Exception {
         createIndex("test");
-        ensureYellow();
 
         index("test", "type", "1", "text", "value");
 

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/BulkTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/BulkTests.java
@@ -621,7 +621,6 @@ public class BulkTests extends ESIntegTestCase {
     // issue 6410
     public void testThatMissingIndexDoesNotAbortFullBulkRequest() throws Exception{
         createIndex("bulkindex1", "bulkindex2");
-        ensureYellow();
         BulkRequest bulkRequest = new BulkRequest();
         bulkRequest.add(new IndexRequest("bulkindex1", "index1_type", "1").source("text", "hallo1"))
                    .add(new IndexRequest("bulkindex2", "index2_type", "1").source("text", "hallo2"))
@@ -644,7 +643,6 @@ public class BulkTests extends ESIntegTestCase {
     // issue 9821
     public void testFailedRequestsOnClosedIndex() throws Exception {
         createIndex("bulkindex1");
-        ensureYellow();
 
         client().prepareIndex("bulkindex1", "index1_type", "1").setSource("text", "test").get();
         assertAcked(client().admin().indices().prepareClose("bulkindex1"));

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/FunctionScoreTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/FunctionScoreTests.java
@@ -61,7 +61,6 @@ public class FunctionScoreTests extends ESIntegTestCase {
 
     public void testScriptScoresNested() throws IOException {
         createIndex(INDEX);
-        ensureYellow();
         index(INDEX, TYPE, "1", jsonBuilder().startObject().field("dummy_field", 1).endObject());
         refresh();
         SearchResponse response = client().search(
@@ -82,7 +81,6 @@ public class FunctionScoreTests extends ESIntegTestCase {
 
     public void testScriptScoresWithAgg() throws IOException {
         createIndex(INDEX);
-        ensureYellow();
         index(INDEX, TYPE, "1", jsonBuilder().startObject().field("dummy_field", 1).endObject());
         refresh();
         SearchResponse response = client().search(
@@ -100,7 +98,6 @@ public class FunctionScoreTests extends ESIntegTestCase {
     public void testMinScoreFunctionScoreBasic() throws IOException {
         index(INDEX, TYPE, jsonBuilder().startObject().field("num", 2).endObject());
         refresh();
-        ensureYellow();
         float score = randomFloat();
         float minScore = randomFloat();
         SearchResponse searchResponse = client().search(
@@ -136,7 +133,6 @@ public class FunctionScoreTests extends ESIntegTestCase {
             docs.add(client().prepareIndex(INDEX, TYPE, Integer.toString(i)).setSource("num", i + scoreOffset));
         }
         indexRandom(true, docs);
-        ensureYellow();
         Script script = new Script("return (doc['num'].value)");
         int numMatchingDocs = numDocs + scoreOffset - minScore;
         if (numMatchingDocs < 0) {
@@ -172,7 +168,6 @@ public class FunctionScoreTests extends ESIntegTestCase {
     /** make sure min_score works if functions is empty, see https://github.com/elastic/elasticsearch/issues/10253 */
     public void testWithEmptyFunctions() throws IOException, ExecutionException, InterruptedException {
         assertAcked(prepareCreate("test"));
-        ensureYellow();
         index("test", "testtype", "1", jsonBuilder().startObject().field("text", "test text").endObject());
         refresh();
 

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/IndexLookupTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/IndexLookupTests.java
@@ -423,7 +423,6 @@ public class IndexLookupTests extends ESIntegTestCase {
                         .put("index.analysis.filter.delimited_int.encoding", "int")
                         .put("index.analysis.filter.delimited_int.type", "delimited_payload_filter")
                         .put("index.number_of_shards", 1)));
-        ensureYellow();
         indexRandom(true, client().prepareIndex("test", "type1", "1").setSource("float_payload_field", "a|1 b|2 a|3 b "), client()
                 .prepareIndex("test", "type1", "2").setSource("string_payload_field", "a|a b|b a|a b "),
                 client().prepareIndex("test", "type1", "3").setSource("float_payload_field", "a|4 b|5 a|6 b "),

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/RandomScoreFunctionTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/RandomScoreFunctionTests.java
@@ -125,7 +125,6 @@ public class RandomScoreFunctionTests extends ESIntegTestCase {
     public void testScoreAccessWithinScript() throws Exception {
         assertAcked(prepareCreate("test").addMapping("type", "body", "type=text", "index",
                 "type=" + randomFrom("short", "float", "long", "integer", "double")));
-        ensureYellow();
 
         int docCount = randomIntBetween(100, 200);
         for (int i = 0; i < docCount; i++) {

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/SearchFieldsTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/SearchFieldsTests.java
@@ -83,7 +83,6 @@ public class SearchFieldsTests extends ESIntegTestCase {
 
     public void testStoredFields() throws Exception {
         createIndex("test");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
 
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
                 .startObject("properties")
@@ -168,7 +167,6 @@ public class SearchFieldsTests extends ESIntegTestCase {
 
     public void testScriptDocAndFields() throws Exception {
         createIndex("test");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
 
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties")
                 .startObject("num1").field("type", "double").field("store", true).endObject()
@@ -252,7 +250,6 @@ public class SearchFieldsTests extends ESIntegTestCase {
 
     public void testUidBasedScriptFields() throws Exception {
         prepareCreate("test").addMapping("type1", "num1", "type=long").execute().actionGet();
-        ensureYellow();
 
         int numDocs = randomIntBetween(1, 30);
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[numDocs];
@@ -328,7 +325,6 @@ public class SearchFieldsTests extends ESIntegTestCase {
 
     public void testScriptFieldUsingSource() throws Exception {
         createIndex("test");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
 
         client().prepareIndex("test", "type1", "1")
                 .setSource(jsonBuilder().startObject()
@@ -387,8 +383,6 @@ public class SearchFieldsTests extends ESIntegTestCase {
 
     public void testPartialFields() throws Exception {
         createIndex("test");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
-
 
         client().prepareIndex("test", "type1", "1").setSource(XContentFactory.jsonBuilder().startObject()
                 .field("field1", "value1")
@@ -406,7 +400,6 @@ public class SearchFieldsTests extends ESIntegTestCase {
 
     public void testStoredFieldsWithoutSource() throws Exception {
         createIndex("test");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
 
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("_source").field("enabled", false).endObject().startObject("properties")
                 .startObject("byte_field").field("type", "byte").field("store", true).endObject()
@@ -587,7 +580,6 @@ public class SearchFieldsTests extends ESIntegTestCase {
 
     public void testFieldsPulledFromFieldData() throws Exception {
         createIndex("test");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
 
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("_source").field("enabled", false).endObject().startObject("properties")
                 .startObject("text_field").field("type", "text").field("fielddata", true).endObject()


### PR DESCRIPTION
Removes ensureYellow() calls after index creation in the integration
tests, as they are no longer needed with index creation now waiting 
for shards to be started before returning from the index creation call 
(by default, it waits for the primary of each shard to be started 
before returning, which is what ensureYellow() was ensuring anyway).

Relates #19450
