### PR TITLE
More resilient blob handling in snapshot repositories

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.NoSuchFileException;
 import java.util.Collection;
 import java.util.Map;
 
@@ -53,7 +54,8 @@ public interface BlobContainer {
      * @param   blobName
      *          The name of the blob to get an {@link InputStream} for.
      * @return  The {@code InputStream} to read the blob.
-     * @throws  IOException if the blob does not exist or can not be read.
+     * @throws  NoSuchFileException if the blob does not exist
+     * @throws  IOException if the blob can not be read.
      */
     InputStream readBlob(String blobName) throws IOException;
 
@@ -95,7 +97,8 @@ public interface BlobContainer {
      *
      * @param   blobName
      *          The name of the blob to delete.
-     * @throws  IOException if the blob does not exist, or if the blob exists but could not be deleted.
+     * @throws  NoSuchFileException if the blob does not exist
+     * @throws  IOException if the blob exists but could not be deleted.
      */
     void deleteBlob(String blobName) throws IOException;
 

--- a/core/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.NoSuchFileException;
-import java.util.Collection;
 import java.util.Map;
 
 /**

--- a/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -35,6 +35,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashMap;
 import java.util.Map;
@@ -106,8 +107,7 @@ public class FsBlobContainer extends AbstractBlobContainer {
     @Override
     public void writeBlob(String blobName, InputStream inputStream, long blobSize) throws IOException {
         final Path file = path.resolve(blobName);
-        // TODO: why is this not specifying CREATE_NEW? Do we really need to be able to truncate existing files?
-        try (OutputStream outputStream = Files.newOutputStream(file)) {
+        try (OutputStream outputStream = Files.newOutputStream(file, StandardOpenOption.CREATE_NEW)) {
             Streams.copy(inputStream, outputStream, new byte[blobStore.bufferSizeInBytes()]);
         }
         IOUtils.fsync(file, false);

--- a/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -30,7 +30,6 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -86,12 +85,9 @@ public class FsBlobContainer extends AbstractBlobContainer {
     @Override
     public void deleteBlob(String blobName) throws IOException {
         Path blobPath = path.resolve(blobName);
-        try {
-            if (!Files.deleteIfExists(blobPath)) {
-                throw new IOException("File " + blobPath.toString() + " does not exist");
-            }
-        } catch (DirectoryNotEmptyException | SecurityException e) {
-            throw new IOException(e);
+        if (!Files.deleteIfExists(blobPath)) {
+            // blobPath does not exist
+            throw new IOException("File " + blobPath.toString() + " does not exist");
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -87,7 +87,7 @@ public class FsBlobContainer extends AbstractBlobContainer {
         Path blobPath = path.resolve(blobName);
         if (!Files.deleteIfExists(blobPath)) {
             // blobPath does not exist
-            throw new IOException("File " + blobPath.toString() + " does not exist");
+            throw new IOException("File [" + blobPath.toString() + "] does not exist");
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -30,6 +30,7 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -85,7 +86,13 @@ public class FsBlobContainer extends AbstractBlobContainer {
     @Override
     public void deleteBlob(String blobName) throws IOException {
         Path blobPath = path.resolve(blobName);
-        Files.deleteIfExists(blobPath);
+        try {
+            if (!Files.deleteIfExists(blobPath)) {
+                throw new IOException("File " + blobPath.toString() + " does not exist");
+            }
+        } catch (DirectoryNotEmptyException | SecurityException e) {
+            throw new IOException(e);
+        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -95,7 +96,11 @@ public class FsBlobContainer extends AbstractBlobContainer {
 
     @Override
     public InputStream readBlob(String name) throws IOException {
-        return new BufferedInputStream(Files.newInputStream(path.resolve(name)), blobStore.bufferSizeInBytes());
+        final Path resolvedPath = path.resolve(name);
+        if (!Files.exists(resolvedPath)) {
+            throw new NoSuchFileException("[" + resolvedPath + "] file not found");
+        }
+        return new BufferedInputStream(Files.newInputStream(resolvedPath), blobStore.bufferSizeInBytes());
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -85,10 +85,7 @@ public class FsBlobContainer extends AbstractBlobContainer {
     @Override
     public void deleteBlob(String blobName) throws IOException {
         Path blobPath = path.resolve(blobName);
-        if (!Files.deleteIfExists(blobPath)) {
-            // blobPath does not exist
-            throw new IOException("File [" + blobPath.toString() + "] does not exist");
-        }
+        Files.delete(blobPath);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.blobstore.support.PlainBlobMetaData;
 import org.elasticsearch.common.io.Streams;
 
 import java.io.BufferedInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -98,10 +99,11 @@ public class FsBlobContainer extends AbstractBlobContainer {
     @Override
     public InputStream readBlob(String name) throws IOException {
         final Path resolvedPath = path.resolve(name);
-        if (!Files.exists(resolvedPath)) {
-            throw new NoSuchFileException("[" + resolvedPath + "] file not found");
+        try {
+            return new BufferedInputStream(Files.newInputStream(resolvedPath), blobStore.bufferSizeInBytes());
+        } catch (FileNotFoundException fnfe) {
+            throw new NoSuchFileException("[" + name + "] blob not found");
         }
-        return new BufferedInputStream(Files.newInputStream(resolvedPath), blobStore.bufferSizeInBytes());
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/blobstore/support/AbstractBlobContainer.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/support/AbstractBlobContainer.java
@@ -20,14 +20,11 @@
 package org.elasticsearch.common.blobstore.support;
 
 import org.elasticsearch.common.blobstore.BlobContainer;
-import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.bytes.BytesReference;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collection;
-import java.util.Map;
 
 /**
  * A base abstract blob container that implements higher level container methods.

--- a/core/src/main/java/org/elasticsearch/common/util/set/Sets.java
+++ b/core/src/main/java/org/elasticsearch/common/util/set/Sets.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -50,13 +49,6 @@ public final class Sets {
     public static <T> HashSet<T> newHashSet(T... elements) {
         Objects.requireNonNull(elements);
         HashSet<T> set = new HashSet<>(elements.length);
-        Collections.addAll(set, elements);
-        return set;
-    }
-
-    public static <T> LinkedHashSet<T> newLinkedHashSet(T... elements) {
-        Objects.requireNonNull(elements);
-        LinkedHashSet<T> set = new LinkedHashSet<>(elements.length);
         Collections.addAll(set, elements);
         return set;
     }

--- a/core/src/main/java/org/elasticsearch/common/util/set/Sets.java
+++ b/core/src/main/java/org/elasticsearch/common/util/set/Sets.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -49,6 +50,13 @@ public final class Sets {
     public static <T> HashSet<T> newHashSet(T... elements) {
         Objects.requireNonNull(elements);
         HashSet<T> set = new HashSet<>(elements.length);
+        Collections.addAll(set, elements);
+        return set;
+    }
+
+    public static <T> LinkedHashSet<T> newLinkedHashSet(T... elements) {
+        Objects.requireNonNull(elements);
+        LinkedHashSet<T> set = new LinkedHashSet<>(elements.length);
         Collections.addAll(set, elements);
         return set;
     }

--- a/core/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -43,6 +43,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.snapshots.IndexShardRestoreFailedException;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.Repository;
 
 import java.io.IOException;
@@ -394,10 +395,12 @@ final class StoreRecovery {
             translogState.totalOperationsOnStart(0);
             indexShard.prepareForIndexRecovery();
             ShardId snapshotShardId = shardId;
-            if (!shardId.getIndexName().equals(restoreSource.index())) {
-                snapshotShardId = new ShardId(restoreSource.index(), IndexMetaData.INDEX_UUID_NA_VALUE, shardId.id());
+            final String indexName = restoreSource.index();
+            if (!shardId.getIndexName().equals(indexName)) {
+                snapshotShardId = new ShardId(indexName, IndexMetaData.INDEX_UUID_NA_VALUE, shardId.id());
             }
-            repository.restoreShard(indexShard, restoreSource.snapshot().getSnapshotId(), restoreSource.version(), snapshotShardId, indexShard.recoveryState());
+            final IndexId indexId = repository.getRepositoryData().resolveIndexId(indexName);
+            repository.restoreShard(indexShard, restoreSource.snapshot().getSnapshotId(), restoreSource.version(), indexId, snapshotShardId, indexShard.recoveryState());
             indexShard.skipTranslogRecovery();
             indexShard.finalizeRecovery();
             indexShard.postRecovery("restore done");

--- a/core/src/main/java/org/elasticsearch/repositories/IndexId.java
+++ b/core/src/main/java/org/elasticsearch/repositories/IndexId.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Represents a single snapshotted index in the repository.
+ */
+public final class IndexId implements Writeable, ToXContent {
+    protected static final String NAME = "name";
+    protected static final String ID = "id";
+
+    private final String name;
+    private final String id;
+
+    public IndexId(final String name, final String id) {
+        this.name = name;
+        this.id = id;
+    }
+
+    public IndexId(final StreamInput in) throws IOException {
+        this.name = in.readString();
+        this.id = in.readString();
+    }
+
+    /**
+     * The name of the index.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * The unique ID for the index within the repository.  This is *not* the same as the
+     * index's UUID, but merely a unique file/URL friendly identifier that a repository can
+     * use to name blobs for the index.
+     */
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String toString() {
+        return "[" + name + "/" + id + "]";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        @SuppressWarnings("unchecked") IndexId that = (IndexId) o;
+        return Objects.equals(name, that.name) && Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, id);
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        out.writeString(name);
+        out.writeString(id);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        builder.field(NAME, name);
+        builder.field(ID, id);
+        builder.endObject();
+        return builder;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/repositories/IndexId.java
+++ b/core/src/main/java/org/elasticsearch/repositories/IndexId.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.Index;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -59,6 +60,12 @@ public final class IndexId implements Writeable, ToXContent {
      * The unique ID for the index within the repository.  This is *not* the same as the
      * index's UUID, but merely a unique file/URL friendly identifier that a repository can
      * use to name blobs for the index.
+     *
+     * We could not use the index's actual UUID (See {@link Index#getUUID()}) because in the
+     * case of snapshot/restore, the index UUID in the snapshotted index will be different
+     * from the index UUID assigned to it when it is restored. Hence, the actual index UUID
+     * is not useful in the context of snapshot/restore for tying a snapshotted index to the
+     * index it was snapshot from, and so we are using a separate UUID here.
      */
     public String getId() {
         return id;

--- a/core/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -47,7 +47,7 @@ import java.util.List;
  * <ul>
  * <li>Master calls {@link #initializeSnapshot(SnapshotId, List, org.elasticsearch.cluster.metadata.MetaData)}
  * with list of indices that will be included into the snapshot</li>
- * <li>Data nodes call {@link Repository#snapshotShard(IndexShard, SnapshotId, IndexCommit, IndexShardSnapshotStatus)}
+ * <li>Data nodes call {@link Repository#snapshotShard(IndexShard, SnapshotId, IndexId, IndexCommit, IndexShardSnapshotStatus)}
  * for each shard</li>
  * <li>When all shard calls return master calls {@link #finalizeSnapshot} with possible list of failures</li>
  * </ul>
@@ -88,15 +88,14 @@ public interface Repository extends LifecycleComponent {
      * @param indices    list of indices
      * @return information about snapshot
      */
-    MetaData getSnapshotMetaData(SnapshotInfo snapshot, List<String> indices) throws IOException;
+    MetaData getSnapshotMetaData(SnapshotInfo snapshot, List<IndexId> indices) throws IOException;
 
     /**
-     * Returns the list of snapshots currently stored in the repository that match the given predicate on the snapshot name.
-     * To get all snapshots, the predicate filter should return true regardless of the input.
-     *
-     * @return snapshot list
+     * Returns a {@link RepositoryData} to describe the data in the repository, including the snapshots
+     * and the indices across all snapshots found in the repository.  Throws a {@link RepositoryException}
+     * if there was an error in reading the data.
      */
-    List<SnapshotId> getSnapshots();
+    RepositoryData getRepositoryData();
 
     /**
      * Starts snapshotting process
@@ -105,7 +104,7 @@ public interface Repository extends LifecycleComponent {
      * @param indices    list of indices to be snapshotted
      * @param metaData   cluster metadata
      */
-    void initializeSnapshot(SnapshotId snapshotId, List<String> indices, MetaData metaData);
+    void initializeSnapshot(SnapshotId snapshotId, List<IndexId> indices, MetaData metaData);
 
     /**
      * Finalizes snapshotting process
@@ -113,12 +112,14 @@ public interface Repository extends LifecycleComponent {
      * This method is called on master after all shards are snapshotted.
      *
      * @param snapshotId    snapshot id
+     * @param indices       list of indices in the snapshot
+     * @param startTime     start time of the snapshot
      * @param failure       global failure reason or null
      * @param totalShards   total number of shards
      * @param shardFailures list of shard failures
      * @return snapshot description
      */
-    SnapshotInfo finalizeSnapshot(SnapshotId snapshotId, List<String> indices, long startTime, String failure, int totalShards, List<SnapshotShardFailure> shardFailures);
+    SnapshotInfo finalizeSnapshot(SnapshotId snapshotId, List<IndexId> indices, long startTime, String failure, int totalShards, List<SnapshotShardFailure> shardFailures);
 
     /**
      * Deletes snapshot
@@ -181,10 +182,11 @@ public interface Repository extends LifecycleComponent {
      *
      * @param shard               shard to be snapshotted
      * @param snapshotId          snapshot id
+     * @param indexId             id for the index being snapshotted
      * @param snapshotIndexCommit commit point
      * @param snapshotStatus      snapshot status
      */
-    void snapshotShard(IndexShard shard, SnapshotId snapshotId, IndexCommit snapshotIndexCommit, IndexShardSnapshotStatus snapshotStatus);
+    void snapshotShard(IndexShard shard, SnapshotId snapshotId, IndexId indexId, IndexCommit snapshotIndexCommit, IndexShardSnapshotStatus snapshotStatus);
 
     /**
      * Restores snapshot of the shard.
@@ -194,20 +196,22 @@ public interface Repository extends LifecycleComponent {
      * @param shard           the shard to restore the index into
      * @param snapshotId      snapshot id
      * @param version         version of elasticsearch that created this snapshot
+     * @param indexId         id of the index in the repository from which the restore is occurring
      * @param snapshotShardId shard id (in the snapshot)
      * @param recoveryState   recovery state
      */
-    void restoreShard(IndexShard shard, SnapshotId snapshotId, Version version, ShardId snapshotShardId, RecoveryState recoveryState);
+    void restoreShard(IndexShard shard, SnapshotId snapshotId, Version version, IndexId indexId, ShardId snapshotShardId, RecoveryState recoveryState);
 
     /**
      * Retrieve shard snapshot status for the stored snapshot
      *
      * @param snapshotId snapshot id
      * @param version    version of elasticsearch that created this snapshot
+     * @param indexId    the snapshotted index id for the shard to get status for
      * @param shardId    shard id
      * @return snapshot status
      */
-    IndexShardSnapshotStatus getShardSnapshotStatus(SnapshotId snapshotId, Version version, ShardId shardId);
+    IndexShardSnapshotStatus getShardSnapshotStatus(SnapshotId snapshotId, Version version, IndexId indexId, ShardId shardId);
 
 
 }

--- a/core/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/core/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.snapshots.SnapshotId;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A class that represents the data in a repository, as captured in the
+ * repository's index blob.
+ */
+public final class RepositoryData implements ToXContent {
+
+    public static final RepositoryData EMPTY = new RepositoryData(Collections.emptyList(), Collections.emptyMap());
+
+    /**
+     * The ids of the snapshots in the repository.
+     */
+    private final List<SnapshotId> snapshotIds;
+    /**
+     * The indices found in the repository across all snapshots.
+     */
+    private final Map<String, IndexMeta> indices;
+
+    public RepositoryData(List<SnapshotId> snapshotIds, Map<String, IndexMeta> indices) {
+        this.snapshotIds = Collections.unmodifiableList(snapshotIds);
+        this.indices = Collections.unmodifiableMap(indices);
+    }
+
+    /**
+     * Returns an unmodifiable list of the snapshot ids.
+     */
+    public List<SnapshotId> getSnapshotIds() {
+        return snapshotIds;
+    }
+
+    /**
+     * Returns an unmodifiable map of the index names to index metadata in the repository.
+     */
+    public Map<String, IndexMeta> getIndices() {
+        return indices;
+    }
+
+    /**
+     * Add a snapshot and its indices to the repository; returns a new instance.  If the snapshot
+     * already exists in the repository data, this method throws an IllegalArgumentException.
+     */
+    public RepositoryData addSnapshot(final SnapshotId snapshotId, final List<IndexId> snapshottedIndices) {
+        if (snapshotIds.contains(snapshotId)) {
+            throw new IllegalArgumentException("[" + snapshotId + "] already exists in the repository data");
+        }
+        List<SnapshotId> snapshots = new ArrayList<>(snapshotIds);
+        snapshots.add(snapshotId);
+        Map<String, IndexMeta> indexMetaMap = getIndices();
+        Map<String, IndexMeta> addedIndices = new HashMap<>();
+        for (IndexId indexId : snapshottedIndices) {
+            final String indexName = indexId.getName();
+            IndexMeta newIndexMeta;
+            if (indexMetaMap.containsKey(indexName)) {
+                newIndexMeta = indexMetaMap.get(indexName).addSnapshot(snapshotId);
+            } else {
+                Set<SnapshotId> ids = new LinkedHashSet<>();
+                ids.add(snapshotId);
+                newIndexMeta = new IndexMeta(indexId, ids);
+            }
+            addedIndices.put(indexName, newIndexMeta);
+        }
+        Map<String, IndexMeta> allIndices = new HashMap<>(indices);
+        allIndices.putAll(addedIndices);
+        return new RepositoryData(snapshots, allIndices);
+    }
+
+    /**
+     * Add indices to the repository metadata; returns a new instance.
+     */
+    public RepositoryData addIndices(final Map<String, IndexMeta> newIndices) {
+        Map<String, IndexMeta> map = new HashMap<>(indices);
+        map.putAll(newIndices);
+        return new RepositoryData(snapshotIds, map);
+    }
+
+    /**
+     * Remove a snapshot and remove any indices that no longer exist in the repository due to the deletion of the snapshot.
+     */
+    public RepositoryData removeSnapshot(final SnapshotId snapshotId) {
+        List<SnapshotId> newSnapshotIds = snapshotIds
+                                              .stream()
+                                              .filter(id -> snapshotId.equals(id) == false)
+                                              .collect(Collectors.toList());
+        Map<String, IndexMeta> newIndices = new HashMap<>();
+        for (IndexMeta indexMeta : indices.values()) {
+            Set<SnapshotId> set;
+            if (indexMeta.getSnapshotIds().contains(snapshotId)) {
+                if (indexMeta.getSnapshotIds().size() == 1) {
+                    // removing the snapshot will mean no more snapshots have this index, so just skip over it
+                    continue;
+                }
+                set = new LinkedHashSet<>(indexMeta.getSnapshotIds());
+                set.remove(snapshotId);
+            } else {
+                set = indexMeta.getSnapshotIds();
+            }
+            newIndices.put(indexMeta.getName(), new IndexMeta(indexMeta.getIndexId(), set));
+        }
+
+        return new RepositoryData(newSnapshotIds, newIndices);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        @SuppressWarnings("unchecked") RepositoryData that = (RepositoryData) obj;
+        return snapshotIds.equals(that.snapshotIds) && indices.equals(that.indices);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(snapshotIds, indices);
+    }
+
+    /**
+     * Resolve the index name to the index id specific to the repository,
+     * throwing an exception if the index could not be resolved.
+     */
+    public IndexId resolveIndexId(final String indexName) {
+        if (indices.containsKey(indexName)) {
+            return indices.get(indexName).getIndexId();
+        } else {
+            // on repositories created before 5.0, there was no indices information in the index
+            // blob, so if the repository hasn't been updated with new snapshots, no new index blob
+            // would have been written, so we only have old snapshots without the index information.
+            // in this case, the index id is just the index name
+            return new IndexId(indexName, indexName);
+        }
+    }
+
+    /**
+     * Resolve the given index names to index ids, throwing an exception
+     * if any of the indices could not be resolved.
+     */
+    public List<IndexId> resolveIndices(final List<String> indices) {
+        List<IndexId> resolvedIndices = new ArrayList<>(indices.size());
+        for (final String indexName : indices) {
+            resolvedIndices.add(resolveIndexId(indexName));
+        }
+        return resolvedIndices;
+    }
+
+    private static final String SNAPSHOTS = "snapshots";
+    private static final String INDICES = "indices";
+    private static final String INDEX_ID = "id";
+
+    @Override
+    public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
+        builder.startObject();
+        // write the snapshots list
+        builder.startArray(SNAPSHOTS);
+        for (final SnapshotId snapshot : getSnapshotIds()) {
+            snapshot.toXContent(builder, params);
+        }
+        builder.endArray();
+        // write the indices map
+        builder.startObject(INDICES);
+        for (final IndexMeta indexMeta : getIndices().values()) {
+            builder.startObject(indexMeta.getName());
+            builder.field(INDEX_ID, indexMeta.getId());
+            builder.startArray(SNAPSHOTS);
+            for (final SnapshotId snapshotId : indexMeta.getSnapshotIds()) {
+                snapshotId.toXContent(builder, params);
+            }
+            builder.endArray();
+            builder.endObject();
+        }
+        builder.endObject();
+        builder.endObject();
+        return builder;
+    }
+
+    public static RepositoryData fromXContent(final XContentParser parser) throws IOException {
+        List<SnapshotId> snapshots = new ArrayList<>();
+        Map<String, IndexMeta> indices = new HashMap<>();
+        if (parser.nextToken() == XContentParser.Token.START_OBJECT) {
+            while (parser.nextToken() == XContentParser.Token.FIELD_NAME) {
+                String currentFieldName = parser.currentName();
+                if (SNAPSHOTS.equals(currentFieldName)) {
+                    if (parser.nextToken() == XContentParser.Token.START_ARRAY) {
+                        while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                            snapshots.add(SnapshotId.fromXContent(parser));
+                        }
+                    } else {
+                        throw new ElasticsearchParseException("expected array for [" + currentFieldName + "]");
+                    }
+                } else if (INDICES.equals(currentFieldName)) {
+                    if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
+                        throw new ElasticsearchParseException("start object expected [indices]");
+                    }
+                    while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                        String indexName = parser.currentName();
+                        String indexId = null;
+                        Set<SnapshotId> snapshotIds = new LinkedHashSet<>();
+                        if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
+                            throw new ElasticsearchParseException("start object expected index[" + indexName + "]");
+                        }
+                        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                            String indexMetaFieldName = parser.currentName();
+                            parser.nextToken();
+                            if (INDEX_ID.equals(indexMetaFieldName)) {
+                                indexId = parser.text();
+                            } else if (SNAPSHOTS.equals(indexMetaFieldName)) {
+                                if (parser.currentToken() != XContentParser.Token.START_ARRAY) {
+                                    throw new ElasticsearchParseException("start array expected [snapshots]");
+                                }
+                                while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                                    snapshotIds.add(SnapshotId.fromXContent(parser));
+                                }
+                            }
+                        }
+                        assert indexId != null;
+                        indices.put(indexName, new IndexMeta(indexName, indexId, snapshotIds));
+                    }
+                } else {
+                    throw new ElasticsearchParseException("unknown field name  [" + currentFieldName + "]");
+                }
+            }
+        } else {
+            throw new ElasticsearchParseException("start object expected");
+        }
+        return new RepositoryData(snapshots, indices);
+    }
+
+    /**
+     * Represents information about a single index snapshotted in a repository.
+     */
+    public static final class IndexMeta implements Writeable {
+        private final IndexId indexId;
+        private final Set<SnapshotId> snapshotIds;
+
+        public IndexMeta(final String name, final String id, final Set<SnapshotId> snapshotIds) {
+            this(new IndexId(name, id), snapshotIds);
+        }
+
+        public IndexMeta(final IndexId indexId, final Set<SnapshotId> snapshotIds) {
+            this.indexId = indexId;
+            this.snapshotIds = Collections.unmodifiableSet(snapshotIds);
+        }
+
+        public IndexMeta(final StreamInput in) throws IOException {
+            indexId = new IndexId(in);
+            final int size = in.readVInt();
+            Set<SnapshotId> ids = new LinkedHashSet<>();
+            for (int i = 0; i < size; i++) {
+                ids.add(new SnapshotId(in));
+            }
+            snapshotIds = Collections.unmodifiableSet(ids);
+        }
+
+        /**
+         * The name of the index.
+         */
+        public String getName() {
+            return indexId.getName();
+        }
+
+        /**
+         * The unique ID for the index within the repository.  This is *not* the same as the
+         * index's UUID, but merely a unique file/URL friendly identifier that a repository can
+         * use to name blobs for the index.
+         */
+        public String getId() {
+            return indexId.getId();
+        }
+
+        /**
+         * An unmodifiable set of snapshot ids that contain this index as part of its snapshot.
+         */
+        public Set<SnapshotId> getSnapshotIds() {
+            return snapshotIds;
+        }
+
+        /**
+         * The snapshotted index id.
+         */
+        public IndexId getIndexId() {
+            return indexId;
+        }
+
+        /**
+         * Add a snapshot id to the list of snapshots that contain this index.
+         */
+        public IndexMeta addSnapshot(final SnapshotId snapshotId) {
+            Set<SnapshotId> withAdded = new LinkedHashSet<>(snapshotIds);
+            withAdded.add(snapshotId);
+            return new IndexMeta(indexId, withAdded);
+        }
+
+        @Override
+        public void writeTo(final StreamOutput out) throws IOException {
+            indexId.writeTo(out);
+            out.writeVInt(snapshotIds.size());
+            for (SnapshotId snapshotId : snapshotIds) {
+                snapshotId.writeTo(out);
+            }
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            @SuppressWarnings("unchecked") IndexMeta that = (IndexMeta) obj;
+            return indexId.equals(that.indexId) && snapshotIds.equals(that.snapshotIds);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(indexId, snapshotIds);
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/core/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -58,17 +58,26 @@ public final class RepositoryData implements ToXContent {
      * The snapshots that each index belongs to.
      */
     private final Map<IndexId, Set<SnapshotId>> indexSnapshots;
+    /**
+     * Whether the repository data is in the legacy (pre 5.0) format
+     */
+    private final boolean legacyFormat;
 
-    public RepositoryData(List<SnapshotId> snapshotIds, Map<IndexId, Set<SnapshotId>> indexSnapshots) {
+    private RepositoryData(List<SnapshotId> snapshotIds, Map<IndexId, Set<SnapshotId>> indexSnapshots, boolean legacyFormat) {
         this.snapshotIds = Collections.unmodifiableList(snapshotIds);
         this.indices = Collections.unmodifiableMap(indexSnapshots.keySet()
                                                        .stream()
                                                        .collect(Collectors.toMap(IndexId::getName, Function.identity())));
         this.indexSnapshots = Collections.unmodifiableMap(indexSnapshots);
+        this.legacyFormat = legacyFormat;
+    }
+
+    public RepositoryData(List<SnapshotId> snapshotIds, Map<IndexId, Set<SnapshotId>> indexSnapshots) {
+        this(snapshotIds, indexSnapshots, false);
     }
 
     protected RepositoryData copy() {
-        return new RepositoryData(snapshotIds, indexSnapshots);
+        return new RepositoryData(snapshotIds, indexSnapshots, legacyFormat);
     }
 
     /**
@@ -83,6 +92,13 @@ public final class RepositoryData implements ToXContent {
      */
     public Map<String, IndexId> getIndices() {
         return indices;
+    }
+
+    /**
+     * Returns whether the repository data format is in the legacy (pre 5.0) format or not
+     */
+    public boolean isLegacyFormat() {
+        return legacyFormat;
     }
 
     /**
@@ -256,7 +272,7 @@ public final class RepositoryData implements ToXContent {
         return builder;
     }
 
-    public static RepositoryData fromXContent(final XContentParser parser) throws IOException {
+    public static RepositoryData fromXContent(final XContentParser parser, boolean legacyFormat) throws IOException {
         List<SnapshotId> snapshots = new ArrayList<>();
         Map<IndexId, Set<SnapshotId>> indexSnapshots = new HashMap<>();
         if (parser.nextToken() == XContentParser.Token.START_OBJECT) {
@@ -305,7 +321,7 @@ public final class RepositoryData implements ToXContent {
         } else {
             throw new ElasticsearchParseException("start object expected");
         }
-        return new RepositoryData(snapshots, indexSnapshots);
+        return new RepositoryData(snapshots, indexSnapshots, legacyFormat);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/core/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -58,26 +58,17 @@ public final class RepositoryData implements ToXContent {
      * The snapshots that each index belongs to.
      */
     private final Map<IndexId, Set<SnapshotId>> indexSnapshots;
-    /**
-     * Whether the repository data is in the legacy (pre 5.0) format
-     */
-    private final boolean legacyFormat;
 
-    private RepositoryData(List<SnapshotId> snapshotIds, Map<IndexId, Set<SnapshotId>> indexSnapshots, boolean legacyFormat) {
+    public RepositoryData(List<SnapshotId> snapshotIds, Map<IndexId, Set<SnapshotId>> indexSnapshots) {
         this.snapshotIds = Collections.unmodifiableList(snapshotIds);
         this.indices = Collections.unmodifiableMap(indexSnapshots.keySet()
                                                        .stream()
                                                        .collect(Collectors.toMap(IndexId::getName, Function.identity())));
         this.indexSnapshots = Collections.unmodifiableMap(indexSnapshots);
-        this.legacyFormat = legacyFormat;
-    }
-
-    public RepositoryData(List<SnapshotId> snapshotIds, Map<IndexId, Set<SnapshotId>> indexSnapshots) {
-        this(snapshotIds, indexSnapshots, false);
     }
 
     protected RepositoryData copy() {
-        return new RepositoryData(snapshotIds, indexSnapshots, legacyFormat);
+        return new RepositoryData(snapshotIds, indexSnapshots);
     }
 
     /**
@@ -92,13 +83,6 @@ public final class RepositoryData implements ToXContent {
      */
     public Map<String, IndexId> getIndices() {
         return indices;
-    }
-
-    /**
-     * Returns whether the repository data format is in the legacy (pre 5.0) format or not
-     */
-    public boolean isLegacyFormat() {
-        return legacyFormat;
     }
 
     /**
@@ -272,7 +256,7 @@ public final class RepositoryData implements ToXContent {
         return builder;
     }
 
-    public static RepositoryData fromXContent(final XContentParser parser, boolean legacyFormat) throws IOException {
+    public static RepositoryData fromXContent(final XContentParser parser) throws IOException {
         List<SnapshotId> snapshots = new ArrayList<>();
         Map<IndexId, Set<SnapshotId>> indexSnapshots = new HashMap<>();
         if (parser.nextToken() == XContentParser.Token.START_OBJECT) {
@@ -321,7 +305,7 @@ public final class RepositoryData implements ToXContent {
         } else {
             throw new ElasticsearchParseException("start object expected");
         }
-        return new RepositoryData(snapshots, indexSnapshots, legacyFormat);
+        return new RepositoryData(snapshots, indexSnapshots);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -45,6 +45,8 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.store.InputStreamIndexInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.iterable.Iterables;
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.snapshots.IndexShardRestoreFailedException;
 import org.elasticsearch.index.snapshots.IndexShardSnapshotException;
@@ -58,6 +60,9 @@ import org.elasticsearch.index.snapshots.blobstore.SnapshotFiles;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.StoreFileMetaData;
 import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.repositories.RepositoryData;
+import org.elasticsearch.repositories.RepositoryData.IndexMeta;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.Strings;
@@ -103,6 +108,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
@@ -120,9 +127,9 @@ import static java.util.Collections.unmodifiableMap;
  *   STORE_ROOT
  *   |- index-N           - list of all snapshot name as JSON array, N is the generation of the file
  *   |- index.latest      - contains the numeric value of the latest generation of the index file (i.e. N from above)
- *   |- snapshot-20131010 - JSON serialized Snapshot for snapshot "20131010"
+ *   |- snap-20131010 - JSON serialized Snapshot for snapshot "20131010"
  *   |- meta-20131010.dat - JSON serialized MetaData for snapshot "20131010" (includes only global metadata)
- *   |- snapshot-20131011 - JSON serialized Snapshot for snapshot "20131011"
+ *   |- snap-20131011 - JSON serialized Snapshot for snapshot "20131011"
  *   |- meta-20131011.dat - JSON serialized MetaData for snapshot "20131011"
  *   .....
  *   |- indices/ - data for all indices
@@ -163,13 +170,13 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     private static final String SNAPSHOT_PREFIX = "snap-";
 
-    protected static final String SNAPSHOT_CODEC = "snapshot";
+    private static final String SNAPSHOT_CODEC = "snapshot";
 
     static final String SNAPSHOTS_FILE = "index"; // package private for unit testing
 
-    private static final String SNAPSHOTS_FILE_PREFIX = "index-";
+    private static final String INDEX_FILE_PREFIX = "index-";
 
-    private static final String SNAPSHOTS_INDEX_LATEST_BLOB = "index.latest";
+    private static final String INDEX_LATEST_BLOB = "index.latest";
 
     private static final String TESTS_FILE = "tests-";
 
@@ -299,13 +306,26 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         return null;
     }
 
+    public Map<String, IndexId> getIndices() {
+        try {
+            return readIndexGen()
+                       .getIndices()
+                       .values()
+                       .stream()
+                       .map(IndexMeta::getIndexId)
+                       .collect(Collectors.toMap(IndexId::getName, Function.identity()));
+        } catch (IOException e) {
+            throw new RepositoryException(metadata.name(), "Could not get the indices in the repository.", e);
+        }
+    }
+
     @Override
     public RepositoryMetaData getMetadata() {
         return metadata;
     }
 
     @Override
-    public void initializeSnapshot(SnapshotId snapshotId, List<String> indices, MetaData clusterMetadata) {
+    public void initializeSnapshot(SnapshotId snapshotId, List<IndexId> indices, MetaData clusterMetaData) {
         if (isReadOnly()) {
             throw new RepositoryException(metadata.name(), "cannot create snapshot in a readonly repository");
         }
@@ -319,11 +339,17 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     snapshotLegacyFormat.exists(snapshotsBlobContainer, snapshotName)) {
                 throw new SnapshotCreationException(metadata.name(), snapshotId, "snapshot with such name already exists");
             }
+
+            // update the index file if created pre 5.0 to include the indices in the repository
+            updateIndexGenIfNecessary();
+
             // Write Global MetaData
-            globalMetaDataFormat.write(clusterMetadata, snapshotsBlobContainer, blobId(snapshotId));
-            for (String index : indices) {
-                final IndexMetaData indexMetaData = clusterMetadata.index(index);
-                final BlobPath indexPath = basePath().add("indices").add(index);
+            globalMetaDataFormat.write(clusterMetaData, snapshotsBlobContainer, blobId(snapshotId));
+
+            // write the index metadata for each index in the snapshot
+            for (IndexId index : indices) {
+                final IndexMetaData indexMetaData = clusterMetaData.index(index.getName());
+                final BlobPath indexPath = basePath().add("indices").add(index.getId());
                 final BlobContainer indexMetaDataBlobContainer = blobStore().blobContainer(indexPath);
                 indexMetaDataFormat.write(indexMetaData, indexMetaDataBlobContainer, blobId(snapshotId));
             }
@@ -332,11 +358,49 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         }
     }
 
+    // Older repository index files (index-N) only contain snapshot info, not indices info,
+    // so if the index file is of the older format, populate it with the indices entries
+    // so we know which indices of snapshots have blob ids in the older format.
+    private void updateIndexGenIfNecessary() {
+        if (isReadOnly()) {
+            // nothing to update on read only repositories
+            return;
+        }
+        if (snapshotsBlobContainer.blobExists(SNAPSHOTS_FILE) == false) {
+            // pre 5.0 repositories have a single index file instead of generational index-N files,
+            // so if the single index file is missing, we already have an up to date repository.
+            return;
+        }
+        final RepositoryData repositoryData = getRepositoryData();
+        final Map<String, Set<SnapshotId>> indexToSnapshots = new HashMap<>();
+        for (final SnapshotId snapshotId : repositoryData.getSnapshotIds()) {
+            for (final String indexName : getSnapshotInfo(snapshotId).indices()) {
+                if (indexToSnapshots.containsKey(indexName)) {
+                    indexToSnapshots.get(indexName).add(snapshotId);
+                } else {
+                    indexToSnapshots.put(indexName, Sets.newHashSet(snapshotId));
+                }
+            }
+        }
+        final Map<String, IndexMeta> indices = new HashMap<>();
+        for (Map.Entry<String, Set<SnapshotId>> entry : indexToSnapshots.entrySet()) {
+            final String indexName = entry.getKey();
+            indices.put(indexName, new IndexMeta(indexName, indexName, entry.getValue()));
+        }
+        try {
+            // write the new index gen file with the indices included
+            writeIndexGen(repositoryData.addIndices(indices));
+        } catch (IOException e) {
+            throw new RepositoryException(metadata.name(), "failed to update the repository index blob with indices data on startup", e);
+        }
+    }
+
     @Override
     public void deleteSnapshot(SnapshotId snapshotId) {
         if (isReadOnly()) {
             throw new RepositoryException(metadata.name(), "cannot delete snapshot from a readonly repository");
         }
+        final RepositoryData repositoryData = getRepositoryData();
         List<String> indices = Collections.emptyList();
         SnapshotInfo snapshot = null;
         try {
@@ -350,19 +414,16 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         MetaData metaData = null;
         try {
             if (snapshot != null) {
-                metaData = readSnapshotMetaData(snapshotId, snapshot.version(), indices, true);
+                metaData = readSnapshotMetaData(snapshotId, snapshot.version(), repositoryData.resolveIndices(indices), true);
             } else {
-                metaData = readSnapshotMetaData(snapshotId, null, indices, true);
+                metaData = readSnapshotMetaData(snapshotId, null, repositoryData.resolveIndices(indices), true);
             }
         } catch (IOException | SnapshotException ex) {
             logger.warn("cannot read metadata for snapshot [{}]", ex, snapshotId);
         }
         try {
-            // Delete snapshot from the snapshot list, since it is the maintainer of truth of active snapshots
-            List<SnapshotId> snapshotIds = getSnapshots().stream()
-                                               .filter(id -> snapshotId.equals(id) == false)
-                                               .collect(Collectors.toList());
-            writeSnapshotsToIndexGen(snapshotIds);
+            // Delete snapshot from the index file, since it is the maintainer of truth of active snapshots
+            writeIndexGen(repositoryData.removeSnapshot(snapshotId));
 
             // delete the snapshot file
             safeSnapshotBlobDelete(snapshot, blobId(snapshotId));
@@ -371,7 +432,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
             // Now delete all indices
             for (String index : indices) {
-                BlobPath indexPath = basePath().add("indices").add(index);
+                final IndexId indexId = repositoryData.resolveIndexId(index);
+                BlobPath indexPath = basePath().add("indices").add(indexId.getId());
                 BlobContainer indexMetaDataBlobContainer = blobStore().blobContainer(indexPath);
                 try {
                     indexMetaDataFormat(snapshot.version()).delete(indexMetaDataBlobContainer, blobId(snapshotId));
@@ -383,7 +445,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     if (indexMetaData != null) {
                         for (int shardId = 0; shardId < indexMetaData.getNumberOfShards(); shardId++) {
                             try {
-                                delete(snapshotId, snapshot.version(), new ShardId(indexMetaData.getIndex(), shardId));
+                                delete(snapshotId, snapshot.version(), indexId, new ShardId(indexMetaData.getIndex(), shardId));
                             } catch (SnapshotException ex) {
                                 logger.warn("[{}] failed to delete shard data for shard [{}][{}]", ex, snapshotId, index, shardId);
                             }
@@ -449,26 +511,24 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      */
     @Override
     public SnapshotInfo finalizeSnapshot(final SnapshotId snapshotId,
-                                         final List<String> indices,
+                                         final List<IndexId> indices,
                                          final long startTime,
                                          final String failure,
                                          final int totalShards,
                                          final List<SnapshotShardFailure> shardFailures) {
         try {
             SnapshotInfo blobStoreSnapshot = new SnapshotInfo(snapshotId,
-                                                              indices,
+                                                              indices.stream().map(IndexId::getName).collect(Collectors.toList()),
                                                               startTime,
                                                               failure,
                                                               System.currentTimeMillis(),
                                                               totalShards,
                                                               shardFailures);
             snapshotFormat.write(blobStoreSnapshot, snapshotsBlobContainer, blobId(snapshotId));
-            List<SnapshotId> snapshotIds = getSnapshots();
+            final RepositoryData repositoryData = getRepositoryData();
+            List<SnapshotId> snapshotIds = repositoryData.getSnapshotIds();
             if (!snapshotIds.contains(snapshotId)) {
-                snapshotIds = new ArrayList<>(snapshotIds);
-                snapshotIds.add(snapshotId);
-                snapshotIds = Collections.unmodifiableList(snapshotIds);
-                writeSnapshotsToIndexGen(snapshotIds);
+                writeIndexGen(repositoryData.addSnapshot(snapshotId, indices));
             }
             return blobStoreSnapshot;
         } catch (IOException ex) {
@@ -476,20 +536,12 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         }
     }
 
-    @Override
     public List<SnapshotId> getSnapshots() {
-        try {
-            return Collections.unmodifiableList(readSnapshotsFromIndex());
-        } catch (NoSuchFileException | FileNotFoundException e) {
-            // its a fresh repository, no index file exists, so return an empty list
-            return Collections.emptyList();
-        } catch (IOException ioe) {
-            throw new RepositoryException(metadata.name(), "failed to list snapshots in repository", ioe);
-        }
+        return getRepositoryData().getSnapshotIds();
     }
 
     @Override
-    public MetaData getSnapshotMetaData(SnapshotInfo snapshot, List<String> indices) throws IOException {
+    public MetaData getSnapshotMetaData(SnapshotInfo snapshot, List<IndexId> indices) throws IOException {
         return readSnapshotMetaData(snapshot.snapshotId(), snapshot.version(), indices, false);
     }
 
@@ -511,7 +563,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         }
     }
 
-    private MetaData readSnapshotMetaData(SnapshotId snapshotId, Version snapshotVersion, List<String> indices, boolean ignoreIndexErrors) throws IOException {
+    private MetaData readSnapshotMetaData(SnapshotId snapshotId, Version snapshotVersion, List<IndexId> indices, boolean ignoreIndexErrors) throws IOException {
         MetaData metaData;
         if (snapshotVersion == null) {
             // When we delete corrupted snapshots we might not know which version we are dealing with
@@ -533,14 +585,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             throw new SnapshotException(metadata.name(), snapshotId, "failed to get snapshots", ex);
         }
         MetaData.Builder metaDataBuilder = MetaData.builder(metaData);
-        for (String index : indices) {
-            BlobPath indexPath = basePath().add("indices").add(index);
+        for (IndexId index : indices) {
+            BlobPath indexPath = basePath().add("indices").add(index.getId());
             BlobContainer indexMetaDataBlobContainer = blobStore().blobContainer(indexPath);
             try {
                 metaDataBuilder.put(indexMetaDataFormat(snapshotVersion).read(indexMetaDataBlobContainer, blobId(snapshotId)), false);
             } catch (ElasticsearchParseException | IOException ex) {
                 if (ignoreIndexErrors) {
-                    logger.warn("[{}] [{}] failed to read metadata for index", ex, snapshotId, index);
+                    logger.warn("[{}] [{}] failed to read metadata for index", ex, snapshotId, index.getName());
                 } else {
                     throw ex;
                 }
@@ -608,10 +660,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         }
     }
 
-    private static final String SNAPSHOTS = "snapshots";
-    private static final String NAME = "name";
-    private static final String UUID = "uuid";
-
     @Override
     public long getSnapshotThrottleTimeInNanos() {
         return snapshotRateLimitingTimeInNanos.count();
@@ -655,6 +703,18 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         }
     }
 
+    @Override
+    public RepositoryData getRepositoryData() {
+        try {
+            return readIndexGen();
+        } catch (NoSuchFileException nsfe) {
+            // repository doesn't have an index blob, its a new blank repo
+            return RepositoryData.EMPTY;
+        } catch (IOException ioe) {
+            throw new RepositoryException(metadata.name(), "could not read repository data from index blob", ioe);
+        }
+    }
+
     public static String testBlobPrefix(String seed) {
         return TESTS_FILE + seed;
     }
@@ -669,34 +729,29 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         return snapshotsBlobContainer;
     }
 
-    protected void writeSnapshotsToIndexGen(final List<SnapshotId> snapshots) throws IOException {
+    protected void writeIndexGen(final RepositoryData repositoryData) throws IOException {
         assert isReadOnly() == false; // can not write to a read only repository
         final BytesReference snapshotsBytes;
         try (BytesStreamOutput bStream = new BytesStreamOutput()) {
             try (StreamOutput stream = new OutputStreamStreamOutput(bStream)) {
                 XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON, stream);
-                builder.startObject();
-                builder.startArray(SNAPSHOTS);
-                for (SnapshotId snapshot : snapshots) {
-                    builder.startObject();
-                    builder.field(NAME, snapshot.getName());
-                    builder.field(UUID, snapshot.getUUID());
-                    builder.endObject();
-                }
-                builder.endArray();
-                builder.endObject();
+                repositoryData.toXContent(builder, ToXContent.EMPTY_PARAMS);
                 builder.close();
             }
             snapshotsBytes = bStream.bytes();
         }
         final long gen = latestIndexBlobId() + 1;
         // write the index file
-        writeAtomic(SNAPSHOTS_FILE_PREFIX + Long.toString(gen), snapshotsBytes);
+        writeAtomic(INDEX_FILE_PREFIX + Long.toString(gen), snapshotsBytes);
         // delete the N-2 index file if it exists, keep the previous one around as a backup
         if (isReadOnly() == false && gen - 2 >= 0) {
-            final String oldSnapshotIndexFile = SNAPSHOTS_FILE_PREFIX + Long.toString(gen - 2);
+            final String oldSnapshotIndexFile = INDEX_FILE_PREFIX + Long.toString(gen - 2);
             if (snapshotsBlobContainer.blobExists(oldSnapshotIndexFile)) {
                 snapshotsBlobContainer.deleteBlob(oldSnapshotIndexFile);
+            }
+            // delete the old index file (non-generational) if it exists
+            if (snapshotsBlobContainer.blobExists(SNAPSHOTS_FILE)) {
+                snapshotsBlobContainer.deleteBlob(SNAPSHOTS_FILE);
             }
         }
 
@@ -706,13 +761,13 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             bStream.writeLong(gen);
             genBytes = bStream.bytes();
         }
-        if (snapshotsBlobContainer.blobExists(SNAPSHOTS_INDEX_LATEST_BLOB)) {
-            snapshotsBlobContainer.deleteBlob(SNAPSHOTS_INDEX_LATEST_BLOB);
+        if (snapshotsBlobContainer.blobExists(INDEX_LATEST_BLOB)) {
+            snapshotsBlobContainer.deleteBlob(INDEX_LATEST_BLOB);
         }
-        writeAtomic(SNAPSHOTS_INDEX_LATEST_BLOB, genBytes);
+        writeAtomic(INDEX_LATEST_BLOB, genBytes);
     }
 
-    protected List<SnapshotId> readSnapshotsFromIndex() throws IOException {
+    RepositoryData readIndexGen() throws IOException {
         final long indexGen = latestIndexBlobId();
         final String snapshotsIndexBlobName;
         if (indexGen == -1) {
@@ -720,47 +775,15 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             // old format, so look for the older index file before returning an empty list
             snapshotsIndexBlobName = SNAPSHOTS_FILE;
         } else {
-            snapshotsIndexBlobName = SNAPSHOTS_FILE_PREFIX + Long.toString(indexGen);
+            snapshotsIndexBlobName = INDEX_FILE_PREFIX + Long.toString(indexGen);
         }
 
         try (InputStream blob = snapshotsBlobContainer.readBlob(snapshotsIndexBlobName)) {
             BytesStreamOutput out = new BytesStreamOutput();
             Streams.copy(blob, out);
-            ArrayList<SnapshotId> snapshots = new ArrayList<>();
             try (XContentParser parser = XContentHelper.createParser(out.bytes())) {
-                if (parser.nextToken() == XContentParser.Token.START_OBJECT) {
-                    if (parser.nextToken() == XContentParser.Token.FIELD_NAME) {
-                        String currentFieldName = parser.currentName();
-                        if (SNAPSHOTS.equals(currentFieldName)) {
-                            if (parser.nextToken() == XContentParser.Token.START_ARRAY) {
-                                while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                                    // the new format from 5.0 which contains the snapshot name and uuid
-                                    String name = null;
-                                    String uuid = null;
-                                    if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
-                                        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-                                            currentFieldName = parser.currentName();
-                                            parser.nextToken();
-                                            if (NAME.equals(currentFieldName)) {
-                                                name = parser.text();
-                                            } else if (UUID.equals(currentFieldName)) {
-                                                uuid = parser.text();
-                                            }
-                                        }
-                                        snapshots.add(new SnapshotId(name, uuid));
-                                    }
-                                    // the old format pre 5.0 that only contains the snapshot name, use the name as the uuid too
-                                    else {
-                                        name = parser.text();
-                                        snapshots.add(new SnapshotId(name, SnapshotId.UNASSIGNED_UUID));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                return RepositoryData.fromXContent(parser);
             }
-            return Collections.unmodifiableList(snapshots);
         }
     }
 
@@ -807,7 +830,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     // package private for testing
     long readSnapshotIndexLatestBlob() throws IOException {
-        try (InputStream blob = snapshotsBlobContainer.readBlob(SNAPSHOTS_INDEX_LATEST_BLOB)) {
+        try (InputStream blob = snapshotsBlobContainer.readBlob(INDEX_LATEST_BLOB)) {
             BytesStreamOutput out = new BytesStreamOutput();
             Streams.copy(blob, out);
             return Numbers.bytesToLong(out.bytes().toBytesRef());
@@ -815,7 +838,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     }
 
     private long listBlobsToGetLatestIndexId() throws IOException {
-        Map<String, BlobMetaData> blobs = snapshotsBlobContainer.listBlobsByPrefix(SNAPSHOTS_FILE_PREFIX);
+        Map<String, BlobMetaData> blobs = snapshotsBlobContainer.listBlobsByPrefix(INDEX_FILE_PREFIX);
         long latest = -1;
         if (blobs.isEmpty()) {
             // no snapshot index blobs have been written yet
@@ -824,7 +847,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         for (final BlobMetaData blobMetaData : blobs.values()) {
             final String blobName = blobMetaData.name();
             try {
-                final long curr = Long.parseLong(blobName.substring(SNAPSHOTS_FILE_PREFIX.length()));
+                final long curr = Long.parseLong(blobName.substring(INDEX_FILE_PREFIX.length()));
                 latest = Math.max(latest, curr);
             } catch (NumberFormatException nfe) {
                 // the index- blob wasn't of the format index-N where N is a number,
@@ -847,9 +870,11 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         }
     }
 
+
+
     @Override
-    public void snapshotShard(IndexShard shard, SnapshotId snapshotId, IndexCommit snapshotIndexCommit, IndexShardSnapshotStatus snapshotStatus) {
-        SnapshotContext snapshotContext = new SnapshotContext(shard, snapshotId, snapshotStatus);
+    public void snapshotShard(IndexShard shard, SnapshotId snapshotId, IndexId indexId, IndexCommit snapshotIndexCommit, IndexShardSnapshotStatus snapshotStatus) {
+        SnapshotContext snapshotContext = new SnapshotContext(shard, snapshotId, indexId, snapshotStatus);
         snapshotStatus.startTime(System.currentTimeMillis());
 
         try {
@@ -869,8 +894,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     }
 
     @Override
-    public void restoreShard(IndexShard shard, SnapshotId snapshotId, Version version, ShardId snapshotShardId, RecoveryState recoveryState) {
-        final RestoreContext snapshotContext = new RestoreContext(shard, snapshotId, version, snapshotShardId, recoveryState);
+    public void restoreShard(IndexShard shard, SnapshotId snapshotId, Version version, IndexId indexId, ShardId snapshotShardId, RecoveryState recoveryState) {
+        final RestoreContext snapshotContext = new RestoreContext(shard, snapshotId, version, indexId, snapshotShardId, recoveryState);
         try {
             snapshotContext.restore();
         } catch (Exception e) {
@@ -879,8 +904,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     }
 
     @Override
-    public IndexShardSnapshotStatus getShardSnapshotStatus(SnapshotId snapshotId, Version version, ShardId shardId) {
-        Context context = new Context(snapshotId, version, shardId);
+    public IndexShardSnapshotStatus getShardSnapshotStatus(SnapshotId snapshotId, Version version, IndexId indexId, ShardId shardId) {
+        Context context = new Context(snapshotId, version, indexId, shardId);
         BlobStoreIndexShardSnapshot snapshot = context.loadSnapshot();
         IndexShardSnapshotStatus status = new IndexShardSnapshotStatus();
         status.updateStage(IndexShardSnapshotStatus.Stage.DONE);
@@ -914,8 +939,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      * @param snapshotId snapshot id
      * @param shardId    shard id
      */
-    public void delete(SnapshotId snapshotId, Version version, ShardId shardId) {
-        Context context = new Context(snapshotId, version, shardId, shardId);
+    private void delete(SnapshotId snapshotId, Version version, IndexId indexId, ShardId shardId) {
+        Context context = new Context(snapshotId, version, indexId, shardId, shardId);
         context.delete();
     }
 
@@ -948,15 +973,15 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
         protected final Version version;
 
-        public Context(SnapshotId snapshotId, Version version, ShardId shardId) {
-            this(snapshotId, version, shardId, shardId);
+        public Context(SnapshotId snapshotId, Version version, IndexId indexId, ShardId shardId) {
+            this(snapshotId, version, indexId, shardId, shardId);
         }
 
-        public Context(SnapshotId snapshotId, Version version, ShardId shardId, ShardId snapshotShardId) {
+        public Context(SnapshotId snapshotId, Version version, IndexId indexId, ShardId shardId, ShardId snapshotShardId) {
             this.snapshotId = snapshotId;
             this.version = version;
             this.shardId = shardId;
-            blobContainer = blobStore().blobContainer(basePath().add("indices").add(snapshotShardId.getIndexName()).add(Integer.toString(snapshotShardId.getId())));
+            blobContainer = blobStore().blobContainer(basePath().add("indices").add(indexId.getId()).add(Integer.toString(snapshotShardId.getId())));
         }
 
         /**
@@ -1154,10 +1179,11 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
          *
          * @param shard          shard to be snapshotted
          * @param snapshotId     snapshot id
+         * @param indexId        the id of the index being snapshotted
          * @param snapshotStatus snapshot status to report progress
          */
-        public SnapshotContext(IndexShard shard, SnapshotId snapshotId, IndexShardSnapshotStatus snapshotStatus) {
-            super(snapshotId, Version.CURRENT, shard.shardId());
+        public SnapshotContext(IndexShard shard, SnapshotId snapshotId, IndexId indexId, IndexShardSnapshotStatus snapshotStatus) {
+            super(snapshotId, Version.CURRENT, indexId, shard.shardId());
             this.snapshotStatus = snapshotStatus;
             this.store = shard.store();
         }
@@ -1441,11 +1467,12 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
          *
          * @param shard           shard to restore into
          * @param snapshotId      snapshot id
+         * @param indexId         id of the index being restored
          * @param snapshotShardId shard in the snapshot that data should be restored from
          * @param recoveryState   recovery state to report progress
          */
-        public RestoreContext(IndexShard shard, SnapshotId snapshotId, Version version, ShardId snapshotShardId, RecoveryState recoveryState) {
-            super(snapshotId, version, shard.shardId(), snapshotShardId);
+        public RestoreContext(IndexShard shard, SnapshotId snapshotId, Version version, IndexId indexId, ShardId snapshotShardId, RecoveryState recoveryState) {
+            super(snapshotId, version, indexId, shard.shardId(), snapshotShardId);
             this.recoveryState = recoveryState;
             store = shard.store();
         }
@@ -1619,6 +1646,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 }
             }
         }
-
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotId.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotId.java
@@ -34,10 +34,6 @@ import java.util.Objects;
  */
 public final class SnapshotId implements Writeable, ToXContent {
 
-    /**
-     * This value is for older snapshots that don't have a UUID.
-     */
-    public static final String UNASSIGNED_UUID = "_na_";
     private static final String NAME = "name";
     private static final String UUID = "uuid";
 
@@ -144,10 +140,10 @@ public final class SnapshotId implements Writeable, ToXContent {
                 }
             }
             return new SnapshotId(name, uuid);
-        }
-        // the old format pre 5.0 that only contains the snapshot name, use the name as the uuid too
-        else {
-            return new SnapshotId(parser.text(), SnapshotId.UNASSIGNED_UUID);
+        } else {
+            // the old format pre 5.0 that only contains the snapshot name, use the name as the uuid too
+            final String name = parser.text();
+            return new SnapshotId(name, name);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotId.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotId.java
@@ -22,6 +22,9 @@ package org.elasticsearch.snapshots;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -29,12 +32,14 @@ import java.util.Objects;
 /**
  * SnapshotId - snapshot name + snapshot UUID
  */
-public final class SnapshotId implements Writeable {
+public final class SnapshotId implements Writeable, ToXContent {
 
     /**
      * This value is for older snapshots that don't have a UUID.
      */
     public static final String UNASSIGNED_UUID = "_na_";
+    private static final String NAME = "name";
+    private static final String UUID = "uuid";
 
     private final String name;
     private final String uuid;
@@ -113,6 +118,37 @@ public final class SnapshotId implements Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
         out.writeString(uuid);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(NAME, name);
+        builder.field(UUID, uuid);
+        builder.endObject();
+        return builder;
+    }
+
+    public static SnapshotId fromXContent(XContentParser parser) throws IOException {
+        // the new format from 5.0 which contains the snapshot name and uuid
+        if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
+            String name = null;
+            String uuid = null;
+            while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                String currentFieldName = parser.currentName();
+                parser.nextToken();
+                if (NAME.equals(currentFieldName)) {
+                    name = parser.text();
+                } else if (UUID.equals(currentFieldName)) {
+                    uuid = parser.text();
+                }
+            }
+            return new SnapshotId(name, uuid);
+        }
+        // the old format pre 5.0 that only contains the snapshot name, use the name as the uuid too
+        else {
+            return new SnapshotId(parser.text(), SnapshotId.UNASSIGNED_UUID);
+        }
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -458,7 +458,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         }
         if (uuid == null) {
             // the old format where there wasn't a UUID
-            uuid = SnapshotId.UNASSIGNED_UUID;
+            uuid = name;
         }
         return new SnapshotInfo(new SnapshotId(name, uuid),
                                 indices,

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -46,6 +46,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.snapshots.IndexShardSnapshotFailedException;
 import org.elasticsearch.index.snapshots.IndexShardSnapshotStatus;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.EmptyTransportResponseHandler;
@@ -66,6 +67,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
@@ -208,8 +211,11 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
         Map<Snapshot, Map<ShardId, IndexShardSnapshotStatus>> newSnapshots = new HashMap<>();
         // Now go through all snapshots and update existing or create missing
         final String localNodeId = clusterService.localNode().getId();
+        final Map<Snapshot, Map<String, IndexId>> snapshotIndices = new HashMap<>();
         if (snapshotsInProgress != null) {
             for (SnapshotsInProgress.Entry entry : snapshotsInProgress.entries()) {
+                snapshotIndices.put(entry.snapshot(),
+                                    entry.indices().stream().collect(Collectors.toMap(IndexId::getName, Function.identity())));
                 if (entry.state() == SnapshotsInProgress.State.STARTED) {
                     Map<ShardId, IndexShardSnapshotStatus> startedShards = new HashMap<>();
                     SnapshotShards snapshotShards = shardSnapshots.get(entry.snapshot());
@@ -289,14 +295,20 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
         if (newSnapshots.isEmpty() == false) {
             Executor executor = threadPool.executor(ThreadPool.Names.SNAPSHOT);
             for (final Map.Entry<Snapshot, Map<ShardId, IndexShardSnapshotStatus>> entry : newSnapshots.entrySet()) {
+                Map<String, IndexId> indicesMap = snapshotIndices.get(entry.getKey());
+                assert indicesMap != null;
                 for (final Map.Entry<ShardId, IndexShardSnapshotStatus> shardEntry : entry.getValue().entrySet()) {
                     final ShardId shardId = shardEntry.getKey();
                     try {
                         final IndexShard indexShard = indicesService.indexServiceSafe(shardId.getIndex()).getShardOrNull(shardId.id());
+                        final IndexId indexId = indicesMap.get(shardId.getIndexName());
+                        if (indexId == null) {
+                            throw new IllegalStateException("[" + shardId.getIndexName() + "] being snapshotted, but not found in the snapshots in progress");
+                        }
                         executor.execute(new AbstractRunnable() {
                             @Override
                             public void doRun() {
-                                snapshot(indexShard, entry.getKey(), shardEntry.getValue());
+                                snapshot(indexShard, entry.getKey(), indexId, shardEntry.getValue());
                                 updateIndexShardSnapshotStatus(entry.getKey(), shardId, new SnapshotsInProgress.ShardSnapshotStatus(localNodeId, SnapshotsInProgress.State.SUCCESS));
                             }
 
@@ -321,7 +333,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
      * @param snapshot       snapshot
      * @param snapshotStatus snapshot status
      */
-    private void snapshot(final IndexShard indexShard, final Snapshot snapshot, final IndexShardSnapshotStatus snapshotStatus) {
+    private void snapshot(final IndexShard indexShard, final Snapshot snapshot, final IndexId indexId, final IndexShardSnapshotStatus snapshotStatus) {
         Repository repository = snapshotsService.getRepositoriesService().repository(snapshot.getRepository());
         ShardId shardId = indexShard.shardId();
         if (!indexShard.routingEntry().primary()) {
@@ -340,7 +352,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
             // we flush first to make sure we get the latest writes snapshotted
             IndexCommit snapshotIndexCommit = indexShard.snapshotIndex(true);
             try {
-                repository.snapshotShard(indexShard, snapshot.getSnapshotId(), snapshotIndexCommit, snapshotStatus);
+                repository.snapshotShard(indexShard, snapshot.getSnapshotId(), indexId, snapshotIndexCommit, snapshotStatus);
                 if (logger.isDebugEnabled()) {
                     StringBuilder sb = new StringBuilder();
                     sb.append("    index    : version [").append(snapshotStatus.indexVersion()).append("], number_of_files [").append(snapshotStatus.numberOfFiles()).append("] with total_size [").append(new ByteSizeValue(snapshotStatus.totalSize())).append("]\n");

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -302,9 +302,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                     try {
                         final IndexShard indexShard = indicesService.indexServiceSafe(shardId.getIndex()).getShardOrNull(shardId.id());
                         final IndexId indexId = indicesMap.get(shardId.getIndexName());
-                        if (indexId == null) {
-                            throw new IllegalStateException("[" + shardId.getIndexName() + "] being snapshotted, but not found in the snapshots in progress");
-                        }
+                        assert indexId != null;
                         executor.execute(new AbstractRunnable() {
                             @Override
                             public void doRun() {

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -56,8 +56,11 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.snapshots.IndexShardSnapshotStatus;
+import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
+import org.elasticsearch.repositories.RepositoryData;
+import org.elasticsearch.repositories.RepositoryData.IndexMeta;
 import org.elasticsearch.repositories.RepositoryMissingException;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -132,7 +135,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     public List<SnapshotId> snapshotIds(final String repositoryName) {
         Repository repository = repositoriesService.repository(repositoryName);
         assert repository != null; // should only be called once we've validated the repository exists
-        return repository.getSnapshots();
+        return repository.getRepositoryData().getSnapshotIds();
     }
 
     /**
@@ -218,6 +221,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         final String snapshotName = request.snapshotName;
         validate(repositoryName, snapshotName);
         final SnapshotId snapshotId = new SnapshotId(snapshotName, UUIDs.randomBase64UUID()); // new UUID for the snapshot
+        final Repository repository = repositoriesService.repository(repositoryName);
+        final Map<String, IndexMeta> indexIds = repository.getRepositoryData().getIndices();
 
         clusterService.submitStateUpdateTask(request.cause(), new ClusterStateUpdateTask() {
 
@@ -232,11 +237,21 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     // Store newSnapshot here to be processed in clusterStateProcessed
                     List<String> indices = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(currentState, request.indicesOptions(), request.indices()));
                     logger.trace("[{}][{}] creating snapshot for indices [{}]", repositoryName, snapshotName, indices);
+                    List<IndexId> snapshotIndices = new ArrayList<>();
+                    for (String index : indices) {
+                        final IndexId indexId;
+                        if (indexIds.containsKey(index)) {
+                            indexId = indexIds.get(index).getIndexId();
+                        } else {
+                            indexId = new IndexId(index, UUIDs.randomBase64UUID());
+                        }
+                        snapshotIndices.add(indexId);
+                    }
                     newSnapshot = new SnapshotsInProgress.Entry(new Snapshot(repositoryName, snapshotId),
                                                                 request.includeGlobalState(),
                                                                 request.partial(),
                                                                 State.INIT,
-                                                                indices,
+                                                                snapshotIndices,
                                                                 System.currentTimeMillis(),
                                                                 null);
                     snapshots = new SnapshotsInProgress(newSnapshot);
@@ -334,8 +349,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             if (!snapshot.includeGlobalState()) {
                 // Remove global state from the cluster state
                 MetaData.Builder builder = MetaData.builder();
-                for (String index : snapshot.indices()) {
-                    builder.put(metaData.index(index), false);
+                for (IndexId index : snapshot.indices()) {
+                    builder.put(metaData.index(index.getName()), false);
                 }
                 metaData = builder.build();
             }
@@ -473,7 +488,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     }
 
     private SnapshotInfo inProgressSnapshot(SnapshotsInProgress.Entry entry) {
-        return new SnapshotInfo(entry.snapshot().getSnapshotId(), entry.indices(), entry.startTime());
+        return new SnapshotInfo(entry.snapshot().getSnapshotId(),
+                                   entry.indices().stream().map(IndexId::getName).collect(Collectors.toList()),
+                                   entry.startTime());
     }
 
     /**
@@ -546,8 +563,10 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                                                                  final SnapshotInfo snapshotInfo) throws IOException {
         Map<ShardId, IndexShardSnapshotStatus> shardStatus = new HashMap<>();
         Repository repository = repositoriesService.repository(repositoryName);
-        MetaData metaData = repository.getSnapshotMetaData(snapshotInfo, snapshotInfo.indices());
+        RepositoryData repositoryData = repository.getRepositoryData();
+        MetaData metaData = repository.getSnapshotMetaData(snapshotInfo, repositoryData.resolveIndices(snapshotInfo.indices()));
         for (String index : snapshotInfo.indices()) {
+            IndexId indexId = repositoryData.resolveIndexId(index);
             IndexMetaData indexMetaData = metaData.indices().get(index);
             if (indexMetaData != null) {
                 int numberOfShards = indexMetaData.getNumberOfShards();
@@ -561,7 +580,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         shardStatus.put(shardId, shardSnapshotStatus);
                     } else {
                         IndexShardSnapshotStatus shardSnapshotStatus =
-                            repository.getShardSnapshotStatus(snapshotInfo.snapshotId(), snapshotInfo.version(), shardId);
+                            repository.getShardSnapshotStatus(snapshotInfo.snapshotId(), snapshotInfo.version(), indexId, shardId);
                         shardStatus.put(shardId, shardSnapshotStatus);
                     }
                 }
@@ -953,7 +972,10 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     public void deleteSnapshot(final String repositoryName, final String snapshotName, final DeleteSnapshotListener listener) {
         // First, look for the snapshot in the repository
         final Repository repository = repositoriesService.repository(repositoryName);
-        Optional<SnapshotId> matchedEntry = repository.getSnapshots().stream().filter(s -> s.getName().equals(snapshotName)).findFirst();
+        Optional<SnapshotId> matchedEntry = repository.getRepositoryData().getSnapshotIds()
+                                                .stream()
+                                                .filter(s -> s.getName().equals(snapshotName))
+                                                .findFirst();
         // if nothing found by the same name, then look in the cluster state for current in progress snapshots
         if (matchedEntry.isPresent() == false) {
             matchedEntry = currentSnapshots(repositoryName, Collections.emptyList()).stream()
@@ -1121,21 +1143,22 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
      * @param indices      list of indices to be snapshotted
      * @return list of shard to be included into current snapshot
      */
-    private ImmutableOpenMap<ShardId, SnapshotsInProgress.ShardSnapshotStatus> shards(ClusterState clusterState, List<String> indices) {
+    private ImmutableOpenMap<ShardId, SnapshotsInProgress.ShardSnapshotStatus> shards(ClusterState clusterState, List<IndexId> indices) {
         ImmutableOpenMap.Builder<ShardId, SnapshotsInProgress.ShardSnapshotStatus> builder = ImmutableOpenMap.builder();
         MetaData metaData = clusterState.metaData();
-        for (String index : indices) {
-            IndexMetaData indexMetaData = metaData.index(index);
+        for (IndexId index : indices) {
+            final String indexName = index.getName();
+            IndexMetaData indexMetaData = metaData.index(indexName);
             if (indexMetaData == null) {
                 // The index was deleted before we managed to start the snapshot - mark it as missing.
-                builder.put(new ShardId(index, IndexMetaData.INDEX_UUID_NA_VALUE, 0), new SnapshotsInProgress.ShardSnapshotStatus(null, State.MISSING, "missing index"));
+                builder.put(new ShardId(indexName, IndexMetaData.INDEX_UUID_NA_VALUE, 0), new SnapshotsInProgress.ShardSnapshotStatus(null, State.MISSING, "missing index"));
             } else if (indexMetaData.getState() == IndexMetaData.State.CLOSE) {
                 for (int i = 0; i < indexMetaData.getNumberOfShards(); i++) {
                     ShardId shardId = new ShardId(indexMetaData.getIndex(), i);
                     builder.put(shardId, new SnapshotsInProgress.ShardSnapshotStatus(null, State.MISSING, "index is closed"));
                 }
             } else {
-                IndexRoutingTable indexRoutingTable = clusterState.getRoutingTable().index(index);
+                IndexRoutingTable indexRoutingTable = clusterState.getRoutingTable().index(indexName);
                 for (int i = 0; i < indexMetaData.getNumberOfShards(); i++) {
                     ShardId shardId = new ShardId(indexMetaData.getIndex(), i);
                     if (indexRoutingTable != null) {
@@ -1191,8 +1214,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             for (final SnapshotsInProgress.Entry entry : snapshots.entries()) {
                 if (entry.partial() == false) {
                     if (entry.state() == State.INIT) {
-                        for (String index : entry.indices()) {
-                            IndexMetaData indexMetaData = currentState.metaData().index(index);
+                        for (IndexId index : entry.indices()) {
+                            IndexMetaData indexMetaData = currentState.metaData().index(index.getName());
                             if (indexMetaData != null && indices.contains(indexMetaData)) {
                                 if (indicesToFail == null) {
                                     indicesToFail = new HashSet<>();

--- a/core/src/test/java/org/elasticsearch/bwcompat/RepositoryUpgradabilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/RepositoryUpgradabilityIT.java
@@ -46,7 +46,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
  * as blob names and repository blob formats have changed between the snapshot versions.
  */
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST)
-// this test sometimes fails in recovery when the recovery is reset, increasing the logging level to help debug 
+// this test sometimes fails in recovery when the recovery is reset, increasing the logging level to help debug
 @TestLogging("indices.recovery:DEBUG")
 public class RepositoryUpgradabilityIT extends AbstractSnapshotIntegTestCase {
 
@@ -70,7 +70,7 @@ public class RepositoryUpgradabilityIT extends AbstractSnapshotIntegTestCase {
             final Set<SnapshotInfo> snapshotInfos = Sets.newHashSet(getSnapshots(repoName));
             assertThat(snapshotInfos.size(), equalTo(1));
             SnapshotInfo originalSnapshot = snapshotInfos.iterator().next();
-            assertThat(originalSnapshot.snapshotId(), equalTo(new SnapshotId("test_1", SnapshotId.UNASSIGNED_UUID)));
+            assertThat(originalSnapshot.snapshotId(), equalTo(new SnapshotId("test_1", "test_1")));
             assertThat(Sets.newHashSet(originalSnapshot.indices()), equalTo(indices));
 
             logger.info("--> restore the original snapshot");

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
@@ -53,7 +53,6 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.snapshots.Snapshot;
-import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.util.Collections;
@@ -659,7 +658,7 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
                                 randomBoolean(),
                                 randomBoolean(),
                                 SnapshotsInProgress.State.fromValue((byte) randomIntBetween(0, 6)),
-                                Collections.<String>emptyList(),
+                                Collections.emptyList(),
                                 Math.abs(randomLong()),
                                 ImmutableOpenMap.of()));
                     case 1:

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -103,7 +103,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.RepositoryData;
-import org.elasticsearch.repositories.RepositoryData.IndexMeta;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotInfo;
@@ -1675,8 +1674,8 @@ public class IndexShardTests extends ESSingleNodeTestCase {
         }
         @Override
         public RepositoryData getRepositoryData() {
-            Map<String, IndexMeta> map = new HashMap<>();
-            map.put(indexName, new IndexMeta(indexName, "blah", Collections.emptySet()));
+            Map<IndexId, Set<SnapshotId>> map = new HashMap<>();
+            map.put(new IndexId(indexName, "blah"), Collections.emptySet());
             return new RepositoryData(Collections.emptyList(), map);
         }
         @Override

--- a/core/src/test/java/org/elasticsearch/repositories/IndexIdTests.java
+++ b/core/src/test/java/org/elasticsearch/repositories/IndexIdTests.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories;
+
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+/**
+ * Tests for the {@link IndexId} class.
+ */
+public class IndexIdTests extends ESTestCase {
+
+    public void testEqualsAndHashCode() {
+        // assert equals and hashcode
+        String name = randomAsciiOfLength(8);
+        String id = UUIDs.randomBase64UUID();
+        IndexId indexId1 = new IndexId(name, id);
+        IndexId indexId2 = new IndexId(name, id);
+        assertEquals(indexId1, indexId2);
+        assertEquals(indexId1.hashCode(), indexId2.hashCode());
+        // assert equals when using index name for id
+        id = name;
+        indexId1 = new IndexId(name, id);
+        indexId2 = new IndexId(name, id);
+        assertEquals(indexId1, indexId2);
+        assertEquals(indexId1.hashCode(), indexId2.hashCode());
+        //assert not equals when name or id differ
+        indexId2 = new IndexId(randomAsciiOfLength(8), id);
+        assertNotEquals(indexId1, indexId2);
+        assertNotEquals(indexId1.hashCode(), indexId2.hashCode());
+        indexId2 = new IndexId(name, UUIDs.randomBase64UUID());
+        assertNotEquals(indexId1, indexId2);
+        assertNotEquals(indexId1.hashCode(), indexId2.hashCode());
+    }
+
+    public void testSerialization() throws IOException {
+        IndexId indexId = new IndexId(randomAsciiOfLength(8), UUIDs.randomBase64UUID());
+        BytesStreamOutput out = new BytesStreamOutput();
+        indexId.writeTo(out);
+        assertEquals(indexId, new IndexId(out.bytes().streamInput()));
+    }
+
+    public void testXContent() throws IOException {
+        IndexId indexId = new IndexId(randomAsciiOfLength(8), UUIDs.randomBase64UUID());
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        indexId.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        XContentParser parser = XContentType.JSON.xContent().createParser(builder.bytes());
+        assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+        String name = null;
+        String id = null;
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            final String currentFieldName = parser.currentName();
+            parser.nextToken();
+            if (currentFieldName.equals(IndexId.NAME)) {
+                name = parser.text();
+            } else if (currentFieldName.equals(IndexId.ID)) {
+                id = parser.text();
+            }
+        }
+        assertNotNull(name);
+        assertNotNull(id);
+        assertEquals(indexId, new IndexId(name, id));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
+++ b/core/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
@@ -57,7 +57,7 @@ public class RepositoryDataTests extends ESTestCase {
         XContentBuilder builder = JsonXContent.contentBuilder();
         repositoryData.toXContent(builder, ToXContent.EMPTY_PARAMS);
         XContentParser parser = XContentType.JSON.xContent().createParser(builder.bytes());
-        assertEquals(repositoryData, RepositoryData.fromXContent(parser));
+        assertEquals(repositoryData, RepositoryData.fromXContent(parser, true));
     }
 
     public void testAddSnapshots() {

--- a/core/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
+++ b/core/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
@@ -57,7 +57,7 @@ public class RepositoryDataTests extends ESTestCase {
         XContentBuilder builder = JsonXContent.contentBuilder();
         repositoryData.toXContent(builder, ToXContent.EMPTY_PARAMS);
         XContentParser parser = XContentType.JSON.xContent().createParser(builder.bytes());
-        assertEquals(repositoryData, RepositoryData.fromXContent(parser, true));
+        assertEquals(repositoryData, RepositoryData.fromXContent(parser));
     }
 
     public void testAddSnapshots() {

--- a/core/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
+++ b/core/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories;
+
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.repositories.RepositoryData.IndexMeta;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ * Tests for the {@link RepositoryData} class.
+ */
+public class RepositoryDataTests extends ESTestCase {
+
+    public void testEqualsAndHashCode() {
+        RepositoryData repositoryData1 = generateRandomRepoData();
+        RepositoryData repositoryData2 = new RepositoryData(repositoryData1.getSnapshotIds(), repositoryData1.getIndices());
+        assertEquals(repositoryData1, repositoryData2);
+        assertEquals(repositoryData1.hashCode(), repositoryData2.hashCode());
+    }
+
+    public void testXContent() throws IOException {
+        RepositoryData repositoryData = generateRandomRepoData();
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        repositoryData.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        XContentParser parser = XContentType.JSON.xContent().createParser(builder.bytes());
+        assertEquals(repositoryData, RepositoryData.fromXContent(parser));
+    }
+
+    public void testAddSnapshots() {
+        RepositoryData repositoryData = generateRandomRepoData();
+        // test that adding the same snapshot id to the repository data throws an exception
+        final SnapshotId snapshotId = repositoryData.getSnapshotIds().get(0);
+        Map<String, IndexMeta> indexMetaMap = repositoryData.getIndices();
+        expectThrows(IllegalArgumentException.class,
+            () -> repositoryData.addSnapshot(new SnapshotId(snapshotId.getName(), snapshotId.getUUID()), Collections.emptyList()));
+        // test that adding a snapshot and its indices works
+        SnapshotId newSnapshot = new SnapshotId(randomAsciiOfLength(7), UUIDs.randomBase64UUID());
+        List<IndexId> indices = new ArrayList<>();
+        Set<IndexId> newIndices = new HashSet<>();
+        int numNew = randomIntBetween(1, 10);
+        for (int i = 0; i < numNew; i++) {
+            IndexId indexId = new IndexId(randomAsciiOfLength(7), UUIDs.randomBase64UUID());
+            newIndices.add(indexId);
+            indices.add(indexId);
+        }
+        int numOld = randomIntBetween(1, indexMetaMap.size());
+        List<String> indexNames = new ArrayList<>(indexMetaMap.keySet());
+        for (int i = 0; i < numOld; i++) {
+            IndexId indexId = indexMetaMap.get(indexNames.get(i)).getIndexId();
+            indices.add(indexId);
+        }
+        RepositoryData newRepoData = repositoryData.addSnapshot(newSnapshot, indices);
+        // verify that the new repository data has the new snapshot and its indices
+        assertTrue(newRepoData.getSnapshotIds().contains(newSnapshot));
+        indexMetaMap = newRepoData.getIndices();
+        for (IndexId indexId : indices) {
+            Set<SnapshotId> snapshotIds = indexMetaMap.get(indexId.getName()).getSnapshotIds();
+            assertTrue(snapshotIds.contains(newSnapshot));
+            if (newIndices.contains(indexId)) {
+                assertEquals(snapshotIds.size(), 1); // if it was a new index, only the new snapshot should be in its set
+            }
+        }
+    }
+
+    public void testAddIndices() {
+        final int numSnapshots = randomIntBetween(1, 30);
+        final List<SnapshotId> snapshotIds = new ArrayList<>(numSnapshots);
+        for (int i = 0; i < numSnapshots; i++) {
+            snapshotIds.add(new SnapshotId(randomAsciiOfLength(8), UUIDs.randomBase64UUID()));
+        }
+        RepositoryData repositoryData = new RepositoryData(snapshotIds, Collections.emptyMap());
+        // test that adding indices works
+        Map<String, IndexMeta> indices = randomIndices(snapshotIds);
+        RepositoryData newRepoData = repositoryData.addIndices(indices);
+        assertEquals(repositoryData.getSnapshotIds(), newRepoData.getSnapshotIds());
+        assertEquals(indices, newRepoData.getIndices());
+    }
+
+    public void testRemoveSnapshot() {
+        RepositoryData repositoryData = generateRandomRepoData();
+        List<SnapshotId> snapshotIds = new ArrayList<>(repositoryData.getSnapshotIds());
+        assertThat(snapshotIds.size(), greaterThan(0));
+        SnapshotId removedSnapshotId = snapshotIds.remove(randomIntBetween(0, snapshotIds.size() - 1));
+        RepositoryData newRepositoryData = repositoryData.removeSnapshot(removedSnapshotId);
+        // make sure the repository data's indices no longer contain the removed snapshot
+        for (IndexMeta indexMeta : newRepositoryData.getIndices().values()) {
+            assertFalse(indexMeta.getSnapshotIds().contains(removedSnapshotId));
+        }
+    }
+
+    public void testResolveIndexId() {
+        RepositoryData repositoryData = generateRandomRepoData();
+        Map<String, IndexMeta> indices = repositoryData.getIndices();
+        Set<String> indexNames = indices.keySet();
+        assertThat(indexNames.size(), greaterThan(0));
+        String indexName = indexNames.iterator().next();
+        IndexId indexId = indices.get(indexName).getIndexId();
+        assertEquals(indexId, repositoryData.resolveIndexId(indexName));
+        String notInRepoData = randomAsciiOfLength(5);
+        assertFalse(indexName.contains(notInRepoData));
+        assertEquals(new IndexId(notInRepoData, notInRepoData), repositoryData.resolveIndexId(notInRepoData));
+    }
+
+    public static RepositoryData generateRandomRepoData() {
+        return generateRandomRepoData(new ArrayList<>());
+    }
+
+    public static RepositoryData generateRandomRepoData(final List<SnapshotId> origSnapshotIds) {
+        List<SnapshotId> snapshotIds = randomSnapshots(origSnapshotIds);
+        return new RepositoryData(snapshotIds, randomIndices(snapshotIds));
+    }
+
+    private static List<SnapshotId> randomSnapshots(final List<SnapshotId> origSnapshotIds) {
+        final int numSnapshots = randomIntBetween(1, 30);
+        final List<SnapshotId> snapshotIds = new ArrayList<>(origSnapshotIds);
+        for (int i = 0; i < numSnapshots; i++) {
+            snapshotIds.add(new SnapshotId(randomAsciiOfLength(8), UUIDs.randomBase64UUID()));
+        }
+        return snapshotIds;
+    }
+
+    private static Map<String, IndexMeta> randomIndices(final List<SnapshotId> snapshotIds) {
+        final int totalSnapshots = snapshotIds.size();
+        final int numIndices = randomIntBetween(1, 30);
+        final Map<String, IndexMeta> indices = new HashMap<>(numIndices);
+        for (int i = 0; i < numIndices; i++) {
+            final String indexName = randomAsciiOfLength(8);
+            final Set<SnapshotId> indexSnapshots = new LinkedHashSet<>();
+            final int numIndicesForSnapshot = randomIntBetween(1, numIndices);
+            for (int j = 0; j < numIndicesForSnapshot; j++) {
+                indexSnapshots.add(snapshotIds.get(randomIntBetween(0, totalSnapshots - 1)));
+            }
+            indices.put(indexName, new IndexMeta(indexName, UUIDs.randomBase64UUID(), indexSnapshots));
+        }
+        return indices;
+    }
+}

--- a/core/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/core/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -183,10 +183,10 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
         assertThat(blobId(snapshotId), equalTo("abc-123")); // just the snapshot name
         String uuid = UUIDs.randomBase64UUID();
         snapshotId = new SnapshotId("abc123", uuid);
-        assertThat(blobId(snapshotId), equalTo("abc123-" + uuid)); // snapshot name + '-' + uuid
+        assertThat(blobId(snapshotId), equalTo(uuid)); // uuid only
         uuid = UUIDs.randomBase64UUID();
         snapshotId = new SnapshotId("abc-123", uuid);
-        assertThat(blobId(snapshotId), equalTo("abc-123-" + uuid)); // snapshot name + '-' + uuid
+        assertThat(blobId(snapshotId), equalTo(uuid)); // uuid only
     }
 
     private BlobStoreRepository setupRepo() {

--- a/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -61,7 +61,9 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.IndexStore;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.indices.InvalidIndexNameException;
+import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 
@@ -2017,6 +2019,9 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
 
         logger.info("--> emulate an orphan snapshot");
+        RepositoriesService repositoriesService = internalCluster().getInstance(RepositoriesService.class, internalCluster().getMasterName());
+        final RepositoryData repositoryData = repositoriesService.repository(repositoryName).getRepositoryData();
+        final IndexId indexId = repositoryData.resolveIndexId(idxName);
 
         clusterService.submitStateUpdateTask("orphan snapshot test", new ClusterStateUpdateTask() {
 
@@ -2033,7 +2038,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                                                    true,
                                                    false,
                                                    State.ABORTED,
-                                                   Collections.singletonList(idxName),
+                                                   Collections.singletonList(indexId),
                                                    System.currentTimeMillis(),
                                                    shards.build()));
                 return ClusterState.builder(currentState).putCustom(SnapshotsInProgress.TYPE, new SnapshotsInProgress(Collections.unmodifiableList(entries))).build();
@@ -2189,7 +2194,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
 
         logger.info("--> truncate snapshot file to make it unreadable");
-        Path snapshotPath = repo.resolve("snap-test-snap-2-" + createSnapshotResponse.getSnapshotInfo().snapshotId().getUUID() + ".dat");
+        Path snapshotPath = repo.resolve("snap-" + createSnapshotResponse.getSnapshotInfo().snapshotId().getUUID() + ".dat");
         try(SeekableByteChannel outChan = Files.newByteChannel(snapshotPath, StandardOpenOption.WRITE)) {
             outChan.truncate(randomInt(10));
         }

--- a/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -884,7 +884,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
 
         logger.info("--> delete index metadata and shard metadata");
-        Path metadata = repo.resolve("meta-test-snap-1.dat");
+        Path metadata = repo.resolve("meta-" + createSnapshotResponse.getSnapshotInfo().snapshotId().getUUID() + ".dat");
         Files.delete(metadata);
 
         logger.info("--> delete snapshot");
@@ -917,7 +917,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
 
         logger.info("--> truncate snapshot file to make it unreadable");
-        Path snapshotPath = repo.resolve("snap-test-snap-1-" + createSnapshotResponse.getSnapshotInfo().snapshotId().getUUID() + ".dat");
+        Path snapshotPath = repo.resolve("snap-" + createSnapshotResponse.getSnapshotInfo().snapshotId().getUUID() + ".dat");
         try(SeekableByteChannel outChan = Files.newByteChannel(snapshotPath, StandardOpenOption.WRITE)) {
             outChan.truncate(randomInt(10));
         }

--- a/core/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -48,6 +48,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.RepositoryPlugin;
 import org.elasticsearch.repositories.Repository;
+import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.snapshots.SnapshotId;
 
@@ -112,7 +113,7 @@ public class MockRepository extends FsRepository {
     }
 
     @Override
-    public void initializeSnapshot(SnapshotId snapshotId, List<String> indices, MetaData clusterMetadata) {
+    public void initializeSnapshot(SnapshotId snapshotId, List<IndexId> indices, MetaData clusterMetadata) {
         if (blockOnInitialization) {
             blockExecution();
         }

--- a/core/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -113,7 +113,7 @@ public class MockRepository extends FsRepository {
 
     @Override
     public void initializeSnapshot(SnapshotId snapshotId, List<String> indices, MetaData clusterMetadata) {
-        if (blockOnInitialization ) {
+        if (blockOnInitialization) {
             blockExecution();
         }
         super.initializeSnapshot(snapshotId, indices, clusterMetadata);

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
@@ -119,7 +119,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
         logger.trace("deleteBlob({})", blobName);
 
         if (!blobExists(blobName)) {
-            throw new IOException("Blob [" + blobName + "] does not exist");
+            throw new NoSuchFileException("Blob [" + blobName + "] does not exist");
         }
 
         try {

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
@@ -121,6 +121,11 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     @Override
     public void deleteBlob(String blobName) throws IOException {
         logger.trace("deleteBlob({})", blobName);
+
+        if (!blobExists(blobName)) {
+            throw new IOException("Blob [" + blobName + "] does not exist");
+        }
+
         try {
             blobStore.deleteBlob(blobStore.container(), buildKey(blobName));
         } catch (URISyntaxException | StorageException e) {

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
@@ -30,12 +30,12 @@ import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.repositories.RepositoryException;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
+import java.nio.file.NoSuchFileException;
 import java.util.Map;
 
 /**
@@ -72,14 +72,14 @@ public class AzureBlobContainer extends AbstractBlobContainer {
         logger.trace("readBlob({})", blobName);
 
         if (!blobExists(blobName)) {
-            throw new IOException("Blob [" + blobName + "] does not exist");
+            throw new NoSuchFileException("Blob [" + blobName + "] does not exist");
         }
 
         try {
             return blobStore.getInputStream(blobStore.container(), buildKey(blobName));
         } catch (StorageException e) {
             if (e.getHttpStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
-                throw new FileNotFoundException(e.getMessage());
+                throw new NoSuchFileException(e.getMessage());
             }
             throw new IOException(e);
         } catch (URISyntaxException e) {
@@ -108,7 +108,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
             return new AzureOutputStream(blobStore.getOutputStream(blobStore.container(), buildKey(blobName)));
         } catch (StorageException e) {
             if (e.getHttpStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
-                throw new FileNotFoundException(e.getMessage());
+                throw new NoSuchFileException(e.getMessage());
             }
             throw new IOException(e);
         } catch (URISyntaxException e) {

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
@@ -70,6 +70,11 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     @Override
     public InputStream readBlob(String blobName) throws IOException {
         logger.trace("readBlob({})", blobName);
+
+        if (!blobExists(blobName)) {
+            throw new IOException("Blob [" + blobName + "] does not exist");
+        }
+
         try {
             return blobStore.getInputStream(blobStore.container(), buildKey(blobName));
         } catch (StorageException e) {

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
@@ -71,10 +71,6 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     public InputStream readBlob(String blobName) throws IOException {
         logger.trace("readBlob({})", blobName);
 
-        if (!blobExists(blobName)) {
-            throw new NoSuchFileException("Blob [" + blobName + "] does not exist");
-        }
-
         try {
             return blobStore.getInputStream(blobStore.container(), buildKey(blobName));
         } catch (StorageException e) {

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
@@ -32,6 +32,8 @@ import org.elasticsearch.cloud.azure.storage.AzureStorageService;
 import org.elasticsearch.cloud.azure.storage.AzureStorageService.Storage;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
@@ -44,7 +46,6 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.repositories.RepositoryVerificationException;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.snapshots.SnapshotCreationException;
-import org.elasticsearch.snapshots.SnapshotId;
 
 import static org.elasticsearch.cloud.azure.storage.AzureStorageSettings.getEffectiveSetting;
 import static org.elasticsearch.cloud.azure.storage.AzureStorageSettings.getValue;
@@ -153,7 +154,7 @@ public class AzureRepository extends BlobStoreRepository {
     }
 
     @Override
-    public void initializeSnapshot(SnapshotId snapshotId, List<String> indices, MetaData clusterMetadata) {
+    public void initializeSnapshot(SnapshotId snapshotId, List<IndexId> indices, MetaData clusterMetadata) {
         try {
             if (!blobStore.doesContainerExist(blobStore.container())) {
                 logger.debug("container [{}] does not exist. Creating...", blobStore.container());

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceMock.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceMock.java
@@ -21,22 +21,19 @@ package org.elasticsearch.cloud.azure.storage;
 
 import com.microsoft.azure.storage.LocationMode;
 import com.microsoft.azure.storage.StorageException;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.blobstore.support.PlainBlobMetaData;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.component.AbstractComponent;
-import org.elasticsearch.common.component.AbstractLifecycleComponent;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
+import java.nio.file.NoSuchFileException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -82,7 +79,7 @@ public class AzureStorageServiceMock extends AbstractComponent implements AzureS
     @Override
     public InputStream getInputStream(String account, LocationMode mode, String container, String blob) throws IOException {
         if (!blobExists(account, mode, container, blob)) {
-            throw new FileNotFoundException("missing blob [" + blob + "]");
+            throw new NoSuchFileException("missing blob [" + blob + "]");
         }
         return new ByteArrayInputStream(blobs.get(blob).toByteArray());
     }

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceMock.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceMock.java
@@ -99,7 +99,7 @@ public class AzureStorageServiceMock extends AbstractComponent implements AzureS
         MapBuilder<String, BlobMetaData> blobsBuilder = MapBuilder.newMapBuilder();
         for (String blobName : blobs.keySet()) {
             final String checkBlob;
-            if (keyPath != null || keyPath.isEmpty()) {
+            if (keyPath != null && !keyPath.isEmpty()) {
                 // strip off key path from the beginning of the blob name
                 checkBlob = blobName.replace(keyPath, "");
             } else {

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceMock.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceMock.java
@@ -99,13 +99,13 @@ public class AzureStorageServiceMock extends AbstractComponent implements AzureS
         MapBuilder<String, BlobMetaData> blobsBuilder = MapBuilder.newMapBuilder();
         for (String blobName : blobs.keySet()) {
             final String checkBlob;
-            if (keyPath != null) {
+            if (keyPath != null || keyPath.isEmpty()) {
                 // strip off key path from the beginning of the blob name
                 checkBlob = blobName.replace(keyPath, "");
             } else {
                 checkBlob = blobName;
             }
-            if (startsWithIgnoreCase(checkBlob, prefix)) {
+            if (prefix == null || startsWithIgnoreCase(checkBlob, prefix)) {
                 blobsBuilder.put(blobName, new PlainBlobMetaData(checkBlob, blobs.get(blobName).size()));
             }
         }

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobStoreContainerTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobStoreContainerTests.java
@@ -21,36 +21,25 @@ package org.elasticsearch.repositories.azure;
 
 import com.microsoft.azure.storage.StorageException;
 import org.elasticsearch.cloud.azure.blobstore.AzureBlobStore;
-import org.elasticsearch.cloud.azure.storage.AzureStorageService;
-import org.elasticsearch.cloud.azure.storage.AzureStorageServiceImpl;
+import org.elasticsearch.cloud.azure.storage.AzureStorageServiceMock;
 import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.repositories.ESBlobStoreContainerTestCase;
 import org.elasticsearch.repositories.RepositoryName;
 import org.elasticsearch.repositories.RepositorySettings;
-import org.elasticsearch.test.ESIntegTestCase;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import static org.elasticsearch.cloud.azure.AzureTestUtils.readSettingsFromFile;
-
-/**
- * You must specify {@code -Dtests.thirdparty=true -Dtests.config=/path/to/elasticsearch.yml}
- * in order to run these tests.
- */
-@ESIntegTestCase.ThirdParty
 public class AzureBlobStoreContainerTests extends ESBlobStoreContainerTestCase {
     @Override
     protected BlobStore newBlobStore() throws IOException {
         try {
             RepositoryName repositoryName = new RepositoryName("azure", "ittest");
-            Settings settings = readSettingsFromFile();
-            RepositorySettings repositorySettings = new RepositorySettings(settings, Settings.builder().build());
-            AzureStorageService storageService = new AzureStorageServiceImpl(settings);
-            AzureBlobStore blobStore = new AzureBlobStore(repositoryName, settings, repositorySettings, storageService);
-            blobStore.createContainer(blobStore.container());
-            return blobStore;
+            RepositorySettings repositorySettings = new RepositorySettings(
+                    Settings.EMPTY, Settings.EMPTY);
+            AzureStorageServiceMock client = new AzureStorageServiceMock(Settings.EMPTY);
+            return new AzureBlobStore(repositoryName, Settings.EMPTY, repositorySettings, client);
         } catch (URISyntaxException | StorageException e) {
             throw new IOException(e);
         }

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobStoreContainerTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobStoreContainerTests.java
@@ -22,11 +22,10 @@ package org.elasticsearch.repositories.azure;
 import com.microsoft.azure.storage.StorageException;
 import org.elasticsearch.cloud.azure.blobstore.AzureBlobStore;
 import org.elasticsearch.cloud.azure.storage.AzureStorageServiceMock;
+import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.repositories.ESBlobStoreContainerTestCase;
-import org.elasticsearch.repositories.RepositoryName;
-import org.elasticsearch.repositories.RepositorySettings;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -35,11 +34,9 @@ public class AzureBlobStoreContainerTests extends ESBlobStoreContainerTestCase {
     @Override
     protected BlobStore newBlobStore() throws IOException {
         try {
-            RepositoryName repositoryName = new RepositoryName("azure", "ittest");
-            RepositorySettings repositorySettings = new RepositorySettings(
-                    Settings.EMPTY, Settings.EMPTY);
-            AzureStorageServiceMock client = new AzureStorageServiceMock(Settings.EMPTY);
-            return new AzureBlobStore(repositoryName, Settings.EMPTY, repositorySettings, client);
+            RepositoryMetaData repositoryMetaData = new RepositoryMetaData("azure", "ittest", Settings.EMPTY);
+            AzureStorageServiceMock client = new AzureStorageServiceMock();
+            return new AzureBlobStore(repositoryMetaData, Settings.EMPTY, client);
         } catch (URISyntaxException | StorageException e) {
             throw new IOException(e);
         }

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobStoreContainerTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobStoreContainerTests.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories.azure;
+
+import com.microsoft.azure.storage.StorageException;
+import org.elasticsearch.cloud.azure.blobstore.AzureBlobStore;
+import org.elasticsearch.cloud.azure.storage.AzureStorageService;
+import org.elasticsearch.cloud.azure.storage.AzureStorageServiceImpl;
+import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.repositories.ESBlobStoreContainerTestCase;
+import org.elasticsearch.repositories.RepositoryName;
+import org.elasticsearch.repositories.RepositorySettings;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import static org.elasticsearch.cloud.azure.AzureTestUtils.readSettingsFromFile;
+
+/**
+ * You must specify {@code -Dtests.thirdparty=true -Dtests.config=/path/to/elasticsearch.yml}
+ * in order to run these tests.
+ */
+@ESIntegTestCase.ThirdParty
+public class AzureBlobStoreContainerTests extends ESBlobStoreContainerTestCase {
+    @Override
+    protected BlobStore newBlobStore() throws IOException {
+        try {
+            RepositoryName repositoryName = new RepositoryName("azure", "ittest");
+            Settings settings = readSettingsFromFile();
+            RepositorySettings repositorySettings = new RepositorySettings(settings, Settings.builder().build());
+            AzureStorageService storageService = new AzureStorageServiceImpl(settings);
+            AzureBlobStore blobStore = new AzureBlobStore(repositoryName, settings, repositorySettings, storageService);
+            blobStore.createContainer(blobStore.container());
+            return blobStore;
+        } catch (URISyntaxException | StorageException e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/common/blobstore/gcs/GoogleCloudStorageBlobStore.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/common/blobstore/gcs/GoogleCloudStorageBlobStore.java
@@ -189,9 +189,6 @@ public class GoogleCloudStorageBlobStore extends AbstractComponent implements Bl
      * @return an InputStream
      */
     InputStream readBlob(String blobName) throws IOException {
-        if (!blobExists(blobName)) {
-            throw new NoSuchFileException("Blob [" + blobName + "] does not exist");
-        }
         return doPrivileged(() -> {
             try {
                 Storage.Objects.Get object = client.objects().get(bucket, blobName);

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/common/blobstore/gcs/GoogleCloudStorageBlobStore.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/common/blobstore/gcs/GoogleCloudStorageBlobStore.java
@@ -41,9 +41,9 @@ import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.CountDown;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.NoSuchFileException;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -189,6 +189,9 @@ public class GoogleCloudStorageBlobStore extends AbstractComponent implements Bl
      * @return an InputStream
      */
     InputStream readBlob(String blobName) throws IOException {
+        if (!blobExists(blobName)) {
+            throw new NoSuchFileException("Blob [" + blobName + "] does not exist");
+        }
         return doPrivileged(() -> {
             try {
                 Storage.Objects.Get object = client.objects().get(bucket, blobName);
@@ -196,7 +199,7 @@ public class GoogleCloudStorageBlobStore extends AbstractComponent implements Bl
             } catch (GoogleJsonResponseException e) {
                 GoogleJsonError error = e.getDetails();
                 if ((e.getStatusCode() == HTTP_NOT_FOUND) || ((error != null) && (error.getCode() == HTTP_NOT_FOUND))) {
-                    throw new FileNotFoundException(e.getMessage());
+                    throw new NoSuchFileException(e.getMessage());
                 }
                 throw e;
             }
@@ -227,6 +230,9 @@ public class GoogleCloudStorageBlobStore extends AbstractComponent implements Bl
      * @param blobName name of the blob
      */
     void deleteBlob(String blobName) throws IOException {
+        if (!blobExists(blobName)) {
+            throw new NoSuchFileException("Blob [" + blobName + "] does not exist");
+        }
         doPrivileged(() -> client.objects().delete(bucket, blobName).execute());
     }
 

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
@@ -75,8 +75,8 @@ final class HdfsBlobContainer extends AbstractBlobContainer {
                     return fileContext.delete(new Path(path, blobName), true);
                 }
             });
-        } catch (FileNotFoundException ok) {
-            // behaves like Files.deleteIfExists
+        } catch (FileNotFoundException e) {
+            throw new IOException(e);
         }
     }
 

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
@@ -68,6 +68,10 @@ final class HdfsBlobContainer extends AbstractBlobContainer {
 
     @Override
     public void deleteBlob(String blobName) throws IOException {
+        if (!blobExists(blobName)) {
+            throw new IOException("Blob [" + blobName + "] does not exist");
+        }
+
         store.execute(new Operation<Boolean>() {
             @Override
             public Boolean run(FileContext fileContext) throws IOException {

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
@@ -32,9 +32,9 @@ import org.elasticsearch.common.blobstore.support.AbstractBlobContainer;
 import org.elasticsearch.common.blobstore.support.PlainBlobMetaData;
 import org.elasticsearch.repositories.hdfs.HdfsBlobStore.Operation;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.NoSuchFileException;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
@@ -69,7 +69,7 @@ final class HdfsBlobContainer extends AbstractBlobContainer {
     @Override
     public void deleteBlob(String blobName) throws IOException {
         if (!blobExists(blobName)) {
-            throw new IOException("Blob [" + blobName + "] does not exist");
+            throw new NoSuchFileException("Blob [" + blobName + "] does not exist");
         }
 
         store.execute(new Operation<Boolean>() {
@@ -93,6 +93,9 @@ final class HdfsBlobContainer extends AbstractBlobContainer {
 
     @Override
     public InputStream readBlob(String blobName) throws IOException {
+        if (!blobExists(blobName)) {
+            throw new NoSuchFileException("Blob [" + blobName + "] does not exist");
+        }
         // FSDataInputStream does buffering internally
         return store.execute(new Operation<InputStream>() {
             @Override

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
@@ -68,16 +68,12 @@ final class HdfsBlobContainer extends AbstractBlobContainer {
 
     @Override
     public void deleteBlob(String blobName) throws IOException {
-        try {
-            store.execute(new Operation<Boolean>() {
-                @Override
-                public Boolean run(FileContext fileContext) throws IOException {
-                    return fileContext.delete(new Path(path, blobName), true);
-                }
-            });
-        } catch (FileNotFoundException e) {
-            throw new IOException(e);
-        }
+        store.execute(new Operation<Boolean>() {
+            @Override
+            public Boolean run(FileContext fileContext) throws IOException {
+                return fileContext.delete(new Path(path, blobName), true);
+            }
+        });
     }
 
     @Override

--- a/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsBlobStoreContainerTests.java
+++ b/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsBlobStoreContainerTests.java
@@ -16,18 +16,89 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch.repositories.hdfs;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.AbstractFileSystem;
 import org.apache.hadoop.fs.FileContext;
+import org.apache.hadoop.fs.UnsupportedFileSystemException;
 import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.repositories.ESBlobStoreContainerTestCase;
 
+import javax.security.auth.Subject;
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.AccessController;
+import java.security.Principal;
+import java.security.PrivilegedAction;
+import java.util.Collections;
 
 public class HdfsBlobStoreContainerTests extends ESBlobStoreContainerTestCase {
 
     @Override
     protected BlobStore newBlobStore() throws IOException {
-        return new HdfsBlobStore(FileContext.getFileContext(), "", 100);
+        return AccessController.doPrivileged(
+                new PrivilegedAction<HdfsBlobStore>() {
+                    @Override
+                    public HdfsBlobStore run() {
+                        try {
+                            FileContext fileContext = createContext(new URI("hdfs:///"));
+                            return new HdfsBlobStore(fileContext, "temp", 1024);
+                        } catch (IOException | URISyntaxException e) {
+                            throw new RuntimeException(e);
+                        }
+            }
+        });
+    }
+
+    public FileContext createContext(URI uri) {
+        // mirrors HdfsRepository.java behaviour
+        Configuration cfg = new Configuration(true);
+        cfg.setClassLoader(HdfsRepository.class.getClassLoader());
+        cfg.reloadConfiguration();
+
+        Constructor<?> ctor;
+        Subject subject;
+
+        try {
+            Class<?> clazz = Class.forName("org.apache.hadoop.security.User");
+            ctor = clazz.getConstructor(String.class);
+            ctor.setAccessible(true);
+        }  catch (ClassNotFoundException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+
+        try {
+            Principal principal = (Principal) ctor.newInstance(System.getProperty("user.name"));
+            subject = new Subject(false, Collections.singleton(principal),
+                    Collections.emptySet(), Collections.emptySet());
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+
+        // disable file system cache
+        cfg.setBoolean("fs.hdfs.impl.disable.cache", true);
+
+        // set file system to TestingFs to avoid a bunch of security
+        // checks, similar to what is done in HdfsTests.java
+        cfg.set(String.format("fs.AbstractFileSystem.%s.impl", uri.getScheme()),
+                TestingFs.class.getName());
+
+        // create the FileContext with our user
+        return Subject.doAs(subject, new PrivilegedAction<FileContext>() {
+            @Override
+            public FileContext run() {
+                try {
+                    TestingFs fs = (TestingFs) AbstractFileSystem.get(uri, cfg);
+                    return FileContext.getFileContext(fs, cfg);
+                } catch (UnsupportedFileSystemException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
     }
 }

--- a/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsBlobStoreContainerTests.java
+++ b/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsBlobStoreContainerTests.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.repositories.hdfs;
+
+import org.apache.hadoop.fs.FileContext;
+import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.repositories.ESBlobStoreContainerTestCase;
+
+import java.io.IOException;
+
+public class HdfsBlobStoreContainerTests extends ESBlobStoreContainerTestCase {
+
+    @Override
+    protected BlobStore newBlobStore() throws IOException {
+        return new HdfsBlobStore(FileContext.getFileContext(), "", 100);
+    }
+}

--- a/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsBlobStoreContainerTests.java
+++ b/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsBlobStoreContainerTests.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.AbstractFileSystem;
 import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.UnsupportedFileSystemException;
+import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.repositories.ESBlobStoreContainerTestCase;
 
@@ -55,7 +56,8 @@ public class HdfsBlobStoreContainerTests extends ESBlobStoreContainerTestCase {
         });
     }
 
-    public FileContext createContext(URI uri) {
+    @SuppressForbidden(reason = "lesser of two evils (the other being a bunch of JNI/classloader nightmares)")
+    private FileContext createContext(URI uri) {
         // mirrors HdfsRepository.java behaviour
         Configuration cfg = new Configuration(true);
         cfg.setClassLoader(HdfsRepository.class.getClassLoader());
@@ -85,8 +87,7 @@ public class HdfsBlobStoreContainerTests extends ESBlobStoreContainerTestCase {
 
         // set file system to TestingFs to avoid a bunch of security
         // checks, similar to what is done in HdfsTests.java
-        cfg.set(String.format("fs.AbstractFileSystem.%s.impl", uri.getScheme()),
-                TestingFs.class.getName());
+        cfg.set("fs.AbstractFileSystem." + uri.getScheme() + ".impl", TestingFs.class.getName());
 
         // create the FileContext with our user
         return Subject.doAs(subject, new PrivilegedAction<FileContext>() {

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobContainer.java
@@ -37,10 +37,10 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.io.Streams;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.NoSuchFileException;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -89,7 +89,7 @@ public class S3BlobContainer extends AbstractBlobContainer {
                 } else {
                     if (e instanceof AmazonS3Exception) {
                         if (404 == ((AmazonS3Exception) e).getStatusCode()) {
-                            throw new FileNotFoundException("Blob object [" + blobName + "] not found: " + e.getMessage());
+                            throw new NoSuchFileException("Blob object [" + blobName + "] not found: " + e.getMessage());
                         }
                     }
                     throw e;
@@ -116,7 +116,7 @@ public class S3BlobContainer extends AbstractBlobContainer {
     @Override
     public void deleteBlob(String blobName) throws IOException {
         if (!blobExists(blobName)) {
-            throw new IOException("Blob [" + blobName + "] does not exist");
+            throw new NoSuchFileException("Blob [" + blobName + "] does not exist");
         }
 
         try {

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobContainer.java
@@ -115,6 +115,10 @@ public class S3BlobContainer extends AbstractBlobContainer {
 
     @Override
     public void deleteBlob(String blobName) throws IOException {
+        if (!blobExists(blobName)) {
+            throw new IOException("Blob [" + blobName + "] does not exist");
+        }
+
         try {
             blobStore.client().deleteObject(blobStore.bucket(), buildKey(blobName));
         } catch (AmazonClientException e) {

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/blobstore/MockAmazonS3.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/blobstore/MockAmazonS3.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cloud.aws.blobstore;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AbstractAmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+import com.amazonaws.services.s3.model.CopyObjectResult;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.amazonaws.util.Base64;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.DigestInputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+class MockAmazonS3 extends AbstractAmazonS3 {
+
+    private Map<String, InputStream> blobs = new ConcurrentHashMap<>();
+
+    // in ESBlobStoreContainerTestCase.java, the maximum
+    // length of the input data is 100 bytes
+    private byte[] byteCounter = new byte[100];
+
+    @Override
+    public boolean doesBucketExist(String bucket) {
+        return true;
+    }
+
+    @Override
+    public ObjectMetadata getObjectMetadata(
+            GetObjectMetadataRequest getObjectMetadataRequest)
+            throws AmazonClientException, AmazonServiceException {
+        String blobName = getObjectMetadataRequest.getKey();
+
+        if (!blobs.containsKey(blobName)) {
+            throw new AmazonS3Exception("[" + blobName + "] does not exist.");
+        }
+
+        return new ObjectMetadata(); // nothing is done with it
+    }
+
+    @Override
+    public PutObjectResult putObject(PutObjectRequest putObjectRequest)
+            throws AmazonClientException, AmazonServiceException {
+        String blobName = putObjectRequest.getKey();
+        DigestInputStream stream = (DigestInputStream) putObjectRequest.getInputStream();
+
+        if (blobs.containsKey(blobName)) {
+            throw new AmazonS3Exception("[" + blobName + "] already exists.");
+        }
+
+        blobs.put(blobName, stream);
+
+        // input and output md5 hashes need to match to avoid an exception
+        String md5 = Base64.encodeAsString(stream.getMessageDigest().digest());
+        PutObjectResult result = new PutObjectResult();
+        result.setContentMd5(md5);
+
+        return result;
+    }
+
+    @Override
+    public S3Object getObject(GetObjectRequest getObjectRequest)
+            throws AmazonClientException, AmazonServiceException {
+        // in ESBlobStoreContainerTestCase.java, the prefix is empty,
+        // so the key and blobName are equivalent to each other
+        String blobName = getObjectRequest.getKey();
+
+        if (!blobs.containsKey(blobName)) {
+            throw new AmazonS3Exception("[" + blobName + "] does not exist.");
+        }
+
+        // the HTTP request attribute is irrelevant for reading
+        S3ObjectInputStream stream = new S3ObjectInputStream(
+                blobs.get(blobName), null, false);
+        S3Object s3Object = new S3Object();
+        s3Object.setObjectContent(stream);
+        return s3Object;
+    }
+
+    @Override
+    public ObjectListing listObjects(ListObjectsRequest listObjectsRequest)
+            throws AmazonClientException, AmazonServiceException {
+        MockObjectListing list = new MockObjectListing();
+        list.setTruncated(false);
+
+        String blobName;
+        String prefix = listObjectsRequest.getPrefix();
+
+        ArrayList<S3ObjectSummary> mockObjectSummaries = new ArrayList<>();
+
+        for (Map.Entry<String, InputStream> blob : blobs.entrySet()) {
+            blobName = blob.getKey();
+            S3ObjectSummary objectSummary = new S3ObjectSummary();
+
+            if (prefix.isEmpty() || blobName.startsWith(prefix)) {
+                objectSummary.setKey(blobName);
+
+                try {
+                    objectSummary.setSize(getSize(blob.getValue()));
+                } catch (IOException e) {
+                    throw new AmazonS3Exception("Object listing " +
+                            "failed for blob [" + blob.getKey() + "]");
+                }
+
+                mockObjectSummaries.add(objectSummary);
+            }
+        }
+
+        list.setObjectSummaries(mockObjectSummaries);
+        return list;
+    }
+
+    @Override
+    public CopyObjectResult copyObject(CopyObjectRequest copyObjectRequest)
+            throws AmazonClientException, AmazonServiceException {
+        String sourceBlobName = copyObjectRequest.getSourceKey();
+        String targetBlobName = copyObjectRequest.getDestinationKey();
+
+        if (!blobs.containsKey(sourceBlobName)) {
+            throw new AmazonS3Exception("Source blob [" +
+                    sourceBlobName + "] does not exist.");
+        }
+
+        if (blobs.containsKey(targetBlobName)) {
+            throw new AmazonS3Exception("Target blob [" +
+                    targetBlobName + "] already exists.");
+        }
+
+        blobs.put(targetBlobName, blobs.get(sourceBlobName));
+        return new CopyObjectResult(); // nothing is done with it
+    }
+
+    @Override
+    public void deleteObject(DeleteObjectRequest deleteObjectRequest)
+            throws AmazonClientException, AmazonServiceException {
+        String blobName = deleteObjectRequest.getKey();
+
+        if (!blobs.containsKey(blobName)) {
+            throw new AmazonS3Exception("[" + blobName + "] does not exist.");
+        }
+
+        blobs.remove(blobName);
+    }
+
+    private int getSize(InputStream stream) throws IOException {
+        int size = stream.read(byteCounter);
+        stream.reset(); // in case we ever need the size again
+        return size;
+    }
+
+    private class MockObjectListing extends ObjectListing {
+        // the objectSummaries attribute in ObjectListing.java
+        // is read-only, but we need to be able to write to it,
+        // so we create a mock of it to work around this
+        private List<S3ObjectSummary> mockObjectSummaries;
+
+        @Override
+        public List<S3ObjectSummary> getObjectSummaries() {
+            return mockObjectSummaries;
+        }
+
+        private void setObjectSummaries(List<S3ObjectSummary> objectSummaries) {
+            mockObjectSummaries = objectSummaries;
+        }
+    }
+}

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/blobstore/S3BlobStoreContainerTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/blobstore/S3BlobStoreContainerTests.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cloud.aws.blobstore;
+
+import com.amazonaws.Protocol;
+import com.amazonaws.services.s3.AmazonS3;
+import org.elasticsearch.cloud.aws.InternalAwsS3Service;
+import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.repositories.ESBlobStoreContainerTestCase;
+
+import java.io.IOException;
+import java.util.Locale;
+
+public class S3BlobStoreContainerTests extends ESBlobStoreContainerTestCase {
+    protected BlobStore newBlobStore() throws IOException {
+        int maxRetries = 5;
+        String region = null;
+        Settings settings = Settings.EMPTY;
+
+        InternalAwsS3Service service = new InternalAwsS3Service(settings);
+        AmazonS3 client = service.client(null, Protocol.HTTPS, region, null, null, maxRetries);
+        String bucket = randomAsciiOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
+
+        return new S3BlobStore(settings, client, bucket, region, false,
+            new ByteSizeValue(100), maxRetries, "public-read-write", "standard");
+    }
+}

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/blobstore/S3BlobStoreContainerTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/blobstore/S3BlobStoreContainerTests.java
@@ -19,11 +19,9 @@
 
 package org.elasticsearch.cloud.aws.blobstore;
 
-import com.amazonaws.Protocol;
-import com.amazonaws.services.s3.AmazonS3;
-import org.elasticsearch.cloud.aws.InternalAwsS3Service;
 import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.repositories.ESBlobStoreContainerTestCase;
 
@@ -32,15 +30,10 @@ import java.util.Locale;
 
 public class S3BlobStoreContainerTests extends ESBlobStoreContainerTestCase {
     protected BlobStore newBlobStore() throws IOException {
-        int maxRetries = 5;
-        String region = null;
-        Settings settings = Settings.EMPTY;
-
-        InternalAwsS3Service service = new InternalAwsS3Service(settings);
-        AmazonS3 client = service.client(null, Protocol.HTTPS, region, null, null, maxRetries);
+        MockAmazonS3 client = new MockAmazonS3();
         String bucket = randomAsciiOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
 
-        return new S3BlobStore(settings, client, bucket, region, false,
-            new ByteSizeValue(100), maxRetries, "public-read-write", "standard");
+        return new S3BlobStore(Settings.EMPTY, client, bucket, null, false,
+            new ByteSizeValue(10, ByteSizeUnit.MB), 5, "public-read-write", "standard");
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/repositories/ESBlobStoreContainerTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/ESBlobStoreContainerTestCase.java
@@ -112,6 +112,22 @@ public abstract class ESBlobStoreContainerTestCase extends ESTestCase {
         }
     }
 
+    public void testDeleteBlob() throws IOException {
+        try (final BlobStore store = newBlobStore()) {
+            final String blobName = "foobar";
+            final BlobContainer container = store.blobContainer(new BlobPath());
+            expectThrows(IOException.class, () -> container.deleteBlob(blobName));
+
+            byte[] data = randomBytes(randomIntBetween(10, scaledRandomIntBetween(1024, 1 << 16)));
+            final BytesArray bytesArray = new BytesArray(data);
+            container.writeBlob(blobName, bytesArray);
+            container.deleteBlob(blobName); // should not raise
+
+            // blob deleted, so should raise again
+            expectThrows(IOException.class, () -> container.deleteBlob(blobName));
+        }
+    }
+
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/15579")
     public void testOverwriteFails() throws IOException {
         try (final BlobStore store = newBlobStore()) {

--- a/test/framework/src/main/java/org/elasticsearch/repositories/ESBlobStoreContainerTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/ESBlobStoreContainerTestCase.java
@@ -129,16 +129,17 @@ public abstract class ESBlobStoreContainerTestCase extends ESTestCase {
     }
 
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/15579")
-    public void testOverwriteFails() throws IOException {
+    public void testVerifyOverwriteFails() throws IOException {
         try (final BlobStore store = newBlobStore()) {
             final String blobName = "foobar";
             final BlobContainer container = store.blobContainer(new BlobPath());
             byte[] data = randomBytes(randomIntBetween(10, scaledRandomIntBetween(1024, 1 << 16)));
             final BytesArray bytesArray = new BytesArray(data);
             container.writeBlob(blobName, bytesArray);
+            // should not be able to overwrite existing blob
             expectThrows(IOException.class, () -> container.writeBlob(blobName, bytesArray));
             container.deleteBlob(blobName);
-            container.writeBlob(blobName, bytesArray); // deleted it, so should be able to write it again
+            container.writeBlob(blobName, bytesArray); // after deleting the previous blob, we should be able to write to it again
         }
     }
 


### PR DESCRIPTION
This PR encompasses work done to enhance the resiliency of snapshot repository blob handling.  In particular:
1. deleteBlob methods in the `Repository` interface now throw an IOException if the blob does not exist.
2. Due to some test scenarios, this enhancement caused test failures, because blob names were based on the snapshot name (instead of snapshot UUID), which led to non-unique (i.e. mutable) blobs. So the deleteBlob change had to be accompanied by naming repository blobs by their snapshot UUIDs instead of snapshot names, which was part of the plan in #18156 
3. To consolidate all blob naming changes to one PR in order to avoid incompatibility issues, we also added the notion of an index ID (separate from the index UUID) used to name indices in the repositories `indices` folder, in order to prevent invalid characters in blob names as described in #7540

This PR is a combination of two other PRs:
#18815
#19421

Relates #18156 
