### PR TITLE
Primary shard allocator observes limits in forcing allocation

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -252,6 +252,17 @@ public class RoutingAllocation {
         nodes.add(nodeId);
     }
 
+    /**
+     * Returns whether the given node id should be ignored from consideration when {@link AllocationDeciders}
+     * is deciding whether to allocate the specified shard id to that node.  The node will be ignored if
+     * the specified shard failed on that node, triggering the current round of allocation.  Since the shard
+     * just failed on that node, we don't want to try to reassign it there, if the node is still a part
+     * of the cluster.
+     *
+     * @param shardId the shard id to be allocated
+     * @param nodeId the node id to check against
+     * @return true if the node id should be ignored in allocation decisions, false otherwise
+     */
     public boolean shouldIgnoreShardForNode(ShardId shardId, String nodeId) {
         if (ignoredShardToNodes == null) {
             return false;

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
@@ -102,17 +102,11 @@ public abstract class AllocationDecider extends AbstractComponent {
     /**
      * Returns a {@link Decision} whether the given primary shard can be
      * forcibly allocated on the given node. This method should only be called
-     * on nodes for which previous allocations exist for the primary shard.
-     * The default is {@link Decision#YES}.
+     * for unassigned primary shards where the node has a shard copy on disk.
      */
     public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
-        assert shardRouting.primary() : "must not call canForceAllocatePrimary on a non-primary shard [" + shardRouting.shardId() + "]";
-        final Decision decision = canAllocate(shardRouting, node, allocation);
-        if (decision == Decision.NO) {
-            // on a NO decision, we can force allocate the primary by default
-            return Decision.YES;
-        } else {
-            return decision;
-        }
+        assert shardRouting.primary() : "must not call canForceAllocatePrimary on a non-primary shard " + shardRouting;
+        assert shardRouting.unassigned() : "must not call canForceAllocatePrimary on an assigned shard " + shardRouting;
+        return Decision.YES; // by default, a decider will allow force allocation of the primary
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
@@ -98,4 +98,16 @@ public abstract class AllocationDecider extends AbstractComponent {
     public Decision canRebalance(RoutingAllocation allocation) {
         return Decision.ALWAYS;
     }
+
+    /**
+     * Returns a {@link Decision} whether the given primary shard can be
+     * forcibly allocated on the given node. This method should only be called
+     * on nodes for which previous allocations exist for the primary shard.
+     * The default is {@link Decision#YES}.
+     */
+    public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        assert shardRouting.primary() : "must not call canForceAllocatePrimary on a non-primary shard routing [" +
+                                            shardRouting.shardId() + "]";
+        return Decision.YES;
+    }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
@@ -106,8 +106,13 @@ public abstract class AllocationDecider extends AbstractComponent {
      * The default is {@link Decision#YES}.
      */
     public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
-        assert shardRouting.primary() : "must not call canForceAllocatePrimary on a non-primary shard routing [" +
-                                            shardRouting.shardId() + "]";
-        return Decision.YES;
+        assert shardRouting.primary() : "must not call canForceAllocatePrimary on a non-primary shard [" + shardRouting.shardId() + "]";
+        final Decision decision = canAllocate(shardRouting, node, allocation);
+        if (decision == Decision.NO) {
+            // on a NO decision, we can force allocate the primary by default
+            return Decision.YES;
+        } else {
+            return decision;
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
 
@@ -103,10 +104,25 @@ public abstract class AllocationDecider extends AbstractComponent {
      * Returns a {@link Decision} whether the given primary shard can be
      * forcibly allocated on the given node. This method should only be called
      * for unassigned primary shards where the node has a shard copy on disk.
+     *
+     * Note: all implementations that override this behavior should take into account
+     * the results of {@link #canAllocate(ShardRouting, RoutingNode, RoutingAllocation)}
+     * before making a decision on force allocation, because force allocation should only
+     * be considered if all deciders return {@link Decision#NO}.
      */
     public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
         assert shardRouting.primary() : "must not call canForceAllocatePrimary on a non-primary shard " + shardRouting;
         assert shardRouting.unassigned() : "must not call canForceAllocatePrimary on an assigned shard " + shardRouting;
-        return Decision.YES; // by default, a decider will allow force allocation of the primary
+        Decision decision = canAllocate(shardRouting, node, allocation);
+        if (decision.type() == Type.NO) {
+            // On a NO decision, by default, we allow force allocating the primary.
+            return allocation.decision(Decision.YES,
+                                       decision.label(),
+                                       "primary shard [{}] allowed to force allocate on node [{}]",
+                                       shardRouting.shardId(), node.nodeId());
+        } else {
+            // On a THROTTLE/YES decision, we use the same decision instead of forcing allocation
+            return decision;
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -206,11 +206,7 @@ public class AllocationDeciders extends AllocationDecider {
         }
         Decision.Multi ret = new Decision.Multi();
         for (AllocationDecider decider : allocations) {
-            Decision decision = decider.canAllocate(shardRouting, node, allocation);
-            if (decision == Decision.NO) {
-                // on a NO decision, see if we can force allocate the primary
-                decision = decider.canForceAllocatePrimary(shardRouting, node, allocation);
-            }
+            Decision decision = decider.canForceAllocatePrimary(shardRouting, node, allocation);
             // short track if a NO is returned.
             if (decision == Decision.NO) {
                 if (logger.isTraceEnabled()) {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -196,4 +196,29 @@ public class AllocationDeciders extends AllocationDecider {
         }
         return ret;
     }
+
+    @Override
+    public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        assert shardRouting.primary() : "must not call canForceAllocatePrimary on a non-primary shard routing [" +
+                                            shardRouting.shardId() + "]";
+        Decision.Multi ret = new Decision.Multi();
+        for (AllocationDecider decider : allocations) {
+            Decision decision = decider.canForceAllocatePrimary(shardRouting, node, allocation);
+            // short track if a NO is returned.
+            if (decision == Decision.NO) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Shard [{}] can not be forcefully allocated to node [{}] due to [{}].",
+                        shardRouting.shardId(), node.nodeId(), decider.getClass().getSimpleName());
+                }
+                if (!allocation.debugDecision()) {
+                    return decision;
+                } else {
+                    ret.add(decision);
+                }
+            } else if (decision != Decision.ALWAYS) {
+                ret.add(decision);
+            }
+        }
+        return ret;
+    }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
@@ -53,7 +53,7 @@ public abstract class Decision implements ToXContent {
      * @param explanationParams additional parameters for the decision
      * @return new {@link Decision} instance
      */
-    public static Decision single(Type type, String label, String explanation, Object... explanationParams) {
+    public static Decision single(Type type, @Nullable String label, @Nullable String explanation, @Nullable Object... explanationParams) {
         return new Single(type, label, explanation, explanationParams);
     }
 
@@ -146,6 +146,9 @@ public abstract class Decision implements ToXContent {
      */
     public abstract Type type();
 
+    /**
+     * Get the description label for this decision.
+     */
     @Nullable
     public abstract String label();
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
@@ -83,8 +83,7 @@ public class MaxRetryAllocationDecider extends AllocationDecider {
 
     @Override
     public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
-        assert shardRouting.primary() : "must not call canForceAllocatePrimary on a non-primary shard routing [" +
-                                            shardRouting.shardId() + "]";
+        assert shardRouting.primary() : "must not call canForceAllocatePrimary on a non-primary shard [" + shardRouting.shardId() + "]";
         // check if we have passed the maximum retry threshold through canAllocate,
         // if so, we don't want to force the primary allocation here
         return canAllocate(shardRouting, node, allocation);

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
@@ -80,4 +80,13 @@ public class MaxRetryAllocationDecider extends AllocationDecider {
     public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
         return canAllocate(shardRouting, allocation);
     }
+
+    @Override
+    public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        assert shardRouting.primary() : "must not call canForceAllocatePrimary on a non-primary shard routing [" +
+                                            shardRouting.shardId() + "]";
+        // check if we have passed the maximum retry threshold through canAllocate,
+        // if so, we don't want to force the primary allocation here
+        return canAllocate(shardRouting, node, allocation);
+    }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
@@ -83,7 +83,7 @@ public class MaxRetryAllocationDecider extends AllocationDecider {
 
     @Override
     public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
-        assert shardRouting.primary() : "must not call canForceAllocatePrimary on a non-primary shard [" + shardRouting.shardId() + "]";
+        assert shardRouting.primary() : "must not call canForceAllocatePrimary on a non-primary shard " + shardRouting;
         // check if we have passed the maximum retry threshold through canAllocate,
         // if so, we don't want to force the primary allocation here
         return canAllocate(shardRouting, node, allocation);

--- a/core/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
@@ -176,9 +176,7 @@ public abstract class PrimaryShardAllocator extends AbstractComponent {
                 unassignedIterator.initialize(nodeShardState.getNode().getId(), nodeShardState.allocationId(), ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE);
             } else if (nodesToAllocate.throttleNodeShards.isEmpty() == true && nodesToAllocate.noNodeShards.isEmpty() == false) {
                 // The deciders returned a NO decision for all nodes with shard copies, so we check if primary shard
-                // can be force-allocated to one of the nodes, despite getting a NO decision for allocation. The decision
-                // to force allocate a primary to a node comes from AllocationDeciders#canForceAllocatePrimary, which calls
-                // the same method on each individual decider.
+                // can be force-allocated to one of the nodes.
                 final NodesToAllocate nodesToForceAllocate = buildNodesToAllocate(
                     allocation, nodeShardsResult.orderedAllocationCandidates, shard, true
                 );

--- a/core/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequestBuild
 import org.elasticsearch.action.admin.indices.shards.IndicesShardStoresResponse;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.allocation.command.AllocateEmptyPrimaryAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.AllocateStalePrimaryAllocationCommand;
 import org.elasticsearch.common.collect.ImmutableOpenIntMap;
@@ -218,5 +219,34 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         logger.info("--> checking that index still gets allocated with only 1 shard copy being available");
         ensureYellow("test");
         assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 1L);
+    }
+
+    /**
+     * This test ensures that for an unassigned primary shard that has a valid shard copy on at least one node,
+     * we will force allocate the primary shard to one of those nodes, even if the allocation deciders all return
+     * a NO decision to allocate.
+     */
+    public void testForceAllocatePrimaryOnNoDecision() throws Exception {
+        logger.info("--> starting 1 node");
+        final String node = internalCluster().startNodeAsync().get();
+        logger.info("--> creating index with 1 primary and 0 replicas");
+        final String indexName = "test-idx";
+        assertAcked(client().admin().indices()
+                        .prepareCreate(indexName)
+                        .setWaitForActiveShards(ActiveShardCount.ALL)
+                        .setSettings(Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+                                         .put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0))
+                        .get());
+        logger.info("--> update the settings to prevent allocation to the data node");
+        assertTrue(client().admin().indices().prepareUpdateSettings(indexName)
+                       .setSettings(Settings.builder().put(IndexMetaData.INDEX_ROUTING_EXCLUDE_GROUP_SETTING.getKey() + "_name", node))
+                       .get()
+                       .isAcknowledged());
+        logger.info("--> full cluster restart");
+        internalCluster().fullRestart();
+        logger.info("--> checking that the primary shard is force allocated to the data node despite being blocked by the exclude filter");
+        ensureYellow(indexName);
+        assertEquals(1, internalCluster().clusterService(internalCluster().getMasterName())
+                            .state().routingTable().index(indexName).shardsWithState(ShardRoutingState.STARTED).size());
     }
 }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -233,7 +233,6 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         final String indexName = "test-idx";
         assertAcked(client().admin().indices()
                         .prepareCreate(indexName)
-                        .setWaitForActiveShards(ActiveShardCount.ALL)
                         .setSettings(Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
                                          .put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0))
                         .get());
@@ -245,8 +244,8 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         logger.info("--> full cluster restart");
         internalCluster().fullRestart();
         logger.info("--> checking that the primary shard is force allocated to the data node despite being blocked by the exclude filter");
-        ensureYellow(indexName);
-        assertEquals(1, internalCluster().clusterService(internalCluster().getMasterName())
-                            .state().routingTable().index(indexName).shardsWithState(ShardRoutingState.STARTED).size());
+        ensureGreen(indexName);
+        assertEquals(1, client().admin().cluster().prepareState().get().getState()
+                            .routingTable().index(indexName).shardsWithState(ShardRoutingState.STARTED).size());
     }
 }

--- a/core/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -649,7 +649,6 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
 
     private AllocationDecider getNoDeciderThatAllowsForceAllocate() {
         return getNoDeciderWithForceAllocate(Decision.YES);
-
     }
 
     private AllocationDecider getNoDeciderThatThrottlesForceAllocate() {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESAllocationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESAllocationTestCase.java
@@ -197,18 +197,27 @@ public abstract class ESAllocationTestCase extends ESTestCase {
     }
 
     /**
-     * A decider class that allows controlling the decision on force allocating a primary shard.
+     * A decider class that allows controlling the decision on both allocating (AllocationDecider#canAllocate)
+     * and force allocating (AllocationDecider#canForceAllocatePrimary) a primary shard.
      */
     protected static class ForcePrimaryDecider extends TestAllocateDecision {
         private final Decision forceAllocatePrimary;
 
-        public ForcePrimaryDecider(Decision forceAllocatePrimary) {
-            super(Decision.NO);
+        /**
+         * Constructs a decider that allows to specify decisions to be returned for both allocating a shard
+         * and for force allocating a primary shard.
+         *
+         * @param allocate the decision to return for allocating a shard
+         * @param forceAllocatePrimary the decision to return for force allocating a primary shard
+         */
+        public ForcePrimaryDecider(Decision allocate, Decision forceAllocatePrimary) {
+            super(allocate);
             this.forceAllocatePrimary = forceAllocatePrimary;
         }
 
         @Override
         public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+            assert shardRouting.primary() : "must not call canForceAllocatePrimary on a non primary shard " + shardRouting;
             return forceAllocatePrimary;
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESAllocationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESAllocationTestCase.java
@@ -196,6 +196,23 @@ public abstract class ESAllocationTestCase extends ESTestCase {
         }
     }
 
+    /**
+     * A decider class that allows controlling the decision on force allocating a primary shard.
+     */
+    protected static class ForcePrimaryDecider extends TestAllocateDecision {
+        private final Decision forceAllocatePrimary;
+
+        public ForcePrimaryDecider(Decision forceAllocatePrimary) {
+            super(Decision.NO);
+            this.forceAllocatePrimary = forceAllocatePrimary;
+        }
+
+        @Override
+        public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+            return forceAllocatePrimary;
+        }
+    }
+
     /** A lock {@link AllocationService} allowing tests to override time */
     protected static class MockAllocationService extends AllocationService {
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESAllocationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESAllocationTestCase.java
@@ -196,32 +196,6 @@ public abstract class ESAllocationTestCase extends ESTestCase {
         }
     }
 
-    /**
-     * A decider class that allows controlling the decision on both allocating (AllocationDecider#canAllocate)
-     * and force allocating (AllocationDecider#canForceAllocatePrimary) a primary shard.
-     */
-    protected static class ForcePrimaryDecider extends TestAllocateDecision {
-        private final Decision forceAllocatePrimary;
-
-        /**
-         * Constructs a decider that allows to specify decisions to be returned for both allocating a shard
-         * and for force allocating a primary shard.
-         *
-         * @param allocate the decision to return for allocating a shard
-         * @param forceAllocatePrimary the decision to return for force allocating a primary shard
-         */
-        public ForcePrimaryDecider(Decision allocate, Decision forceAllocatePrimary) {
-            super(allocate);
-            this.forceAllocatePrimary = forceAllocatePrimary;
-        }
-
-        @Override
-        public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
-            assert shardRouting.primary() : "must not call canForceAllocatePrimary on a non primary shard " + shardRouting;
-            return forceAllocatePrimary;
-        }
-    }
-
     /** A lock {@link AllocationService} allowing tests to override time */
     protected static class MockAllocationService extends AllocationService {
 


### PR DESCRIPTION
Previously, during primary shards allocation of shards
with prior allocation IDs, if all nodes returned a
NO decision for allocation (e.g. the settings blocked
allocation on that node), we would chose one of those
nodes and force the primary shard to be allocated to it.

However, this meant that primary shard allocation
would not adhere to the decision of the MaxRetryAllocationDecider,
which would lead to attempting to allocate a shard
which has failed N number of times already (presumably
due to some configuration issue).

This commit solves this issue by introducing the
notion of force allocating a primary shard to a node
and each decider implementation must implement whether
this is allowed or not. In the case of MaxRetryAllocationDecider,
it just forwards the request to canAllocate.

Closes #19446
