### PR TITLE
Add `// NOTCONSOLE` to docs

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
@@ -42,8 +42,8 @@ public class DocsTestPlugin extends RestTestPlugin {
                 'List snippets that probably should be marked // CONSOLE'
         listConsoleCandidates.perSnippet {
             if (
-                       it.console      // Already marked, nothing to do
-                    || it.testResponse // It is a response
+                       it.console != null // Already marked, nothing to do
+                    || it.testResponse    // It is a response
                 ) {
                 return
             }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
@@ -48,8 +48,8 @@ public class DocsTestPlugin extends RestTestPlugin {
                 return
             }
             List<String> languages = [
-                // These languages should almost always be marked console
-                'js', 'json',
+                // This language should almost always be marked console
+                'js',
                 // These are often curl commands that should be converted but
                 // are probably false positives
                 'sh', 'shell',

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
@@ -32,6 +32,12 @@ import java.util.regex.Matcher
  * Generates REST tests for each snippet marked // TEST.
  */
 public class RestTestsFromSnippetsTask extends SnippetsTask {
+    /**
+     * These languages aren't supported by the syntax highlighter so we
+     * shouldn't use them.
+     */
+    private static final List BAD_LANGUAGES = ['json', 'javascript']
+
     @Input
     Map<String, String> setups = new HashMap()
 
@@ -87,9 +93,9 @@ public class RestTestsFromSnippetsTask extends SnippetsTask {
          * calls buildTest to actually build the test.
          */
         void handleSnippet(Snippet snippet) {
-            if (snippet.language == 'json') {
+            if (BAD_LANGUAGES.contains(snippet.language)) {
                 throw new InvalidUserDataException(
-                        "$snippet: Use `js` instead of `json`.")
+                        "$snippet: Use `js` instead of `${snippet.language}`.")
             }
             if (snippet.testSetup) {
                 setup(snippet)

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/SnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/SnippetsTask.groovy
@@ -114,23 +114,38 @@ public class SnippetsTask extends DefaultTask {
                     return
                 }
                 if (line ==~ /\/\/\s*AUTOSENSE\s*/) {
-                    throw new InvalidUserDataException("AUTOSENSE has been " +
-                            "replaced by CONSOLE. Use that instead at " +
-                            "$file:$lineNumber")
+                    throw new InvalidUserDataException("$file:$lineNumber: "
+                        + "AUTOSENSE has been replaced by CONSOLE.")
                 }
                 if (line ==~ /\/\/\s*CONSOLE\s*/) {
                     if (snippet == null) {
-                        throw new InvalidUserDataException("CONSOLE not " +
-                            "paired with a snippet at $file:$lineNumber")
+                        throw new InvalidUserDataException("$file:$lineNumber: "
+                            + "CONSOLE not paired with a snippet")
+                    }
+                    if (snippet.console != null) {
+                        throw new InvalidUserDataException("$file:$lineNumber: "
+                            + "Can't be both CONSOLE and NOTCONSOLE")
                     }
                     snippet.console = true
+                    return
+                }
+                if (line ==~ /\/\/\s*NOTCONSOLE\s*/) {
+                    if (snippet == null) {
+                        throw new InvalidUserDataException("$file:$lineNumber: "
+                            + "NOTCONSOLE not paired with a snippet")
+                    }
+                    if (snippet.console != null) {
+                        throw new InvalidUserDataException("$file:$lineNumber: "
+                            + "Can't be both CONSOLE and NOTCONSOLE")
+                    }
+                    snippet.console = false
                     return
                 }
                 matcher = line =~ /\/\/\s*TEST(\[(.+)\])?\s*/
                 if (matcher.matches()) {
                     if (snippet == null) {
-                        throw new InvalidUserDataException("TEST not " +
-                            "paired with a snippet at $file:$lineNumber")
+                        throw new InvalidUserDataException("$file:$lineNumber: "
+                            + "TEST not paired with a snippet at ")
                     }
                     snippet.test = true
                     if (matcher.group(2) != null) {
@@ -172,8 +187,8 @@ public class SnippetsTask extends DefaultTask {
                 matcher = line =~ /\/\/\s*TESTRESPONSE(\[(.+)\])?\s*/
                 if (matcher.matches()) {
                     if (snippet == null) {
-                        throw new InvalidUserDataException("TESTRESPONSE not " +
-                            "paired with a snippet at $file:$lineNumber")
+                        throw new InvalidUserDataException("$file:$lineNumber: "
+                            + "TESTRESPONSE not paired with a snippet")
                     }
                     snippet.testResponse = true
                     if (matcher.group(2) != null) {
@@ -226,7 +241,7 @@ public class SnippetsTask extends DefaultTask {
         int end = NOT_FINISHED
         String contents
 
-        boolean console = false
+        Boolean console = null
         boolean test = false
         boolean testResponse = false
         boolean testSetup = false
@@ -243,8 +258,8 @@ public class SnippetsTask extends DefaultTask {
             if (language != null) {
                 result += "($language)"
             }
-            if (console) {
-                result += '// CONSOLE'
+            if (console != null) {
+                result += console ? '// CONSOLE' : '// NOTCONSOLE'
             }
             if (test) {
                 result += '// TEST'

--- a/docs/plugins/analysis-icu.asciidoc
+++ b/docs/plugins/analysis-icu.asciidoc
@@ -17,6 +17,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install analysis-icu
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -31,6 +32,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove analysis-icu
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 

--- a/docs/plugins/analysis-kuromoji.asciidoc
+++ b/docs/plugins/analysis-kuromoji.asciidoc
@@ -14,6 +14,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install analysis-kuromoji
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -28,6 +29,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove analysis-kuromoji
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 

--- a/docs/plugins/analysis-phonetic.asciidoc
+++ b/docs/plugins/analysis-phonetic.asciidoc
@@ -15,6 +15,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install analysis-phonetic
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -29,6 +30,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove analysis-phonetic
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 

--- a/docs/plugins/analysis-smartcn.asciidoc
+++ b/docs/plugins/analysis-smartcn.asciidoc
@@ -20,6 +20,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install analysis-smartcn
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -34,6 +35,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove analysis-smartcn
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 
@@ -45,4 +47,3 @@ The plugin provides the `smartcn` analyzer and `smartcn_tokenizer` tokenizer,
 which are not configurable.
 
 NOTE: The `smartcn_word` token filter and `smartcn_sentence` have been deprecated.
-

--- a/docs/plugins/analysis-stempel.asciidoc
+++ b/docs/plugins/analysis-stempel.asciidoc
@@ -17,6 +17,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install analysis-stempel
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -31,6 +32,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove analysis-stempel
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 
@@ -40,4 +42,3 @@ The node must be stopped before removing the plugin.
 
 The plugin provides the `polish` analyzer and `polish_stem` token filter,
 which are not configurable.
-

--- a/docs/plugins/discovery-azure-classic.asciidoc
+++ b/docs/plugins/discovery-azure-classic.asciidoc
@@ -17,6 +17,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install discovery-azure-classic
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -31,6 +32,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove discovery-azure-classic
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 

--- a/docs/plugins/discovery-azure-classic.asciidoc
+++ b/docs/plugins/discovery-azure-classic.asciidoc
@@ -387,7 +387,7 @@ curl http://localhost:9200/
 
 This command should give you a JSON result:
 
-[source,javascript]
+[source,js]
 ----
 {
   "status" : 200,

--- a/docs/plugins/discovery-ec2.asciidoc
+++ b/docs/plugins/discovery-ec2.asciidoc
@@ -13,6 +13,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install discovery-ec2
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -27,6 +28,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove discovery-ec2
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 
@@ -140,7 +142,7 @@ discovery:
 You must also set `cloud.aws.region` if you are not using default AWS region. See <<discovery-ec2-usage-region>> for details.
 
 The ec2 discovery is using the same credentials as the rest of the AWS services provided by this plugin (`repositories`).
-See <<discovery-ec2-usage>> for details. 
+See <<discovery-ec2-usage>> for details.
 
 The following are a list of settings (prefixed with `discovery.ec2`) that can further control the discovery:
 
@@ -267,7 +269,7 @@ When selecting disk please be aware of the following order of preference:
 * http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html[Instance Store] - When running clusters of larger size and with replicas the ephemeral nature of Instance Store is ideal since Elasticsearch can tolerate the loss of shards. With Instance Store one gets the performance benefit of having disk physically attached to the host running the instance and also the cost benefit of avoiding paying extra for EBS.
 
 
-Prefer https://aws.amazon.com/amazon-linux-ami/[Amazon Linux AMIs] as since Elasticsearch runs on the JVM, OS dependencies are very minimal and one can benefit from the lightweight nature, support, and performance tweaks specific to EC2 that the Amazon Linux AMIs offer. 
+Prefer https://aws.amazon.com/amazon-linux-ami/[Amazon Linux AMIs] as since Elasticsearch runs on the JVM, OS dependencies are very minimal and one can benefit from the lightweight nature, support, and performance tweaks specific to EC2 that the Amazon Linux AMIs offer.
 
 ===== Networking
 * Networking throttling takes place on smaller instance types in both the form of https://lab.getbase.com/how-we-discovered-limitations-on-the-aws-tcp-stack/[bandwidth and number of connections]. Therefore if large number of connections are needed and networking is becoming a bottleneck, avoid https://aws.amazon.com/ec2/instance-types/[instance types] with networking labeled as `Moderate` or `Low`.

--- a/docs/plugins/discovery-gce.asciidoc
+++ b/docs/plugins/discovery-gce.asciidoc
@@ -13,6 +13,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install discovery-gce
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -27,6 +28,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove discovery-gce
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 

--- a/docs/plugins/ingest-attachment.asciidoc
+++ b/docs/plugins/ingest-attachment.asciidoc
@@ -21,6 +21,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install ingest-attachment
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -35,6 +36,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove ingest-attachment
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 

--- a/docs/plugins/ingest-geoip.asciidoc
+++ b/docs/plugins/ingest-geoip.asciidoc
@@ -21,6 +21,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install ingest-geoip
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -35,6 +36,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove ingest-geoip
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 

--- a/docs/plugins/ingest-user-agent.asciidoc
+++ b/docs/plugins/ingest-user-agent.asciidoc
@@ -16,6 +16,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install ingest-user-agent
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -30,6 +31,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove ingest-user-agent
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 

--- a/docs/plugins/lang-javascript.asciidoc
+++ b/docs/plugins/lang-javascript.asciidoc
@@ -15,6 +15,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install lang-javascript
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -29,6 +30,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove lang-javascript
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 

--- a/docs/plugins/lang-python.asciidoc
+++ b/docs/plugins/lang-python.asciidoc
@@ -14,6 +14,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install lang-python
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -28,6 +29,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove lang-python
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 

--- a/docs/plugins/mapper-attachments.asciidoc
+++ b/docs/plugins/mapper-attachments.asciidoc
@@ -19,6 +19,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install mapper-attachments
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -33,6 +34,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove mapper-attachments
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 

--- a/docs/plugins/mapper-murmur3.asciidoc
+++ b/docs/plugins/mapper-murmur3.asciidoc
@@ -15,6 +15,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install mapper-murmur3
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -29,6 +30,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove mapper-murmur3
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 

--- a/docs/plugins/mapper-size.asciidoc
+++ b/docs/plugins/mapper-size.asciidoc
@@ -15,6 +15,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install mapper-size
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -29,6 +30,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove mapper-size
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 
@@ -106,4 +108,3 @@ GET my_index/_search
 <2> Aggregating on the `_size` field
 <3> Sorting on the `_size` field
 <4> Accessing the `_size` field in scripts (inline scripts must be modules-security-scripting.html#enable-dynamic-scripting[enabled] for this example to work)
-

--- a/docs/plugins/repository-azure.asciidoc
+++ b/docs/plugins/repository-azure.asciidoc
@@ -14,6 +14,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install repository-azure
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -28,6 +29,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove repository-azure
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 

--- a/docs/plugins/repository-gcs.asciidoc
+++ b/docs/plugins/repository-gcs.asciidoc
@@ -14,6 +14,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install repository-gcs
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 NOTE: The plugin requires new permission to be installed in order to work
 
@@ -30,6 +31,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove repository-gcs
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 

--- a/docs/plugins/repository-hdfs.asciidoc
+++ b/docs/plugins/repository-hdfs.asciidoc
@@ -14,6 +14,7 @@ This plugin can be installed through the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install repository-hdfs
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on _every_ node in the cluster, and each node must
 be restarted after installation.
@@ -28,6 +29,7 @@ The plugin can be removed by specifying the _installed_ package:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove repository-hdfs
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 

--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -14,6 +14,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install repository-s3
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -28,6 +29,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove repository-s3
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 

--- a/docs/plugins/store-smb.asciidoc
+++ b/docs/plugins/store-smb.asciidoc
@@ -13,6 +13,7 @@ This plugin can be installed using the plugin manager:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin install store-smb
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
@@ -27,6 +28,7 @@ The plugin can be removed with the following command:
 ----------------------------------------------------------------
 sudo bin/elasticsearch-plugin remove store-smb
 ----------------------------------------------------------------
+// NOTCONSOLE
 
 The node must be stopped before removing the plugin.
 


### PR DESCRIPTION
We have 1074 snippets that look like they should be converted to
`// CONSOLE`. At least that is what `gradle docs:listConsoleCandidates`
says. This adds `// NOTCONSOLE` to explicitly mark snippets that
_shouldn't_ be converted to `// CONSOLE`. After marking the blindingly
obvious ones this cuts the remaining snippet count to 1032.

Relates to #18160
