### PR TITLE
Add shardId and node name in search slow log

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/SearchSlowLog.java
+++ b/core/src/main/java/org/elasticsearch/index/SearchSlowLog.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 /**
  */
 public final class SearchSlowLog implements SearchOperationListener {
-    private final Index index;
     private boolean reformat;
 
     private long queryWarnThreshold;
@@ -84,10 +83,8 @@ public final class SearchSlowLog implements SearchOperationListener {
 
     public SearchSlowLog(IndexSettings indexSettings) {
 
-        this.queryLogger = Loggers.getLogger(INDEX_SEARCH_SLOWLOG_PREFIX + ".query");
-        this.fetchLogger = Loggers.getLogger(INDEX_SEARCH_SLOWLOG_PREFIX + ".fetch");
-
-        this.index = indexSettings.getIndex();
+        this.queryLogger = Loggers.getLogger(INDEX_SEARCH_SLOWLOG_PREFIX + ".query", indexSettings.getSettings());
+        this.fetchLogger = Loggers.getLogger(INDEX_SEARCH_SLOWLOG_PREFIX + ".fetch", indexSettings.getSettings());
 
         indexSettings.getScopedSettings().addSettingsUpdateConsumer(INDEX_SEARCH_SLOWLOG_REFORMAT, this::setReformat);
         this.reformat = indexSettings.getValue(INDEX_SEARCH_SLOWLOG_REFORMAT);
@@ -122,38 +119,36 @@ public final class SearchSlowLog implements SearchOperationListener {
     @Override
     public void onQueryPhase(SearchContext context, long tookInNanos) {
         if (queryWarnThreshold >= 0 && tookInNanos > queryWarnThreshold) {
-            queryLogger.warn("{}", new SlowLogSearchContextPrinter(index, context, tookInNanos, reformat));
+            queryLogger.warn("{}", new SlowLogSearchContextPrinter(context, tookInNanos, reformat));
         } else if (queryInfoThreshold >= 0 && tookInNanos > queryInfoThreshold) {
-            queryLogger.info("{}", new SlowLogSearchContextPrinter(index, context, tookInNanos, reformat));
+            queryLogger.info("{}", new SlowLogSearchContextPrinter(context, tookInNanos, reformat));
         } else if (queryDebugThreshold >= 0 && tookInNanos > queryDebugThreshold) {
-            queryLogger.debug("{}", new SlowLogSearchContextPrinter(index, context, tookInNanos, reformat));
+            queryLogger.debug("{}", new SlowLogSearchContextPrinter(context, tookInNanos, reformat));
         } else if (queryTraceThreshold >= 0 && tookInNanos > queryTraceThreshold) {
-            queryLogger.trace("{}", new SlowLogSearchContextPrinter(index, context, tookInNanos, reformat));
+            queryLogger.trace("{}", new SlowLogSearchContextPrinter(context, tookInNanos, reformat));
         }
     }
 
     @Override
     public void onFetchPhase(SearchContext context, long tookInNanos) {
         if (fetchWarnThreshold >= 0 && tookInNanos > fetchWarnThreshold) {
-            fetchLogger.warn("{}", new SlowLogSearchContextPrinter(index, context, tookInNanos, reformat));
+            fetchLogger.warn("{}", new SlowLogSearchContextPrinter(context, tookInNanos, reformat));
         } else if (fetchInfoThreshold >= 0 && tookInNanos > fetchInfoThreshold) {
-            fetchLogger.info("{}", new SlowLogSearchContextPrinter(index, context, tookInNanos, reformat));
+            fetchLogger.info("{}", new SlowLogSearchContextPrinter(context, tookInNanos, reformat));
         } else if (fetchDebugThreshold >= 0 && tookInNanos > fetchDebugThreshold) {
-            fetchLogger.debug("{}", new SlowLogSearchContextPrinter(index, context, tookInNanos, reformat));
+            fetchLogger.debug("{}", new SlowLogSearchContextPrinter(context, tookInNanos, reformat));
         } else if (fetchTraceThreshold >= 0 && tookInNanos > fetchTraceThreshold) {
-            fetchLogger.trace("{}", new SlowLogSearchContextPrinter(index, context, tookInNanos, reformat));
+            fetchLogger.trace("{}", new SlowLogSearchContextPrinter(context, tookInNanos, reformat));
         }
     }
 
     static final class SlowLogSearchContextPrinter {
         private final SearchContext context;
-        private final Index index;
         private final long tookInNanos;
         private final boolean reformat;
 
-        public SlowLogSearchContextPrinter(Index index, SearchContext context, long tookInNanos, boolean reformat) {
+        public SlowLogSearchContextPrinter(SearchContext context, long tookInNanos, boolean reformat) {
             this.context = context;
-            this.index = index;
             this.tookInNanos = tookInNanos;
             this.reformat = reformat;
         }
@@ -161,7 +156,7 @@ public final class SearchSlowLog implements SearchOperationListener {
         @Override
         public String toString() {
             StringBuilder sb = new StringBuilder();
-            sb.append(index).append(" ");
+            sb.append(context.indexShard().shardId()).append(" ");
             sb.append("took[").append(TimeValue.timeValueNanos(tookInNanos)).append("], took_millis[").append(TimeUnit.NANOSECONDS.toMillis(tookInNanos)).append("], ");
             if (context.getQueryShardContext().getTypes() == null) {
                 sb.append("types[], ");

--- a/core/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
+++ b/core/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 
 import static org.hamcrest.Matchers.startsWith;
 
-
 public class SearchSlowLogTests extends ESSingleNodeTestCase {
     @Override
     protected SearchContext createSearchContext(IndexService indexService) {
@@ -54,7 +53,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
                 return new ShardSearchRequest() {
                     @Override
                     public ShardId shardId() {
-                        return null;
+                        return new ShardId(indexService.index(), 0);
                     }
 
                     @Override
@@ -129,8 +128,8 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
         IndexService index = createIndex("foo");
         // Turning off document logging doesn't log source[]
         SearchContext searchContext = createSearchContext(index);
-        SearchSlowLog.SlowLogSearchContextPrinter p = new SearchSlowLog.SlowLogSearchContextPrinter(index.index(), searchContext, 10, true);
-        assertThat(p.toString(), startsWith(index.index().toString()));
+        SearchSlowLog.SlowLogSearchContextPrinter p = new SearchSlowLog.SlowLogSearchContextPrinter(searchContext, 10, true);
+        assertThat(p.toString(), startsWith("[foo][0]"));
     }
 
     public void testReformatSetting() {


### PR DESCRIPTION
Add the shard ID and the node name in the output of the search slow log.
This change outputs '[nodeName] [indexName][shardId]' instead of [indexName/indexUUID]

closes #19735
