### PR TITLE
Allow gradle to run the other client's tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -90,6 +90,7 @@ public class RestIntegTestTask extends RandomizedTestingTask {
                 integTestExternal.environment = [
                     'TEST_ES_SERVER': "${-> node.httpUri()}",
                     'TEST_ES_YAML_DIR': "${-> restTestOutput.asPath}/rest-api-spec/test",
+                    'LANG': 'en_US.UTF-8', // Required by the python tests or they can't parse utf-8 in yaml....
                 ]
                 dependsOn integTestExternal
                 for (Task finalizer : finalizedBy.getDependencies(this)) {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -92,7 +92,9 @@ public class RestIntegTestTask extends RandomizedTestingTask {
                     'TEST_ES_YAML_DIR': "${-> restTestOutput.asPath}/rest-api-spec/test",
                 ]
                 dependsOn integTestExternal
-                // NOCOMMIT failure prevents us from shutting down Elasticsearch - probably need to copy all the finalizedBy
+                for (Task finalizer : finalizedBy.getDependencies(this)) {
+                    integTestExternal.finalizedBy(finalizer)
+                }
             }
         }
     }


### PR DESCRIPTION
This adds a hack to the `integTest` task to support running external processes. It looks like:

```
mkdir tmp
cd tmp
git clone https://github.com/nik9000/elasticsearch.git
cd elasticsearch
git checkout gradle_runs_clients
cd ..
git clone https://github.com/elastic/elasticsearch-py.git
cd elasticsearch-py
gradle -p ../elasticsearch distribution:integ-test-zip:integTest -Drest.test.executable=python3 -Drest.test.executable.args='setup.py test'
```

That results in a few failures but that is fine because at least it runs. And most things pass which is cool. Now you can run other plugins yaml tests:

```
gradle -p ../elasticsearch modules:reindex:integTest -Drest.test.executable=python3 -Drest.test.executable.args='setup.py test'
gradle -p ../elasticsearch modules:lang-painless:integTest -Drest.test.executable=python3 -Drest.test.executable.args='setup.py test'
gradle -p ../elasticsearch plugins:ingest-user-agent:integTest -Drest.test.executable=python3 -Drest.test.executable.args='setup.py test'
```

The `python3 setup.py test` part isn't quite right because it runs _all_ the tests, not just the REST ones. But I think that is a thing we can address in the clients at some point.

The neat thing about this is that the clients that we run don't have to know about the fixtures required to run the various rest tests.
