### PR TITLE
[DOCS] replace {es.version} in maven coordinates with current version

### DIFF
--- a/docs/groovy-api/index.asciidoc
+++ b/docs/groovy-api/index.asciidoc
@@ -1,6 +1,7 @@
 = Groovy API
 :ref:  http://www.elastic.co/guide/en/elasticsearch/reference/current
 :java: http://www.elastic.co/guide/en/elasticsearch/client/java-api/current
+:version: 5.0.0-alpha4
 
 [preface]
 == Preface
@@ -26,12 +27,12 @@ Central].
 
 For example, you can define the latest version in your `pom.xml` file:
 
-[source,xml]
+["source","xml",subs="attributes"]
 --------------------------------------------------
 <dependency>
     <groupId>org.elasticsearch</groupId>
     <artifactId>elasticsearch-groovy</artifactId>
-    <version>${es.version}</version>
+    <version>{version}</version>
 </dependency>
 --------------------------------------------------
 

--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -1,6 +1,7 @@
 [[java-api]]
 = Java API
 :ref: http://www.elastic.co/guide/en/elasticsearch/reference/master
+:version: 5.0.0-alpha4
 
 [preface]
 == Preface
@@ -25,12 +26,12 @@ Central].
 
 For example, you can define the latest version in your `pom.xml` file:
 
-[source,xml]
+["source","xml",subs="attributes"]
 --------------------------------------------------
 <dependency>
     <groupId>org.elasticsearch.client</groupId>
     <artifactId>transport</artifactId>
-    <version>${es.version}</version>
+    <version>{version}</version>
 </dependency>
 --------------------------------------------------
 


### PR DESCRIPTION
In the maven coordinates for java api and groovy api we have an {es.version} placeholder that people need to replace with the version they are looking for. With this change we replace it with the current version, which is the version that they are browsing the docs for.
