### PR TITLE
Remove unused methods from SuggestUtils

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
@@ -374,7 +374,7 @@ public final class DirectCandidateGeneratorBuilder implements CandidateGenerator
         DirectCandidateGeneratorBuilder tempGenerator = new DirectCandidateGeneratorBuilder("_na_");
         // bucket for the field name, needed as constructor arg later
         Set<String> tmpFieldName = new HashSet<>(1);
-        PARSER.parse(parseContext.parser(), new Tuple<Set<String>, DirectCandidateGeneratorBuilder>(tmpFieldName, tempGenerator),
+        PARSER.parse(parseContext.parser(), new Tuple<>(tmpFieldName, tempGenerator),
                 parseContext);
         if (tmpFieldName.size() != 1) {
             throw new IllegalArgumentException("[" + TYPE + "] expects exactly one field parameter, but found " + tmpFieldName);


### PR DESCRIPTION
When the parsing code for the suggesters was moved to the builder objects, some methods were left behind unused in SuggestUtils.
