### PR TITLE
RESTART_ON_UPGRADE incorrectly named ES_RESTART_ON_UPGRADE in sysconfig

### DIFF
--- a/distribution/src/main/packaging/env/elasticsearch
+++ b/distribution/src/main/packaging/env/elasticsearch
@@ -24,7 +24,7 @@
 #ES_JAVA_OPTS=
 
 # Configure restart on package upgrade (true, every other setting will lead to not restarting)
-#ES_RESTART_ON_UPGRADE=true
+#RESTART_ON_UPGRADE=true
 
 ################################
 # Elasticsearch service


### PR DESCRIPTION
The sysconfig file has the commented out environment variable `ES_RESTART_ON_UPGRADE`
but the install scripts refer to `RESTART_ON_UPGRADE` instead.

This commit fixes the sysconfig file.

Closes #19950
