### PR TITLE
Mappings: Allow to force dots in field names

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
@@ -26,6 +26,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.CopyOnWriteHashMap;
@@ -60,6 +61,9 @@ public class ObjectMapper extends Mapper implements AllFieldMapper.IncludeInAll,
 
     public static final String CONTENT_TYPE = "object";
     public static final String NESTED_CONTENT_TYPE = "nested";
+
+    private static final boolean DOTS_IN_FIELD_ALLOWED = Booleans.parseBooleanExact(
+        System.getProperty("mapper.allow_dots_in_name", "false"));
 
     public static class Defaults {
         public static final boolean ENABLED = true;
@@ -269,7 +273,7 @@ public class ObjectMapper extends Mapper implements AllFieldMapper.IncludeInAll,
             while (iterator.hasNext()) {
                 Map.Entry<String, Object> entry = iterator.next();
                 String fieldName = entry.getKey();
-                if (fieldName.contains(".")) {
+                if (fieldName.contains(".") && DOTS_IN_FIELD_ALLOWED == false) {
                     throw new MapperParsingException("Field name [" + fieldName + "] cannot contain '.'");
                 }
                 // Should accept empty arrays, as a work around for when the


### PR DESCRIPTION
With the changes in 5.0 to allow dots in field names for documents as
well as mappings, we now have the possibility to allow a path forward
for users which must have dots in fields on 2.x. This change adds an
option to override the dot checks, `mapper.allow_dots_in_name` which may
be set to `true` to omit the dots in field names error check. The
resulting mappings will contain dots in the field names, and on upgrade
to 5.x, those will be automatically converted to object mappings on
startup.

Note that this works because the underlying lucene indexes uses the full
path. If a luser uses this to produce corrupt mappings, for example, two
fields `foo` and `foo.bar` which are both text, the upgrade to 5.x will
fail (because `foo` cannot be an object as well as a string field).

One open question is how to test. I've checked that this upgrade path works manually. I don't think a unit test will work (would depend on a sysprop being set which we should not generally have set in tests).  I think the best way would be to add a special case in the bwc generation script, so that 2.4 indexes will have a field name with dot, and then the normal static bwc index tests will check that the upgrade works.
