### PR TITLE
Fix create_bwc_index for 5.x

### DIFF
--- a/dev-tools/create_bwc_index.py
+++ b/dev-tools/create_bwc_index.py
@@ -245,29 +245,57 @@ def generate_index(client, version, index_name):
         'auto_boost': True
       }
     }
-
-  mappings['norms'] = {
-    'properties': {
-      'string_with_norms_disabled': {
-        'type': 'text',
-        'norms' : False
-      },
-      'string_with_norms_enabled': {
-        'type': 'text',
-        'index': 'not_analyzed',
-        'norms': True
+  if parse_version(version) < parse_version("5.0.0-alpha1"):
+    mappings['norms'] = {
+      'properties': {
+        'string_with_norms_disabled': {
+          'type': 'string',
+          'norms' : {
+            'enabled' : False
+          }
+        },
+        'string_with_norms_enabled': {
+          'type': 'string',
+          'index': 'not_analyzed',
+          'norms': {
+            'enabled' : True,
+            'loading': 'eager'
+          }
+        }
       }
     }
-  }
 
-  mappings['doc'] = {
-    'properties': {
-      'string': {
-        'type': 'text',
-        'boost': 4
+    mappings['doc'] = {
+      'properties': {
+        'string': {
+          'type': 'string',
+          'boost': 4
+        }
       }
     }
-  }
+  else: # current version of the norms mapping
+    mappings['norms'] = {
+      'properties': {
+        'string_with_norms_disabled': {
+          'type': 'text',
+          'norms' : False
+        },
+        'string_with_norms_enabled': {
+          'type': 'text',
+          'index': 'not_analyzed',
+          'norms': True,
+          'eager_global_ordinals' : True
+        }
+      }
+    }
+    mappings['doc'] = {
+      'properties': {
+        'string': {
+          'type': 'text',
+          'boost': 4
+        }
+      }
+    }
 
   settings = {
     'number_of_shards': 1,

--- a/dev-tools/create_bwc_index.py
+++ b/dev-tools/create_bwc_index.py
@@ -250,17 +250,12 @@ def generate_index(client, version, index_name):
     'properties': {
       'string_with_norms_disabled': {
         'type': 'text',
-        'norms': {
-          'enabled': False
-        }
+        'norms' : False
       },
       'string_with_norms_enabled': {
         'type': 'text',
         'index': 'not_analyzed',
-        'norms': {
-          'enabled': True,
-          'loading': 'eager'
-        }
+        'norms': True
       }
     }
   }
@@ -448,7 +443,6 @@ def parse_version(version):
     splitted = splitted + ['GA']
   splitted = [s.lower() for s in splitted]
   assert len(splitted) == 4;
-  print (splitted)
   return splitted
 
 assert parse_version('5.0.0-alpha1') == parse_version('5.0.0-alpha1')

--- a/dev-tools/create_bwc_index.py
+++ b/dev-tools/create_bwc_index.py
@@ -281,7 +281,7 @@ def generate_index(client, version, index_name):
           'norms' : False
         },
         'string_with_norms_enabled': {
-          'type': 'text',
+          'type': 'keyword',
           'index': 'not_analyzed',
           'norms': True,
           'eager_global_ordinals' : True


### PR DESCRIPTION
`create_bwc_index.py` has some cruft in it that only works on 2.x or
even before. This commit make the tool functional, yet there might still
be some bwc relevant things missing here.

Closes #19253
