### PR TITLE
Fixes active shard count check in the case of `all` shards

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/ActiveShardCount.java
+++ b/core/src/main/java/org/elasticsearch/action/support/ActiveShardCount.java
@@ -160,12 +160,15 @@ public final class ActiveShardCount implements Writeable {
      * to meet the required shard count represented by this instance.
      */
     public boolean enoughShardsActive(final IndexShardRoutingTable shardRoutingTable) {
+        final int activeShardCount = shardRoutingTable.activeShards().size();
         if (this == ActiveShardCount.ALL) {
-            return shardRoutingTable.allShardsStarted();
+            // adding 1 for the primary in addition to the total number of replicas,
+            // which gives us the total number of shard copies
+            return activeShardCount == shardRoutingTable.replicaShards().size() + 1;
         } else if (this == ActiveShardCount.DEFAULT) {
-            return shardRoutingTable.primaryShard().started();
+            return activeShardCount >= 1;
         } else {
-            return shardRoutingTable.activeShards().size() >= value;
+            return activeShardCount >= value;
         }
     }
 


### PR DESCRIPTION
Fixes the active shard count check in the case of
ActiveShardCount.ALL by checking for active shards,
not just started shards, as a shard could be active
but in the relocating state (i.e. not in the started
state).

Previously, the `ReplicationOperationTests#testWaitForActiveShards` failed with the following reproduce:

```
gradle :core:test -Dtests.seed=4AFDAC476714C11 -Dtests.class=org.elasticsearch.action.support.replication.ReplicationOperationTests -Dtests.method="testWaitForActiveShards" -Dtests.security.manager=true -Dtests.locale=ar-SD -Dtests.timezone=Europe/Istanbul
```

It no longer fails with this PR
