### PR TITLE
Fix NPE when initializing replica shard has no UnassignedInfo

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -237,10 +237,9 @@ public final class ShardRouting implements Writeable, ToXContent {
             return true;
         }
 
-        // unassigned info is only cleared when a shard moves to started, so
-        // for unassigned and initializing (we checked for active() before),
-        // we can safely assume it is there
-        if (unassignedInfo.getReason() == UnassignedInfo.Reason.INDEX_CREATED) {
+        // initializing replica might not have unassignedInfo
+        assert unassignedInfo != null || (primary == false && state == ShardRoutingState.INITIALIZING);
+        if (unassignedInfo != null && unassignedInfo.getReason() == UnassignedInfo.Reason.INDEX_CREATED) {
             return false;
         }
 


### PR DESCRIPTION
An initializing replica shard might not have an UnassignedInfo object, for example when it is a relocation target.  The method `allocatedPostIndexCreate` does not account for this situation.

Closes #19488
