### PR TITLE
Add index pattern wildcards support to _cat/shards

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -73,6 +73,7 @@ public class RestShardsAction extends AbstractCatAction {
             public void processResponse(final ClusterStateResponse clusterStateResponse) {
                 IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
                 indicesStatsRequest.all();
+                indicesStatsRequest.indices(indices);
                 client.admin().indices().stats(indicesStatsRequest, new RestResponseListener<IndicesStatsResponse>(channel) {
                     @Override
                     public RestResponse buildResponse(IndicesStatsResponse indicesStatsResponse) throws Exception {

--- a/docs/reference/cat/shards.asciidoc
+++ b/docs/reference/cat/shards.asciidoc
@@ -25,7 +25,7 @@ some bandwidth by supplying an index pattern to the end.
 
 [source,sh]
 --------------------------------------------------
-% curl 192.168.56.20:9200/_cat/shards/wiki2
+% curl 192.168.56.20:9200/_cat/shards/wiki*
 wiki2 0 p STARTED 197 3.2mb 192.168.56.10 Stiletto
 wiki2 1 p STARTED 205 5.9mb 192.168.56.30 Frankie Raye
 wiki2 2 p STARTED 275 7.8mb 192.168.56.20 Commander Kraken

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yaml
@@ -69,3 +69,50 @@
                          \s*
                 )
                 $/
+
+---
+"Test cat indices using wildcards":
+
+  - do:
+      indices.create:
+        index: foo
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+
+  - do:
+      indices.create:
+        index: bar
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+
+  - do:
+      indices.create:
+        index: baz
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+
+  - do:
+      cat.indices:
+        index: f*
+        v: false
+        h: i
+
+  - match:
+      $body: |
+               /^(foo \n?)$/
+
+  - do:
+      cat.indices:
+        index: ba*
+        v: false
+        h: i
+
+  - match:
+      $body: |
+               /^(ba(r|z) \n?){2}$/

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.segments/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.segments/10_basic.yaml
@@ -114,3 +114,71 @@
       catch: forbidden
       cat.segments:
         index: index1
+
+---
+"Test cat segments using wildcards":
+
+  - do:
+      indices.create:
+        index: foo
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+
+  - do:
+      index:
+        index: foo
+        type: type
+        body: { test: foo }
+        refresh: true
+
+  - do:
+      indices.create:
+        index: bar
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+
+  - do:
+      index:
+        index: bar
+        type: type
+        body: { test: bar }
+        refresh: true
+
+  - do:
+      indices.create:
+        index: baz
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+
+  - do:
+      index:
+        index: baz
+        type: type
+        body: { test: baz }
+        refresh: true
+
+  - do:
+      cat.segments:
+        index: f*
+        v: false
+        h: i
+
+  - match:
+      $body: |
+               /^(foo \n?)$/
+
+  - do:
+      cat.segments:
+        index: ba*
+        v: false
+        h: i
+
+  - match:
+      $body: |
+               /^(ba(r|z) \n?){2}$/

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.segments/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.segments/10_basic.yaml
@@ -46,9 +46,6 @@
         body: { foo: bar }
         refresh: true
   - do:
-       cluster.health:
-         wait_for_status: green
-  - do:
       cat.segments: {}
   - match:
       $body: |
@@ -62,11 +59,6 @@
           settings:
             number_of_shards: "3"
             number_of_replicas: "0"
-  - do:
-       cluster.health:
-         wait_for_status: green
-         wait_for_relocating_shards: 0
-
   - do:
       index:
         index: index2
@@ -101,10 +93,6 @@
           settings:
             number_of_shards: "1"
             number_of_replicas: "0"
-
-  - do:
-       cluster.health:
-         wait_for_status: green
 
   - do:
       indices.close:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.shards/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.shards/10_basic.yaml
@@ -189,3 +189,50 @@
   - match:
       $body: |
                /^(index3 \s+ \d \s+ (p|s) \s+ ((STARTED|INITIALIZING|RELOCATING) \s+ (\d \s+ (\d+|\d+[.]\d+)(kb|b) \s+)? \d{1,3}.\d{1,3}.\d{1,3}.\d{1,3} \s+ .+|UNASSIGNED \s+) \n?){2}$/
+
+---
+"Test cat shards using wildcards":
+
+  - do:
+      indices.create:
+        index: foo
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+
+  - do:
+      indices.create:
+        index: bar
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+
+  - do:
+      indices.create:
+        index: baz
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+
+  - do:
+      cat.shards:
+        index: f*
+        v: false
+        h: i
+
+  - match:
+      $body: |
+               /^(foo \n?)$/
+
+  - do:
+      cat.shards:
+        index: ba*
+        v: false
+        h: i
+
+  - match:
+      $body: |
+               /^(ba(r|z) \n?){2}$/

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.shards/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.shards/10_basic.yaml
@@ -88,9 +88,6 @@
             number_of_replicas: 0
 
   - do:
-      cluster.health:
-        wait_for_status: green
-  - do:
       indices.flush_synced:
         index: sync_id_test
 
@@ -115,10 +112,6 @@
           settings:
             number_of_shards: 5
             number_of_replicas: 0
-
-  - do:
-      cluster.health:
-        wait_for_status: green
 
   - do:
       cat.shards:
@@ -153,9 +146,6 @@
           settings:
             number_of_shards: "5"
             number_of_replicas: "0"
-  - do:
-       cluster.health:
-         wait_for_relocating_shards: 0
 
   - do:
       cat.shards: {}
@@ -179,9 +169,6 @@
             number_of_replicas: "1"
             shadow_replicas: true
             shared_filesystem: false
-  - do:
-       cluster.health:
-         wait_for_relocating_shards: 0
 
   - do:
       cat.shards:


### PR DESCRIPTION
`/_cat/shards` does not support wildcards for indices (like `/_cat/shards/boo*`) but it should according to the documentation.

closes #19634
