### PR TITLE
Remove useless PK lookup in IndicesTTLService

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
+++ b/core/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.indices.ttl;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.Term;
+import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.SimpleCollector;
@@ -48,7 +48,7 @@ import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.TTLFieldMapper;
 import org.elasticsearch.index.mapper.Uid;
-import org.elasticsearch.index.mapper.UidFieldMapper;
+import org.elasticsearch.index.mapper.VersionFieldMapper;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.indices.IndicesService;
@@ -237,6 +237,7 @@ public class IndicesTTLService extends AbstractLifecycleComponent {
     private class ExpiredDocsCollector extends SimpleCollector {
         private LeafReaderContext context;
         private List<DocToPurge> docsToPurge = new ArrayList<>();
+        private NumericDocValues versions;
 
         public ExpiredDocsCollector() {
         }
@@ -256,7 +257,7 @@ public class IndicesTTLService extends AbstractLifecycleComponent {
                 FieldsVisitor fieldsVisitor = new FieldsVisitor(false);
                 context.reader().document(doc, fieldsVisitor);
                 Uid uid = fieldsVisitor.uid();
-                final long version = Versions.loadVersion(context.reader(), new Term(UidFieldMapper.NAME, uid.toBytesRef()));
+                final long version = versions == null ? Versions.NOT_FOUND : versions.get(doc);
                 docsToPurge.add(new DocToPurge(uid.type(), uid.id(), version, fieldsVisitor.routing()));
             } catch (Exception e) {
                 logger.trace("failed to collect doc", e);
@@ -266,6 +267,7 @@ public class IndicesTTLService extends AbstractLifecycleComponent {
         @Override
         public void doSetNextReader(LeafReaderContext context) throws IOException {
             this.context = context;
+            this.versions = context.reader().getNumericDocValues(VersionFieldMapper.NAME);
         }
 
         public List<DocToPurge> getDocsToPurge() {


### PR DESCRIPTION
This is a follow up of https://github.com/elastic/elasticsearch/pull/19944#issuecomment-239119859
Since the docid is known we can directly access the version doc value.
