### PR TITLE
Simplify plugin configuration for rest tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,11 @@ subprojects {
     "org.elasticsearch.distribution.rpm:elasticsearch:${version}": ':distribution:rpm',
     "org.elasticsearch.distribution.deb:elasticsearch:${version}": ':distribution:deb',
     "org.elasticsearch.test:logger-usage:${version}": ':test:logger-usage',
+    // for transport client
+    "org.elasticsearch.plugin:transport-netty3-client:${version}": ':modules:transport-netty3',
+    "org.elasticsearch.plugin:reindex-client:${version}": ':modules:reindex',
+    "org.elasticsearch.plugin:lang-mustache-client:${version}": ':modules:lang-mustache',
+    "org.elasticsearch.plugin:percolator-client:${version}": ':modules:percolator',
   ]
   configurations.all {
     resolutionStrategy.dependencySubstitution { DependencySubstitutions subs ->

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -71,8 +71,8 @@ public class PluginBuildPlugin extends BuildPlugin {
                 project.integTest.clusterConfig.module(project)
                 project.tasks.run.clusterConfig.module(project)
             } else {
-                project.integTest.clusterConfig.plugin(name, project.bundlePlugin.outputs.files)
-                project.tasks.run.clusterConfig.plugin(name, project.bundlePlugin.outputs.files)
+                project.integTest.clusterConfig.plugin(project.path)
+                project.tasks.run.clusterConfig.plugin(project.path)
                 addZipPomGeneration(project)
             }
 
@@ -83,6 +83,7 @@ public class PluginBuildPlugin extends BuildPlugin {
         }
         createIntegTestTask(project)
         createBundleTask(project)
+        project.configurations.getByName('default').extendsFrom(project.configurations.getByName('runtime'))
         project.tasks.create('run', RunTask) // allow running ES with this plugin in the foreground of a build
     }
 
@@ -141,13 +142,9 @@ public class PluginBuildPlugin extends BuildPlugin {
         }
         project.assemble.dependsOn(bundle)
 
-        // remove jar from the archives (things that will be published), and set it to the zip
-        project.configurations.archives.artifacts.removeAll { it.archiveTask.is project.jar }
-        project.artifacts.add('archives', bundle)
-
-        // also make the zip the default artifact (used when depending on this project)
-        project.configurations.getByName('default').extendsFrom = []
-        project.artifacts.add('default', bundle)
+        // also make the zip available as a configuration (used when depending on this project)
+        project.configurations.create('zip')
+        project.artifacts.add('zip', bundle)
     }
 
     /** Adds a task to move jar and associated files to a "-client" name. */

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
@@ -20,11 +20,14 @@ package org.elasticsearch.gradle.test
 
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Input
 
 /** Configuration for an elasticsearch cluster, used for integration tests. */
 class ClusterConfiguration {
+
+    private final Project project
 
     @Input
     String distribution = 'integ-test-zip'
@@ -77,6 +80,10 @@ class ClusterConfiguration {
         return tmpFile.exists()
     }
 
+    public ClusterConfiguration(Project project) {
+        this.project = project
+    }
+
     Map<String, String> systemProperties = new HashMap<>()
 
     Map<String, String> settings = new HashMap<>()
@@ -84,7 +91,7 @@ class ClusterConfiguration {
     // map from destination path, to source file
     Map<String, Object> extraConfigFiles = new HashMap<>()
 
-    LinkedHashMap<String, Object> plugins = new LinkedHashMap<>()
+    LinkedHashMap<String, Project> plugins = new LinkedHashMap<>()
 
     List<Project> modules = new ArrayList<>()
 
@@ -101,13 +108,9 @@ class ClusterConfiguration {
     }
 
     @Input
-    void plugin(String name, FileCollection file) {
-        plugins.put(name, file)
-    }
-
-    @Input
-    void plugin(String name, Project pluginProject) {
-        plugins.put(name, pluginProject)
+    void plugin(String path) {
+        Project pluginProject = project.project(path)
+        plugins.put(pluginProject.name, pluginProject)
     }
 
     /** Add a module to the cluster. The project must be an esplugin and have a single zip default artifact. */

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -32,7 +32,7 @@ import org.gradle.util.ConfigureUtil
  */
 public class RestIntegTestTask extends RandomizedTestingTask {
 
-    ClusterConfiguration clusterConfig = new ClusterConfiguration()
+    ClusterConfiguration clusterConfig
 
     /** Flag indicating whether the rest tests in the rest spec should be run. */
     @Input
@@ -44,6 +44,7 @@ public class RestIntegTestTask extends RandomizedTestingTask {
         dependsOn(project.testClasses)
         classpath = project.sourceSets.test.runtimeClasspath
         testClassesDir = project.sourceSets.test.output.classesDir
+        clusterConfig = new ClusterConfiguration(project)
 
         // start with the common test configuration
         configure(BuildPlugin.commonTestConfig(project))

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RunTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RunTask.groovy
@@ -7,11 +7,15 @@ import org.gradle.util.ConfigureUtil
 
 public class RunTask extends DefaultTask {
 
-    ClusterConfiguration clusterConfig = new ClusterConfiguration(httpPort: 9200, transportPort: 9300, daemonize: false)
+    ClusterConfiguration clusterConfig
 
     public RunTask() {
         description = "Runs elasticsearch with '${project.path}'"
         group = 'Verification'
+        clusterConfig = new ClusterConfiguration(project)
+        clusterConfig.httpPort = 9200
+        clusterConfig.transportPort = 9300
+        clusterConfig.daemonize = false
         project.afterEvaluate {
             ClusterFormationTasks.setup(project, this, clusterConfig)
         }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -36,16 +36,18 @@ integTest {
 }
 
 // Build the cluser with all plugins
+
 project.rootProject.subprojects.findAll { it.parent.path == ':plugins' }.each { subproj ->
   /* Skip repositories. We just aren't going to be able to test them so it
    * doesn't make sense to waste time installing them. */
   if (subproj.path.startsWith(':plugins:repository-')) {
     return
   }
-  integTest {
-    cluster {
-      // We need a non-decorated project object, so we lookup the project by path
-      plugin subproj.name, project(subproj.path)
+  subproj.afterEvaluate { // need to wait until the project has been configured
+    integTest {
+      cluster {
+        plugin subproj.path
+      }
     }
   }
 }

--- a/qa/smoke-test-ingest-with-all-dependencies/build.gradle
+++ b/qa/smoke-test-ingest-with-all-dependencies/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
 integTest {
     cluster {
-        plugin 'ingest-geoip', project(':plugins:ingest-geoip')
+        plugin ':plugins:ingest-geoip'
         setting 'script.inline', 'true'
         setting 'path.scripts', "${project.buildDir}/resources/test/scripts"
     }

--- a/qa/smoke-test-plugins/build.gradle
+++ b/qa/smoke-test-plugins/build.gradle
@@ -25,8 +25,7 @@ ext.pluginsCount = 0
 project.rootProject.subprojects.findAll { it.parent.path == ':plugins' }.each { subproj ->
   integTest {
     cluster {
-      // need to get a non-decorated project object, so must re-lookup the project by path
-      plugin subproj.name, project(subproj.path)
+      plugin subproj.path
     }
   }
   pluginsCount += 1


### PR DESCRIPTION
This change removes the multiple ways that plugins can be added to the
integ test cluster. It also removes the use of the default
configuration, and instead adds a zip configuration to all plugins. This
will enable using project substitutions with plugins, which must be done
with the default configuration.

/cc @s1monw 
