### PR TITLE
Rename FieldDataFieldsContext and FieldDataFieldsFetchSubPhase in DocValueFieldsContext and DocValueFieldsFetchSubPhase

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
@@ -34,8 +34,8 @@ import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder.ScriptField;
-import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
-import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsFetchSubPhase;
+import org.elasticsearch.search.fetch.docvalues.DocValueFieldsContext;
+import org.elasticsearch.search.fetch.docvalues.DocValueFieldsFetchSubPhase;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.highlight.HighlightBuilder;
@@ -574,12 +574,12 @@ public final class InnerHitBuilder extends ToXContentToBytes implements Writeabl
             }
         }
         if (docValueFields != null) {
-            FieldDataFieldsContext fieldDataFieldsContext = innerHitsContext
-                    .getFetchSubPhaseContext(FieldDataFieldsFetchSubPhase.CONTEXT_FACTORY);
+            DocValueFieldsContext docValueFieldsContext = innerHitsContext
+                    .getFetchSubPhaseContext(DocValueFieldsFetchSubPhase.CONTEXT_FACTORY);
             for (String field : docValueFields) {
-                fieldDataFieldsContext.add(new FieldDataFieldsContext.FieldDataField(field));
+                docValueFieldsContext.add(new DocValueFieldsContext.DocValueField(field));
             }
-            fieldDataFieldsContext.setHitExecutionNeeded(true);
+            docValueFieldsContext.setHitExecutionNeeded(true);
         }
         if (scriptFields != null) {
             for (ScriptField field : scriptFields) {

--- a/core/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -246,7 +246,7 @@ import org.elasticsearch.search.controller.SearchPhaseController;
 import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.explain.ExplainFetchSubPhase;
-import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsFetchSubPhase;
+import org.elasticsearch.search.fetch.docvalues.DocValueFieldsFetchSubPhase;
 import org.elasticsearch.search.fetch.matchedqueries.MatchedQueriesFetchSubPhase;
 import org.elasticsearch.search.fetch.parent.ParentFieldSubFetchPhase;
 import org.elasticsearch.search.fetch.script.ScriptFieldsFetchSubPhase;
@@ -792,7 +792,7 @@ public class SearchModule extends AbstractModule {
 
     private void registerFetchSubPhases(List<SearchPlugin> plugins) {
         registerFetchSubPhase(new ExplainFetchSubPhase());
-        registerFetchSubPhase(new FieldDataFieldsFetchSubPhase());
+        registerFetchSubPhase(new DocValueFieldsFetchSubPhase());
         registerFetchSubPhase(new ScriptFieldsFetchSubPhase());
         registerFetchSubPhase(new FetchSourceSubPhase());
         registerFetchSubPhase(new VersionFetchSubPhase());

--- a/core/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchService.java
@@ -39,7 +39,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.ConcurrentMapLong;
-import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -67,9 +66,9 @@ import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.QueryFetchSearchResult;
 import org.elasticsearch.search.fetch.ScrollQueryFetchSearchResult;
 import org.elasticsearch.search.fetch.ShardFetchRequest;
-import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
-import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext.FieldDataField;
-import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsFetchSubPhase;
+import org.elasticsearch.search.fetch.docvalues.DocValueFieldsContext;
+import org.elasticsearch.search.fetch.docvalues.DocValueFieldsContext.DocValueField;
+import org.elasticsearch.search.fetch.docvalues.DocValueFieldsFetchSubPhase;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext.ScriptField;
 import org.elasticsearch.search.highlight.HighlightBuilder;
 import org.elasticsearch.search.internal.DefaultSearchContext;
@@ -726,11 +725,11 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             context.fetchSourceContext(source.fetchSource());
         }
         if (source.docValueFields() != null) {
-            FieldDataFieldsContext fieldDataFieldsContext = context.getFetchSubPhaseContext(FieldDataFieldsFetchSubPhase.CONTEXT_FACTORY);
+            DocValueFieldsContext docValuesFieldsContext = context.getFetchSubPhaseContext(DocValueFieldsFetchSubPhase.CONTEXT_FACTORY);
             for (String field : source.docValueFields()) {
-                fieldDataFieldsContext.add(new FieldDataField(field));
+                docValuesFieldsContext.add(new DocValueField(field));
             }
-            fieldDataFieldsContext.setHitExecutionNeeded(true);
+            docValuesFieldsContext.setHitExecutionNeeded(true);
         }
         if (source.highlighter() != null) {
             HighlightBuilder highlightBuilder = source.highlighter();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregatorFactory.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregatorFactory.java
@@ -28,9 +28,9 @@ import org.elasticsearch.search.aggregations.InternalAggregation.Type;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.builder.SearchSourceBuilder.ScriptField;
-import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
-import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext.FieldDataField;
-import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsFetchSubPhase;
+import org.elasticsearch.search.fetch.docvalues.DocValueFieldsContext;
+import org.elasticsearch.search.fetch.docvalues.DocValueFieldsContext.DocValueField;
+import org.elasticsearch.search.fetch.docvalues.DocValueFieldsFetchSubPhase;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.highlight.HighlightBuilder;
 import org.elasticsearch.search.internal.SubSearchContext;
@@ -54,12 +54,12 @@ public class TopHitsAggregatorFactory extends AggregatorFactory<TopHitsAggregato
     private final List<SortBuilder<?>> sorts;
     private final HighlightBuilder highlightBuilder;
     private final List<String> fieldNames;
-    private final List<String> fieldDataFields;
+    private final List<String> docValueFields;
     private final Set<ScriptField> scriptFields;
     private final FetchSourceContext fetchSourceContext;
 
     public TopHitsAggregatorFactory(String name, Type type, int from, int size, boolean explain, boolean version, boolean trackScores,
-            List<SortBuilder<?>> sorts, HighlightBuilder highlightBuilder, List<String> fieldNames, List<String> fieldDataFields,
+            List<SortBuilder<?>> sorts, HighlightBuilder highlightBuilder, List<String> fieldNames, List<String> docValueFields,
             Set<ScriptField> scriptFields, FetchSourceContext fetchSourceContext, AggregationContext context, AggregatorFactory<?> parent,
             AggregatorFactories.Builder subFactories, Map<String, Object> metaData) throws IOException {
         super(name, type, context, parent, subFactories, metaData);
@@ -71,7 +71,7 @@ public class TopHitsAggregatorFactory extends AggregatorFactory<TopHitsAggregato
         this.sorts = sorts;
         this.highlightBuilder = highlightBuilder;
         this.fieldNames = fieldNames;
-        this.fieldDataFields = fieldDataFields;
+        this.docValueFields = docValueFields;
         this.scriptFields = scriptFields;
         this.fetchSourceContext = fetchSourceContext;
     }
@@ -95,13 +95,13 @@ public class TopHitsAggregatorFactory extends AggregatorFactory<TopHitsAggregato
         if (fieldNames != null) {
             subSearchContext.fieldNames().addAll(fieldNames);
         }
-        if (fieldDataFields != null) {
-            FieldDataFieldsContext fieldDataFieldsContext = subSearchContext
-                    .getFetchSubPhaseContext(FieldDataFieldsFetchSubPhase.CONTEXT_FACTORY);
-            for (String field : fieldDataFields) {
-                fieldDataFieldsContext.add(new FieldDataField(field));
+        if (docValueFields != null) {
+            DocValueFieldsContext docValueFieldsContext = subSearchContext
+                    .getFetchSubPhaseContext(DocValueFieldsFetchSubPhase.CONTEXT_FACTORY);
+            for (String field : docValueFields) {
+                docValueFieldsContext.add(new DocValueField(field));
             }
-            fieldDataFieldsContext.setHitExecutionNeeded(true);
+            docValueFieldsContext.setHitExecutionNeeded(true);
         }
         if (scriptFields != null) {
             for (ScriptField field : scriptFields) {

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseContext.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseContext.java
@@ -19,11 +19,13 @@
 
 package org.elasticsearch.search.fetch;
 
+import org.elasticsearch.search.fetch.docvalues.DocValueFieldsContext;
+
 /**
  * All configuration and context needed by the FetchSubPhase to execute on hits.
  * The only required information in this base class is whether or not the sub phase needs to be run at all.
  * It can be extended by FetchSubPhases to hold information the phase needs to execute on hits.
- * See {@link org.elasticsearch.search.fetch.FetchSubPhase.ContextFactory} and also {@link org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext} for an example.
+ * See {@link org.elasticsearch.search.fetch.FetchSubPhase.ContextFactory} and also {@link DocValueFieldsContext} for an example.
  */
 public class FetchSubPhaseContext {
 

--- a/core/src/main/java/org/elasticsearch/search/fetch/docvalues/DocValueFieldsContext.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/docvalues/DocValueFieldsContext.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.fetch.fielddata;
+package org.elasticsearch.search.fetch.docvalues;
 
 import org.elasticsearch.search.fetch.FetchSubPhaseContext;
 
@@ -24,14 +24,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * All the required context to pull a field from the field data cache.
+ * All the required context to pull a field from the doc values.
  */
-public class FieldDataFieldsContext extends FetchSubPhaseContext {
+public class DocValueFieldsContext extends FetchSubPhaseContext {
 
-    public static class FieldDataField {
+    public static class DocValueField {
         private final String name;
 
-        public FieldDataField(String name) {
+        public DocValueField(String name) {
             this.name = name;
         }
 
@@ -40,16 +40,16 @@ public class FieldDataFieldsContext extends FetchSubPhaseContext {
         }
     }
 
-    private List<FieldDataField> fields = new ArrayList<>();
+    private List<DocValueField> fields = new ArrayList<>();
 
-    public FieldDataFieldsContext() {
+    public DocValueFieldsContext() {
     }
 
-    public void add(FieldDataField field) {
+    public void add(DocValueField field) {
         this.fields.add(field);
     }
 
-    public List<FieldDataField> fields() {
+    public List<DocValueField> fields() {
         return this.fields;
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/fetch/docvalues/DocValueFieldsFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/docvalues/DocValueFieldsFetchSubPhase.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.fetch.fielddata;
+package org.elasticsearch.search.fetch.docvalues;
 
 import org.elasticsearch.index.fielddata.AtomicFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
@@ -30,24 +30,23 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 /**
- * Query sub phase which pulls data from field data (using the cache if
- * available, building it if not).
+ * Query sub phase which pulls data from doc values
  *
- * Specifying {@code "fielddata_fields": ["field1", "field2"]}
+ * Specifying {@code "docvalue_fields": ["field1", "field2"]}
  */
-public final class FieldDataFieldsFetchSubPhase implements FetchSubPhase {
+public final class DocValueFieldsFetchSubPhase implements FetchSubPhase {
 
-    public static final String[] NAMES = {"fielddata_fields", "fielddataFields"};
-    public static final ContextFactory<FieldDataFieldsContext> CONTEXT_FACTORY = new ContextFactory<FieldDataFieldsContext>() {
+    public static final String NAME = "docvalue_fields";
+    public static final ContextFactory<DocValueFieldsContext> CONTEXT_FACTORY = new ContextFactory<DocValueFieldsContext>() {
 
         @Override
         public String getName() {
-            return NAMES[0];
+            return NAME;
         }
 
         @Override
-        public FieldDataFieldsContext newContextInstance() {
-            return new FieldDataFieldsContext();
+        public DocValueFieldsContext newContextInstance() {
+            return new DocValueFieldsContext();
         }
     };
 
@@ -56,7 +55,7 @@ public final class FieldDataFieldsFetchSubPhase implements FetchSubPhase {
         if (context.getFetchSubPhaseContext(CONTEXT_FACTORY).hitExecutionNeeded() == false) {
             return;
         }
-        for (FieldDataFieldsContext.FieldDataField field : context.getFetchSubPhaseContext(CONTEXT_FACTORY).fields()) {
+        for (DocValueFieldsContext.DocValueField field : context.getFetchSubPhaseContext(CONTEXT_FACTORY).fields()) {
             if (hitContext.hit().fieldsOrNull() == null) {
                 hitContext.hit().fields(new HashMap<>(2));
             }


### PR DESCRIPTION
This change renames the package org.elasticsearch.search.fetch.fielddata to org.elasticsearch.search.fetch.docvalues and renames the
FieldData\* classes in DocValue*.
This is a follow up of the renaming that happened in #18943
