### PR TITLE
Add back norelease check when building a release

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/ForbiddenPatternsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/ForbiddenPatternsTask.groovy
@@ -61,6 +61,9 @@ public class ForbiddenPatternsTask extends DefaultTask {
         // add mandatory rules
         patterns.put('nocommit', /nocommit/)
         patterns.put('tab', /\t/)
+        if (System.getProperty('build.snapshot', 'true').equals('false')) {
+            patterns.put('norelease', /norelease/)
+        }
 
         inputs.property("excludes", filesFilter.excludes)
         inputs.property("rules", patterns)


### PR DESCRIPTION
This was lost around 2.1. This change adds it back.

closes #19246
