### PR TITLE
Remove dead OOM handling in engine

### DIFF
--- a/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -180,19 +180,6 @@ public final class ExceptionsHelper {
     }
 
     /**
-     * Returns <code>true</code> iff the given throwable is and OutOfMemoryException, otherwise <code>false</code>
-     */
-    public static boolean isOOM(Throwable t) {
-        return t != null
-                && (t instanceof OutOfMemoryError
-                    || (t instanceof IllegalStateException
-                        && t.getMessage() != null
-                        && t.getMessage().contains("OutOfMemoryError")
-                        )
-                    );
-    }
-
-    /**
      * Throws the specified exception. If null if specified then <code>true</code> is returned.
      */
     public static boolean reThrowIfNotNull(@Nullable Throwable e) {

--- a/core/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -705,9 +705,6 @@ public abstract class Engine implements Closeable {
         if (Lucene.isCorruptionException(e)) {
             failEngine("corrupt file (source: [" + source + "])", e);
             return true;
-        } else if (ExceptionsHelper.isOOM(e)) {
-            failEngine("out of memory (source: [" + source + "])", e);
-            return true;
         }
         return false;
     }


### PR DESCRIPTION
Previously, the engine would catch an out of memory error and would try
to handle the error (it would try to fail the engine, and then it would
swallow the out of memory error). Catching the out of memory errors was
removed in 3343ceeae44f3d28e3c1ba7861886848df74e390 so this code path is
not effectively dead. This commit removes this dead code from the
engine.
