### PR TITLE
Only log running out of slots when out of slots

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
@@ -207,7 +207,9 @@ public abstract class TransportWriteAction<
                 if (location != null) {
                     pendingOps = true;
                     indexShard.addRefreshListener(location, forcedRefresh -> {
-                        logger.warn("block_until_refresh request ran out of slots and forced a refresh: [{}]", request);
+                        if (forcedRefresh) {
+                            logger.warn("block_until_refresh request ran out of slots and forced a refresh: [{}]", request);
+                        }
                         respond.respondAfterAsyncAction(forcedRefresh);
                     });
                 }


### PR DESCRIPTION
We were logging on every `refresh=wait_for`.
