### PR TITLE
Fixes CORS handling so that it uses the defaults

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/Strings.java
+++ b/core/src/main/java/org/elasticsearch/common/Strings.java
@@ -512,10 +512,8 @@ public class Strings {
 
     /**
      * A convenience method for splitting a delimited string into
-     * a set, and also trimming any whitespace found after the
-     * delimiter.  Trimming allows splitting strings like "A, B, C"
-     * into ["A","B","C"] instead of ["A", " B", " C"].  The trimming
-     * will *only* apply if the delimiter is not a whitespace character.
+     * a set and trimming leading and trailing whitespace from all
+     * split strings.
      *
      * @param s the string to split
      * @param c the delimiter to split on
@@ -533,26 +531,32 @@ public class Strings {
             }
         }
         final Set<String> result = new HashSet<>(count);
-        final boolean doTrim = Character.isWhitespace(c) == false;
         final int len = chars.length;
         int start = 0;  // starting index in chars of the current substring.
         int pos = 0;    // current index in chars.
+        int whitespaceStart = -1; // the position of the start of the current whitespace, -1 if not on whitespace
         for (; pos < len; pos++) {
-            // if the delimiter is a non-whitespace character and we
-            // have whitespace after the comma, skip over the whitespace
-            if (doTrim && start == pos && Character.isWhitespace(chars[pos])) {
-                start++;
-                continue;
-            }
             if (chars[pos] == c) {
-                int size = pos - start;
+                int size = (whitespaceStart < 0 ? pos : whitespaceStart) - start;
                 if (size > 0) { // only add non empty strings
                     result.add(new String(chars, start, size));
                 }
                 start = pos + 1;
+                whitespaceStart = -1;
+            } else if (Character.isWhitespace(chars[pos])) {
+                if (start == pos) {
+                    // skip over preceding whitespace
+                    start++;
+                } else if (whitespaceStart < 0) {
+                    // start of whitespace
+                    whitespaceStart = pos;
+                }
+            } else {
+                // reset whitespace position
+                whitespaceStart = -1;
             }
         }
-        int size = pos - start;
+        int size = (whitespaceStart < 0 ? pos : whitespaceStart) - start;
         if (size > 0) {
             result.add(new String(chars, start, size));
         }

--- a/core/src/main/java/org/elasticsearch/common/Strings.java
+++ b/core/src/main/java/org/elasticsearch/common/Strings.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -501,7 +502,7 @@ public class Strings {
     }
 
     public static Set<String> splitStringByCommaToSet(final String s) {
-        return splitStringToSet(s, ',');
+        return splitStringToSet(s, ',', false);
     }
 
     public static String[] splitStringByCommaToArray(final String s) {
@@ -509,7 +510,27 @@ public class Strings {
         else return s.split(",");
     }
 
-    public static Set<String> splitStringToSet(final String s, final char c) {
+    public static Set<String> splitStringByCommaAndTrim(final String s) {
+        return splitStringToSet(s, ',', true);
+    }
+
+    /**
+     * A convenience method for splitting a delimited string into
+     * a set, while having the option to trim the whitespace after
+     * the delimiter.  Trimming allows splitting strings like "A, B, C"
+     * into ["A","B","C"] instead of ["A", " B", " C"].  The trimming
+     * will *only* apply if the delimiter is not a whitespace character,
+     * even if the option is set to true.
+     *
+     * @param s the string to split
+     * @param c the delimiter to split on
+     * @param trim whether or not to trim the whitespace after the delimiter
+     * @return the set of split strings
+     */
+    public static Set<String> splitStringToSet(final String s, final char c, final boolean trim) {
+        if (s == null || s.isEmpty()) {
+            return Collections.emptySet();
+        }
         final char[] chars = s.toCharArray();
         int count = 1;
         for (final char x : chars) {
@@ -518,10 +539,17 @@ public class Strings {
             }
         }
         final Set<String> result = new HashSet<>(count);
+        final boolean doTrim = trim & Character.isWhitespace(c) == false;
         final int len = chars.length;
         int start = 0;  // starting index in chars of the current substring.
         int pos = 0;    // current index in chars.
         for (; pos < len; pos++) {
+            // if the option is set and the delimiter is a non-whitespace character, and we
+            // have whitespace after the comma, ignore the whitespace
+            if (doTrim && start == pos && Character.isWhitespace(chars[pos])) {
+                start++;
+                continue;
+            }
             if (chars[pos] == c) {
                 int size = pos - start;
                 if (size > 0) { // only add non empty strings

--- a/core/src/main/java/org/elasticsearch/common/Strings.java
+++ b/core/src/main/java/org/elasticsearch/common/Strings.java
@@ -534,29 +534,25 @@ public class Strings {
         final int len = chars.length;
         int start = 0;  // starting index in chars of the current substring.
         int pos = 0;    // current index in chars.
-        int whitespaceStart = -1; // the position of the start of the current whitespace, -1 if not on whitespace
+        int end = 0; // the position of the end of the current token
         for (; pos < len; pos++) {
             if (chars[pos] == c) {
-                int size = (whitespaceStart < 0 ? pos : whitespaceStart) - start;
+                int size = end - start;
                 if (size > 0) { // only add non empty strings
                     result.add(new String(chars, start, size));
                 }
                 start = pos + 1;
-                whitespaceStart = -1;
+                end = start;
             } else if (Character.isWhitespace(chars[pos])) {
                 if (start == pos) {
                     // skip over preceding whitespace
                     start++;
-                } else if (whitespaceStart < 0) {
-                    // start of whitespace
-                    whitespaceStart = pos;
                 }
             } else {
-                // reset whitespace position
-                whitespaceStart = -1;
+                end = pos + 1;
             }
         }
-        int size = (whitespaceStart < 0 ? pos : whitespaceStart) - start;
+        int size = end - start;
         if (size > 0) {
             result.add(new String(chars, start, size));
         }

--- a/core/src/main/java/org/elasticsearch/common/Strings.java
+++ b/core/src/main/java/org/elasticsearch/common/Strings.java
@@ -502,7 +502,7 @@ public class Strings {
     }
 
     public static Set<String> splitStringByCommaToSet(final String s) {
-        return splitStringToSet(s, ',', false);
+        return splitStringToSet(s, ',');
     }
 
     public static String[] splitStringByCommaToArray(final String s) {
@@ -510,24 +510,18 @@ public class Strings {
         else return s.split(",");
     }
 
-    public static Set<String> splitStringByCommaAndTrim(final String s) {
-        return splitStringToSet(s, ',', true);
-    }
-
     /**
      * A convenience method for splitting a delimited string into
-     * a set, while having the option to trim the whitespace after
-     * the delimiter.  Trimming allows splitting strings like "A, B, C"
+     * a set, and also trimming any whitespace found after the
+     * delimiter.  Trimming allows splitting strings like "A, B, C"
      * into ["A","B","C"] instead of ["A", " B", " C"].  The trimming
-     * will *only* apply if the delimiter is not a whitespace character,
-     * even if the option is set to true.
+     * will *only* apply if the delimiter is not a whitespace character.
      *
      * @param s the string to split
      * @param c the delimiter to split on
-     * @param trim whether or not to trim the whitespace after the delimiter
      * @return the set of split strings
      */
-    public static Set<String> splitStringToSet(final String s, final char c, final boolean trim) {
+    public static Set<String> splitStringToSet(final String s, final char c) {
         if (s == null || s.isEmpty()) {
             return Collections.emptySet();
         }
@@ -539,13 +533,13 @@ public class Strings {
             }
         }
         final Set<String> result = new HashSet<>(count);
-        final boolean doTrim = trim & Character.isWhitespace(c) == false;
+        final boolean doTrim = Character.isWhitespace(c) == false;
         final int len = chars.length;
         int start = 0;  // starting index in chars of the current substring.
         int pos = 0;    // current index in chars.
         for (; pos < len; pos++) {
-            // if the option is set and the delimiter is a non-whitespace character, and we
-            // have whitespace after the comma, ignore the whitespace
+            // if the delimiter is a non-whitespace character and we
+            // have whitespace after the comma, skip over the whitespace
             if (doTrim && start == pos && Character.isWhitespace(chars[pos])) {
                 start++;
                 continue;

--- a/core/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
+++ b/core/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
@@ -40,9 +40,9 @@ public final class HttpTransportSettings {
     public static final Setting<Integer> SETTING_CORS_MAX_AGE =
         Setting.intSetting("http.cors.max-age", 1728000, Property.NodeScope);
     public static final Setting<String> SETTING_CORS_ALLOW_METHODS =
-        new Setting<>("http.cors.allow-methods", "OPTIONS, HEAD, GET, POST, PUT, DELETE", (value) -> value, Property.NodeScope);
+        new Setting<>("http.cors.allow-methods", "OPTIONS,HEAD,GET,POST,PUT,DELETE", (value) -> value, Property.NodeScope);
     public static final Setting<String> SETTING_CORS_ALLOW_HEADERS =
-        new Setting<>("http.cors.allow-headers", "X-Requested-With, Content-Type, Content-Length", (value) -> value, Property.NodeScope);
+        new Setting<>("http.cors.allow-headers", "X-Requested-With,Content-Type,Content-Length", (value) -> value, Property.NodeScope);
     public static final Setting<Boolean> SETTING_CORS_ALLOW_CREDENTIALS =
         Setting.boolSetting("http.cors.allow-credentials", false, Property.NodeScope);
     public static final Setting<Boolean> SETTING_PIPELINING =

--- a/core/src/test/java/org/elasticsearch/common/StringsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/StringsTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common;
 
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.test.ESTestCase;
@@ -72,5 +73,22 @@ public class StringsTests extends ESTestCase {
         toString = Strings.toString(needsEnclosingObject, true);
         assertThat(toString, containsString("\"ok\":\"here\""));
         assertThat(toString, containsString("\"catastrophe\":\"\""));
+    }
+
+    public void testSplitStringToSet() {
+        assertEquals(Strings.splitStringByCommaToSet(null), Sets.newHashSet());
+        assertEquals(Strings.splitStringByCommaToSet(""), Sets.newHashSet());
+        assertEquals(Strings.splitStringByCommaToSet("a,b,c"), Sets.newHashSet("a","b","c"));
+        assertEquals(Strings.splitStringByCommaToSet("a, b, c"), Sets.newHashSet("a"," b"," c"));
+        assertEquals(Strings.splitStringByCommaToSet(" a ,  b,c"), Sets.newHashSet(" a ","  b","c"));
+        assertEquals(Strings.splitStringByCommaToSet("aa, bb, cc"), Sets.newHashSet("aa"," bb"," cc"));
+
+        assertEquals(Strings.splitStringByCommaAndTrim(null), Sets.newHashSet());
+        assertEquals(Strings.splitStringByCommaAndTrim(""), Sets.newHashSet());
+        assertEquals(Strings.splitStringByCommaAndTrim("a,b,c"), Sets.newHashSet("a","b","c"));
+        assertEquals(Strings.splitStringByCommaAndTrim("a, b, c"), Sets.newHashSet("a","b","c"));
+        assertEquals(Strings.splitStringByCommaAndTrim(" a ,  b, c"), Sets.newHashSet("a ","b","c"));
+        assertEquals(Strings.splitStringByCommaAndTrim("aa, bb, cc"), Sets.newHashSet("aa","bb","cc"));
+        assertEquals(Strings.splitStringByCommaAndTrim(" a "), Sets.newHashSet("a "));
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/StringsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/StringsTests.java
@@ -79,16 +79,9 @@ public class StringsTests extends ESTestCase {
         assertEquals(Strings.splitStringByCommaToSet(null), Sets.newHashSet());
         assertEquals(Strings.splitStringByCommaToSet(""), Sets.newHashSet());
         assertEquals(Strings.splitStringByCommaToSet("a,b,c"), Sets.newHashSet("a","b","c"));
-        assertEquals(Strings.splitStringByCommaToSet("a, b, c"), Sets.newHashSet("a"," b"," c"));
-        assertEquals(Strings.splitStringByCommaToSet(" a ,  b,c"), Sets.newHashSet(" a ","  b","c"));
-        assertEquals(Strings.splitStringByCommaToSet("aa, bb, cc"), Sets.newHashSet("aa"," bb"," cc"));
-
-        assertEquals(Strings.splitStringByCommaAndTrim(null), Sets.newHashSet());
-        assertEquals(Strings.splitStringByCommaAndTrim(""), Sets.newHashSet());
-        assertEquals(Strings.splitStringByCommaAndTrim("a,b,c"), Sets.newHashSet("a","b","c"));
-        assertEquals(Strings.splitStringByCommaAndTrim("a, b, c"), Sets.newHashSet("a","b","c"));
-        assertEquals(Strings.splitStringByCommaAndTrim(" a ,  b, c"), Sets.newHashSet("a ","b","c"));
-        assertEquals(Strings.splitStringByCommaAndTrim("aa, bb, cc"), Sets.newHashSet("aa","bb","cc"));
-        assertEquals(Strings.splitStringByCommaAndTrim(" a "), Sets.newHashSet("a "));
+        assertEquals(Strings.splitStringByCommaToSet("a, b, c"), Sets.newHashSet("a","b","c"));
+        assertEquals(Strings.splitStringByCommaToSet(" a ,  b, c"), Sets.newHashSet("a ","b","c"));
+        assertEquals(Strings.splitStringByCommaToSet("aa, bb, cc"), Sets.newHashSet("aa","bb","cc"));
+        assertEquals(Strings.splitStringByCommaToSet(" a "), Sets.newHashSet("a "));
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/StringsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/StringsTests.java
@@ -80,8 +80,26 @@ public class StringsTests extends ESTestCase {
         assertEquals(Strings.splitStringByCommaToSet(""), Sets.newHashSet());
         assertEquals(Strings.splitStringByCommaToSet("a,b,c"), Sets.newHashSet("a","b","c"));
         assertEquals(Strings.splitStringByCommaToSet("a, b, c"), Sets.newHashSet("a","b","c"));
-        assertEquals(Strings.splitStringByCommaToSet(" a ,  b, c"), Sets.newHashSet("a ","b","c"));
+        assertEquals(Strings.splitStringByCommaToSet(" a ,  b, c  "), Sets.newHashSet("a","b","c"));
         assertEquals(Strings.splitStringByCommaToSet("aa, bb, cc"), Sets.newHashSet("aa","bb","cc"));
-        assertEquals(Strings.splitStringByCommaToSet(" a "), Sets.newHashSet("a "));
+        assertEquals(Strings.splitStringByCommaToSet(" a "), Sets.newHashSet("a"));
+        assertEquals(Strings.splitStringByCommaToSet("   a   "), Sets.newHashSet("a"));
+        assertEquals(Strings.splitStringByCommaToSet("   aa   "), Sets.newHashSet("aa"));
+        assertEquals(Strings.splitStringByCommaToSet("   "), Sets.newHashSet());
+
+        assertEquals(Strings.splitStringToSet(null, ' '), Sets.newHashSet());
+        assertEquals(Strings.splitStringToSet("", ' '), Sets.newHashSet());
+        assertEquals(Strings.splitStringToSet("a b c", ' '), Sets.newHashSet("a","b","c"));
+        assertEquals(Strings.splitStringToSet("a, b, c", ' '), Sets.newHashSet("a,","b,","c"));
+        assertEquals(Strings.splitStringToSet(" a   b c  ", ' '), Sets.newHashSet("a","b","c"));
+        assertEquals(Strings.splitStringToSet("  a   b   c  ", ' '), Sets.newHashSet("a","b","c"));
+        assertEquals(Strings.splitStringToSet("aa bb cc", ' '), Sets.newHashSet("aa","bb","cc"));
+        assertEquals(Strings.splitStringToSet(" a ", ' '), Sets.newHashSet("a"));
+        assertEquals(Strings.splitStringToSet("    a    ", ' '), Sets.newHashSet("a"));
+        assertEquals(Strings.splitStringToSet(" a   ", ' '), Sets.newHashSet("a"));
+        assertEquals(Strings.splitStringToSet("a   ", ' '), Sets.newHashSet("a"));
+        assertEquals(Strings.splitStringToSet("   aa   ", ' '), Sets.newHashSet("aa"));
+        assertEquals(Strings.splitStringToSet("aa   ", ' '), Sets.newHashSet("aa"));
+        assertEquals(Strings.splitStringToSet("   ", ' '), Sets.newHashSet());
     }
 }

--- a/modules/transport-netty3/src/main/java/org/elasticsearch/http/netty3/Netty3HttpServerTransport.java
+++ b/modules/transport-netty3/src/main/java/org/elasticsearch/http/netty3/Netty3HttpServerTransport.java
@@ -392,10 +392,10 @@ public class Netty3HttpServerTransport extends AbstractLifecycleComponent implem
         if (SETTING_CORS_ALLOW_CREDENTIALS.get(settings)) {
             builder.allowCredentials();
         }
-        Set<String> strMethods = Strings.splitStringByCommaAndTrim(SETTING_CORS_ALLOW_METHODS.get(settings));
+        Set<String> strMethods = Strings.splitStringByCommaToSet(SETTING_CORS_ALLOW_METHODS.get(settings));
         return builder.allowedRequestMethods(strMethods.stream().map(HttpMethod::valueOf).collect(Collectors.toSet()))
                       .maxAge(SETTING_CORS_MAX_AGE.get(settings))
-                      .allowedRequestHeaders(Strings.splitStringByCommaAndTrim(SETTING_CORS_ALLOW_HEADERS.get(settings)))
+                      .allowedRequestHeaders(Strings.splitStringByCommaToSet(SETTING_CORS_ALLOW_HEADERS.get(settings)))
                       .shortCircuit()
                       .build();
     }

--- a/modules/transport-netty3/src/main/java/org/elasticsearch/http/netty3/Netty3HttpServerTransport.java
+++ b/modules/transport-netty3/src/main/java/org/elasticsearch/http/netty3/Netty3HttpServerTransport.java
@@ -81,9 +81,11 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.settings.Setting.boolSetting;
 import static org.elasticsearch.common.settings.Setting.byteSizeSetting;
@@ -390,14 +392,10 @@ public class Netty3HttpServerTransport extends AbstractLifecycleComponent implem
         if (SETTING_CORS_ALLOW_CREDENTIALS.get(settings)) {
             builder.allowCredentials();
         }
-        String[] strMethods = settings.getAsArray(SETTING_CORS_ALLOW_METHODS.getKey());
-        HttpMethod[] methods = Arrays.asList(strMethods)
-                                     .stream()
-                                     .map(HttpMethod::valueOf)
-                                     .toArray(size -> new HttpMethod[size]);
-        return builder.allowedRequestMethods(methods)
+        Set<String> strMethods = Strings.splitStringByCommaAndTrim(SETTING_CORS_ALLOW_METHODS.get(settings));
+        return builder.allowedRequestMethods(strMethods.stream().map(HttpMethod::valueOf).collect(Collectors.toSet()))
                       .maxAge(SETTING_CORS_MAX_AGE.get(settings))
-                      .allowedRequestHeaders(settings.getAsArray(SETTING_CORS_ALLOW_HEADERS.getKey()))
+                      .allowedRequestHeaders(Strings.splitStringByCommaAndTrim(SETTING_CORS_ALLOW_HEADERS.get(settings)))
                       .shortCircuit()
                       .build();
     }

--- a/modules/transport-netty3/src/main/java/org/elasticsearch/http/netty3/cors/Netty3CorsConfigBuilder.java
+++ b/modules/transport-netty3/src/main/java/org/elasticsearch/http/netty3/cors/Netty3CorsConfigBuilder.java
@@ -193,8 +193,8 @@ public final class Netty3CorsConfigBuilder {
      * @param methods the {@link HttpMethod}s that should be allowed.
      * @return {@link Netty3CorsConfigBuilder} to support method chaining.
      */
-    public Netty3CorsConfigBuilder allowedRequestMethods(final HttpMethod... methods) {
-        requestMethods.addAll(Arrays.asList(methods));
+    public Netty3CorsConfigBuilder allowedRequestMethods(final Set<HttpMethod> methods) {
+        requestMethods.addAll(methods);
         return this;
     }
 
@@ -214,8 +214,8 @@ public final class Netty3CorsConfigBuilder {
      * @param headers the headers to be added to the preflight 'Access-Control-Allow-Headers' response header.
      * @return {@link Netty3CorsConfigBuilder} to support method chaining.
      */
-    public Netty3CorsConfigBuilder allowedRequestHeaders(final String... headers) {
-        requestHeaders.addAll(Arrays.asList(headers));
+    public Netty3CorsConfigBuilder allowedRequestHeaders(final Set<String> headers) {
+        requestHeaders.addAll(headers);
         return this;
     }
 

--- a/modules/transport-netty3/src/test/java/org/elasticsearch/http/netty3/Netty3HttpServerTransportTests.java
+++ b/modules/transport-netty3/src/test/java/org/elasticsearch/http/netty3/Netty3HttpServerTransportTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.http.netty3.cors.Netty3CorsConfig;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
@@ -82,6 +83,21 @@ public class Netty3HttpServerTransportTests extends ESTestCase {
         final Netty3HttpServerTransport transport = new Netty3HttpServerTransport(settings, networkService, bigArrays, threadPool);
         final Netty3CorsConfig corsConfig = transport.getCorsConfig();
         assertThat(corsConfig.isAnyOriginSupported(), equalTo(true));
+        assertThat(corsConfig.allowedRequestHeaders(), equalTo(headers));
+        assertThat(corsConfig.allowedRequestMethods().stream().map(HttpMethod::getName).collect(Collectors.toSet()), equalTo(methods));
+        transport.close();
+    }
+
+    public void testCorsConfigDefaults() {
+        final Set<String> headers = Sets.newHashSet("X-Requested-With", "Content-Type", "Content-Length");
+        final Set<String> methods = Sets.newHashSet("OPTIONS", "HEAD", "GET", "POST", "PUT", "DELETE");
+        final Settings settings = Settings.builder()
+                                      .put(SETTING_CORS_ENABLED.getKey(), true)
+                                      .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), "*")
+                                      .put(SETTING_CORS_ALLOW_CREDENTIALS.getKey(), true)
+                                      .build();
+        final Netty3HttpServerTransport transport = new Netty3HttpServerTransport(settings, networkService, bigArrays, threadPool);
+        final Netty3CorsConfig corsConfig = transport.getCorsConfig();
         assertThat(corsConfig.allowedRequestHeaders(), equalTo(headers));
         assertThat(corsConfig.allowedRequestMethods().stream().map(HttpMethod::getName).collect(Collectors.toSet()), equalTo(methods));
         transport.close();


### PR DESCRIPTION
Fixes CORS handling so that it uses the defaults for  for http.cors.allow-methods
and http.cors.allow-headers if none are specified in the config.

Closes #19520
