### PR TITLE
Renaming operation to result and reworking responses 

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -41,10 +41,11 @@ import java.util.Locale;
 public abstract class DocWriteResponse extends ReplicationResponse implements WriteResponse, StatusToXContent {
 
     public enum Operation implements Writeable {
-        CREATE(0),
-        INDEX(1),
-        DELETE(2),
-        NOOP(3);
+        CREATED(0),
+        UPDATED(1),
+        DELETED(2),
+        NOT_FOUND(3),
+        NOOP(4);
 
         private final byte op;
         private final String lowercase;
@@ -66,12 +67,14 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
             Byte opcode = in.readByte();
             switch(opcode){
                 case 0:
-                    return CREATE;
+                    return CREATED;
                 case 1:
-                    return INDEX;
+                    return UPDATED;
                 case 2:
-                    return DELETE;
+                    return DELETED;
                 case 3:
+                    return NOT_FOUND;
+                case 4:
                     return NOOP;
                 default:
                     throw new IllegalArgumentException("Unknown operation code: " + opcode);
@@ -219,7 +222,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
             .field("_type", type)
             .field("_id", id)
             .field("_version", version)
-            .field("_operation", getOperation().getLowercase());
+            .field("result", getOperation().getLowercase());
         if (forcedRefresh) {
             builder.field("forced_refresh", forcedRefresh);
         }

--- a/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -40,7 +40,11 @@ import java.util.Locale;
  */
 public abstract class DocWriteResponse extends ReplicationResponse implements WriteResponse, StatusToXContent {
 
-    public enum Operation implements Writeable {
+    /**
+     * An enum that represents the the results of CRUD operations, primarily used to communicate the type of
+     * operation that occurred.
+     */
+    public enum Result implements Writeable {
         CREATED(0),
         UPDATED(1),
         DELETED(2),
@@ -50,7 +54,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
         private final byte op;
         private final String lowercase;
 
-        Operation(int op) {
+        Result(int op) {
             this.op = (byte) op;
             this.lowercase = this.toString().toLowerCase(Locale.ENGLISH);
         }
@@ -63,7 +67,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
             return lowercase;
         }
 
-        public static Operation readFrom(StreamInput in) throws IOException{
+        public static Result readFrom(StreamInput in) throws IOException{
             Byte opcode = in.readByte();
             switch(opcode){
                 case 0:
@@ -77,7 +81,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
                 case 4:
                     return NOOP;
                 default:
-                    throw new IllegalArgumentException("Unknown operation code: " + opcode);
+                    throw new IllegalArgumentException("Unknown result code: " + opcode);
             }
         }
 
@@ -92,14 +96,14 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
     private String type;
     private long version;
     private boolean forcedRefresh;
-    protected Operation operation;
+    protected Result result;
 
-    public DocWriteResponse(ShardId shardId, String type, String id, long version, Operation operation) {
+    public DocWriteResponse(ShardId shardId, String type, String id, long version, Result result) {
         this.shardId = shardId;
         this.type = type;
         this.id = id;
         this.version = version;
-        this.operation = operation;
+        this.result = result;
     }
 
     // needed for deserialization
@@ -109,8 +113,8 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
     /**
      * The change that occurred to the document.
      */
-    public Operation getOperation() {
-        return operation;
+    public Result getResult() {
+        return result;
     }
 
     /**
@@ -201,7 +205,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
         id = in.readString();
         version = in.readZLong();
         forcedRefresh = in.readBoolean();
-        operation = Operation.readFrom(in);
+        result = Result.readFrom(in);
     }
 
     @Override
@@ -212,7 +216,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
         out.writeString(id);
         out.writeZLong(version);
         out.writeBoolean(forcedRefresh);
-        operation.writeTo(out);
+        result.writeTo(out);
     }
 
     @Override
@@ -222,7 +226,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
             .field("_type", type)
             .field("_id", id)
             .field("_version", version)
-            .field("result", getOperation().getLowercase());
+            .field("result", getResult().getLowercase());
         if (forcedRefresh) {
             builder.field("forced_refresh", forcedRefresh);
         }

--- a/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
@@ -39,17 +39,17 @@ public class DeleteResponse extends DocWriteResponse {
     }
 
     public DeleteResponse(ShardId shardId, String type, String id, long version, boolean found) {
-        super(shardId, type, id, version, found ? Operation.DELETED : Operation.NOT_FOUND);
+        super(shardId, type, id, version, found ? Result.DELETED : Result.NOT_FOUND);
     }
 
     @Override
     public RestStatus status() {
-        return operation == Operation.DELETED ? super.status() : RestStatus.NOT_FOUND;
+        return result == Result.DELETED ? super.status() : RestStatus.NOT_FOUND;
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field("found", operation == Operation.DELETED);
+        builder.field("found", result == Result.DELETED);
         super.toXContent(builder, params);
         return builder;
     }
@@ -62,7 +62,7 @@ public class DeleteResponse extends DocWriteResponse {
         builder.append(",type=").append(getType());
         builder.append(",id=").append(getId());
         builder.append(",version=").append(getVersion());
-        builder.append(",operation=").append(getOperation().getLowercase());
+        builder.append(",result=").append(getResult().getLowercase());
         builder.append(",shards=").append(getShardInfo());
         return builder.append("]").toString();
     }

--- a/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
@@ -39,17 +39,17 @@ public class DeleteResponse extends DocWriteResponse {
     }
 
     public DeleteResponse(ShardId shardId, String type, String id, long version, boolean found) {
-        super(shardId, type, id, version, found ? Operation.DELETE : Operation.NOOP);
+        super(shardId, type, id, version, found ? Operation.DELETED : Operation.NOT_FOUND);
     }
 
     @Override
     public RestStatus status() {
-        return operation == Operation.DELETE ? super.status() : RestStatus.NOT_FOUND;
+        return operation == Operation.DELETED ? super.status() : RestStatus.NOT_FOUND;
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field("found", operation == Operation.DELETE);
+        builder.field("found", operation == Operation.DELETED);
         super.toXContent(builder, params);
         return builder;
     }

--- a/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
@@ -39,12 +39,12 @@ public class IndexResponse extends DocWriteResponse {
     }
 
     public IndexResponse(ShardId shardId, String type, String id, long version, boolean created) {
-        super(shardId, type, id, version, created ? Operation.CREATE : Operation.INDEX);
+        super(shardId, type, id, version, created ? Operation.CREATED : Operation.UPDATED);
     }
 
     @Override
     public RestStatus status() {
-        return operation == Operation.CREATE ? RestStatus.CREATED : super.status();
+        return operation == Operation.CREATED ? RestStatus.CREATED : super.status();
     }
 
     @Override
@@ -63,7 +63,7 @@ public class IndexResponse extends DocWriteResponse {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         super.toXContent(builder, params);
-        builder.field("created", operation == Operation.CREATE);
+        builder.field("created", operation == Operation.CREATED);
         return builder;
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
@@ -39,12 +39,12 @@ public class IndexResponse extends DocWriteResponse {
     }
 
     public IndexResponse(ShardId shardId, String type, String id, long version, boolean created) {
-        super(shardId, type, id, version, created ? Operation.CREATED : Operation.UPDATED);
+        super(shardId, type, id, version, created ? Result.CREATED : Result.UPDATED);
     }
 
     @Override
     public RestStatus status() {
-        return operation == Operation.CREATED ? RestStatus.CREATED : super.status();
+        return result == Result.CREATED ? RestStatus.CREATED : super.status();
     }
 
     @Override
@@ -55,7 +55,7 @@ public class IndexResponse extends DocWriteResponse {
         builder.append(",type=").append(getType());
         builder.append(",id=").append(getId());
         builder.append(",version=").append(getVersion());
-        builder.append(",operation=").append(getOperation().getLowercase());
+        builder.append(",result=").append(getResult().getLowercase());
         builder.append(",shards=").append(getShardInfo());
         return builder.append("]").toString();
     }
@@ -63,7 +63,7 @@ public class IndexResponse extends DocWriteResponse {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         super.toXContent(builder, params);
-        builder.field("created", operation == Operation.CREATED);
+        builder.field("created", result == Result.CREATED);
         return builder;
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -22,7 +22,6 @@ package org.elasticsearch.action.update;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
-import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
@@ -179,7 +178,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
         final IndexShard indexShard = indexService.getShard(shardId.getId());
         final UpdateHelper.Result result = updateHelper.prepare(request, indexShard);
         switch (result.operation()) {
-            case CREATE:
+            case CREATED:
                 IndexRequest upsertRequest = result.action();
                 // we fetch it from the index request so we don't generate the bytes twice, its already done in the index request
                 final BytesReference upsertSourceBytes = upsertRequest.source();
@@ -217,7 +216,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                     }
                 });
                 break;
-            case INDEX:
+            case UPDATED:
                 IndexRequest indexRequest = result.action();
                 // we fetch it from the index request so we don't generate the bytes twice, its already done in the index request
                 final BytesReference indexSourceBytes = indexRequest.source();
@@ -248,7 +247,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                     }
                 });
                 break;
-            case DELETE:
+            case DELETED:
                 DeleteRequest deleteRequest = result.action();
                 deleteAction.execute(deleteRequest, new ActionListener<DeleteResponse>() {
                     @Override

--- a/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -177,7 +177,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
         final IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
         final IndexShard indexShard = indexService.getShard(shardId.getId());
         final UpdateHelper.Result result = updateHelper.prepare(request, indexShard);
-        switch (result.operation()) {
+        switch (result.getResponseResult()) {
             case CREATED:
                 IndexRequest upsertRequest = result.action();
                 // we fetch it from the index request so we don't generate the bytes twice, its already done in the index request
@@ -185,7 +185,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 indexAction.execute(upsertRequest, new ActionListener<IndexResponse>() {
                     @Override
                     public void onResponse(IndexResponse response) {
-                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), response.getOperation());
+                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), response.getResult());
                         if (request.fields() != null && request.fields().length > 0) {
                             Tuple<XContentType, Map<String, Object>> sourceAndContent = XContentHelper.convertToMap(upsertSourceBytes, true);
                             update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), sourceAndContent.v2(), sourceAndContent.v1(), upsertSourceBytes));
@@ -223,7 +223,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 indexAction.execute(indexRequest, new ActionListener<IndexResponse>() {
                     @Override
                     public void onResponse(IndexResponse response) {
-                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), response.getOperation());
+                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), response.getResult());
                         update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), indexSourceBytes));
                         update.setForcedRefresh(response.forcedRefresh());
                         listener.onResponse(update);
@@ -252,7 +252,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 deleteAction.execute(deleteRequest, new ActionListener<DeleteResponse>() {
                     @Override
                     public void onResponse(DeleteResponse response) {
-                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), response.getOperation());
+                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), response.getResult());
                         update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), null));
                         update.setForcedRefresh(response.forcedRefresh());
                         listener.onResponse(update);
@@ -288,7 +288,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 listener.onResponse(update);
                 break;
             default:
-                throw new IllegalStateException("Illegal operation " + result.operation());
+                throw new IllegalStateException("Illegal result " + result.getResponseResult());
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -136,7 +136,7 @@ public class UpdateHelper extends AbstractComponent {
                 // in all but the internal versioning mode, we want to create the new document using the given version.
                 indexRequest.version(request.version()).versionType(request.versionType());
             }
-            return new Result(indexRequest, DocWriteResponse.Operation.CREATE, null, null);
+            return new Result(indexRequest, DocWriteResponse.Operation.CREATED, null, null);
         }
 
         long updateVersion = getResult.getVersion();
@@ -227,13 +227,13 @@ public class UpdateHelper extends AbstractComponent {
                     .consistencyLevel(request.consistencyLevel())
                     .timestamp(timestamp).ttl(ttl)
                     .setRefreshPolicy(request.getRefreshPolicy());
-            return new Result(indexRequest, DocWriteResponse.Operation.INDEX, updatedSourceAsMap, updateSourceContentType);
+            return new Result(indexRequest, DocWriteResponse.Operation.UPDATED, updatedSourceAsMap, updateSourceContentType);
         } else if ("delete".equals(operation)) {
             DeleteRequest deleteRequest = Requests.deleteRequest(request.index()).type(request.type()).id(request.id()).routing(routing).parent(parent)
                     .version(updateVersion).versionType(request.versionType())
                     .consistencyLevel(request.consistencyLevel())
                     .setRefreshPolicy(request.getRefreshPolicy());
-            return new Result(deleteRequest, DocWriteResponse.Operation.DELETE, updatedSourceAsMap, updateSourceContentType);
+            return new Result(deleteRequest, DocWriteResponse.Operation.DELETED, updatedSourceAsMap, updateSourceContentType);
         } else if ("none".equals(operation)) {
             UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(), DocWriteResponse.Operation.NOOP);
             update.setGetResult(extractGetResult(request, request.index(), getResult.getVersion(), updatedSourceAsMap, updateSourceContentType, getResult.internalSourceRef()));

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -117,9 +117,9 @@ public class UpdateHelper extends AbstractComponent {
                                 request.script.getScript());
                     }
                     UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(),
-                            getResult.getVersion(), DocWriteResponse.Operation.NOOP);
+                            getResult.getVersion(), DocWriteResponse.Result.NOOP);
                     update.setGetResult(getResult);
-                    return new Result(update, DocWriteResponse.Operation.NOOP, upsertDoc, XContentType.JSON);
+                    return new Result(update, DocWriteResponse.Result.NOOP, upsertDoc, XContentType.JSON);
                 }
                 indexRequest.source((Map) ctx.get("_source"));
             }
@@ -136,7 +136,7 @@ public class UpdateHelper extends AbstractComponent {
                 // in all but the internal versioning mode, we want to create the new document using the given version.
                 indexRequest.version(request.version()).versionType(request.versionType());
             }
-            return new Result(indexRequest, DocWriteResponse.Operation.CREATED, null, null);
+            return new Result(indexRequest, DocWriteResponse.Result.CREATED, null, null);
         }
 
         long updateVersion = getResult.getVersion();
@@ -227,21 +227,21 @@ public class UpdateHelper extends AbstractComponent {
                     .consistencyLevel(request.consistencyLevel())
                     .timestamp(timestamp).ttl(ttl)
                     .setRefreshPolicy(request.getRefreshPolicy());
-            return new Result(indexRequest, DocWriteResponse.Operation.UPDATED, updatedSourceAsMap, updateSourceContentType);
+            return new Result(indexRequest, DocWriteResponse.Result.UPDATED, updatedSourceAsMap, updateSourceContentType);
         } else if ("delete".equals(operation)) {
             DeleteRequest deleteRequest = Requests.deleteRequest(request.index()).type(request.type()).id(request.id()).routing(routing).parent(parent)
                     .version(updateVersion).versionType(request.versionType())
                     .consistencyLevel(request.consistencyLevel())
                     .setRefreshPolicy(request.getRefreshPolicy());
-            return new Result(deleteRequest, DocWriteResponse.Operation.DELETED, updatedSourceAsMap, updateSourceContentType);
+            return new Result(deleteRequest, DocWriteResponse.Result.DELETED, updatedSourceAsMap, updateSourceContentType);
         } else if ("none".equals(operation)) {
-            UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(), DocWriteResponse.Operation.NOOP);
+            UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(), DocWriteResponse.Result.NOOP);
             update.setGetResult(extractGetResult(request, request.index(), getResult.getVersion(), updatedSourceAsMap, updateSourceContentType, getResult.internalSourceRef()));
-            return new Result(update, DocWriteResponse.Operation.NOOP, updatedSourceAsMap, updateSourceContentType);
+            return new Result(update, DocWriteResponse.Result.NOOP, updatedSourceAsMap, updateSourceContentType);
         } else {
             logger.warn("Used update operation [{}] for script [{}], doing nothing...", operation, request.script.getScript());
-            UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(), DocWriteResponse.Operation.NOOP);
-            return new Result(update, DocWriteResponse.Operation.NOOP, updatedSourceAsMap, updateSourceContentType);
+            UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(), DocWriteResponse.Result.NOOP);
+            return new Result(update, DocWriteResponse.Result.NOOP, updatedSourceAsMap, updateSourceContentType);
         }
     }
 
@@ -310,13 +310,13 @@ public class UpdateHelper extends AbstractComponent {
     public static class Result {
 
         private final Streamable action;
-        private final DocWriteResponse.Operation operation;
+        private final DocWriteResponse.Result result;
         private final Map<String, Object> updatedSourceAsMap;
         private final XContentType updateSourceContentType;
 
-        public Result(Streamable action, DocWriteResponse.Operation operation, Map<String, Object> updatedSourceAsMap, XContentType updateSourceContentType) {
+        public Result(Streamable action, DocWriteResponse.Result result, Map<String, Object> updatedSourceAsMap, XContentType updateSourceContentType) {
             this.action = action;
-            this.operation = operation;
+            this.result = result;
             this.updatedSourceAsMap = updatedSourceAsMap;
             this.updateSourceContentType = updateSourceContentType;
         }
@@ -326,8 +326,8 @@ public class UpdateHelper extends AbstractComponent {
             return (T) action;
         }
 
-        public DocWriteResponse.Operation operation() {
-            return operation;
+        public DocWriteResponse.Result getResponseResult() {
+            return result;
         }
 
         public Map<String, Object> updatedSourceAsMap() {

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
@@ -40,13 +40,13 @@ public class UpdateResponse extends DocWriteResponse {
      * Constructor to be used when a update didn't translate in a write.
      * For example: update script with operation set to none
      */
-    public UpdateResponse(ShardId shardId, String type, String id, long version, Operation operation) {
-        this(new ShardInfo(0, 0), shardId, type, id, version, operation);
+    public UpdateResponse(ShardId shardId, String type, String id, long version, Result result) {
+        this(new ShardInfo(0, 0), shardId, type, id, version, result);
     }
 
     public UpdateResponse(ShardInfo shardInfo, ShardId shardId, String type, String id,
-                          long version, Operation operation) {
-        super(shardId, type, id, version, operation);
+                          long version, Result result) {
+        super(shardId, type, id, version, result);
         setShardInfo(shardInfo);
     }
 
@@ -60,7 +60,7 @@ public class UpdateResponse extends DocWriteResponse {
 
     @Override
     public RestStatus status() {
-        return this.operation == Operation.CREATED ? RestStatus.CREATED : super.status();
+        return this.result == Result.CREATED ? RestStatus.CREATED : super.status();
     }
 
     @Override
@@ -106,7 +106,7 @@ public class UpdateResponse extends DocWriteResponse {
         builder.append(",type=").append(getType());
         builder.append(",id=").append(getId());
         builder.append(",version=").append(getVersion());
-        builder.append(",operation=").append(getOperation().getLowercase());
+        builder.append(",result=").append(getResult().getLowercase());
         builder.append(",shards=").append(getShardInfo());
         return builder.append("]").toString();
     }

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
@@ -60,7 +60,7 @@ public class UpdateResponse extends DocWriteResponse {
 
     @Override
     public RestStatus status() {
-        return this.operation == Operation.CREATE ? RestStatus.CREATED : super.status();
+        return this.operation == Operation.CREATED ? RestStatus.CREATED : super.status();
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/action/DocWriteResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/DocWriteResponseTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action;
 
-import org.elasticsearch.action.DocWriteResponse.Operation;
+import org.elasticsearch.action.DocWriteResponse.Result;
 import org.elasticsearch.action.support.replication.ReplicationResponse.ShardInfo;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.not;
 
 public class DocWriteResponseTests extends ESTestCase {
     public void testGetLocation() {
-        DocWriteResponse response = new DocWriteResponse(new ShardId("index", "uuid", 0), "type", "id", 0, Operation.CREATED) {
+        DocWriteResponse response = new DocWriteResponse(new ShardId("index", "uuid", 0), "type", "id", 0, Result.CREATED) {
             // DocWriteResponse is abstract so we have to sneak a subclass in here to test it.
         };
         assertEquals("/index/type/id", response.getLocation(null));
@@ -48,7 +48,7 @@ public class DocWriteResponseTests extends ESTestCase {
      * is true. We can't assert this in the yaml tests because "not found" is also "false" there....
      */
     public void testToXContentDoesntIncludeForcedRefreshUnlessForced() throws IOException {
-        DocWriteResponse response = new DocWriteResponse(new ShardId("index", "uuid", 0), "type", "id", 0, Operation.CREATED) {
+        DocWriteResponse response = new DocWriteResponse(new ShardId("index", "uuid", 0), "type", "id", 0, Result.CREATED) {
          // DocWriteResponse is abstract so we have to sneak a subclass in here to test it.
         };
         response.setShardInfo(new ShardInfo(1, 1));

--- a/core/src/test/java/org/elasticsearch/action/DocWriteResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/DocWriteResponseTests.java
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.not;
 
 public class DocWriteResponseTests extends ESTestCase {
     public void testGetLocation() {
-        DocWriteResponse response = new DocWriteResponse(new ShardId("index", "uuid", 0), "type", "id", 0, Operation.CREATE) {
+        DocWriteResponse response = new DocWriteResponse(new ShardId("index", "uuid", 0), "type", "id", 0, Operation.CREATED) {
             // DocWriteResponse is abstract so we have to sneak a subclass in here to test it.
         };
         assertEquals("/index/type/id", response.getLocation(null));
@@ -48,7 +48,7 @@ public class DocWriteResponseTests extends ESTestCase {
      * is true. We can't assert this in the yaml tests because "not found" is also "false" there....
      */
     public void testToXContentDoesntIncludeForcedRefreshUnlessForced() throws IOException {
-        DocWriteResponse response = new DocWriteResponse(new ShardId("index", "uuid", 0), "type", "id", 0, Operation.CREATE) {
+        DocWriteResponse response = new DocWriteResponse(new ShardId("index", "uuid", 0), "type", "id", 0, Operation.CREATED) {
          // DocWriteResponse is abstract so we have to sneak a subclass in here to test it.
         };
         response.setShardInfo(new ShardInfo(1, 1));

--- a/core/src/test/java/org/elasticsearch/action/IndicesRequestIT.java
+++ b/core/src/test/java/org/elasticsearch/action/IndicesRequestIT.java
@@ -234,7 +234,7 @@ public class IndicesRequestIT extends ESIntegTestCase {
         client().prepareIndex(indexOrAlias, "type", "id").setSource("field", "value").get();
         UpdateRequest updateRequest = new UpdateRequest(indexOrAlias, "type", "id").doc("field1", "value1");
         UpdateResponse updateResponse = internalCluster().coordOnlyNodeClient().update(updateRequest).actionGet();
-        assertEquals(DocWriteResponse.Operation.UPDATED, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.UPDATED, updateResponse.getResult());
 
         clearInterceptedActions();
         assertSameIndices(updateRequest, updateShardActions);
@@ -248,7 +248,7 @@ public class IndicesRequestIT extends ESIntegTestCase {
         String indexOrAlias = randomIndexOrAlias();
         UpdateRequest updateRequest = new UpdateRequest(indexOrAlias, "type", "id").upsert("field", "value").doc("field1", "value1");
         UpdateResponse updateResponse = internalCluster().coordOnlyNodeClient().update(updateRequest).actionGet();
-        assertEquals(DocWriteResponse.Operation.CREATED, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, updateResponse.getResult());
 
         clearInterceptedActions();
         assertSameIndices(updateRequest, updateShardActions);
@@ -264,7 +264,7 @@ public class IndicesRequestIT extends ESIntegTestCase {
         UpdateRequest updateRequest = new UpdateRequest(indexOrAlias, "type", "id")
                 .script(new Script("ctx.op='delete'", ScriptService.ScriptType.INLINE, CustomScriptPlugin.NAME, Collections.emptyMap()));
         UpdateResponse updateResponse = internalCluster().coordOnlyNodeClient().update(updateRequest).actionGet();
-        assertEquals(DocWriteResponse.Operation.DELETED, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.DELETED, updateResponse.getResult());
 
         clearInterceptedActions();
         assertSameIndices(updateRequest, updateShardActions);

--- a/core/src/test/java/org/elasticsearch/action/IndicesRequestIT.java
+++ b/core/src/test/java/org/elasticsearch/action/IndicesRequestIT.java
@@ -234,7 +234,7 @@ public class IndicesRequestIT extends ESIntegTestCase {
         client().prepareIndex(indexOrAlias, "type", "id").setSource("field", "value").get();
         UpdateRequest updateRequest = new UpdateRequest(indexOrAlias, "type", "id").doc("field1", "value1");
         UpdateResponse updateResponse = internalCluster().coordOnlyNodeClient().update(updateRequest).actionGet();
-        assertEquals(DocWriteResponse.Operation.INDEX, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.UPDATED, updateResponse.getOperation());
 
         clearInterceptedActions();
         assertSameIndices(updateRequest, updateShardActions);
@@ -248,7 +248,7 @@ public class IndicesRequestIT extends ESIntegTestCase {
         String indexOrAlias = randomIndexOrAlias();
         UpdateRequest updateRequest = new UpdateRequest(indexOrAlias, "type", "id").upsert("field", "value").doc("field1", "value1");
         UpdateResponse updateResponse = internalCluster().coordOnlyNodeClient().update(updateRequest).actionGet();
-        assertEquals(DocWriteResponse.Operation.CREATE, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, updateResponse.getOperation());
 
         clearInterceptedActions();
         assertSameIndices(updateRequest, updateShardActions);
@@ -264,7 +264,7 @@ public class IndicesRequestIT extends ESIntegTestCase {
         UpdateRequest updateRequest = new UpdateRequest(indexOrAlias, "type", "id")
                 .script(new Script("ctx.op='delete'", ScriptService.ScriptType.INLINE, CustomScriptPlugin.NAME, Collections.emptyMap()));
         UpdateResponse updateResponse = internalCluster().coordOnlyNodeClient().update(updateRequest).actionGet();
-        assertEquals(DocWriteResponse.Operation.DELETE, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, updateResponse.getOperation());
 
         clearInterceptedActions();
         assertSameIndices(updateRequest, updateShardActions);

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
@@ -207,11 +207,11 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
                 .add(client().prepareIndex("test", "type", "2").setCreate(true).setSource("field", "1"))
                 .add(client().prepareIndex("test", "type", "1").setSource("field", "2")).get();
 
-        assertEquals(DocWriteResponse.Operation.CREATE, bulkResponse.getItems()[0].getResponse().getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, bulkResponse.getItems()[0].getResponse().getOperation());
         assertThat(bulkResponse.getItems()[0].getResponse().getVersion(), equalTo(1L));
-        assertEquals(DocWriteResponse.Operation.CREATE, bulkResponse.getItems()[1].getResponse().getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, bulkResponse.getItems()[1].getResponse().getOperation());
         assertThat(bulkResponse.getItems()[1].getResponse().getVersion(), equalTo(1L));
-        assertEquals(DocWriteResponse.Operation.INDEX, bulkResponse.getItems()[2].getResponse().getOperation());
+        assertEquals(DocWriteResponse.Operation.UPDATED, bulkResponse.getItems()[2].getResponse().getOperation());
         assertThat(bulkResponse.getItems()[2].getResponse().getVersion(), equalTo(2L));
 
         bulkResponse = client().prepareBulk()
@@ -232,11 +232,11 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
                         .setSource("field", "2").setVersion(12).setVersionType(VersionType.EXTERNAL))
                 .get();
 
-        assertEquals(DocWriteResponse.Operation.CREATE, bulkResponse.getItems()[0].getResponse().getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, bulkResponse.getItems()[0].getResponse().getOperation());
         assertThat(bulkResponse.getItems()[0].getResponse().getVersion(), equalTo(10L));
-        assertEquals(DocWriteResponse.Operation.CREATE, bulkResponse.getItems()[1].getResponse().getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, bulkResponse.getItems()[1].getResponse().getOperation());
         assertThat(bulkResponse.getItems()[1].getResponse().getVersion(), equalTo(10L));
-        assertEquals(DocWriteResponse.Operation.INDEX, bulkResponse.getItems()[2].getResponse().getOperation());
+        assertEquals(DocWriteResponse.Operation.UPDATED, bulkResponse.getItems()[2].getResponse().getOperation());
         assertThat(bulkResponse.getItems()[2].getResponse().getVersion(), equalTo(12L));
 
         bulkResponse = client().prepareBulk()

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
@@ -207,11 +207,11 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
                 .add(client().prepareIndex("test", "type", "2").setCreate(true).setSource("field", "1"))
                 .add(client().prepareIndex("test", "type", "1").setSource("field", "2")).get();
 
-        assertEquals(DocWriteResponse.Operation.CREATED, bulkResponse.getItems()[0].getResponse().getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, bulkResponse.getItems()[0].getResponse().getResult());
         assertThat(bulkResponse.getItems()[0].getResponse().getVersion(), equalTo(1L));
-        assertEquals(DocWriteResponse.Operation.CREATED, bulkResponse.getItems()[1].getResponse().getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, bulkResponse.getItems()[1].getResponse().getResult());
         assertThat(bulkResponse.getItems()[1].getResponse().getVersion(), equalTo(1L));
-        assertEquals(DocWriteResponse.Operation.UPDATED, bulkResponse.getItems()[2].getResponse().getOperation());
+        assertEquals(DocWriteResponse.Result.UPDATED, bulkResponse.getItems()[2].getResponse().getResult());
         assertThat(bulkResponse.getItems()[2].getResponse().getVersion(), equalTo(2L));
 
         bulkResponse = client().prepareBulk()
@@ -232,11 +232,11 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
                         .setSource("field", "2").setVersion(12).setVersionType(VersionType.EXTERNAL))
                 .get();
 
-        assertEquals(DocWriteResponse.Operation.CREATED, bulkResponse.getItems()[0].getResponse().getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, bulkResponse.getItems()[0].getResponse().getResult());
         assertThat(bulkResponse.getItems()[0].getResponse().getVersion(), equalTo(10L));
-        assertEquals(DocWriteResponse.Operation.CREATED, bulkResponse.getItems()[1].getResponse().getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, bulkResponse.getItems()[1].getResponse().getResult());
         assertThat(bulkResponse.getItems()[1].getResponse().getVersion(), equalTo(10L));
-        assertEquals(DocWriteResponse.Operation.UPDATED, bulkResponse.getItems()[2].getResponse().getOperation());
+        assertEquals(DocWriteResponse.Result.UPDATED, bulkResponse.getItems()[2].getResponse().getResult());
         assertThat(bulkResponse.getItems()[2].getResponse().getVersion(), equalTo(12L));
 
         bulkResponse = client().prepareBulk()

--- a/core/src/test/java/org/elasticsearch/action/support/master/IndexingMasterFailoverIT.java
+++ b/core/src/test/java/org/elasticsearch/action/support/master/IndexingMasterFailoverIT.java
@@ -98,7 +98,7 @@ public class IndexingMasterFailoverIT extends ESIntegTestCase {
                 for (int i = 0; i < 10; i++) {
                     // index data with mapping changes
                     IndexResponse response = client(dataNode).prepareIndex("myindex", "mytype").setSource("field_" + i, "val").get();
-                    assertEquals(DocWriteResponse.Operation.CREATED, response.getOperation());
+                    assertEquals(DocWriteResponse.Result.CREATED, response.getResult());
                 }
             }
         });

--- a/core/src/test/java/org/elasticsearch/action/support/master/IndexingMasterFailoverIT.java
+++ b/core/src/test/java/org/elasticsearch/action/support/master/IndexingMasterFailoverIT.java
@@ -98,7 +98,7 @@ public class IndexingMasterFailoverIT extends ESIntegTestCase {
                 for (int i = 0; i < 10; i++) {
                     // index data with mapping changes
                     IndexResponse response = client(dataNode).prepareIndex("myindex", "mytype").setSource("field_" + i, "val").get();
-                    assertEquals(DocWriteResponse.Operation.CREATE, response.getOperation());
+                    assertEquals(DocWriteResponse.Operation.CREATED, response.getOperation());
                 }
             }
         });

--- a/core/src/test/java/org/elasticsearch/bwcompat/BasicBackwardsCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/BasicBackwardsCompatibilityIT.java
@@ -119,7 +119,7 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
         for (int i = 0; i < numDocs; i++) {
             String routingKey = routing ? randomRealisticUnicodeOfLength(10) : null;
             String id = Integer.toString(i);
-            assertEquals(id, DocWriteResponse.Operation.CREATE, client().prepareIndex("test", "type1", id)
+            assertEquals(id, DocWriteResponse.Operation.CREATED, client().prepareIndex("test", "type1", id)
                 .setRouting(routingKey).setSource("field1", English.intToEnglish(i)).get().getOperation());
             GetResponse get = client().prepareGet("test", "type1", id).setRouting(routingKey).setVersion(1).get();
             assertThat("Document with ID " + id + " should exist but doesn't", get.isExists(), is(true));
@@ -478,7 +478,7 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
         assertThat(searchResponse.getHits().totalHits(), equalTo((long) numDocs));
 
         DeleteResponse deleteResponse = client().prepareDelete("test", "test", firstDocId).setRouting("routing").get();
-        assertEquals(DocWriteResponse.Operation.DELETE, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
         GetResponse getResponse = client().prepareGet("test", "test", firstDocId).setRouting("routing").get();
         assertThat(getResponse.isExists(), equalTo(false));
         refresh();
@@ -493,7 +493,7 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
         int numDocs = iterations(10, 50);
         for (int i = 0; i < numDocs; i++) {
             IndexResponse indexResponse = client().prepareIndex(indexOrAlias(), "type", Integer.toString(i)).setSource("field", "value-" + i).get();
-            assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+            assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
             assertThat(indexResponse.getIndex(), equalTo("test"));
             assertThat(indexResponse.getType(), equalTo("type"));
             assertThat(indexResponse.getId(), equalTo(Integer.toString(i)));
@@ -508,7 +508,7 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
         assertThat(getResponse.getId(), equalTo(docId));
 
         DeleteResponse deleteResponse = client().prepareDelete(indexOrAlias(), "type", docId).get();
-        assertEquals(DocWriteResponse.Operation.DELETE, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
         assertThat(deleteResponse.getIndex(), equalTo("test"));
         assertThat(deleteResponse.getType(), equalTo("type"));
         assertThat(deleteResponse.getId(), equalTo(docId));
@@ -532,7 +532,7 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
         assertThat(updateResponse.getIndex(), equalTo("test"));
         assertThat(updateResponse.getType(), equalTo("type1"));
         assertThat(updateResponse.getId(), equalTo("1"));
-        assertEquals(DocWriteResponse.Operation.CREATE, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, updateResponse.getOperation());
 
         GetResponse getResponse = client().prepareGet("test", "type1", "1").get();
         assertThat(getResponse.isExists(), equalTo(true));
@@ -543,7 +543,7 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
         assertThat(updateResponse.getIndex(), equalTo("test"));
         assertThat(updateResponse.getType(), equalTo("type1"));
         assertThat(updateResponse.getId(), equalTo("1"));
-        assertEquals(DocWriteResponse.Operation.INDEX, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.UPDATED, updateResponse.getOperation());
 
         getResponse = client().prepareGet("test", "type1", "1").get();
         assertThat(getResponse.isExists(), equalTo(true));

--- a/core/src/test/java/org/elasticsearch/bwcompat/BasicBackwardsCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/BasicBackwardsCompatibilityIT.java
@@ -119,8 +119,8 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
         for (int i = 0; i < numDocs; i++) {
             String routingKey = routing ? randomRealisticUnicodeOfLength(10) : null;
             String id = Integer.toString(i);
-            assertEquals(id, DocWriteResponse.Operation.CREATED, client().prepareIndex("test", "type1", id)
-                .setRouting(routingKey).setSource("field1", English.intToEnglish(i)).get().getOperation());
+            assertEquals(id, DocWriteResponse.Result.CREATED, client().prepareIndex("test", "type1", id)
+                .setRouting(routingKey).setSource("field1", English.intToEnglish(i)).get().getResult());
             GetResponse get = client().prepareGet("test", "type1", id).setRouting(routingKey).setVersion(1).get();
             assertThat("Document with ID " + id + " should exist but doesn't", get.isExists(), is(true));
             assertThat(get.getVersion(), equalTo(1L));
@@ -478,7 +478,7 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
         assertThat(searchResponse.getHits().totalHits(), equalTo((long) numDocs));
 
         DeleteResponse deleteResponse = client().prepareDelete("test", "test", firstDocId).setRouting("routing").get();
-        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
         GetResponse getResponse = client().prepareGet("test", "test", firstDocId).setRouting("routing").get();
         assertThat(getResponse.isExists(), equalTo(false));
         refresh();
@@ -493,7 +493,7 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
         int numDocs = iterations(10, 50);
         for (int i = 0; i < numDocs; i++) {
             IndexResponse indexResponse = client().prepareIndex(indexOrAlias(), "type", Integer.toString(i)).setSource("field", "value-" + i).get();
-            assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+            assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
             assertThat(indexResponse.getIndex(), equalTo("test"));
             assertThat(indexResponse.getType(), equalTo("type"));
             assertThat(indexResponse.getId(), equalTo(Integer.toString(i)));
@@ -508,7 +508,7 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
         assertThat(getResponse.getId(), equalTo(docId));
 
         DeleteResponse deleteResponse = client().prepareDelete(indexOrAlias(), "type", docId).get();
-        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
         assertThat(deleteResponse.getIndex(), equalTo("test"));
         assertThat(deleteResponse.getType(), equalTo("type"));
         assertThat(deleteResponse.getId(), equalTo(docId));
@@ -532,7 +532,7 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
         assertThat(updateResponse.getIndex(), equalTo("test"));
         assertThat(updateResponse.getType(), equalTo("type1"));
         assertThat(updateResponse.getId(), equalTo("1"));
-        assertEquals(DocWriteResponse.Operation.CREATED, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, updateResponse.getResult());
 
         GetResponse getResponse = client().prepareGet("test", "type1", "1").get();
         assertThat(getResponse.isExists(), equalTo(true));
@@ -543,7 +543,7 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
         assertThat(updateResponse.getIndex(), equalTo("test"));
         assertThat(updateResponse.getType(), equalTo("type1"));
         assertThat(updateResponse.getId(), equalTo("1"));
-        assertEquals(DocWriteResponse.Operation.UPDATED, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.UPDATED, updateResponse.getResult());
 
         getResponse = client().prepareGet("test", "type1", "1").get();
         assertThat(getResponse.isExists(), equalTo(true));

--- a/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
@@ -491,7 +491,7 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
                                 logger.trace("[{}] indexing id [{}] through node [{}] targeting shard [{}]", name, id, node, shard);
                                 IndexResponse response =
                                         client.prepareIndex("test", "type", id).setSource("{}").setTimeout(timeout).get(timeout);
-                                assertEquals(DocWriteResponse.Operation.CREATED, response.getOperation());
+                                assertEquals(DocWriteResponse.Result.CREATED, response.getResult());
                                 ackedDocs.put(id, node);
                                 logger.trace("[{}] indexed id [{}] through node [{}]", name, id, node);
                             } catch (ElasticsearchException e) {

--- a/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
@@ -491,7 +491,7 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
                                 logger.trace("[{}] indexing id [{}] through node [{}] targeting shard [{}]", name, id, node, shard);
                                 IndexResponse response =
                                         client.prepareIndex("test", "type", id).setSource("{}").setTimeout(timeout).get(timeout);
-                                assertEquals(DocWriteResponse.Operation.CREATE, response.getOperation());
+                                assertEquals(DocWriteResponse.Operation.CREATED, response.getOperation());
                                 ackedDocs.put(id, node);
                                 logger.trace("[{}] indexed id [{}] through node [{}]", name, id, node);
                             } catch (ElasticsearchException e) {

--- a/core/src/test/java/org/elasticsearch/get/GetActionIT.java
+++ b/core/src/test/java/org/elasticsearch/get/GetActionIT.java
@@ -177,7 +177,7 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(response.getSourceAsMap().get("field2").toString(), equalTo("value2_2"));
 
         DeleteResponse deleteResponse = client().prepareDelete("test", "type1", "1").get();
-        assertEquals(DocWriteResponse.Operation.DELETE, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
 
         response = client().prepareGet(indexOrAlias(), "type1", "1").get();
         assertThat(response.isExists(), equalTo(false));

--- a/core/src/test/java/org/elasticsearch/get/GetActionIT.java
+++ b/core/src/test/java/org/elasticsearch/get/GetActionIT.java
@@ -177,7 +177,7 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(response.getSourceAsMap().get("field2").toString(), equalTo("value2_2"));
 
         DeleteResponse deleteResponse = client().prepareDelete("test", "type1", "1").get();
-        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
 
         response = client().prepareGet(indexOrAlias(), "type1", "1").get();
         assertThat(response.isExists(), equalTo(false));

--- a/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasIT.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasIT.java
@@ -415,7 +415,7 @@ public class IndexWithShadowReplicasIT extends ESIntegTestCase {
                     try {
                         final IndexResponse indexResponse = client().prepareIndex(IDX, "doc",
                                 Integer.toString(counter.incrementAndGet())).setSource("foo", "bar").get();
-                        assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+                        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
                     } catch (Exception e) {
                         exceptions.add(e);
                     }
@@ -508,7 +508,7 @@ public class IndexWithShadowReplicasIT extends ESIntegTestCase {
                 while (counter.get() < (numPhase1Docs + numPhase2Docs + numPhase3Docs)) {
                     final IndexResponse indexResponse = client().prepareIndex(IDX, "doc",
                             Integer.toString(counter.incrementAndGet())).setSource("foo", "bar").get();
-                    assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+                    assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
                     final int docCount = counter.get();
                     if (docCount == numPhase1Docs) {
                         phase1finished.countDown();

--- a/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasIT.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasIT.java
@@ -415,7 +415,7 @@ public class IndexWithShadowReplicasIT extends ESIntegTestCase {
                     try {
                         final IndexResponse indexResponse = client().prepareIndex(IDX, "doc",
                                 Integer.toString(counter.incrementAndGet())).setSource("foo", "bar").get();
-                        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+                        assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
                     } catch (Exception e) {
                         exceptions.add(e);
                     }
@@ -508,7 +508,7 @@ public class IndexWithShadowReplicasIT extends ESIntegTestCase {
                 while (counter.get() < (numPhase1Docs + numPhase2Docs + numPhase3Docs)) {
                     final IndexResponse indexResponse = client().prepareIndex(IDX, "doc",
                             Integer.toString(counter.incrementAndGet())).setSource("foo", "bar").get();
-                    assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+                    assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
                     final int docCount = counter.get();
                     if (docCount == numPhase1Docs) {
                         phase1finished.countDown();

--- a/core/src/test/java/org/elasticsearch/index/WaitUntilRefreshIT.java
+++ b/core/src/test/java/org/elasticsearch/index/WaitUntilRefreshIT.java
@@ -84,7 +84,7 @@ public class WaitUntilRefreshIT extends ESIntegTestCase {
 
         // Now delete with blockUntilRefresh
         DeleteResponse delete = client().prepareDelete("test", "test", "1").setRefreshPolicy(RefreshPolicy.WAIT_UNTIL).get();
-        assertEquals(DocWriteResponse.Operation.DELETE, delete.getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, delete.getOperation());
         assertFalse("request shouldn't have forced a refresh", delete.forcedRefresh());
         assertNoSearchHits(client().prepareSearch("test").setQuery(matchQuery("foo", "bar")).get());
     }

--- a/core/src/test/java/org/elasticsearch/index/WaitUntilRefreshIT.java
+++ b/core/src/test/java/org/elasticsearch/index/WaitUntilRefreshIT.java
@@ -84,7 +84,7 @@ public class WaitUntilRefreshIT extends ESIntegTestCase {
 
         // Now delete with blockUntilRefresh
         DeleteResponse delete = client().prepareDelete("test", "test", "1").setRefreshPolicy(RefreshPolicy.WAIT_UNTIL).get();
-        assertEquals(DocWriteResponse.Operation.DELETED, delete.getOperation());
+        assertEquals(DocWriteResponse.Result.DELETED, delete.getResult());
         assertFalse("request shouldn't have forced a refresh", delete.forcedRefresh());
         assertNoSearchHits(client().prepareSearch("test").setQuery(matchQuery("foo", "bar")).get());
     }

--- a/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
@@ -100,7 +100,7 @@ public class DynamicMappingIT extends ESIntegTestCase {
                 public void run() {
                     try {
                         startLatch.await();
-                        assertEquals(DocWriteResponse.Operation.CREATE, client().prepareIndex("index", "type", id)
+                        assertEquals(DocWriteResponse.Operation.CREATED, client().prepareIndex("index", "type", id)
                             .setSource("field" + id, "bar").get().getOperation());
                     } catch (Exception e) {
                         error.compareAndSet(null, e);

--- a/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
@@ -100,8 +100,8 @@ public class DynamicMappingIT extends ESIntegTestCase {
                 public void run() {
                     try {
                         startLatch.await();
-                        assertEquals(DocWriteResponse.Operation.CREATED, client().prepareIndex("index", "type", id)
-                            .setSource("field" + id, "bar").get().getOperation());
+                        assertEquals(DocWriteResponse.Result.CREATED, client().prepareIndex("index", "type", id)
+                            .setSource("field" + id, "bar").get().getResult());
                     } catch (Exception e) {
                         error.compareAndSet(null, e);
                     }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapperIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapperIntegrationIT.java
@@ -137,13 +137,13 @@ public class TokenCountFieldMapperIntegrationIT extends ESIntegTestCase {
                 .endObject().endObject()).get();
         ensureGreen();
 
-        assertEquals(DocWriteResponse.Operation.CREATED, prepareIndex("single", "I have four terms").get().getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, prepareIndex("single", "I have four terms").get().getResult());
         BulkResponse bulk = client().prepareBulk()
                 .add(prepareIndex("bulk1", "bulk three terms"))
                 .add(prepareIndex("bulk2", "this has five bulk terms")).get();
         assertFalse(bulk.buildFailureMessage(), bulk.hasFailures());
-        assertEquals(DocWriteResponse.Operation.CREATED,
-                     prepareIndex("multi", "two terms", "wow now I have seven lucky terms").get().getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED,
+                     prepareIndex("multi", "two terms", "wow now I have seven lucky terms").get().getResult());
         bulk = client().prepareBulk()
                 .add(prepareIndex("multibulk1", "one", "oh wow now I have eight unlucky terms"))
                 .add(prepareIndex("multibulk2", "six is a bunch of terms", "ten!  ten terms is just crazy!  too many too count!")).get();

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapperIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapperIntegrationIT.java
@@ -137,12 +137,12 @@ public class TokenCountFieldMapperIntegrationIT extends ESIntegTestCase {
                 .endObject().endObject()).get();
         ensureGreen();
 
-        assertEquals(DocWriteResponse.Operation.CREATE, prepareIndex("single", "I have four terms").get().getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, prepareIndex("single", "I have four terms").get().getOperation());
         BulkResponse bulk = client().prepareBulk()
                 .add(prepareIndex("bulk1", "bulk three terms"))
                 .add(prepareIndex("bulk2", "this has five bulk terms")).get();
         assertFalse(bulk.buildFailureMessage(), bulk.hasFailures());
-        assertEquals(DocWriteResponse.Operation.CREATE,
+        assertEquals(DocWriteResponse.Operation.CREATED,
                      prepareIndex("multi", "two terms", "wow now I have seven lucky terms").get().getOperation());
         bulk = client().prepareBulk()
                 .add(prepareIndex("multibulk1", "one", "oh wow now I have eight unlucky terms"))

--- a/core/src/test/java/org/elasticsearch/index/mapper/date/LegacyDateMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/date/LegacyDateMappingTests.java
@@ -449,7 +449,7 @@ public class LegacyDateMappingTests extends ESSingleNodeTestCase {
         ParsedDocument doc = defaultMapper.parse("test", "type", "1", document.bytes());
         assertThat(getDateAsMillis(doc.rootDoc(), "date_field"), equalTo(1433239200000L));
         IndexResponse indexResponse = client().prepareIndex("test2", "test").setSource(document).get();
-        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
 
         // integers should always be parsed as well... cannot be sure it is a unix timestamp only
         doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
@@ -459,7 +459,7 @@ public class LegacyDateMappingTests extends ESSingleNodeTestCase {
                 .bytes());
         assertThat(getDateAsMillis(doc.rootDoc(), "date_field"), equalTo(1433239200000L));
         indexResponse = client().prepareIndex("test", "test").setSource(document).get();
-        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
     }
 
     public void testThatNewIndicesOnlyAllowStrictDates() throws Exception {

--- a/core/src/test/java/org/elasticsearch/index/mapper/date/LegacyDateMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/date/LegacyDateMappingTests.java
@@ -449,7 +449,7 @@ public class LegacyDateMappingTests extends ESSingleNodeTestCase {
         ParsedDocument doc = defaultMapper.parse("test", "type", "1", document.bytes());
         assertThat(getDateAsMillis(doc.rootDoc(), "date_field"), equalTo(1433239200000L));
         IndexResponse indexResponse = client().prepareIndex("test2", "test").setSource(document).get();
-        assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
 
         // integers should always be parsed as well... cannot be sure it is a unix timestamp only
         doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
@@ -459,7 +459,7 @@ public class LegacyDateMappingTests extends ESSingleNodeTestCase {
                 .bytes());
         assertThat(getDateAsMillis(doc.rootDoc(), "date_field"), equalTo(1433239200000L));
         indexResponse = client().prepareIndex("test", "test").setSource(document).get();
-        assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
     }
 
     public void testThatNewIndicesOnlyAllowStrictDates() throws Exception {

--- a/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -30,8 +30,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
-import org.elasticsearch.action.admin.indices.recovery.RecoveryRequest;
-import org.elasticsearch.action.admin.indices.stats.IndexShardStats;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.index.TransportIndexAction;
@@ -82,8 +80,6 @@ import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportResponse;
-import org.junit.After;
-import org.junit.Before;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -257,7 +253,7 @@ public abstract class ESIndexLevelReplicationTestCase extends ESTestCase {
                 final IndexRequest indexRequest = new IndexRequest(index.getName(), "type", Integer.toString(docId.incrementAndGet()))
                     .source("{}");
                 final IndexResponse response = index(indexRequest);
-                assertEquals(DocWriteResponse.Operation.CREATE, response.getOperation());
+                assertEquals(DocWriteResponse.Operation.CREATED, response.getOperation());
             }
             return numOfDoc;
         }

--- a/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -253,7 +253,7 @@ public abstract class ESIndexLevelReplicationTestCase extends ESTestCase {
                 final IndexRequest indexRequest = new IndexRequest(index.getName(), "type", Integer.toString(docId.incrementAndGet()))
                     .source("{}");
                 final IndexResponse response = index(indexRequest);
-                assertEquals(DocWriteResponse.Operation.CREATED, response.getOperation());
+                assertEquals(DocWriteResponse.Result.CREATED, response.getResult());
             }
             return numOfDoc;
         }

--- a/core/src/test/java/org/elasticsearch/indexing/IndexActionIT.java
+++ b/core/src/test/java/org/elasticsearch/indexing/IndexActionIT.java
@@ -94,15 +94,15 @@ public class IndexActionIT extends ESIntegTestCase {
         ensureGreen();
 
         IndexResponse indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
 
         indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.INDEX, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.UPDATED, indexResponse.getOperation());
 
         client().prepareDelete("test", "type", "1").execute().actionGet();
 
         indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
 
     }
 
@@ -111,14 +111,14 @@ public class IndexActionIT extends ESIntegTestCase {
         ensureGreen();
 
         IndexResponse indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
 
         client().prepareDelete("test", "type", "1").execute().actionGet();
 
         flush();
 
         indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
     }
 
     public void testCreatedFlagParallelExecution() throws Exception {
@@ -139,7 +139,7 @@ public class IndexActionIT extends ESIntegTestCase {
                 public Void call() throws Exception {
                     int docId = random.nextInt(docCount);
                     IndexResponse indexResponse = index("test", "type", Integer.toString(docId), "field1", "value");
-                    if (indexResponse.getOperation() == DocWriteResponse.Operation.CREATE) {
+                    if (indexResponse.getOperation() == DocWriteResponse.Operation.CREATED) {
                         createdCounts.incrementAndGet(docId);
                     }
                     return null;
@@ -161,7 +161,7 @@ public class IndexActionIT extends ESIntegTestCase {
 
         IndexResponse indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(123)
                                               .setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
     }
 
     public void testCreateFlagWithBulk() {
@@ -172,7 +172,7 @@ public class IndexActionIT extends ESIntegTestCase {
         assertThat(bulkResponse.hasFailures(), equalTo(false));
         assertThat(bulkResponse.getItems().length, equalTo(1));
         IndexResponse indexResponse = bulkResponse.getItems()[0].getResponse();
-        assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
     }
 
     public void testCreateIndexWithLongName() {

--- a/core/src/test/java/org/elasticsearch/indexing/IndexActionIT.java
+++ b/core/src/test/java/org/elasticsearch/indexing/IndexActionIT.java
@@ -94,15 +94,15 @@ public class IndexActionIT extends ESIntegTestCase {
         ensureGreen();
 
         IndexResponse indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
 
         indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.UPDATED, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.UPDATED, indexResponse.getResult());
 
         client().prepareDelete("test", "type", "1").execute().actionGet();
 
         indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
 
     }
 
@@ -111,14 +111,14 @@ public class IndexActionIT extends ESIntegTestCase {
         ensureGreen();
 
         IndexResponse indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
 
         client().prepareDelete("test", "type", "1").execute().actionGet();
 
         flush();
 
         indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
     }
 
     public void testCreatedFlagParallelExecution() throws Exception {
@@ -139,7 +139,7 @@ public class IndexActionIT extends ESIntegTestCase {
                 public Void call() throws Exception {
                     int docId = random.nextInt(docCount);
                     IndexResponse indexResponse = index("test", "type", Integer.toString(docId), "field1", "value");
-                    if (indexResponse.getOperation() == DocWriteResponse.Operation.CREATED) {
+                    if (indexResponse.getResult() == DocWriteResponse.Result.CREATED) {
                         createdCounts.incrementAndGet(docId);
                     }
                     return null;
@@ -161,7 +161,7 @@ public class IndexActionIT extends ESIntegTestCase {
 
         IndexResponse indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(123)
                                               .setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
     }
 
     public void testCreateFlagWithBulk() {
@@ -172,7 +172,7 @@ public class IndexActionIT extends ESIntegTestCase {
         assertThat(bulkResponse.hasFailures(), equalTo(false));
         assertThat(bulkResponse.getItems().length, equalTo(1));
         IndexResponse indexResponse = bulkResponse.getItems()[0].getResponse();
-        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
     }
 
     public void testCreateIndexWithLongName() {

--- a/core/src/test/java/org/elasticsearch/indices/DateMathIndexExpressionsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/DateMathIndexExpressionsIntegrationIT.java
@@ -24,7 +24,6 @@ import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.update.UpdateHelper;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.joda.time.DateTime;
@@ -76,15 +75,15 @@ public class DateMathIndexExpressionsIntegrationIT extends ESIntegTestCase {
         assertThat(indicesStatsResponse.getIndex(index3), notNullValue());
 
         DeleteResponse deleteResponse = client().prepareDelete(dateMathExp1, "type", "1").get();
-        assertEquals(DocWriteResponse.Operation.DELETE, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
         assertThat(deleteResponse.getId(), equalTo("1"));
 
         deleteResponse = client().prepareDelete(dateMathExp2, "type", "2").get();
-        assertEquals(DocWriteResponse.Operation.DELETE, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
         assertThat(deleteResponse.getId(), equalTo("2"));
 
         deleteResponse = client().prepareDelete(dateMathExp3, "type", "3").get();
-        assertEquals(DocWriteResponse.Operation.DELETE, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
         assertThat(deleteResponse.getId(), equalTo("3"));
     }
 

--- a/core/src/test/java/org/elasticsearch/indices/DateMathIndexExpressionsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/DateMathIndexExpressionsIntegrationIT.java
@@ -75,15 +75,15 @@ public class DateMathIndexExpressionsIntegrationIT extends ESIntegTestCase {
         assertThat(indicesStatsResponse.getIndex(index3), notNullValue());
 
         DeleteResponse deleteResponse = client().prepareDelete(dateMathExp1, "type", "1").get();
-        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
         assertThat(deleteResponse.getId(), equalTo("1"));
 
         deleteResponse = client().prepareDelete(dateMathExp2, "type", "2").get();
-        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
         assertThat(deleteResponse.getId(), equalTo("2"));
 
         deleteResponse = client().prepareDelete(dateMathExp3, "type", "3").get();
-        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
         assertThat(deleteResponse.getId(), equalTo("3"));
     }
 

--- a/core/src/test/java/org/elasticsearch/indices/recovery/IndexPrimaryRelocationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/IndexPrimaryRelocationIT.java
@@ -56,9 +56,9 @@ public class IndexPrimaryRelocationIT extends ESIntegTestCase {
             public void run() {
                 while (finished.get() == false) {
                     IndexResponse indexResponse = client().prepareIndex("test", "type", "id").setSource("field", "value").get();
-                    assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+                    assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
                     DeleteResponse deleteResponse = client().prepareDelete("test", "type", "id").get();
-                    assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
+                    assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
                 }
             }
         };

--- a/core/src/test/java/org/elasticsearch/indices/recovery/IndexPrimaryRelocationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/IndexPrimaryRelocationIT.java
@@ -56,9 +56,9 @@ public class IndexPrimaryRelocationIT extends ESIntegTestCase {
             public void run() {
                 while (finished.get() == false) {
                     IndexResponse indexResponse = client().prepareIndex("test", "type", "id").setSource("field", "value").get();
-                    assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+                    assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
                     DeleteResponse deleteResponse = client().prepareDelete("test", "type", "id").get();
-                    assertEquals(DocWriteResponse.Operation.DELETE, deleteResponse.getOperation());
+                    assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
                 }
             }
         };

--- a/core/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
@@ -35,7 +35,6 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
@@ -1037,8 +1036,8 @@ public class IndexStatsIT extends ESIntegTestCase {
             assertThat(stats.getTotal().queryCache.getCacheSize(), greaterThan(0L));
         });
 
-        assertEquals(DocWriteResponse.Operation.DELETE, client().prepareDelete("index", "type", "1").get().getOperation());
-        assertEquals(DocWriteResponse.Operation.DELETE, client().prepareDelete("index", "type", "2").get().getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, client().prepareDelete("index", "type", "1").get().getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, client().prepareDelete("index", "type", "2").get().getOperation());
         refresh();
         response = client().admin().indices().prepareStats("index").setQueryCache(true).get();
         assertCumulativeQueryCacheStats(response);

--- a/core/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
@@ -1036,8 +1036,8 @@ public class IndexStatsIT extends ESIntegTestCase {
             assertThat(stats.getTotal().queryCache.getCacheSize(), greaterThan(0L));
         });
 
-        assertEquals(DocWriteResponse.Operation.DELETED, client().prepareDelete("index", "type", "1").get().getOperation());
-        assertEquals(DocWriteResponse.Operation.DELETED, client().prepareDelete("index", "type", "2").get().getOperation());
+        assertEquals(DocWriteResponse.Result.DELETED, client().prepareDelete("index", "type", "1").get().getResult());
+        assertEquals(DocWriteResponse.Result.DELETED, client().prepareDelete("index", "type", "2").get().getResult());
         refresh();
         response = client().admin().indices().prepareStats("index").setQueryCache(true).get();
         assertCumulativeQueryCacheStats(response);

--- a/core/src/test/java/org/elasticsearch/ingest/IngestClientIT.java
+++ b/core/src/test/java/org/elasticsearch/ingest/IngestClientIT.java
@@ -162,7 +162,7 @@ public class IngestClientIT extends ESIntegTestCase {
                     itemResponse.isFailed(), is(false));
                 assertThat(indexResponse, notNullValue());
                 assertThat(indexResponse.getId(), equalTo(Integer.toString(i)));
-                assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+                assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/ingest/IngestClientIT.java
+++ b/core/src/test/java/org/elasticsearch/ingest/IngestClientIT.java
@@ -162,7 +162,7 @@ public class IngestClientIT extends ESIntegTestCase {
                     itemResponse.isFailed(), is(false));
                 assertThat(indexResponse, notNullValue());
                 assertThat(indexResponse.getId(), equalTo(Integer.toString(i)));
-                assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+                assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsIT.java
@@ -107,7 +107,7 @@ public class SearchWithRandomExceptionsIT extends ESIntegTestCase {
         for (int i = 0; i < numDocs; i++) {
             try {
                 IndexResponse indexResponse = client().prepareIndex("test", "type", "" + i).setTimeout(TimeValue.timeValueSeconds(1)).setSource("test", English.intToEnglish(i)).get();
-                if (indexResponse.getOperation() == DocWriteResponse.Operation.CREATED) {
+                if (indexResponse.getResult() == DocWriteResponse.Result.CREATED) {
                     numCreated++;
                     added[i] = true;
                 }

--- a/core/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsIT.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.Settings.Builder;
-import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.MockEngineFactoryPlugin;
@@ -108,7 +107,7 @@ public class SearchWithRandomExceptionsIT extends ESIntegTestCase {
         for (int i = 0; i < numDocs; i++) {
             try {
                 IndexResponse indexResponse = client().prepareIndex("test", "type", "" + i).setTimeout(TimeValue.timeValueSeconds(1)).setSource("test", English.intToEnglish(i)).get();
-                if (indexResponse.getOperation() == DocWriteResponse.Operation.CREATE) {
+                if (indexResponse.getOperation() == DocWriteResponse.Operation.CREATED) {
                     numCreated++;
                     added[i] = true;
                 }

--- a/core/src/test/java/org/elasticsearch/search/basic/SearchWithRandomIOExceptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/basic/SearchWithRandomIOExceptionsIT.java
@@ -137,7 +137,7 @@ public class SearchWithRandomIOExceptionsIT extends ESIntegTestCase {
             added[i] = false;
             try {
                 IndexResponse indexResponse = client().prepareIndex("test", "type", Integer.toString(i)).setTimeout(TimeValue.timeValueSeconds(1)).setSource("test", English.intToEnglish(i)).get();
-                if (indexResponse.getOperation() == DocWriteResponse.Operation.CREATE) {
+                if (indexResponse.getOperation() == DocWriteResponse.Operation.CREATED) {
                     numCreated++;
                     added[i] = true;
                 }

--- a/core/src/test/java/org/elasticsearch/search/basic/SearchWithRandomIOExceptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/basic/SearchWithRandomIOExceptionsIT.java
@@ -137,7 +137,7 @@ public class SearchWithRandomIOExceptionsIT extends ESIntegTestCase {
             added[i] = false;
             try {
                 IndexResponse indexResponse = client().prepareIndex("test", "type", Integer.toString(i)).setTimeout(TimeValue.timeValueSeconds(1)).setSource("test", English.intToEnglish(i)).get();
-                if (indexResponse.getOperation() == DocWriteResponse.Operation.CREATED) {
+                if (indexResponse.getResult() == DocWriteResponse.Result.CREATED) {
                     numCreated++;
                     added[i] = true;
                 }

--- a/core/src/test/java/org/elasticsearch/search/nested/SimpleNestedIT.java
+++ b/core/src/test/java/org/elasticsearch/search/nested/SimpleNestedIT.java
@@ -149,7 +149,7 @@ public class SimpleNestedIT extends ESIntegTestCase {
 
         // check delete, so all is gone...
         DeleteResponse deleteResponse = client().prepareDelete("test", "type1", "2").execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
 
         // flush, so we fetch it from the index (as see that we filter nested docs)
         flush();

--- a/core/src/test/java/org/elasticsearch/search/nested/SimpleNestedIT.java
+++ b/core/src/test/java/org/elasticsearch/search/nested/SimpleNestedIT.java
@@ -149,7 +149,7 @@ public class SimpleNestedIT extends ESIntegTestCase {
 
         // check delete, so all is gone...
         DeleteResponse deleteResponse = client().prepareDelete("test", "type1", "2").execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.DELETE, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
 
         // flush, so we fetch it from the index (as see that we filter nested docs)
         flush();

--- a/core/src/test/java/org/elasticsearch/ttl/SimpleTTLIT.java
+++ b/core/src/test/java/org/elasticsearch/ttl/SimpleTTLIT.java
@@ -106,14 +106,14 @@ public class SimpleTTLIT extends ESIntegTestCase {
         long now = System.currentTimeMillis();
         IndexResponse indexResponse = client().prepareIndex("test", "type1", "1").setSource("field1", "value1")
                 .setTimestamp(String.valueOf(now)).setTTL(providedTTLValue).setRefreshPolicy(IMMEDIATE).get();
-        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
         indexResponse = client().prepareIndex("test", "type1", "with_routing").setSource("field1", "value1")
                 .setTimestamp(String.valueOf(now)).setTTL(providedTTLValue).setRouting("routing").setRefreshPolicy(IMMEDIATE).get();
-        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
         indexResponse = client().prepareIndex("test", "type1", "no_ttl").setSource("field1", "value1").get();
-        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
         indexResponse = client().prepareIndex("test", "type2", "default_ttl").setSource("field1", "value1").get();
-        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
 
         // realtime get check
         long currentTime = System.currentTimeMillis();
@@ -259,7 +259,7 @@ public class SimpleTTLIT extends ESIntegTestCase {
         long thirdTtl = aLongTime * 1;
         IndexResponse indexResponse = client().prepareIndex("test", "type1", "1").setSource("field1", "value1")
                 .setTTL(firstTtl).setRefreshPolicy(IMMEDIATE).get();
-        assertTrue(indexResponse.getOperation() == DocWriteResponse.Operation.CREATED);
+        assertTrue(indexResponse.getResult() == DocWriteResponse.Result.CREATED);
         assertThat(getTtl("type1", 1), both(lessThanOrEqualTo(firstTtl)).and(greaterThan(secondTtl)));
 
         // Updating with the default detect_noop without a change to the document doesn't change the ttl.

--- a/core/src/test/java/org/elasticsearch/ttl/SimpleTTLIT.java
+++ b/core/src/test/java/org/elasticsearch/ttl/SimpleTTLIT.java
@@ -106,14 +106,14 @@ public class SimpleTTLIT extends ESIntegTestCase {
         long now = System.currentTimeMillis();
         IndexResponse indexResponse = client().prepareIndex("test", "type1", "1").setSource("field1", "value1")
                 .setTimestamp(String.valueOf(now)).setTTL(providedTTLValue).setRefreshPolicy(IMMEDIATE).get();
-        assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
         indexResponse = client().prepareIndex("test", "type1", "with_routing").setSource("field1", "value1")
                 .setTimestamp(String.valueOf(now)).setTTL(providedTTLValue).setRouting("routing").setRefreshPolicy(IMMEDIATE).get();
-        assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
         indexResponse = client().prepareIndex("test", "type1", "no_ttl").setSource("field1", "value1").get();
-        assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
         indexResponse = client().prepareIndex("test", "type2", "default_ttl").setSource("field1", "value1").get();
-        assertEquals(DocWriteResponse.Operation.CREATE, indexResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, indexResponse.getOperation());
 
         // realtime get check
         long currentTime = System.currentTimeMillis();
@@ -259,7 +259,7 @@ public class SimpleTTLIT extends ESIntegTestCase {
         long thirdTtl = aLongTime * 1;
         IndexResponse indexResponse = client().prepareIndex("test", "type1", "1").setSource("field1", "value1")
                 .setTTL(firstTtl).setRefreshPolicy(IMMEDIATE).get();
-        assertTrue(indexResponse.getOperation() == DocWriteResponse.Operation.CREATE);
+        assertTrue(indexResponse.getOperation() == DocWriteResponse.Operation.CREATED);
         assertThat(getTtl("type1", 1), both(lessThanOrEqualTo(firstTtl)).and(greaterThan(secondTtl)));
 
         // Updating with the default detect_noop without a change to the document doesn't change the ttl.

--- a/core/src/test/java/org/elasticsearch/update/UpdateIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateIT.java
@@ -371,7 +371,7 @@ public class UpdateIT extends ESIntegTestCase {
                 .setUpsert(XContentFactory.jsonBuilder().startObject().field("field", 1).endObject())
                 .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
                 .execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.CREATE, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, updateResponse.getOperation());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
@@ -383,7 +383,7 @@ public class UpdateIT extends ESIntegTestCase {
                 .setUpsert(XContentFactory.jsonBuilder().startObject().field("field", 1).endObject())
                 .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
                 .execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.INDEX, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.UPDATED, updateResponse.getOperation());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
@@ -412,7 +412,7 @@ public class UpdateIT extends ESIntegTestCase {
                 .setScriptedUpsert(true)
                 .setScript(new Script("", ScriptService.ScriptType.INLINE, "scripted_upsert", params))
                 .execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.CREATE, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.CREATED, updateResponse.getOperation());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
@@ -426,7 +426,7 @@ public class UpdateIT extends ESIntegTestCase {
                 .setScriptedUpsert(true)
                 .setScript(new Script("", ScriptService.ScriptType.INLINE, "scripted_upsert", params))
                 .execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.INDEX, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.UPDATED, updateResponse.getOperation());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
@@ -582,7 +582,7 @@ public class UpdateIT extends ESIntegTestCase {
         UpdateResponse updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
                 .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null)).execute().actionGet();
         assertThat(updateResponse.getVersion(), equalTo(2L));
-        assertEquals(DocWriteResponse.Operation.INDEX, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.UPDATED, updateResponse.getOperation());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
@@ -595,7 +595,7 @@ public class UpdateIT extends ESIntegTestCase {
         updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
                 .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", params)).execute().actionGet();
         assertThat(updateResponse.getVersion(), equalTo(3L));
-        assertEquals(DocWriteResponse.Operation.INDEX, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.UPDATED, updateResponse.getOperation());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
@@ -619,7 +619,7 @@ public class UpdateIT extends ESIntegTestCase {
         updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
                 .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("_ctx", Collections.singletonMap("op", "delete")))).execute().actionGet();
         assertThat(updateResponse.getVersion(), equalTo(4L));
-        assertEquals(DocWriteResponse.Operation.DELETE, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, updateResponse.getOperation());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {

--- a/core/src/test/java/org/elasticsearch/update/UpdateIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateIT.java
@@ -371,7 +371,7 @@ public class UpdateIT extends ESIntegTestCase {
                 .setUpsert(XContentFactory.jsonBuilder().startObject().field("field", 1).endObject())
                 .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
                 .execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.CREATED, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, updateResponse.getResult());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
@@ -383,7 +383,7 @@ public class UpdateIT extends ESIntegTestCase {
                 .setUpsert(XContentFactory.jsonBuilder().startObject().field("field", 1).endObject())
                 .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
                 .execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.UPDATED, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.UPDATED, updateResponse.getResult());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
@@ -412,7 +412,7 @@ public class UpdateIT extends ESIntegTestCase {
                 .setScriptedUpsert(true)
                 .setScript(new Script("", ScriptService.ScriptType.INLINE, "scripted_upsert", params))
                 .execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.CREATED, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.CREATED, updateResponse.getResult());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
@@ -426,7 +426,7 @@ public class UpdateIT extends ESIntegTestCase {
                 .setScriptedUpsert(true)
                 .setScript(new Script("", ScriptService.ScriptType.INLINE, "scripted_upsert", params))
                 .execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.UPDATED, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.UPDATED, updateResponse.getResult());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
@@ -582,7 +582,7 @@ public class UpdateIT extends ESIntegTestCase {
         UpdateResponse updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
                 .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null)).execute().actionGet();
         assertThat(updateResponse.getVersion(), equalTo(2L));
-        assertEquals(DocWriteResponse.Operation.UPDATED, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.UPDATED, updateResponse.getResult());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
@@ -595,7 +595,7 @@ public class UpdateIT extends ESIntegTestCase {
         updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
                 .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", params)).execute().actionGet();
         assertThat(updateResponse.getVersion(), equalTo(3L));
-        assertEquals(DocWriteResponse.Operation.UPDATED, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.UPDATED, updateResponse.getResult());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
@@ -607,7 +607,7 @@ public class UpdateIT extends ESIntegTestCase {
         updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
                 .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("_ctx", Collections.singletonMap("op", "none")))).execute().actionGet();
         assertThat(updateResponse.getVersion(), equalTo(3L));
-        assertEquals(DocWriteResponse.Operation.NOOP, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.NOOP, updateResponse.getResult());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
@@ -619,7 +619,7 @@ public class UpdateIT extends ESIntegTestCase {
         updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
                 .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("_ctx", Collections.singletonMap("op", "delete")))).execute().actionGet();
         assertThat(updateResponse.getVersion(), equalTo(4L));
-        assertEquals(DocWriteResponse.Operation.DELETED, updateResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.DELETED, updateResponse.getResult());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {

--- a/core/src/test/java/org/elasticsearch/versioning/SimpleVersioningIT.java
+++ b/core/src/test/java/org/elasticsearch/versioning/SimpleVersioningIT.java
@@ -59,7 +59,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         // Note - external version doesn't throw version conflicts on deletes of non existent records. This is different from internal versioning
 
         DeleteResponse deleteResponse = client().prepareDelete("test", "type", "1").setVersion(17).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.NOOP, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.NOT_FOUND, deleteResponse.getOperation());
 
         // this should conflict with the delete command transaction which told us that the object was deleted at version 17.
         assertThrows(
@@ -98,7 +98,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         // deleting with a lower version works.
         long v = randomIntBetween(12, 14);
         DeleteResponse deleteResponse = client().prepareDelete("test", "type", "1").setVersion(v).setVersionType(VersionType.FORCE).get();
-        assertEquals(DocWriteResponse.Operation.DELETE, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
         assertThat(deleteResponse.getVersion(), equalTo(v));
     }
 
@@ -133,7 +133,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         // Delete with a higher or equal version deletes all versions up to the given one.
         long v = randomIntBetween(14, 17);
         DeleteResponse deleteResponse = client().prepareDelete("test", "type", "1").setVersion(v).setVersionType(VersionType.EXTERNAL_GTE).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.DELETE, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
         assertThat(deleteResponse.getVersion(), equalTo(v));
 
         // Deleting with a lower version keeps on failing after a delete.
@@ -144,7 +144,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
 
         // But delete with a higher version is OK.
         deleteResponse = client().prepareDelete("test", "type", "1").setVersion(18).setVersionType(VersionType.EXTERNAL_GTE).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.NOOP, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.NOT_FOUND, deleteResponse.getOperation());
         assertThat(deleteResponse.getVersion(), equalTo(18L));
     }
 
@@ -175,7 +175,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
 
         // Delete with a higher version deletes all versions up to the given one.
         DeleteResponse deleteResponse = client().prepareDelete("test", "type", "1").setVersion(17).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.DELETE, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
         assertThat(deleteResponse.getVersion(), equalTo(17L));
 
         // Deleting with a lower version keeps on failing after a delete.
@@ -186,7 +186,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
 
         // But delete with a higher version is OK.
         deleteResponse = client().prepareDelete("test", "type", "1").setVersion(18).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.NOOP, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.NOT_FOUND, deleteResponse.getOperation());
         assertThat(deleteResponse.getVersion(), equalTo(18L));
 
 
@@ -196,7 +196,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
 
 
         deleteResponse = client().prepareDelete("test", "type", "1").setVersion(20).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.DELETE, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
         assertThat(deleteResponse.getVersion(), equalTo(20L));
 
         // Make sure that the next delete will be GC. Note we do it on the index settings so it will be cleaned up
@@ -281,7 +281,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         }
 
         DeleteResponse deleteResponse = client().prepareDelete("test", "type", "1").setVersion(2).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.DELETE, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
         assertThat(deleteResponse.getVersion(), equalTo(3L));
 
         assertThrows(client().prepareDelete("test", "type", "1").setVersion(2).execute(), VersionConflictEngineException.class);
@@ -290,7 +290,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         // This is intricate - the object was deleted but a delete transaction was with the right version. We add another one
         // and thus the transaction is increased.
         deleteResponse = client().prepareDelete("test", "type", "1").setVersion(3).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.NOOP, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Operation.NOT_FOUND, deleteResponse.getOperation());
         assertThat(deleteResponse.getVersion(), equalTo(4L));
     }
 
@@ -479,7 +479,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
                     sb.append(" version=");
                     sb.append(deleteResponse.getVersion());
                     sb.append(" found=");
-                    sb.append(deleteResponse.getOperation() == DocWriteResponse.Operation.DELETE);
+                    sb.append(deleteResponse.getOperation() == DocWriteResponse.Operation.DELETED);
                 } else if (response instanceof IndexResponse) {
                     IndexResponse indexResponse = (IndexResponse) response;
                     sb.append(" index=");
@@ -491,7 +491,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
                     sb.append(" version=");
                     sb.append(indexResponse.getVersion());
                     sb.append(" created=");
-                    sb.append(indexResponse.getOperation() == DocWriteResponse.Operation.CREATE);
+                    sb.append(indexResponse.getOperation() == DocWriteResponse.Operation.CREATED);
                 } else {
                     sb.append("  response: " + response);
                 }

--- a/core/src/test/java/org/elasticsearch/versioning/SimpleVersioningIT.java
+++ b/core/src/test/java/org/elasticsearch/versioning/SimpleVersioningIT.java
@@ -59,7 +59,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         // Note - external version doesn't throw version conflicts on deletes of non existent records. This is different from internal versioning
 
         DeleteResponse deleteResponse = client().prepareDelete("test", "type", "1").setVersion(17).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.NOT_FOUND, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.NOT_FOUND, deleteResponse.getResult());
 
         // this should conflict with the delete command transaction which told us that the object was deleted at version 17.
         assertThrows(
@@ -98,7 +98,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         // deleting with a lower version works.
         long v = randomIntBetween(12, 14);
         DeleteResponse deleteResponse = client().prepareDelete("test", "type", "1").setVersion(v).setVersionType(VersionType.FORCE).get();
-        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
         assertThat(deleteResponse.getVersion(), equalTo(v));
     }
 
@@ -133,7 +133,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         // Delete with a higher or equal version deletes all versions up to the given one.
         long v = randomIntBetween(14, 17);
         DeleteResponse deleteResponse = client().prepareDelete("test", "type", "1").setVersion(v).setVersionType(VersionType.EXTERNAL_GTE).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
         assertThat(deleteResponse.getVersion(), equalTo(v));
 
         // Deleting with a lower version keeps on failing after a delete.
@@ -144,7 +144,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
 
         // But delete with a higher version is OK.
         deleteResponse = client().prepareDelete("test", "type", "1").setVersion(18).setVersionType(VersionType.EXTERNAL_GTE).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.NOT_FOUND, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.NOT_FOUND, deleteResponse.getResult());
         assertThat(deleteResponse.getVersion(), equalTo(18L));
     }
 
@@ -175,7 +175,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
 
         // Delete with a higher version deletes all versions up to the given one.
         DeleteResponse deleteResponse = client().prepareDelete("test", "type", "1").setVersion(17).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
         assertThat(deleteResponse.getVersion(), equalTo(17L));
 
         // Deleting with a lower version keeps on failing after a delete.
@@ -186,7 +186,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
 
         // But delete with a higher version is OK.
         deleteResponse = client().prepareDelete("test", "type", "1").setVersion(18).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.NOT_FOUND, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.NOT_FOUND, deleteResponse.getResult());
         assertThat(deleteResponse.getVersion(), equalTo(18L));
 
 
@@ -196,7 +196,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
 
 
         deleteResponse = client().prepareDelete("test", "type", "1").setVersion(20).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
         assertThat(deleteResponse.getVersion(), equalTo(20L));
 
         // Make sure that the next delete will be GC. Note we do it on the index settings so it will be cleaned up
@@ -281,7 +281,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         }
 
         DeleteResponse deleteResponse = client().prepareDelete("test", "type", "1").setVersion(2).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.DELETED, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
         assertThat(deleteResponse.getVersion(), equalTo(3L));
 
         assertThrows(client().prepareDelete("test", "type", "1").setVersion(2).execute(), VersionConflictEngineException.class);
@@ -290,7 +290,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         // This is intricate - the object was deleted but a delete transaction was with the right version. We add another one
         // and thus the transaction is increased.
         deleteResponse = client().prepareDelete("test", "type", "1").setVersion(3).execute().actionGet();
-        assertEquals(DocWriteResponse.Operation.NOT_FOUND, deleteResponse.getOperation());
+        assertEquals(DocWriteResponse.Result.NOT_FOUND, deleteResponse.getResult());
         assertThat(deleteResponse.getVersion(), equalTo(4L));
     }
 
@@ -479,7 +479,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
                     sb.append(" version=");
                     sb.append(deleteResponse.getVersion());
                     sb.append(" found=");
-                    sb.append(deleteResponse.getOperation() == DocWriteResponse.Operation.DELETED);
+                    sb.append(deleteResponse.getResult() == DocWriteResponse.Result.DELETED);
                 } else if (response instanceof IndexResponse) {
                     IndexResponse indexResponse = (IndexResponse) response;
                     sb.append(" index=");
@@ -491,7 +491,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
                     sb.append(" version=");
                     sb.append(indexResponse.getVersion());
                     sb.append(" created=");
-                    sb.append(indexResponse.getOperation() == DocWriteResponse.Operation.CREATED);
+                    sb.append(indexResponse.getResult() == DocWriteResponse.Result.CREATED);
                 } else {
                     sb.append("  response: " + response);
                 }

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -57,7 +57,7 @@ $ cat requests
 { "index" : { "_index" : "test", "_type" : "type1", "_id" : "1" } }
 { "field1" : "value1" }
 $ curl -s -XPOST localhost:9200/_bulk --data-binary "@requests"; echo
-{"took":7, "errors": false, "items":[{"index":{"_index":"test","_type":"type1","_id":"1","_version":1,"_operation":"create","forced_refresh":false}}]}
+{"took":7, "errors": false, "items":[{"index":{"_index":"test","_type":"type1","_id":"1","_version":1,"result":"created","forced_refresh":false}}]}
 --------------------------------------------------
 
 Because this format uses literal `\n`'s as delimiters, please be sure

--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -26,7 +26,7 @@ The result of the above delete operation is:
     "_type" : "tweet",
     "_id" : "1",
     "_version" : 2,
-    "_operation: delete"
+    "result: deleted"
 }
 --------------------------------------------------
 

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -31,7 +31,7 @@ The result of the above index operation is:
     "_id" : "1",
     "_version" : 1,
     "created" : true,
-    "_operation" : create
+    "result" : created
 }
 --------------------------------------------------
 // TESTRESPONSE[s/"successful" : 2/"successful" : 1/]
@@ -231,7 +231,7 @@ The result of the above index operation is:
     "_id" : "6a8ca01c-7896-48e9-81cc-9f70661fcb32",
     "_version" : 1,
     "created" : true,
-    "_operation": "create"
+    "result": "created"
 }
 --------------------------------------------------
 // TESTRESPONSE[s/6a8ca01c-7896-48e9-81cc-9f70661fcb32/$body._id/ s/"successful" : 2/"successful" : 1/]

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -133,7 +133,7 @@ curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
 --------------------------------------------------
 
 If `name` was `new_name` before the request was sent then the entire update
-request is ignored. The `operation` element in the response returns `noop` if
+request is ignored. The `result` element in the response returns `noop` if
 the request was ignored.
 
 [source,js]
@@ -143,7 +143,7 @@ the request was ignored.
    "_type": "type1",
    "_id": "1",
    "_version": 1,
-   "_operation": noop
+   "result": noop
 }
 --------------------------------------------------
 

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByScrollAction.java
@@ -261,7 +261,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
                 case "index":
                 case "create":
                     IndexResponse ir = item.getResponse();
-                    if (ir.getOperation() == DocWriteResponse.Operation.CREATED) {
+                    if (ir.getResult() == DocWriteResponse.Result.CREATED) {
                         task.countCreated();
                     } else {
                         task.countUpdated();

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByScrollAction.java
@@ -261,7 +261,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
                 case "index":
                 case "create":
                     IndexResponse ir = item.getResponse();
-                    if (ir.getOperation() == DocWriteResponse.Operation.CREATE) {
+                    if (ir.getOperation() == DocWriteResponse.Operation.CREATED) {
                         task.countCreated();
                     } else {
                         task.countUpdated();

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/AsyncBulkByScrollActionTests.java
@@ -778,7 +778,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
                         UpdateRequest update = (UpdateRequest) item;
                         opType = "update";
                         response = new UpdateResponse(shardId, update.type(), update.id(),
-                                randomIntBetween(0, Integer.MAX_VALUE), DocWriteResponse.Operation.CREATE);
+                                randomIntBetween(0, Integer.MAX_VALUE), DocWriteResponse.Operation.CREATED);
                     } else if (item instanceof DeleteRequest) {
                         DeleteRequest delete = (DeleteRequest) item;
                         opType = "delete";

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/AsyncBulkByScrollActionTests.java
@@ -778,7 +778,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
                         UpdateRequest update = (UpdateRequest) item;
                         opType = "update";
                         response = new UpdateResponse(shardId, update.type(), update.id(),
-                                randomIntBetween(0, Integer.MAX_VALUE), DocWriteResponse.Operation.CREATED);
+                                randomIntBetween(0, Integer.MAX_VALUE), DocWriteResponse.Result.CREATED);
                     } else if (item instanceof DeleteRequest) {
                         DeleteRequest delete = (DeleteRequest) item;
                         opType = "delete";

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/delete/12_operation.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/delete/12_operation.yaml
@@ -14,7 +14,7 @@
           type:    test
           id:      1
 
- - match: { _operation: delete }
+ - match: { result: deleted }
 
  - do:
       catch: missing
@@ -23,4 +23,4 @@
           type:    test
           id:      1
 
- - match: { _operation: noop }
+ - match: { result: not_found }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/delete/12_result.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/delete/12_result.yaml
@@ -1,5 +1,5 @@
 ---
-"Delete operation field":
+"Delete result field":
 
  - do:
       index:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/12_operation.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/12_operation.yaml
@@ -8,7 +8,7 @@
           id:     1
           body:   { foo: bar }
 
-  - match:   { _operation: create }
+  - match:   { result: created }
 
   - do:
       index:
@@ -18,4 +18,4 @@
           body:     { foo: bar }
           op_type:  index
 
-  - match:   { _operation: index }
+  - match:   { result: updated }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/12_result.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/12_result.yaml
@@ -1,5 +1,5 @@
 ---
-"Index operation field":
+"Index result field":
 
   - do:
       index:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/12_operation.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/12_operation.yaml
@@ -11,7 +11,7 @@
             doc_as_upsert:  true
 
   - match: { _version:   1      }
-  - match: { _operation: create }
+  - match: { result: created }
 
   - do:
       update:
@@ -23,7 +23,7 @@
             doc_as_upsert:  true
 
   - match: { _version:   1    }
-  - match: { _operation: noop }
+  - match: { result: noop }
 
   - do:
       update:
@@ -36,7 +36,7 @@
             detect_noop:    false
 
   - match: { _version:   2     }
-  - match: { _operation: index }
+  - match: { result: updated }
 
   - do:
       update:
@@ -49,4 +49,4 @@
             detect_noop:    true
 
   - match: { _version:   3     }
-  - match: { _operation: index }
+  - match: { result: updated }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/12_result.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/12_result.yaml
@@ -1,5 +1,5 @@
 ---
-"Update operation field":
+"Update result field":
 
   - do:
       update:

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1382,7 +1382,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
             // delete the bogus types again - it might trigger merges or at least holes in the segments and enforces deleted docs!
             for (Tuple<String, String> doc : bogusIds) {
                 assertEquals("failed to delete a dummy doc [" + doc.v1() + "][" + doc.v2() + "]",
-                    DocWriteResponse.Operation.DELETE,
+                    DocWriteResponse.Operation.DELETED,
                     client().prepareDelete(doc.v1(), RANDOM_BOGUS_TYPE, doc.v2()).get().getOperation());
             }
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1382,8 +1382,8 @@ public abstract class ESIntegTestCase extends ESTestCase {
             // delete the bogus types again - it might trigger merges or at least holes in the segments and enforces deleted docs!
             for (Tuple<String, String> doc : bogusIds) {
                 assertEquals("failed to delete a dummy doc [" + doc.v1() + "][" + doc.v2() + "]",
-                    DocWriteResponse.Operation.DELETED,
-                    client().prepareDelete(doc.v1(), RANDOM_BOGUS_TYPE, doc.v2()).get().getOperation());
+                    DocWriteResponse.Result.DELETED,
+                    client().prepareDelete(doc.v1(), RANDOM_BOGUS_TYPE, doc.v2()).get().getResult());
             }
         }
         if (forceRefresh) {


### PR DESCRIPTION
Closes #19664 
Implemented the changes suggested by @nik9000 in #19664.
Added an extra element to the Operation enum to represent not_found versus noop, and renamed the elements.
Changed the `_operation` REST API field to `result`.

I thought about changing the enum name from Operation to something else, but the two options I tried (OperationResult, Result) seemed to make things more confusing, so I just left Operation as-is.

Here are the same requests from #19664 run on this version of the code:
`$curl -s -XPOST localhost:9200/test/test/1?pretty -d'{"test": "test"}' | grep result`
`>  "result" : "created",`

`$curl -s -XPOST localhost:9200/test/test/1?pretty -d'{"test": "test"}' | grep result`
`>  "result" : "updated",`

`$curl -s -XDELETE localhost:9200/test/test/1?pretty | grep result`
`>  "result" : "deleted",`

`$curl -s -XDELETE localhost:9200/test/test/1?pretty | grep result`
`>  "result" : "not_found",`

```
$curl -s -XPOST localhost:9200/test/test/1/_update?pretty -d '{
    "doc" : {
        "test" : "test"
    },
    "doc_as_upsert" : true
}' | grep result
```

`>  "result" : "created",`

```
$curl -s -XPOST localhost:9200/test/test/1/_update?pretty -d '{
    "doc" : {
        "test" : "test"
    },
    "doc_as_upsert" : true
}' | grep result
```

`>  "result" : "noop",`

```
$curl -s -XPOST localhost:9200/test/test/1/_update?pretty -d '{
    "doc" : {
        "test" : "test1"
    },
    "doc_as_upsert" : true
}' | grep result
```

`> "result" : "updated",`
