### PR TITLE
Fix wrong status code for SearchPhaseExecutionException

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
@@ -149,6 +149,7 @@ public class DateHistogramParser extends NumericValuesSourceParser {
         if ("_count".equals(key)) {
             return (InternalOrder) (asc ? InternalOrder.COUNT_ASC : InternalOrder.COUNT_DESC);
         }
+        // TODO check for valid sub-aggregation names and fields here instead of reduce phase.
         return new InternalOrder.Aggregation(key, asc);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramParser.java
@@ -141,6 +141,7 @@ public class HistogramParser extends NumericValuesSourceParser {
         if ("_count".equals(key)) {
             return (InternalOrder) (asc ? InternalOrder.COUNT_ASC : InternalOrder.COUNT_DESC);
         }
+        // TODO check for valid sub-aggregation names and fields here instead of reduce phase.
         return new InternalOrder.Aggregation(key, asc);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -396,6 +396,12 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         } else {
             // sorted by sub-aggregation, need to fall back to a costly n*log(n) sort
             CollectionUtil.introSort(reducedBuckets, order.comparator());
+            if (reducedBuckets.size() == 1) {
+                // hack: force check of sub-aggregation names and fields if there is only 1 bucket (sort code bypassed)
+                // TODO check for valid sub-aggregation names and fields during parsing instead of reduce phase
+                Bucket b = reducedBuckets.get(0);
+                order.comparator().compare(b, b);
+            }
         }
 
         return new InternalDateHistogram(getName(), reducedBuckets, order, minDocCount, offset, emptyBucketInfo,

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -379,6 +379,12 @@ public final class InternalHistogram extends InternalMultiBucketAggregation<Inte
         } else {
             // sorted by sub-aggregation, need to fall back to a costly n*log(n) sort
             CollectionUtil.introSort(reducedBuckets, order.comparator());
+            if (reducedBuckets.size() == 1) {
+                // hack: force check of sub-aggregation names and fields if there is only 1 bucket (sort code bypassed)
+                // TODO check for valid sub-aggregation names and fields during parsing instead of reduce phase
+                Bucket b = reducedBuckets.get(0);
+                order.comparator().compare(b, b);
+            }
         }
 
         return new InternalHistogram(getName(), reducedBuckets, order, minDocCount, emptyBucketInfo, format, keyed, pipelineAggregators(),


### PR DESCRIPTION
Fix wrong status code for `SearchPhaseExecutionException`.
Updated `SearchPhaseExecutionException` to determine the status from the cause if one exists and there were no shard failures.

Throw exception if (date) histogram order path is invalid and there is only one bucket.
Forced check of sub-aggregation names and fields used in (date) histogram order path if there is only one bucket. The previous code relied on the sorting code (bypassed if less than 2 buckets) to do this check. Ideally these checks should be performed during parsing instead of the reduce phase.

Tests pass: `gradle test` and `gradle core:integTest`

Closes #14771
