### PR TITLE
Fail build if JVM crashes

### DIFF
--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingTask.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingTask.groovy
@@ -187,6 +187,7 @@ class RandomizedTestingTask extends DefaultTask {
     void executeTests() {
         Map attributes = [
             jvm: jvm,
+            jvmOutputAction: 'PIPE,FAIL',
             parallelism: parallelism,
             heartbeat: testLoggingConfig.slowTests.heartbeat,
             dir: workingDir,


### PR DESCRIPTION
The build should fail if a slave JVM crashes, and this commit causes
this to be the case.
