### PR TITLE
Add response body to ResponseException error message

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/Response.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/Response.java
@@ -96,6 +96,10 @@ public final class Response {
         return response.getEntity();
     }
 
+    HttpResponse getHttpResponse() {
+        return response;
+    }
+
     @Override
     public String toString() {
         return "Response{" +

--- a/client/rest/src/main/java/org/elasticsearch/client/ResponseException.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/ResponseException.java
@@ -19,6 +19,10 @@
 
 package org.elasticsearch.client;
 
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.BufferedHttpEntity;
+import org.apache.http.util.EntityUtils;
+
 import java.io.IOException;
 
 /**
@@ -34,9 +38,19 @@ public final class ResponseException extends IOException {
         this.response = response;
     }
 
-    private static String buildMessage(Response response) {
-        return response.getRequestLine().getMethod() + " " + response.getHost() + response.getRequestLine().getUri()
+    private static String buildMessage(Response response) throws IOException {
+        String message = response.getRequestLine().getMethod() + " " + response.getHost() + response.getRequestLine().getUri()
                 + ": " + response.getStatusLine().toString();
+
+        HttpEntity entity = response.getEntity();
+        if (entity != null) {
+            if (entity.isRepeatable() == false) {
+                entity = new BufferedHttpEntity(entity);
+                response.getHttpResponse().setEntity(entity);
+            }
+            message += "\n" + EntityUtils.toString(entity);
+        }
+        return message;
     }
 
     /**

--- a/client/rest/src/test/java/org/elasticsearch/client/RequestLoggerTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RequestLoggerTests.java
@@ -149,6 +149,7 @@ public class RequestLoggerTests extends RestClientTestCase {
             if (getRandom().nextBoolean()) {
                 entity = new StringEntity(responseBody, StandardCharsets.UTF_8);
             } else {
+                //test a non repeatable entity
                 entity = new InputStreamEntity(new ByteArrayInputStream(responseBody.getBytes(StandardCharsets.UTF_8)));
             }
             httpResponse.setEntity(entity);

--- a/client/rest/src/test/java/org/elasticsearch/client/ResponseExceptionTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/ResponseExceptionTests.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.RequestLine;
+import org.apache.http.StatusLine;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicRequestLine;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.util.EntityUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class ResponseExceptionTests extends RestClientTestCase {
+
+    public void testResponseException() throws IOException {
+        ProtocolVersion protocolVersion = new ProtocolVersion("http", 1, 1);
+        StatusLine statusLine = new BasicStatusLine(protocolVersion, 500, "Internal Server Error");
+        HttpResponse httpResponse = new BasicHttpResponse(statusLine);
+
+        String responseBody = "{\"error\":{\"root_cause\": {}}}";
+        boolean hasBody = getRandom().nextBoolean();
+        if (hasBody) {
+            HttpEntity entity;
+            if (getRandom().nextBoolean()) {
+                entity = new StringEntity(responseBody, StandardCharsets.UTF_8);
+            } else {
+                //test a non repeatable entity
+                entity = new InputStreamEntity(new ByteArrayInputStream(responseBody.getBytes(StandardCharsets.UTF_8)));
+            }
+            httpResponse.setEntity(entity);
+        }
+
+        RequestLine requestLine = new BasicRequestLine("GET", "/", protocolVersion);
+        HttpHost httpHost = new HttpHost("localhost", 9200);
+        Response response = new Response(requestLine, httpHost, httpResponse);
+        ResponseException responseException = new ResponseException(response);
+
+        assertSame(response, responseException.getResponse());
+        if (hasBody) {
+            assertEquals(responseBody, EntityUtils.toString(responseException.getResponse().getEntity()));
+        } else {
+            assertNull(responseException.getResponse().getEntity());
+        }
+
+        String message = response.getRequestLine().getMethod() + " " + response.getHost() + response.getRequestLine().getUri()
+                + ": " + response.getStatusLine().toString();
+        if (hasBody) {
+            message += "\n" + responseBody;
+        }
+        assertEquals(message, responseException.getMessage());
+    }
+}


### PR DESCRIPTION
Consuming the response body to make it part of the exception message means that it may not be readable anymore later, depending on whether the entity is repeatable or not. Turns out that the response body tells a lot about the error itself, and considering that we don't expect bodies to be incredibly big for errors, we can wrap the entity into a BufferedHttpEntity to make it repeatable.

Closes #19653 
