### PR TITLE
[TEST] Fix reproducible HistogramTests.testEmptyWithExtendedBounds failure

### DIFF
--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/HistogramTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/HistogramTests.java
@@ -1001,10 +1001,7 @@ public class HistogramTests extends ESIntegTestCase {
 
         // constructing the newly expected bucket list
         int bucketsCount = (int) ((boundsMaxKey - boundsMinKey) / interval) + 1;
-        long[] extendedValueCounts = new long[bucketsCount];
-        System.arraycopy(valueCounts, 0, extendedValueCounts, addedBucketsLeft, valueCounts.length);
-
-        SearchResponse response = null;
+        SearchResponse response;
         try {
             response = client().prepareSearch("idx")
                     .setQuery(QueryBuilders.termQuery("foo", "bar")).addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME)


### PR DESCRIPTION
This fixes a reproducible failure in `HistogramTests.testEmptyWithExtendedBounds`` unit test. An unused array size is inconsistent with the computed expected result. The fix removes the unused array but maybe we can remove the whole test? I couldn't exactly follow everything it was trying to do and it looks like there might be other unused variables. Maybe it just needs to be fixed up?

closes #19558
