### PR TITLE
Change the get pipeline api response format to be object based instead of array based

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ingest/GetPipelineResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/GetPipelineResponse.java
@@ -76,11 +76,9 @@ public class GetPipelineResponse extends ActionResponse implements StatusToXCont
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startArray("pipelines");
         for (PipelineConfiguration pipeline : pipelines) {
-            pipeline.toXContent(builder, params);
+            builder.field(pipeline.getId(), pipeline.getConfigAsMap());
         }
-        builder.endArray();
         return builder;
     }
 }

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -71,20 +71,17 @@ Example response:
 [source,js]
 --------------------------------------------------
 {
-  "pipelines": [ {
-    "id": "my-pipeline-id",
-    "config": {
-      "description": "describe pipeline",
-      "processors": [
-        {
-          "set" : {
-            "field": "foo",
-            "value": "bar"
-          }
+  "my-pipeline-id" : {
+    "description" : "describe pipeline",
+    "processors" : [
+      {
+        "set" : {
+          "field" : "foo",
+          "value" : "bar"
         }
-      ]
-    }
-  } ]
+      }
+    ]
+  }
 }
 --------------------------------------------------
 // TESTRESPONSE

--- a/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/20_crud.yaml
+++ b/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/20_crud.yaml
@@ -35,13 +35,11 @@ teardown:
   - do:
       ingest.get_pipeline:
         id: "my_pipeline"
-  - match: { pipelines.0.id: "my_pipeline" }
-  - match: { pipelines.0.config.description: "_description" }
+  - match: { my_pipeline.description: "_description" }
 
   - do:
       ingest.get_pipeline: {}
-  - match: { pipelines.0.id: "my_pipeline" }
-  - match: { pipelines.0.config.description: "_description" }
+  - match: { my_pipeline.description: "_description" }
 
   - do:
       ingest.delete_pipeline:
@@ -54,7 +52,7 @@ teardown:
         id: "my_pipeline"
 
 ---
-"Test Get All Pipelines (unordered)":
+"Test Get All Pipelines":
   - do:
       ingest.put_pipeline:
         id: "first_pipeline"
@@ -79,11 +77,10 @@ teardown:
             "processors": []
           }
 
-  # Order is not guaranteed by the response, so we check for length instead; above tests that we get appropriate values
   - do:
       ingest.get_pipeline: {}
-  - length: { pipelines: 2 }
-
+  - match: { first_pipeline.description: "first" }
+  - match: { second_pipeline.description: "second" }
 
 ---
 "Test invalid config":
@@ -155,8 +152,7 @@ teardown:
   - do:
       ingest.get_pipeline:
         id: "my_pipeline"
-  - match: { pipelines.0.id: "my_pipeline" }
-  - match: { pipelines.0.config.description: "_description" }
+  - match: { my_pipeline.description: "_description" }
 
   - do:
       ingest.delete_pipeline:

--- a/qa/smoke-test-ingest-disabled/src/test/resources/rest-api-spec/test/ingest_mustache/10_ingest_disabled.yaml
+++ b/qa/smoke-test-ingest-disabled/src/test/resources/rest-api-spec/test/ingest_mustache/10_ingest_disabled.yaml
@@ -20,8 +20,7 @@
   - do:
       ingest.get_pipeline:
         id: "my_pipeline"
-  - match: { pipelines.0.id: "my_pipeline" }
-  - match: { pipelines.0.config.description: "_description" }
+  - match: { my_pipeline.description: "_description" }
 
   - do:
       ingest.delete_pipeline:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/ingest/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/ingest/10_basic.yaml
@@ -14,8 +14,7 @@
   - do:
       ingest.get_pipeline:
         id: "my_pipeline"
-  - match: { pipelines.0.id: "my_pipeline" }
-  - match: { pipelines.0.config.description: "_description" }
+  - match: { my_pipeline.description: "_description" }
 
   - do:
       ingest.delete_pipeline:
@@ -28,6 +27,30 @@
         id: "my_pipeline"
 
 ---
+"Test Get All Pipelines":
+  - do:
+      ingest.put_pipeline:
+        id: "first_pipeline"
+        body:  >
+          {
+            "description": "first",
+            "processors": []
+          }
+  - do:
+      ingest.put_pipeline:
+        id: "second_pipeline"
+        body:  >
+          {
+            "description": "second",
+            "processors": []
+          }
+
+  - do:
+      ingest.get_pipeline: {}
+  - match: { first_pipeline.description: "first" }
+  - match: { second_pipeline.description: "second" }
+
+---
 "Test invalid config":
   - do:
       catch: /parse_exception/
@@ -36,10 +59,6 @@
         body:  >
           {
             "description": "_description",
-            "processors": [
-              {
-                "set" : {
-                }
-              }
-            ]
+            "processors": [],
+            "invalid_field" : {}
           }


### PR DESCRIPTION
Make the response format of the get pipeline api match with the response format of the index template api.

Right now the response is (assuming two pipelines (A and B):

``` json
{
  "pipelines" : [
    {
       "id" : "A",
       "config" : {
          "processors" : []
       }
    },
    {
       "id" : "B",
       "config" : {
          "processors" : []
       }
    }
  ]
}
```

with this change the response becomes:

``` json
{
  "A": {
    "processors": []
  },
  "B": {
    "processors": []
  }
}
```

PR for #19585
