### PR TITLE
Adding _operation field to index, update, delete response.

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -248,7 +248,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                         BytesReference indexSourceAsBytes = indexRequest.source();
                         // add the response
                         IndexResponse indexResponse = result.getResponse();
-                        UpdateResponse updateResponse = new UpdateResponse(indexResponse.getShardInfo(), indexResponse.getShardId(), indexResponse.getType(), indexResponse.getId(), indexResponse.getVersion(), indexResponse.isCreated());
+                        UpdateResponse updateResponse = new UpdateResponse(indexResponse.getShardInfo(), indexResponse.getShardId(), indexResponse.getType(), indexResponse.getId(), indexResponse.getVersion(), indexResponse.getOperation());
                         if (updateRequest.fields() != null && updateRequest.fields().length > 0) {
                             Tuple<XContentType, Map<String, Object>> sourceAndContent = XContentHelper.convertToMap(indexSourceAsBytes, true);
                             updateResponse.setGetResult(updateHelper.extractGetResult(updateRequest, request.index(), indexResponse.getVersion(), sourceAndContent.v2(), sourceAndContent.v1(), indexSourceAsBytes));
@@ -261,7 +261,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                         WriteResult<DeleteResponse> writeResult = updateResult.writeResult;
                         DeleteResponse response = writeResult.getResponse();
                         DeleteRequest deleteRequest = updateResult.request();
-                        updateResponse = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), false);
+                        updateResponse = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), response.getOperation());
                         updateResponse.setGetResult(updateHelper.extractGetResult(updateRequest, request.index(), response.getVersion(), updateResult.result.updatedSourceAsMap(), updateResult.result.updateSourceContentType(), null));
                         // Replace the update request to the translated delete request to execute on the replica.
                         item = request.items()[requestIndex] = new BulkItemRequest(request.items()[requestIndex].id(), deleteRequest);

--- a/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
@@ -20,8 +20,6 @@
 package org.elasticsearch.action.delete;
 
 import org.elasticsearch.action.DocWriteResponse;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
@@ -41,11 +39,7 @@ public class DeleteResponse extends DocWriteResponse {
     }
 
     public DeleteResponse(ShardId shardId, String type, String id, long version, boolean found) {
-        super(shardId, type, id, version, toOperation(found));
-    }
-
-    public static Operation toOperation(boolean found) {
-        return found ? Operation.DELETE: Operation.NOOP;
+        super(shardId, type, id, version, found ? Operation.DELETE : Operation.NOOP);
     }
 
     /**
@@ -56,27 +50,13 @@ public class DeleteResponse extends DocWriteResponse {
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-    }
-
-    @Override
     public RestStatus status() {
         return isFound() ? super.status() : RestStatus.NOT_FOUND;
     }
 
-    static final class Fields {
-        static final String FOUND = "found";
-    }
-
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field(Fields.FOUND, isFound());
+        builder.field("found", isFound());
         super.toXContent(builder, params);
         return builder;
     }
@@ -89,7 +69,6 @@ public class DeleteResponse extends DocWriteResponse {
         builder.append(",type=").append(getType());
         builder.append(",id=").append(getId());
         builder.append(",version=").append(getVersion());
-        builder.append(",found=").append(isFound());
         builder.append(",operation=").append(getOperation().getLowercase());
         builder.append(",shards=").append(getShardInfo());
         return builder.append("]").toString();

--- a/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
@@ -40,17 +40,8 @@ public class IndexResponse extends DocWriteResponse {
 
     }
 
-    @Override
-    public Operation getOperation() {
-        return isCreated() ? Operation.CREATE : Operation.INDEX;
-    }
-
     public IndexResponse(ShardId shardId, String type, String id, long version, boolean created) {
-        super(shardId, type, id, version, toOperation(created));
-    }
-
-    public static Operation toOperation(boolean created) {
-        return created ? Operation.CREATE : Operation.INDEX;
+        super(shardId, type, id, version, created ? Operation.CREATE : Operation.INDEX);
     }
 
     /**
@@ -66,16 +57,6 @@ public class IndexResponse extends DocWriteResponse {
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-    }
-
-    @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
         builder.append("IndexResponse[");
@@ -83,20 +64,15 @@ public class IndexResponse extends DocWriteResponse {
         builder.append(",type=").append(getType());
         builder.append(",id=").append(getId());
         builder.append(",version=").append(getVersion());
-        builder.append(",created=").append(isCreated());
         builder.append(",operation=").append(getOperation().getLowercase());
         builder.append(",shards=").append(getShardInfo());
         return builder.append("]").toString();
     }
 
-    static final class Fields {
-        static final String CREATED = "created";
-    }
-
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         super.toXContent(builder, params);
-        builder.field(Fields.CREATED, isCreated());
+        builder.field("created", isCreated());
         return builder;
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.update;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
@@ -185,7 +186,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 indexAction.execute(upsertRequest, new ActionListener<IndexResponse>() {
                     @Override
                     public void onResponse(IndexResponse response) {
-                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), response.isCreated());
+                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), response.getOperation());
                         if (request.fields() != null && request.fields().length > 0) {
                             Tuple<XContentType, Map<String, Object>> sourceAndContent = XContentHelper.convertToMap(upsertSourceBytes, true);
                             update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), sourceAndContent.v2(), sourceAndContent.v1(), upsertSourceBytes));
@@ -223,7 +224,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 indexAction.execute(indexRequest, new ActionListener<IndexResponse>() {
                     @Override
                     public void onResponse(IndexResponse response) {
-                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), response.isCreated());
+                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), response.getOperation());
                         update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), indexSourceBytes));
                         update.setForcedRefresh(response.forcedRefresh());
                         listener.onResponse(update);
@@ -252,7 +253,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 deleteAction.execute(deleteRequest, new ActionListener<DeleteResponse>() {
                     @Override
                     public void onResponse(DeleteResponse response) {
-                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), false);
+                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), response.getOperation());
                         update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), null));
                         update.setForcedRefresh(response.forcedRefresh());
                         listener.onResponse(update);

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -116,7 +116,7 @@ public class UpdateHelper extends AbstractComponent {
                                 request.script.getScript());
                     }
                     UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(),
-                            getResult.getVersion(), false);
+                            getResult.getVersion(), UpdateResponse.convert(Operation.NONE));
                     update.setGetResult(getResult);
                     return new Result(update, Operation.NONE, upsertDoc, XContentType.JSON);
                 }
@@ -234,12 +234,12 @@ public class UpdateHelper extends AbstractComponent {
                     .setRefreshPolicy(request.getRefreshPolicy());
             return new Result(deleteRequest, Operation.DELETE, updatedSourceAsMap, updateSourceContentType);
         } else if ("none".equals(operation)) {
-            UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(), false);
+            UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(), UpdateResponse.convert(Operation.NONE));
             update.setGetResult(extractGetResult(request, request.index(), getResult.getVersion(), updatedSourceAsMap, updateSourceContentType, getResult.internalSourceRef()));
             return new Result(update, Operation.NONE, updatedSourceAsMap, updateSourceContentType);
         } else {
             logger.warn("Used update operation [{}] for script [{}], doing nothing...", operation, request.script.getScript());
-            UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(), false);
+            UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(), UpdateResponse.convert(Operation.NONE));
             return new Result(update, Operation.NONE, updatedSourceAsMap, updateSourceContentType);
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
@@ -127,7 +127,6 @@ public class UpdateResponse extends DocWriteResponse {
         builder.append(",type=").append(getType());
         builder.append(",id=").append(getId());
         builder.append(",version=").append(getVersion());
-        builder.append(",created=").append(isCreated());
         builder.append(",operation=").append(getOperation().getLowercase());
         builder.append(",shards=").append(getShardInfo());
         return builder.append("]").toString();

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
@@ -29,11 +29,8 @@ import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 
-/**
- */
 public class UpdateResponse extends DocWriteResponse {
 
-    private boolean created;
     private GetResult getResult;
 
     public UpdateResponse() {
@@ -43,14 +40,28 @@ public class UpdateResponse extends DocWriteResponse {
      * Constructor to be used when a update didn't translate in a write.
      * For example: update script with operation set to none
      */
-    public UpdateResponse(ShardId shardId, String type, String id, long version, boolean created) {
-        this(new ShardInfo(0, 0), shardId, type, id, version, created);
+    public UpdateResponse(ShardId shardId, String type, String id, long version, Operation operation) {
+        this(new ShardInfo(0, 0), shardId, type, id, version, operation);
     }
 
-    public UpdateResponse(ShardInfo shardInfo, ShardId shardId, String type, String id, long version, boolean created) {
-        super(shardId, type, id, version);
+    public UpdateResponse(ShardInfo shardInfo, ShardId shardId, String type, String id,
+                          long version, Operation operation) {
+        super(shardId, type, id, version, operation);
         setShardInfo(shardInfo);
-        this.created = created;
+    }
+
+    public static Operation convert(UpdateHelper.Operation op) {
+        switch(op) {
+            case UPSERT:
+                return Operation.CREATE;
+            case INDEX:
+                return Operation.INDEX;
+            case DELETE:
+                return Operation.DELETE;
+            case NONE:
+                return Operation.NOOP;
+        }
+        throw new IllegalArgumentException();
     }
 
     public void setGetResult(GetResult getResult) {
@@ -65,22 +76,17 @@ public class UpdateResponse extends DocWriteResponse {
      * Returns true if document was created due to an UPSERT operation
      */
     public boolean isCreated() {
-        return this.created;
-
+        return this.operation == Operation.CREATE;
     }
 
     @Override
     public RestStatus status() {
-        if (created) {
-            return RestStatus.CREATED;
-        }
-        return super.status();
+        return isCreated() ? RestStatus.CREATED : super.status();
     }
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        created = in.readBoolean();
         if (in.readBoolean()) {
             getResult = GetResult.readGetResult(in);
         }
@@ -89,7 +95,6 @@ public class UpdateResponse extends DocWriteResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeBoolean(created);
         if (getResult == null) {
             out.writeBoolean(false);
         } else {
@@ -122,7 +127,8 @@ public class UpdateResponse extends DocWriteResponse {
         builder.append(",type=").append(getType());
         builder.append(",id=").append(getId());
         builder.append(",version=").append(getVersion());
-        builder.append(",created=").append(created);
+        builder.append(",created=").append(isCreated());
+        builder.append(",operation=").append(getOperation().getLowercase());
         builder.append(",shards=").append(getShardInfo());
         return builder.append("]").toString();
     }

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -57,7 +57,7 @@ $ cat requests
 { "index" : { "_index" : "test", "_type" : "type1", "_id" : "1" } }
 { "field1" : "value1" }
 $ curl -s -XPOST localhost:9200/_bulk --data-binary "@requests"; echo
-{"took":7,"items":[{"create":{"_index":"test","_type":"type1","_id":"1","_version":1}}]}
+{"took":7, "errors": false, "items":[{"index":{"_index":"test","_type":"type1","_id":"1","_version":1,"_operation":"create","forced_refresh":false}}]}
 --------------------------------------------------
 
 Because this format uses literal `\n`'s as delimiters, please be sure

--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -25,7 +25,8 @@ The result of the above delete operation is:
     "_index" : "twitter",
     "_type" : "tweet",
     "_id" : "1",
-    "_version" : 2
+    "_version" : 2,
+    "_operation: delete"
 }
 --------------------------------------------------
 

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -31,6 +31,7 @@ The result of the above index operation is:
     "_id" : "1",
     "_version" : 1,
     "created" : true,
+    "_operation" : create,
     "forced_refresh": false
 }
 --------------------------------------------------
@@ -231,6 +232,7 @@ The result of the above index operation is:
     "_id" : "6a8ca01c-7896-48e9-81cc-9f70661fcb32",
     "_version" : 1,
     "created" : true,
+    "_operation": "create",
     "forced_refresh": false
 }
 --------------------------------------------------

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -133,8 +133,8 @@ curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
 --------------------------------------------------
 
 If `name` was `new_name` before the request was sent then the entire update
-request is ignored. The `noop` element in the response indicates if the
-request was ignored.
+request is ignored. The `operation` element in the response returns `noop` if
+the request was ignored.
 
 [source,js]
 --------------------------------------------------
@@ -143,7 +143,7 @@ request was ignored.
    "_type": "type1",
    "_id": "1",
    "_version": 1,
-   "_noop": true
+   "_operation": noop
 }
 --------------------------------------------------
 

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -132,8 +132,20 @@ curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
 }'
 --------------------------------------------------
 
-If `name` was `new_name` before the request was sent then document is still
-reindexed.
+If `name` was `new_name` before the request was sent then the entire update
+request is ignored. The `noop` element in the response indicates if the
+request was ignored.
+
+[source,js]
+--------------------------------------------------
+{
+   "_index": "test",
+   "_type": "type1",
+   "_id": "1",
+   "_version": 1,
+   "_noop": true
+}
+--------------------------------------------------
 
 [[upserts]]
 [float]

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/AsyncBulkByScrollActionTests.java
@@ -314,7 +314,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         };
         ScrollableHitSource.Response response = new ScrollableHitSource.Response(false, emptyList(), 0, emptyList(), null);
         simulateScrollResponse(new DummyAbstractAsyncBulkByScrollAction(), timeValueNanos(System.nanoTime()), 10, response);
-        ExecutionException e = expectThrows(ExecutionException.class, () -> listener.get()); 
+        ExecutionException e = expectThrows(ExecutionException.class, () -> listener.get());
         assertThat(e.getMessage(), equalTo("EsRejectedExecutionException[test]"));
         assertThat(client.scrollsCleared, contains(scrollId));
 
@@ -773,7 +773,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
                         UpdateRequest update = (UpdateRequest) item;
                         opType = "update";
                         response = new UpdateResponse(shardId, update.type(), update.id(),
-                                randomIntBetween(0, Integer.MAX_VALUE), true);
+                                randomIntBetween(0, Integer.MAX_VALUE), DocWriteResponse.Operation.CREATE);
                     } else if (item instanceof DeleteRequest) {
                         DeleteRequest delete = (DeleteRequest) item;
                         opType = "delete";

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/delete/12_operation.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/delete/12_operation.yaml
@@ -1,0 +1,26 @@
+---
+"Delete operation field":
+
+ - do:
+      index:
+          index:   test_1
+          type:    test
+          id:      1
+          body:    { foo: bar }
+
+ - do:
+      delete:
+          index:   test_1
+          type:    test
+          id:      1
+
+ - match: { _operation: delete }
+
+ - do:
+      catch: missing
+      delete:
+          index:   test_1
+          type:    test
+          id:      1
+
+ - match: { _operation: noop }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/12_operation.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/12_operation.yaml
@@ -1,0 +1,21 @@
+---
+"Index operation field":
+
+  - do:
+      index:
+          index:  test_index
+          type:   test
+          id:     1
+          body:   { foo: bar }
+
+  - match:   { _operation: create }
+
+  - do:
+      index:
+          index:    test_index
+          type:     test
+          id:       1
+          body:     { foo: bar }
+          op_type:  index
+
+  - match:   { _operation: index }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/12_operation.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/12_operation.yaml
@@ -1,5 +1,5 @@
 ---
-"Noop":
+"Update operation field":
 
   - do:
       update:
@@ -8,23 +8,10 @@
           id:               1
           body:
             doc:            { foo: bar }
-            doc_as_upsert:  1
+            doc_as_upsert:  true
 
-  - match: { _version: 1  }
-  - match: { _noop: false }
-
-  - do:
-      update:
-          index:            test_1
-          type:             test
-          id:               1
-          body:
-            doc:            { foo: bar }
-            doc_as_upsert:  1
-            detect_noop:    true
-
-  - match: { _version: 1    }
-  - match: { _noop:    true }
+  - match: { _version:   1      }
+  - match: { _operation: create }
 
   - do:
       update:
@@ -33,11 +20,23 @@
           id:               1
           body:
             doc:            { foo: bar }
-            doc_as_upsert:  1
+            doc_as_upsert:  true
+
+  - match: { _version:   1    }
+  - match: { _operation: noop }
+
+  - do:
+      update:
+          index:            test_1
+          type:             test
+          id:               1
+          body:
+            doc:            { foo: bar }
+            doc_as_upsert:  true
             detect_noop:    false
 
-  - match: { _version: 2     }
-  - match: { _noop:    false }
+  - match: { _version:   2     }
+  - match: { _operation: index }
 
   - do:
       update:
@@ -46,8 +45,8 @@
           id:               1
           body:
             doc:            { foo: baz }
-            doc_as_upsert:  1
+            doc_as_upsert:  true
             detect_noop:    true
 
-  - match: { _version: 3     }
-  - match: { _noop:    false }
+  - match: { _version:   3     }
+  - match: { _operation: index }

--- a/rest-api-spec/test/update/27_noop.yaml
+++ b/rest-api-spec/test/update/27_noop.yaml
@@ -1,0 +1,53 @@
+---
+"Noop":
+
+  - do:
+      update:
+          index:            test_1
+          type:             test
+          id:               1
+          body:
+            doc:            { foo: bar }
+            doc_as_upsert:  1
+
+  - match: { _version: 1  }
+  - match: { _noop: false }
+
+  - do:
+      update:
+          index:            test_1
+          type:             test
+          id:               1
+          body:
+            doc:            { foo: bar }
+            doc_as_upsert:  1
+            detect_noop:    true
+
+  - match: { _version: 1    }
+  - match: { _noop:    true }
+
+  - do:
+      update:
+          index:            test_1
+          type:             test
+          id:               1
+          body:
+            doc:            { foo: bar }
+            doc_as_upsert:  1
+            detect_noop:    false
+
+  - match: { _version: 2     }
+  - match: { _noop:    false }
+
+  - do:
+      update:
+          index:            test_1
+          type:             test
+          id:               1
+          body:
+            doc:            { foo: baz }
+            doc_as_upsert:  1
+            detect_noop:    true
+
+  - match: { _version: 3     }
+  - match: { _noop:    false }


### PR DESCRIPTION
Revival of #9736
Closes #9642
Closes #19267

I attempted to follow the steps suggested by @nik9000 in #9736. 
I was unsure of whether the IndexResponse#isCreated method and "created": field should be changed, as the version of ES is way past 2.0.0, when the original comment was written, so I left them.

Performing the bulk request shown in #19267 now results in the following:
`{"_index":"test","_type":"test","_id":"1","_version":1,"_operation":"create","forced_refresh":false,"_shards":{"total":2,"successful":1,"failed":0},"status":201}`
`{"_index":"test","_type":"test","_id":"1","_version":1,"_operation":"noop","forced_refresh":false,"_shards":{"total":2,"successful":1,"failed":0},"status":200}`
