### PR TITLE
Single comma-delimited response header for multiple values

### DIFF
--- a/modules/transport-netty3/src/test/java/org/elasticsearch/http/netty3/Netty3HttpChannelTests.java
+++ b/modules/transport-netty3/src/test/java/org/elasticsearch/http/netty3/Netty3HttpChannelTests.java
@@ -370,7 +370,7 @@ public class Netty3HttpChannelTests extends ESTestCase {
         }
     }
 
-    private static class TestHttpRequest implements HttpRequest {
+    public static class TestHttpRequest implements HttpRequest {
 
         private HttpHeaders headers = new DefaultHttpHeaders();
 

--- a/modules/transport-netty3/src/test/java/org/elasticsearch/http/netty3/cors/Netty3CorsHandlerTests.java
+++ b/modules/transport-netty3/src/test/java/org/elasticsearch/http/netty3/cors/Netty3CorsHandlerTests.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.http.netty3.cors;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.http.netty3.Netty3HttpChannelTests;
+import org.elasticsearch.test.ESTestCase;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_HEADERS;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_METHODS;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_ORIGIN;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ENABLED;
+
+/**
+ * Tests for {@link Netty3CorsHandler}
+ */
+public class Netty3CorsHandlerTests extends ESTestCase {
+
+    public void testPreflightMultiValueResponseHeaders() {
+        // test when only one value
+        String headersRequestHeader = "content-type";
+        String methodsRequestHeader = "GET";
+        Settings settings = Settings.builder()
+                                .put(SETTING_CORS_ENABLED.getKey(), true)
+                                .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), Netty3CorsHandler.ANY_ORIGIN)
+                                .put(SETTING_CORS_ALLOW_HEADERS.getKey(), headersRequestHeader)
+                                .put(SETTING_CORS_ALLOW_METHODS.getKey(), methodsRequestHeader)
+                                .build();
+        HttpResponse response = execPreflight(settings, Netty3CorsHandler.ANY_ORIGIN, "request-host");
+        assertEquals(headersRequestHeader, response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS));
+        assertEquals(methodsRequestHeader, response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_METHODS));
+
+        // test with a set of values
+        headersRequestHeader = "content-type,x-requested-with,accept";
+        methodsRequestHeader = "GET,POST";
+        settings = Settings.builder()
+                       .put(SETTING_CORS_ENABLED.getKey(), true)
+                       .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), Netty3CorsHandler.ANY_ORIGIN)
+                       .put(SETTING_CORS_ALLOW_HEADERS.getKey(), headersRequestHeader)
+                       .put(SETTING_CORS_ALLOW_METHODS.getKey(), methodsRequestHeader)
+                       .build();
+        response = execPreflight(settings, Netty3CorsHandler.ANY_ORIGIN, "request-host");
+        assertEquals(Strings.commaDelimitedListToSet(headersRequestHeader),
+            Strings.commaDelimitedListToSet(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS)));
+        assertEquals(Strings.commaDelimitedListToSet(methodsRequestHeader),
+            Strings.commaDelimitedListToSet(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_METHODS)));
+
+        // test with defaults
+        settings = Settings.builder()
+                       .put(SETTING_CORS_ENABLED.getKey(), true)
+                       .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), Netty3CorsHandler.ANY_ORIGIN)
+                       .build();
+        response = execPreflight(settings, Netty3CorsHandler.ANY_ORIGIN, "request-host");
+        assertEquals(Strings.commaDelimitedListToSet(SETTING_CORS_ALLOW_HEADERS.getDefault(settings)),
+            Strings.commaDelimitedListToSet(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS)));
+        assertEquals(Strings.commaDelimitedListToSet(SETTING_CORS_ALLOW_METHODS.getDefault(settings)),
+            Strings.commaDelimitedListToSet(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_METHODS)));
+    }
+
+    private HttpResponse execPreflight(final Settings settings, final String originValue, final String host) {
+        // simulate execution of a preflight request
+        HttpRequest httpRequest = new Netty3HttpChannelTests.TestHttpRequest();
+        httpRequest.setMethod(HttpMethod.OPTIONS);
+        httpRequest.headers().add(HttpHeaders.Names.ORIGIN, originValue);
+        httpRequest.headers().add(HttpHeaders.Names.HOST, host);
+        httpRequest.headers().add(HttpHeaders.Names.ACCESS_CONTROL_REQUEST_METHOD, "GET");
+
+        Netty3CorsHandler corsHandler = new Netty3CorsHandler(Netty3CorsConfig.buildCorsConfig(settings));
+        return corsHandler.handlePreflight(httpRequest);
+    }
+
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/cors/Netty4CorsConfig.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/cors/Netty4CorsConfig.java
@@ -23,7 +23,11 @@ import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestUtils;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -31,6 +35,14 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
+
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_CREDENTIALS;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_HEADERS;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_METHODS;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_ORIGIN;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ENABLED;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_MAX_AGE;
+import static org.elasticsearch.http.netty4.cors.Netty4CorsHandler.ANY_ORIGIN;
 
 /**
  * Configuration for Cross-Origin Resource Sharing (CORS).
@@ -230,6 +242,42 @@ public final class Netty4CorsConfig {
             ", allowedRequestMethods=" + allowedRequestMethods +
             ", allowedRequestHeaders=" + allowedRequestHeaders +
             ", preflightHeaders=" + preflightHeaders + ']';
+    }
+
+    /**
+     * Constructs a {@link Netty4CorsConfig} from the given settings.
+     */
+    public static Netty4CorsConfig buildCorsConfig(Settings settings) {
+        if (SETTING_CORS_ENABLED.get(settings) == false) {
+            return Netty4CorsConfigBuilder.forOrigins().disable().build();
+        }
+        String origin = SETTING_CORS_ALLOW_ORIGIN.get(settings);
+        final Netty4CorsConfigBuilder builder;
+        if (Strings.isNullOrEmpty(origin)) {
+            builder = Netty4CorsConfigBuilder.forOrigins();
+        } else if (origin.equals(ANY_ORIGIN)) {
+            builder = Netty4CorsConfigBuilder.forAnyOrigin();
+        } else {
+            Pattern p = RestUtils.checkCorsSettingForRegex(origin);
+            if (p == null) {
+                builder = Netty4CorsConfigBuilder.forOrigins(RestUtils.corsSettingAsArray(origin));
+            } else {
+                builder = Netty4CorsConfigBuilder.forPattern(p);
+            }
+        }
+        if (SETTING_CORS_ALLOW_CREDENTIALS.get(settings)) {
+            builder.allowCredentials();
+        }
+        String[] strMethods = Strings.splitStringByCommaToArray(SETTING_CORS_ALLOW_METHODS.get(settings));
+        HttpMethod[] methods = Arrays.asList(strMethods)
+                                   .stream()
+                                   .map(HttpMethod::valueOf)
+                                   .toArray(size -> new HttpMethod[size]);
+        return builder.allowedRequestMethods(methods)
+                   .maxAge(SETTING_CORS_MAX_AGE.get(settings))
+                   .allowedRequestHeaders(Strings.splitStringByCommaToArray(SETTING_CORS_ALLOW_HEADERS.get(settings)))
+                   .shortCircuit()
+                   .build();
     }
 
 }

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/cors/Netty4CorsHandlerTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/cors/Netty4CorsHandlerTests.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.http.netty4.cors;
+
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpVersion;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_HEADERS;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_METHODS;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_ORIGIN;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ENABLED;
+
+/**
+ * Tests for {@link Netty4CorsHandler}
+ */
+public class Netty4CorsHandlerTests extends ESTestCase {
+
+    public void testPreflightMultiValueResponseHeaders() {
+        // test when only one value
+        String headersRequestHeader = "content-type";
+        String methodsRequestHeader = "GET";
+        Settings settings = Settings.builder()
+                                .put(SETTING_CORS_ENABLED.getKey(), true)
+                                .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), Netty4CorsHandler.ANY_ORIGIN)
+                                .put(SETTING_CORS_ALLOW_HEADERS.getKey(), headersRequestHeader)
+                                .put(SETTING_CORS_ALLOW_METHODS.getKey(), methodsRequestHeader)
+                                .build();
+        HttpResponse response = execPreflight(settings, Netty4CorsHandler.ANY_ORIGIN, "request-host");
+        assertEquals(headersRequestHeader, response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS));
+        assertEquals(methodsRequestHeader, response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS));
+
+        // test with a set of values
+        headersRequestHeader = "content-type,x-requested-with,accept";
+        methodsRequestHeader = "GET,POST";
+        settings = Settings.builder()
+                       .put(SETTING_CORS_ENABLED.getKey(), true)
+                       .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), Netty4CorsHandler.ANY_ORIGIN)
+                       .put(SETTING_CORS_ALLOW_HEADERS.getKey(), headersRequestHeader)
+                       .put(SETTING_CORS_ALLOW_METHODS.getKey(), methodsRequestHeader)
+                       .build();
+        response = execPreflight(settings, Netty4CorsHandler.ANY_ORIGIN, "request-host");
+        assertEquals(Strings.commaDelimitedListToSet(headersRequestHeader),
+            Strings.commaDelimitedListToSet(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS)));
+        assertEquals(Strings.commaDelimitedListToSet(methodsRequestHeader),
+            Strings.commaDelimitedListToSet(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)));
+
+        // test with defaults
+        settings = Settings.builder()
+                       .put(SETTING_CORS_ENABLED.getKey(), true)
+                       .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), Netty4CorsHandler.ANY_ORIGIN)
+                       .build();
+        response = execPreflight(settings, Netty4CorsHandler.ANY_ORIGIN, "request-host");
+        assertEquals(Strings.commaDelimitedListToSet(SETTING_CORS_ALLOW_HEADERS.getDefault(settings)),
+            Strings.commaDelimitedListToSet(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS)));
+        assertEquals(Strings.commaDelimitedListToSet(SETTING_CORS_ALLOW_METHODS.getDefault(settings)),
+            Strings.commaDelimitedListToSet(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)));
+    }
+
+    private HttpResponse execPreflight(final Settings settings, final String originValue, final String host) {
+        // simulate execution of a preflight request
+        final FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+        httpRequest.setMethod(HttpMethod.OPTIONS);
+        httpRequest.headers().add(HttpHeaderNames.ORIGIN, originValue);
+        httpRequest.headers().add(HttpHeaderNames.HOST, host);
+        httpRequest.headers().add(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "GET");
+
+        Netty4CorsHandler corsHandler = new Netty4CorsHandler(Netty4CorsConfig.buildCorsConfig(settings));
+        return corsHandler.handlePreflight(httpRequest);
+    }
+}


### PR DESCRIPTION
Ensures that CORS preflight requests return multi-value
Access-Control-Allow-Headers and Access-Control-Allow-Methods
response headers as single headers with comma separated values,
which is closest to the RFC specification (see http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2) and supports browsers
like IE which do not handle separate response header lines for
each value.

This PR also refactors some of the CORS code to make it easier
to test.

Note that the Netty4 module required no updates to the CORS handling
because while Netty3 creates a new header (with the same field name) for
each value in a collection, Netty4 is more in line with the RFC and creates
a single response header with a comma-separated value.

Closes #19841
