### PR TITLE
Fix NPE when simulating a pipeline with no id

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
@@ -81,7 +81,7 @@ public class SimulatePipelineRequest extends ActionRequest<SimulatePipelineReque
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        id = in.readString();
+        id = in.readOptionalString();
         verbose = in.readBoolean();
         source = in.readBytesReference();
     }
@@ -89,7 +89,7 @@ public class SimulatePipelineRequest extends ActionRequest<SimulatePipelineReque
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(id);
+        out.writeOptionalString(id);
         out.writeBoolean(verbose);
         out.writeBytesReference(source);
     }

--- a/core/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineResponse.java
@@ -60,7 +60,7 @@ public class SimulatePipelineResponse extends ActionResponse implements ToXConte
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(pipelineId);
+        out.writeOptionalString(pipelineId);
         out.writeBoolean(verbose);
         out.writeVInt(results.size());
         for (SimulateDocumentResult response : results) {
@@ -71,7 +71,7 @@ public class SimulatePipelineResponse extends ActionResponse implements ToXConte
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        this.pipelineId = in.readString();
+        this.pipelineId = in.readOptionalString();
         boolean verbose = in.readBoolean();
         int responsesLength = in.readVInt();
         results = new ArrayList<>();

--- a/core/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestTests.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.ingest;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.RandomDocumentPicks;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.elasticsearch.ingest.IngestDocumentTests.assertIngestDocument;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.nullValue;
+
+public class SimulatePipelineRequestTests extends ESTestCase {
+
+    public void testSerialization() throws IOException {
+        SimulatePipelineRequest request = new SimulatePipelineRequest(new BytesArray(""));
+        // Sometimes we set an id
+        if (randomBoolean()) {
+            request.setId(randomAsciiOfLengthBetween(1, 10));
+        }
+
+        // Sometimes we explicitly set a boolean (with whatever value)
+        if (randomBoolean()) {
+            request.setVerbose(randomBoolean());
+        }
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        request.writeTo(out);
+        StreamInput streamInput = out.bytes().streamInput();
+        SimulatePipelineRequest otherRequest = new SimulatePipelineRequest();
+        otherRequest.readFrom(streamInput);
+
+        assertThat(otherRequest.getId(), equalTo(request.getId()));
+        assertThat(otherRequest.isVerbose(), equalTo(request.isVerbose()));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineResponseTests.java
@@ -39,6 +39,7 @@ public class SimulatePipelineResponseTests extends ESTestCase {
 
     public void testSerialization() throws IOException {
         boolean isVerbose = randomBoolean();
+        String id = randomBoolean() ? randomAsciiOfLengthBetween(1, 10) : null;
         int numResults = randomIntBetween(1, 10);
         List<SimulateDocumentResult> results = new ArrayList<>(numResults);
         for (int i = 0; i < numResults; i++) {
@@ -70,7 +71,7 @@ public class SimulatePipelineResponseTests extends ESTestCase {
             }
         }
 
-        SimulatePipelineResponse response = new SimulatePipelineResponse(randomAsciiOfLengthBetween(1, 10), isVerbose, results);
+        SimulatePipelineResponse response = new SimulatePipelineResponse(id, isVerbose, results);
         BytesStreamOutput out = new BytesStreamOutput();
         response.writeTo(out);
         StreamInput streamInput = out.bytes().streamInput();


### PR DESCRIPTION
When you simulate a pipeline without specifying an id against a node where the request is redirected to a master node,
the request and the response is throwing a NPE:

```
java.lang.NullPointerException
    at __randomizedtesting.SeedInfo.seed([3B9536AC6AA23C06:DD62280CF765DA1F]:0)
    at org.elasticsearch.common.io.stream.StreamOutput.writeString(StreamOutput.java:300)
    at org.elasticsearch.action.ingest.SimulatePipelineRequest.writeTo(SimulatePipelineRequest.java:92)
    at org.elasticsearch.transport.local.LocalTransport.sendRequest(LocalTransport.java:222)
    at org.elasticsearch.test.transport.AssertingLocalTransport.sendRequest(AssertingLocalTransport.java:95)
    at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:470)
    at org.elasticsearch.action.TransportActionNodeProxy.execute(TransportActionNodeProxy.java:51)
    at org.elasticsearch.client.transport.support.TransportProxyClient.lambda$execute$441(TransportProxyClient.java:63)
    at org.elasticsearch.client.transport.TransportClientNodesService.execute(TransportClientNodesService.java:233)
    at org.elasticsearch.client.transport.support.TransportProxyClient.execute(TransportProxyClient.java:63)
    at org.elasticsearch.client.transport.TransportClient.doExecute(TransportClient.java:309)
    at org.elasticsearch.client.support.AbstractClient.execute(AbstractClient.java:403)
    at org.elasticsearch.client.FilterClient.doExecute(FilterClient.java:67)
    at org.elasticsearch.client.support.AbstractClient.execute(AbstractClient.java:403)
    at org.elasticsearch.client.support.AbstractClient$ClusterAdmin.execute(AbstractClient.java:710)
    at org.elasticsearch.action.ActionRequestBuilder.execute(ActionRequestBuilder.java:80)
    at org.elasticsearch.action.ActionRequestBuilder.execute(ActionRequestBuilder.java:54)
    at org.elasticsearch.action.ActionRequestBuilder.get(ActionRequestBuilder.java:62)
    at org.elasticsearch.ingest.bano.BanoProcessorIntegrationTest.testSimulateProcessorConfigTarget(BanoProcessorIntegrationTest.java:139)
```

This patch fixes this and adds some random tests.
