### PR TITLE
Fix typos in inner-hits documentation

### DIFF
--- a/docs/reference/search/request/inner-hits.asciidoc
+++ b/docs/reference/search/request/inner-hits.asciidoc
@@ -2,8 +2,8 @@
 === Inner hits
 
 The <<mapping-parent-field, parent/child>> and <<nested, nested>> features allow the return of documents that
-have matches in a different scope. In the parent/child case, parent document are returned based on matches in child
-documents or child document are returned based on matches in parent documents. In the nested case, documents are returned
+have matches in a different scope. In the parent/child case, parent documents are returned based on matches in child
+documents or child documents are returned based on matches in parent documents. In the nested case, documents are returned
 based on matches in nested inner objects.
 
 In both cases, the actual matches in the different scopes that caused a document to be returned is hidden. In many cases,


### PR DESCRIPTION
Fixed some typos that make it hard to understand what was going on.
