### PR TITLE
Adds ability to specify path to field to use for matching rated documents to hits.

### DIFF
--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/DiscountedCumulativeGainAt.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/DiscountedCumulativeGainAt.java
@@ -125,7 +125,7 @@ public class DiscountedCumulativeGainAt extends RankedListQualityMetric {
     }
 
     @Override
-    public EvalQueryQuality evaluate(SearchHit[] hits, List<RatedDocument> ratedDocs) {
+    public EvalQueryQuality evaluate(SearchHit[] hits, List<RatedDocument> ratedDocs, String keyPath) {
         Map<RatedDocumentKey, RatedDocument> ratedDocsByKey = new HashMap<>();
         for (RatedDocument doc : ratedDocs) {
             ratedDocsByKey.put(doc.getKey(), doc);
@@ -134,7 +134,9 @@ public class DiscountedCumulativeGainAt extends RankedListQualityMetric {
         Collection<RatedDocumentKey> unknownDocIds = new ArrayList<>();
         List<Integer> ratings = new ArrayList<>();
         for (int i = 0; (i < position && i < hits.length); i++) {
-            RatedDocumentKey id = new RatedDocumentKey(hits[i].getIndex(), hits[i].getType(), hits[i].getId());
+            // NORELEASE I'm pretty sure this needs better error handling e.g. when not pointing to a field holding something
+            // that can be cast to a string hits[i].field(keyPath).value()
+            RatedDocumentKey id = new RatedDocumentKey(hits[i].getIndex(), hits[i].getType(), hits[i].field(keyPath).value());
             RatedDocument ratedDoc = ratedDocsByKey.get(id);
             if (ratedDoc != null) {
                 ratings.add(ratedDoc.getRating());

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/PrecisionAtN.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/PrecisionAtN.java
@@ -97,7 +97,7 @@ public class PrecisionAtN extends RankedListQualityMetric {
      * @return precision at n for above {@link SearchResult} list.
      **/
     @Override
-    public EvalQueryQuality evaluate(SearchHit[] hits, List<RatedDocument> ratedDocs) {
+    public EvalQueryQuality evaluate(SearchHit[] hits, List<RatedDocument> ratedDocs, String keyPath) {
 
         Collection<RatedDocumentKey> relevantDocIds = new ArrayList<>();
         Collection<RatedDocumentKey> irrelevantDocIds = new ArrayList<>();
@@ -113,7 +113,9 @@ public class PrecisionAtN extends RankedListQualityMetric {
         int bad = 0;
         Collection<RatedDocumentKey> unknownDocIds = new ArrayList<>();
         for (int i = 0; (i < n && i < hits.length); i++) {
-            RatedDocumentKey hitKey = new RatedDocumentKey(hits[i].getIndex(), hits[i].getType(), hits[i].getId());
+            // NORELEASE I'm pretty sure this needs better error handling e.g. when not pointing to a field holding something
+            // that can be cast to a string hits[i].field(keyPath).value()
+            RatedDocumentKey hitKey = new RatedDocumentKey(hits[i].getIndex(), hits[i].getType(), hits[i].field(keyPath).value());
             if (relevantDocIds.contains(hitKey)) {
                 good++;
             } else if (irrelevantDocIds.contains(hitKey)) {

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/QuerySpec.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/QuerySpec.java
@@ -183,7 +183,10 @@ public class QuerySpec implements Writeable {
      *           },
      *           "size": 10
      *   },
-     *   "ratings": [{ "1": 1 }, { "2": 0 }, { "3": 1 } ]
+     *   "ratings": [
+     *                  {"key": {"index": "index_name", "type": "type_name", "doc_id": "1"}, "rating": 1 },
+     *                  {"key": {"index": "index_name", "type": "type_name", "doc_id": "2"}, "rating": 0 },
+     *                  {"key": {"index": "index_name", "type": "type_name", "doc_id": "3"}, "rating": 1 } ]
      *  }
      */
     public static QuerySpec fromXContent(XContentParser parser, RankEvalContext context) throws IOException {

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankedListQualityMetric.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankedListQualityMetric.java
@@ -43,9 +43,11 @@ public abstract class RankedListQualityMetric implements NamedWriteable {
      * wrt. to a set of document Ids labeled as relevant for this search.
      *
      * @param hits the result hits as returned by some search
+     * @param ratedDocs a list of documents including their annotated ratings
+     * @param keyPath path to use to match hits to rated documents
      * @return some metric representing the quality of the result hit list wrt. to relevant doc ids.
      * */
-    public abstract EvalQueryQuality evaluate(SearchHit[] hits, List<RatedDocument> ratedDocs);
+    public abstract EvalQueryQuality evaluate(SearchHit[] hits, List<RatedDocument> ratedDocs, String keyPath);
 
     public static RankedListQualityMetric fromXContent(XContentParser parser, ParseFieldMatcherSupplier context) throws IOException {
         RankedListQualityMetric rc;

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedDocumentKey.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedDocumentKey.java
@@ -32,19 +32,17 @@ import java.io.IOException;
 import java.util.Objects;
 
 public class RatedDocumentKey extends ToXContentToBytes implements Writeable {
-    public static final ParseField ID_PATH_FIELD = new ParseField("id_path");
-    public static final ParseField ID_VALUE_FIELD = new ParseField("id_value");
+    public static final ParseField KEY_VALUE_FIELD = new ParseField("key_value");
     public static final ParseField TYPE_FIELD = new ParseField("type");
     public static final ParseField INDEX_FIELD = new ParseField("index");
 
     private static final ConstructingObjectParser<RatedDocumentKey, RankEvalContext> PARSER = new ConstructingObjectParser<>("ratings",
-            a -> new RatedDocumentKey((String) a[0], (String) a[1], (String) a[2], (String) a[3]));
+            a -> new RatedDocumentKey((String) a[0], (String) a[1], (String) a[2]));
 
     static {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), INDEX_FIELD);
         PARSER.declareString(ConstructingObjectParser.constructorArg(), TYPE_FIELD);
-        PARSER.declareString(ConstructingObjectParser.constructorArg(), ID_PATH_FIELD);
-        PARSER.declareString(ConstructingObjectParser.constructorArg(), ID_VALUE_FIELD);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), KEY_VALUE_FIELD);
     }
 
     @Override
@@ -52,30 +50,26 @@ public class RatedDocumentKey extends ToXContentToBytes implements Writeable {
         builder.startObject();
         builder.field(INDEX_FIELD.getPreferredName(), index);
         builder.field(TYPE_FIELD.getPreferredName(), type);
-        builder.field(ID_PATH_FIELD.getPreferredName(), idPath);
-        builder.field(ID_VALUE_FIELD.getPreferredName(), idValue);
+        builder.field(KEY_VALUE_FIELD.getPreferredName(), keyValue);
         builder.endObject();
         return builder;
     }
 
     // TODO instead of docId use path to id and id itself
-    private String idPath;
-    private String idValue;
+    private String keyValue;
     private String type;
     private String index;
 
-    public RatedDocumentKey(String index, String type, String idPath, String idValue) {
+    public RatedDocumentKey(String index, String type, String idValue) {
         this.index = index;
         this.type = type;
-        this.idPath = idPath;
-        this.idValue = idValue;
+        this.keyValue = idValue;
     }
 
     public RatedDocumentKey(StreamInput in) throws IOException {
         this.index = in.readString();
         this.type = in.readString();
-        this.idPath = in.readString();
-        this.idValue = in.readString();
+        this.keyValue = in.readString();
     }
 
     public String getIndex() {
@@ -86,20 +80,15 @@ public class RatedDocumentKey extends ToXContentToBytes implements Writeable {
         return type;
     }
 
-    public String getIdPath() {
-        return idPath;
-    }
-
     public String getIdValue() {
-        return idValue;
+        return keyValue;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(index);
         out.writeString(type);
-        out.writeString(idPath);
-        out.writeString(idValue);
+        out.writeString(keyValue);
     }
     
     public static RatedDocumentKey fromXContent(XContentParser parser, RankEvalContext context) throws IOException {
@@ -117,12 +106,11 @@ public class RatedDocumentKey extends ToXContentToBytes implements Writeable {
         RatedDocumentKey other = (RatedDocumentKey) obj;
         return Objects.equals(index, other.index) &&
                 Objects.equals(type, other.type) &&
-                Objects.equals(idPath, other.idPath) &&
-                Objects.equals(idValue, other.idValue);
+                Objects.equals(keyValue, other.keyValue);
     }
     
     @Override
     public final int hashCode() {
-        return Objects.hash(getClass(), index, type, idPath, idValue);
+        return Objects.hash(getClass(), index, type, keyValue);
     }
 }

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedDocumentKey.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedDocumentKey.java
@@ -32,17 +32,19 @@ import java.io.IOException;
 import java.util.Objects;
 
 public class RatedDocumentKey extends ToXContentToBytes implements Writeable {
-    public static final ParseField DOC_ID_FIELD = new ParseField("doc_id");
+    public static final ParseField ID_PATH_FIELD = new ParseField("id_path");
+    public static final ParseField ID_VALUE_FIELD = new ParseField("id_value");
     public static final ParseField TYPE_FIELD = new ParseField("type");
     public static final ParseField INDEX_FIELD = new ParseField("index");
 
     private static final ConstructingObjectParser<RatedDocumentKey, RankEvalContext> PARSER = new ConstructingObjectParser<>("ratings",
-            a -> new RatedDocumentKey((String) a[0], (String) a[1], (String) a[2]));
+            a -> new RatedDocumentKey((String) a[0], (String) a[1], (String) a[2], (String) a[3]));
 
     static {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), INDEX_FIELD);
         PARSER.declareString(ConstructingObjectParser.constructorArg(), TYPE_FIELD);
-        PARSER.declareString(ConstructingObjectParser.constructorArg(), DOC_ID_FIELD);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), ID_PATH_FIELD);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), ID_VALUE_FIELD);
     }
 
     @Override
@@ -50,38 +52,30 @@ public class RatedDocumentKey extends ToXContentToBytes implements Writeable {
         builder.startObject();
         builder.field(INDEX_FIELD.getPreferredName(), index);
         builder.field(TYPE_FIELD.getPreferredName(), type);
-        builder.field(DOC_ID_FIELD.getPreferredName(), docId);
+        builder.field(ID_PATH_FIELD.getPreferredName(), idPath);
+        builder.field(ID_VALUE_FIELD.getPreferredName(), idValue);
         builder.endObject();
         return builder;
     }
 
     // TODO instead of docId use path to id and id itself
-    private String docId;
+    private String idPath;
+    private String idValue;
     private String type;
     private String index;
 
-    void setIndex(String index) {
-        this.index = index;
-    }
-
-    void setType(String type) {
-        this.type = type;
-    }
-    
-    void setDocId(String docId) {
-        this.docId = docId;
-    }
-
-    public RatedDocumentKey(String index, String type, String docId) {
+    public RatedDocumentKey(String index, String type, String idPath, String idValue) {
         this.index = index;
         this.type = type;
-        this.docId = docId;
+        this.idPath = idPath;
+        this.idValue = idValue;
     }
 
     public RatedDocumentKey(StreamInput in) throws IOException {
         this.index = in.readString();
         this.type = in.readString();
-        this.docId = in.readString();
+        this.idPath = in.readString();
+        this.idValue = in.readString();
     }
 
     public String getIndex() {
@@ -92,15 +86,20 @@ public class RatedDocumentKey extends ToXContentToBytes implements Writeable {
         return type;
     }
 
-    public String getDocID() {
-        return docId;
+    public String getIdPath() {
+        return idPath;
+    }
+
+    public String getIdValue() {
+        return idValue;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(index);
         out.writeString(type);
-        out.writeString(docId);
+        out.writeString(idPath);
+        out.writeString(idValue);
     }
     
     public static RatedDocumentKey fromXContent(XContentParser parser, RankEvalContext context) throws IOException {
@@ -118,11 +117,12 @@ public class RatedDocumentKey extends ToXContentToBytes implements Writeable {
         RatedDocumentKey other = (RatedDocumentKey) obj;
         return Objects.equals(index, other.index) &&
                 Objects.equals(type, other.type) &&
-                Objects.equals(docId, other.docId);
+                Objects.equals(idPath, other.idPath) &&
+                Objects.equals(idValue, other.idValue);
     }
     
     @Override
     public final int hashCode() {
-        return Objects.hash(getClass(), index, type, docId);
+        return Objects.hash(getClass(), index, type, idPath, idValue);
     }
 }

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/ReciprocalRank.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/ReciprocalRank.java
@@ -94,7 +94,7 @@ public class ReciprocalRank extends RankedListQualityMetric {
      * @return reciprocal Rank for above {@link SearchResult} list.
      **/
     @Override
-    public EvalQueryQuality evaluate(SearchHit[] hits, List<RatedDocument> ratedDocs) {
+    public EvalQueryQuality evaluate(SearchHit[] hits, List<RatedDocument> ratedDocs, String keyPath) {
         Set<RatedDocumentKey> relevantDocIds = new HashSet<>();
         Set<RatedDocumentKey> irrelevantDocIds = new HashSet<>();
         for (RatedDocument doc : ratedDocs) {
@@ -109,7 +109,9 @@ public class ReciprocalRank extends RankedListQualityMetric {
         int firstRelevant = -1;
         boolean found = false;
         for (int i = 0; i < hits.length; i++) {
-            RatedDocumentKey id = new RatedDocumentKey(hits[i].getIndex(), hits[i].getType(), hits[i].getId());
+            // NORELEASE I'm pretty sure this needs better error handling e.g. when not pointing to a field holding something
+            // that can be cast to a string hits[i].field(keyPath).value()
+            RatedDocumentKey id = new RatedDocumentKey(hits[i].getIndex(), hits[i].getType(), hits[i].field(keyPath).getValue());
             if (relevantDocIds.contains(id)) {
                 if (found == false && i < maxAcceptableRank) {
                     firstRelevant = i + 1; // add one because rank is not

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RestRankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RestRankEvalAction.java
@@ -58,7 +58,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
     "requests": [{
         "id": "human_readable_id",
         "request": { ... request to check ... },
-        "ratings": { ... mapping from doc id to rating value ... }
+        "ratings": { ... mapping from document key to rating value ... }
      }],
     "metric": {
         "... metric_name... ": {
@@ -71,8 +71,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
  *
  *
    {"spec_id": "huge_weight_on_location",
-    "requests": [{
-        "id": "amsterdam_query",
+    "requests": [
+       {"id": "amsterdam_query",
         "request": {
                 "query": {
                     "bool": {
@@ -83,18 +83,15 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
                             {"term": {"ip_location": {"value": "ams","boost": 10}}}]}
                 },
                 "size": 10
-            }
         },
-        "ratings": {
-            "1": 1,
-            "2": 0,
-            "3": 1,
-            "4": 1
-        }
-        }
-    }, {
-        "id": "berlin_query",
-        "request": {
+        "ratings": [
+            {"key": {"index": "index_name", "type": "type_name", "doc_id": "1"}, "rating": 1},
+            {"key": {"index": "index_name", "type": "type_name", "doc_id": "2"}, "rating": 0},
+            {"key": {"index": "index_name", "type": "type_name", "doc_id": "3"}, "rating": 1},
+            {"key": {"index": "index_name", "type": "type_name", "doc_id": "4"}, "rating": 1}
+        ]}, 
+        {"id": "berlin_query",
+         "request": {
                 "query": {
                     "bool": {
                         "must": [
@@ -104,20 +101,13 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
                             {"term": {"ip_location": {"value": "ber","boost": 10}}}]}
                 },
                 "size": 10
-            }
         },
-        "ratings": {
-            "1": 0,
-            "5": 1,
-            "6": 1
-        }
-    }],
-    "metric": {
-        "precisionAtN": {
-            "size": 10
-            }
-    }
-  }
+        "ratings": [
+            {"key": {"index": "index_name", "type": "type_name", "doc_id": "1"}, "rating": 0},
+            {"key": {"index": "index_name", "type": "type_name", "doc_id": "5"}, "rating": 1},
+            {"key": {"index": "index_name", "type": "type_name", "doc_id": "6"}, "rating": 1}
+        ]}],
+    "metric": {"precisionAtN": {"size": 10}}}
 
  *
  * Output format:

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RestRankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RestRankEvalAction.java
@@ -84,11 +84,12 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
                 },
                 "size": 10
         },
+        "key_path": "_id",
         "ratings": [
-            {"key": {"index": "index_name", "type": "type_name", "doc_id": "1"}, "rating": 1},
-            {"key": {"index": "index_name", "type": "type_name", "doc_id": "2"}, "rating": 0},
-            {"key": {"index": "index_name", "type": "type_name", "doc_id": "3"}, "rating": 1},
-            {"key": {"index": "index_name", "type": "type_name", "doc_id": "4"}, "rating": 1}
+            {"key": {"index": "index_name", "type": "type_name", "key_value": "1"}, "rating": 1},
+            {"key": {"index": "index_name", "type": "type_name", "key_value": "2"}, "rating": 0},
+            {"key": {"index": "index_name", "type": "type_name", "key_value": "3"}, "rating": 1},
+            {"key": {"index": "index_name", "type": "type_name", "key_value": "4"}, "rating": 1}
         ]}, 
         {"id": "berlin_query",
          "request": {
@@ -102,10 +103,11 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
                 },
                 "size": 10
         },
+        "key_path": "_id",
         "ratings": [
-            {"key": {"index": "index_name", "type": "type_name", "doc_id": "1"}, "rating": 0},
-            {"key": {"index": "index_name", "type": "type_name", "doc_id": "5"}, "rating": 1},
-            {"key": {"index": "index_name", "type": "type_name", "doc_id": "6"}, "rating": 1}
+            {"key": {"index": "index_name", "type": "type_name", "key_value": "1"}, "rating": 0},
+            {"key": {"index": "index_name", "type": "type_name", "key_value": "5"}, "rating": 1},
+            {"key": {"index": "index_name", "type": "type_name", "key_value": "6"}, "rating": 1}
         ]}],
     "metric": {"precisionAtN": {"size": 10}}}
 

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
@@ -82,7 +82,6 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
         RankEvalSpec qualityTask = request.getRankEvalSpec();
         RankedListQualityMetric metric = qualityTask.getEvaluator();
 
-        double qualitySum = 0;
         Map<String, Collection<RatedDocumentKey>> unknownDocs = new HashMap<>();
         Collection<QuerySpec> specifications = qualityTask.getSpecifications();
         Vector<EvalQueryQuality> partialResults = new Vector<>(specifications.size());
@@ -100,7 +99,7 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
             ActionFuture<SearchResponse> searchResponse = transportSearchAction.execute(templatedRequest);
             SearchHits hits = searchResponse.actionGet().getHits();
 
-            EvalQueryQuality queryQuality = metric.evaluate(hits.getHits(), spec.getRatedDocs());
+            EvalQueryQuality queryQuality = metric.evaluate(hits.getHits(), spec.getRatedDocs(), spec.getKeyPath());
             partialResults.addElement(queryQuality);
             unknownDocs.put(spec.getSpecId(), queryQuality.getUnknownDocs());
         }

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/DiscountedCumulativeGainAtTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/DiscountedCumulativeGainAtTests.java
@@ -60,7 +60,7 @@ public class DiscountedCumulativeGainAtTests extends ESTestCase {
             hits[i].shard(new SearchShardTarget("testnode", new ShardId("index", "uuid", 0)));
         }
         DiscountedCumulativeGainAt dcg = new DiscountedCumulativeGainAt(6);
-        assertEquals(13.84826362927298, dcg.evaluate(hits, rated).getQualityLevel(), 0.00001);
+        assertEquals(13.84826362927298, dcg.evaluate(hits, rated, "_id").getQualityLevel(), 0.00001);
 
         /**
          * Check with normalization: to get the maximal possible dcg, sort documents by relevance in descending order
@@ -77,7 +77,7 @@ public class DiscountedCumulativeGainAtTests extends ESTestCase {
          * idcg = 14.595390756454922 (sum of last column)
          */
         dcg.setNormalize(true);
-        assertEquals(13.84826362927298 / 14.595390756454922, dcg.evaluate(hits, rated).getQualityLevel(), 0.00001);
+        assertEquals(13.84826362927298 / 14.595390756454922, dcg.evaluate(hits, rated, "_id").getQualityLevel(), 0.00001);
     }
 
     /**
@@ -106,7 +106,7 @@ public class DiscountedCumulativeGainAtTests extends ESTestCase {
             hits[i].shard(new SearchShardTarget("testnode", new ShardId("index", "uuid", 0)));
         }
         DiscountedCumulativeGainAt dcg = new DiscountedCumulativeGainAt(6);
-        EvalQueryQuality result = dcg.evaluate(hits, rated);
+        EvalQueryQuality result = dcg.evaluate(hits, rated, "_id");
         assertEquals(12.392789260714371, result.getQualityLevel(), 0.00001);
         assertEquals(3, result.getUnknownDocs().size());
     }

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/PrecisionAtNTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/PrecisionAtNTests.java
@@ -46,7 +46,7 @@ public class PrecisionAtNTests extends ESTestCase {
         InternalSearchHit[] hits = new InternalSearchHit[1];
         hits[0] = new InternalSearchHit(0, "0", new Text("testtype"), Collections.emptyMap());
         hits[0].shard(new SearchShardTarget("testnode", new Index("test", "uuid"), 0));
-        assertEquals(1, (new PrecisionAtN(5)).evaluate(hits, rated).getQualityLevel(), 0.00001);
+        assertEquals(1, (new PrecisionAtN(5)).evaluate(hits, rated, "_id").getQualityLevel(), 0.00001);
     }
 
     public void testPrecisionAtFiveIgnoreOneResult() throws IOException, InterruptedException, ExecutionException {
@@ -61,7 +61,7 @@ public class PrecisionAtNTests extends ESTestCase {
             hits[i] = new InternalSearchHit(i, i+"", new Text("testtype"), Collections.emptyMap());
             hits[i].shard(new SearchShardTarget("testnode", new Index("test", "uuid"), 0));
         }
-        assertEquals((double) 4 / 5, (new PrecisionAtN(5)).evaluate(hits, rated).getQualityLevel(), 0.00001);
+        assertEquals((double) 4 / 5, (new PrecisionAtN(5)).evaluate(hits, rated, "_id").getQualityLevel(), 0.00001);
     }
 
     public void testPrecisionAtFiveCorrectIndex() throws IOException, InterruptedException, ExecutionException {
@@ -76,7 +76,7 @@ public class PrecisionAtNTests extends ESTestCase {
             hits[i] = new InternalSearchHit(i, i+"", new Text("testtype"), Collections.emptyMap());
             hits[i].shard(new SearchShardTarget("testnode", new Index("test", "uuid"), 0));
         }
-        assertEquals((double) 2 / 3, (new PrecisionAtN(5)).evaluate(hits, rated).getQualityLevel(), 0.00001);
+        assertEquals((double) 2 / 3, (new PrecisionAtN(5)).evaluate(hits, rated, "_id").getQualityLevel(), 0.00001);
     }
 
     public void testPrecisionAtFiveCorrectType() throws IOException, InterruptedException, ExecutionException {
@@ -91,7 +91,7 @@ public class PrecisionAtNTests extends ESTestCase {
             hits[i] = new InternalSearchHit(i, i+"", new Text("testtype"), Collections.emptyMap());
             hits[i].shard(new SearchShardTarget("testnode", new Index("test", "uuid"), 0));
         }
-        assertEquals((double) 2 / 3, (new PrecisionAtN(5)).evaluate(hits, rated).getQualityLevel(), 0.00001);
+        assertEquals((double) 2 / 3, (new PrecisionAtN(5)).evaluate(hits, rated, "_id").getQualityLevel(), 0.00001);
     }
 
     public void testParseFromXContent() throws IOException {

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/QuerySpecTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/QuerySpecTests.java
@@ -79,10 +79,11 @@ public class QuerySpecTests extends ESTestCase {
          + "           },\n"
          + "           \"size\": 10\n"
          + "   },\n"
+         + "   \"key_path\" : \"_id\",\n"
          + "   \"ratings\": [ "
-         + "        {\"key\": {\"index\": \"test\", \"type\": \"testtype\", \"doc_id\": \"1\"}, \"rating\" : 1 }, "
-         + "        {\"key\": {\"index\": \"test\", \"type\": \"testtype\", \"doc_id\": \"2\"}, \"rating\" : 0 }, "
-         + "        {\"key\": {\"index\": \"test\", \"type\": \"testtype\", \"doc_id\": \"3\"}, \"rating\" : 1 }]\n"
+         + "        {\"key\": {\"index\": \"test\", \"type\": \"testtype\", \"key_value\": \"1\"}, \"rating\" : 1 }, "
+         + "        {\"key\": {\"index\": \"test\", \"type\": \"testtype\", \"key_value\": \"2\"}, \"rating\" : 0 }, "
+         + "        {\"key\": {\"index\": \"test\", \"type\": \"testtype\", \"key_value\": \"3\"}, \"rating\" : 1 }]\n"
          + "}";
         XContentParser parser = XContentFactory.xContent(querySpecString).createParser(querySpecString);
         QueryParseContext queryContext = new QueryParseContext(queriesRegistry, parser, ParseFieldMatcher.STRICT);
@@ -93,11 +94,11 @@ public class QuerySpecTests extends ESTestCase {
         assertNotNull(specification.getTestRequest());
         List<RatedDocument> ratedDocs = specification.getRatedDocs();
         assertEquals(3, ratedDocs.size());
-        assertEquals("1", ratedDocs.get(0).getKey().getDocID());
+        assertEquals("1", ratedDocs.get(0).getKey().getIdValue());
         assertEquals(1, ratedDocs.get(0).getRating());
-        assertEquals("2", ratedDocs.get(1).getKey().getDocID());
+        assertEquals("2", ratedDocs.get(1).getKey().getIdValue());
         assertEquals(0, ratedDocs.get(1).getRating());
-        assertEquals("3", ratedDocs.get(2).getKey().getDocID());
+        assertEquals("3", ratedDocs.get(2).getKey().getIdValue());
         assertEquals(1, ratedDocs.get(2).getRating());
     }
 }

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalRequestTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalRequestTests.java
@@ -84,8 +84,8 @@ public class RankEvalRequestTests  extends ESIntegTestCase {
         List<QuerySpec> specifications = new ArrayList<>();
         SearchSourceBuilder testQuery = new SearchSourceBuilder();
         testQuery.query(new MatchAllQueryBuilder());
-        specifications.add(new QuerySpec("amsterdam_query",  testQuery, indices, types, createRelevant("2", "3", "4", "5")));
-        specifications.add(new QuerySpec("berlin_query",  testQuery, indices, types, createRelevant("1")));
+        specifications.add(new QuerySpec("amsterdam_query",  testQuery, indices, types, "_id", createRelevant("2", "3", "4", "5")));
+        specifications.add(new QuerySpec("berlin_query",  testQuery, indices, types, "_id", createRelevant("1")));
 
         RankEvalSpec task = new RankEvalSpec(specId, specifications, new PrecisionAtN(10));
 

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/ReciprocalRankTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/ReciprocalRankTests.java
@@ -63,13 +63,13 @@ public class ReciprocalRankTests extends ESTestCase {
         }
 
         int rankAtFirstRelevant = relevantAt + 1;
-        EvalQueryQuality evaluation = reciprocalRank.evaluate(hits, ratedDocs);
+        EvalQueryQuality evaluation = reciprocalRank.evaluate(hits, ratedDocs, "_id");
         if (rankAtFirstRelevant <= maxRank) {
             assertEquals(1.0 / rankAtFirstRelevant, evaluation.getQualityLevel(), Double.MIN_VALUE);
 
             // check that if we lower maxRank by one, we don't find any result and get 0.0 quality level
             reciprocalRank = new ReciprocalRank(rankAtFirstRelevant - 1);
-            evaluation = reciprocalRank.evaluate(hits, ratedDocs);
+            evaluation = reciprocalRank.evaluate(hits, ratedDocs, "_id");
             assertEquals(0.0, evaluation.getQualityLevel(), Double.MIN_VALUE);
 
         } else {
@@ -99,7 +99,7 @@ public class ReciprocalRankTests extends ESTestCase {
             }
         }
 
-        EvalQueryQuality evaluation = reciprocalRank.evaluate(hits, ratedDocs);
+        EvalQueryQuality evaluation = reciprocalRank.evaluate(hits, ratedDocs, "_id");
         assertEquals(1.0 / (relevantAt + 1), evaluation.getQualityLevel(), Double.MIN_VALUE);
     }
 
@@ -120,7 +120,7 @@ public class ReciprocalRankTests extends ESTestCase {
             hits[i].shard(new SearchShardTarget("testnode", new Index("test", "uuid"), 0));
         }
         List<RatedDocument> ratedDocs = new ArrayList<>();
-        EvalQueryQuality evaluation = reciprocalRank.evaluate(hits, ratedDocs);
+        EvalQueryQuality evaluation = reciprocalRank.evaluate(hits, ratedDocs, "_id");
         assertEquals(0.0, evaluation.getQualityLevel(), Double.MIN_VALUE);
     }
 }


### PR DESCRIPTION
WIP PR to fix #19747 - adding the ability to explicitly specify the path to use for matching rated documents to hits.

@cbuescher Would be great if you could have a look at the proposal.
