### PR TITLE
Update link to mapper-murmur3 plugin in card docs

### DIFF
--- a/docs/reference/aggregations/metrics/cardinality-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/cardinality-aggregation.asciidoc
@@ -84,7 +84,7 @@ On string fields that have a high cardinality, it might be faster to store the
 hash of your field values in your index and then run the cardinality aggregation
 on this field. This can either be done by providing hash values from client-side
 or by letting elasticsearch compute hash values for you by using the 
-{plugins}/mapper-size.html[`mapper-murmur3`] plugin.
+{plugins}/mapper-murmur3.html[`mapper-murmur3`] plugin.
 
 NOTE: Pre-computing hashes is usually only useful on very large and/or
 high-cardinality fields as it saves CPU and memory. However, on numeric


### PR DESCRIPTION
This PR fixes a minor bug in the documentation for the cardinality aggregation in which the incorrect plugin was linked; I have not first opened a ticket (in violation of the [CONTRIBUTING](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-code-and-documentation-changes) guidelines) as this change is minuscule and obvious.
