### PR TITLE
Update gateway.asciidoc

### DIFF
--- a/docs/reference/modules/gateway.asciidoc
+++ b/docs/reference/modules/gateway.asciidoc
@@ -4,9 +4,9 @@
 The local gateway module stores the cluster state and shard data across full
 cluster restarts.
 
-The following _static_ settings, which must be set on every data node in the
-cluster, controls how long nodes should wait before they try to recover any
-shards which are stored locally:
+ The following _static_ settings, which must be set on every master node,
+  control how long a freshly elected master should wait before it tries to
+  recover the cluster state and the cluster's data:
 
 `gateway.expected_nodes`::
 
@@ -48,5 +48,3 @@ as long as the following conditions are met:
     Recover as long as this many data nodes have joined the cluster.
 
 NOTE: These settings only take effect on a full cluster restart.
-
-NOTE: The settings of the currently elected master take precedence.

--- a/docs/reference/modules/gateway.asciidoc
+++ b/docs/reference/modules/gateway.asciidoc
@@ -49,3 +49,4 @@ as long as the following conditions are met:
 
 NOTE: These settings only take effect on a full cluster restart.
 
+NOTE: The settings of the currently elected master take precedence.


### PR DESCRIPTION
Added a note to clarify that, in cases where nodes in a cluster may have different settings, the settings on the node that is the elected master take precedence over anything else.
