### PR TITLE
Fix various concurrency issues in transport

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -69,12 +69,12 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     protected ThreadPool threadPool;
 
     protected static final Version version0 = Version.CURRENT.minimumCompatibilityVersion();
-    protected DiscoveryNode nodeA;
-    protected MockTransportService serviceA;
+    protected volatile DiscoveryNode nodeA;
+    protected volatile MockTransportService serviceA;
 
     protected static final Version version1 = Version.fromId(Version.CURRENT.id + 1);
-    protected DiscoveryNode nodeB;
-    protected MockTransportService serviceB;
+    protected volatile DiscoveryNode nodeB;
+    protected volatile MockTransportService serviceB;
 
     protected abstract MockTransportService build(Settings settings, Version version);
 
@@ -489,9 +489,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         assertThat(latch.await(5, TimeUnit.SECONDS), equalTo(true));
     }
 
-    @TestLogging("transport:DEBUG,transport.tracer:TRACE")
-    // boaz is on this
-    @AwaitsFix(bugUrl = "https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+multijob-os-compatibility/os=oraclelinux/835")
     public void testConcurrentSendRespondAndDisconnect() throws BrokenBarrierException, InterruptedException {
         Set<Exception> sendingErrors = ConcurrentCollections.newConcurrentSet();
         Set<Exception> responseErrors = ConcurrentCollections.newConcurrentSet();

--- a/test/framework/src/main/java/org/elasticsearch/transport/MockTcpTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/MockTcpTransport.java
@@ -122,7 +122,7 @@ public class MockTcpTransport extends TcpTransport<MockTcpTransport.MockChannel>
         try {
             started.await();
         } catch (InterruptedException e) {
-            Thread.interrupted();
+            Thread.currentThread().interrupt();
         }
         return serverMockChannel;
     }
@@ -261,6 +261,14 @@ public class MockTcpTransport extends TcpTransport<MockTcpTransport.MockChannel>
         private final CancellableThreads cancellableThreads = new CancellableThreads();
         private final Closeable onClose;
 
+        /**
+         * Constructs a new MockChannel instance intended as client.
+         *
+         * @param socket The client socket. Mut not be null.
+         * @param localAddress Address associated with the corresponding local server socket. Must not be null.
+         * @param profile The associated profile name.
+         * @param onClose Callback to execute when this channel is closed.
+         */
         public MockChannel(Socket socket, InetSocketAddress localAddress, String profile, Consumer<MockChannel> onClose) {
             this.localAddress = localAddress;
             this.activeChannel = socket;
@@ -268,13 +276,35 @@ public class MockTcpTransport extends TcpTransport<MockTcpTransport.MockChannel>
             this.profile = profile;
             this.onClose = () -> onClose.accept(this);
         }
+
+        /**
+         * Constructs a new MockChannel instance intended for serving requests.
+         *
+         * @param serverSocket The associated server socket. Must not be null.
+         * @param profile The associated profile name.
+         */
+        public MockChannel(ServerSocket serverSocket, String profile) {
+            this.localAddress = (InetSocketAddress) serverSocket.getLocalSocketAddress();
+            this.serverSocket = serverSocket;
+            this.profile = profile;
+            this.activeChannel = null;
+            this.onClose = null;
+        }
+
         public void accept(Executor executor) throws IOException {
             while (isOpen.get()) {
                 Socket accept = serverSocket.accept();
                 configureSocket(accept);
                 MockChannel mockChannel = new MockChannel(accept, localAddress, profile, workerChannels::remove);
-                workerChannels.put(mockChannel, Boolean.TRUE);
-                mockChannel.loopRead(executor);
+                //establish a happens-before edge between closing and accepting a new connection
+                synchronized (this) {
+                    if (isOpen.get()) {
+                        workerChannels.put(mockChannel, Boolean.TRUE);
+                        mockChannel.loopRead(executor);
+                    } else {
+                        IOUtils.closeWhileHandlingException(accept);
+                    }
+                }
             }
         }
 
@@ -294,26 +324,21 @@ public class MockTcpTransport extends TcpTransport<MockTcpTransport.MockChannel>
                 @Override
                 protected void doRun() throws Exception {
                     StreamInput input = new InputStreamStreamInput(new BufferedInputStream(activeChannel.getInputStream()));
-                    while (isOpen.get()) {
+                    while (isOpen.get() && !Thread.currentThread().isInterrupted()) {
                         cancellableThreads.executeIO(() -> readMessage(MockChannel.this, input));
                     }
                 }
             });
         }
 
-        public MockChannel(ServerSocket serverSocket, String profile) {
-            this.localAddress = (InetSocketAddress) serverSocket.getLocalSocketAddress();
-            this.serverSocket = serverSocket;
-            this.profile = profile;
-            this.activeChannel = null;
-            this.onClose = null;
-        }
-
         @Override
         public void close() throws IOException {
             if (isOpen.compareAndSet(true, false)) {
-                IOUtils.close( () -> cancellableThreads.cancel("channel closed"), serverSocket, activeChannel,
-                    () -> IOUtils.close(workerChannels.keySet()), onClose);
+                //establish a happens-before edge between closing and accepting a new connection
+                synchronized (this) {
+                    IOUtils.close(serverSocket, activeChannel, () -> IOUtils.close(workerChannels.keySet()),
+                        () -> cancellableThreads.cancel("channel closed"), onClose);
+                }
             }
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/transport/MockTcpTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/MockTcpTransport.java
@@ -333,9 +333,8 @@ public class MockTcpTransport extends TcpTransport<MockTcpTransport.MockChannel>
                 @Override
                 protected void doRun() throws Exception {
                     StreamInput input = new InputStreamStreamInput(new BufferedInputStream(activeChannel.getInputStream()));
-                    // as per interruption policy of CancellableThreads we don't need to check for interrupts.
-                    // the only possibility to ever exit this loop is that #close() is invoked.
-                    while (isOpen.get()) {
+                    // There is a (slim) chance that we get interrupted right after a loop iteration, so check explicitly
+                    while (isOpen.get() && !Thread.currentThread().isInterrupted()) {
                         cancellableThreads.executeIO(() -> readMessage(MockChannel.this, input));
                     }
                 }


### PR DESCRIPTION
Due to various issues (most notably a missing happens-before edge 
between socket accept and channel close in MockTcpTransport), 
MockTcpTransportTests sometimes did not terminate.

With this commit we fix various concurrency issues that led to
this hanging test.

Failing example build: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+multijob-os-compatibility/os=oraclelinux/835/console
