### PR TITLE
Automatically created indices should honor `index.mapper.dynamic`.

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -119,29 +119,21 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
 
         if (needToCheck()) {
             // Keep track of all unique indices and all unique types per index for the create index requests:
-            final Map<String, Set<String>> indicesAndTypes = new HashMap<>();
+            final Set<String> autoCreateIndices = new HashSet<>();
             for (ActionRequest request : bulkRequest.requests) {
                 if (request instanceof DocumentRequest) {
                     DocumentRequest req = (DocumentRequest) request;
-                    Set<String> types = indicesAndTypes.get(req.index());
-                    if (types == null) {
-                        indicesAndTypes.put(req.index(), types = new HashSet<>());
-                    }
-                    types.add(req.type());
+                    autoCreateIndices.add(req.index());
                 } else {
                     throw new ElasticsearchException("Parsed unknown request in bulk actions: " + request.getClass().getSimpleName());
                 }
             }
-            final AtomicInteger counter = new AtomicInteger(indicesAndTypes.size());
+            final AtomicInteger counter = new AtomicInteger(autoCreateIndices.size());
             ClusterState state = clusterService.state();
-            for (Map.Entry<String, Set<String>> entry : indicesAndTypes.entrySet()) {
-                final String index = entry.getKey();
+            for (String index : autoCreateIndices) {
                 if (shouldAutoCreate(index, state)) {
                     CreateIndexRequest createIndexRequest = new CreateIndexRequest();
                     createIndexRequest.index(index);
-                    for (String type : entry.getValue()) {
-                        createIndexRequest.mapping(type);
-                    }
                     createIndexRequest.cause("auto(bulk api)");
                     createIndexRequest.masterNodeTimeout(bulkRequest.timeout());
                     createIndexAction.execute(createIndexRequest, new ActionListener<CreateIndexResponse>() {

--- a/core/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
@@ -91,7 +91,6 @@ public class TransportIndexAction extends TransportWriteAction<IndexRequest, Ind
         if (autoCreateIndex.shouldAutoCreate(request.index(), state)) {
             CreateIndexRequest createIndexRequest = new CreateIndexRequest();
             createIndexRequest.index(request.index());
-            createIndexRequest.mapping(request.type());
             createIndexRequest.cause("auto(index api)");
             createIndexRequest.masterNodeTimeout(request.timeout());
             createIndexAction.execute(task, createIndexRequest, new ActionListener<CreateIndexResponse>() {

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -538,7 +538,8 @@ public class MapperService extends AbstractIndexComponent {
             return new DocumentMapperForType(mapper, null);
         }
         if (!dynamic) {
-            throw new TypeMissingException(index(), type, "trying to auto create mapping, but dynamic mapping is disabled");
+            throw new TypeMissingException(index(),
+                    new IllegalStateException("trying to auto create mapping, but dynamic mapping is disabled"), type);
         }
         mapper = parse(type, null, true);
         return new DocumentMapperForType(mapper, mapper.mapping());

--- a/core/src/main/java/org/elasticsearch/indices/TypeMissingException.java
+++ b/core/src/main/java/org/elasticsearch/indices/TypeMissingException.java
@@ -33,7 +33,12 @@ import java.util.Arrays;
 public class TypeMissingException extends ElasticsearchException {
 
     public TypeMissingException(Index index, String... types) {
-        super("type[" + Arrays.toString(types) + "] missing");
+        super("type" + Arrays.toString(types) + " missing");
+        setIndex(index);
+    }
+
+    public TypeMissingException(Index index, Throwable cause, String... types) {
+        super("type" + Arrays.toString(types) + " missing", cause);
         setIndex(index);
     }
 


### PR DESCRIPTION
Today they don't because the create index request that is implicitly created
adds an empty mapping for the type of the document. So to Elasticsearch it
looks like this type was explicitly created and `index.mapper.dynamic` is not
checked.

Closes #17592
