### PR TITLE
Support specific key/secret for EC2

### DIFF
--- a/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/AwsService.java
+++ b/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/AwsService.java
@@ -20,16 +20,6 @@
 package org.elasticsearch.cloud.aws;
 
 public interface AwsService {
-    /**
-     * Should be either moved to Core if this settings makes sense
-     * Or removed. See https://github.com/elastic/elasticsearch/issues/12809
-     */
-    @Deprecated
-    final class CLOUD {
-        public static final String KEY = "cloud.key";
-        public static final String ACCOUNT = "cloud.account";
-    }
-
     final class CLOUD_AWS {
         public static final String KEY = "cloud.aws.access_key";
         public static final String SECRET = "cloud.aws.secret_key";

--- a/plugins/cloud-aws/src/test/java/org/elasticsearch/discovery/ec2/Ec2CredentialSettingsTests.java
+++ b/plugins/cloud-aws/src/test/java/org/elasticsearch/discovery/ec2/Ec2CredentialSettingsTests.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.discovery.ec2;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.ec2.AmazonEC2;
+import org.elasticsearch.cloud.aws.AwsEc2Service;
+import org.elasticsearch.cloud.aws.AwsEc2ServiceImpl;
+import org.elasticsearch.cloud.aws.AwsModule;
+import org.elasticsearch.cloud.aws.AwsService;
+import org.elasticsearch.cluster.node.DiscoveryNodeService;
+import org.elasticsearch.common.network.NetworkService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.is;
+
+public class Ec2CredentialSettingsTests extends ESTestCase {
+
+    public void testAwsSettings() {
+        Settings settings = Settings.builder()
+                .put(AwsService.CLOUD_AWS.KEY, "aws_key")
+                .put(AwsService.CLOUD_AWS.SECRET, "aws_secret")
+                .build();
+
+        AWSCredentialsProvider credentials = AwsEc2ServiceImpl.buildCredentials(settings);
+        assertThat(credentials.getCredentials().getAWSAccessKeyId(), is("aws_key"));
+        assertThat(credentials.getCredentials().getAWSSecretKey(), is("aws_secret"));
+    }
+
+    public void testEc2Settings() {
+        Settings settings = Settings.builder()
+            .put(AwsService.CLOUD_AWS.KEY, "aws_key")
+            .put(AwsService.CLOUD_AWS.SECRET, "aws_secret")
+            .put(AwsEc2Service.CLOUD_EC2.KEY, "ec2_key")
+            .put(AwsEc2Service.CLOUD_EC2.SECRET, "ec2_secret")
+            .build();
+
+        AWSCredentialsProvider credentials = AwsEc2ServiceImpl.buildCredentials(settings);
+        assertThat(credentials.getCredentials().getAWSAccessKeyId(), is("ec2_key"));
+        assertThat(credentials.getCredentials().getAWSSecretKey(), is("ec2_secret"));
+    }
+}


### PR DESCRIPTION
We have a bug described in #19445 where a user wants to define specific key/secret for EC2 and S3:

```
cloud:
    aws:
        s3:
            access_key: xxxxxxxxxxxx
            secret_key: XXxxxxxXxxxxXxxxXxXxXxxx
        ec2:
            access_key: yyyyyyyyyyyyy
            secret_key: yyyYyyyyyYyyyyYyyyYyYyY
```

This is documented and should work.

This commit fixes that and adds a test.

BTW, while working on this issue, I discovered that the removal effort made in #12978 has been reintroduced by mistake in fe7421986c71851ac9689b1ab9feaed618a7064a. So I removed this again.

Closes #19445
