### PR TITLE
Add field for plugins installed on issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,6 +17,8 @@ request block and provide responses for all of the below items.
 
 **Elasticsearch version**:
 
+**Plugins installed**: []
+
 **JVM version**:
 
 **OS version**:


### PR DESCRIPTION
This commit adds a field to the GitHub issue template for a list of the
plugins that are installed on the Elasticsearch installation. This is a
common enough ask that it is better to just collect this information up
front.
