### PR TITLE
Function as though max_local_storage_nodes defaults to 1 in prod mode

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -175,7 +175,7 @@ final class Bootstrap {
         node = new Node(environment) {
             @Override
             protected void validateNodeBeforeAcceptingRequests(Settings settings, BoundTransportAddress boundTransportAddress) {
-                BootstrapCheck.check(settings, boundTransportAddress);
+                BootstrapCheck.check(settings, getNodeEnvironment().getNodeLockId(), boundTransportAddress);
             }
         };
     }

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
@@ -60,14 +60,14 @@ final class BootstrapCheck {
      * checks
      *
      * @param settings              the current node settings
-     * @param dataDirectoryNumber   the integer number of the directories who's locks under the data directory we were able to take
+     * @param dataDirectoryIndex   the index of the directories who's locks under the data directories we were able to take
      * @param boundTransportAddress the node network bindings
      */
-    static void check(final Settings settings, final int dataDirectoryNumber, final BoundTransportAddress boundTransportAddress) {
+    static void check(final Settings settings, final int dataDirectoryIndex, final BoundTransportAddress boundTransportAddress) {
         check(
                 enforceLimits(boundTransportAddress),
                 BootstrapSettings.IGNORE_SYSTEM_BOOTSTRAP_CHECKS.get(settings),
-                checks(settings, dataDirectoryNumber),
+                checks(settings, dataDirectoryIndex),
                 Node.NODE_NAME_SETTING.get(settings));
     }
 
@@ -155,7 +155,7 @@ final class BootstrapCheck {
     }
 
     // the list of checks to execute
-    static List<Check> checks(final Settings settings, final int dataDirectoryNumber) {
+    static List<Check> checks(final Settings settings, final int dataDirectoryIndex) {
         final List<Check> checks = new ArrayList<>();
         checks.add(new HeapSizeCheck());
         final FileDescriptorCheck fileDescriptorCheck
@@ -180,7 +180,7 @@ final class BootstrapCheck {
          * check will produce consistent results even if Elasticsearch isn't being run in production mode. We rely on the production mode
          * detection that BootstrapCheck already does decide whether or not to throw an error.
          */
-        checks.add(new DataDirectoryLockNumberCheck(dataDirectoryNumber, NodeEnvironment.getMaxLocalStorageNodes(settings, true)));
+        checks.add(new DataDirectoryLockNumberCheck(dataDirectoryIndex, NodeEnvironment.getMaxLocalStorageNodes(settings, true)));
         return Collections.unmodifiableList(checks);
     }
 
@@ -605,22 +605,22 @@ final class BootstrapCheck {
      * {@link NodeEnvironment#MAX_LOCAL_STORAGE_NODES_SETTING}.
      */
     static class DataDirectoryLockNumberCheck implements BootstrapCheck.Check {
-        private final int dataDirectoryNumber;
+        private final int dataDirectoryIndex;
         private final int maxLocalStorageNodes;
 
-        DataDirectoryLockNumberCheck(int dataDirectoryNumber, int maxLocalStorageNodes) {
-            this.dataDirectoryNumber = dataDirectoryNumber;
+        DataDirectoryLockNumberCheck(int dataDirectoryIndex, int maxLocalStorageNodes) {
+            this.dataDirectoryIndex = dataDirectoryIndex;
             this.maxLocalStorageNodes = maxLocalStorageNodes;
         }
 
         @Override
         public boolean check() {
-            return dataDirectoryNumber < maxLocalStorageNodes;
+            return dataDirectoryIndex < maxLocalStorageNodes;
         }
 
         @Override
         public String errorMessage() {
-            return "there are already [" + dataDirectoryNumber + "] Elasticsearch processes running with this data directory";
+            return "there are already [" + dataDirectoryIndex + "] Elasticsearch processes running with this data directory";
         }
 
         @Override

--- a/docs/reference/migration/migrate_5_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_5_0/settings.asciidoc
@@ -73,7 +73,7 @@ scope (e.g. `_local_,_site_` for all loopback and private network addresses)
 or by explicit interface names, hostnames, or addresses.
 
 The `netty.epollBugWorkaround` settings is removed. This settings allow people to enable
-a netty work around for https://github.com/netty/netty/issues/327[a high CPU usage issue] with early JVM versions. 
+a netty work around for https://github.com/netty/netty/issues/327[a high CPU usage issue] with early JVM versions.
 This bug was http://bugs.java.com/view_bug.do?bug_id=6403933[fixed in Java 7]. Since Elasticsearch 5.0 requires Java 8 the settings is removed. Note that if the workaround needs to be reintroduced you can still set the `org.jboss.netty.epollBugWorkaround` system property to control Netty directly.
 
 ==== Forbid changing of thread pool types
@@ -258,6 +258,15 @@ The `action.get.realtime` setting has been removed. This setting was
 a fallback realtime setting for the get and mget APIs when realtime
 wasn't specified. Now if the parameter isn't specified we always
 default to true.
+
+==== `node.max_local_storage_nodes` defaults to 1 in production mode
+
+If you don't explicitly set `node.max_local_storage_nodes` and you start
+multiple Elasticsearch processes in the same source directories then
+Elasticsearch will log warning if it hasn't bound to any non-local addresses.
+If it *has* bound to any non-local addresses then it'll refuse to start,
+with the message
+`there are already [1] Elasticsearch processes running with this data directory`.
 
 === Script settings
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -82,7 +82,7 @@ cluster health to have a stable master node.
 Any master-eligible node (all nodes by default) may be elected to become the
 master node by the <<modules-discovery-zen,master election process>>.
 
-IMPORTANT: Master nodes must have access to the `data/` directory (just like 
+IMPORTANT: Master nodes must have access to the `data/` directory (just like
 `data` nodes) as this is where the cluster state is persisted between node restarts.
 
 Indexing and searching your data is CPU-, memory-, and I/O-intensive work
@@ -284,14 +284,19 @@ your data! The RPM and Debian distributions do this for you already.
 The <<data-path,data path>> can be shared by multiple nodes, even by nodes
 from different clusters.  This is very useful for testing failover and
 different configurations on your development machine.  In production, however,
-it is recommended to run only one node of Elasticsearch per server.
+it is recommended to run only one node of Elasticsearch per server. If you
+don't explicitly set `node.max_local_storage_nodes` then Elasticsearch will
+log a warning if multiple nodes share the same data directory and it hasn't
+bound to any non-local addresses. If it has bound to any non-local addresses
+then it'll refuse to start.
 
-To prevent more than one node from sharing the same data path, add this
-setting to the `elasticsearch.yml` config file:
+You can always override the setting to *allow* more than one node to share the
+same data directory in production mode by setting it in the `elasticsearch.yml`
+config file:
 
 [source,yaml]
 ------------------------------
-node.max_local_storage_nodes: 1
+node.max_local_storage_nodes: 2
 ------------------------------
 
 WARNING: Never run different node types (i.e. master, data) from the

--- a/docs/reference/setup/important-settings.asciidoc
+++ b/docs/reference/setup/important-settings.asciidoc
@@ -12,7 +12,6 @@ configured before going into production.
 * <<network.host,`network.host`>>
 * <<unicast.hosts,`discovery.zen.ping.unicast.hosts`>>
 * <<minimum_master_nodes,`discovery.zen.minimum_master_nodes`>>
-* <<node.max_local_storage_nodes,`node.max_local_storage_nodes`>>
 
 [float]
 [[path-settings]]
@@ -185,32 +184,3 @@ discovery.zen.minimum_master_nodes: 2
 IMPORTANT: If `discovery.zen.minimum_master_nodes` is not set when
 Elasticsearch is running in <<dev-vs-prod,production mode>>, an exception will
 be thrown which will prevent the node from starting.
-
-[float]
-[[node.max_local_storage_nodes]]
-=== `node.max_local_storage_nodes`
-
-It is possible to start more than one node on the same server from the same
-`$ES_HOME`, just by doing the following:
-
-[source,sh]
---------------------------------------------------
-./bin/elasticsearch -d
-./bin/elasticsearch -d
---------------------------------------------------
-
-This works just fine: the data directory structure is designed to let multiple
-nodes coexist.  However, a single instance of Elasticsearch is able to use all
-of the resources of a single server and it seldom makes sense to run multiple
-nodes on the same server in production.
-
-It is, however, possible to start more than one node on the same server by
-mistake and to be completely unaware that this problem exists. To prevent more
-than one node from sharing the same data directory, it is advisable to add the
-following setting:
-
-[source,yaml]
---------------------------------------------------
-node.max_local_storage_nodes: 1
---------------------------------------------------
-


### PR DESCRIPTION
Defaulting `max_local_storage_nodes` to `50` is useful for testing so
this patch moves that default from "all the time" to "if you don't bind
a public ip". If you _do_ bind a public IP and attempt to use more than
a single node per data directory without _explicitly_ setting
`max_local_storage_nodes` then Elasticsearch will now fail to start.

Since you can't change the default for a setting depending on the
"prod-mode/non-prod-mode" flag we instead use a sentinel value (`0`) of
`max_local_storage_nodes` to mean "user didn't specify, pick it from
the "prod-mode/non-prod-mode" flag".

Since we don't know if we're in prod mode when we pick the data directory
we instead assume that we _aren't_ and then check if the directory that
we picked was OK when we run the `BootstrapCheck`s. The nice thing about
doing it this way is that we warn the user if they have more than one
Elasticsearch in their data directory even if they are running even in dev
mode!

While this is the easiest way to make this change the cost is that, even
if Elasticsearch fails to start because it is in production mode and
`max_local_storage_nodes` isn't configured it'll still create a directory.

This also removes some of the documentation that suggests you override the
setting on all production clusters. That is no longer important because
Elasticsearch won't start in production mode if you try to start more
than one node.

Closes #19679
