### PR TITLE
Migration Guide changes for BlobContainer

### DIFF
--- a/docs/reference/migration/migrate_5_0/java.asciidoc
+++ b/docs/reference/migration/migrate_5_0/java.asciidoc
@@ -357,3 +357,26 @@ in favor of using `addTokenFilter(String)`/`addTokenFilter(Map)` and `addCharFil
 
 The `setTokenFilters(String...)` and `setCharFilters(String...)` methods have been removed
 in favor of using `addTokenFilter(String)`/`addTokenFilter(Map)` and `addCharFilter(String)`/`addCharFilter(Map)` each filters
+
+==== BlobContainer Interface for Snapshot/Restore
+
+Some methods have been removed from the `BlobContainer` interface for Snapshot/Restore repositories.  In particular,
+the following three methods have been removed:
+
+ 1. `deleteBlobs(Collection<String>)` (use `deleteBlob(String)` instead)
+ 2. `deleteBlobsByPrefix(String)` (use `deleteBlob(String)` instead)
+ 3. `writeBlob(String, BytesReference)` (use `writeBlob(String, InputStream, long)` instead)
+
+The `deleteBlob` methods that took multiple blobs as arguments were deleted because no atomic guarantees can be made about either deleting all blobs or deleting none of them, and exception handling in such a situation is ambiguous and best left to the caller. Hence, all delete blob calls use the singular `deleteBlob(String)` method. 
+
+The extra `writeBlob` method offered no real advantage to the interface and all calls to `writeBlob(blobName, bytesRef)` can be replaced with:
+
+[source,java]
+-----
+try (InputStream stream = bytesRef.streamInput()) {
+    blobContainer.writeBlob(blobName, stream, bytesRef.length());
+}
+-----
+
+For any custom implementations of the `BlobContainer` interface, these three methods must be removed.
+

--- a/docs/reference/migration/migrate_5_0/java.asciidoc
+++ b/docs/reference/migration/migrate_5_0/java.asciidoc
@@ -378,5 +378,5 @@ try (InputStream stream = bytesRef.streamInput()) {
 }
 -----
 
-For any custom implementations of the `BlobContainer` interface, these three methods must be removed.
+For any custom implementation of the `BlobContainer` interface, these three methods must be removed.
 


### PR DESCRIPTION
Adds a notice in the migration guide for removing two deleteBlobs and one writeBlob method from the BlobContainer interface.
