### PR TITLE
Deprecate template query

### DIFF
--- a/docs/reference/migration/migrate_5_0/scripting.asciidoc
+++ b/docs/reference/migration/migrate_5_0/scripting.asciidoc
@@ -310,3 +310,8 @@ transportClient.addTransportAddress(
 
 Also the helper methods in `QueryBuilders` class that create a `TemplateQueryBuilder` instance have been removed,
 instead the constructors on `TemplateQueryBuilder` should be used.
+
+==== Template query
+
+The `template` query has been deprecated in favour of the search template api. The `template` query is scheduled
+to be removed in the next major version.

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TemplateQueryBuilder.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TemplateQueryBuilder.java
@@ -23,6 +23,8 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -47,8 +49,12 @@ import java.util.Optional;
 /**
  * Facilitates creating template query requests.
  * */
+@Deprecated
+// TODO remove this class in 6.0
 public class TemplateQueryBuilder extends AbstractQueryBuilder<TemplateQueryBuilder> {
+
     public static final String NAME = "template";
+    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(TemplateQueryBuilder.class));
 
     /** Template to fill. */
     private final Script template;
@@ -63,6 +69,7 @@ public class TemplateQueryBuilder extends AbstractQueryBuilder<TemplateQueryBuil
 
     // for tests, so that mock script can be used:
     TemplateQueryBuilder(Script template) {
+        DEPRECATION_LOGGER.deprecated("[{}] query is deprecated, use search template api instead", NAME);
         if (template == null) {
             throw new IllegalArgumentException("query template cannot be null");
         }


### PR DESCRIPTION
Both the search template api and the `template` query support templating the search request. However the search template api is able to template the entire search request while the `template` query can template only part of the query. Having both options around doesn't make much sense and since the search template api is more powerful it makes sense to deprecate the `template` query.

PR for #19390
