### PR TITLE
Explicitly tell Netty to not use unsafe

### DIFF
--- a/distribution/src/main/resources/config/jvm.options
+++ b/distribution/src/main/resources/config/jvm.options
@@ -59,6 +59,9 @@
 # use our provided JNA always versus the system one
 -Djna.nosys=true
 
+# flag to explicitly tell Netty to not use unsafe
+-Dio.netty.noUnsafe=true
+
 ## heap dumps
 
 # generate a heap dump when an allocation from the Java heap fails


### PR DESCRIPTION
With the security permissions that we grant to Netty, Netty can not
access unsafe (because it relies on having the runtime permission
accessDeclaredMembers and the reflect permission
suppressAccessChecks). Instead, we should just explicitly tell Netty to
not use unsafe. This commit adds a flag to the default jvm.options to
tell Netty to not look for unsafe.

Relates #19562, relates netty/netty#5624
