### PR TITLE
Add support for path_style_access

### DIFF
--- a/docs/plugins/cloud-aws.asciidoc
+++ b/docs/plugins/cloud-aws.asciidoc
@@ -377,6 +377,12 @@ The following settings are supported:
     currently supported by the plugin. For more information about the
     different classes, see http://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html[AWS Storage Classes Guide]
 
+`path_style_access`::
+
+    Activate path style access for [virtual hosting of buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html).
+    The default behaviour is to detect which access style to use based on the configured endpoint (an IP will result
+    in path-style access) and the bucket being accessed (some buckets are not valid DNS names).
+
 Note that you can define S3 repository settings for all S3 repositories in `elasticsearch.yml` configuration file.
 They are all prefixed with `repositories.s3.`. For example, you can define compression for all S3 repositories
 by setting `repositories.s3.compress: true` in `elasticsearch.yml`.

--- a/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
+++ b/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
@@ -57,8 +57,9 @@ public interface AwsS3Service extends LifecycleComponent<AwsS3Service> {
         public static final String STORAGE_CLASS = "repositories.s3.storage_class";
         public static final String CANNED_ACL = "repositories.s3.canned_acl";
         public static final String BASE_PATH = "repositories.s3.base_path";
+        public static final String PATH_STYLE_ACCESS = "repositories.s3.path_style_access";
     }
 
     AmazonS3 client(String endpoint, String protocol, String region, String account, String key, Integer maxRetries,
-                    boolean useThrottleRetries);
+                    boolean useThrottleRetries, Boolean pathStyleAccess);
 }

--- a/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -26,6 +26,7 @@ import com.amazonaws.http.IdleConnectionReaper;
 import com.amazonaws.internal.StaticCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.S3ClientOptions;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cloud.aws.AwsService.CLOUD_AWS;
 import org.elasticsearch.common.collect.Tuple;
@@ -54,7 +55,7 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent<AwsS3Servic
 
     @Override
     public synchronized AmazonS3 client(String endpoint, String protocol, String region, String account, String key, Integer maxRetries,
-                                        boolean useThrottleRetries) {
+                                        boolean useThrottleRetries, Boolean pathStyleAccess) {
         if (region != null && endpoint == null) {
             endpoint = getEndpoint(region);
             logger.debug("using s3 region [{}], with endpoint [{}]", region, endpoint);
@@ -66,12 +67,12 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent<AwsS3Servic
             key = settings.get(CLOUD_S3.SECRET, settings.get(CLOUD_AWS.SECRET));
         }
 
-        return getClient(endpoint, protocol, account, key, maxRetries, useThrottleRetries);
+        return getClient(endpoint, protocol, account, key, maxRetries, useThrottleRetries, pathStyleAccess);
     }
 
 
     private synchronized AmazonS3 getClient(String endpoint, String protocol, String account, String key, Integer maxRetries,
-                                            boolean useThrottleRetries) {
+                                            boolean useThrottleRetries, Boolean pathStyleAccess) {
         Tuple<String, String> clientDescriptor = new Tuple<String, String>(endpoint, account);
         AmazonS3Client client = clients.get(clientDescriptor);
         if (client != null) {
@@ -147,6 +148,11 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent<AwsS3Servic
         if (endpoint != null) {
             client.setEndpoint(endpoint);
         }
+
+        if (pathStyleAccess != null) {
+            client.setS3ClientOptions(new S3ClientOptions().withPathStyleAccess(pathStyleAccess));
+        }
+
         clients.put(clientDescriptor, client);
         return client;
     }

--- a/plugins/cloud-aws/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/cloud-aws/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -121,19 +121,20 @@ public class S3Repository extends BlobStoreRepository {
         boolean useThrottleRetries = repositorySettings.settings().getAsBoolean("use_throttle_retries", settings.getAsBoolean(REPOSITORY_S3.USE_THROTTLE_RETRIES, ClientConfiguration.DEFAULT_THROTTLE_RETRIES));
         this.chunkSize = repositorySettings.settings().getAsBytesSize("chunk_size", settings.getAsBytesSize(REPOSITORY_S3.CHUNK_SIZE, new ByteSizeValue(100, ByteSizeUnit.MB)));
         this.compress = repositorySettings.settings().getAsBoolean("compress", settings.getAsBoolean(REPOSITORY_S3.COMPRESS, false));
+        Boolean pathStyleAccess = repositorySettings.settings().getAsBoolean("path_style_access", settings.getAsBoolean(REPOSITORY_S3.PATH_STYLE_ACCESS, null));
 
         // Parse and validate the user's S3 Storage Class setting
         String storageClass = repositorySettings.settings().get("storage_class", settings.get(REPOSITORY_S3.STORAGE_CLASS, null));
         String cannedACL = repositorySettings.settings().get("canned_acl", settings.get(REPOSITORY_S3.CANNED_ACL, null));
 
         logger.debug("using bucket [{}], region [{}], endpoint [{}], protocol [{}], chunk_size [{}], server_side_encryption [{}], " +
-                "buffer_size [{}], max_retries [{}], use_throttle_retries [{}], cannedACL [{}], storageClass [{}]",
+                "buffer_size [{}], max_retries [{}], use_throttle_retries [{}], cannedACL [{}], storageClass [{}], path_style_access [{}]",
             bucket, region, endpoint, protocol, chunkSize, serverSideEncryption, bufferSize, maxRetries, useThrottleRetries, cannedACL,
-            storageClass);
+            storageClass, pathStyleAccess);
 
         blobStore = new S3BlobStore(settings, s3Service.client(endpoint, protocol, region, repositorySettings.settings().get("access_key"),
-            repositorySettings.settings().get("secret_key"), maxRetries, useThrottleRetries), bucket, region, serverSideEncryption,
-            bufferSize, maxRetries, cannedACL, storageClass);
+            repositorySettings.settings().get("secret_key"), maxRetries, useThrottleRetries, pathStyleAccess),
+            bucket, region, serverSideEncryption, bufferSize, maxRetries, cannedACL, storageClass);
 
         String basePath = repositorySettings.settings().get("base_path", settings.get(REPOSITORY_S3.BASE_PATH));
         if (Strings.hasLength(basePath)) {

--- a/plugins/cloud-aws/src/test/java/org/elasticsearch/cloud/aws/TestAwsS3Service.java
+++ b/plugins/cloud-aws/src/test/java/org/elasticsearch/cloud/aws/TestAwsS3Service.java
@@ -51,8 +51,8 @@ public class TestAwsS3Service extends InternalAwsS3Service {
 
     @Override
     public synchronized AmazonS3 client(String endpoint, String protocol, String region, String account, String key, Integer maxRetries,
-                                        boolean useThrottleRetries) {
-        return cachedWrapper(super.client(endpoint, protocol, region, account, key, maxRetries, useThrottleRetries));
+                                        boolean useThrottleRetries, Boolean pathStyleAccess) {
+        return cachedWrapper(super.client(endpoint, protocol, region, account, key, maxRetries, useThrottleRetries, pathStyleAccess));
     }
 
     private AmazonS3 cachedWrapper(AmazonS3 client) {

--- a/plugins/cloud-aws/src/test/java/org/elasticsearch/repositories/s3/AbstractS3SnapshotRestoreTestCase.java
+++ b/plugins/cloud-aws/src/test/java/org/elasticsearch/repositories/s3/AbstractS3SnapshotRestoreTestCase.java
@@ -208,7 +208,7 @@ abstract public class AbstractS3SnapshotRestoreTestCase extends AbstractAwsTestC
             bucket.get("region", settings.get("repositories.s3.region")),
             bucket.get("access_key", settings.get("cloud.aws.access_key")),
             bucket.get("secret_key", settings.get("cloud.aws.secret_key")),
-            null, randomBoolean());
+            null, randomBoolean(), null);
 
         String bucketName = bucket.get("bucket");
         logger.info("--> verify encryption for bucket [{}], prefix [{}]", bucketName, basePath);
@@ -473,7 +473,7 @@ abstract public class AbstractS3SnapshotRestoreTestCase extends AbstractAwsTestC
             // as described in README
             assertThat("Your settings in elasticsearch.yml are incorrects. Check README file.", bucketName, notNullValue());
             AmazonS3 client = internalCluster().getInstance(AwsS3Service.class).client(endpoint, protocol, region, accessKey, secretKey,
-                null, randomBoolean());
+                null, randomBoolean(), null);
             try {
                 ObjectListing prevListing = null;
                 //From http://docs.amazonwebservices.com/AmazonS3/latest/dev/DeletingMultipleObjectsUsingJava.html


### PR DESCRIPTION
Add a new option `path_style_access` for S3 buckets. It adds support for path style access for [virtual hosting of buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html).

The default behaviour is to detect which access style to use based on the configured endpoint (an IP will result in path-style access) and the bucket being accessed (some buckets are not valid DNS names).

Backport of #15114 in 2.4 branch.

See also:
- https://github.com/elastic/elasticsearch-cloud-aws/issues/124
- https://github.com/elastic/elasticsearch-cloud-aws/pull/159
