### PR TITLE
Migrate serial_diff aggregation to NamedWriteable

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -644,8 +644,11 @@ public class SearchModule extends AbstractModule {
                 BucketScriptPipelineAggregationBuilder.AGGREGATION_NAME_FIELD);
         registerPipelineAggregation(BucketSelectorPipelineAggregationBuilder::new, BucketSelectorPipelineAggregationBuilder::parse,
                 BucketSelectorPipelineAggregationBuilder.AGGREGATION_NAME_FIELD);
-        registerPipelineAggregation(SerialDiffPipelineAggregationBuilder::new, SerialDiffPipelineAggregationBuilder::parse,
-                SerialDiffPipelineAggregationBuilder.AGGREGATION_NAME_FIELD);
+        registerPipelineAggregation(new PipelineAggregationSpec(
+                SerialDiffPipelineAggregationBuilder::new,
+                SerialDiffPipelineAggregationBuilder::parse,
+                SerialDiffPipelineAggregationBuilder.AGGREGATION_NAME_FIELD)
+                    .addResultReader(SerialDiffPipelineAggregator::new));
     }
 
     protected void configureSearch() {
@@ -889,6 +892,5 @@ public class SearchModule extends AbstractModule {
         CumulativeSumPipelineAggregator.registerStreams();
         BucketScriptPipelineAggregator.registerStreams();
         BucketSelectorPipelineAggregator.registerStreams();
-        SerialDiffPipelineAggregator.registerStreams();
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/serialdiff/SerialDiffPipelineAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/serialdiff/SerialDiffPipelineAggregationBuilder.java
@@ -41,7 +41,7 @@ import static org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.
 import static org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.Parser.FORMAT;
 
 public class SerialDiffPipelineAggregationBuilder extends AbstractPipelineAggregationBuilder<SerialDiffPipelineAggregationBuilder> {
-    public static final String NAME = SerialDiffPipelineAggregator.TYPE.name();
+    public static final String NAME = "serial_diff";
     public static final ParseField AGGREGATION_NAME_FIELD = new ParseField(NAME);
 
     private static final ParseField GAP_POLICY = new ParseField("gap_policy");
@@ -52,14 +52,14 @@ public class SerialDiffPipelineAggregationBuilder extends AbstractPipelineAggreg
     private int lag = 1;
 
     public SerialDiffPipelineAggregationBuilder(String name, String bucketsPath) {
-        super(name, SerialDiffPipelineAggregator.TYPE.name(), new String[] { bucketsPath });
+        super(name, NAME, new String[] { bucketsPath });
     }
 
     /**
      * Read from a stream.
      */
     public SerialDiffPipelineAggregationBuilder(StreamInput in) throws IOException {
-        super(in, SerialDiffPipelineAggregator.TYPE.name());
+        super(in, NAME);
         format = in.readOptionalString();
         gapPolicy = GapPolicy.readFrom(in);
         lag = in.readVInt();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/serialdiff/SerialDiffPipelineAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/serialdiff/SerialDiffPipelineAggregator.java
@@ -26,13 +26,11 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
-import org.elasticsearch.search.aggregations.InternalAggregation.Type;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.histogram.InternalHistogram;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.elasticsearch.search.aggregations.pipeline.InternalSimpleValue;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorStreams;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -44,25 +42,9 @@ import java.util.stream.StreamSupport;
 import static org.elasticsearch.search.aggregations.pipeline.BucketHelpers.resolveBucketValue;
 
 public class SerialDiffPipelineAggregator extends PipelineAggregator {
-
-    public static final Type TYPE = new Type("serial_diff");
-
-    public static final PipelineAggregatorStreams.Stream STREAM = in -> {
-        SerialDiffPipelineAggregator result = new SerialDiffPipelineAggregator();
-        result.readFrom(in);
-        return result;
-    };
-
-    public static void registerStreams() {
-        PipelineAggregatorStreams.registerStream(STREAM, TYPE.stream());
-    }
-
     private DocValueFormat formatter;
     private GapPolicy gapPolicy;
     private int lag;
-
-    public SerialDiffPipelineAggregator() {
-    }
 
     public SerialDiffPipelineAggregator(String name, String[] bucketsPaths, @Nullable DocValueFormat formatter, GapPolicy gapPolicy,
                                         int lag, Map<String, Object> metadata) {
@@ -72,9 +54,26 @@ public class SerialDiffPipelineAggregator extends PipelineAggregator {
         this.lag = lag;
     }
 
+    /**
+     * Read from a stream.
+     */
+    public SerialDiffPipelineAggregator(StreamInput in) throws IOException {
+        super(in);
+        formatter = in.readNamedWriteable(DocValueFormat.class);
+        gapPolicy = GapPolicy.readFrom(in);
+        lag = in.readVInt();
+    }
+
     @Override
-    public Type type() {
-        return TYPE;
+    public void doWriteTo(StreamOutput out) throws IOException {
+        out.writeNamedWriteable(formatter);
+        gapPolicy.writeTo(out);
+        out.writeVInt(lag);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return SerialDiffPipelineAggregationBuilder.NAME;
     }
 
     @Override
@@ -124,19 +123,5 @@ public class SerialDiffPipelineAggregator extends PipelineAggregator {
 
         }
         return factory.create(newBuckets, histo);
-    }
-
-    @Override
-    public void doReadFrom(StreamInput in) throws IOException {
-        formatter = in.readNamedWriteable(DocValueFormat.class);
-        gapPolicy = GapPolicy.readFrom(in);
-        lag = in.readVInt();
-    }
-
-    @Override
-    public void doWriteTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteable(formatter);
-        gapPolicy.writeTo(out);
-        out.writeVInt(lag);
     }
 }


### PR DESCRIPTION
This is the last migration before AggregationStreams and
PipelineAggregatorStreams can be removed to remove redundant
code.
