### PR TITLE
Document and enforce cancellation policy of CancellableThreads

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/util/CancellableThreads.java
+++ b/core/src/main/java/org/elasticsearch/common/util/CancellableThreads.java
@@ -30,11 +30,14 @@ import java.util.Set;
 /**
  * A utility class for multi threaded operation that needs to be cancellable via interrupts. Every cancellable operation should be
  * executed via {@link #execute(Interruptable)}, which will capture the executing thread and make sure it is interrupted in the case
- * cancellation.
+ * of cancellation.
+ *
+ * Cancellation policy: This class does not support external interruption via <code>Thread#interrupt()</code>. Always use #cancel() instead.
  */
 public class CancellableThreads {
     private final Set<Thread> threads = new HashSet<>();
-    private boolean cancelled = false;
+    // needs to be volatile as it is also read outside of synchronized blocks.
+    private volatile boolean cancelled = false;
     private String reason;
 
     public synchronized boolean isCancelled() {
@@ -94,13 +97,18 @@ public class CancellableThreads {
      */
     public void executeIO(IOInterruptable interruptable) throws IOException {
         boolean wasInterrupted = add();
+        boolean cancelledByExternalInterrupt = false;
         RuntimeException runtimeException = null;
         IOException ioException = null;
 
         try {
             interruptable.run();
         } catch (InterruptedException | ThreadInterruptedException e) {
-            // assume this is us and ignore
+            // ignore, this interrupt has been triggered by us in #cancel()...
+            assert cancelled : "Interruption via Thread#interrupt() is unsupported. Use CancellableThreads#cancel() instead";
+            // we can only reach here if assertions are disabled. If we reach this code and cancelled is false, this means that we've
+            // been interrupted externally (which we don't support).
+            cancelledByExternalInterrupt = !cancelled;
         } catch (RuntimeException t) {
             runtimeException = t;
         } catch (IOException e) {
@@ -128,6 +136,12 @@ public class CancellableThreads {
                 throw runtimeException;
             }
         }
+        if (cancelledByExternalInterrupt) {
+            // restore interrupt flag to at least adhere to expected behavior
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interruption via Thread#interrupt() is unsupported. Use CancellableThreads#cancel() instead");
+        }
+
     }
 
 


### PR DESCRIPTION
With this commit we add documentation and additional checks to
enforce the cancellation policy of CancellableThreads (which is
disallow `Thread#interrupt()` on any of the threads managed by
it).
