### PR TITLE
Fixed QueryParsingException in multi match query

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
@@ -221,7 +221,7 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
         assertNoFailures(searchResponse);
         assertFirstHit(searchResponse, hasId("theone"));
 
-        String[] fields = {"full_name", "first_name", "last_name", "last_name_phrase", "first_name_phrase", "category_phrase", "category"};
+        String[] fields = {"full_name", "first_name", "last_name", "last_name_phrase", "first_name_phrase", "category_phrase", "category", "missing_field", "missing_fields*"};
 
         String[] query = {"marvel","hero", "captain",  "america", "15", "17", "1", "5", "ultimate", "Man",
                 "marvel", "wolferine", "ninja"};


### PR DESCRIPTION
Fixed QueryParsingException in multi match query when a wildcard expression results in no fields.
The query will now return 0 hits (null query) instead of throwing an exception. This matches the behavior if a nonexistent field is specified.
These changes were backported from latest master (mostly from #13405).

All test pass when I ran `mvn clean verify`

Closes #16098 
