### PR TITLE
Prebuild Japanese Stop Words Token Filter

### DIFF
--- a/plugins/analysis-kuromoji/src/main/java/org/elasticsearch/indices/analysis/KuromojiIndicesAnalysis.java
+++ b/plugins/analysis-kuromoji/src/main/java/org/elasticsearch/indices/analysis/KuromojiIndicesAnalysis.java
@@ -21,6 +21,7 @@ package org.elasticsearch.indices.analysis;
 
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.core.StopFilter;
 import org.apache.lucene.analysis.ja.*;
 import org.apache.lucene.analysis.ja.JapaneseTokenizer.Mode;
 import org.elasticsearch.common.component.AbstractComponent;
@@ -127,5 +128,19 @@ public class KuromojiIndicesAnalysis extends AbstractComponent {
                         return new JapaneseKatakanaStemFilter(tokenStream);
                     }
                 }));
+
+        indicesAnalysisService.tokenFilterFactories().put("ja_stop",
+            new PreBuiltTokenFilterFactoryFactory(new TokenFilterFactory() {
+                @Override
+                public String name() {
+                    return "ja_stop";
+                }
+
+                @Override
+                public TokenStream create(TokenStream tokenStream) {
+                    return new StopFilter(tokenStream, JapaneseAnalyzer.getDefaultStopSet());
+                }
+            }));
     }
+
 }


### PR DESCRIPTION
Prebuild Japanese stop words token filter to make sure we don't create this filter for every index if Kuromoji plugin is installed.

This PR is only for 2.x branch, a similar issue for 5.x is discussed in #19814 
