### PR TITLE
Make NamedWriteableRegistry immutable and add extension point for named writeables

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilders.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilders.java
@@ -19,11 +19,10 @@
 
 package org.elasticsearch.common.geo.builders;
 
-import com.vividsolutions.jts.geom.Coordinate;
-
-import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-
 import java.util.List;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry.Entry;
 
 /**
  * A collection of static methods for creating ShapeBuilders.
@@ -140,15 +139,15 @@ public class ShapeBuilders {
         return new EnvelopeBuilder(topLeft, bottomRight);
     }
 
-    public static void register(NamedWriteableRegistry namedWriteableRegistry) {
-        namedWriteableRegistry.register(ShapeBuilder.class, PointBuilder.TYPE.shapeName(), PointBuilder::new);
-        namedWriteableRegistry.register(ShapeBuilder.class, CircleBuilder.TYPE.shapeName(), CircleBuilder::new);
-        namedWriteableRegistry.register(ShapeBuilder.class, EnvelopeBuilder.TYPE.shapeName(), EnvelopeBuilder::new);
-        namedWriteableRegistry.register(ShapeBuilder.class, MultiPointBuilder.TYPE.shapeName(), MultiPointBuilder::new);
-        namedWriteableRegistry.register(ShapeBuilder.class, LineStringBuilder.TYPE.shapeName(), LineStringBuilder::new);
-        namedWriteableRegistry.register(ShapeBuilder.class, MultiLineStringBuilder.TYPE.shapeName(), MultiLineStringBuilder::new);
-        namedWriteableRegistry.register(ShapeBuilder.class, PolygonBuilder.TYPE.shapeName(), PolygonBuilder::new);
-        namedWriteableRegistry.register(ShapeBuilder.class, MultiPolygonBuilder.TYPE.shapeName(), MultiPolygonBuilder::new);
-        namedWriteableRegistry.register(ShapeBuilder.class, GeometryCollectionBuilder.TYPE.shapeName(), GeometryCollectionBuilder::new);
+    public static void register(List<Entry> namedWriteables) {
+        namedWriteables.add(new Entry(ShapeBuilder.class, PointBuilder.TYPE.shapeName(), PointBuilder::new));
+        namedWriteables.add(new Entry(ShapeBuilder.class, CircleBuilder.TYPE.shapeName(), CircleBuilder::new));
+        namedWriteables.add(new Entry(ShapeBuilder.class, EnvelopeBuilder.TYPE.shapeName(), EnvelopeBuilder::new));
+        namedWriteables.add(new Entry(ShapeBuilder.class, MultiPointBuilder.TYPE.shapeName(), MultiPointBuilder::new));
+        namedWriteables.add(new Entry(ShapeBuilder.class, LineStringBuilder.TYPE.shapeName(), LineStringBuilder::new));
+        namedWriteables.add(new Entry(ShapeBuilder.class, MultiLineStringBuilder.TYPE.shapeName(), MultiLineStringBuilder::new));
+        namedWriteables.add(new Entry(ShapeBuilder.class, PolygonBuilder.TYPE.shapeName(), PolygonBuilder::new));
+        namedWriteables.add(new Entry(ShapeBuilder.class, MultiPolygonBuilder.TYPE.shapeName(), MultiPolygonBuilder::new));
+        namedWriteables.add(new Entry(ShapeBuilder.class, GeometryCollectionBuilder.TYPE.shapeName(), GeometryCollectionBuilder::new));
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableRegistry.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableRegistry.java
@@ -19,70 +19,102 @@
 
 package org.elasticsearch.common.io.stream;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.elasticsearch.plugins.Plugin;
 
 /**
- * Registry for {@link NamedWriteable} objects. Allows to register and retrieve prototype instances of writeable objects
- * given their name.
+ * A registry for {@link org.elasticsearch.common.io.stream.Writeable.Reader} readers of {@link NamedWriteable}.
+ *
+ * The registration is keyed by the combination of the category class of {@link NamedWriteable}, and a name unique
+ * to that category.
  */
 public class NamedWriteableRegistry {
 
-    private final Map<Class<?>, InnerRegistry<?>> registry = new HashMap<>();
+    /** An entry in the registry, made up of a category class and name, and a reader for that category class. */
+    public static class Entry {
 
-    /**
-     * Register a {@link NamedWriteable} given its category, its name, and a function to read it from the stream.
-     *
-     * This method suppresses the rawtypes warning because it intentionally using NamedWriteable instead of {@code NamedWriteable<T>} so it
-     * is easier to use and because we might be able to drop the type parameter from NamedWriteable entirely some day.
-     */
-    public synchronized <T extends NamedWriteable> void register(Class<T> categoryClass, String name,
-            Writeable.Reader<? extends T> reader) {
-        @SuppressWarnings("unchecked")
-        InnerRegistry<T> innerRegistry = (InnerRegistry<T>) registry.get(categoryClass);
-        if (innerRegistry == null) {
-            innerRegistry = new InnerRegistry<>(categoryClass);
-            registry.put(categoryClass, innerRegistry);
+        /** The superclass of a {@link NamedWriteable} which will be read by {@link #reader}. */
+        public final Class<?> categoryClass;
+
+        /** A name for the writeable which is unique to the {@link #categoryClass}. */
+        public final String name;
+
+        /** A reader captability of reading*/
+        public final Writeable.Reader<?> reader;
+
+        /** Creates a new entry which can be stored by the registry. */
+        public <T extends NamedWriteable> Entry(Class<T> categoryClass, String name, Writeable.Reader<? extends T> reader) {
+            this.categoryClass = Objects.requireNonNull(categoryClass);
+            this.name = Objects.requireNonNull(name);
+            this.reader = Objects.requireNonNull(reader);
         }
-        innerRegistry.register(name, reader);
     }
 
     /**
-     * Returns a prototype of the {@link NamedWriteable} object identified by the name provided as argument and its category
+     * The underlying data of the registry maps from the category to an inner
+     * map of name unique to that category, to the actual reader.
      */
-    public synchronized <T> Writeable.Reader<? extends T> getReader(Class<T> categoryClass, String name) {
-        @SuppressWarnings("unchecked")
-        InnerRegistry<T> innerRegistry = (InnerRegistry<T>)registry.get(categoryClass);
-        if (innerRegistry == null) {
-            throw new IllegalArgumentException("unknown named writeable category [" + categoryClass.getName() + "]");
+    private final Map<Class<?>, Map<String, Writeable.Reader<?>>> registry;
+
+    /**
+     * Constructs a new registry from the given entries.
+     */
+    public NamedWriteableRegistry(List<Entry> entries) {
+        if (entries.isEmpty()) {
+            registry = Collections.emptyMap();
+            return;
         }
-        return innerRegistry.getReader(name);
+        entries = new ArrayList<>(entries);
+        entries.sort((e1, e2) -> e1.categoryClass.getName().compareTo(e2.categoryClass.getName()));
+
+        Map<Class<?>, Map<String, Writeable.Reader<?>>> registry = new HashMap<>();
+        Map<String, Writeable.Reader<?>> readers = null;
+        Class currentCategory = null;
+        for (Entry entry : entries) {
+            if (currentCategory != entry.categoryClass) {
+                if (currentCategory != null) {
+                    // we've seen the last of this category, put it into the big map
+                    registry.put(currentCategory, Collections.unmodifiableMap(readers));
+                }
+                readers = new HashMap<>();
+                currentCategory = entry.categoryClass;
+            }
+
+            Writeable.Reader<?> oldReader = readers.put(entry.name, entry.reader);
+            if (oldReader != null) {
+                throw new IllegalArgumentException("NamedWriteable [" + currentCategory.getName() + "][" + entry.name + "]" +
+                    " is already registered for [" + oldReader.getClass().getName() + "]," +
+                    " cannot register [" + entry.reader.getClass().getName() + "]");
+            }
+        }
+        // handle the last category
+        registry.put(currentCategory, Collections.unmodifiableMap(readers));
+
+        this.registry = Collections.unmodifiableMap(registry);
     }
 
-    private static class InnerRegistry<T> {
-
-        private final Map<String, Writeable.Reader<? extends T>> registry = new HashMap<>();
-        private final Class<T> categoryClass;
-
-        private InnerRegistry(Class<T> categoryClass) {
-            this.categoryClass = categoryClass;
+    /**
+     * Returns a reader for a {@link NamedWriteable} object identified by the
+     * name provided as argument and its category.
+     */
+    public <T> Writeable.Reader<? extends T> getReader(Class<T> categoryClass, String name) {
+        Map<String, Writeable.Reader<?>> readers = registry.get(categoryClass);
+        if (readers == null) {
+            throw new IllegalArgumentException("Unknown NamedWriteable category [" + categoryClass.getName() + "]");
         }
-
-        private void register(String name, Writeable.Reader<? extends T> reader) {
-            Writeable.Reader<? extends T> existingReader = registry.get(name);
-            if (existingReader != null) {
-                throw new IllegalArgumentException(
-                        "named writeable [" + categoryClass.getName() + "][" + name + "] is already registered by [" + reader + "]");
-            }
-            registry.put(name, reader);
+        @SuppressWarnings("unchecked")
+        Writeable.Reader<? extends T> reader = (Writeable.Reader<? extends T>)readers.get(name);
+        if (reader == null) {
+            throw new IllegalArgumentException("Unknown NamedWriteable [" + categoryClass.getName() + "][" + name + "]");
         }
-
-        private Writeable.Reader<? extends T> getReader(String name) {
-            Writeable.Reader<? extends T> reader = registry.get(name);
-            if (reader == null) {
-                throw new IllegalArgumentException("unknown named writeable [" + categoryClass.getName() + "][" + name + "]");
-            }
-            return reader;
-        }
+        return reader;
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/network/NetworkModule.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkModule.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.common.network;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.elasticsearch.action.support.replication.ReplicationTask;
 import org.elasticsearch.cluster.routing.allocation.command.AllocateEmptyPrimaryAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.AllocateReplicaAllocationCommand;
@@ -31,6 +34,7 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.util.Providers;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry.Entry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -70,21 +74,18 @@ public class NetworkModule extends AbstractModule {
     private final ExtensionPoint.SelectedType<TransportService> transportServiceTypes = new ExtensionPoint.SelectedType<>("transport_service", TransportService.class);
     private final ExtensionPoint.SelectedType<Transport> transportTypes = new ExtensionPoint.SelectedType<>("transport", Transport.class);
     private final ExtensionPoint.SelectedType<HttpServerTransport> httpTransportTypes = new ExtensionPoint.SelectedType<>("http_transport", HttpServerTransport.class);
-    private final NamedWriteableRegistry namedWriteableRegistry;
+    private final List<Entry> namedWriteables = new ArrayList<>();
 
     /**
      * Creates a network module that custom networking classes can be plugged into.
      *  @param networkService A constructed network service object to bind.
      * @param settings The settings for the node
      * @param transportClient True if only transport classes should be allowed to be registered, false otherwise.
-     * @param namedWriteableRegistry registry for named writeables for use during streaming
      */
-    public NetworkModule(NetworkService networkService, Settings settings, boolean transportClient,
-                         NamedWriteableRegistry namedWriteableRegistry) {
+    public NetworkModule(NetworkService networkService, Settings settings, boolean transportClient) {
         this.networkService = networkService;
         this.settings = settings;
         this.transportClient = transportClient;
-        this.namedWriteableRegistry = namedWriteableRegistry;
         registerTransportService("default", TransportService.class);
         registerTransport(LOCAL_TRANSPORT, LocalTransport.class);
         registerTaskStatus(ReplicationTask.Status.NAME, ReplicationTask.Status::new);
@@ -116,7 +117,7 @@ public class NetworkModule extends AbstractModule {
     }
 
     public void registerTaskStatus(String name, Writeable.Reader<? extends Task.Status> reader) {
-        namedWriteableRegistry.register(Task.Status.class, name, reader);
+        namedWriteables.add(new Entry(Task.Status.class, name, reader));
     }
 
     /**
@@ -132,7 +133,7 @@ public class NetworkModule extends AbstractModule {
     private <T extends AllocationCommand> void registerAllocationCommand(Writeable.Reader<T> reader, AllocationCommand.Parser<T> parser,
             ParseField commandName) {
         allocationCommandRegistry.register(parser, commandName);
-        namedWriteableRegistry.register(AllocationCommand.class, commandName.getPreferredName(), reader);
+        namedWriteables.add(new Entry(AllocationCommand.class, commandName.getPreferredName(), reader));
     }
 
     /**
@@ -142,10 +143,13 @@ public class NetworkModule extends AbstractModule {
         return allocationCommandRegistry;
     }
 
+    public List<Entry> getNamedWriteables() {
+        return namedWriteables;
+    }
+
     @Override
     protected void configure() {
         bind(NetworkService.class).toInstance(networkService);
-        bind(NamedWriteableRegistry.class).toInstance(namedWriteableRegistry);
         transportServiceTypes.bindType(binder(), settings, TRANSPORT_SERVICE_TYPE_KEY, "default");
         transportTypes.bindType(binder(), settings, TRANSPORT_TYPE_KEY, TRANSPORT_DEFAULT_TYPE_SETTING.get(settings));
 

--- a/core/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.metadata.MetaDataIndexUpgradeService;
 import org.elasticsearch.common.geo.ShapesAvailability;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry.Entry;
 import org.elasticsearch.index.NodeServicesProvider;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
@@ -67,6 +68,7 @@ import org.elasticsearch.indices.store.TransportNodesListShardStoreMetaData;
 import org.elasticsearch.indices.ttl.IndicesTTLService;
 import org.elasticsearch.plugins.MapperPlugin;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -80,19 +82,22 @@ public class IndicesModule extends AbstractModule {
     private final Map<String, Mapper.TypeParser> mapperParsers;
     private final Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers;
     private final MapperRegistry mapperRegistry;
-    private final NamedWriteableRegistry namedWritableRegistry;
+    private final List<Entry> namedWritables = new ArrayList<>();
 
-    public IndicesModule(NamedWriteableRegistry namedWriteableRegistry, List<MapperPlugin> mapperPlugins) {
-        this.namedWritableRegistry = namedWriteableRegistry;
+    public IndicesModule(List<MapperPlugin> mapperPlugins) {
         this.mapperParsers = getMappers(mapperPlugins);
         this.metadataMapperParsers = getMetadataMappers(mapperPlugins);
         this.mapperRegistry = new MapperRegistry(mapperParsers, metadataMapperParsers);
-        registerBuildInWritables();
+        registerBuiltinWritables();
     }
 
-    private void registerBuildInWritables() {
-        namedWritableRegistry.register(Condition.class, MaxAgeCondition.NAME, MaxAgeCondition::new);
-        namedWritableRegistry.register(Condition.class, MaxDocsCondition.NAME, MaxDocsCondition::new);
+    private void registerBuiltinWritables() {
+        namedWritables.add(new Entry(Condition.class, MaxAgeCondition.NAME, MaxAgeCondition::new));
+        namedWritables.add(new Entry(Condition.class, MaxDocsCondition.NAME, MaxDocsCondition::new));
+    }
+
+    public List<Entry> getNamedWriteables() {
+        return namedWritables;
     }
 
     private Map<String, Mapper.TypeParser> getMappers(List<MapperPlugin> mapperPlugins) {

--- a/core/src/main/java/org/elasticsearch/plugins/Plugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/Plugin.java
@@ -22,12 +22,16 @@ package org.elasticsearch.plugins;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.elasticsearch.action.ActionModule;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
@@ -90,6 +94,14 @@ public abstract class Plugin {
      */
     public Settings additionalSettings() {
         return Settings.Builder.EMPTY_SETTINGS;
+    }
+
+    /**
+     * Returns parsers for {@link NamedWriteable} this plugin will use over the transport protocol.
+     * @see NamedWriteableRegistry
+     */
+    public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return Collections.emptyList();
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/plugins/SearchPlugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/SearchPlugin.java
@@ -98,7 +98,7 @@ public interface SearchPlugin {
     /**
      * Specification of custom {@link ScoreFunction}.
      */
-    public class ScoreFunctionSpec<T extends ScoreFunctionBuilder<T>> extends SearchExtensionSpec<T, ScoreFunctionParser<T>> {
+    class ScoreFunctionSpec<T extends ScoreFunctionBuilder<T>> extends SearchExtensionSpec<T, ScoreFunctionParser<T>> {
         public ScoreFunctionSpec(ParseField name, Reader<T> reader, ScoreFunctionParser<T> parser) {
             super(name, reader, parser);
         }
@@ -111,7 +111,7 @@ public interface SearchPlugin {
     /**
      * Specification of custom {@link Query}.
      */
-    public class QuerySpec<T extends QueryBuilder> extends SearchExtensionSpec<T, QueryParser<T>> {
+    class QuerySpec<T extends QueryBuilder> extends SearchExtensionSpec<T, QueryParser<T>> {
         /**
          * Specification of custom {@link Query}.
          *
@@ -148,7 +148,7 @@ public interface SearchPlugin {
      * @param P the type of the parser for this spec. The parser runs on the coordinating node, converting {@link XContent} into the
      *        behavior to execute
      */
-    public class SearchExtensionSpec<W extends NamedWriteable, P> {
+    class SearchExtensionSpec<W extends NamedWriteable, P> {
         private final ParseField name;
         private final Writeable.Reader<W> reader;
         private final P parser;
@@ -205,7 +205,7 @@ public interface SearchPlugin {
     /**
      * Context available during fetch phase construction.
      */
-    public class FetchPhaseConstructionContext {
+    class FetchPhaseConstructionContext {
         private final Map<String, Highlighter> highlighters;
 
         public FetchPhaseConstructionContext(Map<String, Highlighter> highlighters) {

--- a/core/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -19,6 +19,13 @@
 
 package org.elasticsearch.search;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
 import org.apache.lucene.search.BooleanQuery;
 import org.elasticsearch.common.NamedRegistry;
 import org.elasticsearch.common.ParseField;
@@ -26,7 +33,7 @@ import org.elasticsearch.common.geo.ShapesAvailability;
 import org.elasticsearch.common.geo.builders.ShapeBuilders;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.io.stream.NamedWriteable;
-import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry.Entry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.settings.Setting;
@@ -245,8 +252,8 @@ import org.elasticsearch.search.aggregations.pipeline.serialdiff.SerialDiffPipel
 import org.elasticsearch.search.controller.SearchPhaseController;
 import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.fetch.FetchSubPhase;
-import org.elasticsearch.search.fetch.explain.ExplainFetchSubPhase;
 import org.elasticsearch.search.fetch.docvalues.DocValueFieldsFetchSubPhase;
+import org.elasticsearch.search.fetch.explain.ExplainFetchSubPhase;
 import org.elasticsearch.search.fetch.matchedqueries.MatchedQueriesFetchSubPhase;
 import org.elasticsearch.search.fetch.parent.ParentFieldSubFetchPhase;
 import org.elasticsearch.search.fetch.script.ScriptFieldsFetchSubPhase;
@@ -275,13 +282,6 @@ import org.elasticsearch.search.suggest.phrase.SmoothingModel;
 import org.elasticsearch.search.suggest.phrase.StupidBackoff;
 import org.elasticsearch.search.suggest.term.TermSuggester;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.function.Consumer;
-import java.util.function.Function;
-
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
 
@@ -307,17 +307,15 @@ public class SearchModule extends AbstractModule {
     private final List<FetchSubPhase> fetchSubPhases = new ArrayList<>();
 
     private final Settings settings;
-    private final NamedWriteableRegistry namedWriteableRegistry;
+    private final List<Entry> namedWriteables = new ArrayList<>();
     public static final Setting<Integer> INDICES_MAX_CLAUSE_COUNT_SETTING = Setting.intSetting("indices.query.bool.max_clause_count",
         1024, 1, Integer.MAX_VALUE, Setting.Property.NodeScope);
 
     // pkg private so tests can mock
     Class<? extends SearchService> searchServiceImpl = SearchService.class;
 
-    public SearchModule(Settings settings, NamedWriteableRegistry namedWriteableRegistry, boolean transportClient,
-            List<SearchPlugin> plugins) {
+    public SearchModule(Settings settings, boolean transportClient, List<SearchPlugin> plugins) {
         this.settings = settings;
-        this.namedWriteableRegistry = namedWriteableRegistry;
         this.transportClient = transportClient;
         suggesters = setupSuggesters(plugins);
         highlighters = setupHighlighters(settings, plugins);
@@ -330,6 +328,11 @@ public class SearchModule extends AbstractModule {
         registerMovingAverageModels(plugins);
         registerBuiltinAggregations();
         registerFetchSubPhases(plugins);
+        registerShapes();
+    }
+
+    public List<Entry> getNamedWriteables() {
+        return namedWriteables;
     }
 
     public Suggesters getSuggesters() {
@@ -368,11 +371,11 @@ public class SearchModule extends AbstractModule {
         if (false == transportClient) {
             aggregationParserRegistry.register(spec.parser, spec.name);
         }
-        namedWriteableRegistry.register(AggregationBuilder.class, spec.name.getPreferredName(), spec.builderReader);
+        namedWriteables.add(new Entry(AggregationBuilder.class, spec.name.getPreferredName(), spec.builderReader));
         for (Map.Entry<String, Writeable.Reader<? extends InternalAggregation>> t : spec.resultReaders.entrySet()) {
             String writeableName = t.getKey();
             Writeable.Reader<? extends InternalAggregation> internalReader = t.getValue();
-            namedWriteableRegistry.register(InternalAggregation.class, writeableName, internalReader);
+            namedWriteables.add(new Entry(InternalAggregation.class, writeableName, internalReader));
         }
     }
 
@@ -421,10 +424,10 @@ public class SearchModule extends AbstractModule {
         if (false == transportClient) {
             pipelineAggregationParserRegistry.register(spec.parser, spec.name);
         }
-        namedWriteableRegistry.register(PipelineAggregationBuilder.class, spec.name.getPreferredName(), spec.builderReader);
-        namedWriteableRegistry.register(PipelineAggregator.class, spec.name.getPreferredName(), spec.aggregatorReader);
+        namedWriteables.add(new Entry(PipelineAggregationBuilder.class, spec.name.getPreferredName(), spec.builderReader));
+        namedWriteables.add(new Entry(PipelineAggregator.class, spec.name.getPreferredName(), spec.aggregatorReader));
         for (Map.Entry<String, Writeable.Reader<? extends InternalAggregation>> resultReader : spec.resultReaders.entrySet()) {
-            namedWriteableRegistry.register(InternalAggregation.class, resultReader.getKey(), resultReader.getValue());
+            namedWriteables.add(new Entry(InternalAggregation.class, resultReader.getKey(), resultReader.getValue()));
         }
     }
 
@@ -482,7 +485,6 @@ public class SearchModule extends AbstractModule {
             configureSearch();
             bind(AggregatorParsers.class).toInstance(aggregatorParsers);
         }
-        configureShapes();
     }
 
     private void registerBuiltinAggregations() {
@@ -656,21 +658,21 @@ public class SearchModule extends AbstractModule {
         }
     }
 
-    private void configureShapes() {
+    private void registerShapes() {
         if (ShapesAvailability.JTS_AVAILABLE && ShapesAvailability.SPATIAL4J_AVAILABLE) {
-            ShapeBuilders.register(namedWriteableRegistry);
+            ShapeBuilders.register(namedWriteables);
         }
     }
 
     private void registerRescorers() {
-        namedWriteableRegistry.register(RescoreBuilder.class, QueryRescorerBuilder.NAME, QueryRescorerBuilder::new);
+        namedWriteables.add(new Entry(RescoreBuilder.class, QueryRescorerBuilder.NAME, QueryRescorerBuilder::new));
     }
 
     private void registerSorts() {
-        namedWriteableRegistry.register(SortBuilder.class, GeoDistanceSortBuilder.NAME, GeoDistanceSortBuilder::new);
-        namedWriteableRegistry.register(SortBuilder.class, ScoreSortBuilder.NAME, ScoreSortBuilder::new);
-        namedWriteableRegistry.register(SortBuilder.class, ScriptSortBuilder.NAME, ScriptSortBuilder::new);
-        namedWriteableRegistry.register(SortBuilder.class, FieldSortBuilder.NAME, FieldSortBuilder::new);
+        namedWriteables.add(new Entry(SortBuilder.class, GeoDistanceSortBuilder.NAME, GeoDistanceSortBuilder::new));
+        namedWriteables.add(new Entry(SortBuilder.class, ScoreSortBuilder.NAME, ScoreSortBuilder::new));
+        namedWriteables.add(new Entry(SortBuilder.class, ScriptSortBuilder.NAME, ScriptSortBuilder::new));
+        namedWriteables.add(new Entry(SortBuilder.class, FieldSortBuilder.NAME, FieldSortBuilder::new));
     }
 
     private <T> void registerFromPlugin(List<SearchPlugin> plugins, Function<SearchPlugin, List<T>> producer, Consumer<T> consumer) {
@@ -681,21 +683,21 @@ public class SearchModule extends AbstractModule {
         }
     }
 
-    public static void registerSmoothingModels(NamedWriteableRegistry namedWriteableRegistry) {
-        namedWriteableRegistry.register(SmoothingModel.class, Laplace.NAME, Laplace::new);
-        namedWriteableRegistry.register(SmoothingModel.class, LinearInterpolation.NAME, LinearInterpolation::new);
-        namedWriteableRegistry.register(SmoothingModel.class, StupidBackoff.NAME, StupidBackoff::new);
+    public static void registerSmoothingModels(List<Entry> namedWriteables) {
+        namedWriteables.add(new Entry(SmoothingModel.class, Laplace.NAME, Laplace::new));
+        namedWriteables.add(new Entry(SmoothingModel.class, LinearInterpolation.NAME, LinearInterpolation::new));
+        namedWriteables.add(new Entry(SmoothingModel.class, StupidBackoff.NAME, StupidBackoff::new));
     }
 
     private Map<String, Suggester<?>> setupSuggesters(List<SearchPlugin> plugins) {
-        registerSmoothingModels(namedWriteableRegistry);
+        registerSmoothingModels(namedWriteables);
 
         // Suggester<?> is weird - it is both a Parser and a reader....
         NamedRegistry<Suggester<?>> suggesters = new NamedRegistry<Suggester<?>>("suggester") {
             @Override
             public void register(String name, Suggester<?> t) {
                 super.register(name, t);
-                namedWriteableRegistry.register(SuggestionBuilder.class, name, t);
+                namedWriteables.add(new Entry(SuggestionBuilder.class, name, t));
             }
         };
         suggesters.register("phrase", PhraseSuggester.INSTANCE);
@@ -733,14 +735,14 @@ public class SearchModule extends AbstractModule {
 
         //weight doesn't have its own parser, so every function supports it out of the box.
         //Can be a single function too when not associated to any other function, which is why it needs to be registered manually here.
-        namedWriteableRegistry.register(ScoreFunctionBuilder.class, WeightBuilder.NAME, WeightBuilder::new);
+        namedWriteables.add(new Entry(ScoreFunctionBuilder.class, WeightBuilder.NAME, WeightBuilder::new));
 
         registerFromPlugin(plugins, SearchPlugin::getScoreFunctions, this::registerScoreFunction);
     }
 
     private void registerScoreFunction(ScoreFunctionSpec<?> scoreFunction) {
         scoreFunctionParserRegistry.register(scoreFunction.getParser(), scoreFunction.getName());
-        namedWriteableRegistry.register(ScoreFunctionBuilder.class, scoreFunction.getName().getPreferredName(), scoreFunction.getReader());
+        namedWriteables.add(new Entry(ScoreFunctionBuilder.class, scoreFunction.getName().getPreferredName(), scoreFunction.getReader()));
     }
 
     private void registerValueFormats() {
@@ -756,7 +758,7 @@ public class SearchModule extends AbstractModule {
      * Register a new ValueFormat.
      */
     private void registerValueFormat(String name, Writeable.Reader<? extends DocValueFormat> reader) {
-        namedWriteableRegistry.register(DocValueFormat.class, name, reader);
+        namedWriteables.add(new Entry(DocValueFormat.class, name, reader));
     }
 
     private void registerSignificanceHeuristics(List<SearchPlugin> plugins) {
@@ -772,7 +774,7 @@ public class SearchModule extends AbstractModule {
 
     private void registerSignificanceHeuristic(SearchExtensionSpec<SignificanceHeuristic, SignificanceHeuristicParser> heuristic) {
         significanceHeuristicParserRegistry.register(heuristic.getParser(), heuristic.getName());
-        namedWriteableRegistry.register(SignificanceHeuristic.class, heuristic.getName().getPreferredName(), heuristic.getReader());
+        namedWriteables.add(new Entry(SignificanceHeuristic.class, heuristic.getName().getPreferredName(), heuristic.getReader()));
     }
 
     private void registerMovingAverageModels(List<SearchPlugin> plugins) {
@@ -787,7 +789,7 @@ public class SearchModule extends AbstractModule {
 
     private void registerMovingAverageModel(SearchExtensionSpec<MovAvgModel, MovAvgModel.AbstractModelParser> movAvgModel) {
         movingAverageModelParserRegistry.register(movAvgModel.getParser(), movAvgModel.getName());
-        namedWriteableRegistry.register(MovAvgModel.class, movAvgModel.getName().getPreferredName(), movAvgModel.getReader());
+        namedWriteables.add(new Entry(MovAvgModel.class, movAvgModel.getName().getPreferredName(), movAvgModel.getReader()));
     }
 
     private void registerFetchSubPhases(List<SearchPlugin> plugins) {
@@ -881,6 +883,6 @@ public class SearchModule extends AbstractModule {
 
     private void registerQuery(QuerySpec<?> spec) {
         queryParserRegistry.register(spec.getParser(), spec.getName());
-        namedWriteableRegistry.register(QueryBuilder.class, spec.getName().getPreferredName(), spec.getReader());
+        namedWriteables.add(new Entry(QueryBuilder.class, spec.getName().getPreferredName(), spec.getReader()));
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
@@ -18,6 +18,13 @@
  */
 package org.elasticsearch.action.admin.cluster.node.tasks;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.TransportCancelTasksAction;
@@ -49,12 +56,6 @@ import org.elasticsearch.transport.local.LocalTransport;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
@@ -167,7 +168,7 @@ public abstract class TaskManagerTestCase extends ESTestCase {
         public TestNode(String name, ThreadPool threadPool, Settings settings) {
             clusterService = createClusterService(threadPool);
             transportService = new TransportService(settings,
-                    new LocalTransport(settings, threadPool, new NamedWriteableRegistry(),
+                    new LocalTransport(settings, threadPool, new NamedWriteableRegistry(Collections.emptyList()),
                         new NoneCircuitBreakerService()), threadPool) {
                 @Override
                 protected TaskManager createTaskManager() {

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteRequestTests.java
@@ -74,8 +74,9 @@ public class ClusterRerouteRequestTests extends ESTestCase {
     private final AllocationCommandRegistry allocationCommandRegistry;
 
     public ClusterRerouteRequestTests() {
-        namedWriteableRegistry = new NamedWriteableRegistry();
-        allocationCommandRegistry = new NetworkModule(null, null, true, namedWriteableRegistry).getAllocationCommandRegistry();
+        NetworkModule networkModule = new NetworkModule(null, null, true);
+        allocationCommandRegistry = networkModule.getAllocationCommandRegistry();
+        namedWriteableRegistry = new NamedWriteableRegistry(networkModule.getNamedWriteables());
     }
 
     private ClusterRerouteRequest randomRequest() {

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
@@ -64,8 +64,8 @@ public class ClusterRerouteTests extends ESAllocationTestCase {
         BytesStreamOutput out = new BytesStreamOutput();
         req.writeTo(out);
         BytesReference bytes = out.bytes();
-        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry();
-        new NetworkModule(null, Settings.EMPTY, true, namedWriteableRegistry);
+        NetworkModule networkModule = new NetworkModule(null, Settings.EMPTY, true);
+        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(networkModule.getNamedWriteables());
         StreamInput wrap = new NamedWriteableAwareStreamInput(bytes.streamInput(),
             namedWriteableRegistry);
         ClusterRerouteRequest deserializedReq = new ClusterRerouteRequest();

--- a/core/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
@@ -54,6 +54,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -89,7 +90,7 @@ public class BroadcastReplicationTests extends ESTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        LocalTransport transport = new LocalTransport(Settings.EMPTY, threadPool, new NamedWriteableRegistry(), circuitBreakerService);
+        LocalTransport transport = new LocalTransport(Settings.EMPTY, threadPool, new NamedWriteableRegistry(Collections.emptyList()), circuitBreakerService);
         clusterService = createClusterService(threadPool);
         transportService = new TransportService(clusterService.getSettings(), transport, threadPool);
         transportService.start();

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
@@ -436,8 +436,8 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         StreamInput in = bytes.bytes().streamInput();
 
         // Since the commands are named writeable we need to register them and wrap the input stream
-        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry();
-        new NetworkModule(null, Settings.EMPTY, true, namedWriteableRegistry);
+        NetworkModule networkModule = new NetworkModule(null, Settings.EMPTY, true);
+        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(networkModule.getNamedWriteables());
         in = new NamedWriteableAwareStreamInput(in, namedWriteableRegistry);
 
         // Now we can read them!
@@ -483,8 +483,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         // move two tokens, parser expected to be "on" `commands` field
         parser.nextToken();
         parser.nextToken();
-        AllocationCommandRegistry registry = new NetworkModule(null, Settings.EMPTY, true, new NamedWriteableRegistry())
-            .getAllocationCommandRegistry();
+        AllocationCommandRegistry registry = new NetworkModule(null, Settings.EMPTY, true).getAllocationCommandRegistry();
         AllocationCommands sCommands = AllocationCommands.fromXContent(parser, ParseFieldMatcher.STRICT, registry);
 
         assertThat(sCommands.commands().size(), equalTo(5));

--- a/core/src/test/java/org/elasticsearch/common/geo/builders/AbstractShapeBuilderTestCase.java
+++ b/core/src/test/java/org/elasticsearch/common/geo/builders/AbstractShapeBuilderTestCase.java
@@ -34,6 +34,10 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
@@ -48,8 +52,9 @@ public abstract class AbstractShapeBuilderTestCase<SB extends ShapeBuilder> exte
     @BeforeClass
     public static void init() {
         if (namedWriteableRegistry == null) {
-            namedWriteableRegistry = new NamedWriteableRegistry();
-            ShapeBuilders.register(namedWriteableRegistry);
+            List<NamedWriteableRegistry.Entry> shapes = new ArrayList<>();
+            ShapeBuilders.register(shapes);
+            namedWriteableRegistry = new NamedWriteableRegistry(shapes);
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/common/io/stream/NamedWriteableRegistryTests.java
+++ b/core/src/test/java/org/elasticsearch/common/io/stream/NamedWriteableRegistryTests.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.io.stream;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.elasticsearch.test.ESTestCase;
+
+public class NamedWriteableRegistryTests extends ESTestCase {
+
+    private static class DummyNamedWriteable implements NamedWriteable {
+        public DummyNamedWriteable(StreamInput in) {}
+        @Override
+        public String getWriteableName() {
+            return "test";
+        }
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {}
+    }
+
+    public void testEmpty() throws IOException {
+        new NamedWriteableRegistry(Collections.emptyList()); // does not throw exception
+    }
+
+    public void testBasic() throws IOException {
+        NamedWriteableRegistry.Entry entry =
+            new NamedWriteableRegistry.Entry(NamedWriteable.class, "test", DummyNamedWriteable::new);
+        NamedWriteableRegistry registry = new NamedWriteableRegistry(Collections.singletonList(entry));
+        Writeable.Reader<? extends NamedWriteable> reader = registry.getReader(NamedWriteable.class, "test");
+        assertNotNull(reader.read(null));
+    }
+
+    public void testDuplicates() throws IOException {
+        NamedWriteableRegistry.Entry entry =
+            new NamedWriteableRegistry.Entry(NamedWriteable.class, "test", DummyNamedWriteable::new);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> new NamedWriteableRegistry(Arrays.asList(entry, entry)));
+        assertTrue(e.getMessage(), e.getMessage().contains("is already registered"));
+    }
+
+    public void testUnknownCategory() throws IOException {
+        NamedWriteableRegistry registry = new NamedWriteableRegistry(Collections.emptyList());
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
+            registry.getReader(NamedWriteable.class, "test"));
+        assertTrue(e.getMessage(), e.getMessage().contains("Unknown NamedWriteable category ["));
+    }
+
+    public void testUnknownName() throws IOException {
+        NamedWriteableRegistry.Entry entry =
+            new NamedWriteableRegistry.Entry(NamedWriteable.class, "test", DummyNamedWriteable::new);
+        NamedWriteableRegistry registry = new NamedWriteableRegistry(Collections.singletonList(entry));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
+            registry.getReader(NamedWriteable.class, "dne"));
+        assertTrue(e.getMessage(), e.getMessage().contains("Unknown NamedWriteable ["));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/common/network/NetworkModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/common/network/NetworkModuleTests.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.common.network;
 
+import java.io.IOException;
+import java.util.Collections;
+
 import org.elasticsearch.action.support.replication.ReplicationTask;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Table;
@@ -42,9 +45,6 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.transport.AssertingLocalTransport;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
-
-import java.io.IOException;
-import java.util.Collections;
 
 public class NetworkModuleTests extends ModuleTestCase {
 
@@ -113,14 +113,13 @@ public class NetworkModuleTests extends ModuleTestCase {
             .put(NetworkModule.HTTP_ENABLED.getKey(), false)
             .put(NetworkModule.TRANSPORT_TYPE_KEY, "local")
             .build();
-        NetworkModule module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, false,
-            new NamedWriteableRegistry());
+        NetworkModule module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, false);
         module.registerTransportService("custom", FakeTransportService.class);
         assertBinding(module, TransportService.class, FakeTransportService.class);
         assertFalse(module.isTransportClient());
 
         // check it works with transport only as well
-        module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, true, new NamedWriteableRegistry());
+        module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, true);
         module.registerTransportService("custom", FakeTransportService.class);
         assertBinding(module, TransportService.class, FakeTransportService.class);
         assertTrue(module.isTransportClient());
@@ -130,14 +129,13 @@ public class NetworkModuleTests extends ModuleTestCase {
         Settings settings = Settings.builder().put(NetworkModule.TRANSPORT_TYPE_KEY, "custom")
             .put(NetworkModule.HTTP_ENABLED.getKey(), false)
             .build();
-        NetworkModule module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, false,
-            new NamedWriteableRegistry());
+        NetworkModule module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, false);
         module.registerTransport("custom", FakeTransport.class);
         assertBinding(module, Transport.class, FakeTransport.class);
         assertFalse(module.isTransportClient());
 
         // check it works with transport only as well
-        module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, true, new NamedWriteableRegistry());
+        module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, true);
         module.registerTransport("custom", FakeTransport.class);
         assertBinding(module, Transport.class, FakeTransport.class);
         assertTrue(module.isTransportClient());
@@ -147,14 +145,13 @@ public class NetworkModuleTests extends ModuleTestCase {
         Settings settings = Settings.builder()
             .put(NetworkModule.HTTP_TYPE_SETTING.getKey(), "custom")
             .put(NetworkModule.TRANSPORT_TYPE_KEY, "local").build();
-        NetworkModule module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, false,
-            new NamedWriteableRegistry());
+        NetworkModule module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, false);
         module.registerHttpTransport("custom", FakeHttpTransport.class);
         assertBinding(module, HttpServerTransport.class, FakeHttpTransport.class);
         assertFalse(module.isTransportClient());
 
         // check registration not allowed for transport only
-        module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, true, new NamedWriteableRegistry());
+        module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, true);
         assertTrue(module.isTransportClient());
         try {
             module.registerHttpTransport("custom", FakeHttpTransport.class);
@@ -167,23 +164,22 @@ public class NetworkModuleTests extends ModuleTestCase {
         // not added if http is disabled
         settings = Settings.builder().put(NetworkModule.HTTP_ENABLED.getKey(), false)
             .put(NetworkModule.TRANSPORT_TYPE_KEY, "local").build();
-        module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, false, new NamedWriteableRegistry());
+        module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, false);
         assertNotBound(module, HttpServerTransport.class);
         assertFalse(module.isTransportClient());
     }
 
     public void testRegisterTaskStatus() {
-        NamedWriteableRegistry registry = new NamedWriteableRegistry();
         Settings settings = Settings.EMPTY;
-        NetworkModule module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, false, registry);
+        NetworkModule module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, false);
+        NamedWriteableRegistry registry = new NamedWriteableRegistry(module.getNamedWriteables());
         assertFalse(module.isTransportClient());
 
         // Builtin reader comes back
         assertNotNull(registry.getReader(Task.Status.class, ReplicationTask.Status.NAME));
 
         module.registerTaskStatus(DummyTaskStatus.NAME, DummyTaskStatus::new);
-        assertEquals("test", expectThrows(UnsupportedOperationException.class,
-                () -> registry.getReader(Task.Status.class, DummyTaskStatus.NAME).read(null)).getMessage());
+        assertTrue(module.getNamedWriteables().stream().anyMatch(x -> x.name.equals(DummyTaskStatus.NAME)));
     }
 
     private class DummyTaskStatus implements Task.Status {

--- a/core/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
@@ -134,7 +134,7 @@ public class ZenFaultDetectionTests extends ESTestCase {
     }
 
     protected MockTransportService build(Settings settings, Version version) {
-        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry();
+        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(Collections.emptyList());
         MockTransportService transportService =
                 new MockTransportService(
                         Settings.builder()

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingIT.java
@@ -200,7 +200,7 @@ public class UnicastZenPingIT extends ESTestCase {
     private NetworkHandle startServices(Settings settings, ThreadPool threadPool, NetworkService networkService, String nodeId,
                                         Version version) {
         MockTcpTransport transport = new MockTcpTransport(settings, threadPool, BigArrays.NON_RECYCLING_INSTANCE,
-            new NoneCircuitBreakerService(), new NamedWriteableRegistry(), networkService, version);
+            new NoneCircuitBreakerService(), new NamedWriteableRegistry(Collections.emptyList()), networkService, version);
         final TransportService transportService = new TransportService(settings, transport, threadPool);
         transportService.start();
         transportService.acceptIncomingRequests();

--- a/core/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -135,7 +135,7 @@ public class IndexModuleTests extends ESTestCase {
         environment = new Environment(settings);
         nodeServicesProvider = newNodeServiceProvider(settings, environment, null);
         nodeEnvironment = new NodeEnvironment(settings, environment);
-        mapperRegistry = new IndicesModule(new NamedWriteableRegistry(), Collections.emptyList()).getMapperRegistry();
+        mapperRegistry = new IndicesModule(Collections.emptyList()).getMapperRegistry();
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -2023,7 +2023,7 @@ public class InternalEngineTests extends ESTestCase {
             IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(index, settings);
             AnalysisService analysisService = new AnalysisService(indexSettings, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
             SimilarityService similarityService = new SimilarityService(indexSettings, Collections.emptyMap());
-            MapperRegistry mapperRegistry = new IndicesModule(new NamedWriteableRegistry(), Collections.emptyList()).getMapperRegistry();
+            MapperRegistry mapperRegistry = new IndicesModule(Collections.emptyList()).getMapperRegistry();
             MapperService mapperService = new MapperService(indexSettings, analysisService, similarityService, mapperRegistry, () -> null);
             DocumentMapper.Builder b = new DocumentMapper.Builder(rootBuilder, mapperService);
             this.docMapper = b.build(mapperService);

--- a/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingDisabledTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingDisabledTests.java
@@ -74,8 +74,8 @@ public class DynamicMappingDisabledTests extends ESSingleNodeTestCase {
                 .put(MapperService.INDEX_MAPPER_DYNAMIC_SETTING.getKey(), false)
                 .build();
         clusterService = createClusterService(THREAD_POOL);
-        transport =
-                new LocalTransport(settings, THREAD_POOL, new NamedWriteableRegistry(), new NoneCircuitBreakerService());
+        transport = new LocalTransport(settings, THREAD_POOL, new NamedWriteableRegistry(Collections.emptyList()),
+                    new NoneCircuitBreakerService());
         transportService = new TransportService(clusterService.getSettings(), transport, THREAD_POOL);
         indicesService = getInstanceFromNode(IndicesService.class);
         shardStateAction = new ShardStateAction(settings, clusterService, transportService, null, null, THREAD_POOL);

--- a/core/src/test/java/org/elasticsearch/index/mapper/parent/ParentMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/parent/ParentMappingTests.java
@@ -107,7 +107,7 @@ public class ParentMappingTests extends ESSingleNodeTestCase {
             Collections.emptyMap(), Collections.emptyMap());
         SimilarityService similarityService = new SimilarityService(indexSettings, Collections.emptyMap());
         MapperService mapperService = new MapperService(indexSettings, analysisService, similarityService,
-            new IndicesModule(new NamedWriteableRegistry(), emptyList()).getMapperRegistry(), () -> null);
+            new IndicesModule(emptyList()).getMapperRegistry(), () -> null);
         XContentBuilder mappingSource = jsonBuilder().startObject().startObject("some_type")
             .startObject("properties")
             .endObject()

--- a/core/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
@@ -68,8 +68,9 @@ public class InnerHitBuilderTests extends ESTestCase {
 
     @BeforeClass
     public static void init() {
-        namedWriteableRegistry = new NamedWriteableRegistry();
-        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, namedWriteableRegistry, false, emptyList()).getQueryParserRegistry();
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, emptyList());
+        namedWriteableRegistry = new NamedWriteableRegistry(searchModule.getNamedWriteables());
+        indicesQueriesRegistry = searchModule.getQueryParserRegistry();
     }
 
     @AfterClass

--- a/core/src/test/java/org/elasticsearch/index/query/QueryParseContextTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryParseContextTests.java
@@ -42,8 +42,7 @@ public class QueryParseContextTests extends ESTestCase {
 
     @BeforeClass
     public static void init() {
-        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false, emptyList())
-                .getQueryParserRegistry();
+        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, false, emptyList()).getQueryParserRegistry();
     }
 
     public void testParseTopLevelBuilder() throws IOException {

--- a/core/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
@@ -73,13 +73,13 @@ public class IndicesModuleTests extends ESTestCase {
     });
 
     public void testBuiltinMappers() {
-        IndicesModule module = new IndicesModule(new NamedWriteableRegistry(), Collections.emptyList());
+        IndicesModule module = new IndicesModule(Collections.emptyList());
         assertFalse(module.getMapperRegistry().getMapperParsers().isEmpty());
         assertFalse(module.getMapperRegistry().getMetadataMapperParsers().isEmpty());
     }
 
     public void testBuiltinWithPlugins() {
-        IndicesModule module = new IndicesModule(new NamedWriteableRegistry(), fakePlugins);
+        IndicesModule module = new IndicesModule(fakePlugins);
         MapperRegistry registry = module.getMapperRegistry();
         assertThat(registry.getMapperParsers().size(), Matchers.greaterThan(1));
         assertThat(registry.getMetadataMapperParsers().size(), Matchers.greaterThan(1));
@@ -93,7 +93,7 @@ public class IndicesModuleTests extends ESTestCase {
             }
         });
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-            () -> new IndicesModule(new NamedWriteableRegistry(), plugins));
+            () -> new IndicesModule(plugins));
         assertThat(e.getMessage(), Matchers.containsString("already registered"));
     }
 
@@ -106,7 +106,7 @@ public class IndicesModuleTests extends ESTestCase {
         };
         List<MapperPlugin> plugins = Arrays.asList(plugin, plugin);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-            () -> new IndicesModule(new NamedWriteableRegistry(), plugins));
+            () -> new IndicesModule(plugins));
         assertThat(e.getMessage(), Matchers.containsString("already registered"));
     }
 
@@ -118,7 +118,7 @@ public class IndicesModuleTests extends ESTestCase {
             }
         });
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-            () -> new IndicesModule(new NamedWriteableRegistry(), plugins));
+            () -> new IndicesModule(plugins));
         assertThat(e.getMessage(), Matchers.containsString("already registered"));
     }
 
@@ -131,7 +131,7 @@ public class IndicesModuleTests extends ESTestCase {
         };
         List<MapperPlugin> plugins = Arrays.asList(plugin, plugin);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-            () -> new IndicesModule(new NamedWriteableRegistry(), plugins));
+            () -> new IndicesModule(plugins));
         assertThat(e.getMessage(), Matchers.containsString("already registered"));
     }
 
@@ -143,19 +143,19 @@ public class IndicesModuleTests extends ESTestCase {
             }
         });
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-            () -> new IndicesModule(new NamedWriteableRegistry(), plugins));
+            () -> new IndicesModule(plugins));
         assertThat(e.getMessage(), Matchers.containsString("cannot contain metadata mapper [_field_names]"));
     }
 
     public void testFieldNamesIsLast() {
-        IndicesModule module = new IndicesModule(new NamedWriteableRegistry(), Collections.emptyList());
+        IndicesModule module = new IndicesModule(Collections.emptyList());
         List<String> fieldNames = module.getMapperRegistry().getMetadataMapperParsers().keySet()
             .stream().collect(Collectors.toList());
         assertEquals(FieldNamesFieldMapper.NAME, fieldNames.get(fieldNames.size() - 1));
     }
 
     public void testFieldNamesIsLastWithPlugins() {
-        IndicesModule module = new IndicesModule(new NamedWriteableRegistry(), fakePlugins);
+        IndicesModule module = new IndicesModule(fakePlugins);
         List<String> fieldNames = module.getMapperRegistry().getMetadataMapperParsers().keySet()
             .stream().collect(Collectors.toList());
         assertEquals(FieldNamesFieldMapper.NAME, fieldNames.get(fieldNames.size() - 1));

--- a/core/src/test/java/org/elasticsearch/search/DocValueFormatTests.java
+++ b/core/src/test/java/org/elasticsearch/search/DocValueFormatTests.java
@@ -19,11 +19,15 @@
 
 package org.elasticsearch.search;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry.Entry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.network.InetAddresses;
@@ -33,13 +37,14 @@ import org.joda.time.DateTimeZone;
 public class DocValueFormatTests extends ESTestCase {
 
     public void testSerialization() throws Exception {
-        NamedWriteableRegistry registry = new NamedWriteableRegistry();
-        registry.register(DocValueFormat.class, DocValueFormat.BOOLEAN.getWriteableName(), in -> DocValueFormat.BOOLEAN);
-        registry.register(DocValueFormat.class, DocValueFormat.DateTime.NAME, DocValueFormat.DateTime::new);
-        registry.register(DocValueFormat.class, DocValueFormat.Decimal.NAME, DocValueFormat.Decimal::new);
-        registry.register(DocValueFormat.class, DocValueFormat.GEOHASH.getWriteableName(), in -> DocValueFormat.GEOHASH);
-        registry.register(DocValueFormat.class, DocValueFormat.IP.getWriteableName(), in -> DocValueFormat.IP);
-        registry.register(DocValueFormat.class, DocValueFormat.RAW.getWriteableName(), in -> DocValueFormat.RAW);
+        List<Entry> entries = new ArrayList<>();
+        entries.add(new Entry(DocValueFormat.class, DocValueFormat.BOOLEAN.getWriteableName(), in -> DocValueFormat.BOOLEAN));
+        entries.add(new Entry(DocValueFormat.class, DocValueFormat.DateTime.NAME, DocValueFormat.DateTime::new));
+        entries.add(new Entry(DocValueFormat.class, DocValueFormat.Decimal.NAME, DocValueFormat.Decimal::new));
+        entries.add(new Entry(DocValueFormat.class, DocValueFormat.GEOHASH.getWriteableName(), in -> DocValueFormat.GEOHASH));
+        entries.add(new Entry(DocValueFormat.class, DocValueFormat.IP.getWriteableName(), in -> DocValueFormat.IP));
+        entries.add(new Entry(DocValueFormat.class, DocValueFormat.RAW.getWriteableName(), in -> DocValueFormat.RAW));
+        NamedWriteableRegistry registry = new NamedWriteableRegistry(entries);
 
         BytesStreamOutput out = new BytesStreamOutput();
         out.writeNamedWriteable(DocValueFormat.BOOLEAN);

--- a/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -71,7 +71,7 @@ public class SearchModuleTests extends ModuleTestCase {
             }
         };
         expectThrows(IllegalArgumentException.class,
-                () -> new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false, singletonList(registersDupeHighlighter)));
+                () -> new SearchModule(Settings.EMPTY, false, singletonList(registersDupeHighlighter)));
 
         SearchPlugin registersDupeSuggester = new SearchPlugin() {
             @Override
@@ -80,7 +80,7 @@ public class SearchModuleTests extends ModuleTestCase {
             }
         };
         expectThrows(IllegalArgumentException.class,
-                () -> new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false, singletonList(registersDupeSuggester)));
+                () -> new SearchModule(Settings.EMPTY, false, singletonList(registersDupeSuggester)));
 
         SearchPlugin registersDupeScoreFunction = new SearchPlugin() {
             @Override
@@ -90,7 +90,7 @@ public class SearchModuleTests extends ModuleTestCase {
             }
         };
         expectThrows(IllegalArgumentException.class,
-                () -> new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false, singletonList(registersDupeScoreFunction)));
+                () -> new SearchModule(Settings.EMPTY, false, singletonList(registersDupeScoreFunction)));
 
         SearchPlugin registersDupeSignificanceHeuristic = new SearchPlugin() {
             @Override
@@ -98,7 +98,7 @@ public class SearchModuleTests extends ModuleTestCase {
                 return singletonList(new SearchExtensionSpec<>(ChiSquare.NAME, ChiSquare::new, ChiSquare.PARSER));
             }
         };
-        expectThrows(IllegalArgumentException.class, () -> new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false,
+        expectThrows(IllegalArgumentException.class, () -> new SearchModule(Settings.EMPTY, false,
                 singletonList(registersDupeSignificanceHeuristic)));
 
         SearchPlugin registersDupeMovAvgModel = new SearchPlugin() {
@@ -107,7 +107,7 @@ public class SearchModuleTests extends ModuleTestCase {
                 return singletonList(new SearchExtensionSpec<>(SimpleModel.NAME, SimpleModel::new, SimpleModel.PARSER));
             }
         };
-        expectThrows(IllegalArgumentException.class, () -> new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false,
+        expectThrows(IllegalArgumentException.class, () -> new SearchModule(Settings.EMPTY, false,
                 singletonList(registersDupeMovAvgModel)));
 
         SearchPlugin registersDupeFetchSubPhase = new SearchPlugin() {
@@ -116,7 +116,7 @@ public class SearchModuleTests extends ModuleTestCase {
                 return singletonList(new ExplainFetchSubPhase());
             }
         };
-        expectThrows(IllegalArgumentException.class, () -> new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false,
+        expectThrows(IllegalArgumentException.class, () -> new SearchModule(Settings.EMPTY, false,
                 singletonList(registersDupeFetchSubPhase)));
 
         SearchPlugin registersDupeFetchQuery = new SearchPlugin() {
@@ -124,12 +124,12 @@ public class SearchModuleTests extends ModuleTestCase {
                 return singletonList(new QuerySpec<>(TermQueryBuilder.NAME, TermQueryBuilder::new, TermQueryBuilder::fromXContent));
             }
         };
-        expectThrows(IllegalArgumentException.class, () -> new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false,
+        expectThrows(IllegalArgumentException.class, () -> new SearchModule(Settings.EMPTY, false,
                 singletonList(registersDupeFetchQuery)));
     }
 
     public void testRegisterSuggester() {
-        SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false, singletonList(new SearchPlugin() {
+        SearchModule module = new SearchModule(Settings.EMPTY, false, singletonList(new SearchPlugin() {
             @Override
             public Map<String, Suggester<?>> getSuggesters() {
                 return singletonMap("custom", CustomSuggester.INSTANCE);
@@ -143,7 +143,7 @@ public class SearchModuleTests extends ModuleTestCase {
 
     public void testRegisterHighlighter() {
         CustomHighlighter customHighlighter = new CustomHighlighter();
-        SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false, singletonList(new SearchPlugin() {
+        SearchModule module = new SearchModule(Settings.EMPTY, false, singletonList(new SearchPlugin() {
             @Override
             public Map<String, Highlighter> getHighlighters() {
                 return singletonMap("custom", customHighlighter);
@@ -158,7 +158,7 @@ public class SearchModuleTests extends ModuleTestCase {
     }
 
     public void testRegisteredQueries() throws IOException {
-        SearchModule module = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false, emptyList());
+        SearchModule module = new SearchModule(Settings.EMPTY, false, emptyList());
         List<String> allSupportedQueries = new ArrayList<>();
         Collections.addAll(allSupportedQueries, NON_DEPRECATED_QUERIES);
         Collections.addAll(allSupportedQueries, DEPRECATED_QUERIES);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
@@ -107,8 +107,8 @@ public class SignificanceHeuristicTests extends ESTestCase {
         // read
         ByteArrayInputStream inBuffer = new ByteArrayInputStream(outBuffer.toByteArray());
         StreamInput in = new InputStreamStreamInput(inBuffer);
-        NamedWriteableRegistry registry = new NamedWriteableRegistry();
-        new SearchModule(Settings.EMPTY, registry, false, emptyList()); // populates the registry through side effects
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, emptyList()); // populates the registry through side effects
+        NamedWriteableRegistry registry = new NamedWriteableRegistry(searchModule.getNamedWriteables());
         in = new NamedWriteableAwareStreamInput(in, registry);
         in.setVersion(version);
         InternalMappedSignificantTerms<?, ?> read = (InternalMappedSignificantTerms<?, ?>) in.readNamedWriteable(InternalAggregation.class);
@@ -217,7 +217,7 @@ public class SignificanceHeuristicTests extends ESTestCase {
     // 1. The output of the builders can actually be parsed
     // 2. The parser does not swallow parameters after a significance heuristic was defined
     public void testBuilderAndParser() throws Exception {
-        SearchModule searchModule = new SearchModule(Settings.EMPTY, new NamedWriteableRegistry(), false, emptyList());
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, emptyList());
         ParseFieldRegistry<SignificanceHeuristicParser> heuristicParserMapper = searchModule.getSignificanceHeuristicParserRegistry();
         SearchContext searchContext = new SignificantTermsTestSearchContext();
 

--- a/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -122,7 +122,6 @@ public class SearchSourceBuilderTests extends ESTestCase {
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
                 .put(ScriptService.SCRIPT_AUTO_RELOAD_ENABLED_SETTING.getKey(), false).build();
 
-        namedWriteableRegistry = new NamedWriteableRegistry();
         index = new Index(randomAsciiOfLengthBetween(1, 10), "_na_");
         Settings indexSettings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, version).build();
         final ThreadPool threadPool = new ThreadPool(settings);
@@ -133,25 +132,29 @@ public class SearchSourceBuilderTests extends ESTestCase {
         List<Setting<?>> scriptSettings = scriptModule.getSettings();
         scriptSettings.add(InternalSettingsPlugin.VERSION_CREATED);
         SettingsModule settingsModule = new SettingsModule(settings, scriptSettings, Collections.emptyList());
+        IndicesModule indicesModule = new IndicesModule(Collections.emptyList()) {
+            @Override
+            protected void configure() {
+                bindMapperExtension();
+            }
+        };
+        SearchModule searchModule = new SearchModule(settings, false, emptyList()) {
+            @Override
+            protected void configureSearch() {
+                // Skip me
+            }
+        };
+        List<NamedWriteableRegistry.Entry> entries = new ArrayList<>();
+        entries.addAll(indicesModule.getNamedWriteables());
+        entries.addAll(searchModule.getNamedWriteables());
+        namedWriteableRegistry = new NamedWriteableRegistry(entries);
         injector = new ModulesBuilder().add(
                 (b) -> {
                     b.bind(Environment.class).toInstance(new Environment(settings));
                     b.bind(ThreadPool.class).toInstance(threadPool);
                     b.bind(ScriptService.class).toInstance(scriptModule.getScriptService());
                 },
-                settingsModule,
-                new IndicesModule(namedWriteableRegistry, Collections.emptyList()) {
-                    @Override
-                    protected void configure() {
-                        bindMapperExtension();
-                    }
-                },
-                new SearchModule(settings, namedWriteableRegistry, false, emptyList()) {
-                    @Override
-                    protected void configureSearch() {
-                        // Skip me
-                    }
-                },
+                settingsModule, indicesModule, searchModule,
                 new IndexSettingsModule(index, settings),
                 new AbstractModule() {
                     @Override

--- a/core/src/test/java/org/elasticsearch/search/highlight/HighlightBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/HighlightBuilderTests.java
@@ -83,8 +83,9 @@ public class HighlightBuilderTests extends ESTestCase {
      */
     @BeforeClass
     public static void init() {
-        namedWriteableRegistry = new NamedWriteableRegistry();
-        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, namedWriteableRegistry, false, emptyList()).getQueryParserRegistry();
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, emptyList());
+        namedWriteableRegistry = new NamedWriteableRegistry(searchModule.getNamedWriteables());
+        indicesQueriesRegistry = searchModule.getQueryParserRegistry();
     }
 
     @AfterClass

--- a/core/src/test/java/org/elasticsearch/search/rescore/QueryRescoreBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/rescore/QueryRescoreBuilderTests.java
@@ -70,8 +70,9 @@ public class QueryRescoreBuilderTests extends ESTestCase {
      */
     @BeforeClass
     public static void init() {
-        namedWriteableRegistry = new NamedWriteableRegistry();
-        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, namedWriteableRegistry, false, emptyList()).getQueryParserRegistry();
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, emptyList());
+        namedWriteableRegistry = new NamedWriteableRegistry(searchModule.getNamedWriteables());
+        indicesQueriesRegistry = searchModule.getQueryParserRegistry();
     }
 
     @AfterClass

--- a/core/src/test/java/org/elasticsearch/search/searchafter/SearchAfterBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/searchafter/SearchAfterBuilderTests.java
@@ -45,7 +45,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class SearchAfterBuilderTests extends ESTestCase {
     private static final int NUMBER_OF_TESTBUILDERS = 20;
-    private static NamedWriteableRegistry namedWriteableRegistry;
     private static IndicesQueriesRegistry indicesQueriesRegistry;
 
     /**
@@ -53,7 +52,6 @@ public class SearchAfterBuilderTests extends ESTestCase {
      */
     @BeforeClass
     public static void init() {
-        namedWriteableRegistry = new NamedWriteableRegistry();
         indicesQueriesRegistry = new IndicesQueriesRegistry();
         QueryParser<MatchAllQueryBuilder> parser = MatchAllQueryBuilder::fromXContent;
         indicesQueriesRegistry.register(parser, MatchAllQueryBuilder.NAME);
@@ -61,7 +59,6 @@ public class SearchAfterBuilderTests extends ESTestCase {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        namedWriteableRegistry = null;
         indicesQueriesRegistry = null;
     }
 
@@ -164,7 +161,7 @@ public class SearchAfterBuilderTests extends ESTestCase {
     private static SearchAfterBuilder serializedCopy(SearchAfterBuilder original) throws IOException {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             original.writeTo(output);
-            try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), namedWriteableRegistry)) {
+            try (StreamInput in = output.bytes().streamInput()) {
                 return new SearchAfterBuilder(in);
             }
         }

--- a/core/src/test/java/org/elasticsearch/search/slice/SliceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/slice/SliceBuilderTests.java
@@ -68,7 +68,6 @@ import static org.mockito.Mockito.when;
 
 public class SliceBuilderTests extends ESTestCase {
     private static final int MAX_SLICE = 20;
-    private static NamedWriteableRegistry namedWriteableRegistry;
     private static IndicesQueriesRegistry indicesQueriesRegistry;
 
     /**
@@ -76,7 +75,6 @@ public class SliceBuilderTests extends ESTestCase {
      */
     @BeforeClass
     public static void init() {
-        namedWriteableRegistry = new NamedWriteableRegistry();
         indicesQueriesRegistry = new IndicesQueriesRegistry();
         QueryParser<MatchAllQueryBuilder> parser = MatchAllQueryBuilder::fromXContent;
         indicesQueriesRegistry.register(parser, MatchAllQueryBuilder.NAME);
@@ -84,7 +82,6 @@ public class SliceBuilderTests extends ESTestCase {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        namedWriteableRegistry = null;
         indicesQueriesRegistry = null;
     }
 
@@ -98,8 +95,7 @@ public class SliceBuilderTests extends ESTestCase {
     private static SliceBuilder serializedCopy(SliceBuilder original) throws IOException {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             original.writeTo(output);
-            try (StreamInput in =
-                     new NamedWriteableAwareStreamInput(output.bytes().streamInput(), namedWriteableRegistry)) {
+            try (StreamInput in = output.bytes().streamInput()) {
                 return new SliceBuilder(in);
             }
         }

--- a/core/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
@@ -106,8 +106,9 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
             }
         };
 
-        namedWriteableRegistry = new NamedWriteableRegistry();
-        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, namedWriteableRegistry, false, emptyList()).getQueryParserRegistry();
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, emptyList());
+        namedWriteableRegistry = new NamedWriteableRegistry(searchModule.getNamedWriteables());
+        indicesQueriesRegistry = searchModule.getQueryParserRegistry();
     }
 
     @AfterClass

--- a/core/src/test/java/org/elasticsearch/search/sort/SortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/SortBuilderTests.java
@@ -53,8 +53,9 @@ public class SortBuilderTests extends ESTestCase {
 
     @BeforeClass
     public static void init() {
-        namedWriteableRegistry = new NamedWriteableRegistry();
-        indicesQueriesRegistry = new SearchModule(Settings.EMPTY, namedWriteableRegistry, false, emptyList()).getQueryParserRegistry();
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, emptyList());
+        namedWriteableRegistry = new NamedWriteableRegistry(searchModule.getNamedWriteables());
+        indicesQueriesRegistry = searchModule.getQueryParserRegistry();
     }
 
     @AfterClass

--- a/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -57,8 +57,8 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
      */
     @BeforeClass
     public static void init() throws IOException {
-        namedWriteableRegistry = new NamedWriteableRegistry();
-        SearchModule searchModule = new SearchModule(Settings.EMPTY, namedWriteableRegistry, false, emptyList());
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, emptyList());
+        namedWriteableRegistry = new NamedWriteableRegistry(searchModule.getNamedWriteables());
         queriesRegistry = searchModule.getQueryParserRegistry();
         suggesters = searchModule.getSuggesters();
         parseFieldMatcher = ParseFieldMatcher.STRICT;

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestBuilderTests.java
@@ -54,8 +54,9 @@ public class SuggestBuilderTests extends WritableTestCase<SuggestBuilder> {
      */
     @BeforeClass
     public static void init() {
-        namedWriteableRegistry = new NamedWriteableRegistry();
-        suggesters = new SearchModule(Settings.EMPTY, namedWriteableRegistry, false, emptyList()).getSuggesters();
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, emptyList());
+        namedWriteableRegistry = new NamedWriteableRegistry(searchModule.getNamedWriteables());
+        suggesters = searchModule.getSuggesters();
     }
 
     @AfterClass

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/WritableTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/WritableTestCase.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -110,6 +111,6 @@ public abstract class WritableTestCase<M extends Writeable> extends ESTestCase {
     }
 
     protected NamedWriteableRegistry provideNamedWritableRegistry() {
-        return new NamedWriteableRegistry();
+        return new NamedWriteableRegistry(Collections.emptyList());
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/suggest/phrase/SmoothingModelTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/phrase/SmoothingModelTestCase.java
@@ -50,7 +50,9 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -66,8 +68,9 @@ public abstract class SmoothingModelTestCase extends ESTestCase {
     @BeforeClass
     public static void init() {
         if (namedWriteableRegistry == null) {
-            namedWriteableRegistry = new NamedWriteableRegistry();
-            SearchModule.registerSmoothingModels(namedWriteableRegistry);
+            List<NamedWriteableRegistry.Entry> namedWriteables = new ArrayList<>();
+            SearchModule.registerSmoothingModels(namedWriteables);
+            namedWriteableRegistry = new NamedWriteableRegistry(namedWriteables);
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/tasks/PersistedTaskInfoTests.java
+++ b/core/src/test/java/org/elasticsearch/tasks/PersistedTaskInfoTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -41,8 +42,8 @@ import java.util.TreeMap;
  */
 public class PersistedTaskInfoTests extends ESTestCase {
     public void testBinaryRoundTrip() throws IOException {
-        NamedWriteableRegistry registry = new NamedWriteableRegistry();
-        registry.register(Task.Status.class, RawTaskStatus.NAME, RawTaskStatus::new);
+        NamedWriteableRegistry registry = new NamedWriteableRegistry(Collections.singletonList(
+            new NamedWriteableRegistry.Entry(Task.Status.class, RawTaskStatus.NAME, RawTaskStatus::new)));
         PersistedTaskInfo result = randomTaskResult();
         PersistedTaskInfo read;
         try (BytesStreamOutput out = new BytesStreamOutput()) {

--- a/core/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -63,7 +63,7 @@ public class TransportServiceHandshakeTests extends ESTestCase {
                         threadPool,
                         BigArrays.NON_RECYCLING_INSTANCE,
                         new NoneCircuitBreakerService(),
-                        new NamedWriteableRegistry(),
+                        new NamedWriteableRegistry(Collections.emptyList()),
                         new NetworkService(settings, Collections.emptyList()));
         TransportService transportService = new MockTransportService(settings, transport, threadPool);
         transportService.start();

--- a/modules/transport-netty3/src/test/java/org/elasticsearch/transport/Netty3SizeHeaderFrameDecoderTests.java
+++ b/modules/transport-netty3/src/test/java/org/elasticsearch/transport/Netty3SizeHeaderFrameDecoderTests.java
@@ -64,8 +64,8 @@ public class Netty3SizeHeaderFrameDecoderTests extends ESTestCase {
         threadPool = new ThreadPool(settings);
         NetworkService networkService = new NetworkService(settings, Collections.emptyList());
         BigArrays bigArrays = new MockBigArrays(Settings.EMPTY, new NoneCircuitBreakerService());
-        nettyTransport = new Netty3Transport(settings, threadPool, networkService, bigArrays, new NamedWriteableRegistry(),
-            new NoneCircuitBreakerService());
+        nettyTransport = new Netty3Transport(settings, threadPool, networkService, bigArrays,
+            new NamedWriteableRegistry(Collections.emptyList()), new NoneCircuitBreakerService());
         nettyTransport.start();
         TransportService transportService = new TransportService(settings, nettyTransport, threadPool);
         nettyTransport.transportServiceAdapter(transportService.createAdapter());

--- a/modules/transport-netty3/src/test/java/org/elasticsearch/transport/netty3/Netty3ScheduledPingTests.java
+++ b/modules/transport-netty3/src/test/java/org/elasticsearch/transport/netty3/Netty3ScheduledPingTests.java
@@ -62,16 +62,15 @@ public class Netty3ScheduledPingTests extends ESTestCase {
 
         CircuitBreakerService circuitBreakerService = new NoneCircuitBreakerService();
 
-        NamedWriteableRegistry registryA = new NamedWriteableRegistry();
+        NamedWriteableRegistry registry = new NamedWriteableRegistry(Collections.emptyList());
         final Netty3Transport nettyA = new Netty3Transport(settings, threadPool, new NetworkService(settings, Collections.emptyList()),
-            BigArrays.NON_RECYCLING_INSTANCE, registryA, circuitBreakerService);
+            BigArrays.NON_RECYCLING_INSTANCE, registry, circuitBreakerService);
         MockTransportService serviceA = new MockTransportService(settings, nettyA, threadPool);
         serviceA.start();
         serviceA.acceptIncomingRequests();
 
-        NamedWriteableRegistry registryB = new NamedWriteableRegistry();
         final Netty3Transport nettyB = new Netty3Transport(settings, threadPool, new NetworkService(settings, Collections.emptyList()),
-            BigArrays.NON_RECYCLING_INSTANCE, registryB, circuitBreakerService);
+            BigArrays.NON_RECYCLING_INSTANCE, registry, circuitBreakerService);
         MockTransportService serviceB = new MockTransportService(settings, nettyB, threadPool);
 
         serviceB.start();

--- a/modules/transport-netty3/src/test/java/org/elasticsearch/transport/netty3/Netty3TransportMultiPortTests.java
+++ b/modules/transport-netty3/src/test/java/org/elasticsearch/transport/netty3/Netty3TransportMultiPortTests.java
@@ -138,7 +138,7 @@ public class Netty3TransportMultiPortTests extends ESTestCase {
     private TcpTransport<?> startTransport(Settings settings, ThreadPool threadPool) {
         BigArrays bigArrays = new MockBigArrays(Settings.EMPTY, new NoneCircuitBreakerService());
         TcpTransport<?> transport = new Netty3Transport(settings, threadPool, new NetworkService(settings, Collections.emptyList()),
-            bigArrays, new NamedWriteableRegistry(), new NoneCircuitBreakerService());
+            bigArrays, new NamedWriteableRegistry(Collections.emptyList()), new NoneCircuitBreakerService());
         transport.start();
 
         assertThat(transport.lifecycleState(), is(Lifecycle.State.STARTED));

--- a/modules/transport-netty3/src/test/java/org/elasticsearch/transport/netty3/SimpleNetty3TransportTests.java
+++ b/modules/transport-netty3/src/test/java/org/elasticsearch/transport/netty3/SimpleNetty3TransportTests.java
@@ -47,7 +47,7 @@ public class SimpleNetty3TransportTests extends AbstractSimpleTransportTestCase 
     public static MockTransportService nettyFromThreadPool(
         Settings settings,
         ThreadPool threadPool, final Version version) {
-        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry();
+        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(Collections.emptyList());
         Transport transport = new Netty3Transport(settings, threadPool, new NetworkService(settings, Collections.emptyList()),
             BigArrays.NON_RECYCLING_INSTANCE, namedWriteableRegistry, new NoneCircuitBreakerService()) {
             @Override

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4ScheduledPingTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4ScheduledPingTests.java
@@ -62,16 +62,15 @@ public class Netty4ScheduledPingTests extends ESTestCase {
 
         CircuitBreakerService circuitBreakerService = new NoneCircuitBreakerService();
 
-        NamedWriteableRegistry registryA = new NamedWriteableRegistry();
+        NamedWriteableRegistry registry = new NamedWriteableRegistry(Collections.emptyList());
         final Netty4Transport nettyA = new Netty4Transport(settings, threadPool, new NetworkService(settings, Collections.emptyList()),
-            BigArrays.NON_RECYCLING_INSTANCE, registryA, circuitBreakerService);
+            BigArrays.NON_RECYCLING_INSTANCE, registry, circuitBreakerService);
         MockTransportService serviceA = new MockTransportService(settings, nettyA, threadPool);
         serviceA.start();
         serviceA.acceptIncomingRequests();
 
-        NamedWriteableRegistry registryB = new NamedWriteableRegistry();
         final Netty4Transport nettyB = new Netty4Transport(settings, threadPool, new NetworkService(settings, Collections.emptyList()),
-            BigArrays.NON_RECYCLING_INSTANCE, registryB, circuitBreakerService);
+            BigArrays.NON_RECYCLING_INSTANCE, registry, circuitBreakerService);
         MockTransportService serviceB = new MockTransportService(settings, nettyB, threadPool);
 
         serviceB.start();

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4SizeHeaderFrameDecoderTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4SizeHeaderFrameDecoderTests.java
@@ -64,8 +64,8 @@ public class Netty4SizeHeaderFrameDecoderTests extends ESTestCase {
         threadPool = new ThreadPool(settings);
         NetworkService networkService = new NetworkService(settings, Collections.emptyList());
         BigArrays bigArrays = new MockBigArrays(Settings.EMPTY, new NoneCircuitBreakerService());
-        nettyTransport = new Netty4Transport(settings, threadPool, networkService, bigArrays, new NamedWriteableRegistry(),
-            new NoneCircuitBreakerService());
+        nettyTransport = new Netty4Transport(settings, threadPool, networkService, bigArrays,
+            new NamedWriteableRegistry(Collections.emptyList()), new NoneCircuitBreakerService());
         nettyTransport.start();
 
         TransportAddress[] boundAddresses = nettyTransport.boundAddress().boundAddresses();

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/NettyTransportMultiPortTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/NettyTransportMultiPortTests.java
@@ -138,7 +138,7 @@ public class NettyTransportMultiPortTests extends ESTestCase {
     private TcpTransport<?> startTransport(Settings settings, ThreadPool threadPool) {
         BigArrays bigArrays = new MockBigArrays(Settings.EMPTY, new NoneCircuitBreakerService());
         TcpTransport<?> transport = new Netty4Transport(settings, threadPool, new NetworkService(settings, Collections.emptyList()),
-            bigArrays, new NamedWriteableRegistry(), new NoneCircuitBreakerService());
+            bigArrays, new NamedWriteableRegistry(Collections.emptyList()), new NoneCircuitBreakerService());
         transport.start();
 
         assertThat(transport.lifecycleState(), is(Lifecycle.State.STARTED));

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/SimpleNetty4TransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/SimpleNetty4TransportTests.java
@@ -47,7 +47,7 @@ public class SimpleNetty4TransportTests extends AbstractSimpleTransportTestCase 
     public static MockTransportService nettyFromThreadPool(
         Settings settings,
         ThreadPool threadPool, final Version version) {
-        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry();
+        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(Collections.emptyList());
         Transport transport = new Netty4Transport(settings, threadPool, new NetworkService(settings, Collections.emptyList()),
             BigArrays.NON_RECYCLING_INSTANCE, namedWriteableRegistry, new NoneCircuitBreakerService()) {
             @Override

--- a/test/framework/src/main/java/org/elasticsearch/index/MapperTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/MapperTestUtils.java
@@ -42,7 +42,7 @@ import static org.elasticsearch.test.ESTestCase.createAnalysisService;
 public class MapperTestUtils {
 
     public static MapperService newMapperService(Path tempDir, Settings indexSettings) throws IOException {
-        IndicesModule indicesModule = new IndicesModule(new NamedWriteableRegistry(), Collections.emptyList());
+        IndicesModule indicesModule = new IndicesModule(Collections.emptyList());
         return newMapperService(tempDir, indexSettings, indicesModule);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -842,7 +842,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     /** Creates an IndicesModule for testing with the given mappers and metadata mappers. */
     public static IndicesModule newTestIndicesModule(Map<String, Mapper.TypeParser> extraMappers,
                                                      Map<String, MetadataFieldMapper.TypeParser> extraMetadataMappers) {
-        return new IndicesModule(new NamedWriteableRegistry(), Collections.singletonList(
+        return new IndicesModule(Collections.singletonList(
             new MapperPlugin() {
                 @Override
                 public Map<String, Mapper.TypeParser> getMappers() {

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -639,8 +639,8 @@ public class ElasticsearchAssertions {
         if (ESIntegTestCase.isInternalCluster()) {
             registry = ESIntegTestCase.internalCluster().getInstance(NamedWriteableRegistry.class);
         } else {
-            registry = new NamedWriteableRegistry();
-            new SearchModule(Settings.EMPTY, registry, false, emptyList());
+            SearchModule searchModule = new SearchModule(Settings.EMPTY, false, emptyList());
+            registry = new NamedWriteableRegistry(searchModule.getNamedWriteables());
         }
         assertVersionSerializable(version, streamable, registry);
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -53,6 +53,7 @@ import org.elasticsearch.transport.local.LocalTransport;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -89,7 +90,7 @@ public class MockTransportService extends TransportService {
     }
 
     public static MockTransportService local(Settings settings, Version version, ThreadPool threadPool) {
-        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry();
+        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(Collections.emptyList());
         Transport transport = new LocalTransport(settings, threadPool, namedWriteableRegistry, new NoneCircuitBreakerService()) {
             @Override
             protected Version getVersion() {

--- a/test/framework/src/test/java/org/elasticsearch/transport/MockTcpTransportTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/MockTcpTransportTests.java
@@ -31,7 +31,7 @@ import java.util.Collections;
 public class MockTcpTransportTests extends AbstractSimpleTransportTestCase {
     @Override
     protected MockTransportService build(Settings settings, Version version) {
-        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry();
+        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(Collections.emptyList());
         Transport transport = new MockTcpTransport(settings, threadPool, BigArrays.NON_RECYCLING_INSTANCE,
             new NoneCircuitBreakerService(), namedWriteableRegistry, new NetworkService(settings, Collections.emptyList()), version);
         MockTransportService mockTransportService = new MockTransportService(Settings.EMPTY, transport, threadPool);


### PR DESCRIPTION
Currently any code that wants to added NamedWriteables to the
NamedWriteableRegistry can do so via guice injection of the registry,
and registering at construction time. However, this makes the registry
complex: it has both get and register methods synchronized, and there is
likely contention on the read side from multiple threads.  The
registration has mostly already been contained to guice modules at node
construction time.

This change makes the registry immutable, taking all of the
NamedWriteable readers at construction time. It also allows plugins to
added arbitrary named writables that it may use in its own transport
actions.
