### PR TITLE
Default REST tests to use one shard

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yaml
@@ -9,6 +9,7 @@
         wait_for_active_shards: 1
         body:
           settings:
+            number_of_shards: "2"
             number_of_replicas: "0"
   - do:
       index:


### PR DESCRIPTION
This commit modifies the REST test setup to add a top-level template
that sets the number of shards to one. The motivation for this is to
reduce the runtime of the REST tests, which are plagued by an excessive
number of fsyncs that can be reduced by reducing the number of shards.
