### PR TITLE
Fix threadpool settings example

### DIFF
--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -64,9 +64,10 @@ thread pool to have more threads:
 
 [source,yaml]
 --------------------------------------------------
-threadpool:
+thread_pool:
     index:
         size: 30
+        queue_size: 1000
 --------------------------------------------------
 
 NOTE: you can update thread pool settings dynamically using <<cluster-update-settings>>.


### PR DESCRIPTION
First, it's not `threadpool`, it's `thread_pool` : https://github.com/elastic/elasticsearch/blob/b22c526b34c5bba261ec79a083a41e40f6f1483d/core/src/main/java/org/elasticsearch/threadpool/FixedExecutorBuilder.java#L54
Second, there was no example on how to change the `queue_size` : https://github.com/elastic/elasticsearch/blob/b22c526b34c5bba261ec79a083a41e40f6f1483d/core/src/main/java/org/elasticsearch/threadpool/FixedExecutorBuilder.java#L75
