### PR TITLE
Test: Fixed incorrect YAML indentation in the `indices.put_template/10_basic.yaml` test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_template/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_template/10_basic.yaml
@@ -87,34 +87,34 @@
             index.analysis.analyzer.foobar_search.type: "standard"
 
   - do:
-    index:
-      index:  test_index
-      type:   test
-      body:   { field: "the quick brown fox" }
+      index:
+        index:  test_index
+        type:   test
+        body:   { field: "the quick brown fox" }
 
   - do:
-    indices.refresh:
-      index: test_index
+      indices.refresh:
+        index: test_index
 
   - do:
-    search:
-      index: test_index
-      type:  test
-      body:
-        query:
-          term:
-            field: "the quick brown fox"
+      search:
+        index: test_index
+        type:  test
+        body:
+          query:
+            term:
+              field: "the quick brown fox"
 
   - match: {hits.total: 1}
 
   - do:
-    search:
-      index: test_index
-      type:  test
-      body:
-        query:
-          match:
-            field: "the quick brown fox"
+      search:
+        index: test_index
+        type:  test
+        body:
+          query:
+            match:
+              field: "the quick brown fox"
 
   - match: {hits.total: 0}
 


### PR DESCRIPTION
The Ruby YAML parser ignores the `do` actions when they are not indented, making the test suite fail.

Can you please review, @s1monw?

Related: #19506 
