### PR TITLE
Allow plugins to upgrade global custom metadata on startup

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -460,6 +460,11 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
         return null;
     }
 
+    /** Returns true iff existing index has the same {@link IndexMetaData} instance */
+    public boolean hasIndexMetaData(final IndexMetaData indexMetaData) {
+        return indices.get(indexMetaData.getIndex().getName()) == indexMetaData;
+    }
+
     /**
      * Returns the {@link IndexMetaData} for this index.
      * @throws IndexNotFoundException if no metadata for this index is found

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -36,6 +36,7 @@ import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.MasterNodeChangePredicate;
 import org.elasticsearch.cluster.NodeConnectionsService;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RoutingService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -96,6 +97,7 @@ import org.elasticsearch.plugins.DiscoveryPlugin;
 import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.MetaDataUpgrader;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.plugins.RepositoryPlugin;
 import org.elasticsearch.plugins.ScriptPlugin;
@@ -134,6 +136,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -349,6 +352,11 @@ public class Node implements Closeable {
                 .flatMap(p -> p.createComponents(client, clusterService, threadPool, resourceWatcherService,
                                                  scriptModule.getScriptService(), searchModule.getSearchRequestParsers()).stream())
                 .collect(Collectors.toList());
+            Collection<UnaryOperator<Map<String, MetaData.Custom>>> customMetaDataUpgraders =
+                pluginsService.filterPlugins(Plugin.class).stream()
+                .map(Plugin::getCustomMetaDataUpgrader)
+                .collect(Collectors.toList());
+            final MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(customMetaDataUpgraders);
             modules.add(b -> {
                     b.bind(PluginsService.class).toInstance(pluginsService);
                     b.bind(Client.class).toInstance(client);
@@ -371,6 +379,7 @@ public class Node implements Closeable {
                         b.bind(SearchService.class).to(searchServiceImpl).asEagerSingleton();
                     }
                     pluginComponents.stream().forEach(p -> b.bind((Class) p.getClass()).toInstance(p));
+                    b.bind(MetaDataUpgrader.class).toInstance(metaDataUpgrader);
                 }
             );
             injector = modules.createInjector();

--- a/core/src/main/java/org/elasticsearch/plugins/MetaDataUpgrader.java
+++ b/core/src/main/java/org/elasticsearch/plugins/MetaDataUpgrader.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import org.elasticsearch.cluster.metadata.MetaData;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+/**
+ * Upgrades {@link MetaData} on startup on behalf of installed {@link Plugin}s
+ */
+public class MetaDataUpgrader {
+    public final UnaryOperator<Map<String, MetaData.Custom>> customMetaDataUpgraders;
+
+    public MetaDataUpgrader(Collection<UnaryOperator<Map<String, MetaData.Custom>>> customMetaDataUpgraders) {
+        this.customMetaDataUpgraders = customs -> {
+            Map<String, MetaData.Custom> upgradedCustoms = new HashMap<>(customs);
+            for (UnaryOperator<Map<String, MetaData.Custom>> customMetaDataUpgrader : customMetaDataUpgraders) {
+                upgradedCustoms = customMetaDataUpgrader.apply(upgradedCustoms);
+            }
+            return upgradedCustoms;
+        };
+    }
+}

--- a/core/src/main/java/org/elasticsearch/plugins/Plugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/Plugin.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.elasticsearch.action.ActionModule;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.inject.Module;
@@ -42,6 +43,9 @@ import org.elasticsearch.search.SearchRequestParsers;
 import org.elasticsearch.threadpool.ExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
+
+import java.util.Map;
+import java.util.function.UnaryOperator;
 
 /**
  * An extension point allowing to plug in custom functionality.
@@ -123,6 +127,18 @@ public abstract class Plugin {
      * Returns a list of additional settings filter for this plugin
      */
     public List<String> getSettingsFilter() { return Collections.emptyList(); }
+
+    /**
+     * Provides a function to modify global custom meta data on startup.
+     * <p>
+     * Plugins should return the input custom map via {@link UnaryOperator#identity()} if no upgrade is required.
+     * @return Never {@code null}. The same or upgraded {@code MetaData.Custom} map.
+     * @throws IllegalStateException if the node should not start because at least one {@code MetaData.Custom}
+     *         is unsupported
+     */
+    public UnaryOperator<Map<String, MetaData.Custom>> getCustomMetaDataUpgrader() {
+        return UnaryOperator.identity();
+    }
 
     /**
      * Old-style guice index level extension point.

--- a/core/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.metadata.MetaDataIndexUpgradeService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -31,9 +32,15 @@ import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.plugins.MetaDataUpgrader;
 import org.elasticsearch.test.ESAllocationTestCase;
+import org.elasticsearch.test.TestCustomMetaData;
+import org.junit.Before;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -53,6 +60,12 @@ import static org.hamcrest.Matchers.equalTo;
  * for data only nodes: shard initializing on shard
  */
 public class GatewayMetaStateTests extends ESAllocationTestCase {
+
+    @Before
+    public void setup() {
+        MetaData.registerPrototype(CustomMetaData1.TYPE, new CustomMetaData1(""));
+        MetaData.registerPrototype(CustomMetaData2.TYPE, new CustomMetaData2(""));
+    }
 
     ClusterChangedEvent generateEvent(boolean initializing, boolean versionChanged, boolean masterEligible) {
         //ridiculous settings to make sure we don't run into uninitialized because fo default
@@ -244,5 +257,209 @@ public class GatewayMetaStateTests extends ESAllocationTestCase {
         boolean stateInMemory = true;
         ClusterChangedEvent event = generateCloseEvent(masterEligible);
         assertState(event, stateInMemory, expectMetaData);
+    }
+
+    public void testAddCustomMetaDataOnUpgrade() throws Exception {
+        MetaData metaData = randomMetaData();
+        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(
+            Collections.singletonList(customs -> {
+                customs.put(CustomMetaData1.TYPE, new CustomMetaData1("modified_data1"));
+                return customs;
+            })
+        );
+        MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
+        assertTrue(upgrade != metaData);
+        assertFalse(MetaData.isGlobalStateEquals(upgrade, metaData));
+        assertNotNull(upgrade.custom(CustomMetaData1.TYPE));
+        assertThat(((TestCustomMetaData) upgrade.custom(CustomMetaData1.TYPE)).getData(), equalTo("modified_data1"));
+    }
+
+    public void testRemoveCustomMetaDataOnUpgrade() throws Exception {
+        MetaData metaData = randomMetaData(new CustomMetaData1("data"));
+        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(
+            Collections.singletonList(customs -> {
+                customs.remove(CustomMetaData1.TYPE);
+                return customs;
+            })
+        );
+        MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
+        assertTrue(upgrade != metaData);
+        assertFalse(MetaData.isGlobalStateEquals(upgrade, metaData));
+        assertNull(upgrade.custom(CustomMetaData1.TYPE));
+    }
+
+    public void testUpdateCustomMetaDataOnUpgrade() throws Exception {
+        MetaData metaData = randomMetaData(new CustomMetaData1("data"));
+        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(
+            Collections.singletonList(customs -> {
+                customs.put(CustomMetaData1.TYPE, new CustomMetaData1("modified_data1"));
+                return customs;
+            })
+        );
+
+        MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
+        assertTrue(upgrade != metaData);
+        assertFalse(MetaData.isGlobalStateEquals(upgrade, metaData));
+        assertNotNull(upgrade.custom(CustomMetaData1.TYPE));
+        assertThat(((TestCustomMetaData) upgrade.custom(CustomMetaData1.TYPE)).getData(), equalTo("modified_data1"));
+    }
+
+    public void testNoMetaDataUpgrade() throws Exception {
+        MetaData metaData = randomMetaData(new CustomMetaData1("data"));
+        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(Collections.emptyList());
+        MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
+        assertTrue(upgrade == metaData);
+        assertTrue(MetaData.isGlobalStateEquals(upgrade, metaData));
+        for (IndexMetaData indexMetaData : upgrade) {
+            assertTrue(metaData.hasIndexMetaData(indexMetaData));
+        }
+    }
+
+    public void testCustomMetaDataValidation() throws Exception {
+        MetaData metaData = randomMetaData(new CustomMetaData1("data"));
+        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(Collections.singletonList(
+            customs -> {
+                throw new IllegalStateException("custom meta data too old");
+            }
+        ));
+        try {
+            GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage(), equalTo("custom meta data too old"));
+        }
+    }
+
+    public void testMultipleCustomMetaDataUpgrade() throws Exception {
+        final MetaData metaData;
+        switch (randomIntBetween(0, 2)) {
+            case 0:
+                metaData = randomMetaData(new CustomMetaData1("data1"), new CustomMetaData2("data2"));
+                break;
+            case 1:
+                metaData = randomMetaData(randomBoolean() ? new CustomMetaData1("data1") : new CustomMetaData2("data2"));
+                break;
+            case 2:
+                metaData = randomMetaData();
+                break;
+            default: throw new IllegalStateException("should never happen");
+        }
+        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(
+            Arrays.asList(
+                customs -> {
+                    customs.put(CustomMetaData1.TYPE, new CustomMetaData1("modified_data1"));
+                    return customs;
+                },
+                customs -> {
+                    customs.put(CustomMetaData2.TYPE, new CustomMetaData1("modified_data2"));
+                    return customs;
+                })
+        );
+        MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
+        assertTrue(upgrade != metaData);
+        assertFalse(MetaData.isGlobalStateEquals(upgrade, metaData));
+        assertNotNull(upgrade.custom(CustomMetaData1.TYPE));
+        assertThat(((TestCustomMetaData) upgrade.custom(CustomMetaData1.TYPE)).getData(), equalTo("modified_data1"));
+        assertNotNull(upgrade.custom(CustomMetaData2.TYPE));
+        assertThat(((TestCustomMetaData) upgrade.custom(CustomMetaData2.TYPE)).getData(), equalTo("modified_data2"));
+        for (IndexMetaData indexMetaData : upgrade) {
+            assertTrue(metaData.hasIndexMetaData(indexMetaData));
+        }
+    }
+
+    public void testIndexMetaDataUpgrade() throws Exception {
+        MetaData metaData = randomMetaData();
+        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(Collections.emptyList());
+        MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(true), metaDataUpgrader);
+        assertTrue(upgrade != metaData);
+        assertTrue(MetaData.isGlobalStateEquals(upgrade, metaData));
+        for (IndexMetaData indexMetaData : upgrade) {
+            assertFalse(metaData.hasIndexMetaData(indexMetaData));
+        }
+    }
+
+    public void testCustomMetaDataNoChange() throws Exception {
+        MetaData metaData = randomMetaData(new CustomMetaData1("data"));
+        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(Collections.singletonList(HashMap::new));
+        MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
+        assertTrue(upgrade == metaData);
+        assertTrue(MetaData.isGlobalStateEquals(upgrade, metaData));
+        for (IndexMetaData indexMetaData : upgrade) {
+            assertTrue(metaData.hasIndexMetaData(indexMetaData));
+        }
+    }
+
+    private static class MockMetaDataIndexUpgradeService extends MetaDataIndexUpgradeService {
+        private final boolean upgrade;
+
+        public MockMetaDataIndexUpgradeService(boolean upgrade) {
+            super(Settings.EMPTY, null, null);
+            this.upgrade = upgrade;
+        }
+        @Override
+        public IndexMetaData upgradeIndexMetaData(IndexMetaData indexMetaData) {
+            return upgrade ? IndexMetaData.builder(indexMetaData).build() : indexMetaData;
+        }
+    }
+
+    private static class CustomMetaData1 extends TestCustomMetaData {
+        public static final String TYPE = "custom_md_1";
+
+        protected CustomMetaData1(String data) {
+            super(data);
+        }
+
+        @Override
+        protected TestCustomMetaData newTestCustomMetaData(String data) {
+            return new CustomMetaData1(data);
+        }
+
+        @Override
+        public String type() {
+            return TYPE;
+        }
+
+        @Override
+        public EnumSet<MetaData.XContentContext> context() {
+            return EnumSet.of(MetaData.XContentContext.GATEWAY);
+        }
+    }
+
+    private static class CustomMetaData2 extends TestCustomMetaData {
+        public static final String TYPE = "custom_md_2";
+
+        protected CustomMetaData2(String data) {
+            super(data);
+        }
+
+        @Override
+        protected TestCustomMetaData newTestCustomMetaData(String data) {
+            return new CustomMetaData2(data);
+        }
+
+        @Override
+        public String type() {
+            return TYPE;
+        }
+
+        @Override
+        public EnumSet<MetaData.XContentContext> context() {
+            return EnumSet.of(MetaData.XContentContext.GATEWAY);
+        }
+    }
+
+    private static MetaData randomMetaData(TestCustomMetaData... customMetaDatas) {
+        MetaData.Builder builder = MetaData.builder();
+        for (TestCustomMetaData customMetaData : customMetaDatas) {
+            builder.putCustom(customMetaData.type(), customMetaData);
+        }
+        for (int i = 0; i < randomIntBetween(1, 5); i++) {
+            builder.put(
+                IndexMetaData.builder(randomAsciiOfLength(10))
+                    .settings(settings(Version.CURRENT))
+                    .numberOfReplicas(randomIntBetween(0, 3))
+                    .numberOfShards(randomIntBetween(1, 5))
+            );
+        }
+        return builder.build();
     }
 }


### PR DESCRIPTION
Currently plugins can not inspect or upgrade custom
meta data on startup. This commit allow plugins
to check and/or upgrade global custom meta data on startup.
Plugins can stop a node if any custom meta data is not supported.
