### PR TITLE
Fix PreBuiltTransportClientTests to run and pass

### DIFF
--- a/client/transport/build.gradle
+++ b/client/transport/build.gradle
@@ -34,6 +34,7 @@ dependencies {
   compile "org.elasticsearch.plugin:percolator-client:${version}"
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testCompile "junit:junit:${versions.junit}"
+  testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"`
 }
 
 dependencyLicenses {

--- a/client/transport/build.gradle
+++ b/client/transport/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   compile "org.elasticsearch.plugin:percolator-client:${version}"
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testCompile "junit:junit:${versions.junit}"
-  testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"`
+  testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
 }
 
 dependencyLicenses {

--- a/client/transport/src/main/java/org/elasticsearch/transport/client/PreBuiltTransportClient.java
+++ b/client/transport/src/main/java/org/elasticsearch/transport/client/PreBuiltTransportClient.java
@@ -91,7 +91,7 @@ public class PreBuiltTransportClient extends TransportClient {
     @Override
     public void close() {
         super.close();
-        if (!NetworkModule.TRANSPORT_TYPE_SETTING.exists(settings)
+        if (NetworkModule.TRANSPORT_TYPE_SETTING.exists(settings) == false
             || NetworkModule.TRANSPORT_TYPE_SETTING.get(settings).equals(Netty4Plugin.NETTY_TRANSPORT_NAME)) {
             try {
                 GlobalEventExecutor.INSTANCE.awaitInactivity(5, TimeUnit.SECONDS);

--- a/client/transport/src/main/java/org/elasticsearch/transport/client/PreBuiltTransportClient.java
+++ b/client/transport/src/main/java/org/elasticsearch/transport/client/PreBuiltTransportClient.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.transport.client;
 
 import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.reindex.ReindexPlugin;
@@ -79,10 +78,7 @@ public class PreBuiltTransportClient extends TransportClient {
 
         @Override
         public Settings additionalSettings() {
-            return Settings.builder()
-                    .put(NetworkModule.TRANSPORT_TYPE_KEY, Netty4Plugin.NETTY_TRANSPORT_NAME)
-                    .put(NetworkModule.HTTP_TYPE_KEY, Netty4Plugin.NETTY_HTTP_TRANSPORT_NAME)
-                    .put("netty.assert.buglevel", true)
+            return Settings.builder().put("netty.assert.buglevel", true)
                     .build();
         }
 

--- a/client/transport/src/main/java/org/elasticsearch/transport/client/PreBuiltTransportClient.java
+++ b/client/transport/src/main/java/org/elasticsearch/transport/client/PreBuiltTransportClient.java
@@ -21,6 +21,7 @@ package org.elasticsearch.transport.client;
 
 import io.netty.util.ThreadDeathWatcher;
 import io.netty.util.concurrent.GlobalEventExecutor;
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Setting;
@@ -95,9 +96,13 @@ public class PreBuiltTransportClient extends TransportClient {
             || NetworkModule.TRANSPORT_TYPE_SETTING.get(settings).equals(Netty4Plugin.NETTY_TRANSPORT_NAME)) {
             try {
                 GlobalEventExecutor.INSTANCE.awaitInactivity(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            try {
                 ThreadDeathWatcher.awaitInactivity(5, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
-                throw new RuntimeException(e);
+                Thread.currentThread().interrupt();
             }
         }
     }

--- a/client/transport/src/test/java/org/elasticsearch/transport/client/PreBuiltTransportClientTests.java
+++ b/client/transport/src/test/java/org/elasticsearch/transport/client/PreBuiltTransportClientTests.java
@@ -32,8 +32,8 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class PreBuiltTransportClientTests extends RandomizedTest {

--- a/client/transport/src/test/java/org/elasticsearch/transport/client/PreBuiltTransportClientTests.java
+++ b/client/transport/src/test/java/org/elasticsearch/transport/client/PreBuiltTransportClientTests.java
@@ -27,11 +27,12 @@ import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.percolator.PercolatorPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.mustache.MustachePlugin;
-import org.elasticsearch.transport.Netty3Plugin;
+import org.elasticsearch.transport.Netty4Plugin;
 import org.junit.Test;
 
 import java.util.Arrays;
 
+import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -41,7 +42,8 @@ public class PreBuiltTransportClientTests extends RandomizedTest {
     public void testPluginInstalled() {
         try (TransportClient client = new PreBuiltTransportClient(Settings.EMPTY)) {
             Settings settings = client.settings();
-            assertEquals(Netty3Plugin.NETTY_TRANSPORT_NAME, NetworkModule.HTTP_DEFAULT_TYPE_SETTING.get(settings));
+            assertEquals(Netty4Plugin.NETTY_TRANSPORT_NAME, NetworkModule.HTTP_DEFAULT_TYPE_SETTING.get(settings));
+            assertEquals(Netty4Plugin.NETTY_TRANSPORT_NAME, NetworkModule.TRANSPORT_DEFAULT_TYPE_SETTING.get(settings));
         }
     }
 
@@ -54,7 +56,7 @@ public class PreBuiltTransportClientTests extends RandomizedTest {
                 new PreBuiltTransportClient(Settings.EMPTY, plugin);
                 fail("exception expected");
             } catch (IllegalArgumentException ex) {
-                assertEquals("plugin is already installed", ex.getMessage());
+                assertTrue(ex.getMessage().startsWith("plugin already exists: "));
             }
         }
     }

--- a/client/transport/src/test/java/org/elasticsearch/transport/client/PreBuiltTransportClientTests.java
+++ b/client/transport/src/test/java/org/elasticsearch/transport/client/PreBuiltTransportClientTests.java
@@ -56,7 +56,8 @@ public class PreBuiltTransportClientTests extends RandomizedTest {
                 new PreBuiltTransportClient(Settings.EMPTY, plugin);
                 fail("exception expected");
             } catch (IllegalArgumentException ex) {
-                assertTrue(ex.getMessage().startsWith("plugin already exists: "));
+                assertTrue("Expected message to start with [plugin already exists: ] but was instead [" + ex.getMessage() + "]",
+                        ex.getMessage().startsWith("plugin already exists: "));
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/common/network/NetworkModule.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkModule.java
@@ -33,7 +33,6 @@ import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationComman
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.util.Providers;
-import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry.Entry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Setting;
@@ -57,9 +56,12 @@ public class NetworkModule extends AbstractModule {
     public static final String TRANSPORT_SERVICE_TYPE_KEY = "transport.service.type";
     public static final String HTTP_TYPE_KEY = "http.type";
     public static final String LOCAL_TRANSPORT = "local";
+    public static final String HTTP_TYPE_DEFAULT_KEY = "http.type.default";
+    public static final String TRANSPORT_TYPE_DEFAULT_KEY = "transport.type.default";
 
-    public static final Setting<String> TRANSPORT_DEFAULT_TYPE_SETTING = Setting.simpleString("transport.type.default", Property.NodeScope);
-    public static final Setting<String> HTTP_DEFAULT_TYPE_SETTING = Setting.simpleString("http.type.default", Property.NodeScope);
+    public static final Setting<String> TRANSPORT_DEFAULT_TYPE_SETTING = Setting.simpleString(TRANSPORT_TYPE_DEFAULT_KEY,
+            Property.NodeScope);
+    public static final Setting<String> HTTP_DEFAULT_TYPE_SETTING = Setting.simpleString(HTTP_TYPE_DEFAULT_KEY, Property.NodeScope);
     public static final Setting<String> HTTP_TYPE_SETTING = Setting.simpleString(HTTP_TYPE_KEY, Property.NodeScope);
     public static final Setting<Boolean> HTTP_ENABLED = Setting.boolSetting("http.enabled", true, Property.NodeScope);
     public static final Setting<String> TRANSPORT_SERVICE_TYPE_SETTING =


### PR DESCRIPTION
This change does four things:
1. Makes PreBuiltTransportClientTests run since it was silently
   failing on a missing dependency
2. Makes PreBuiltTransportClientTests pass
3. Removes the http.type and transport.type from being set in the
   transport clients additional settings since these are set to `netty4` by
   default anyway.
4. Wait for Netty 4 threads to terminate on close - Today if the 
   PreBuiltTransportClient is using Netty 4 transport, on
   shutdown some Netty 4 threads could linger. This commit causes the
   client to wait for these threads to shutdown upon termination.
