### PR TITLE
make ctors protected

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingResponse.java
@@ -30,11 +30,11 @@ import java.io.IOException;
  */
 public class PutMappingResponse extends AcknowledgedResponse {
 
-    PutMappingResponse() {
+    protected PutMappingResponse() {
 
     }
 
-    PutMappingResponse(boolean acknowledged) {
+    protected PutMappingResponse(boolean acknowledged) {
         super(acknowledged);
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateResponse.java
@@ -29,10 +29,10 @@ import java.io.IOException;
  */
 public class PutIndexTemplateResponse extends AcknowledgedResponse {
 
-    PutIndexTemplateResponse() {
+    protected PutIndexTemplateResponse() {
     }
 
-    PutIndexTemplateResponse(boolean acknowledged) {
+    protected PutIndexTemplateResponse(boolean acknowledged) {
         super(acknowledged);
     }
 


### PR DESCRIPTION
This is useful if we need an acknowledged instance in a test.
I only changed these two but the same might in the future apply to others. 
