### PR TITLE
[Test] move methods from bwc test to test package for use in plugins

### DIFF
--- a/core/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityIT.java
@@ -19,10 +19,8 @@
 
 package org.elasticsearch.bwcompat;
 
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.util.LuceneTestCase;
-import org.apache.lucene.util.SmallFloat;
 import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
@@ -36,12 +34,9 @@ import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.elasticsearch.common.io.FileSystemUtils;
-import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.util.IndexFolderUpgrader;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -50,7 +45,6 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.gateway.MetaDataStateFormat;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.MergePolicyConfig;
 import org.elasticsearch.index.engine.Segment;
 import org.elasticsearch.index.mapper.string.StringFieldMapperPositionIncrementGapTests;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -64,6 +58,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.OldIndexBackwardsCompatibilityUtils;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.Matchers;
@@ -72,13 +67,8 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.DirectoryStream;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -113,19 +103,8 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
 
     @Before
     public void initIndexesList() throws Exception {
-        indexes = loadIndexesList("index");
-        unsupportedIndexes = loadIndexesList("unsupported");
-    }
-
-    private List<String> loadIndexesList(String prefix) throws IOException {
-        List<String> indexes = new ArrayList<>();
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(getBwcIndicesPath(), prefix + "-*.zip")) {
-            for (Path path : stream) {
-                indexes.add(path.getFileName().toString());
-            }
-        }
-        Collections.sort(indexes);
-        return indexes;
+        indexes = OldIndexBackwardsCompatibilityUtils.loadIndexesList("index", getBwcIndicesPath());
+        unsupportedIndexes = OldIndexBackwardsCompatibilityUtils.loadIndexesList("unsupported", getBwcIndicesPath());
     }
 
     @AfterClass
@@ -138,11 +117,7 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
 
     @Override
     public Settings nodeSettings(int ord) {
-        return Settings.builder()
-                .put(MergePolicyConfig.INDEX_MERGE_ENABLED, false) // disable merging so no segments will be upgraded
-                .put(ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_INCOMING_RECOVERIES_SETTING.getKey(), 30) // speed up recoveries
-                .put(ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_OUTGOING_RECOVERIES_SETTING.getKey(), 30)
-                .build();
+        return OldIndexBackwardsCompatibilityUtils.getSettings();
     }
 
     void setupCluster() throws Exception {
@@ -151,14 +126,15 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
         Path baseTempDir = createTempDir();
         // start single data path node
         Settings.Builder nodeSettings = Settings.builder()
-            .put(Environment.PATH_DATA_SETTING.getKey(), baseTempDir.resolve("single-path").toAbsolutePath())
-            .put(Node.NODE_MASTER_SETTING.getKey(), false); // workaround for dangling index loading issue when node is master
+                .put(Environment.PATH_DATA_SETTING.getKey(), baseTempDir.resolve("single-path").toAbsolutePath())
+                .put(Node.NODE_MASTER_SETTING.getKey(), false); // workaround for dangling index loading issue when node is master
         InternalTestCluster.Async<String> singleDataPathNode = internalCluster().startNodeAsync(nodeSettings.build());
 
         // start multi data path node
         nodeSettings = Settings.builder()
-            .put(Environment.PATH_DATA_SETTING.getKey(), baseTempDir.resolve("multi-path1").toAbsolutePath() + "," + baseTempDir.resolve("multi-path2").toAbsolutePath())
-            .put(Node.NODE_MASTER_SETTING.getKey(), false); // workaround for dangling index loading issue when node is master
+                .put(Environment.PATH_DATA_SETTING.getKey(), baseTempDir.resolve("multi-path1").toAbsolutePath() + "," + baseTempDir
+                        .resolve("multi-path2").toAbsolutePath())
+                .put(Node.NODE_MASTER_SETTING.getKey(), false); // workaround for dangling index loading issue when node is master
         InternalTestCluster.Async<String> multiDataPathNode = internalCluster().startNodeAsync(nodeSettings.build());
 
         // find single data path dir
@@ -174,8 +150,8 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
         multiDataPathNodeName = multiDataPathNode.get();
         nodePaths = internalCluster().getInstance(NodeEnvironment.class, multiDataPathNodeName).nodeDataPaths();
         assertEquals(2, nodePaths.length);
-        multiDataPath = new Path[] {nodePaths[0].resolve(NodeEnvironment.INDICES_FOLDER),
-                                   nodePaths[1].resolve(NodeEnvironment.INDICES_FOLDER)};
+        multiDataPath = new Path[]{nodePaths[0].resolve(NodeEnvironment.INDICES_FOLDER),
+                nodePaths[1].resolve(NodeEnvironment.INDICES_FOLDER)};
         assertFalse(Files.exists(multiDataPath[0]));
         assertFalse(Files.exists(multiDataPath[1]));
         Files.createDirectories(multiDataPath[0]);
@@ -186,86 +162,14 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
     }
 
     void upgradeIndexFolder() throws Exception {
-        final NodeEnvironment nodeEnvironment = internalCluster().getInstance(NodeEnvironment.class, singleDataPathNodeName);
-        IndexFolderUpgrader.upgradeIndicesIfNeeded(Settings.EMPTY, nodeEnvironment);
-        final NodeEnvironment nodeEnv = internalCluster().getInstance(NodeEnvironment.class, multiDataPathNodeName);
-        IndexFolderUpgrader.upgradeIndicesIfNeeded(Settings.EMPTY, nodeEnv);
-    }
-
-    String loadIndex(String indexFile) throws Exception {
-        Path unzipDir = createTempDir();
-        Path unzipDataDir = unzipDir.resolve("data");
-        String indexName = indexFile.replace(".zip", "").toLowerCase(Locale.ROOT).replace("unsupported-", "index-");
-
-        // decompress the index
-        Path backwardsIndex = getBwcIndicesPath().resolve(indexFile);
-        try (InputStream stream = Files.newInputStream(backwardsIndex)) {
-            TestUtil.unzip(stream, unzipDir);
-        }
-
-        // check it is unique
-        assertTrue(Files.exists(unzipDataDir));
-        Path[] list = FileSystemUtils.files(unzipDataDir);
-        if (list.length != 1) {
-            throw new IllegalStateException("Backwards index must contain exactly one cluster");
-        }
-
-        // the bwc scripts packs the indices under this path
-        Path src = list[0].resolve("nodes/0/indices/" + indexName);
-        assertTrue("[" + indexFile + "] missing index dir: " + src.toString(), Files.exists(src));
-
-        if (randomBoolean()) {
-            logger.info("--> injecting index [{}] into single data path", indexName);
-            copyIndex(logger, src, indexName, singleDataPath);
-        } else {
-            logger.info("--> injecting index [{}] into multi data path", indexName);
-            copyIndex(logger, src, indexName, multiDataPath);
-        }
-        return indexName;
+        OldIndexBackwardsCompatibilityUtils.upgradeIndexFolder(internalCluster(), singleDataPathNodeName);
+        OldIndexBackwardsCompatibilityUtils.upgradeIndexFolder(internalCluster(), multiDataPathNodeName);
     }
 
     void importIndex(String indexName) throws IOException {
         // force reloading dangling indices with a cluster state republish
         client().admin().cluster().prepareReroute().get();
         ensureGreen(indexName);
-    }
-
-    // randomly distribute the files from src over dests paths
-    public static void copyIndex(final ESLogger logger, final Path src, final String indexName, final Path... dests) throws IOException {
-        Path destinationDataPath = dests[randomInt(dests.length - 1)];
-        for (Path dest : dests) {
-            Path indexDir = dest.resolve(indexName);
-            assertFalse(Files.exists(indexDir));
-            Files.createDirectories(indexDir);
-        }
-        Files.walkFileTree(src, new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-                Path relativeDir = src.relativize(dir);
-                for (Path dest : dests) {
-                    Path destDir = dest.resolve(indexName).resolve(relativeDir);
-                    Files.createDirectories(destDir);
-                }
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                if (file.getFileName().toString().equals(IndexWriter.WRITE_LOCK_NAME)) {
-                    // skip lock file, we don't need it
-                    logger.trace("Skipping lock file: {}", file);
-                    return FileVisitResult.CONTINUE;
-                }
-
-                Path relativeFile = src.relativize(file);
-                Path destFile = destinationDataPath.resolve(indexName).resolve(relativeFile);
-                logger.trace("--> Moving {} to {}", relativeFile, destFile);
-                Files.move(file, destFile);
-                assertFalse(Files.exists(file));
-                assertTrue(Files.exists(destFile));
-                return FileVisitResult.CONTINUE;
-            }
-        });
     }
 
     void unloadIndex(String indexName) throws Exception {
@@ -295,7 +199,7 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
             fail(msg.toString());
         }
     }
-    
+
     public void testOldIndexes() throws Exception {
         setupCluster();
 
@@ -309,8 +213,18 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
     }
 
     void assertOldIndexWorks(String index) throws Exception {
-        Version version = extractVersion(index);
-        String indexName = loadIndex(index);
+        Version version = OldIndexBackwardsCompatibilityUtils.extractVersion(index);
+        Path[] paths;
+        if (randomBoolean()) {
+            logger.info("--> injecting index [{}] into single data path", index);
+            paths = new Path[]{singleDataPath};
+        } else {
+            logger.info("--> injecting index [{}] into multi data path", index);
+            paths = multiDataPath;
+        }
+
+        String indexName = index.replace(".zip", "").toLowerCase(Locale.ROOT).replace("unsupported-", "index-");
+        OldIndexBackwardsCompatibilityUtils.loadIndex(indexName, index, createTempDir(), getBwcIndicesPath(), logger, paths);
         // we explicitly upgrade the index folders as these indices
         // are imported as dangling indices and not available on
         // node startup
@@ -322,19 +236,10 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
         assertBasicAggregationWorks(indexName);
         assertRealtimeGetWorks(indexName);
         assertNewReplicasWork(indexName);
-        assertUpgradeWorks(indexName, isLatestLuceneVersion(version));
+        assertUpgradeWorks(indexName, OldIndexBackwardsCompatibilityUtils.isLatestLuceneVersion(version));
         assertDeleteByQueryWorked(indexName, version);
         assertPositionIncrementGapDefaults(indexName, version);
         unloadIndex(indexName);
-    }
-
-    Version extractVersion(String index) {
-        return Version.fromString(index.substring(index.indexOf('-') + 1, index.lastIndexOf('.')));
-    }
-
-    boolean isLatestLuceneVersion(Version version) {
-        return version.luceneVersion.major == Version.CURRENT.luceneVersion.major &&
-                version.luceneVersion.minor == Version.CURRENT.luceneVersion.minor;
     }
 
     void assertIndexSanity(String indexName, Version indexCreated) {
@@ -411,7 +316,8 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
 
     void assertBasicAggregationWorks(String indexName) {
         // histogram on a long
-        SearchResponse searchRsp = client().prepareSearch(indexName).addAggregation(AggregationBuilders.histogram("histo").field("long_sort").interval(10)).get();
+        SearchResponse searchRsp = client().prepareSearch(indexName).addAggregation(AggregationBuilders.histogram("histo").field
+                ("long_sort").interval(10)).get();
         ElasticsearchAssertions.assertSearchResponse(searchRsp);
         Histogram histo = searchRsp.getAggregations().get("histo");
         assertNotNull(histo);
@@ -454,7 +360,7 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
         final long startTime = System.currentTimeMillis();
         logger.debug("--> creating [{}] replicas for index [{}]", numReplicas, indexName);
         assertAcked(client().admin().indices().prepareUpdateSettings(indexName).setSettings(Settings.builder()
-                        .put("number_of_replicas", numReplicas)
+                .put("number_of_replicas", numReplicas)
         ).execute().actionGet());
         ensureGreen(TimeValue.timeValueMinutes(2), indexName);
         logger.debug("--> index [{}] is green, took [{}]", indexName, TimeValue.timeValueMillis(System.currentTimeMillis() - startTime));
@@ -484,7 +390,7 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
 
     void assertUpgradeWorks(String indexName, boolean alreadyLatest) throws Exception {
         if (alreadyLatest == false) {
-            UpgradeIT.assertNotUpgraded(client(), indexName);
+            OldIndexBackwardsCompatibilityUtils.assertNotUpgraded(client(), indexName);
         }
         assertNoFailures(client().admin().indices().prepareUpgrade(indexName).get());
         UpgradeIT.assertUpgraded(client(), indexName);

--- a/core/src/test/java/org/elasticsearch/common/util/IndexFolderUpgraderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/IndexFolderUpgraderTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.index.shard.ShardStateMetaData;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.OldIndexBackwardsCompatibilityUtils;
 
 import java.io.BufferedWriter;
 import java.io.FileNotFoundException;
@@ -215,7 +216,7 @@ public class IndexFolderUpgraderTests extends ESTestCase {
             assertTrue("[" + path + "] missing index dir: " + src.toString(), Files.exists(src));
             final Path indicesPath = randomFrom(nodeEnvironment.nodePaths()).indicesPath;
             logger.info("--> injecting index [{}] into [{}]", indexName, indicesPath);
-            OldIndexBackwardsCompatibilityIT.copyIndex(logger, src, indexName, indicesPath);
+            OldIndexBackwardsCompatibilityUtils.copyIndex(logger, src, indexName, indicesPath);
             IndexFolderUpgrader.upgradeIndicesIfNeeded(Settings.EMPTY, nodeEnvironment);
 
             // ensure old index folder is deleted

--- a/core/src/test/java/org/elasticsearch/common/util/IndexFolderUpgraderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/IndexFolderUpgraderTests.java
@@ -23,7 +23,6 @@ import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.Version;
-import org.elasticsearch.bwcompat.OldIndexBackwardsCompatibilityIT;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.AllocationId;
 import org.elasticsearch.common.UUIDs;
@@ -39,7 +38,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.index.shard.ShardStateMetaData;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.OldIndexBackwardsCompatibilityUtils;
+import org.elasticsearch.test.OldIndexUtils;
 
 import java.io.BufferedWriter;
 import java.io.FileNotFoundException;
@@ -216,7 +215,7 @@ public class IndexFolderUpgraderTests extends ESTestCase {
             assertTrue("[" + path + "] missing index dir: " + src.toString(), Files.exists(src));
             final Path indicesPath = randomFrom(nodeEnvironment.nodePaths()).indicesPath;
             logger.info("--> injecting index [{}] into [{}]", indexName, indicesPath);
-            OldIndexBackwardsCompatibilityUtils.copyIndex(logger, src, indexName, indicesPath);
+            OldIndexUtils.copyIndex(logger, src, indexName, indicesPath);
             IndexFolderUpgrader.upgradeIndicesIfNeeded(Settings.EMPTY, nodeEnvironment);
 
             // ensure old index folder is deleted

--- a/test/framework/src/main/java/org/elasticsearch/test/OldIndexBackwardsCompatibilityUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/OldIndexBackwardsCompatibilityUtils.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.util.TestUtil;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.indices.upgrade.get.IndexUpgradeStatus;
+import org.elasticsearch.action.admin.indices.upgrade.get.UpgradeStatusResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
+import org.elasticsearch.common.io.FileSystemUtils;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.IndexFolderUpgrader;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.MergePolicyConfig;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.elasticsearch.test.ESTestCase.randomInt;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+
+
+public class OldIndexBackwardsCompatibilityUtils {
+
+
+    public static List<String> loadIndexesList(String prefix, Path bwcIndicesPath) throws IOException {
+        List<String> indexes = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(bwcIndicesPath, prefix + "-*.zip")) {
+            for (Path path : stream) {
+                indexes.add(path.getFileName().toString());
+            }
+        }
+        Collections.sort(indexes);
+        return indexes;
+    }
+
+    public static Settings getSettings() {
+        return Settings.builder()
+                .put(MergePolicyConfig.INDEX_MERGE_ENABLED, false) // disable merging so no segments will be upgraded
+                .put(ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_INCOMING_RECOVERIES_SETTING.getKey(), 30) //
+                // speed up recoveries
+                .put(ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_OUTGOING_RECOVERIES_SETTING.getKey(), 30)
+                .build();
+    }
+
+    public static void upgradeIndexFolder(InternalTestCluster cluster, String nodeName) throws Exception {
+        final NodeEnvironment nodeEnvironment = cluster.getInstance(NodeEnvironment.class, nodeName);
+        IndexFolderUpgrader.upgradeIndicesIfNeeded(Settings.EMPTY, nodeEnvironment);
+    }
+
+    public static void loadIndex(String indexName, String indexFile, Path unzipDir, Path bwcPath, ESLogger logger, Path... paths) throws
+        Exception {
+        Path unzipDataDir = unzipDir.resolve("data");
+
+        Path backwardsIndex = bwcPath.resolve(indexFile);
+        // decompress the index
+        try (InputStream stream = Files.newInputStream(backwardsIndex)) {
+            TestUtil.unzip(stream, unzipDir);
+        }
+
+        // check it is unique
+        assertTrue(Files.exists(unzipDataDir));
+        Path[] list = FileSystemUtils.files(unzipDataDir);
+        if (list.length != 1) {
+            throw new IllegalStateException("Backwards index must contain exactly one cluster");
+        }
+
+        // the bwc scripts packs the indices under this path
+        Path src = list[0].resolve("nodes/0/indices/" + indexName);
+        assertTrue("[" + indexFile + "] missing index dir: " + src.toString(), Files.exists(src));
+        copyIndex(logger, src, indexName, paths);
+    }
+
+    public static void assertNotUpgraded(Client client, String... index) throws Exception {
+        for (IndexUpgradeStatus status : getUpgradeStatus(client, index)) {
+            assertTrue("index " + status.getIndex() + " should not be zero sized", status.getTotalBytes() != 0);
+            // TODO: it would be better for this to be strictly greater, but sometimes an extra flush
+            // mysteriously happens after the second round of docs are indexed
+            assertTrue("index " + status.getIndex() + " should have recovered some segments from transaction log",
+                    status.getTotalBytes() >= status.getToUpgradeBytes());
+            assertTrue("index " + status.getIndex() + " should need upgrading", status.getToUpgradeBytes() != 0);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Collection<IndexUpgradeStatus> getUpgradeStatus(Client client, String... indices) throws Exception {
+        UpgradeStatusResponse upgradeStatusResponse = client.admin().indices().prepareUpgradeStatus(indices).get();
+        assertNoFailures(upgradeStatusResponse);
+        return upgradeStatusResponse.getIndices().values();
+    }
+
+    // randomly distribute the files from src over dests paths
+    public static void copyIndex(final ESLogger logger, final Path src, final String indexName, final Path... dests) throws IOException {
+        Path destinationDataPath = dests[randomInt(dests.length - 1)];
+        for (Path dest : dests) {
+            Path indexDir = dest.resolve(indexName);
+            assertFalse(Files.exists(indexDir));
+            Files.createDirectories(indexDir);
+        }
+        Files.walkFileTree(src, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                Path relativeDir = src.relativize(dir);
+                for (Path dest : dests) {
+                    Path destDir = dest.resolve(indexName).resolve(relativeDir);
+                    Files.createDirectories(destDir);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                if (file.getFileName().toString().equals(IndexWriter.WRITE_LOCK_NAME)) {
+                    // skip lock file, we don't need it
+                    logger.trace("Skipping lock file: {}", file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                Path relativeFile = src.relativize(file);
+                Path destFile = destinationDataPath.resolve(indexName).resolve(relativeFile);
+                logger.trace("--> Moving {} to {}", relativeFile, destFile);
+                Files.move(file, destFile);
+                assertFalse(Files.exists(file));
+                assertTrue(Files.exists(destFile));
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    public static Version extractVersion(String index) {
+        return Version.fromString(index.substring(index.indexOf('-') + 1, index.lastIndexOf('.')));
+    }
+
+    public static boolean isLatestLuceneVersion(Version version) {
+        return version.luceneVersion.major == Version.CURRENT.luceneVersion.major &&
+                version.luceneVersion.minor == Version.CURRENT.luceneVersion.minor;
+    }
+}


### PR DESCRIPTION
I need this for testing bwc of a plugin otherwise I will have to copy much code. I first thought we might extract a base class but don't think this is a good idea because at least in my case I want to derive from a different base class already.
