### PR TITLE
Allow dots in field names for mapping APIs.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -195,6 +195,8 @@ public class DocumentMapperParser {
     static Map<String,Object> removeDotsInFieldNames(Map<String, ?> mapping) {
         Map<String, Object> result = new HashMap<>(mapping);
         Object propertiesObject = result.get(PROPERTIES_KEY);
+        // if properties is not a map then we don't touch it and the parser
+        // will barf with a nicer error message than what we could do
         if (propertiesObject instanceof Map) {
             @SuppressWarnings("unchecked")
             Map<String, ?> properties = (Map<String, ?>) propertiesObject;

--- a/core/src/test/java/org/elasticsearch/index/mapper/DocumentMapperParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DocumentMapperParserTests.java
@@ -104,7 +104,7 @@ public class DocumentMapperParserTests extends ESTestCase {
         assertEquals(withoutDots, DocumentMapperParser.removeDotsInFieldNames(withDots));
     }
 
-    public void testRemoveDotsInFieldNamesMerge() {
+    public void testRemoveDotsInFieldNamesMerge1() {
         Map<String, Object> withDots = new MapBuilder<String, Object>()
                 .put("properties", new MapBuilder<String, Object>()
                         .put("a.b", new MapBuilder<String, Object>()
@@ -128,6 +128,38 @@ public class DocumentMapperParserTests extends ESTestCase {
                                                 .map())
                                         .put("b", new MapBuilder<String, Object>()
                                                 .put("type", "float")
+                                                .map())
+                                        .map())
+                                .map())
+                        .map())
+                .map();
+        assertEquals(withoutDots, DocumentMapperParser.removeDotsInFieldNames(withDots));
+    }
+
+    public void testRemoveDotsInFieldNamesMerge2() {
+        Map<String, Object> withDots = new MapBuilder<String, Object>()
+                .put("properties", new MapBuilder<String, Object>()
+                        .put("a.b.c", new MapBuilder<String, Object>()
+                                .put("type", "float")
+                                .map())
+                        .put("a.b.d", new MapBuilder<String, Object>()
+                                .put("type", "integer")
+                                .map())
+                        .map())
+                .map();
+        Map<String, Object> withoutDots = new MapBuilder<String, Object>()
+                .put("properties", new MapBuilder<String, Object>()
+                        .put("a", new MapBuilder<String, Object>()
+                                .put("properties", new MapBuilder<String, Object>()
+                                        .put("b", new MapBuilder<String, Object>()
+                                                .put("properties", new MapBuilder<String, Object>()
+                                                        .put("c", new MapBuilder<String, Object>()
+                                                                .put("type", "float")
+                                                                .map())
+                                                        .put("d", new MapBuilder<String, Object>()
+                                                                .put("type", "integer")
+                                                                .map())
+                                                        .map())
                                                 .map())
                                         .map())
                                 .map())

--- a/core/src/test/java/org/elasticsearch/index/mapper/DocumentMapperParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DocumentMapperParserTests.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Map;
+
+public class DocumentMapperParserTests extends ESTestCase {
+
+    public void testRemoveDotsInFieldNames() {
+        Map<String, Object> withDots = new MapBuilder<String, Object>()
+                .put("properties", new MapBuilder<String, Object>()
+                        .put("a.b", new MapBuilder<String, Object>()
+                                .put("type", "float")
+                                .map())
+                        .map())
+                .map();
+        Map<String, Object> withoutDots = new MapBuilder<String, Object>()
+                .put("properties", new MapBuilder<String, Object>()
+                        .put("a", new MapBuilder<String, Object>()
+                                .put("properties", new MapBuilder<String, Object>()
+                                        .put("b", new MapBuilder<String, Object>()
+                                                .put("type", "float")
+                                                .map())
+                                        .map())
+                                .map())
+                        .map())
+                .map();
+        assertEquals(withoutDots, DocumentMapperParser.removeDotsInFieldNames(withDots));
+    }
+
+    public void testRemoveDotsInFieldNames2Levels() {
+        Map<String, Object> withDots = new MapBuilder<String, Object>()
+                .put("properties", new MapBuilder<String, Object>()
+                        .put("a.b.c", new MapBuilder<String, Object>()
+                                .put("type", "float")
+                                .map())
+                        .map())
+                .map();
+        Map<String, Object> withoutDots = new MapBuilder<String, Object>()
+                .put("properties", new MapBuilder<String, Object>()
+                        .put("a", new MapBuilder<String, Object>()
+                                .put("properties", new MapBuilder<String, Object>()
+                                        .put("b", new MapBuilder<String, Object>()
+                                                .put("properties", new MapBuilder<String, Object>()
+                                                        .put("c", new MapBuilder<String, Object>()
+                                                                .put("type", "float")
+                                                                .map())
+                                                        .map())
+                                                .map())
+                                        .map())
+                                .map())
+                        .map())
+                .map();
+        assertEquals(withoutDots, DocumentMapperParser.removeDotsInFieldNames(withDots));
+    }
+
+    public void testRemoveDotsInFieldNamesInInnerObject() {
+        Map<String, Object> withDots = new MapBuilder<String, Object>()
+                .put("properties", new MapBuilder<String, Object>()
+                        .put("a", new MapBuilder<String, Object>()
+                                .put("properties", new MapBuilder<String, Object>()
+                                        .put("b.c", new MapBuilder<String, Object>()
+                                                .put("type", "float")
+                                                .map())
+                                        .map())
+                                .map())
+                        .map())
+                .map();
+        Map<String, Object> withoutDots = new MapBuilder<String, Object>()
+                .put("properties", new MapBuilder<String, Object>()
+                        .put("a", new MapBuilder<String, Object>()
+                                .put("properties", new MapBuilder<String, Object>()
+                                        .put("b", new MapBuilder<String, Object>()
+                                                .put("properties", new MapBuilder<String, Object>()
+                                                        .put("c", new MapBuilder<String, Object>()
+                                                                .put("type", "float")
+                                                                .map())
+                                                        .map())
+                                                .map())
+                                        .map())
+                                .map())
+                        .map())
+                .map();
+        assertEquals(withoutDots, DocumentMapperParser.removeDotsInFieldNames(withDots));
+    }
+
+    public void testRemoveDotsInFieldNamesMerge() {
+        Map<String, Object> withDots = new MapBuilder<String, Object>()
+                .put("properties", new MapBuilder<String, Object>()
+                        .put("a.b", new MapBuilder<String, Object>()
+                                .put("type", "float")
+                                .map())
+                        .put("a", new MapBuilder<String, Object>()
+                                .put("properties", new MapBuilder<String, Object>()
+                                        .put("c", new MapBuilder<String, Object>()
+                                                .put("type", "integer")
+                                                .map())
+                                        .map())
+                                .map())
+                        .map())
+                .map();
+        Map<String, Object> withoutDots = new MapBuilder<String, Object>()
+                .put("properties", new MapBuilder<String, Object>()
+                        .put("a", new MapBuilder<String, Object>()
+                                .put("properties", new MapBuilder<String, Object>()
+                                        .put("c", new MapBuilder<String, Object>()
+                                                .put("type", "integer")
+                                                .map())
+                                        .put("b", new MapBuilder<String, Object>()
+                                                .put("type", "float")
+                                                .map())
+                                        .map())
+                                .map())
+                        .map())
+                .map();
+        assertEquals(withoutDots, DocumentMapperParser.removeDotsInFieldNames(withDots));
+    }
+
+    public void testRemoveDotsInFieldNamesConflict1() {
+        Map<String, Object> withDots = new MapBuilder<String, Object>()
+                .put("properties", new MapBuilder<String, Object>()
+                        .put("a.b", new MapBuilder<String, Object>()
+                                .put("type", "float")
+                                .map())
+                        .put("a", new MapBuilder<String, Object>()
+                                .put("properties", new MapBuilder<String, Object>()
+                                        .put("b", new MapBuilder<String, Object>()
+                                                .put("type", "integer")
+                                                .map())
+                                        .map())
+                                .map())
+                        .map())
+                .map();
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> DocumentMapperParser.removeDotsInFieldNames(withDots));
+        assertEquals("Mapping contains two definitions for field [a.b]", e.getMessage());
+    }
+
+    public void testRemoveDotsInFieldNamesConflict2() {
+        Map<String, Object> withDots = new MapBuilder<String, Object>()
+                .put("properties", new MapBuilder<String, Object>()
+                        .put("a.b", new MapBuilder<String, Object>()
+                                .put("type", "float")
+                                .map())
+                        .put("a", new MapBuilder<String, Object>()
+                                .put("type", "integer")
+                                .map())
+                        .map())
+                .map();
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> DocumentMapperParser.removeDotsInFieldNames(withDots));
+        assertEquals("Need to create an object mapping called [a] for field [a.b] but this field already exists and is a [integer]",
+                e.getMessage());
+    }
+}

--- a/core/src/test/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
@@ -352,4 +352,17 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
         Map<String, Object> f = (Map<String, Object>) properties.get("f");
         assertEquals("n/a", f.get("null_value"));
     }
+
+    public void testDotsInFieldNames() throws IOException {
+        assertAcked(prepareCreate("index").addMapping("type", "a.b", "type=keyword"));
+        GetMappingsResponse mappings = client().admin().indices().prepareGetMappings("index").setTypes("type").get();
+        MappingMetaData typeMapping = mappings.getMappings().get("index").get("type").get();
+        Map<String, Object> properties = (Map<String, Object>) typeMapping.sourceAsMap().get("properties");
+        Map<String, Object> a = (Map<String, Object>) properties.get("a");
+        assertNotNull(a);
+        properties = (Map<String, Object>) a.get("properties");
+        Map<String, Object> b = (Map<String, Object>) properties.get("b");
+        assertNotNull(b);
+        assertEquals("keyword", b.get("type"));
+    }
 }


### PR DESCRIPTION
This commit adds the inner objects at parsing time by recursively walking the
map that stores the mappings.

Closes #19443
