### PR TITLE
[Test] Add test for Netty4 HTTP support of header 100-continue

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpClient.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpClient.java
@@ -29,6 +29,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
@@ -51,6 +52,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
@@ -99,6 +101,12 @@ class Netty4HttpClient implements Closeable {
         return processRequestsWithBody(HttpMethod.POST, remoteAddress, urisAndBodies);
     }
 
+    public final FullHttpResponse post(SocketAddress remoteAddress, FullHttpRequest httpRequest) throws InterruptedException {
+        Collection<FullHttpResponse> responses = sendRequests(remoteAddress, Collections.singleton(httpRequest));
+        assert responses.size() == 1 : "expected 1 and only 1 http response";
+        return responses.iterator().next();
+    }
+
     @SafeVarargs // Safe not because it doesn't do anything with the type parameters but because it won't leak them into other methods.
     public final Collection<FullHttpResponse> put(SocketAddress remoteAddress, Tuple<String, CharSequence>... urisAndBodies)
         throws InterruptedException {
@@ -120,7 +128,7 @@ class Netty4HttpClient implements Closeable {
 
     private synchronized Collection<FullHttpResponse> sendRequests(
         final SocketAddress remoteAddress,
-        final Collection<HttpRequest> requests) throws InterruptedException {
+        final Collection<?> requests) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(requests.size());
         final Collection<FullHttpResponse> content = Collections.synchronizedList(new ArrayList<>(requests.size()));
 
@@ -131,10 +139,10 @@ class Netty4HttpClient implements Closeable {
             channelFuture = clientBootstrap.connect(remoteAddress);
             channelFuture.sync();
 
-            for (HttpRequest request : requests) {
+            for (Object request : requests) {
                 channelFuture.channel().writeAndFlush(request);
             }
-            latch.await();
+            latch.await(10, TimeUnit.SECONDS);
 
         } finally {
             if (channelFuture != null) {

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpClient.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpClient.java
@@ -128,7 +128,7 @@ class Netty4HttpClient implements Closeable {
 
     private synchronized Collection<FullHttpResponse> sendRequests(
         final SocketAddress remoteAddress,
-        final Collection<?> requests) throws InterruptedException {
+        final Collection<HttpRequest> requests) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(requests.size());
         final Collection<FullHttpResponse> content = Collections.synchronizedList(new ArrayList<>(requests.size()));
 
@@ -139,7 +139,7 @@ class Netty4HttpClient implements Closeable {
             channelFuture = clientBootstrap.connect(remoteAddress);
             channelFuture.sync();
 
-            for (Object request : requests) {
+            for (HttpRequest request : requests) {
                 channelFuture.channel().writeAndFlush(request);
             }
             latch.await(10, TimeUnit.SECONDS);

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -19,10 +19,12 @@
 
 package org.elasticsearch.http.netty4;
 
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
@@ -41,6 +43,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -52,7 +55,7 @@ import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_HE
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_METHODS;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_ORIGIN;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ENABLED;
-import static org.elasticsearch.rest.RestStatus.CONTINUE;
+import static org.elasticsearch.rest.RestStatus.OK;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -106,7 +109,7 @@ public class Netty4HttpServerTransportTests extends ESTestCase {
     public void testExpectContinueHeader() throws Exception {
         try (Netty4HttpServerTransport transport = new Netty4HttpServerTransport(Settings.EMPTY, networkService, bigArrays, threadPool)) {
             transport.httpServerAdapter((request, channel, context) ->
-                    channel.sendResponse(new BytesRestResponse(CONTINUE, BytesRestResponse.TEXT_CONTENT_TYPE, BytesArray.EMPTY)));
+                    channel.sendResponse(new BytesRestResponse(OK, BytesRestResponse.TEXT_CONTENT_TYPE, new BytesArray("done"))));
             transport.start();
             InetSocketTransportAddress remoteAddress = (InetSocketTransportAddress) randomFrom(transport.boundAddress().boundAddresses());
 
@@ -115,8 +118,13 @@ public class Netty4HttpServerTransportTests extends ESTestCase {
                 HttpUtil.set100ContinueExpected(request, true);
                 HttpUtil.setContentLength(request, 10);
 
-                HttpResponse response = client.post(remoteAddress.address(), request);
+                FullHttpResponse response = client.post(remoteAddress.address(), request);
                 assertThat(response.status(), is(HttpResponseStatus.CONTINUE));
+
+                request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/", Unpooled.EMPTY_BUFFER);
+                response = client.post(remoteAddress.address(), request);
+                assertThat(response.status(), is(HttpResponseStatus.OK));
+                assertThat(new String(ByteBufUtil.getBytes(response.content()), StandardCharsets.UTF_8), is("done"));
             }
         }
     }


### PR DESCRIPTION
This PR adds a test to verify that the Netty 4 HTTP transport supports the `Expect: 100-continue` header.

Requires #19904
