### PR TITLE
Correct Java setting to pass proxy options to plugin install

### DIFF
--- a/docs/plugins/plugin-script.asciidoc
+++ b/docs/plugins/plugin-script.asciidoc
@@ -165,18 +165,18 @@ sudo bin/elasticsearch-plugin install analysis-icu --timeout 0
 
 To install a plugin via a proxy, you can pass the proxy details in with the
 Java settings `proxyHost` and `proxyPort`. On Unix based systems, these
-options can be set on the command line:
+options can be set on the command line for both http and https:
 
 [source,shell]
 -----------------------------------
-sudo ES_JAVA_OPTS="-DproxyHost=host_name -DproxyPort=port_number" bin/elasticsearch-plugin install mobz/elasticsearch-head
+sudo ES_JAVA_OPTS="-Dhttp.proxyHost=host_name -Dhttp.proxyPort=port_number -Dhttps.proxyHost=host_name -Dhttps.proxyPort=https_port_number" bin/elasticsearch-plugin install mobz/elasticsearch-head
 -----------------------------------
 
 On Windows, they need to be added to the `ES_JAVA_OPTS` environment variable:
 
 [source,shell]
 -----------------------------------
-set ES_JAVA_OPTS="-DproxyHost=host_name -DproxyPort=port_number"
+set ES_JAVA_OPTS="-Dhttp.proxyHost=host_name -Dhttp.proxyPort=port_number -Dhttps.proxyHost=host_name -Dhttps.proxyPort=https_port_number"
 bin/elasticsearch-plugin install analysis-icu
 -----------------------------------
 

--- a/docs/plugins/plugin-script.asciidoc
+++ b/docs/plugins/plugin-script.asciidoc
@@ -164,20 +164,12 @@ sudo bin/elasticsearch-plugin install analysis-icu --timeout 0
 === Proxy settings
 
 To install a plugin via a proxy, you can pass the proxy details in with the
-Java settings `proxyHost` and `proxyPort`. On Unix based systems, these
-options can be set on the command line for both http and https:
+Java settings `http.proxyHost` and `http.proxyPort`. On Unix based systems,
+these options can be set on the command line for both http and https:
 
 [source,shell]
 -----------------------------------
 sudo ES_JAVA_OPTS="-Dhttp.proxyHost=host_name -Dhttp.proxyPort=port_number -Dhttps.proxyHost=host_name -Dhttps.proxyPort=https_port_number" bin/elasticsearch-plugin install mobz/elasticsearch-head
------------------------------------
-
-On Windows, they need to be added to the `ES_JAVA_OPTS` environment variable:
-
-[source,shell]
------------------------------------
-set ES_JAVA_OPTS="-Dhttp.proxyHost=host_name -Dhttp.proxyPort=port_number -Dhttps.proxyHost=host_name -Dhttps.proxyPort=https_port_number"
-bin/elasticsearch-plugin install analysis-icu
 -----------------------------------
 
 === Plugins directory


### PR DESCRIPTION
It appears that `proxyHost` and `proxyPort` are not valid Java
properties; they should be prefixed with either `http` or `https`. There
is no code that the flags pass through in `plugin` that munges the flags
in any way, so they should be passed through as indicated in the Java
docs.

Note that I don't have an environment set up to test these out, but based upon some [discussion in a related puppet-elasticsearch issue](https://github.com/elastic/puppet-elasticsearch/issues/152), it would seem that this never worked and really should have just been the vanilla Java proxy properties all along.

See:
https://docs.oracle.com/javase/7/docs/technotes/guides/net/proxies.html
https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html
