### PR TITLE
Fixed incorrect YAML indentation in the "Rollover" tests again

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yaml
@@ -31,12 +31,12 @@
 
   # perform alias rollover
   - do:
-    indices.rollover:
-      alias: "logs_search"
-      wait_for_active_shards: 1
-      body:
-        conditions:
-          max_docs: 1
+      indices.rollover:
+        alias: "logs_search"
+        wait_for_active_shards: 1
+        body:
+          conditions:
+            max_docs: 1
 
   - match: { old_index: logs-1 }
   - match: { new_index: logs-2 }


### PR DESCRIPTION
As part of changes in d78f40fb1e88c78ce4466fe145d365c205441e43, a fix to the YAML
indentation has been reverted, see location: https://github.com/elastic/elasticsearch/commit/d78f40fb1e88c78ce4466fe145d365c205441e43#diff-eaf129528b571da2cafdfd5490c12453

This patch fixes the YAML notation back.

/cc @abeyad
