### PR TITLE
Allow routing table to be filtered by index pattern

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -81,7 +81,8 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
         if (request.routingTable()) {
             if (request.indices().length > 0) {
                 RoutingTable.Builder routingTableBuilder = RoutingTable.builder();
-                for (String filteredIndex : request.indices()) {
+                String[] indices = indexNameExpressionResolver.concreteIndexNames(currentState, request);
+                for (String filteredIndex : indices) {
                     if (currentState.routingTable().getIndicesRouting().containsKey(filteredIndex)) {
                         routingTableBuilder.add(currentState.routingTable().getIndicesRouting().get(filteredIndex));
                     }

--- a/core/src/test/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
@@ -26,7 +26,11 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -112,18 +116,38 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
     }
 
     public void testThatFilteringByIndexWorksForMetadataAndRoutingTable() throws Exception {
-        ClusterStateResponse clusterStateResponseFiltered = client().admin().cluster().prepareState().clear()
-                .setMetaData(true).setRoutingTable(true).setIndices("foo", "fuu", "non-existent").get();
+        testFilteringByIndexWorks(new String[]{"foo", "fuu", "non-existent"}, new String[]{"foo", "fuu"});
+        testFilteringByIndexWorks(new String[]{"baz"}, new String[]{"baz"});
+        testFilteringByIndexWorks(new String[]{"f*"}, new String[]{"foo", "fuu"});
+        testFilteringByIndexWorks(new String[]{"b*"}, new String[]{"baz"});
+        testFilteringByIndexWorks(new String[]{"*u"}, new String[]{"fuu"});
 
-        // metadata
-        assertThat(clusterStateResponseFiltered.getState().metaData().indices().size(), is(2));
-        assertThat(clusterStateResponseFiltered.getState().metaData().indices(), CollectionAssertions.hasKey("foo"));
-        assertThat(clusterStateResponseFiltered.getState().metaData().indices(), CollectionAssertions.hasKey("fuu"));
+        String[] randomIndices = randomFrom(new String[]{"*"}, new String[]{MetaData.ALL}, Strings.EMPTY_ARRAY, new String[]{"f*", "b*"});
+        testFilteringByIndexWorks(randomIndices, new String[]{"foo", "fuu", "baz"});
+    }
 
-        // routing table
-        assertThat(clusterStateResponseFiltered.getState().routingTable().hasIndex("foo"), is(true));
-        assertThat(clusterStateResponseFiltered.getState().routingTable().hasIndex("fuu"), is(true));
-        assertThat(clusterStateResponseFiltered.getState().routingTable().hasIndex("baz"), is(false));
+    /**
+     * Retrieves the cluster state for the given indices and then checks
+     * that the cluster state returns coherent data for both routing table and metadata.
+     */
+    private void testFilteringByIndexWorks(String[] indices, String[] expected) {
+        ClusterStateResponse clusterState = client().admin().cluster().prepareState()
+                                                                            .clear()
+                                                                            .setMetaData(true)
+                                                                            .setRoutingTable(true)
+                                                                            .setIndices(indices)
+                                                                            .get();
+
+        ImmutableOpenMap<String, IndexMetaData> metaData = clusterState.getState().getMetaData().indices();
+        assertThat(metaData.size(), is(expected.length));
+
+        RoutingTable routingTable = clusterState.getState().getRoutingTable();
+        assertThat(routingTable.indicesRouting().size(), is(expected.length));
+
+        for (String expectedIndex : expected) {
+            assertThat(metaData, CollectionAssertions.hasKey(expectedIndex));
+            assertThat(routingTable.hasIndex(expectedIndex), is(true));
+        }
     }
 
     public void testLargeClusterStatePublishing() throws Exception {

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/20_filtering.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/20_filtering.yaml
@@ -130,3 +130,34 @@ setup:
   - is_true: metadata
   - is_true: routing_table
   - is_true: routing_nodes
+
+---
+"Filtering the cluster state by indices using wildcards should work in routing table and metadata":
+  - do:
+      index:
+        index: index1
+        type:  type
+        id:    testing_document
+        body:
+            "text" : "The quick brown fox is brown."
+
+  - do:
+      index:
+        index: index2
+        type:  type
+        id:    testing_document
+        body:
+            "text" : "The quick brown fox is brown."
+
+  - do:
+      cluster.state:
+        metric: [ routing_table, metadata ]
+        index: [ index* ]
+
+  - is_false: metadata.indices.testidx
+  - is_false: routing_table.indices.testidx
+
+  - is_true: metadata.indices.index1
+  - is_true: routing_table.indices.index1
+  - is_true: metadata.indices.index2
+  - is_true: routing_table.indices.index2

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/20_filtering.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/20_filtering.yaml
@@ -6,8 +6,6 @@ setup:
         id:    testing_document
         body:
             "text" : "The quick brown fox is brown."
-  - do:
-      indices.refresh: {}
 
 ---
 "Filtering the cluster state by blocks should return the blocks field even if the response is empty":
@@ -104,9 +102,6 @@ setup:
         id:    testing_document
         body:
             "text" : "The quick brown fox is brown."
-
-  - do:
-      indices.refresh: {}
 
   - do:
       cluster.state:


### PR DESCRIPTION
Cluster state filtering does not work well for routing tables: it only matches exact index names whereas indices are fully resolved in order to filter the metadata part of the response.

This can lead to incoherent data when using an index pattern in the cluster state api:

With no index pattern:

```
GET /_cluster/state/metadata,routing_table?filter_path=**.state
{
  "metadata" : {
    "indices" : {
      "index1" : {
        "state" : "open"
      },
      "index2" : {
        "state" : "open"
      }
    }
  },
  "routing_table" : {
    "indices" : {
      "index1" : {
        "shards" : ...
      },
      "index2" : {
        "shards" : ...
      }
    }
  }
}
```

With index pattern, only metadata is returned:

```
GET /_cluster/state/metadata,routing_table/index*?filter_path=**.state
{
  "metadata" : {
    "indices" : {
      "index1" : {
        "state" : "open"
      },
      "index2" : {
        "state" : "open"
      }
    }
  }
}
```

This commit aligns the behaviour of the filtering of cluster state's routing table with the filtering of cluster state's metadata so that coherent data are returned for both routing table & metadata when index pattern is requested.
