### PR TITLE
Fix explain output for dfs query

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
@@ -133,6 +133,10 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
 
     @Override
     public Explanation explain(Query query, int doc) throws IOException {
+        if (aggregatedDfs != null) {
+            // dfs data is needed to explain the score
+            return super.explain(createNormalizedWeight(query, true), doc);
+        }
         return in.explain(query, doc);
     }
 

--- a/core/src/test/java/org/elasticsearch/search/basic/TransportTwoNodesSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/basic/TransportTwoNodesSearchIT.java
@@ -60,6 +60,7 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -147,6 +148,10 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
             for (int i = 0; i < hits.length; ++i) {
                 SearchHit hit = hits[i];
                 assertThat(hit.explanation(), notNullValue());
+                assertThat(hit.explanation().getDetails().length, equalTo(1));
+                assertThat(hit.explanation().getDetails()[0].getDetails().length, equalTo(2));
+                assertThat(hit.explanation().getDetails()[0].getDetails()[0].getDescription(),
+                    endsWith("idf(docFreq=100, docCount=100)"));
                 assertThat("id[" + hit.id() + "] -> " + hit.explanation().toString(), hit.id(), equalTo(Integer.toString(100 - total - i - 1)));
             }
             total += hits.length;
@@ -171,6 +176,10 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
             for (int i = 0; i < hits.length; ++i) {
                 SearchHit hit = hits[i];
                 assertThat(hit.explanation(), notNullValue());
+                assertThat(hit.explanation().getDetails().length, equalTo(1));
+                assertThat(hit.explanation().getDetails()[0].getDetails().length, equalTo(2));
+                assertThat(hit.explanation().getDetails()[0].getDetails()[0].getDescription(),
+                    endsWith("idf(docFreq=100, docCount=100)"));
                 assertThat("id[" + hit.id() + "]", hit.id(), equalTo(Integer.toString(total + i)));
             }
             total += hits.length;
@@ -317,6 +326,10 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
             SearchHit hit = searchResponse.getHits().hits()[i];
 //            System.out.println(hit.shard() + ": " +  hit.explanation());
             assertThat(hit.explanation(), notNullValue());
+            assertThat(hit.explanation().getDetails().length, equalTo(1));
+            assertThat(hit.explanation().getDetails()[0].getDetails().length, equalTo(2));
+            assertThat(hit.explanation().getDetails()[0].getDetails()[0].getDescription(),
+                endsWith("idf(docFreq=100, docCount=100)"));
 //            assertThat("id[" + hit.id() + "]", hit.id(), equalTo(Integer.toString(100 - i - 1)));
             assertThat("make sure we don't have duplicates", expectedIds.remove(hit.id()), notNullValue());
         }


### PR DESCRIPTION
ContextIndexSearcher#explain ignores the dfs data to create the normalized weight.
This change fixes this discrepancy by using the dfs data to create the normalized weight when needed.

Fixes #15369
