### PR TITLE
Fixes netty4 module's CORS config to use defaults 

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -381,7 +381,8 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
         return publishPort;
     }
 
-    private Netty4CorsConfig buildCorsConfig(Settings settings) {
+    // package private for testing
+    static Netty4CorsConfig buildCorsConfig(Settings settings) {
         if (SETTING_CORS_ENABLED.get(settings) == false) {
             return Netty4CorsConfigBuilder.forOrigins().disable().build();
         }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -33,7 +33,6 @@ import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.oio.OioEventLoopGroup;
-import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.oio.OioServerSocketChannel;
 import io.netty.handler.codec.ByteToMessageDecoder;
@@ -403,14 +402,14 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
         if (SETTING_CORS_ALLOW_CREDENTIALS.get(settings)) {
             builder.allowCredentials();
         }
-        String[] strMethods = settings.getAsArray(SETTING_CORS_ALLOW_METHODS.getKey());
+        String[] strMethods = Strings.splitStringByCommaToArray(SETTING_CORS_ALLOW_METHODS.get(settings));
         HttpMethod[] methods = Arrays.asList(strMethods)
             .stream()
             .map(HttpMethod::valueOf)
             .toArray(size -> new HttpMethod[size]);
         return builder.allowedRequestMethods(methods)
             .maxAge(SETTING_CORS_MAX_AGE.get(settings))
-            .allowedRequestHeaders(settings.getAsArray(SETTING_CORS_ALLOW_HEADERS.getKey()))
+            .allowedRequestHeaders(Strings.splitStringByCommaToArray(SETTING_CORS_ALLOW_HEADERS.get(settings)))
             .shortCircuit()
             .build();
     }

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -55,8 +55,8 @@ import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_HE
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_METHODS;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_ORIGIN;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ENABLED;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_MAX_AGE;
 import static org.elasticsearch.rest.RestStatus.OK;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 /**
@@ -86,36 +86,33 @@ public class Netty4HttpServerTransportTests extends ESTestCase {
     }
 
     public void testCorsConfig() {
-        Set<String> methods = new HashSet<>(Arrays.asList("get", "options", "post"));
-        Set<String> headers = new HashSet<>(Arrays.asList("Content-Type", "Content-Length"));
-        Settings settings = Settings.builder()
-            .put(SETTING_CORS_ENABLED.getKey(), true)
-            .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), "*")
-            .put(SETTING_CORS_ALLOW_METHODS.getKey(), Strings.collectionToCommaDelimitedString(methods))
-            .put(SETTING_CORS_ALLOW_HEADERS.getKey(), Strings.collectionToCommaDelimitedString(headers))
-            .put(SETTING_CORS_ALLOW_CREDENTIALS.getKey(), true)
-            .build();
-        Netty4HttpServerTransport transport = new Netty4HttpServerTransport(settings, networkService, bigArrays, threadPool);
-        Netty4CorsConfig corsConfig = transport.getCorsConfig();
-        assertThat(corsConfig.isAnyOriginSupported(), equalTo(true));
-        assertThat(corsConfig.allowedRequestHeaders(), equalTo(headers));
-        assertThat(corsConfig.allowedRequestMethods().stream().map(HttpMethod::name).collect(Collectors.toSet()), equalTo(methods));
-        transport.close();
+        final Set<String> methods = new HashSet<>(Arrays.asList("get", "options", "post"));
+        final Set<String> headers = new HashSet<>(Arrays.asList("Content-Type", "Content-Length"));
+        final Settings settings = Settings.builder()
+                                      .put(SETTING_CORS_ENABLED.getKey(), true)
+                                      .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), "*")
+                                      .put(SETTING_CORS_ALLOW_METHODS.getKey(), Strings.collectionToCommaDelimitedString(methods))
+                                      .put(SETTING_CORS_ALLOW_HEADERS.getKey(), Strings.collectionToCommaDelimitedString(headers))
+                                      .put(SETTING_CORS_ALLOW_CREDENTIALS.getKey(), true)
+                                      .build();
+        final Netty4CorsConfig corsConfig = Netty4HttpServerTransport.buildCorsConfig(settings);
+        assertTrue(corsConfig.isAnyOriginSupported());
+        assertEquals(headers, corsConfig.allowedRequestHeaders());
+        assertEquals(methods, corsConfig.allowedRequestMethods().stream().map(HttpMethod::name).collect(Collectors.toSet()));
+    }
 
-        // test with default values
-        methods = Strings.commaDelimitedListToSet(SETTING_CORS_ALLOW_METHODS.getDefault(Settings.EMPTY));
-        headers = Strings.commaDelimitedListToSet(SETTING_CORS_ALLOW_HEADERS.getDefault(Settings.EMPTY));
-        settings = Settings.builder()
-                       .put(SETTING_CORS_ENABLED.getKey(), true)
-                       .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), "*")
-                       .put(SETTING_CORS_ALLOW_CREDENTIALS.getKey(), true)
-                       .build();
-        transport = new Netty4HttpServerTransport(settings, networkService, bigArrays, threadPool);
-        corsConfig = transport.getCorsConfig();
-        assertThat(corsConfig.isAnyOriginSupported(), equalTo(true));
-        assertThat(corsConfig.allowedRequestHeaders(), equalTo(headers));
-        assertThat(corsConfig.allowedRequestMethods().stream().map(HttpMethod::name).collect(Collectors.toSet()), equalTo(methods));
-        transport.close();
+    public void testCorsConfigWithDefaults() {
+        final Set<String> methods = Strings.commaDelimitedListToSet(SETTING_CORS_ALLOW_METHODS.getDefault(Settings.EMPTY));
+        final Set<String> headers = Strings.commaDelimitedListToSet(SETTING_CORS_ALLOW_HEADERS.getDefault(Settings.EMPTY));
+        final long maxAge = SETTING_CORS_MAX_AGE.getDefault(Settings.EMPTY);
+        final Settings settings = Settings.builder().put(SETTING_CORS_ENABLED.getKey(), true).build();
+        final Netty4CorsConfig corsConfig = Netty4HttpServerTransport.buildCorsConfig(settings);
+        assertFalse(corsConfig.isAnyOriginSupported());
+        assertEquals(Collections.emptySet(), corsConfig.origins().get());
+        assertEquals(headers, corsConfig.allowedRequestHeaders());
+        assertEquals(methods, corsConfig.allowedRequestMethods().stream().map(HttpMethod::name).collect(Collectors.toSet()));
+        assertEquals(maxAge, corsConfig.maxAge());
+        assertFalse(corsConfig.isCredentialsAllowed());
     }
 
     /**


### PR DESCRIPTION
Fixes netty4 module's CORS config to use defaults for `http.cors.allow-methods` and `http.cors.allow-headers` when none are specified.  Currently, there was a bug where if no value was specified for `http.cors.allow-methods` or `http.cors.allow-headers`, an empty value was used instead of the actual defaults.

Note that this bug does not exist in the netty3 module.
