### PR TITLE
Catch and wrap AssertionError and NoClassDefFoundError in groovy scripts

### DIFF
--- a/modules/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovySecurityTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovySecurityTests.java
@@ -123,6 +123,13 @@ public class GroovySecurityTests extends ESTestCase {
         }
     }
 
+    public void testGroovyScriptsThatThrowErrors() throws Exception {
+        assertFailure("assert false, \"msg\";", AssertionError.class);
+        assertFailure("def foo=false; assert foo;", AssertionError.class);
+        // Groovy's asserts require org.codehaus.groovy.runtime.InvokerHelper, so they are denied
+        assertFailure("def foo=false; assert foo, \"msg2\";", NoClassDefFoundError.class);
+    }
+
     /** runs a script */
     private void doTest(String script) {
         Map<String, Object> vars = new HashMap<String, Object>();
@@ -146,7 +153,7 @@ public class GroovySecurityTests extends ESTestCase {
         doTest(script);
     }
 
-    /** asserts that a script triggers securityexception */
+    /** asserts that a script triggers the given exceptionclass */
     private void assertFailure(String script, Class<? extends Throwable> exceptionClass) {
         try {
             doTest(script);


### PR DESCRIPTION
Previously, we only caught subclasses of Exception, however, there are
some cases when Errors are thrown instead of Exceptions. These two cases
are `assert` and when a class cannot be found.

Without this change, the exception would bubble up to the
`uncaughtExceptionHandler`, which would in turn, exit the JVM
(related: #19923).

A note of difference between regular Java asserts and Groovy asserts,
from http://docs.groovy-lang.org/docs/latest/html/documentation/core-testing-guide.html

"Another important difference from Java is that in Groovy assertions are
enabled by default. It has been a language design decision to remove the
possibility to deactivate assertions."

In the event that a user uses an assert such as:

``` groovy
def bar=false; assert bar, "message";
```

The GroovyScriptEngineService throws a NoClassDefFoundError being unable
to find the `java.lang.StringBuffer` class. It is _highly_ recommended
that any Groovy scripting user switch to using regular exceptions rather
than unconfigurable Groovy assertions.

Resolves #19806
