### PR TITLE
Simplify RoutingNodes interface

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -55,7 +55,7 @@ import java.util.function.Predicate;
  * or disallowing changes to its elements.
  *
  * The main methods used to update routing entries are:
- * <p><ul>
+ * <ul>
  * <li> {@link #initializeShard} initializes an unassigned shard.
  * <li> {@link #startShard} starts an initializing shard / completes relocation of a shard.
  * <li> {@link #relocateShard} starts relocation of a started shard.

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -553,7 +553,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
                     Decision allocationDecision = allocation.deciders().canAllocate(shardRouting, target, allocation);
                     if (allocationDecision.type() == Type.YES) { // TODO maybe we can respect throttling here too?
                         sourceNode.removeShard(shardRouting);
-                        Tuple<ShardRouting, ShardRouting> relocatingShards = routingNodes.relocate(shardRouting, target.nodeId(), allocation.clusterInfo().getShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE));
+                        Tuple<ShardRouting, ShardRouting> relocatingShards = routingNodes.relocateShard(shardRouting, target.nodeId(), allocation.clusterInfo().getShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE));
                         currentNode.addShard(relocatingShards.v2());
                         if (logger.isTraceEnabled()) {
                             logger.trace("Moved shard [{}] to node [{}]", shardRouting, routingNode.node());
@@ -728,7 +728,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
                                 logger.trace("Assigned shard [{}] to [{}]", shard, minNode.getNodeId());
                             }
 
-                            shard = routingNodes.initialize(shard, minNode.getNodeId(), null, shardSize);
+                            shard = routingNodes.initializeShard(shard, minNode.getNodeId(), null, shardSize);
                             minNode.addShard(shard);
                             changed = true;
                             continue; // don't add to ignoreUnassigned
@@ -820,7 +820,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
                                     minNode.getNodeId());
                         }
                         /* now allocate on the cluster */
-                        minNode.addShard(routingNodes.relocate(candidate, minNode.getNodeId(), shardSize).v1());
+                        minNode.addShard(routingNodes.relocateShard(candidate, minNode.getNodeId(), shardSize).v1());
                         return true;
                     } else {
                         assert decision.type() == Type.THROTTLE;

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/CancelAllocationCommand.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/CancelAllocationCommand.java
@@ -127,8 +127,9 @@ public class CancelAllocationCommand implements AllocationCommand {
         ShardRouting shardRouting = null;
         RoutingNodes routingNodes = allocation.routingNodes();
         RoutingNode routingNode = routingNodes.node(discoNode.getId());
+        IndexMetaData indexMetaData = null;
         if (routingNode != null) {
-            IndexMetaData indexMetaData = allocation.metaData().index(index());
+            indexMetaData = allocation.metaData().index(index());
             if (indexMetaData == null) {
                 throw new IndexNotFoundException(index());
             }
@@ -154,8 +155,8 @@ public class CancelAllocationCommand implements AllocationCommand {
                     discoNode + ", shard is primary and " + shardRouting.state().name().toLowerCase(Locale.ROOT));
             }
         }
-        AllocationService.cancelShard(Loggers.getLogger(CancelAllocationCommand.class), shardRouting,
-            new UnassignedInfo(UnassignedInfo.Reason.REROUTE_CANCELLED, null), routingNodes);
+        routingNodes.failShard(Loggers.getLogger(CancelAllocationCommand.class), shardRouting,
+            new UnassignedInfo(UnassignedInfo.Reason.REROUTE_CANCELLED, null), indexMetaData);
         return new RerouteExplanation(this, allocation.decision(Decision.YES, "cancel_allocation_command",
                 "shard " + shardId + " on node " + discoNode + " can be cancelled"));
     }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/MoveAllocationCommand.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/MoveAllocationCommand.java
@@ -132,7 +132,7 @@ public class MoveAllocationCommand implements AllocationCommand {
             if (decision.type() == Decision.Type.THROTTLE) {
                 // its being throttled, maybe have a flag to take it into account and fail? for now, just do it since the "user" wants it...
             }
-            allocation.routingNodes().relocate(shardRouting, toRoutingNode.nodeId(), allocation.clusterInfo().getShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE));
+            allocation.routingNodes().relocateShard(shardRouting, toRoutingNode.nodeId(), allocation.clusterInfo().getShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE));
         }
 
         if (!found) {

--- a/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.common.Nullable;
@@ -63,7 +64,7 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
         boolean changed = false;
         MetaData metaData = allocation.metaData();
         RoutingNodes routingNodes = allocation.routingNodes();
-        List<Tuple<ShardRouting, UnassignedInfo>> recoveriesToCancel = new ArrayList<>();
+        List<Runnable> recoveriesToCancel = new ArrayList<>();
         for (RoutingNode routingNode : routingNodes) {
             for (ShardRouting shard : routingNode) {
                 if (shard.primary() == true) {
@@ -120,14 +121,14 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
                             "existing allocation of replica to [" + currentNode + "] cancelled, sync id match found on node ["+ nodeWithHighestMatch + "]",
                             null, 0, allocation.getCurrentNanoTime(), System.currentTimeMillis(), false, UnassignedInfo.AllocationStatus.NO_ATTEMPT);
                         // don't cancel shard in the loop as it will cause a ConcurrentModificationException
-                        recoveriesToCancel.add(new Tuple<>(shard, unassignedInfo));
+                        recoveriesToCancel.add(() -> routingNodes.failShard(logger, shard, unassignedInfo, indexMetaData));
                         changed = true;
                     }
                 }
             }
         }
-        for (Tuple<ShardRouting, UnassignedInfo> cancellation : recoveriesToCancel) {
-            routingNodes.moveToUnassigned(cancellation.v1(), cancellation.v2());
+        for (Runnable cancellation : recoveriesToCancel) {
+            cancellation.run();
         }
         return changed;
     }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalanceConfigurationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalanceConfigurationTests.java
@@ -335,37 +335,37 @@ public class BalanceConfigurationTests extends ESAllocationTestCase {
                     switch (sr.id()) {
                         case 0:
                             if (sr.primary()) {
-                                allocation.routingNodes().initialize(sr, "node1", null, -1);
+                                allocation.routingNodes().initializeShard(sr, "node1", null, -1);
                             } else {
-                                allocation.routingNodes().initialize(sr, "node0", null, -1);
+                                allocation.routingNodes().initializeShard(sr, "node0", null, -1);
                             }
                             break;
                         case 1:
                             if (sr.primary()) {
-                                allocation.routingNodes().initialize(sr, "node1", null, -1);
+                                allocation.routingNodes().initializeShard(sr, "node1", null, -1);
                             } else {
-                                allocation.routingNodes().initialize(sr, "node2", null, -1);
+                                allocation.routingNodes().initializeShard(sr, "node2", null, -1);
                             }
                             break;
                         case 2:
                             if (sr.primary()) {
-                                allocation.routingNodes().initialize(sr, "node3", null, -1);
+                                allocation.routingNodes().initializeShard(sr, "node3", null, -1);
                             } else {
-                                allocation.routingNodes().initialize(sr, "node2", null, -1);
+                                allocation.routingNodes().initializeShard(sr, "node2", null, -1);
                             }
                             break;
                         case 3:
                             if (sr.primary()) {
-                                allocation.routingNodes().initialize(sr, "node3", null, -1);
+                                allocation.routingNodes().initializeShard(sr, "node3", null, -1);
                             } else {
-                                allocation.routingNodes().initialize(sr, "node1", null, -1);
+                                allocation.routingNodes().initializeShard(sr, "node1", null, -1);
                             }
                             break;
                         case 4:
                             if (sr.primary()) {
-                                allocation.routingNodes().initialize(sr, "node2", null, -1);
+                                allocation.routingNodes().initializeShard(sr, "node2", null, -1);
                             } else {
-                                allocation.routingNodes().initialize(sr, "node0", null, -1);
+                                allocation.routingNodes().initializeShard(sr, "node0", null, -1);
                             }
                             break;
                     }

--- a/core/src/test/java/org/elasticsearch/gateway/PriorityComparatorTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/PriorityComparatorTests.java
@@ -35,10 +35,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.mockito.Mockito.mock;
+
 public class PriorityComparatorTests extends ESTestCase {
 
     public void testPreferNewIndices() {
-        RoutingNodes.UnassignedShards shards = new RoutingNodes.UnassignedShards(null);
+        RoutingNodes.UnassignedShards shards = new RoutingNodes.UnassignedShards(mock(RoutingNodes.class));
         List<ShardRouting> shardRoutings = Arrays.asList(TestShardRouting.newShardRouting("oldest", 0, null, null, null,
                 randomBoolean(), ShardRoutingState.UNASSIGNED, new UnassignedInfo(randomFrom(UnassignedInfo.Reason.values()), "foobar")), TestShardRouting.newShardRouting("newest", 0, null, null, null,
                 randomBoolean(), ShardRoutingState.UNASSIGNED, new UnassignedInfo(randomFrom(UnassignedInfo.Reason.values()), "foobar")));
@@ -68,7 +70,7 @@ public class PriorityComparatorTests extends ESTestCase {
     }
 
     public void testPreferPriorityIndices() {
-        RoutingNodes.UnassignedShards shards = new RoutingNodes.UnassignedShards((RoutingNodes) null);
+        RoutingNodes.UnassignedShards shards = new RoutingNodes.UnassignedShards(mock(RoutingNodes.class));
         List<ShardRouting> shardRoutings = Arrays.asList(TestShardRouting.newShardRouting("oldest", 0, null, null, null,
                 randomBoolean(), ShardRoutingState.UNASSIGNED, new UnassignedInfo(randomFrom(UnassignedInfo.Reason.values()), "foobar")), TestShardRouting.newShardRouting("newest", 0, null, null, null,
                 randomBoolean(), ShardRoutingState.UNASSIGNED, new UnassignedInfo(randomFrom(UnassignedInfo.Reason.values()), "foobar")));
@@ -98,7 +100,7 @@ public class PriorityComparatorTests extends ESTestCase {
     }
 
     public void testPriorityComparatorSort() {
-        RoutingNodes.UnassignedShards shards = new RoutingNodes.UnassignedShards((RoutingNodes) null);
+        RoutingNodes.UnassignedShards shards = new RoutingNodes.UnassignedShards(mock(RoutingNodes.class));
         int numIndices = randomIntBetween(3, 99);
         IndexMeta[] indices = new IndexMeta[numIndices];
         final Map<String, IndexMeta> map = new HashMap<>();


### PR DESCRIPTION
This PR reduces the interface of `RoutingNodes` considerably, making it easier to ensure its invariants. Only the following methods are available to manipulate the routing nodes:
- `initializeShard()` -> initializes an unassigned shard
- `startShard()` -> starts an initializing shard / completes relocation of a shard
- `relocateShard()` -> starts relocation of a started shard
- `failShard()` -> fails/cancels an assigned shard

In the spirit of PR #19743, where `deassociateDeadNodes` was moved to its own public method to be only called when nodes have actually left the cluster and not on every reroute step, this PR also removes `electPrimariesAndUnassignedDanglingReplicas` from `AllocationService` and folds it into the shard failure logic. This means that an active replica is promoted to primary in the same method where the primary was failed. Previously we would scan in each reroute iteration for active replicas to be promoted to primary.
