### PR TITLE
Throw ParsingException if a query is wrapped in an array

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/ParseField.java
+++ b/core/src/main/java/org/elasticsearch/common/ParseField.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.logging.Loggers;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -108,6 +109,7 @@ public class ParseField {
      *         names for this {@link ParseField}.
      */
     boolean match(String fieldName, boolean strict) {
+        Objects.requireNonNull(fieldName, "fieldName cannot be null");
         // if this parse field has not been completely deprecated then try to
         // match the preferred name
         if (allReplacedWith == null && fieldName.equals(name)) {

--- a/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -109,13 +109,13 @@ public class QueryParseContext implements ParseFieldMatcherSupplier {
         String queryName = parser.currentName();
         // move to the next START_OBJECT
         token = parser.nextToken();
-        if (token != XContentParser.Token.START_OBJECT && token != XContentParser.Token.START_ARRAY) {
-            throw new ParsingException(parser.getTokenLocation(), "[_na] query malformed, no start_object after query name");
+        if (token != XContentParser.Token.START_OBJECT) {
+            throw new ParsingException(parser.getTokenLocation(), "[" + queryName + "] query malformed, no start_object after query name");
         }
         @SuppressWarnings("unchecked")
         Optional<QueryBuilder> result = (Optional<QueryBuilder>) indicesQueriesRegistry.lookup(queryName, parseFieldMatcher,
                 parser.getTokenLocation()).fromXContent(this);
-        if (parser.currentToken() == XContentParser.Token.END_OBJECT || parser.currentToken() == XContentParser.Token.END_ARRAY) {
+        if (parser.currentToken() == XContentParser.Token.END_OBJECT) {
             // if we are at END_OBJECT, move to the next one...
             parser.nextToken();
         }

--- a/core/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTests.java
@@ -24,8 +24,6 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 
@@ -34,16 +32,6 @@ public class MatchAllQueryBuilderTests extends AbstractQueryTestCase<MatchAllQue
     @Override
     protected MatchAllQueryBuilder doCreateTestQueryBuilder() {
         return new MatchAllQueryBuilder();
-    }
-
-    @Override
-    protected Map<String, MatchAllQueryBuilder> getAlternateVersions() {
-        Map<String, MatchAllQueryBuilder> alternateVersions = new HashMap<>();
-        String queryAsString = "{\n" +
-                "    \"match_all\": []\n" +
-                "}";
-        alternateVersions.put(queryAsString, new MatchAllQueryBuilder());
-        return alternateVersions;
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/QueryParseContextTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryParseContextTests.java
@@ -113,7 +113,7 @@ public class QueryParseContextTests extends ESTestCase {
         try (XContentParser parser = JsonXContent.jsonXContent.createParser(source)) {
             QueryParseContext context = new QueryParseContext(indicesQueriesRegistry, parser, ParseFieldMatcher.STRICT);
             ParsingException exception = expectThrows(ParsingException.class, () ->  context.parseInnerQueryBuilder());
-            assertEquals("[_na] query malformed, no start_object after query name", exception.getMessage());
+            assertEquals("[foo] query malformed, no start_object after query name", exception.getMessage());
         }
 
         source = "{ \"foo\" : {} }";


### PR DESCRIPTION
Our parsing code accepted up until now queries in the following form (note that the query starts with `[`):

```
{
    "bool" : [
        {
          "must" : []
        }
    ]
}
```

This would lead to a null pointer exception as most parsers assume that the field name ("must" in this example) is the first thing that can be found in a query if its json is valid. Truth is that the additional array layer doesn't make the json invalid, hence the following code fragment would cause NPE within ParseField, because null gets passed to `parseContext.isDeprecatedSetting`:

```
if (token == XContentParser.Token.FIELD_NAME) {
    currentFieldName = parser.currentName();
} else if (parseContext.isDeprecatedSetting(currentFieldName)) {
    // skip
} else if (token == XContentParser.Token.START_OBJECT) {
```

As a solution we could add null checks in each of our parsers in lots of places, but we rely on `currentFieldName` being non null in all of our parsers, and we should consider it a bug when these unexpected situations are not caught explicitly and early.

The reason why such a query goes through is that we've been allowing a query to start with either `[` or `{`. The only reason I found for that is that we accept `match_all : []`. This seems like an undocumented corner case that we could drop support for. That would allow us to be stricter and accept only `{` as start token of a query. That way the only next token that the parser can encounter if the json is valid (otherwise the json parser would barf earlier) is actually a field_name, hence the assumption that all our parsers make holds again. 

The latter is the fix I made as part of this PR. The downside of it is simply dropping support for `match_all : []`.

Relates to #12887
