### PR TITLE
Fixes debug logging on index creation waiting for shards to be started

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -202,8 +202,10 @@ public class MetaDataCreateIndexService extends AbstractComponent {
             if (response.isAcknowledged()) {
                 activeShardsObserver.waitForActiveShards(request.index(), request.waitForActiveShards(), request.ackTimeout(),
                     shardsAcked -> {
-                        logger.debug("[{}] index created, but the operation timed out while waiting for " +
-                                         "enough shards to be started.", request.index());
+                        if (shardsAcked == false) {
+                            logger.debug("[{}] index created, but the operation timed out while waiting for " +
+                                             "enough shards to be started.", request.index());
+                        }
                         listener.onResponse(new CreateIndexClusterStateUpdateResponse(response.isAcknowledged(), shardsAcked));
                     }, listener::onFailure);
             } else {


### PR DESCRIPTION
Before, the debug logging on timing out was logged whether the shards were started or not.  This fixes it to only log the warning when the shards starting was not acknowledged.
