### PR TITLE
Fix handling of spaces for jvm.options on Windows

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.bat
@@ -62,7 +62,7 @@ SET HOSTNAME=%COMPUTERNAME%
 
 if "%ES_JVM_OPTIONS%" == "" (
 rem '0' is the batch file, '~dp' appends the drive and path
-set ES_JVM_OPTIONS="%~dp0\..\config\jvm.options"
+set ES_JVM_OPTIONS=%~dp0\..\config\jvm.options
 )
 
 @setlocal

--- a/distribution/src/main/resources/bin/service.bat
+++ b/distribution/src/main/resources/bin/service.bat
@@ -168,7 +168,7 @@ if exist "%JAVA_HOME%"\bin\client\jvm.dll (
 
 :foundJVM
 if "%ES_JVM_OPTIONS%" == "" (
-set ES_JVM_OPTIONS="%ES_HOME%\config\jvm.options"
+set ES_JVM_OPTIONS=%ES_HOME%\config\jvm.options
 )
 
 if not "%ES_JAVA_OPTS%" == "" set ES_JAVA_OPTS=%ES_JAVA_OPTS: =;%


### PR DESCRIPTION
This commit fixes the handling of spaces in the path to the jvm.options
file on Windows. The issue is that the extraneous set of quotes were
included as part of the value of ES_JVM_OPTIONS thus confusing further
downstream commands.

Closes #19941
