### PR TITLE
Assert we return Location header with 201 CREATED

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/support/RestStatusToXContentListener.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/support/RestStatusToXContentListener.java
@@ -37,8 +37,10 @@ public class RestStatusToXContentListener<Response extends StatusToXContent> ext
      * Build an instance that doesn't support responses with the status {@code 201 CREATED}.
      */
     public RestStatusToXContentListener(RestChannel channel) {
-        // TODO switch this to throwing an exception?
-        this(channel, r -> null);
+        this(channel, r -> {
+            assert false: "Returned a 201 CREATED but not set up to support a Location header";
+            return null;
+        });
     }
 
     /**


### PR DESCRIPTION
Add an assertion to the most popular way of turning the response object
into the actual http response. As it stands all places we return
`201 CREATED` we return the `Location` header. This will help to keep it
that way, though it won't catch all uses.

Followup to #19509
