### PR TITLE
fix CompletionSuggestion test failed caused by shard is 1

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionTests.java
@@ -32,7 +32,6 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class CompletionSuggestionTests extends ESTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/19896")
     public void testToReduce() throws Exception {
         List<Suggest.Suggestion<CompletionSuggestion.Entry>> shardSuggestions = new ArrayList<>();
         int nShards = randomIntBetween(1, 10);
@@ -47,8 +46,11 @@ public class CompletionSuggestionTests extends ESTestCase {
         float maxScore = randomIntBetween(totalResults, totalResults*2);
         for (int i = 0; i < totalResults; i++) {
             Suggest.Suggestion<CompletionSuggestion.Entry> suggestion = randomFrom(shardSuggestions);
-            suggestion.getEntries().get(0).addOption(new CompletionSuggestion.Entry.Option(i, new Text(""),
-                maxScore - i, Collections.emptyMap()));
+            CompletionSuggestion.Entry entry = suggestion.getEntries().get(0);
+            if (entry.getOptions().size() < size) {
+                entry.addOption(new CompletionSuggestion.Entry.Option(i, new Text(""),
+                    maxScore - i, Collections.emptyMap()));
+            }
         }
         CompletionSuggestion reducedSuggestion = CompletionSuggestion.reduceTo(shardSuggestions);
         assertNotNull(reducedSuggestion);


### PR DESCRIPTION
This PR is for fixing: https://github.com/elastic/elasticsearch/issues/19896

@areek Can you review again? Thanks :)

Seems I have reverted the commit, the before pull request has been removed.

Before @areek suggestion:

Thanks for the PR @chengpohi! I don't think we should remove the optimization for single shard reduce, because a shard suggest will never have more options than the requested suggest size, we check for it here. Upon inspecting, this is actually a test bug instead, where we should limit options to atmost request suggest size for shard-level suggest:

```
diff --git a/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionTests.java b/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionTests.java
index 0623afc..60722fb 100644
--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionTests.java
@@ -46,8 +46,11 @@ public class CompletionSuggestionTests extends ESTestCase {
         float maxScore = randomIntBetween(totalResults, totalResults*2);
         for (int i = 0; i < totalResults; i++) {
             Suggest.Suggestion<CompletionSuggestion.Entry> suggestion = randomFrom(shardSuggestions);
-            suggestion.getEntries().get(0).addOption(new CompletionSuggestion.Entry.Option(i, new Text(""),
-                maxScore - i, Collections.emptyMap()));
+            CompletionSuggestion.Entry entry = suggestion.getEntries().get(0);
+            if (entry.getOptions().size() < size) {
+                entry.addOption(new CompletionSuggestion.Entry.Option(i, new Text(""),
+                    maxScore - i, Collections.emptyMap()));
+            }
         }
         CompletionSuggestion reducedSuggestion = CompletionSuggestion.reduceTo(shardSuggestions);
         assertNotNull(reducedSuggestion);

```
