### PR TITLE
Only write forced_refresh if we forced a refresh

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -219,8 +219,10 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
             .field("_type", type)
             .field("_id", id)
             .field("_version", version)
-            .field("_operation", getOperation().getLowercase())
-            .field("forced_refresh", forcedRefresh);
+            .field("_operation", getOperation().getLowercase());
+        if (forcedRefresh) {
+            builder.field("forced_refresh", forcedRefresh);
+        }
         shardInfo.toXContent(builder, params);
         return builder;
     }

--- a/core/src/test/java/org/elasticsearch/action/DocWriteResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/DocWriteResponseTests.java
@@ -20,8 +20,19 @@
 package org.elasticsearch.action;
 
 import org.elasticsearch.action.DocWriteResponse.Operation;
+import org.elasticsearch.action.support.replication.ReplicationResponse.ShardInfo;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 
 public class DocWriteResponseTests extends ESTestCase {
     public void testGetLocation() {
@@ -30,5 +41,34 @@ public class DocWriteResponseTests extends ESTestCase {
         };
         assertEquals("/index/type/id", response.getLocation(null));
         assertEquals("/index/type/id?routing=test_routing", response.getLocation("test_routing"));
+    }
+
+    /**
+     * Tests that {@link DocWriteResponse#toXContent(XContentBuilder, ToXContent.Params)} doesn't include {@code forced_refresh} unless it
+     * is true. We can't assert this in the yaml tests because "not found" is also "false" there....
+     */
+    public void testToXContentDoesntIncludeForcedRefreshUnlessForced() throws IOException {
+        DocWriteResponse response = new DocWriteResponse(new ShardId("index", "uuid", 0), "type", "id", 0, Operation.CREATE) {
+         // DocWriteResponse is abstract so we have to sneak a subclass in here to test it.
+        };
+        response.setShardInfo(new ShardInfo(1, 1));
+        response.setForcedRefresh(false);
+        try (XContentBuilder builder = JsonXContent.contentBuilder()) {
+            builder.startObject();
+            response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            builder.endObject();
+            try (XContentParser parser = JsonXContent.jsonXContent.createParser(builder.bytes())) {
+                assertThat(parser.map(), not(hasKey("forced_refresh")));
+            }
+        }
+        response.setForcedRefresh(true);
+        try (XContentBuilder builder = JsonXContent.contentBuilder()) {
+            builder.startObject();
+            response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            builder.endObject();
+            try (XContentParser parser = JsonXContent.jsonXContent.createParser(builder.bytes())) {
+                assertThat(parser.map(), hasEntry("forced_refresh", true));
+            }
+        }
     }
 }

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -31,8 +31,7 @@ The result of the above index operation is:
     "_id" : "1",
     "_version" : 1,
     "created" : true,
-    "_operation" : create,
-    "forced_refresh": false
+    "_operation" : create
 }
 --------------------------------------------------
 // TESTRESPONSE[s/"successful" : 2/"successful" : 1/]
@@ -232,8 +231,7 @@ The result of the above index operation is:
     "_id" : "6a8ca01c-7896-48e9-81cc-9f70661fcb32",
     "_version" : 1,
     "created" : true,
-    "_operation": "create",
-    "forced_refresh": false
+    "_operation": "create"
 }
 --------------------------------------------------
 // TESTRESPONSE[s/6a8ca01c-7896-48e9-81cc-9f70661fcb32/$body._id/ s/"successful" : 2/"successful" : 1/]


### PR DESCRIPTION
Otherwise it just adds noise to the response.

Closes #19629
