### PR TITLE
Convert snippets in health docs to CONSOLE

### DIFF
--- a/docs/reference/cluster/health.asciidoc
+++ b/docs/reference/cluster/health.asciidoc
@@ -2,37 +2,47 @@
 == Cluster Health
 
 The cluster health API allows to get a very simple status on the health
-of the cluster.
+of the cluster. For example, on a single node cluster with a single index
+with 5 shards and one replica, this:
 
 [source,js]
 --------------------------------------------------
-$ curl -XGET 'http://localhost:9200/_cluster/health?pretty=true'
+GET _cluster/health
+--------------------------------------------------
+// CONSOLE
+// TEST[s/^/PUT test1\n/]
+
+Returns this:
+--------------------------------------------------
 {
   "cluster_name" : "testcluster",
-  "status" : "green",
+  "status" : "yellow",
   "timed_out" : false,
-  "number_of_nodes" : 2,
-  "number_of_data_nodes" : 2,
+  "number_of_nodes" : 1,
+  "number_of_data_nodes" : 1,
   "active_primary_shards" : 5,
-  "active_shards" : 10,
+  "active_shards" : 5,
   "relocating_shards" : 0,
   "initializing_shards" : 0,
-  "unassigned_shards" : 0,
+  "unassigned_shards" : 5,
   "delayed_unassigned_shards": 0,
   "number_of_pending_tasks" : 0,
   "number_of_in_flight_fetch": 0,
   "task_max_waiting_in_queue_millis": 0,
-  "active_shards_percent_as_number": 100
+  "active_shards_percent_as_number": 50.0
 }
 --------------------------------------------------
+// TESTRESPONSE[s/testcluster/docs_integTest/]
 
 The API can also be executed against one or more indices to get just the
 specified indices health:
 
 [source,js]
 --------------------------------------------------
-$ curl -XGET 'http://localhost:9200/_cluster/health/test1,test2'
+GET /_cluster/health/test1,test2
 --------------------------------------------------
+// CONSOLE
+// TEST[s/^/PUT test1\nPUT test2\n/]
 
 The cluster health status is: `green`, `yellow` or `red`. On the shard
 level, a `red` status indicates that the specific shard is not allocated
@@ -49,8 +59,9 @@ it will return at that point):
 
 [source,js]
 --------------------------------------------------
-$ curl -XGET 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=50s'
+GET /_cluster/health?wait_for_status=yellow&timeout=50s
 --------------------------------------------------
+// CONSOLE
 
 [float]
 [[request-params]]
@@ -97,5 +108,7 @@ The following is an example of getting the cluster health at the
 
 [source,js]
 --------------------------------------------------
-$ curl -XGET 'http://localhost:9200/_cluster/health/twitter?level=shards'
+GET /_cluster/health/twitter?level=shards
 --------------------------------------------------
+// CONSOLE
+// TEST[setup:twitter]


### PR DESCRIPTION
This should make them easier to read and adds them to the test suite
I changed the example from a two node cluster to a single node cluster
because that is what we have running in the integration tests. It is also
what a user just starting out is likely to see so I think that is ok.
