### PR TITLE
Add package-info to o.e.test.rest

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/package-info.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Infrastructure for testing REST. See {@link ESRestTestCase} for running tests against an Elasticsearch cluster using the REST tests and
+ * the rest of the package for mocking utilities.
+ */
+package org.elasticsearch.test.rest;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.test.rest.yaml.client;
+package org.elasticsearch.test.rest.yaml;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 
@@ -34,7 +34,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.util.set.Sets;
-import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 import org.elasticsearch.test.rest.yaml.restspec.ClientYamlSuiteRestApi;
 import org.elasticsearch.test.rest.yaml.restspec.ClientYamlSuiteRestPath;
 import org.elasticsearch.test.rest.yaml.restspec.ClientYamlSuiteRestSpec;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
@@ -24,9 +24,6 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.test.rest.yaml.client.ClientYamlTestClient;
-import org.elasticsearch.test.rest.yaml.client.ClientYamlTestResponse;
-import org.elasticsearch.test.rest.yaml.client.ClientYamlTestResponseException;
 import org.elasticsearch.test.rest.yaml.restspec.ClientYamlSuiteRestSpec;
 
 import java.io.IOException;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestResponse.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestResponse.java
@@ -16,14 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.test.rest.yaml.client;
+package org.elasticsearch.test.rest.yaml;
 
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.test.rest.yaml.ObjectPath;
-import org.elasticsearch.test.rest.yaml.Stash;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestResponseException.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestResponseException.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.test.rest.yaml.client;
+package org.elasticsearch.test.rest.yaml;
 
 import org.elasticsearch.client.ResponseException;
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
@@ -35,7 +35,6 @@ import org.elasticsearch.test.rest.yaml.section.DoSection;
 import org.elasticsearch.test.rest.yaml.section.ExecutableSection;
 import org.elasticsearch.test.rest.yaml.section.SkipSection;
 import org.elasticsearch.test.rest.yaml.section.ClientYamlTestSection;
-import org.elasticsearch.test.rest.yaml.support.FileUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Features.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Features.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.test.rest.yaml.support;
+package org.elasticsearch.test.rest.yaml;
 
 import org.elasticsearch.test.ESIntegTestCase;
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/FileUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/FileUtils.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.test.rest.yaml.support;
+package org.elasticsearch.test.rest.yaml;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.PathUtils;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/package-info.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Infrastructure to run suites of tests written in YAML against a running Elasticsearch cluster using Elasticsearch's low level REST
+ * client. The YAML tests are run by all official clients and serve as tests for both Elasticsearch and the clients.
+ */
+package org.elasticsearch.test.rest.yaml;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/parser/package-info.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/parser/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Parses YAML test {@link org.elasticsearch.test.rest.yaml.section.ClientYamlTestSuite}s containing
+ * {@link org.elasticsearch.test.rest.yaml.section.ClientYamlTestSection}s.
+ */
+package org.elasticsearch.test.rest.yaml.parser;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestSpec.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestSpec.java
@@ -20,7 +20,7 @@ package org.elasticsearch.test.rest.yaml.restspec;
 
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
-import org.elasticsearch.test.rest.yaml.support.FileUtils;
+import org.elasticsearch.test.rest.yaml.FileUtils;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/package-info.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Specification of REST endpoints used to convert YAML {@code do} sections into actual calls to Elasticsearch.
+ */
+package org.elasticsearch.test.rest.yaml.restspec;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -23,8 +23,8 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestExecutionContext;
-import org.elasticsearch.test.rest.yaml.client.ClientYamlTestResponse;
-import org.elasticsearch.test.rest.yaml.client.ClientYamlTestResponseException;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestResponse;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestResponseException;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/SkipSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/SkipSection.java
@@ -20,7 +20,7 @@ package org.elasticsearch.test.rest.yaml.section;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.test.VersionUtils;
-import org.elasticsearch.test.rest.yaml.support.Features;
+import org.elasticsearch.test.rest.yaml.Features;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/package-info.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Sections within the YAML tests that are executed to run the tests.
+ */
+package org.elasticsearch.test.rest.yaml.section;

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/FileUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/FileUtilsTests.java
@@ -16,10 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.test.rest.yaml.support;
+package org.elasticsearch.test.rest.yaml;
 
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.rest.yaml.support.FileUtils;
+import org.elasticsearch.test.rest.yaml.FileUtils;
 
 import java.nio.file.Files;
 import java.nio.file.Path;


### PR DESCRIPTION
This removes two packages, consolidating them into their parent package
and adds `package-info.java` files to describe all of the packages under
`org.elasticsearch.test.rest`.
