### PR TITLE
Reword expect header bug notice

### DIFF
--- a/docs/reference/migration/migrate_5_0.asciidoc
+++ b/docs/reference/migration/migrate_5_0.asciidoc
@@ -8,9 +8,9 @@ your application to Elasticsearch 5.0.
 .Known networking bug in 5.0.0-alpha5
 ======================================================
 
-There is a major bug in the new Netty4 implementation in this release which
-affects any REST requests greater than 1024 bytes in size, and which will
-generate an exception similar to the following:
+There is a bug in the new Netty4 implementation in this release which affects any REST request with
+a body that is sent in two requests, the first with an `Expect: 100-continue` header. This bug will
+manifest with an exception similar to the following:
 
 [source,txt]
 ----


### PR DESCRIPTION
This commit rewords the expect header bug notice to provide the precise
details for the bug arising. In particular, the bug does not impact any
request over 1024 bytes, but instead impacts any request with a body
that is sent in two requests, the first with an Expect: 100-continue
header. The size is irrelevant, and requests with bodies larger than
1024 bytes are okay as long as the Expect: 100-continue header is not
also sent.
