### PR TITLE
Make exception message more descriptive

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
@@ -80,7 +80,7 @@ public final class InnerHitsContext {
     public void addInnerHitDefinition(BaseInnerHits innerHit) {
         if (innerHits.containsKey(innerHit.getName())) {
             throw new IllegalArgumentException("inner_hit definition with the name [" + innerHit.getName() +
-                    "] already exists. Use a different inner_hit name");
+                    "] already exists. Use a different inner_hit name or define one explicitly");
         }
 
         innerHits.put(innerHit.getName(), innerHit);


### PR DESCRIPTION
Exception message should be more descriptive about what to do when
multiple `inner_hit` names collides.

Fixes https://github.com/elastic/elasticsearch/issues/19142
