### PR TITLE
Removes yellow health check in REST tests

### DIFF
--- a/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/30_single_value_field.yaml
+++ b/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/30_single_value_field.yaml
@@ -119,10 +119,6 @@ setup:
     indices.refresh:
       index: [test, unmapped]
 
-  - do:
-      cluster.health:
-        wait_for_status: yellow
-
 ---
 "Unmapped":
 

--- a/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/40_multi_value_field.yaml
+++ b/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/40_multi_value_field.yaml
@@ -119,10 +119,6 @@ setup:
     indices.refresh:
       index: [test, unmapped]
 
-  - do:
-      cluster.health:
-        wait_for_status: yellow
-
 ---
 "Unmapped":
 

--- a/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/10_basic.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/10_basic.yaml
@@ -279,9 +279,6 @@
           settings:
             number_of_shards: 1
   - do:
-      cluster.health:
-          wait_for_status: yellow
-  - do:
       index:
         index:   test
         type:    foo

--- a/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/50_consistency.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/50_consistency.yaml
@@ -7,9 +7,6 @@
             settings:
               number_of_replicas: 5
   - do:
-      cluster.health:
-          wait_for_status: yellow
-  - do:
       index:
         index:       test
         type:        test

--- a/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/70_throttle.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/70_throttle.yaml
@@ -8,9 +8,6 @@
           settings:
             number_of_shards: 1
   - do:
-      cluster.health:
-          wait_for_status: yellow
-  - do:
       index:
         index:   test
         type:    foo
@@ -50,9 +47,6 @@
         body:
           settings:
             number_of_shards: 1
-  - do:
-      cluster.health:
-          wait_for_status: yellow
   - do:
       index:
         index:   test
@@ -94,9 +88,6 @@
         body:
           settings:
             number_of_shards: 1
-  - do:
-      cluster.health:
-          wait_for_status: yellow
   - do:
       index:
         index:   test
@@ -157,9 +148,6 @@
         body:
           settings:
             number_of_shards: 1
-  - do:
-      cluster.health:
-          wait_for_status: yellow
   - do:
       index:
         index:   test

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/60_consistency.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/60_consistency.yaml
@@ -7,9 +7,6 @@
             settings:
               number_of_replicas: 5
   - do:
-      cluster.health:
-          wait_for_status: yellow
-  - do:
       index:
         index:       src
         type:        test

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/70_throttle.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/70_throttle.yaml
@@ -10,9 +10,6 @@
             number_of_shards: "1"
             number_of_replicas: "0"
   - do:
-      cluster.health:
-          wait_for_status: yellow
-  - do:
       index:
         index:   source
         type:    foo
@@ -62,9 +59,6 @@
             number_of_shards: "1"
             number_of_replicas: "0"
   - do:
-      cluster.health:
-          wait_for_status: yellow
-  - do:
       index:
         index:   source
         type:    foo
@@ -113,9 +107,6 @@
           settings:
             number_of_shards: "1"
             number_of_replicas: "0"
-  - do:
-      cluster.health:
-          wait_for_status: yellow
   - do:
       index:
         index:   source
@@ -171,9 +162,6 @@
           settings:
             number_of_shards: "1"
             number_of_replicas: "0"
-  - do:
-      cluster.health:
-          wait_for_status: yellow
   - do:
       index:
         index:   source

--- a/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/10_basic.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/10_basic.yaml
@@ -218,9 +218,6 @@
           settings:
             number_of_shards: 1
   - do:
-      cluster.health:
-          wait_for_status: yellow
-  - do:
       index:
         index:   test
         type:    foo

--- a/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/30_new_fields.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/30_new_fields.yaml
@@ -10,9 +10,6 @@
                 name:
                   type: text
   - do:
-      cluster.health:
-          wait_for_status: yellow
-  - do:
       index:
         index:   test
         type:    place

--- a/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/50_consistency.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/50_consistency.yaml
@@ -7,9 +7,6 @@
             settings:
               number_of_replicas: 5
   - do:
-      cluster.health:
-          wait_for_status: yellow
-  - do:
       index:
         index:       test
         type:        test

--- a/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/60_throttle.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/60_throttle.yaml
@@ -8,9 +8,6 @@
           settings:
             number_of_shards: 1
   - do:
-      cluster.health:
-          wait_for_status: yellow
-  - do:
       index:
         index:   test
         type:    foo
@@ -46,9 +43,6 @@
         body:
           settings:
             number_of_shards: 1
-  - do:
-      cluster.health:
-          wait_for_status: yellow
   - do:
       index:
         index:   test
@@ -86,9 +80,6 @@
         body:
           settings:
             number_of_shards: 1
-  - do:
-      cluster.health:
-          wait_for_status: yellow
   - do:
       index:
         index:   test
@@ -136,9 +127,6 @@
         body:
           settings:
             number_of_shards: 1
-  - do:
-      cluster.health:
-          wait_for_status: yellow
   - do:
       index:
         index:   test

--- a/plugins/analysis-icu/src/test/resources/rest-api-spec/test/analysis_icu/20_search.yaml
+++ b/plugins/analysis-icu/src/test/resources/rest-api-spec/test/analysis_icu/20_search.yaml
@@ -24,9 +24,6 @@
                             text:
                                 type:     text
                                 analyzer: my_analyzer
-    - do:
-       cluster.health:
-           wait_for_status: yellow
 
     - do:
       index:

--- a/plugins/analysis-kuromoji/src/test/resources/rest-api-spec/test/analysis_kuromoji/20_search.yaml
+++ b/plugins/analysis-kuromoji/src/test/resources/rest-api-spec/test/analysis_kuromoji/20_search.yaml
@@ -12,9 +12,6 @@
                 text:
                   type:     text
                   analyzer: kuromoji
-  - do:
-       cluster.health:
-         wait_for_status: yellow
 
   - do:
       index:

--- a/plugins/analysis-phonetic/src/test/resources/rest-api-spec/test/analysis_phonetic/10_metaphone.yaml
+++ b/plugins/analysis-phonetic/src/test/resources/rest-api-spec/test/analysis_phonetic/10_metaphone.yaml
@@ -20,9 +20,6 @@
                                     encoder: metaphone
                                     replace: false
     - do:
-        cluster.health:
-            wait_for_status: yellow
-    - do:
         indices.analyze:
             index: phonetic_sample
             analyzer: my_analyzer

--- a/plugins/analysis-phonetic/src/test/resources/rest-api-spec/test/analysis_phonetic/20_double_metaphone.yaml
+++ b/plugins/analysis-phonetic/src/test/resources/rest-api-spec/test/analysis_phonetic/20_double_metaphone.yaml
@@ -20,9 +20,6 @@
                                     encoder: double_metaphone
                                     max_code_len: 6
     - do:
-        cluster.health:
-            wait_for_status: yellow
-    - do:
         indices.analyze:
             index: phonetic_sample
             analyzer: my_analyzer

--- a/plugins/analysis-phonetic/src/test/resources/rest-api-spec/test/analysis_phonetic/30_beider_morse.yaml
+++ b/plugins/analysis-phonetic/src/test/resources/rest-api-spec/test/analysis_phonetic/30_beider_morse.yaml
@@ -22,9 +22,6 @@
                                     name_type: ashkenazi
                                     languageset: polish
     - do:
-        cluster.health:
-            wait_for_status: yellow
-    - do:
         indices.analyze:
             index: phonetic_sample
             analyzer: my_analyzer

--- a/plugins/analysis-phonetic/src/test/resources/rest-api-spec/test/analysis_phonetic/40_search.yaml
+++ b/plugins/analysis-phonetic/src/test/resources/rest-api-spec/test/analysis_phonetic/40_search.yaml
@@ -24,9 +24,6 @@
                             text:
                                 type:     text
                                 analyzer: my_analyzer
-    - do:
-       cluster.health:
-           wait_for_status: yellow
 
     - do:
       index:

--- a/plugins/analysis-phonetic/src/test/resources/rest-api-spec/test/analysis_phonetic/50_daitch_mokotoff.yaml
+++ b/plugins/analysis-phonetic/src/test/resources/rest-api-spec/test/analysis_phonetic/50_daitch_mokotoff.yaml
@@ -19,9 +19,6 @@
                                     type: phonetic
                                     encoder: daitch_mokotoff
     - do:
-        cluster.health:
-            wait_for_status: yellow
-    - do:
         indices.analyze:
             index: phonetic_sample
             analyzer: my_analyzer

--- a/plugins/analysis-smartcn/src/test/resources/rest-api-spec/test/analysis_smartcn/20_search.yaml
+++ b/plugins/analysis-smartcn/src/test/resources/rest-api-spec/test/analysis_smartcn/20_search.yaml
@@ -12,9 +12,6 @@
                             text:
                                 type:     text
                                 analyzer: smartcn
-    - do:
-       cluster.health:
-           wait_for_status: yellow
 
     - do:
       index:

--- a/plugins/analysis-stempel/src/test/resources/rest-api-spec/test/analysis_stempel/20_search.yaml
+++ b/plugins/analysis-stempel/src/test/resources/rest-api-spec/test/analysis_stempel/20_search.yaml
@@ -12,9 +12,6 @@
                             text:
                                 type:     text
                                 analyzer: polish
-    - do:
-       cluster.health:
-           wait_for_status: yellow
 
     - do:
       index:

--- a/plugins/mapper-attachments/src/test/resources/rest-api-spec/test/mapper_attachments/10_index.yaml
+++ b/plugins/mapper-attachments/src/test/resources/rest-api-spec/test/mapper_attachments/10_index.yaml
@@ -15,10 +15,6 @@
                     file:
                       type: attachment
     - do:
-        cluster.health:
-          wait_for_status: yellow
-
-    - do:
         catch: /(.)*mapper_parsing_exception.+No content is provided\.(.)*/
         index:
             index: test
@@ -59,9 +55,6 @@
                       type: attachment
                     file2:
                       type: attachment
-    - do:
-        cluster.health:
-          wait_for_status: yellow
 
     - do:
         index:
@@ -133,9 +126,6 @@
 #                      type: attachment
 #                    file2:
 #                      type: attachment
-#    - do:
-#        cluster.health:
-#          wait_for_status: yellow
 #
 #    - do:
 #        catch: /(.)*mapper_parsing_exception(.)*The supplied password does not match either the owner or user password in the document\.(.)*/

--- a/plugins/mapper-attachments/src/test/resources/rest-api-spec/test/mapper_attachments/20_search.yaml
+++ b/plugins/mapper-attachments/src/test/resources/rest-api-spec/test/mapper_attachments/20_search.yaml
@@ -11,9 +11,6 @@ setup:
                   properties:
                     file:
                       type: attachment
-    - do:
-        cluster.health:
-          wait_for_status: yellow
 
 ---
 # Encoded content with https://www.base64encode.org/

--- a/plugins/mapper-attachments/src/test/resources/rest-api-spec/test/mapper_attachments/30_mapping.yaml
+++ b/plugins/mapper-attachments/src/test/resources/rest-api-spec/test/mapper_attachments/30_mapping.yaml
@@ -32,9 +32,6 @@
                           "store": true
                         "name":
                           "store": true
-    - do:
-        cluster.health:
-          wait_for_status: yellow
 
     - do:
         index:

--- a/plugins/mapper-attachments/src/test/resources/rest-api-spec/test/mapper_attachments/40_highlight.yaml
+++ b/plugins/mapper-attachments/src/test/resources/rest-api-spec/test/mapper_attachments/40_highlight.yaml
@@ -17,10 +17,6 @@ setup:
                           "store" : true
                           "term_vector": "with_positions_offsets"
 
-    - do:
-        cluster.health:
-          wait_for_status: yellow
-
 ---
 # Encoded content with https://www.base64encode.org/
 #<html xmlns="http://www.w3.org/1999/xhtml">

--- a/plugins/mapper-attachments/src/test/resources/rest-api-spec/test/mapper_attachments/50_files_supported.yaml
+++ b/plugins/mapper-attachments/src/test/resources/rest-api-spec/test/mapper_attachments/50_files_supported.yaml
@@ -20,9 +20,6 @@ setup:
                         content_type:
                           store: true
                         
-    - do:
-        cluster.health:
-          wait_for_status: yellow
 ---
 "Test mapper attachment processor with .doc file":
 

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/hdfs_repository/30_snapshot.yaml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/hdfs_repository/30_snapshot.yaml
@@ -23,11 +23,6 @@
             number_of_shards:   1
             number_of_replicas: 1
 
-  # Wait for yellow
-  - do:
-      cluster.health:
-        wait_for_status: yellow
-
   # Create snapshot
   - do:
       snapshot.create:

--- a/plugins/store-smb/src/test/resources/rest-api-spec/test/store_smb/15_index_creation.yaml
+++ b/plugins/store-smb/src/test/resources/rest-api-spec/test/store_smb/15_index_creation.yaml
@@ -7,10 +7,6 @@
             store.type: smb_mmap_fs
 
   - do:
-      cluster.health:
-        wait_for_status: yellow
-
-  - do:
       index:
         index:  smb-test
         type:   doc

--- a/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/reindex/10_script.yaml
+++ b/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/reindex/10_script.yaml
@@ -90,9 +90,6 @@
             mappings:
               tweet:
                 _parent: { type: "user" }
-  - do:
-      cluster.health:
-          wait_for_status: yellow
 
   - do:
       index:
@@ -192,9 +189,6 @@
             mappings:
               tweet:
                 _parent: { type: "user" }
-  - do:
-      cluster.health:
-          wait_for_status: yellow
 
   - do:
       index:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.allocation/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.allocation/10_basic.yaml
@@ -47,10 +47,6 @@
             index: test
 
   - do:
-        cluster.health:
-            wait_for_status: yellow
-
-  - do:
         cat.allocation: {}
 
   - match:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yaml
@@ -16,9 +16,6 @@
             number_of_shards: "1"
             number_of_replicas: "0"
   - do:
-       cluster.health:
-         wait_for_status: yellow
-  - do:
       cat.indices: {}
 
   - match:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.recovery/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.recovery/10_basic.yaml
@@ -16,9 +16,6 @@
         body:   { foo: bar }
         refresh: true
   - do:
-       cluster.health:
-         wait_for_status: yellow
-  - do:
       cat.recovery:
           h: i,s,t,ty,st,shost,thost,rep,snap,f,fr,fp,tf,b,br,bp,tb,to,tor,top
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.shards/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.shards/10_basic.yaml
@@ -140,9 +140,6 @@
             number_of_shards: "5"
             number_of_replicas: "1"
   - do:
-       cluster.health:
-         wait_for_status: yellow
-  - do:
       cat.shards: {}
 
   - match:
@@ -158,7 +155,6 @@
             number_of_replicas: "0"
   - do:
        cluster.health:
-         wait_for_status: yellow
          wait_for_relocating_shards: 0
 
   - do:
@@ -185,7 +181,6 @@
             shared_filesystem: false
   - do:
        cluster.health:
-         wait_for_status: yellow
          wait_for_relocating_shards: 0
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.allocation_explain/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.allocation_explain/10_basic.yaml
@@ -10,10 +10,6 @@
         index: test
 
   - do:
-      cluster.health:
-        wait_for_status: yellow
-
-  - do:
       cluster.state:
         metric: [ master_node ]
 
@@ -48,10 +44,6 @@
       indices.create:
         index: test
         body: { "index.number_of_shards": 1, "index.number_of_replicas": 9 }
-
-  - do:
-      cluster.health:
-        wait_for_status: yellow
 
   - do:
       cluster.state:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/10_basic.yaml
@@ -46,7 +46,6 @@
         index: test_index
   - do:
       cluster.health:
-        wait_for_status: yellow
         level: indices
 
   - is_true: indices

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/create/50_parent.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/create/50_parent.yaml
@@ -10,10 +10,6 @@
                 _parent: { type: "foo" }
 
  - do:
-      cluster.health:
-          wait_for_status: yellow
-
- - do:
       catch:  /routing_missing_exception/
       create:
           index:   test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/create/60_refresh.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/create/60_refresh.yaml
@@ -9,10 +9,6 @@
                   index.refresh_interval: -1
                   number_of_replicas: 0
  - do:
-      cluster.health:
-          wait_for_status: yellow
-
- - do:
       create:
           index:   test_1
           type:    test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/delete/30_routing.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/delete/30_routing.yaml
@@ -14,9 +14,6 @@
           id:      1
           routing: 5
           body:    { foo: bar }
- - do:
-      cluster.health:
-          wait_for_status: yellow
 
  - do:
       catch:      missing

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/delete/40_parent.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/delete/40_parent.yaml
@@ -9,9 +9,6 @@
             mappings:
               test:
                 _parent: { type: "foo" }
- - do:
-      cluster.health:
-          wait_for_status: yellow
 
  - do:
       index:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/exists/30_parent.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/exists/30_parent.yaml
@@ -7,9 +7,6 @@ setup:
             mappings:
               test:
                 _parent: { type: "foo" }
- - do:
-      cluster.health:
-          wait_for_status: yellow
 
 ---
 "Parent":

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/explain/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/explain/10_basic.yaml
@@ -6,10 +6,6 @@ setup:
               aliases:
                 alias_1: {}
   - do:
-        cluster.health:
-            wait_for_status: yellow
-
-  - do:
       index:
           index:  test_1
           type:   test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get/30_parent.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get/30_parent.yaml
@@ -7,9 +7,6 @@ setup:
             mappings:
               test:
                 _parent: { type: "foo" }
- - do:
-      cluster.health:
-          wait_for_status: yellow
 
  - do:
       index:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/30_parent.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/30_parent.yaml
@@ -7,9 +7,6 @@ setup:
             mappings:
               test:
                 _parent: { type: "foo" }
- - do:
-      cluster.health:
-          wait_for_status: yellow
 
  - do:
       index:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/85_source_missing.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/85_source_missing.yaml
@@ -7,9 +7,6 @@ setup:
             mappings:
               test:
                 _source: { enabled: false }
- - do:
-      cluster.health:
-          wait_for_status: yellow
 
  - do:
       index:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/50_parent.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/50_parent.yaml
@@ -8,9 +8,6 @@
             mappings:
               test:
                 _parent: { type: "foo" }
- - do:
-      cluster.health:
-          wait_for_status: yellow
 
  - do:
       catch:  /routing_missing_exception/

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/60_refresh.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/60_refresh.yaml
@@ -8,9 +8,6 @@
               settings:
                   index.refresh_interval: -1
                   number_of_replicas: 0
- - do:
-      cluster.health:
-          wait_for_status: yellow
 
  - do:
       index:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/10_analyze.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/10_analyze.yaml
@@ -35,10 +35,6 @@ setup:
                   text:
                     type:     text
                     analyzer: whitespace
-    - do:
-        cluster.health:
-          wait_for_status: yellow
-
 
     - do:
         indices.analyze:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yaml
@@ -34,10 +34,6 @@ setup:
             test_blias: {}
 
   - do:
-      cluster.health:
-        wait_for_status: yellow
-
-  - do:
       indices.close:
         index: test_index_3
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/10_basic.yaml
@@ -9,9 +9,6 @@ setup:
                   properties:
                     text:
                       type:     text
-  - do:
-         cluster.health:
-           wait_for_status: yellow
 
 ---
 "Get field mapping with no index and type":

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/20_missing_field.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/20_missing_field.yaml
@@ -11,9 +11,6 @@
                     text:
                       type:     text
                       analyzer: whitespace
-  - do:
-         cluster.health:
-           wait_for_status: yellow
 
   - do:
       indices.get_field_mapping:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/30_missing_type.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/30_missing_type.yaml
@@ -11,9 +11,6 @@
                     text:
                       type:     text
                       analyzer: whitespace
-  - do:
-         cluster.health:
-           wait_for_status: yellow
 
   - do:
       catch: missing

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/50_field_wildcards.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/50_field_wildcards.yaml
@@ -40,10 +40,6 @@ setup:
                         i_t3:
                           type:   text
 
-  - do:
-      cluster.health:
-          wait_for_status: yellow
-
 ---
 "Get field mapping with * for fields":
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yaml
@@ -51,10 +51,6 @@
 
   - is_true: ''
 
-  - do:
-      cluster.health:
-        wait_for_status: yellow
-
   # index into new index
   - do:
       index:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/12_level.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/12_level.yaml
@@ -15,10 +15,6 @@ setup:
           id:    1
           body:  { "foo": "baz" }
 
-  - do:
-      cluster.health:
-          wait_for_status: yellow
-
 ---
 "Level - blank":
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.validate_query/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.validate_query/10_basic.yaml
@@ -6,10 +6,6 @@ setup:
           settings:
             number_of_replicas: 0
 
-  - do:
-      cluster.health:
-        wait_for_status: yellow
-
 ---
 "Validate query api":
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/11_default_index_type.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/11_default_index_type.yaml
@@ -11,10 +11,6 @@
           body:   { foo: bar }
 
   - do:
-      cluster.health:
-          wait_for_status: yellow
-
-  - do:
       mget:
         index:  test_1
         type:   test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/12_non_existent_index.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/12_non_existent_index.yaml
@@ -8,10 +8,6 @@
           body:   { foo: bar }
 
   - do:
-      cluster.health:
-          wait_for_status: yellow
-
-  - do:
       mget:
         body:
           docs:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/13_missing_metadata.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/13_missing_metadata.yaml
@@ -9,10 +9,6 @@
           body:   { foo: bar }
 
   - do:
-      cluster.health:
-          wait_for_status: yellow
-
-  - do:
       catch: /action_request_validation_exception.+ id is missing/
       mget:
         body:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/15_ids.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/15_ids.yaml
@@ -15,10 +15,6 @@
           body:   { foo: baz }
 
   - do:
-      cluster.health:
-          wait_for_status: yellow
-
-  - do:
       mget:
         index:  test_1
         type:   test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/20_fields.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/20_fields.yaml
@@ -9,10 +9,6 @@
           body:   { foo: bar }
 
   - do:
-      cluster.health:
-          wait_for_status: yellow
-
-  - do:
       mget:
         index: test_1
         type:  test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/30_parent.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/30_parent.yaml
@@ -10,9 +10,6 @@
                 _parent: { type: "foo" }
             settings:
               number_of_shards: 5
- - do:
-      cluster.health:
-          wait_for_status: yellow
 
  - do:
       index:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/11_status.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/11_status.yaml
@@ -3,10 +3,6 @@ setup:
   - do:
       indices.create:
         index: test_1
-  - do:
-      cluster.health:
-        wait_for_status: yellow
-
 ---
 "Check Status":
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search_shards/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search_shards/10_basic.yaml
@@ -5,10 +5,6 @@
         index: test_1
 
   - do:
-      cluster.health:
-        wait_for_status: yellow
-
-  - do:
       search_shards:
         index:  test_1
         routing: foo

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.create/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.create/10_basic.yaml
@@ -17,10 +17,6 @@ setup:
             number_of_shards:   1
             number_of_replicas: 1
 
-  - do:
-      cluster.health:
-        wait_for_status: yellow
-
 ---
 "Create a snapshot":
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/50_parent.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/50_parent.yaml
@@ -7,10 +7,6 @@ setup:
             mappings:
               test:
                 _parent: { type: "foo" }
- - do:
-      cluster.health:
-          wait_for_status: yellow
-
 ---
 "Parent":
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/60_refresh.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/60_refresh.yaml
@@ -8,9 +8,6 @@
               settings:
                   index.refresh_interval: -1
                   number_of_replicas: 0
- - do:
-      cluster.health:
-          wait_for_status: yellow
 
  - do:
       update:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/85_fields_meta.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/85_fields_meta.yaml
@@ -14,10 +14,6 @@
                 _parent: { type: "foo" }
 
   - do:
-      cluster.health:
-          wait_for_status: yellow
-
-  - do:
       update:
           index:  test_1
           type:   test


### PR DESCRIPTION
Removes waiting for yellow cluster health upon index 
creation in the REST tests, as we no longer need it due
to index creation now waiting for active shard copies
before returning (by default, it waits for the primary of
each shard, which is the same as ensuring yellow health).

Relates #19450
