### PR TITLE
Catch OutOfMemory and StackOverflow errors in Painless

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngineService.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngineService.java
@@ -127,9 +127,9 @@ public final class PainlessScriptEngineService extends AbstractComponent impleme
             if (value != null) {
                 compilerSettings.setPicky(Boolean.parseBoolean(value));
             }
-            
+
             value = copy.remove(CompilerSettings.INITIAL_CALL_SITE_DEPTH);
-            
+
             if (value != null) {
                 compilerSettings.setInitialCallSiteDepth(Integer.parseInt(value));
             }
@@ -162,7 +162,8 @@ public final class PainlessScriptEngineService extends AbstractComponent impleme
                     return Compiler.compile(loader, scriptName == null ? INLINE_NAME : scriptName, scriptSource, compilerSettings);
                 }
             }, COMPILATION_CONTEXT);
-        } catch (Exception e) {
+        // Note that it is safe to catch any of the following errors since Painless is stateless.
+        } catch (OutOfMemoryError | StackOverflowError | Exception e) {
             throw convertToScriptException(scriptName == null ? scriptSource : scriptName, scriptSource, e);
         }
     }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/ScriptImpl.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/ScriptImpl.java
@@ -119,8 +119,9 @@ final class ScriptImpl implements ExecutableScript, LeafSearchScript {
     public Object run() {
         try {
             return executable.execute(variables, scorer, doc, aggregationValue);
-        } catch (PainlessError | BootstrapMethodError | IllegalAccessError | Exception t) {
-            throw convertToScriptException(t);
+        // Note that it is safe to catch any of the following errors since Painless is stateless.
+        } catch (PainlessError | BootstrapMethodError | OutOfMemoryError | StackOverflowError | Exception e) {
+            throw convertToScriptException(e);
         }
     }
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.painless;
 
+import org.apache.lucene.util.Constants;
+import org.elasticsearch.script.ScriptException;
+
 import java.lang.invoke.WrongMethodTypeException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -216,6 +219,19 @@ public class WhenThingsGoWrongTests extends ScriptTestCase {
     public void testBadBoxingCast() {
         expectScriptThrows(ClassCastException.class, () -> {
             exec("BitSet bs = new BitSet(); bs.and(2);");
+        });
+    }
+
+    public void testOutOfMemoryError() {
+        assumeTrue("test only happens to work for sure on oracle jre", Constants.JAVA_VENDOR.startsWith("Oracle"));
+        expectScriptThrows(OutOfMemoryError.class, () -> {
+            exec("int[] x = new int[Integer.MAX_VALUE - 1];");
+        });
+    }
+
+    public void testStackOverflowError() {
+        expectScriptThrows(StackOverflowError.class, () -> {
+            exec("void recurse(int x, int y) {recurse(x, y)} recurse(1, 2);");
         });
     }
 }


### PR DESCRIPTION
Since Painless is both sandboxed and stateless, it is safe to catch OutOfMemory and StackOverflow errors.  This prevents the users from destroying a node if they happen to write a script that is ridiculous like the following:

`int[] x = new int[Integer.MAX_VALUE];`

There is no reason to halt the entire application for the above script.
