### PR TITLE
Use StringBuilder in favor of StringBuffer

### DIFF
--- a/core/src/main/java/org/elasticsearch/env/ShardLockObtainFailedException.java
+++ b/core/src/main/java/org/elasticsearch/env/ShardLockObtainFailedException.java
@@ -39,7 +39,7 @@ public class ShardLockObtainFailedException extends Exception {
 
     @Override
     public String getMessage() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append(shardId.toString());
         sb.append(": ");
         sb.append(super.getMessage());

--- a/plugins/analysis-phonetic/src/main/java/org/elasticsearch/index/analysis/phonetic/Nysiis.java
+++ b/plugins/analysis-phonetic/src/main/java/org/elasticsearch/index/analysis/phonetic/Nysiis.java
@@ -263,7 +263,7 @@ public class Nysiis implements StringEncoder {
         str = PAT_DT_ETC.matcher(str).replaceFirst("D");
 
         // First character of key = first character of name.
-        StringBuffer key = new StringBuffer(str.length());
+        StringBuilder key = new StringBuilder(str.length());
         key.append(str.charAt(0));
 
         // Transcode remaining characters, incrementing by one character each time


### PR DESCRIPTION
This removes all instances of StringBuffer that are removeable ~~and marks the remaining usages as suppressed forbidden~~.

Uncontended synchronization in Java is pretty cheap, but it's unnecessary in these cases.
