### PR TITLE
Deprecate GeoDistance enums and remove geo distance script helpers

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/geo/GeoDistance.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoDistance.java
@@ -41,7 +41,9 @@ import java.util.Locale;
 public enum GeoDistance implements Writeable {
     /**
      * Calculates distance as points on a plane. Faster, but less accurate than {@link #ARC}.
+     * @deprecated use {@link GeoUtils#planeDistance}
      */
+    @Deprecated
     PLANE {
         @Override
         public double calculate(double sourceLatitude, double sourceLongitude, double targetLatitude, double targetLongitude, DistanceUnit unit) {
@@ -63,7 +65,11 @@ public enum GeoDistance implements Writeable {
 
     /**
      * Calculates distance factor.
+     * Note: {@code calculate} is simply returning the RHS of the spherical law of cosines from 2 lat,lon points.
+     * {@code normalize} also returns the RHS of the spherical law of cosines for a given distance
+     * @deprecated use {@link SloppyMath#haversinMeters} to get distance in meters, law of cosines is being removed
      */
+    @Deprecated
     FACTOR {
         @Override
         public double calculate(double sourceLatitude, double sourceLongitude, double targetLatitude, double targetLongitude, DistanceUnit unit) {
@@ -85,7 +91,9 @@ public enum GeoDistance implements Writeable {
     },
     /**
      * Calculates distance as points on a globe.
+     * @deprecated use {@link GeoUtils#arcDistance}
      */
+    @Deprecated
     ARC {
         @Override
         public double calculate(double sourceLatitude, double sourceLongitude, double targetLatitude, double targetLongitude, DistanceUnit unit) {
@@ -143,6 +151,7 @@ public enum GeoDistance implements Writeable {
      * Default {@link GeoDistance} function. This method should be used, If no specific function has been selected.
      * This is an alias for <code>SLOPPY_ARC</code>
      */
+    @Deprecated
     public static final GeoDistance DEFAULT = SLOPPY_ARC;
 
     public abstract double normalize(double distance, DistanceUnit unit);

--- a/core/src/main/java/org/elasticsearch/common/geo/GeoHashUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoHashUtils.java
@@ -300,4 +300,14 @@ public class GeoHashUtils {
 
         return neighbors;
     }
+
+    /** returns the latitude value from the string based geohash */
+    public static final double decodeLatitude(final String geohash) {
+        return GeoPointField.decodeLatitude(mortonEncode(geohash));
+    }
+
+    /** returns the latitude value from the string based geohash */
+    public static final double decodeLongitude(final String geohash) {
+        return GeoPointField.decodeLongitude(mortonEncode(geohash));
+    }
 }

--- a/core/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
@@ -478,6 +478,21 @@ public class GeoUtils {
       return SloppyMath.haversinMeters(centerLat, centerLon, centerLat, (MAX_LON + centerLon) % 360);
     }
 
+    /** Return the distance (in meters) between 2 lat,lon geo points using the haversine method implemented by lucene */
+    public static double arcDistance(double lat1, double lon1, double lat2, double lon2) {
+        return SloppyMath.haversinMeters(lat1, lon1, lat2, lon2);
+    }
+
+    /**
+     * Return the distance (in meters) between 2 lat,lon geo points using a simple tangential plane
+     * this provides a faster alternative to {@link GeoUtils#arcDistance} when points are within 5 km
+     */
+    public static double planeDistance(double lat1, double lon1, double lat2, double lon2) {
+        double x = (lon2 - lon1) * SloppyMath.TO_RADIANS * Math.cos((lat2 + lat1) / 2.0 * SloppyMath.TO_RADIANS);
+        double y = (lat2 - lat1) * SloppyMath.TO_RADIANS;
+        return Math.sqrt(x * x + y * y) * EARTH_MEAN_RADIUS;
+    }
+
     private GeoUtils() {
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/fielddata/ScriptDocValuesTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/ScriptDocValuesTests.java
@@ -19,9 +19,8 @@
 
 package org.elasticsearch.index.fielddata;
 
-import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.unit.DistanceUnit;
+import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
@@ -39,12 +38,12 @@ public class ScriptDocValuesTests extends ESTestCase {
                 }
                 return points[i];
             }
-            
+
             @Override
             public void setDocument(int docId) {
                 this.docID = docId;
             }
-            
+
             @Override
             public int count() {
                 if (docID != 0) {
@@ -94,18 +93,18 @@ public class ScriptDocValuesTests extends ESTestCase {
 
         final double otherLat = randomLat();
         final double otherLon = randomLon();
-        
-        assertEquals(GeoDistance.ARC.calculate(lat, lon, otherLat, otherLon, DistanceUnit.KILOMETERS),
-                script.arcDistanceInKm(otherLat, otherLon), 0.01);
-        assertEquals(GeoDistance.ARC.calculate(lat, lon, otherLat, otherLon, DistanceUnit.KILOMETERS),
-                script.arcDistanceInKmWithDefault(otherLat, otherLon, 42), 0.01);
-        assertEquals(42, emptyScript.arcDistanceInKmWithDefault(otherLat, otherLon, 42), 0);
 
-        assertEquals(GeoDistance.PLANE.calculate(lat, lon, otherLat, otherLon, DistanceUnit.KILOMETERS),
-                script.distanceInKm(otherLat, otherLon), 0.01);
-        assertEquals(GeoDistance.PLANE.calculate(lat, lon, otherLat, otherLon, DistanceUnit.KILOMETERS),
-                script.distanceInKmWithDefault(otherLat, otherLon, 42), 0.01);
-        assertEquals(42, emptyScript.distanceInKmWithDefault(otherLat, otherLon, 42), 0);
+        assertEquals(GeoUtils.arcDistance(lat, lon, otherLat, otherLon) / 1000d,
+                script.arcDistance(otherLat, otherLon) / 1000d, 0.01);
+        assertEquals(GeoUtils.arcDistance(lat, lon, otherLat, otherLon) / 1000d,
+                script.arcDistanceWithDefault(otherLat, otherLon, 42) / 1000d, 0.01);
+        assertEquals(42, emptyScript.arcDistanceWithDefault(otherLat, otherLon, 42), 0);
+
+        assertEquals(GeoUtils.planeDistance(lat, lon, otherLat, otherLon) / 1000d,
+                script.planeDistance(otherLat, otherLon) / 1000d, 0.01);
+        assertEquals(GeoUtils.planeDistance(lat, lon, otherLat, otherLon) / 1000d,
+                script.planeDistanceWithDefault(otherLat, otherLon, 42) / 1000d, 0.01);
+        assertEquals(42, emptyScript.planeDistanceWithDefault(otherLat, otherLon, 42), 0);
     }
 
 }

--- a/docs/reference/modules/scripting/groovy.asciidoc
+++ b/docs/reference/modules/scripting/groovy.asciidoc
@@ -43,56 +43,26 @@ on the underlying field type):
 `doc['field_name'].lons`::
     The longitudes of a geo point type, or an empty array.
 
-`doc['field_name'].distance(lat, lon)`::
-    The `plane` distance (in meters) of this geo point field from the provided lat/lon.
-
-`doc['field_name'].distanceWithDefault(lat, lon, default)`::
-    The `plane` distance (in meters) of this geo point field from the provided lat/lon with a default value.
-
-`doc['field_name'].distanceInMiles(lat, lon)`::
-    The `plane` distance (in miles) of this geo point field from the provided lat/lon.
-
-`doc['field_name'].distanceInMilesWithDefault(lat, lon, default)`::
-    The `plane` distance (in miles) of this geo point field from the provided lat/lon with a default value.
-
-`doc['field_name'].distanceInKm(lat, lon)`::
-    The `plane` distance (in km) of this geo point field from the provided lat/lon.
-
-`doc['field_name'].distanceInKmWithDefault(lat, lon, default)`::
-    The `plane` distance (in km) of this geo point field from the provided lat/lon with a default value.
-
 `doc['field_name'].arcDistance(lat, lon)`::
     The `arc` distance (in meters) of this geo point field from the provided lat/lon.
 
 `doc['field_name'].arcDistanceWithDefault(lat, lon, default)`::
-    The `arc` distance (in meters) of this geo point field from the provided lat/lon with a default value.
+    The `arc` distance (in meters) of this geo point field from the provided lat/lon with a default value
+    for empty fields.
 
-`doc['field_name'].arcDistanceInMiles(lat, lon)`::
-    The `arc` distance (in miles) of this geo point field from the provided lat/lon.
+`doc['field_name'].planeDistance(lat, lon)`::
+    The `plane` distance (in meters) of this geo point field from the provided lat/lon.
 
-`doc['field_name'].arcDistanceInMilesWithDefault(lat, lon, default)`::
-    The `arc` distance (in miles) of this geo point field from the provided lat/lon with a default value.
-
-`doc['field_name'].arcDistanceInKm(lat, lon)`::
-    The `arc` distance (in km) of this geo point field from the provided lat/lon.
-
-`doc['field_name'].arcDistanceInKmWithDefault(lat, lon, default)`::
-    The `arc` distance (in km) of this geo point field from the provided lat/lon with a default value.
-
-`doc['field_name'].factorDistance(lat, lon)`::
-    The distance factor of this geo point field from the provided lat/lon.
-
-`doc['field_name'].factorDistance(lat, lon, default)`::
-    The distance factor of this geo point field from the provided lat/lon with a default value.
+`doc['field_name'].planeDistanceWithDefault(lat, lon, default)`::
+    The `plane` distance (in meters) of this geo point field from the provided lat/lon with a default value
+    for empty fields.
 
 `doc['field_name'].geohashDistance(geohash)`::
     The `arc` distance (in meters) of this geo point field from the provided geohash.
 
-`doc['field_name'].geohashDistanceInKm(geohash)`::
-    The `arc` distance (in km) of this geo point field from the provided geohash.
-
-`doc['field_name'].geohashDistanceInMiles(geohash)`::
-    The `arc` distance (in miles) of this geo point field from the provided geohash.
+`doc['field_name'].geohashDistanceWithDefault(geohash, default)`::
+    The `arc` distance (in meters) of this geo point field from the provided geohash with a default value
+    for empty fields.
 
 
 [float]

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.txt
@@ -92,26 +92,13 @@ class org.elasticsearch.index.fielddata.ScriptDocValues.GeoPoints -> org.elastic
   double[] getLats()
   double[] getLons()
 
-  # geo distance functions... so many...
-  double factorDistance(double,double)
-  double factorDistanceWithDefault(double,double,double)
-  double factorDistance02(double,double)
-  double factorDistance13(double,double)
+  # geo distance functions
   double arcDistance(double,double)
   double arcDistanceWithDefault(double,double,double)
-  double arcDistanceInKm(double,double)
-  double arcDistanceInKmWithDefault(double,double,double)
-  double arcDistanceInMiles(double,double)
-  double arcDistanceInMilesWithDefault(double,double,double)
-  double distance(double,double)
-  double distanceWithDefault(double,double,double)
-  double distanceInKm(double,double)
-  double distanceInKmWithDefault(double,double,double)
-  double distanceInMiles(double,double)
-  double distanceInMilesWithDefault(double,double,double)
+  double planeDistance(double,double)
+  double planeDistanceWithDefault(double,double,double)
   double geohashDistance(String)
-  double geohashDistanceInKm(String)
-  double geohashDistanceInMiles(String)
+  double geohashDistanceWithDefault(String,double)
 }
 
 # for testing.


### PR DESCRIPTION
GeoDistance is implemented using a crazy enum that causes issues with the scripting modules. This PR moves all distance calculations to `arcDistance` and `planeDistance` static methods in `GeoUtils`. It also removes unnecessary distance helper methods from `ScriptDocValues.GeoPoints`. Docs and tests are updated to reflect changes.
