### PR TITLE
Add zero-padding to auto-generated rollover index name increment

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -47,6 +47,7 @@ import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -171,7 +172,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
             int numberIndex = sourceIndexName.lastIndexOf("-");
             assert numberIndex != -1 : "no separator '-' found";
             int counter = Integer.parseInt(sourceIndexName.substring(numberIndex + 1));
-            return String.join("-", sourceIndexName.substring(0, numberIndex), String.valueOf(++counter));
+            return String.join("-", sourceIndexName.substring(0, numberIndex), String.format(Locale.ROOT, "%06d", ++counter));
         } else {
             throw new IllegalArgumentException("index name [" + sourceIndexName + "] does not match pattern '^.*-(\\d)+$'");
         }

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -39,14 +39,14 @@ public class RolloverIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test_index-1").addAlias(new Alias("test_alias")).get());
         final RolloverResponse response = client().admin().indices().prepareRolloverIndex("test_alias").get();
         assertThat(response.getOldIndex(), equalTo("test_index-1"));
-        assertThat(response.getNewIndex(), equalTo("test_index-2"));
+        assertThat(response.getNewIndex(), equalTo("test_index-000002"));
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
         final ClusterState state = client().admin().cluster().prepareState().get().getState();
         final IndexMetaData oldIndex = state.metaData().index("test_index-1");
         assertFalse(oldIndex.getAliases().containsKey("test_alias"));
-        final IndexMetaData newIndex = state.metaData().index("test_index-2");
+        final IndexMetaData newIndex = state.metaData().index("test_index-000002");
         assertTrue(newIndex.getAliases().containsKey("test_alias"));
     }
 
@@ -56,14 +56,14 @@ public class RolloverIT extends ESIntegTestCase {
         flush("test_index-2");
         final RolloverResponse response = client().admin().indices().prepareRolloverIndex("test_alias").get();
         assertThat(response.getOldIndex(), equalTo("test_index-2"));
-        assertThat(response.getNewIndex(), equalTo("test_index-3"));
+        assertThat(response.getNewIndex(), equalTo("test_index-000003"));
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
         final ClusterState state = client().admin().cluster().prepareState().get().getState();
         final IndexMetaData oldIndex = state.metaData().index("test_index-2");
         assertFalse(oldIndex.getAliases().containsKey("test_alias"));
-        final IndexMetaData newIndex = state.metaData().index("test_index-3");
+        final IndexMetaData newIndex = state.metaData().index("test_index-000003");
         assertTrue(newIndex.getAliases().containsKey("test_alias"));
     }
 
@@ -78,14 +78,14 @@ public class RolloverIT extends ESIntegTestCase {
         final RolloverResponse response = client().admin().indices().prepareRolloverIndex("test_alias")
             .settings(settings).alias(new Alias("extra_alias")).get();
         assertThat(response.getOldIndex(), equalTo("test_index-2"));
-        assertThat(response.getNewIndex(), equalTo("test_index-3"));
+        assertThat(response.getNewIndex(), equalTo("test_index-000003"));
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
         final ClusterState state = client().admin().cluster().prepareState().get().getState();
         final IndexMetaData oldIndex = state.metaData().index("test_index-2");
         assertFalse(oldIndex.getAliases().containsKey("test_alias"));
-        final IndexMetaData newIndex = state.metaData().index("test_index-3");
+        final IndexMetaData newIndex = state.metaData().index("test_index-000003");
         assertThat(newIndex.getNumberOfShards(), equalTo(1));
         assertThat(newIndex.getNumberOfReplicas(), equalTo(0));
         assertTrue(newIndex.getAliases().containsKey("test_alias"));
@@ -98,14 +98,14 @@ public class RolloverIT extends ESIntegTestCase {
         flush("test_index-1");
         final RolloverResponse response = client().admin().indices().prepareRolloverIndex("test_alias").dryRun(true).get();
         assertThat(response.getOldIndex(), equalTo("test_index-1"));
-        assertThat(response.getNewIndex(), equalTo("test_index-2"));
+        assertThat(response.getNewIndex(), equalTo("test_index-000002"));
         assertThat(response.isDryRun(), equalTo(true));
         assertThat(response.isRolledOver(), equalTo(false));
         assertThat(response.getConditionStatus().size(), equalTo(0));
         final ClusterState state = client().admin().cluster().prepareState().get().getState();
         final IndexMetaData oldIndex = state.metaData().index("test_index-1");
         assertTrue(oldIndex.getAliases().containsKey("test_alias"));
-        final IndexMetaData newIndex = state.metaData().index("test_index-2");
+        final IndexMetaData newIndex = state.metaData().index("test_index-000002");
         assertNull(newIndex);
     }
 
@@ -126,7 +126,7 @@ public class RolloverIT extends ESIntegTestCase {
         final ClusterState state = client().admin().cluster().prepareState().get().getState();
         final IndexMetaData oldIndex = state.metaData().index("test_index-0");
         assertTrue(oldIndex.getAliases().containsKey("test_alias"));
-        final IndexMetaData newIndex = state.metaData().index("test_index-1");
+        final IndexMetaData newIndex = state.metaData().index("test_index-000001");
         assertNull(newIndex);
     }
 
@@ -151,14 +151,14 @@ public class RolloverIT extends ESIntegTestCase {
     public void testRolloverOnExistingIndex() throws Exception {
         assertAcked(prepareCreate("test_index-0").addAlias(new Alias("test_alias")).get());
         index("test_index-0", "type1", "1", "field", "value");
-        assertAcked(prepareCreate("test_index-1").get());
-        index("test_index-1", "type1", "1", "field", "value");
-        flush("test_index-0", "test_index-1");
+        assertAcked(prepareCreate("test_index-000001").get());
+        index("test_index-000001", "type1", "1", "field", "value");
+        flush("test_index-0", "test_index-000001");
         try {
             client().admin().indices().prepareRolloverIndex("test_alias").get();
             fail("expected failure due to existing rollover index");
         } catch (IndexAlreadyExistsException e) {
-            assertThat(e.getIndex().getName(), equalTo("test_index-1"));
+            assertThat(e.getIndex().getName(), equalTo("test_index-000001"));
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import static org.elasticsearch.action.admin.indices.rollover.TransportRolloverAction.evaluateConditions;
@@ -158,9 +159,9 @@ public class TransportRolloverActionTests extends ESTestCase {
         final String indexPrefix = randomAsciiOfLength(10);
         String indexEndingInNumbers = indexPrefix + "-" + num;
         assertThat(TransportRolloverAction.generateRolloverIndexName(indexEndingInNumbers),
-            equalTo(indexPrefix + "-" + (num + 1)));
-        assertThat(TransportRolloverAction.generateRolloverIndexName("index-name-1"), equalTo("index-name-2"));
-        assertThat(TransportRolloverAction.generateRolloverIndexName("index-name-2"), equalTo("index-name-3"));
+            equalTo(indexPrefix + "-" + String.format(Locale.ROOT, "%06d", num + 1)));
+        assertThat(TransportRolloverAction.generateRolloverIndexName("index-name-1"), equalTo("index-name-000002"));
+        assertThat(TransportRolloverAction.generateRolloverIndexName("index-name-2"), equalTo("index-name-000003"));
     }
 
     public void testCreateIndexRequest() throws Exception {

--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -12,7 +12,7 @@ the new alias.
 
 [source,js]
 --------------------------------------------------
-PUT /logs-0001 <1>
+PUT /logs-000001 <1>
 {
   "aliases": {
     "logs_write": {}
@@ -28,18 +28,18 @@ POST logs_write/_rollover <2>
 }
 --------------------------------------------------
 // CONSOLE
-<1> Creates an index called `logs-0001` with the alias `logs_write`.
+<1> Creates an index called `logs-0000001` with the alias `logs_write`.
 <2> If the index pointed to by `logs_write` was created 7 or more days ago, or
     contains 1,000 or more documents, then the `logs-0002` index is created
-    and the `logs_write` alias is updated to point to `logs-0002`.
+    and the `logs_write` alias is updated to point to `logs-000002`.
 
 The above request might return the following response:
 
 [source,js]
 --------------------------------------------------
 {
-  "old_index": "logs-0001",
-  "new_index": "logs-0002",
+  "old_index": "logs-000001",
+  "new_index": "logs-000002",
   "rolled_over": true, <1>
   "dry_run": false, <2>
   "conditions": { <3>
@@ -56,8 +56,9 @@ The above request might return the following response:
 === Naming the new index
 
 If the name of the existing index ends with `-` and a number -- e.g.
-`logs-0001` -- then the name of the new index will follow the same pattern,
-just incrementing the number (`logs-0002`).
+`logs-000001` -- then the name of the new index will follow the same pattern,
+incrementing the number (`logs-000002`). The number is zero-padded with a length
+of 6, regardless of the old index name.
 
 If the old name doesn't match this pattern then you must specify the name for
 the new index as follows:
@@ -80,7 +81,7 @@ override any values set in matching index templates. For example, the following
 
 [source,js]
 --------------------------------------------------
-PUT /logs-0001
+PUT /logs-000001
 {
   "aliases": {
     "logs_write": {}
@@ -108,7 +109,7 @@ checked without performing the actual rollover:
 
 [source,js]
 --------------------------------------------------
-PUT /logs-0001
+PUT /logs-000001
 {
   "aliases": {
     "logs_write": {}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yaml
@@ -39,7 +39,7 @@
             max_docs: 1
 
   - match: { old_index: logs-1 }
-  - match: { new_index: logs-2 }
+  - match: { new_index: logs-000002 }
   - match: { rolled_over: true }
   - match: { dry_run: false }
   - match: { conditions: { "[max_docs: 1]": true } }
@@ -47,14 +47,14 @@
   # ensure new index is created
   - do:
       indices.exists:
-        index: logs-2
+        index: logs-000002
 
   - is_true: ''
 
   # index into new index
   - do:
       index:
-        index: logs-2
+        index: logs-000002
         type:  test
         id:    "2"
         body:  { "foo": "hello world" }
@@ -69,5 +69,5 @@
         type:  test
 
   - match: { hits.total: 1 }
-  - match: { hits.hits.0._index: "logs-2"}
+  - match: { hits.hits.0._index: "logs-000002"}
 


### PR DESCRIPTION
This commit adds a zero-padding length of 6 to the 
increment in the auto-generated rollover index name 
to support sorting generated indices by index name.

closes #19484
