### PR TITLE
Remove BWC serialization logic for pre 2.2 nodes

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/internal/InternalSearchResponse.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/InternalSearchResponse.java
@@ -136,14 +136,8 @@ public class InternalSearchResponse implements Streamable, ToXContent {
             suggest = Suggest.readSuggest(in);
         }
         timedOut = in.readBoolean();
-
         terminatedEarly = in.readOptionalBoolean();
-
-        if (in.getVersion().onOrAfter(Version.V_2_2_0) && in.readBoolean()) {
-            profileResults = new SearchProfileShardResults(in);
-        } else {
-            profileResults = null;
-        }
+        profileResults = in.readOptionalWriteable(SearchProfileShardResults::new);
     }
 
     @Override
@@ -162,16 +156,7 @@ public class InternalSearchResponse implements Streamable, ToXContent {
             suggest.writeTo(out);
         }
         out.writeBoolean(timedOut);
-
         out.writeOptionalBoolean(terminatedEarly);
-
-        if (out.getVersion().onOrAfter(Version.V_2_2_0)) {
-            if (profileResults == null) {
-                out.writeBoolean(false);
-            } else {
-                out.writeBoolean(true);
-                profileResults.writeTo(out);
-            }
-        }
+        out.writeOptionalWriteable(profileResults);
     }
 }


### PR DESCRIPTION
This change removes all pre 2.2 logic from `InternalSearchResponse` serialization. It's unneeded in 5.0 since we require full cluster restart
