### PR TITLE
Add the ability to disable the retrieval of the metadata fields

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -289,6 +289,11 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
         return this;
     }
 
+    public SearchRequestBuilder setFetchMetadata(boolean fetch) {
+        sourceBuilder().fetchMetadata(fetch);
+        return this;
+    }
+
     /**
      * Adds a docvalue based field to load and return. The field does not have to be stored,
      * but its recommended to use non analyzed or numeric fields.

--- a/core/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchService.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search;
 
 import com.carrotsearch.hppc.ObjectFloatHashMap;
 import org.apache.lucene.search.FieldDoc;
-import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
@@ -812,6 +811,24 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 throw new SearchContextException(context, "`slice` cannot be used outside of a scroll context");
             }
             context.sliceBuilder(source.slice());
+        }
+
+        if (source.fetchMetadata() != null) {
+            if (source.fetchMetadata() == false) {
+                if (context.version()) {
+                    throw new SearchContextException(context,
+                        "`fetch_metadata` is required when version is requested");
+                }
+                if (context.hasFieldNames()) {
+                    throw new SearchContextException(context,
+                        "`fetch_metadata` is required when stored fields are requested");
+                }
+                if (context.sourceRequested() ||
+                    (context.hasFetchSourceContext() == false && context.hasScriptFields())) {
+                    throw new SearchContextException(context, "`fetch_metadata` cannot be false if _source is requested");
+                }
+            }
+            context.fetchMetadata(source.fetchMetadata());
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/search/fetch/parent/ParentFieldSubFetchPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/parent/ParentFieldSubFetchPhase.java
@@ -38,6 +38,9 @@ public final class ParentFieldSubFetchPhase implements FetchSubPhase {
 
     @Override
     public void hitExecute(SearchContext context, HitContext hitContext) {
+        if (context.fetchMetadata() == false) {
+            return ;
+        }
         ParentFieldMapper parentFieldMapper = context.mapperService().documentMapper(hitContext.hit().type()).parentFieldMapper();
         if (parentFieldMapper.active() == false) {
             return;

--- a/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -109,6 +109,7 @@ public class DefaultSearchContext extends SearchContext {
     private List<String> fieldNames;
     private ScriptFieldsContext scriptFields;
     private FetchSourceContext fetchSourceContext;
+    private boolean fetchMetadata = true;
     private int from = -1;
     private int size = -1;
     private SortAndFormats sort;
@@ -468,6 +469,18 @@ public class DefaultSearchContext extends SearchContext {
         this.fetchSourceContext = fetchSourceContext;
         return this;
     }
+
+    @Override
+    public boolean fetchMetadata() {
+        return fetchMetadata;
+    }
+
+    @Override
+    public SearchContext fetchMetadata(boolean fetch) {
+        this.fetchMetadata = fetch;
+        return this;
+    }
+
 
     @Override
     public ContextIndexSearcher searcher() {

--- a/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -220,6 +220,16 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
+    public boolean fetchMetadata() {
+        return in.fetchMetadata();
+    }
+
+    @Override
+    public SearchContext fetchMetadata(boolean fetch) {
+        return in.fetchMetadata(fetch);
+    }
+
+    @Override
     public ContextIndexSearcher searcher() {
         return in.searcher();
     }

--- a/core/src/main/java/org/elasticsearch/search/internal/InternalSearchHit.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/InternalSearchHit.java
@@ -100,16 +100,16 @@ public class InternalSearchHit implements SearchHit {
 
     }
 
-    public InternalSearchHit(int docId, String id, Text type, Map<String, SearchHitField> fields) {
+    public InternalSearchHit(int docId, @Nullable String id, @Nullable Text type, @Nullable Map<String, SearchHitField> fields) {
         this.docId = docId;
-        this.id = new Text(id);
+        this.id = id != null ? new Text(id) : null;
         this.type = type;
         this.fields = fields;
     }
 
     public InternalSearchHit(int nestedTopDocId, String id, Text type, InternalNestedIdentity nestedIdentity, Map<String, SearchHitField> fields) {
         this.docId = nestedTopDocId;
-        this.id = new Text(id);
+        this.id = id != null ? new Text(id) : null;
         this.type = type;
         this.nestedIdentity = nestedIdentity;
         this.fields = fields;
@@ -168,7 +168,7 @@ public class InternalSearchHit implements SearchHit {
 
     @Override
     public String id() {
-        return id.string();
+        return id != null ? id.string() : null;
     }
 
     @Override
@@ -178,7 +178,7 @@ public class InternalSearchHit implements SearchHit {
 
     @Override
     public String type() {
-        return type.string();
+        return type != null ? type.string() : null;
     }
 
     @Override
@@ -444,8 +444,12 @@ public class InternalSearchHit implements SearchHit {
             if (shard != null) {
                 builder.field(Fields._INDEX, shard.indexText());
             }
-            builder.field(Fields._TYPE, type);
-            builder.field(Fields._ID, id);
+            if (type != null) {
+                builder.field(Fields._TYPE, type);
+            }
+            if (id != null) {
+                builder.field(Fields._ID, id);
+            }
         }
         if (version != -1) {
             builder.field(Fields._VERSION, version);
@@ -555,8 +559,8 @@ public class InternalSearchHit implements SearchHit {
 
     public void readFrom(StreamInput in, InternalSearchHits.StreamContext context) throws IOException {
         score = in.readFloat();
-        id = in.readText();
-        type = in.readText();
+        id = in.readOptionalText();
+        type = in.readOptionalText();
         nestedIdentity = in.readOptionalStreamable(InternalNestedIdentity::new);
         version = in.readLong();
         source = in.readBytesReference();
@@ -664,8 +668,8 @@ public class InternalSearchHit implements SearchHit {
 
     public void writeTo(StreamOutput out, InternalSearchHits.StreamContext context) throws IOException {
         out.writeFloat(score);
-        out.writeText(id);
-        out.writeText(type);
+        out.writeOptionalText(id);
+        out.writeOptionalText(type);
         out.writeOptionalStreamable(nestedIdentity);
         out.writeLong(version);
         out.writeBytesReference(source);

--- a/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -64,7 +64,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class SearchContext implements Releasable {
@@ -199,6 +198,10 @@ public abstract class SearchContext implements Releasable {
     public abstract FetchSourceContext fetchSourceContext();
 
     public abstract SearchContext fetchSourceContext(FetchSourceContext fetchSourceContext);
+
+    public abstract boolean fetchMetadata();
+
+    public abstract SearchContext fetchMetadata(boolean fetch);
 
     public abstract ContextIndexSearcher searcher();
 

--- a/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -408,6 +408,10 @@ public class SearchSourceBuilderTests extends ESTestCase {
                 builder.slice(new SliceBuilder(field, id, max));
             }
         }
+
+        if (randomBoolean()) {
+            builder.fetchMetadata(randomBoolean());
+        }
         return builder;
     }
 
@@ -550,14 +554,14 @@ public class SearchSourceBuilderTests extends ESTestCase {
 
     public void testAggsParsing() throws IOException {
         {
-            String restContent = "{\n" + "    " + 
-                    "\"aggs\": {" + 
-                    "        \"test_agg\": {\n" + 
-                    "            " + "\"terms\" : {\n" + 
-                    "                \"field\": \"foo\"\n" + 
-                    "            }\n" + 
-                    "        }\n" + 
-                    "    }\n" + 
+            String restContent = "{\n" + "    " +
+                    "\"aggs\": {" +
+                    "        \"test_agg\": {\n" +
+                    "            " + "\"terms\" : {\n" +
+                    "                \"field\": \"foo\"\n" +
+                    "            }\n" +
+                    "        }\n" +
+                    "    }\n" +
                     "}\n";
             try (XContentParser parser = XContentFactory.xContent(restContent).createParser(restContent)) {
                 SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.fromXContent(createParseContext(parser), aggParsers,
@@ -566,14 +570,14 @@ public class SearchSourceBuilderTests extends ESTestCase {
             }
         }
         {
-            String restContent = "{\n" + 
-                    "    \"aggregations\": {" + 
-                    "        \"test_agg\": {\n" + 
-                    "            \"terms\" : {\n" + 
-                    "                \"field\": \"foo\"\n" + 
-                    "            }\n" + 
-                    "        }\n" + 
-                    "    }\n" + 
+            String restContent = "{\n" +
+                    "    \"aggregations\": {" +
+                    "        \"test_agg\": {\n" +
+                    "            \"terms\" : {\n" +
+                    "                \"field\": \"foo\"\n" +
+                    "            }\n" +
+                    "        }\n" +
+                    "    }\n" +
                     "}\n";
             try (XContentParser parser = XContentFactory.xContent(restContent).createParser(restContent)) {
                 SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.fromXContent(createParseContext(parser), aggParsers,

--- a/core/src/test/java/org/elasticsearch/search/source/MetadatFetchingIT.java
+++ b/core/src/test/java/org/elasticsearch/search/source/MetadatFetchingIT.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.source;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.SearchContextException;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class MetadatFetchingIT extends ESIntegTestCase {
+    public void testSimple() {
+        assertAcked(prepareCreate("test"));
+        ensureGreen();
+
+        client().prepareIndex("test", "type1", "1").setSource("field", "value").execute().actionGet();
+        refresh();
+
+        SearchResponse response = client()
+            .prepareSearch("test")
+            .setFetchMetadata(false)
+            .setFetchSource(false)
+            .get();
+        assertThat(response.getHits().getAt(0).getId(), nullValue());
+        assertThat(response.getHits().getAt(0).getType(), nullValue());
+        assertThat(response.getHits().getAt(0).sourceAsString(), nullValue());
+
+        response = client()
+            .prepareSearch("test")
+            .setFetchMetadata(false)
+            .get();
+        assertThat(response.getHits().getAt(0).getId(), nullValue());
+        assertThat(response.getHits().getAt(0).getType(), nullValue());
+        assertThat(response.getHits().getAt(0).sourceAsString(), nullValue());
+    }
+
+    public void testWithRouting() {
+        assertAcked(prepareCreate("test"));
+        ensureGreen();
+
+        client().prepareIndex("test", "type1", "1").setSource("field", "value").setRouting("toto").execute().actionGet();
+        refresh();
+
+        SearchResponse response = client()
+            .prepareSearch("test")
+            .setFetchMetadata(false)
+            .setFetchSource(false)
+            .get();
+        assertThat(response.getHits().getAt(0).getId(), nullValue());
+        assertThat(response.getHits().getAt(0).getType(), nullValue());
+        assertThat(response.getHits().getAt(0).field("_routing"), nullValue());
+        assertThat(response.getHits().getAt(0).sourceAsString(), nullValue());
+
+        response = client()
+            .prepareSearch("test")
+            .setFetchMetadata(false)
+            .get();
+        assertThat(response.getHits().getAt(0).getId(), nullValue());
+        assertThat(response.getHits().getAt(0).getType(), nullValue());
+        assertThat(response.getHits().getAt(0).sourceAsString(), nullValue());
+    }
+
+    public void testInvalid() {
+        assertAcked(prepareCreate("test"));
+        ensureGreen();
+
+        index("test", "type1", "1", "field", "value");
+        refresh();
+
+        {
+            SearchPhaseExecutionException exc = expectThrows(SearchPhaseExecutionException.class,
+                () -> client().prepareSearch("test").setFetchSource(true).setFetchMetadata(false).get());
+            Throwable rootCause = ExceptionsHelper.unwrap(exc, SearchContextException.class);
+            assertNotNull(rootCause);
+            assertThat(rootCause.getClass(), equalTo(SearchContextException.class));
+            assertThat(rootCause.getMessage(),
+                equalTo("`fetch_metadata` cannot be false if _source is requested"));
+        }
+        {
+            SearchPhaseExecutionException exc = expectThrows(SearchPhaseExecutionException.class,
+                () -> client().prepareSearch("test").setFetchMetadata(false).setVersion(true).get());
+            Throwable rootCause = ExceptionsHelper.unwrap(exc, SearchContextException.class);
+            assertNotNull(rootCause);
+            assertThat(rootCause.getClass(), equalTo(SearchContextException.class));
+            assertThat(rootCause.getMessage(),
+                equalTo("`fetch_metadata` is required when version is requested"));
+        }
+
+        {
+            SearchPhaseExecutionException exc = expectThrows(SearchPhaseExecutionException.class,
+                () -> client().prepareSearch("test").setFetchMetadata(false).storedFields("field").get());
+            Throwable rootCause = ExceptionsHelper.unwrap(exc, SearchContextException.class);
+            assertNotNull(rootCause);
+            assertThat(rootCause.getClass(), equalTo(SearchContextException.class));
+            assertThat(rootCause.getMessage(),
+                equalTo("`fetch_metadata` is required when stored fields are requested"));
+        }
+    }
+}

--- a/docs/reference/search/request/fetch-metadata.asciidoc
+++ b/docs/reference/search/request/fetch-metadata.asciidoc
@@ -1,0 +1,22 @@
+[[search-request-fetch-metadata]]
+=== Fetch metadata
+
+Allows to disable the retrieval of the metadata fields (`_source`, `_id`, `_type`, `routing`, `parent`).
+
+By default search operations return the metadata fields of each search result.
+
+You can turn off the retrieval by using the `fetch_metadata` parameter:
+
+[source,js]
+--------------------------------------------------
+GET /_search
+{
+    "fetch_metadata": false
+    "query" : {
+        "term" : { "user" : "kimchy" }
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+NOTE: <<search-request-source-filtering,`_source`>>, <<search-request-version, `version`>> and <<search-request-fields, `stored_fields`>> parameters cannot be used if `fetch_metadata` is disabled.

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yaml
@@ -115,3 +115,20 @@ setup:
       search:
         docvalue_fields: [ "count" ]
   - match: { hits.hits.0.fields.count: [1] }
+
+---
+"fetch_metadata: true":
+  - do:
+      search:
+        fetch_metadata: true
+  - is_true: hits.hits.0.id
+  - is_true: hits.hits.0.type
+
+---
+"fetch_metadata: false":
+  - do:
+      search:
+        fetch_metadata: false
+  - is_false: hits.hits.0.id
+  - is_false: hits.hits.0.type
+

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yaml
@@ -115,20 +115,3 @@ setup:
       search:
         docvalue_fields: [ "count" ]
   - match: { hits.hits.0.fields.count: [1] }
-
----
-"fetch_metadata: true":
-  - do:
-      search:
-        fetch_metadata: true
-  - is_true: hits.hits.0.id
-  - is_true: hits.hits.0.type
-
----
-"fetch_metadata: false":
-  - do:
-      search:
-        fetch_metadata: false
-  - is_false: hits.hits.0.id
-  - is_false: hits.hits.0.type
-

--- a/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
@@ -18,10 +18,6 @@
  */
 package org.elasticsearch.test;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.Query;
@@ -64,6 +60,10 @@ import org.elasticsearch.search.rescore.RescoreSearchContext;
 import org.elasticsearch.search.sort.SortAndFormats;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class TestSearchContext extends SearchContext {
 
@@ -258,6 +258,16 @@ public class TestSearchContext extends SearchContext {
 
     @Override
     public SearchContext fetchSourceContext(FetchSourceContext fetchSourceContext) {
+        return null;
+    }
+
+    @Override
+    public boolean fetchMetadata() {
+        return false;
+    }
+
+    @Override
+    public SearchContext fetchMetadata(boolean fetch) {
         return null;
     }
 


### PR DESCRIPTION
This is a follow up of theses discussions https://github.com/elastic/elasticsearch/issues/11887#issuecomment-198408478, https://github.com/elastic/elasticsearch/pull/19877#issuecomment-238597329

By default search operations returns the metadata fields of each search hit.
This change allows to disable the retrieval of these fields (_source, _id, _type, _routing, _parent, ...) by adding a new parameter called `fetch_metadata`. This parameter can be set to false only if `_source`, `version` or `stored_fields` are not explicitly requested.

This could be a nice speed up for the suggestions now that they use the fetch phase to retrieve the _source.
The problem is that even if _source is disabled we visit the stored fields for each suggestion and extract the metadata fields, with this change we could bypass this step.
