### PR TITLE
update and delete by query requests to implement IndicesRequest.Replaceable

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryRequest.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryRequest.java
@@ -43,7 +43,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  *     <li>it's results won't be visible until the index is refreshed.</li>
  * </ul>
  */
-public class DeleteByQueryRequest extends AbstractBulkByScrollRequest<DeleteByQueryRequest> implements IndicesRequest {
+public class DeleteByQueryRequest extends AbstractBulkByScrollRequest<DeleteByQueryRequest> implements IndicesRequest.Replaceable {
 
     public DeleteByQueryRequest() {
     }
@@ -77,6 +77,15 @@ public class DeleteByQueryRequest extends AbstractBulkByScrollRequest<DeleteByQu
         b.append("delete-by-query ");
         searchToString(b);
         return b.toString();
+    }
+
+    //delete by query deletes all documents that match a query. The indices and indices options that affect how
+    //indices are resolved depend entirely on the inner search request. That's why the following methods delegate to it.
+    @Override
+    public IndicesRequest indices(String... indices) {
+        assert getSearchRequest() != null;
+        getSearchRequest().indices(indices);
+        return this;
     }
 
     @Override

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/UpdateByQueryRequest.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/UpdateByQueryRequest.java
@@ -19,15 +19,9 @@
 
 package org.elasticsearch.index.reindex;
 
-import org.elasticsearch.action.CompositeIndicesRequest;
 import org.elasticsearch.action.IndicesRequest;
-import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static java.util.Collections.unmodifiableList;
+import org.elasticsearch.action.support.IndicesOptions;
 
 /**
  * Request to update some documents. That means you can't change their type, id, index, or anything like that. This implements
@@ -35,7 +29,7 @@ import static java.util.Collections.unmodifiableList;
  * representative set of subrequests. This is best-effort but better than {@linkplain ReindexRequest} because scripts can't change the
  * destination index and things.
  */
-public class UpdateByQueryRequest extends AbstractBulkIndexByScrollRequest<UpdateByQueryRequest> implements CompositeIndicesRequest {
+public class UpdateByQueryRequest extends AbstractBulkIndexByScrollRequest<UpdateByQueryRequest> implements IndicesRequest.Replaceable {
     /**
      * Ingest pipeline to set on index requests made by this action.
      */
@@ -75,25 +69,24 @@ public class UpdateByQueryRequest extends AbstractBulkIndexByScrollRequest<Updat
         return b.toString();
     }
 
-    // CompositeIndicesRequest implementation so plugins can reason about the request. This is really just a best effort thing.
-    /**
-     * Accessor to get the underlying {@link IndicesRequest}s that this request wraps. Note that this method is <strong>not
-     * accurate</strong> since it returns dummy {@link IndexRequest}s and not the actual requests that will be issued as part of the
-     * execution of this request.
-     *
-     * @return a list comprising of the {@link SearchRequest} and dummy {@link IndexRequest}s
-     */
+    //update by query updates all documents that match a query. The indices and indices options that affect how
+    //indices are resolved depend entirely on the inner search request. That's why the following methods delegate to it.
     @Override
-    public List<? extends IndicesRequest> subRequests() {
+    public IndicesRequest indices(String... indices) {
         assert getSearchRequest() != null;
-        List<IndicesRequest> subRequests = new ArrayList<>();
-        // One dummy IndexRequest per destination index.
-        for (String index : getSearchRequest().indices()) {
-            IndexRequest request = new IndexRequest();
-            request.index(index);
-            subRequests.add(request);
-        }
-        subRequests.add(getSearchRequest());
-        return unmodifiableList(subRequests);
-    };
+        getSearchRequest().indices(indices);
+        return this;
+    }
+
+    @Override
+    public String[] indices() {
+        assert getSearchRequest() != null;
+        return getSearchRequest().indices();
+    }
+
+    @Override
+    public IndicesOptions indicesOptions() {
+        assert getSearchRequest() != null;
+        return getSearchRequest().indicesOptions();
+    }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryRequestTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryRequestTests.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.reindex;
+
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.apache.lucene.util.TestUtil.randomSimpleString;
+
+public class DeleteByQueryRequestTests extends ESTestCase {
+    public void testDeleteteByQueryRequestImplementsIndicesRequestReplaceable() {
+        int numIndices = between(1, 100);
+        String[] indices = new String[numIndices];
+        for (int i = 0; i < numIndices; i++) {
+            indices[i] = randomSimpleString(random(), 1, 30);
+        }
+
+        SearchRequest searchRequest = new SearchRequest(indices);
+        IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+        searchRequest.indicesOptions(indicesOptions);
+
+        DeleteByQueryRequest request = new DeleteByQueryRequest(searchRequest);
+        for (int i = 0; i < numIndices; i++) {
+            assertEquals(indices[i], request.indices()[i]);
+        }
+
+        assertSame(indicesOptions, request.indicesOptions());
+        assertSame(request.indicesOptions(), request.getSearchRequest().indicesOptions());
+
+        int numNewIndices = between(1, 100);
+        String[] newIndices = new String[numNewIndices];
+        for (int i = 0; i < numNewIndices; i++) {
+            newIndices[i] = randomSimpleString(random(), 1, 30);
+        }
+        request.indices(newIndices);
+        for (int i = 0; i < numNewIndices; i++) {;
+            assertEquals(newIndices[i], request.indices()[i]);
+        }
+        for (int i = 0; i < numNewIndices; i++) {;
+            assertEquals(newIndices[i], request.getSearchRequest().indices()[i]);
+        }
+    }
+}

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryRequestTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryRequestTests.java
@@ -19,31 +19,43 @@
 
 package org.elasticsearch.index.reindex;
 
-import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.List;
-
 import static org.apache.lucene.util.TestUtil.randomSimpleString;
-import static org.hamcrest.Matchers.arrayWithSize;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.sameInstance;
 
 public class UpdateByQueryRequestTests extends ESTestCase {
-    public void testUpdateByQueryRequestImplementsCompositeIndicesRequestWithDummies() {
+    public void testUpdateByQueryRequestImplementsIndicesRequestReplaceable() {
         int numIndices = between(1, 100);
         String[] indices = new String[numIndices];
         for (int i = 0; i < numIndices; i++) {
             indices[i] = randomSimpleString(random(), 1, 30);
         }
-        UpdateByQueryRequest request = new UpdateByQueryRequest(new SearchRequest(indices));
-        List<? extends IndicesRequest> subRequests = request.subRequests();
-        assertThat(subRequests, hasSize(numIndices + 1));
+
+        SearchRequest searchRequest = new SearchRequest(indices);
+        IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+        searchRequest.indicesOptions(indicesOptions);
+
+        UpdateByQueryRequest request = new UpdateByQueryRequest(searchRequest);
         for (int i = 0; i < numIndices; i++) {
-            assertThat(subRequests.get(i).indices(), arrayWithSize(1));
-            assertEquals(indices[i], subRequests.get(i).indices()[0]);
+            assertEquals(indices[i], request.indices()[i]);
         }
-        assertThat(subRequests.get(numIndices), sameInstance(request.getSearchRequest()));
+
+        assertSame(indicesOptions, request.indicesOptions());
+        assertSame(request.indicesOptions(), request.getSearchRequest().indicesOptions());
+
+        int numNewIndices = between(1, 100);
+        String[] newIndices = new String[numNewIndices];
+        for (int i = 0; i < numNewIndices; i++) {
+            newIndices[i] = randomSimpleString(random(), 1, 30);
+        }
+        request.indices(newIndices);
+        for (int i = 0; i < numNewIndices; i++) {;
+            assertEquals(newIndices[i], request.indices()[i]);
+        }
+        for (int i = 0; i < numNewIndices; i++) {;
+            assertEquals(newIndices[i], request.getSearchRequest().indices()[i]);
+        }
     }
 }


### PR DESCRIPTION
Delete by query is a shortcut to search + delete. Given that the request supports wildcards and allows to set its indices, it should implement `IndicesRequest.Repleaceable`.

Update by query is a shortcut to search + index. Given that the request supports wildcards and allows to set its indices, it should implement IndicesRequest.Repleaceable. implementing CompositeIndicesRequest makes little sense as the indices that the request works against depend entirely on the inner search request.
