### PR TITLE
Add score_mode=script to function_score query 

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunction.java
@@ -34,34 +34,6 @@ import java.util.Objects;
 
 public class ScriptScoreFunction extends ScoreFunction {
 
-    static final class CannedScorer extends Scorer {
-        protected int docid;
-        protected float score;
-
-        public CannedScorer() {
-            super(null);
-        }
-
-        @Override
-        public int docID() {
-            return docid;
-        }
-
-        @Override
-        public float score() throws IOException {
-            return score;
-        }
-
-        @Override
-        public int freq() throws IOException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public DocIdSetIterator iterator() {
-            throw new UnsupportedOperationException();
-        }
-    }
 
     private final Script sScript;
 
@@ -77,7 +49,7 @@ public class ScriptScoreFunction extends ScoreFunction {
     @Override
     public LeafScoreFunction getLeafScoreFunction(LeafReaderContext ctx) throws IOException {
         final LeafSearchScript leafScript = script.getLeafSearchScript(ctx);
-        final CannedScorer scorer = new CannedScorer();
+        final FiltersFunctionScoreQuery.CannedScorer scorer = new FiltersFunctionScoreQuery.CannedScorer();
         leafScript.setScorer(scorer);
         return new LeafScoreFunction() {
             @Override

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -409,7 +409,19 @@ public abstract class QueryBuilders {
      * @return the function score query
      */
     public static FunctionScoreQueryBuilder functionScoreQuery(QueryBuilder queryBuilder, FunctionScoreQueryBuilder.FilterFunctionBuilder[] filterFunctionBuilders) {
-        return new FunctionScoreQueryBuilder(queryBuilder, filterFunctionBuilders);
+        return new FunctionScoreQueryBuilder(queryBuilder, filterFunctionBuilders, null);
+    }
+
+    /**
+     * A query that allows to define a custom scoring function
+     *
+     * @param queryBuilder The query to custom score
+     * @param filterFunctionBuilders the filters and functions to execute
+     * @return the function score query
+     */
+    public static FunctionScoreQueryBuilder functionScoreQuery(QueryBuilder queryBuilder,
+            FunctionScoreQueryBuilder.FilterFunctionBuilder[] filterFunctionBuilders, Script script) {
+        return new FunctionScoreQueryBuilder(queryBuilder, filterFunctionBuilders, script);
     }
 
     /**

--- a/docs/reference/query-dsl/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/function-score-query.asciidoc
@@ -82,6 +82,64 @@ First, each document is scored by the defined functions. The parameter
                 is applied
 `max`::         maximum score is used
 `min`::         minimum score is used
+`script`::      use script to determine the final score
+
+In the last case `score_mode: script` a script must be defined in the `score_script` parameter, see <<modules-scripting-using>> for the
+format. When using `score_mode: script`, each function must contain a parameter `var_name` which can then be used to refer to the function score from the script. Additinally a `no_match_score` can be added to each function. If the function's filter does not match a particular document, then the `no_match_score` will be used as the score for that function. If `no_match_score` is not specified, then the default score of 0 is used whenever the document does not match the filter.
+
+As an example of `score_mode: script`, the following query will multiply the result of the first two functions and then subtract the result of the third:
+
+[source,js]
+--------------------------------------------------
+POST test/_search
+{
+  "query": {
+    "function_score": {
+      "functions": [
+        {
+          "filter": {
+            "term": {
+              "text": "happy"
+            }
+          },
+          "weight": 10,
+          "var_name": "first", <1>
+          "no_match_score": 5 <2>
+        },
+        {
+          "filter": {
+            "term": {
+              "text": "hippo"
+            }
+          },
+          "weight": 10,
+          "var_name": "second", <1>
+          "no_match_score": 4 <2>
+        },
+        {
+          "weight": 10,
+          "var_name": "third" <1>
+        }
+      ],
+      "score_script": { <3>
+        "lang": "groovy",
+        "script": "first / second - third"
+      },
+      "score_mode": "script", <4>
+      "boost_mode": "replace"
+    }
+  }
+}
+--------------------------------------------------
+// CONSOLE
+
+<1> name that is later used as variable name in the `score_script`
+<2> default score for the filtered function when the filter does not match
+<3> the script to use when the individual scores are combined
+<4> score_mode "script" must be set in this case
+
+The language for `score_script` cannot be `expression`. In case you use painless the name of the varaible has to be prefixed with
+`params.` in the script (not the `var_name`).
 
 Because scores can be on different scales (for example, between 0 and 1 for decay functions but arbitrary for `field_value_factor`) and also
 because sometimes a different impact of functions on the score is desirable, the score of each function can be adjusted with a user defined

--- a/modules/lang-groovy/src/test/resources/rest-api-spec/test/lang_groovy/30_search.yaml
+++ b/modules/lang-groovy/src/test/resources/rest-api-spec/test/lang_groovy/30_search.yaml
@@ -1,0 +1,83 @@
+# Integration tests for groovy search scripting
+#
+
+"function_score with script combine":
+    - do:
+        index:
+            index: test
+            type: test
+            id: 1
+            body: { "dummy_field": 1 }
+    - do:
+        indices.refresh: {}
+
+
+    - do:
+        index: test
+        search:
+            body:
+                query:
+                    function_score:
+                        score_mode: script
+                        boost_mode: replace
+                        "functions": [ {
+                            "weight": 3,
+                            "var_name": "a"
+                        }, {
+                            "weight": 2,
+                            "var_name": "b"
+                        }, {
+                         "weight": 1,
+                         "var_name": "c"
+                        }]
+                        score_script:
+                           lang: groovy
+                           inline: "a+b-c"
+
+    - match: { hits.total: 1 }
+    - match: { hits.hits.0._score: 4 }
+
+
+---
+"function_score with script combine and _score":
+    - do:
+        index:
+            index: test
+            type: test
+            id: 1
+            body: { "dummy_field": 1 }
+    - do:
+        indices.refresh: {}
+
+
+    - do:
+        index: test
+        search:
+            body:
+                query:
+                    function_score:
+                        query:
+                            function_score:
+                                boost_mode: replace
+                                "functions": [ {
+                                    "weight": 3
+                                }]
+                        score_mode: script
+                        boost_mode: sum
+                        "functions": [ {
+                            "weight": 3,
+                            "var_name": "a"
+                        }, {
+                            "weight": 2,
+                            "var_name": "b"
+                        }, {
+                         "weight": 1,
+                         "var_name": "c"
+                        }]
+                        score_script:
+                           lang: groovy
+                           inline: "(a+b-c)*_score -_score"
+
+    - match: { hits.total: 1 }
+    - match: { hits.hits.0._score: 12 }
+

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/plan_a/30_search.yaml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/plan_a/30_search.yaml
@@ -393,3 +393,43 @@
     - match: { hits.hits.0._score: 1.0 }
     - match: { aggregations.value_agg.buckets.0.key: 2 }
     - match: { aggregations.value_agg.buckets.0.doc_count: 1 }
+
+
+---
+
+"function_score with script combine":
+    - do:
+        index:
+            index: test
+            type: test
+            id: 1
+            body: { "dummy_field": 1 }
+    - do:
+        indices.refresh: {}
+
+
+    - do:
+        index: test
+        search:
+            body:
+                query:
+                    function_score:
+                        score_mode: script
+                        boost_mode: replace
+                        "functions": [ {
+                            "weight": 3,
+                            "var_name": "a"
+                        }, {
+                            "weight": 2,
+                            "var_name": "b"
+                        }, {
+                         "weight": 1,
+                         "var_name": "c"
+                        }]
+                        score_script:
+                           lang: painless
+                           inline: "params.a+params.b-params.c"
+
+    - match: { hits.total: 1 }
+    - match: { hits.hits.0._score: 4 }
+


### PR DESCRIPTION
This PR is in response to #17116. We extend the function_score to allow for script scoring. The functions can each take a new `var_name` parameter, these names can then be referred to from the script specified in `score_script`.
