### PR TITLE
Change file changes listener for resource watcher to an interface

### DIFF
--- a/core/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -487,7 +487,7 @@ public class ScriptService extends AbstractComponent implements Closeable, Clust
         }
     }
 
-    private class ScriptChangesListener extends FileChangesListener {
+    private class ScriptChangesListener implements FileChangesListener {
 
         private Tuple<String, String> getScriptNameExt(Path file) {
             Path scriptPath = scriptsDirectory.relativize(file);

--- a/core/src/main/java/org/elasticsearch/watcher/FileChangesListener.java
+++ b/core/src/main/java/org/elasticsearch/watcher/FileChangesListener.java
@@ -23,53 +23,39 @@ import java.nio.file.Path;
 /**
  * Callback interface that file changes File Watcher is using to notify listeners about changes.
  */
-public class FileChangesListener {
+public interface FileChangesListener {
     /**
      * Called for every file found in the watched directory during initialization
      */
-    public void onFileInit(Path file) {
-
-    }
+    default void onFileInit(Path file) {}
 
     /**
      * Called for every subdirectory found in the watched directory during initialization
      */
-    public void onDirectoryInit(Path file) {
-
-    }
+    default void onDirectoryInit(Path file) {}
 
     /**
      * Called for every new file found in the watched directory
      */
-    public void onFileCreated(Path file) {
-
-    }
+    default void onFileCreated(Path file) {}
 
     /**
      * Called for every file that disappeared in the watched directory
      */
-    public void onFileDeleted(Path file) {
-
-    }
+    default void onFileDeleted(Path file) {}
 
     /**
      * Called for every file that was changed in the watched directory
      */
-    public void onFileChanged(Path file) {
-
-    }
+    default void onFileChanged(Path file) {}
 
     /**
      * Called for every new subdirectory found in the watched directory
      */
-    public void onDirectoryCreated(Path file) {
-
-    }
+    default void onDirectoryCreated(Path file) {}
 
     /**
      * Called for every file that disappeared in the watched directory
      */
-    public void onDirectoryDeleted(Path file) {
-
-    }
+    default void onDirectoryDeleted(Path file) {}
 }

--- a/core/src/test/java/org/elasticsearch/watcher/FileWatcherTests.java
+++ b/core/src/test/java/org/elasticsearch/watcher/FileWatcherTests.java
@@ -37,7 +37,7 @@ import static org.hamcrest.Matchers.hasSize;
 
 @LuceneTestCase.SuppressFileSystems("ExtrasFS")
 public class FileWatcherTests extends ESTestCase {
-    private class RecordingChangeListener extends FileChangesListener {
+    private class RecordingChangeListener implements FileChangesListener {
         private Path rootDir;
 
         private RecordingChangeListener(Path rootDir) {


### PR DESCRIPTION
Currently to use the ResourceWatcherService to watch files, you
implement a FileChangesListener. However, this is a class, not an
interface, even though it has no base state or anything like that, just
defining a few methods. This change converts FileChangesListener to an
interface.
