### PR TITLE
Mark halting the virtual machine as privileged

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandler.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandler.java
@@ -25,6 +25,8 @@ import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 
 import java.io.IOError;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -87,8 +89,14 @@ class ElasticsearchUncaughtExceptionHandler implements Thread.UncaughtExceptionH
     // visible for testing
     @SuppressForbidden(reason = "halt")
     void halt(int status) {
-        // we halt to prevent shutdown hooks from running
-        Runtime.getRuntime().halt(status);
+        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            @Override
+            public Void run() {
+                // we halt to prevent shutdown hooks from running
+                Runtime.getRuntime().halt(status);
+                return null;
+            }
+        });
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandler.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandler.java
@@ -87,9 +87,9 @@ class ElasticsearchUncaughtExceptionHandler implements Thread.UncaughtExceptionH
     }
 
     // visible for testing
-    @SuppressForbidden(reason = "halt")
     void halt(int status) {
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            @SuppressForbidden(reason = "halt")
             @Override
             public Void run() {
                 // we halt to prevent shutdown hooks from running


### PR DESCRIPTION
Today in the uncaught exception handler, we attempt to halt the virtual
machine on fatal errors. Yet, halting the virtual machine requires
privileges which might not be granted to the caller when the exception
is thrown for example from a scripting engine. This means that if an
OutOfMemoryError or another fatal error is hit inside a script, the
virtual machine will not exit because the halt call will be denied for
securiry privileges. In this commit, we mark this halt call as trusted
so that the virtual machine can be halted if a fatal error is
encountered in a script.

Relates #19272, relates #19806
