### PR TITLE
Avoid zen pinging threads to pile up

### DIFF
--- a/core/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -217,7 +217,8 @@ public class UnicastZenPing extends AbstractLifecycleComponent implements ZenPin
         temporalResponses.clear();
     }
 
-    public PingResponse[] pingAndWait(TimeValue duration) {
+    /** For testing purpose **/
+    PingResponse[] pingAndWait(TimeValue duration) {
         final AtomicReference<PingResponse[]> response = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ping(pings -> {

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -46,7 +46,6 @@ import org.elasticsearch.discovery.zen.elect.ElectMasterService;
 import org.elasticsearch.discovery.zen.ping.PingContextProvider;
 import org.elasticsearch.discovery.zen.ping.ZenPing;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.TransportChannel;
@@ -55,6 +54,7 @@ import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.Closeable;
@@ -317,7 +317,6 @@ public class UnicastZenPing extends AbstractLifecycleComponent implements ZenPin
         }
     }
 
-
     void sendPings(final TimeValue timeout, @Nullable TimeValue waitTime, final SendPingsHandler sendPingsHandler) {
         final UnicastPingRequest pingRequest = new UnicastPingRequest();
         pingRequest.id = sendPingsHandler.id();
@@ -381,7 +380,6 @@ public class UnicastZenPing extends AbstractLifecycleComponent implements ZenPin
                         logger.trace("replacing {} with temp node {}", nodeToSend, tempNode);
                         nodeToSend = tempNode;
                     }
-                    sendPingsHandler.nodeToDisconnect.add(nodeToSend);
                 }
                 // fork the connection to another thread
                 final DiscoveryNode finalNodeToSend = nodeToSend;
@@ -397,6 +395,9 @@ public class UnicastZenPing extends AbstractLifecycleComponent implements ZenPin
                             if (!nodeFoundByAddress) {
                                 logger.trace("[{}] connecting (light) to {}", sendPingsHandler.id(), finalNodeToSend);
                                 transportService.connectToNodeLightAndHandshake(finalNodeToSend, timeout.getMillis());
+
+                                logger.trace("[{}] add node {} to the list of nodes to disconnect", sendPingsHandler.id(), finalNodeToSend);
+                                sendPingsHandler.nodeToDisconnect.add(finalNodeToSend);
                             } else {
                                 logger.trace("[{}] connecting to {}", sendPingsHandler.id(), finalNodeToSend);
                                 transportService.connectToNode(finalNodeToSend);

--- a/core/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/core/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -478,15 +478,20 @@ public abstract class TcpTransport<Channel> extends AbstractLifecycleComponent i
 
     @Override
     public void disconnectFromNode(DiscoveryNode node) {
-        try (Releasable ignored = connectionLock.acquire(node.getId())) {
-            NodeChannels nodeChannels = connectedNodes.remove(node);
-            if (nodeChannels != null) {
-                try {
-                    logger.debug("disconnecting from [{}] due to explicit disconnect call", node);
-                    IOUtils.closeWhileHandlingException(nodeChannels);
-                } finally {
-                    logger.trace("disconnected from [{}] due to explicit disconnect call", node);
-                    transportServiceAdapter.raiseNodeDisconnected(node);
+        // this might be called multiple times, so do a lightweight check outside of the lock
+        NodeChannels nodeChannels = connectedNodes.get(node);
+        if (nodeChannels != null) {
+            try (Releasable ignored = connectionLock.acquire(node.getId())) {
+                // check again within the connection lock, if its still applicable to remove it
+                nodeChannels = connectedNodes.remove(node);
+                if (nodeChannels != null) {
+                    try {
+                        logger.debug("disconnecting from [{}] due to explicit disconnect call", node);
+                        IOUtils.closeWhileHandlingException(nodeChannels);
+                    } finally {
+                        logger.trace("disconnected from [{}] due to explicit disconnect call", node);
+                        transportServiceAdapter.raiseNodeDisconnected(node);
+                    }
                 }
             }
         }

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingTests.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.discovery.zen.ping.unicast;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.network.NetworkService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.discovery.zen.elect.ElectMasterService;
+import org.elasticsearch.discovery.zen.ping.PingContextProvider;
+import org.elasticsearch.discovery.zen.ping.ZenPing;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.MockTcpTransport;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportService;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class UnicastZenPingTests extends ESTestCase {
+
+    private static ThreadPool THREAD_POOL;
+
+    private TrackingMockTransportService transportA;
+    private TrackingMockTransportService transportB;
+    private DiscoveryNode nodeA;
+    private DiscoveryNode nodeB;
+
+    @BeforeClass
+    public static void createThreadPool() {
+        THREAD_POOL = new TestThreadPool(UnicastZenPingTests.class.getName());
+    }
+
+    @AfterClass
+    public static void destroyThreadPool() throws InterruptedException {
+        terminate(THREAD_POOL);
+        THREAD_POOL = null;
+    }
+
+    @Before
+    public void startTransports() {
+        transportA = createTransportService();
+        nodeA = new DiscoveryNode("node_a", transportA.boundAddress().publishAddress(), Version.CURRENT);
+        transportA.setLocalNode(nodeA);
+
+        transportB = createTransportService();
+        nodeB = new DiscoveryNode("node_b", transportB.boundAddress().publishAddress(), Version.CURRENT);
+        transportB.setLocalNode(nodeB);
+    }
+
+    @After
+    public void stopTransports() {
+        transportA.stop();
+        transportB.stop();
+    }
+
+    /**
+     * Test the Unicast Zen Ping responses when a node is unreachable at first and then becomes
+     * reachable. It also ensure that no disconnections are issued to an unreachable node.
+     */
+    public void testPingUnreachableThenReachableNode() throws Exception {
+        try (
+                UnicastZenPing zenPingB = createUnicastZenPing(transportB, nodeA.getAddress().toString());
+                UnicastZenPing zenPingA = createUnicastZenPing(transportA, nodeB.getAddress().toString());
+        ) {
+            PingContextProvider contextA = createPingContextProvider(nodeA, null);
+            assertNull("Node A must not resolve Node B by address", contextA.nodes().findByAddress(nodeB.getAddress()));
+            zenPingA.setPingContextProvider(contextA);
+            zenPingA.start();
+
+            PingContextProvider contextB = createPingContextProvider(nodeB, nodeA);
+            assertNotNull("Node B must resolve Node A by address", contextB.nodes().findByAddress(nodeA.getAddress()));
+            zenPingB.setPingContextProvider(contextB);
+            zenPingB.start();
+
+            logger.trace("Node A can't reach Node B");
+            transportA.addFailToSendNoConnectRule(nodeB.getAddress());
+
+            logger.trace("Node A pings Node B, no response is expected");
+            ZenPing.PingResponse[] pings = zenPingA.pingAndWait(TimeValue.timeValueSeconds(1L));
+            assertThat(pings, allOf(notNullValue(), arrayWithSize(0)));
+
+            logger.trace("Node A has no connection to Node B and did not initiate a disconnection");
+            assertFalse(transportA.nodeConnected(nodeB));
+            assertTrue(transportA.getDisconnects().isEmpty());
+
+            logger.trace("Node A can now reach Node B");
+            transportA.clearAllRules();
+
+            logger.trace("Node A pings Node B, one successful ping response is expected");
+            pings = zenPingA.pingAndWait(TimeValue.timeValueSeconds(1L));
+            assertThat(pings, arrayWithSize(1));
+
+            logger.trace("Node B pings Node A, one successful ping response is expected");
+            pings = zenPingB.pingAndWait(TimeValue.timeValueSeconds(1L));
+            assertThat(pings, arrayWithSize(1));
+
+            logger.trace("Node B kept the connection to Node A because it has been resolved by address");
+            assertBusy(() -> {
+                assertTrue(transportB.nodeConnected(nodeA));
+                assertTrue(transportB.getDisconnects().isEmpty());
+            });
+
+            logger.trace("Node A closed the connection to Node B");
+            assertBusy(() -> {
+                assertFalse(transportA.nodeConnected(nodeB));
+                assertThat(transportA.getDisconnects(), hasItem(nodeB.getAddress()));
+            });
+        }
+    }
+
+    private TrackingMockTransportService createTransportService() {
+        MockTcpTransport transport =
+                new MockTcpTransport(
+                        Settings.EMPTY,
+                        THREAD_POOL,
+                        BigArrays.NON_RECYCLING_INSTANCE,
+                        new NoneCircuitBreakerService(),
+                        new NamedWriteableRegistry(emptyList()),
+                        new NetworkService(Settings.EMPTY, emptyList()));
+
+        TrackingMockTransportService transportService = new TrackingMockTransportService(Settings.EMPTY, transport, THREAD_POOL);
+        transportService.start();
+        transportService.acceptIncomingRequests();
+        return transportService;
+    }
+
+    private UnicastZenPing createUnicastZenPing(TransportService transportService, String... unicastHosts) {
+        Settings settings = Settings.builder()
+                .putArray(UnicastZenPing.DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING.getKey(), unicastHosts)
+                .build();
+        return new UnicastZenPing(settings, THREAD_POOL, transportService, new ElectMasterService(settings), emptySet());
+    }
+
+    private PingContextProvider createPingContextProvider(DiscoveryNode local, DiscoveryNode other) {
+        return new PingContextProvider() {
+            @Override
+            public boolean nodeHasJoinedClusterOnce() {
+                return false;
+            }
+
+            @Override
+            public DiscoveryNodes nodes() {
+                DiscoveryNodes.Builder builder = DiscoveryNodes.builder().localNodeId(local.getId()).add(local);
+                if (other != null) {
+                    builder.add(other);
+                }
+                return builder.build();
+            }
+        };
+    }
+
+    /**
+     * A MockTransportService that tracks the number of disconnect attempts
+     **/
+    static class TrackingMockTransportService extends MockTransportService {
+
+        private final List<TransportAddress> disconnects = new CopyOnWriteArrayList<>();
+
+        TrackingMockTransportService(Settings settings, Transport transport, ThreadPool threadPool) {
+            super(settings, transport, threadPool);
+        }
+
+        @Override
+        public void disconnectFromNode(DiscoveryNode node) {
+            disconnects.add(node.getAddress());
+            super.disconnectFromNode(node);
+        }
+
+        List<TransportAddress> getDisconnects() {
+            return disconnects;
+        }
+    }
+}


### PR DESCRIPTION
The Unicast Zen Ping service pings all known nodes every 3 seconds using a light connecting method. For nodes defined in the configuration as unicast hosts and not yet "found by address" (meaning that a successful connection has never been established to them) the node is added to a list of nodes to disconnect once the ping is terminated whatever the result of the ping. The round of pings is executed until a master is elected, but if no master can be elected (because of min master nodes or in case of a tribe client node with an offline remote cluster) the pings are executed over and over.

The thing is that nodes are pinged every `3s` but the connection timeout is configured by default to `30s`. This leads to a situation where many threads are created and added to the generic thread pool in order to disconnect from the node but the disconnect method `TcpTransport.disconnectFromNode(DiscoveryNode node)` blindly tries to acquire a lock on the node even if it will be impossible to disconnect from it (because node is not reachable).  So disconnecting threads are stacked at the rate of 1 every 3sec until the generic thread pool is full.

Adding a check in the `TcpTransport.disconnectFromNode(DiscoveryNode node)` similar to the check done in`disconnectFromNode(DiscoveryNode node, Channel channel, String reason)` avoids threads to block for nothing.

We could also use a connection timeout of 3s when pinging nodes as it would help to fail connection faster and it would keep the number of blocking threads lower but would not resolve the main issue of threads blocking for nothing.

This settings can be used to reproduce the issue (check number of threads of generic thread pool):

```
tribe.t1.cluster.name: "offline"
tribe.t1.discovery.zen.ping.unicast.hosts:
- '10.10.10.10'
```

or

```
discovery.zen.minimum_master_nodes: 2
discovery.zen.ping.unicast.hosts:
- '10.10.10.10'
```

closes #19370

I think we have the same issue in 2.x. in `NettyTransport`
