### PR TITLE
Move `reset recovery` into RecoveriesCollection

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/core/src/main/java/org/elasticsearch/index/store/Store.java
@@ -1317,9 +1317,11 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
     }
 
     public void deleteQuiet(String... files) {
+        ensureOpen();
+        StoreDirectory directory = this.directory;
         for (String file : files) {
             try {
-                directory().deleteFile(file);
+               directory.deleteFile("Store.deleteQuiet", file);
             } catch (Exception ex) {
                 // ignore :(
             }

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveriesCollection.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveriesCollection.java
@@ -84,17 +84,9 @@ public class RecoveriesCollection {
             // which is important since we verify files are on disk etc. after we have written them etc.
             RecoveryTarget status = ref.status();
             RecoveryTarget resetRecovery = status.resetRecovery();
-            boolean success = false;
-            try {
-                if (onGoingRecoveries.replace(id, status, resetRecovery) == false) {
-                    throw new IllegalStateException("failed to replace recovery target");
-                }
-                success = true;
-            } finally {
-                if (success == false) {
-                    onGoingRecoveries.remove(id);
-                    resetRecovery.cancel("reset failed");
-                }
+            if (onGoingRecoveries.replace(id, status, resetRecovery) == false) {
+                resetRecovery.cancel("replace failed");
+                throw new IllegalStateException("failed to replace recovery target");
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTargetService.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTargetService.java
@@ -150,7 +150,7 @@ public class RecoveryTargetService extends AbstractComponent implements IndexEve
 
     private void retryRecovery(final RecoveryTarget recoveryTarget, TimeValue retryAfter, final StartRecoveryRequest currentRequest) {
         try {
-            recoveryTarget.resetRecovery();
+            onGoingRecoveries.resetRecovery(recoveryTarget.recoveryId(), recoveryTarget.shardId());
         } catch (Exception e) {
             onGoingRecoveries.failRecovery(recoveryTarget.recoveryId(), new RecoveryFailedException(currentRequest, e), true);
         }

--- a/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -202,7 +202,7 @@ public abstract class ESIndexLevelReplicationTestCase extends ESTestCase {
     }
 
     protected DiscoveryNode getDiscoveryNode(String id) {
-        return new DiscoveryNode(id, id, LocalTransportAddress.buildUnique(), Collections.emptyMap(),
+        return new DiscoveryNode(id, id, new LocalTransportAddress(id), Collections.emptyMap(),
             Collections.singleton(DiscoveryNode.Role.DATA), Version.CURRENT);
     }
 
@@ -231,7 +231,7 @@ public abstract class ESIndexLevelReplicationTestCase extends ESTestCase {
     }
 
 
-    public class ReplicationGroup implements AutoCloseable, Iterable<IndexShard> {
+    protected class ReplicationGroup implements AutoCloseable, Iterable<IndexShard> {
         private final IndexShard primary;
         private final List<IndexShard> replicas;
         private final IndexMetaData indexMetaData;

--- a/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -29,6 +29,8 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryRequest;
+import org.elasticsearch.action.admin.indices.stats.IndexShardStats;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.index.TransportIndexAction;
@@ -61,6 +63,7 @@ import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.index.shard.IndexEventListener;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.index.similarity.SimilarityService;
@@ -106,7 +109,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public abstract class ESIndexLevelReplicationTestCase extends ESTestCase {
 
-    private ThreadPool threadPool;
+    protected ThreadPool threadPool;
     private final Index index = new Index("test", "uuid");
     private final ShardId shardId = new ShardId(index, 0);
     private final Map<String, String> indexMapping = Collections.singletonMap("type", "{ \"type\": {} }");
@@ -160,14 +163,15 @@ public abstract class ESIndexLevelReplicationTestCase extends ESTestCase {
         }
     }
 
-
-    @Before
-    public void setup() {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         threadPool = new TestThreadPool(getClass().getName());
     }
 
-    @After
-    public void destroy() {
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
         ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
     }
 
@@ -197,7 +201,7 @@ public abstract class ESIndexLevelReplicationTestCase extends ESTestCase {
         return new ReplicationGroup(metaData, homePath);
     }
 
-    private DiscoveryNode getDiscoveryNode(String id) {
+    protected DiscoveryNode getDiscoveryNode(String id) {
         return new DiscoveryNode(id, id, LocalTransportAddress.buildUnique(), Collections.emptyMap(),
             Collections.singleton(DiscoveryNode.Role.DATA), Version.CURRENT);
     }
@@ -227,7 +231,7 @@ public abstract class ESIndexLevelReplicationTestCase extends ESTestCase {
     }
 
 
-    class ReplicationGroup implements AutoCloseable, Iterable<IndexShard> {
+    public class ReplicationGroup implements AutoCloseable, Iterable<IndexShard> {
         private final IndexShard primary;
         private final List<IndexShard> replicas;
         private final IndexMetaData indexMetaData;
@@ -279,15 +283,21 @@ public abstract class ESIndexLevelReplicationTestCase extends ESTestCase {
             replicas.add(replica);
             return replica;
         }
-
         public void recoverReplica(IndexShard replica, BiFunction<IndexShard, DiscoveryNode, RecoveryTarget> targetSupplier)
             throws IOException {
-            final DiscoveryNode pNode;
-            synchronized (this) {
-                pNode = getDiscoveryNode(primary.routingEntry().currentNodeId());
-            }
+            recoverReplica(replica, targetSupplier, true);
+        }
+
+        public void recoverReplica(IndexShard replica, BiFunction<IndexShard, DiscoveryNode, RecoveryTarget> targetSupplier,
+                                   boolean markAsRecovering)
+            throws IOException {
+            final DiscoveryNode pNode = getPrimaryNode();
             final DiscoveryNode rNode = getDiscoveryNode(replica.routingEntry().currentNodeId());
-            replica.markAsRecovering("remote", new RecoveryState(replica.shardId(), false, RecoveryState.Type.REPLICA, pNode, rNode));
+            if (markAsRecovering) {
+                replica.markAsRecovering("remote", new RecoveryState(replica.shardId(), false, RecoveryState.Type.REPLICA, pNode, rNode));
+            } else {
+                assertEquals(replica.state(), IndexShardState.RECOVERING);
+            }
             replica.prepareForIndexRecovery();
             RecoveryTarget recoveryTarget = targetSupplier.apply(replica, pNode);
             StartRecoveryRequest request = new StartRecoveryRequest(replica.shardId(), pNode, rNode,
@@ -297,6 +307,10 @@ public abstract class ESIndexLevelReplicationTestCase extends ESTestCase {
             recovery.recoverToTarget();
             recoveryTarget.markAsDone();
             replica.updateRoutingEntry(ShardRoutingHelper.moveToStarted(replica.routingEntry()));
+        }
+
+        public synchronized DiscoveryNode getPrimaryNode() {
+            return getDiscoveryNode(primary.routingEntry().currentNodeId());
         }
 
         public Future<Void> asyncRecoverReplica(IndexShard replica, BiFunction<IndexShard, DiscoveryNode, RecoveryTarget> targetSupplier)
@@ -374,6 +388,10 @@ public abstract class ESIndexLevelReplicationTestCase extends ESTestCase {
         @Override
         public Iterator<IndexShard> iterator() {
             return Iterators.<IndexShard>concat(replicas.iterator(), Collections.singleton(primary).iterator());
+        }
+
+        public IndexShard getPrimary() {
+            return primary;
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/indices/recovery/RecoveryStatusTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/RecoveryStatusTests.java
@@ -36,8 +36,6 @@ import java.util.regex.Pattern;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 
-/**
- */
 public class RecoveryStatusTests extends ESSingleNodeTestCase {
 
     public void testRenameTempFiles() throws IOException {
@@ -73,7 +71,7 @@ public class RecoveryStatusTests extends ESSingleNodeTestCase {
         Set<String> strings = Sets.newHashSet(status.store().directory().listAll());
         String expectedFile = null;
         for (String file : strings) {
-            if (Pattern.compile("recovery[.]\\d+[.]foo[.]bar").matcher(file).matches()) {
+            if (Pattern.compile("recovery[.][\\w-]+[.]foo[.]bar").matcher(file).matches()) {
                 expectedFile = file;
                 break;
             }

--- a/core/src/test/java/org/elasticsearch/recovery/RecoveriesCollectionTests.java
+++ b/core/src/test/java/org/elasticsearch/recovery/RecoveriesCollectionTests.java
@@ -156,7 +156,7 @@ public class RecoveriesCollectionTests extends ESIndexLevelReplicationTestCase {
                 }, false);
             }
             shards.assertAllEqual(numDocs);
-            assertNull("recovery is dones", collection.getRecovery(recoveryId));
+            assertNull("recovery is done", collection.getRecovery(recoveryId));
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/recovery/RecoveriesCollectionTests.java
+++ b/core/src/test/java/org/elasticsearch/recovery/RecoveriesCollectionTests.java
@@ -18,12 +18,15 @@
  */
 package org.elasticsearch.recovery;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.LocalTransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.replication.ESIndexLevelReplicationTestCase;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
@@ -32,8 +35,12 @@ import org.elasticsearch.indices.recovery.RecoveryFailedException;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.indices.recovery.RecoveryTargetService;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Before;
 
+import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -43,7 +50,7 @@ import static java.util.Collections.emptySet;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 
-public class RecoveriesCollectionTests extends ESSingleNodeTestCase {
+public class RecoveriesCollectionTests extends ESIndexLevelReplicationTestCase {
     static final RecoveryTargetService.RecoveryListener listener = new RecoveryTargetService.RecoveryListener() {
         @Override
         public void onRecoveryDone(RecoveryState state) {
@@ -57,83 +64,112 @@ public class RecoveriesCollectionTests extends ESSingleNodeTestCase {
     };
 
     public void testLastAccessTimeUpdate() throws Exception {
-        createIndex();
-        final RecoveriesCollection collection = new RecoveriesCollection(logger, getInstanceFromNode(ThreadPool.class));
-        final long recoveryId = startRecovery(collection);
-        try (RecoveriesCollection.RecoveryRef status = collection.getRecovery(recoveryId)) {
-            final long lastSeenTime = status.status().lastAccessTime();
-            assertBusy(new Runnable() {
-                @Override
-                public void run() {
+        try (ReplicationGroup shards = createGroup(1)) {
+            final RecoveriesCollection collection = new RecoveriesCollection(logger, threadPool);
+            final long recoveryId = startRecovery(collection, shards.getPrimaryNode(), shards.addReplica());
+            try (RecoveriesCollection.RecoveryRef status = collection.getRecovery(recoveryId)) {
+                final long lastSeenTime = status.status().lastAccessTime();
+                assertBusy(() -> {
                     try (RecoveriesCollection.RecoveryRef currentStatus = collection.getRecovery(recoveryId)) {
                         assertThat("access time failed to update", lastSeenTime, lessThan(currentStatus.status().lastAccessTime()));
                     }
-                }
-            });
-        } finally {
-            collection.cancelRecovery(recoveryId, "life");
+                });
+            } finally {
+                collection.cancelRecovery(recoveryId, "life");
+            }
         }
     }
 
-    public void testRecoveryTimeout() throws InterruptedException {
-        createIndex();
-        final RecoveriesCollection collection = new RecoveriesCollection(logger, getInstanceFromNode(ThreadPool.class));
-        final AtomicBoolean failed = new AtomicBoolean();
-        final CountDownLatch latch = new CountDownLatch(1);
-        final long recoveryId = startRecovery(collection, new RecoveryTargetService.RecoveryListener() {
-            @Override
-            public void onRecoveryDone(RecoveryState state) {
-                latch.countDown();
-            }
+    public void testRecoveryTimeout() throws Exception {
+        try (ReplicationGroup shards = createGroup(1)) {
+            final RecoveriesCollection collection = new RecoveriesCollection(logger, threadPool);
+            final AtomicBoolean failed = new AtomicBoolean();
+            final CountDownLatch latch = new CountDownLatch(1);
+            final long recoveryId = startRecovery(collection, shards.getPrimaryNode(), shards.addReplica(),
+            new RecoveryTargetService.RecoveryListener() {
+                @Override
+                public void onRecoveryDone(RecoveryState state) {
+                    latch.countDown();
+                }
 
-            @Override
-            public void onRecoveryFailure(RecoveryState state, RecoveryFailedException e, boolean sendShardFailure) {
-                failed.set(true);
-                latch.countDown();
+                @Override
+                public void onRecoveryFailure(RecoveryState state, RecoveryFailedException e, boolean sendShardFailure) {
+                    failed.set(true);
+                    latch.countDown();
+                }
+            }, TimeValue.timeValueMillis(100));
+            try {
+                latch.await(30, TimeUnit.SECONDS);
+                assertTrue("recovery failed to timeout", failed.get());
+            } finally {
+                collection.cancelRecovery(recoveryId, "meh");
             }
-        }, TimeValue.timeValueMillis(100));
-        try {
-            latch.await(30, TimeUnit.SECONDS);
-            assertTrue("recovery failed to timeout", failed.get());
-        } finally {
-            collection.cancelRecovery(recoveryId, "meh");
         }
 
     }
 
     public void testRecoveryCancellation() throws Exception {
-        createIndex();
-        final RecoveriesCollection collection = new RecoveriesCollection(logger, getInstanceFromNode(ThreadPool.class));
-        final long recoveryId = startRecovery(collection);
-        final long recoveryId2 = startRecovery(collection);
-        try (RecoveriesCollection.RecoveryRef recoveryRef = collection.getRecovery(recoveryId)) {
-            ShardId shardId = recoveryRef.status().shardId();
-            assertTrue("failed to cancel recoveries", collection.cancelRecoveriesForShard(shardId, "test"));
-            assertThat("all recoveries should be cancelled", collection.size(), equalTo(0));
-        } finally {
-            collection.cancelRecovery(recoveryId, "meh");
-            collection.cancelRecovery(recoveryId2, "meh");
+        try (ReplicationGroup shards = createGroup(1)) {
+            final RecoveriesCollection collection = new RecoveriesCollection(logger, threadPool);
+            final long recoveryId = startRecovery(collection, shards.getPrimaryNode(), shards.addReplica());
+            final long recoveryId2 = startRecovery(collection, shards.getPrimaryNode(), shards.addReplica());
+            try (RecoveriesCollection.RecoveryRef recoveryRef = collection.getRecovery(recoveryId)) {
+                ShardId shardId = recoveryRef.status().shardId();
+                assertTrue("failed to cancel recoveries", collection.cancelRecoveriesForShard(shardId, "test"));
+                assertThat("all recoveries should be cancelled", collection.size(), equalTo(0));
+            } finally {
+                collection.cancelRecovery(recoveryId, "meh");
+                collection.cancelRecovery(recoveryId2, "meh");
+            }
         }
     }
 
-    protected void createIndex() {
-        createIndex("test",
-                Settings.builder()
-                        .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
-                        .build());
-        ensureGreen();
+    public void testResetRecovery() throws Exception {
+        try (ReplicationGroup shards = createGroup(1)) {
+            shards.startAll();
+            int numDocs = randomIntBetween(1, 15);
+            shards.indexDocs(numDocs);
+            final RecoveriesCollection collection = new RecoveriesCollection(logger, threadPool);
+            IndexShard shard = shards.addReplica();
+            final long recoveryId = startRecovery(collection, shards.getPrimaryNode(), shard);
+            try (RecoveriesCollection.RecoveryRef recovery = collection.getRecovery(recoveryId)) {
+                final int currentAsTarget = shard.recoveryStats().currentAsTarget();
+                final int referencesToStore = recovery.status().store().refCount();
+                collection.resetRecovery(recoveryId, recovery.status().shardId());
+                try (RecoveriesCollection.RecoveryRef resetRecovery = collection.getRecovery(recoveryId)) {
+                    assertNotSame(recovery.status(), resetRecovery);
+                    assertSame(recovery.status().CancellableThreads(), resetRecovery.status().CancellableThreads());
+                    assertSame(recovery.status().indexShard(), resetRecovery.status().indexShard());
+                    assertSame(recovery.status().store(), resetRecovery.status().store());
+                    assertEquals(referencesToStore + 1, resetRecovery.status().store().refCount());
+                    assertEquals(currentAsTarget+1, shard.recoveryStats().currentAsTarget()); // we blink for a short moment...
+                    recovery.close();
+                    expectThrows(ElasticsearchException.class, () -> recovery.status().store());
+                    assertEquals(referencesToStore, resetRecovery.status().store().refCount());
+                }
+                assertEquals(currentAsTarget, shard.recoveryStats().currentAsTarget());
+            }
+            try (RecoveriesCollection.RecoveryRef resetRecovery = collection.getRecovery(recoveryId)) {
+                shards.recoverReplica(shard, (s, n) -> {
+                    assertSame(s, resetRecovery.status().indexShard());
+                    return resetRecovery.status();
+                }, false);
+            }
+            shards.assertAllEqual(numDocs);
+            assertNull("recovery is dones", collection.getRecovery(recoveryId));
+        }
     }
 
-
-    long startRecovery(RecoveriesCollection collection) {
-        return startRecovery(collection, listener, TimeValue.timeValueMinutes(60));
+    long startRecovery(RecoveriesCollection collection, DiscoveryNode sourceNode, IndexShard shard) {
+        return startRecovery(collection,sourceNode, shard, listener, TimeValue.timeValueMinutes(60));
     }
 
-    long startRecovery(RecoveriesCollection collection, RecoveryTargetService.RecoveryListener listener, TimeValue timeValue) {
-        IndicesService indexServices = getInstanceFromNode(IndicesService.class);
-        IndexShard indexShard = indexServices.indexServiceSafe(resolveIndex("test")).getShardOrNull(0);
-        final DiscoveryNode sourceNode = new DiscoveryNode("id", LocalTransportAddress.buildUnique(), emptyMap(), emptySet(),
-            Version.CURRENT);
+    long startRecovery(RecoveriesCollection collection, DiscoveryNode sourceNode, IndexShard indexShard,
+                       RecoveryTargetService.RecoveryListener listener, TimeValue timeValue) {
+        final DiscoveryNode rNode = getDiscoveryNode(indexShard.routingEntry().currentNodeId());
+        indexShard.markAsRecovering("remote", new RecoveryState(indexShard.shardId(), false, RecoveryState.Type.REPLICA, sourceNode,
+            rNode));
+        indexShard.prepareForIndexRecovery();
         return collection.startRecovery(indexShard, sourceNode, listener, timeValue);
     }
 }


### PR DESCRIPTION
Today when we reset a recovery because of the source not being
ready or the shard is getting removed on the source (for whatever reason)
we wipe all temp files and reset the recovery without respecting any
reference counting or locking etc. all streams are closed and files are
wiped. Yet, this is problematic since we assert that some files are on disk
etc. when we finish writing a file. These assertions don't hold anymore if we
concurrently wipe the tmp files.

This change moves the logic out of RecoveryTarget into RecoveriesCollection which
basically clones the RecoveryTarget on reset instead which allows in-flight operations
to finish gracefully. This means we now have a single path for cleanups in RecoveryTarget
and can safely use assertions in the class since files won't be removed unless the recovery
is either cancelled, failed or finished.

Closes #19473
