### PR TITLE
Deprecate optimize_bbox on geodistance queries

### DIFF
--- a/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -787,7 +787,7 @@ public class ExceptionSerializationTests extends ESTestCase {
                 reverse.put(entry.getValue(), entry.getKey());
             }
         }
-        
+
         for (Map.Entry<Integer, Constructor<? extends ElasticsearchException>> entry : ElasticsearchException.ID_TO_SUPPLIER.entrySet()) {
             assertNotNull(Integer.toString(entry.getKey()), reverse.get(entry.getValue().getDeclaringClass()));
             assertEquals(reverse.get(entry.getValue().getDeclaringClass()), entry.getKey());

--- a/docs/reference/migration/migrate_2_4.asciidoc
+++ b/docs/reference/migration/migrate_2_4.asciidoc
@@ -9,3 +9,8 @@ The setting `bootstrap.mlockall` has been renamed to
 <<bootstrap.memory_lock,`bootstrap.memory_lock`>>. Future versions of
 Elasticsearch will refuse to start if `bootstrap.mlockall` is set. You
 can switch to the new setting now.
+
+=== Query DSL
+
+The `optimize_bbox` parameter for `geo_distance` and `geo_distance_range` queries
+has been deprecated when querying indexes created after 2.1.

--- a/docs/reference/query-dsl/geo-distance-query.asciidoc
+++ b/docs/reference/query-dsl/geo-distance-query.asciidoc
@@ -156,7 +156,7 @@ The following are options allowed on the filter:
     before the distance check. Defaults to `memory` which will do in memory
     checks. Can also have values of `indexed` to use indexed value check (make
     sure the `geo_point` type index lat lon in this case), or `none` which
-    disables bounding box optimization.
+    disables bounding box optimization. deprecated[2.2]
 
 `_name`::
 


### PR DESCRIPTION
Deprecates the optimize_bbox parameter on geodistance queries. This has no longer been needed since version 2.2 because lucene geo distance queries (postings and `LatLonPoint`) already optimize by bounding box.

closes #20014
