### PR TITLE
Ensure PutMappingRequest.buildFromSimplifiedDef input are pairs

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -177,7 +177,17 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
         return source(buildFromSimplifiedDef(type, source));
     }
 
+    /**
+     * @param type the mapping type
+     * @param source consisting of field/properties pairs (e.g. "field1",
+     *            "type=string,store=true"). If the number of arguments is not
+     *            divisible by two an {@link IllegalArgumentException} is thrown
+     * @return the mappings definition
+     */
     public static XContentBuilder buildFromSimplifiedDef(String type, Object... source) {
+        if (source.length % 2 != 0) {
+            throw new IllegalArgumentException("mapping source must be pairs of fieldnames and properties definition.");
+        }
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.startObject();

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequestTests.java
@@ -57,4 +57,11 @@ public class PutMappingRequestTests extends ESTestCase {
             "Validation Failed: 1: either concrete index or unresolved indices can be set," +
                 " concrete index: [[foo/bar]] and indices: [myindex];");
     }
+
+    public void testBuildFromSimplifiedDef() {
+        // test that method rejects input where input varargs fieldname/properites are not paired correctly
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> PutMappingRequest.buildFromSimplifiedDef("type", "only_field"));
+        assertEquals("mapping source must be pairs of fieldnames and properties definition.", e.getMessage());
+    }
 }


### PR DESCRIPTION
The method expects pairs of fieldnames and property arguments and will fail if the varargs input is an uneven number. We should check this and fail with an appropriate IllegalArgumentException instead.

Relates to #19836 
