### PR TITLE
Snapshot repository cleans up empty index folders

### DIFF
--- a/core/src/main/java/org/elasticsearch/repositories/IndexId.java
+++ b/core/src/main/java/org/elasticsearch/repositories/IndexId.java
@@ -38,15 +38,19 @@ public final class IndexId implements Writeable, ToXContent {
 
     private final String name;
     private final String id;
+    private final int hashCode;
 
     public IndexId(final String name, final String id) {
         this.name = name;
         this.id = id;
+        this.hashCode = computeHashCode();
+
     }
 
     public IndexId(final StreamInput in) throws IOException {
         this.name = in.readString();
         this.id = in.readString();
+        this.hashCode = computeHashCode();
     }
 
     /**
@@ -90,6 +94,10 @@ public final class IndexId implements Writeable, ToXContent {
 
     @Override
     public int hashCode() {
+        return hashCode;
+    }
+
+    private int computeHashCode() {
         return Objects.hash(name, id);
     }
 

--- a/core/src/test/java/org/elasticsearch/snapshots/FsBlobStoreRepositoryIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/FsBlobStoreRepositoryIT.java
@@ -20,7 +20,7 @@ package org.elasticsearch.snapshots;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.repositories.ESBlobStoreRepositoryIntegTestCase;
+import org.elasticsearch.repositories.blobstore.ESBlobStoreRepositoryIntegTestCase;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 

--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugin.repository.gcs.GoogleCloudStoragePlugin;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.repositories.ESBlobStoreRepositoryIntegTestCase;
+import org.elasticsearch.repositories.blobstore.ESBlobStoreRepositoryIntegTestCase;
 import org.junit.BeforeClass;
 
 import java.util.Collection;

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
@@ -16,13 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.repositories;
+package org.elasticsearch.repositories.blobstore;
 
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequestBuilder;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequestBuilder;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.util.Arrays;
@@ -158,6 +164,66 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
         for (int i = 0; i < iterationCount; i++) {
             logger.info("-->  delete snapshot {}:{}", repoName, snapshotName + "-" + i);
             assertAcked(client().admin().cluster().prepareDeleteSnapshot(repoName, snapshotName + "-" + i).get());
+        }
+    }
+
+    public void testIndicesDeletedFromRepository() throws Exception {
+        Client client = client();
+
+        logger.info("-->  creating repository");
+        final String repoName = "test-repo";
+        assertAcked(client.admin().cluster().preparePutRepository(repoName)
+                        .setType("fs").setSettings(Settings.builder().put("location", randomRepoPath())));
+
+        createIndex("test-idx-1", "test-idx-2", "test-idx-3");
+        ensureGreen();
+
+        logger.info("--> indexing some data");
+        for (int i = 0; i < 20; i++) {
+            index("test-idx-1", "doc", Integer.toString(i), "foo", "bar" + i);
+            index("test-idx-2", "doc", Integer.toString(i), "foo", "baz" + i);
+            index("test-idx-3", "doc", Integer.toString(i), "foo", "baz" + i);
+        }
+        refresh();
+
+        logger.info("--> take a snapshot");
+        CreateSnapshotResponse createSnapshotResponse =
+            client.admin().cluster().prepareCreateSnapshot(repoName, "test-snap").setWaitForCompletion(true).get();
+        assertEquals(createSnapshotResponse.getSnapshotInfo().successfulShards(), createSnapshotResponse.getSnapshotInfo().totalShards());
+
+        logger.info("--> indexing more data");
+        for (int i = 20; i < 40; i++) {
+            index("test-idx-1", "doc", Integer.toString(i), "foo", "bar" + i);
+            index("test-idx-2", "doc", Integer.toString(i), "foo", "baz" + i);
+            index("test-idx-3", "doc", Integer.toString(i), "foo", "baz" + i);
+        }
+
+        logger.info("--> take another snapshot with only 2 of the 3 indices");
+        createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot(repoName, "test-snap2")
+                                     .setWaitForCompletion(true)
+                                     .setIndices("test-idx-1", "test-idx-2")
+                                     .get();
+        assertEquals(createSnapshotResponse.getSnapshotInfo().successfulShards(), createSnapshotResponse.getSnapshotInfo().totalShards());
+
+        logger.info("--> verify index directories exist in the repository");
+        RepositoriesService repositoriesSvc = internalCluster().getInstance(RepositoriesService.class, internalCluster().getMasterName());
+        @SuppressWarnings("unchecked") BlobStoreRepository repository = (BlobStoreRepository) repositoriesSvc.repository(repoName);
+        BlobContainer indicesBlobContainer = repository.blobStore().blobContainer(repository.basePath().add("indices"));
+        RepositoryData repositoryData = repository.getRepositoryData();
+        for (IndexId indexId : repositoryData.getIndices().values()) {
+            assertTrue(indicesBlobContainer.blobExists(indexId.getId()));
+        }
+
+        logger.info("--> delete first snapshot");
+        assertAcked(client().admin().cluster().prepareDeleteSnapshot(repoName, "test-snap").get());
+
+        logger.info("--> verify index folder deleted from blob container");
+        for (IndexId indexId : repositoryData.getIndices().values()) {
+            if (indexId.getName().equals("test-idx-3")) {
+                assertFalse(indicesBlobContainer.blobExists(indexId.getId())); // deleted index
+            } else {
+                assertTrue(indicesBlobContainer.blobExists(indexId.getId()));
+            }
         }
     }
 


### PR DESCRIPTION
This commit cleans up indices in a snapshot repository when all
snapshots containing the index are all deleted. Previously, empty
indices folders would lay around after all snapshots containing
them were deleted.
