### PR TITLE
Deprecate geohash parameters for geo_point parser

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/geo/BaseGeoPointFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/geo/BaseGeoPointFieldMapper.java
@@ -225,15 +225,21 @@ public abstract class BaseGeoPointFieldMapper extends FieldMapper implements Arr
                     builder.precisionStep(XContentMapValues.nodeIntegerValue(propNode));
                     iterator.remove();
                 } else if (propName.equals("geohash")) {
+                    deprecationLogger.deprecated(CONTENT_TYPE + " geohash parameter is deprecated and will be removed "
+                        + "in the next major release");
                     builder.enableGeoHash(XContentMapValues.nodeBooleanValue(propNode));
                     iterator.remove();
                 } else if (propName.equals("geohash_prefix")) {
+                    deprecationLogger.deprecated(CONTENT_TYPE + " geohash_prefix parameter is deprecated and will be removed "
+                        + "in the next major release");
                     builder.geoHashPrefix(XContentMapValues.nodeBooleanValue(propNode));
                     if (XContentMapValues.nodeBooleanValue(propNode)) {
                         builder.enableGeoHash(true);
                     }
                     iterator.remove();
                 } else if (propName.equals("geohash_precision")) {
+                    deprecationLogger.deprecated(CONTENT_TYPE + " geohash_precision parameter is deprecated and will be removed "
+                        + "in the next major release");
                     if (propNode instanceof Integer) {
                         builder.geoHashPrecision(XContentMapValues.nodeIntegerValue(propNode));
                     } else {

--- a/docs/reference/mapping/types/geo-point.asciidoc
+++ b/docs/reference/mapping/types/geo-point.asciidoc
@@ -119,16 +119,17 @@ The following parameters are accepted by `geo_point` fields:
 
     Should the geo-point also be indexed as a geohash in the `.geohash`
     sub-field? Defaults to `false`, unless `geohash_prefix` is `true`.
+    deprecated[2.4]
 
 <<geohash-precision,`geohash_precision`>>::
 
     The maximum length of the geohash to use for the `geohash` and
-    `geohash_prefix` options.
+    `geohash_prefix` options. deprecated[2.4]
 
 <<geohash-prefix,`geohash_prefix`>>::
 
     Should the geo-point also be indexed as a geohash plus all its prefixes?
-    Defaults to `false`.
+    Defaults to `false`. deprecated[2.4]
 
 <<ignore-malformed,`ignore_malformed`>>::
 
@@ -138,7 +139,7 @@ The following parameters are accepted by `geo_point` fields:
 <<lat-lon,`lat_lon`>>::
 
     Should the geo-point also be indexed as `.lat` and `.lon` sub-fields?
-    Accepts `true` and `false` (default).
+    Accepts `true` and `false` (default). deprecated[2.3]
 
 ==== Using geo-points in scripts
 


### PR DESCRIPTION
WIP PR to deprecate all `geohash` parameters in the `geo_point` mapper. `geo_point` docs are updated to reflect deprecated parameters (geohash_*, and lat_lon).

closes #20009
