### PR TITLE
Rank eval: Use client instead of creating new TransportSearchAction

### DIFF
--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalAction.java
@@ -22,8 +22,8 @@ package org.elasticsearch.index.rankeval;
 import org.elasticsearch.action.Action;
 import org.elasticsearch.client.ElasticsearchClient;
 
-/** 
- * Action used to start precision at qa evaluations. 
+/**
+ * Action used to start precision at qa evaluations.
  **/
 public class RankEvalAction extends Action<RankEvalRequest, RankEvalResponse, RankEvalRequestBuilder> {
 

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalAction.java
@@ -43,5 +43,4 @@ public class RankEvalAction extends Action<RankEvalRequest, RankEvalResponse, Ra
     public RankEvalResponse newResponse() {
         return new RankEvalResponse();
     }
-
 }

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalResponse.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalResponse.java
@@ -51,12 +51,8 @@ public class RankEvalResponse extends ActionResponse implements ToXContent {
     public RankEvalResponse() {
     }
 
-    @SuppressWarnings("unchecked")
     public RankEvalResponse(StreamInput in) throws IOException {
-        super.readFrom(in);
-        this.specId = in.readString();
-        this.qualityLevel = in.readDouble();
-        this.unknownDocs = (Map<String, Collection<RatedDocumentKey>>) in.readGenericValue();
+        this.readFrom(in);
     }
 
     public RankEvalResponse(String specId, double qualityLevel, Map<String, Collection<RatedDocumentKey>> unknownDocs) {
@@ -65,7 +61,8 @@ public class RankEvalResponse extends ActionResponse implements ToXContent {
         this.unknownDocs = unknownDocs;
     }
 
-    public String getSpecId() {
+
+    public Object getSpecId() {
         return specId;
     }
 
@@ -79,15 +76,24 @@ public class RankEvalResponse extends ActionResponse implements ToXContent {
 
     @Override
     public String toString() {
-        return "RankEvalResult, ID :[" + specId + "], quality: " + qualityLevel + ", unknown docs: " + unknownDocs;
+        return "RankEvalResponse, ID :[" + specId + "], quality: " + qualityLevel + ", unknown docs: " + unknownDocs;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(specId);
-        out.writeDouble(qualityLevel);
+        out.writeOptionalString(specId);
+        out.writeOptionalDouble(qualityLevel);
         out.writeGenericValue(getUnknownDocs());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        this.specId = in.readOptionalString();
+        this.qualityLevel = in.readOptionalDouble();
+        this.unknownDocs = (Map<String, Collection<String>>) in.readGenericValue();
     }
 
     @Override
@@ -105,5 +111,4 @@ public class RankEvalResponse extends ActionResponse implements ToXContent {
         builder.endObject();
         return builder;
     }
-
 }

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalResponse.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalResponse.java
@@ -51,10 +51,6 @@ public class RankEvalResponse extends ActionResponse implements ToXContent {
     public RankEvalResponse() {
     }
 
-    public RankEvalResponse(StreamInput in) throws IOException {
-        this.readFrom(in);
-    }
-
     public RankEvalResponse(String specId, double qualityLevel, Map<String, Collection<RatedDocumentKey>> unknownDocs) {
         this.specId = specId;
         this.qualityLevel = qualityLevel;
@@ -62,7 +58,7 @@ public class RankEvalResponse extends ActionResponse implements ToXContent {
     }
 
 
-    public Object getSpecId() {
+    public String getSpecId() {
         return specId;
     }
 
@@ -82,8 +78,8 @@ public class RankEvalResponse extends ActionResponse implements ToXContent {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeOptionalString(specId);
-        out.writeOptionalDouble(qualityLevel);
+        out.writeString(specId);
+        out.writeDouble(qualityLevel);
         out.writeGenericValue(getUnknownDocs());
     }
 
@@ -91,9 +87,9 @@ public class RankEvalResponse extends ActionResponse implements ToXContent {
     @SuppressWarnings("unchecked")
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        this.specId = in.readOptionalString();
-        this.qualityLevel = in.readOptionalDouble();
-        this.unknownDocs = (Map<String, Collection<String>>) in.readGenericValue();
+        this.specId = in.readString();
+        this.qualityLevel = in.readDouble();
+        this.unknownDocs = (Map<String, Collection<RatedDocumentKey>>) in.readGenericValue();
     }
 
     @Override

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalSpec.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalSpec.java
@@ -59,7 +59,7 @@ public class RankEvalSpec implements Writeable {
         for (int i = 0; i < specSize; i++) {
             specifications.add(new QuerySpec(in));
         }
-        eval = in.readNamedWriteable(RankedListQualityMetric.class); // TODO add to registry
+        eval = in.readNamedWriteable(RankedListQualityMetric.class);
         taskId = in.readString();
     }
 

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankedListQualityMetric.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankedListQualityMetric.java
@@ -27,8 +27,8 @@ import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.search.SearchHit;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
-import java.util.Vector;
 
 /**
  * Classes implementing this interface provide a means to compute the quality of a result list
@@ -76,7 +76,7 @@ public abstract class RankedListQualityMetric implements NamedWriteable {
         return rc;
     }
 
-    double combine(Vector<EvalQueryQuality> partialResults) {
+    double combine(Collection<EvalQueryQuality> partialResults) {
         return partialResults.stream().mapToDouble(EvalQueryQuality::getQualityLevel).sum() / partialResults.size();
     }
 }

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/ReciprocalRank.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/ReciprocalRank.java
@@ -109,6 +109,7 @@ public class ReciprocalRank extends RankedListQualityMetric {
         int firstRelevant = -1;
         boolean found = false;
         for (int i = 0; i < hits.length; i++) {
+            // TODO here we use index/type/id triple not for a rated document but an unrated document in the search hits. Maybe rename?
             RatedDocumentKey id = new RatedDocumentKey(hits[i].getIndex(), hits[i].getType(), hits[i].getId());
             if (relevantDocIds.contains(id)) {
                 if (found == false && i < maxAcceptableRank) {

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalRequestTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalRequestTests.java
@@ -41,8 +41,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, transportClientRatio = 0.0)
-// NORELEASE need to fix transport client use case
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE)
 public class RankEvalRequestTests  extends ESIntegTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> transportClientPlugins() {

--- a/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.test;
 
 import com.carrotsearch.hppc.ObjectArrayList;
+
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.client.Client;


### PR DESCRIPTION
When running RankEvalRequestTest in this modul I saw warnings that we try to register the same transport handler twice. This happens because currently we create new TransportSearchAction instances in our own new TransportAction. My guess is we should use a client instead.

```
[2016-08-04 14:04:03,192][WARN ][org.elasticsearch.transport] [node_s1] registered two transport handlers for action indices:data/read/search, handlers: org.elasticsearch.action.support.HandledTransportAction$TransportHandler@799dbd7f, org.elasticsearch.action.support.HandledTransportAction$TransportHandler@2bef8ed0
[2016-08-04 14:04:03,513][WARN ][org.elasticsearch.transport] [node_s1] registered two transport handlers for action indices:data/read/search, handlers: org.elasticsearch.action.support.HandledTransportAction$TransportHandler@25fe09ed, org.elasticsearch.action.support.HandledTransportAction$TransportHandler@799dbd7f
```
