### PR TITLE
Build: Fix client jars for plugins/modules to have the correct artifactId

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -57,7 +57,7 @@ public class PluginBuildPlugin extends BuildPlugin {
                 // file to a new name, copy the nebula generated pom to the same name,
                 // and generate a different pom for the zip
                 project.signArchives.enabled = false
-                addJarPomGeneration(project)
+                addClientJarPomGeneration(project)
                 addClientJarTask(project)
                 if (isModule == false) {
                     addZipPomGeneration(project)
@@ -192,13 +192,14 @@ public class PluginBuildPlugin extends BuildPlugin {
     }
 
     /** Adds nebula publishing task to generate a pom file for the plugin. */
-    protected static void addJarPomGeneration(Project project) {
+    protected static void addClientJarPomGeneration(Project project) {
         project.plugins.apply(MavenPublishPlugin.class)
 
         project.publishing {
             publications {
                 jar(MavenPublication) {
                     from project.components.java
+                    artifactId = artifactId + '-client'
                     pom.withXml { XmlProvider xml ->
                         Node root = xml.asNode()
                         root.appendNode('name', project.pluginProperties.extension.name)

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -22,6 +22,8 @@ import org.gradle.api.JavaVersion
 
 apply plugin: 'elasticsearch.build'
 apply plugin: 'ru.vyarus.animalsniffer'
+apply plugin: 'nebula.maven-base-publish'
+apply plugin: 'nebula.maven-scm'
 
 targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7

--- a/client/sniffer/build.gradle
+++ b/client/sniffer/build.gradle
@@ -22,6 +22,8 @@ import org.gradle.api.JavaVersion
 
 apply plugin: 'elasticsearch.build'
 apply plugin: 'ru.vyarus.animalsniffer'
+apply plugin: 'nebula.maven-base-publish'
+apply plugin: 'nebula.maven-scm'
 
 targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7

--- a/client/transport/build.gradle
+++ b/client/transport/build.gradle
@@ -20,16 +20,18 @@
 import org.elasticsearch.gradle.precommit.PrecommitTasks
 
 apply plugin: 'elasticsearch.build'
+apply plugin: 'nebula.maven-base-publish'
+apply plugin: 'nebula.maven-scm'
 
 group = 'org.elasticsearch.client'
 
 dependencies {
   compile "org.elasticsearch:elasticsearch:${version}"
-  compile project(path: ':modules:transport-netty3', configuration: 'runtime')
-  compile project(path: ':modules:transport-netty4', configuration: 'runtime')
-  compile project(path: ':modules:reindex', configuration: 'runtime')
-  compile project(path: ':modules:lang-mustache', configuration: 'runtime')
-  compile project(path: ':modules:percolator', configuration: 'runtime')
+  compile "org.elasticsearch.plugin:transport-netty3-client:${version}"
+  compile "org.elasticsearch.plugin:transport-netty4-client:${version}"
+  compile "org.elasticsearch.plugin:reindex-client:${version}"
+  compile "org.elasticsearch.plugin:lang-mustache-client:${version}"
+  compile "org.elasticsearch.plugin:percolator-client:${version}"
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testCompile "junit:junit:${versions.junit}"
 }


### PR DESCRIPTION
For transport client plugins, the jars and poms are renamed with the
-client suffix. But we need the artifactId to match the id in the
filename.
