### PR TITLE
Accept alternative non-deprecated names in ParseField

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -91,7 +91,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
     public static final ParseField SORT_FIELD = new ParseField("sort");
     public static final ParseField TRACK_SCORES_FIELD = new ParseField("track_scores");
     public static final ParseField INDICES_BOOST_FIELD = new ParseField("indices_boost");
-    public static final ParseField AGGREGATIONS_FIELD = new ParseField("aggregations", "aggs");
+    public static final ParseField AGGREGATIONS_FIELD = new ParseField("aggregations", new String[] { "aggs" }, Strings.EMPTY_ARRAY);
     public static final ParseField HIGHLIGHT_FIELD = new ParseField("highlight");
     public static final ParseField SUGGEST_FIELD = new ParseField("suggest");
     public static final ParseField RESCORE_FIELD = new ParseField("rescore");
@@ -998,7 +998,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
                         scriptFields.add(new ScriptField(context));
                     }
                 } else if (context.getParseFieldMatcher().match(currentFieldName, INDICES_BOOST_FIELD)) {
-                    indexBoost = new ObjectFloatHashMap<String>();
+                    indexBoost = new ObjectFloatHashMap<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                         if (token == XContentParser.Token.FIELD_NAME) {
                             currentFieldName = parser.currentName();


### PR DESCRIPTION
Previously all names except the first passed to the `ParseField` were
considered deprecated. But we have a few cases where a field has more
than one acceptable (non-deprecated) name (e.g. `aggregations`
and `aggs` for declaring aggregations.

This change adds a constructor to `ParseField` which allows alternative
names to be added as well as deprecated names. The change is fully
backwards compatible as The previous constructor still exists.

Note that it is intentionally a little awkward to specify a field with
alternative names since this is something that should only be used in
rare circumstances and should not become the norm.

Closes #19504
