### PR TITLE
Use internal from/to when creating InternalDateRange.Bucket

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/InternalDateRange.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/InternalDateRange.java
@@ -64,6 +64,14 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket, I
             return Double.isInfinite(((Number) to).doubleValue()) ? null : new DateTime(((Number) to).longValue(), DateTimeZone.UTC);
         }
 
+        private Double internalGetFrom() {
+            return from;
+        }
+
+        private Double internalGetTo() {
+            return to;
+        }
+
         @Override
         protected InternalRange.Factory<Bucket, ?> getFactory() {
             return FACTORY;
@@ -109,8 +117,8 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket, I
 
         @Override
         public Bucket createBucket(InternalAggregations aggregations, Bucket prototype) {
-            return new Bucket(prototype.getKey(), ((Number) prototype.getFrom()).doubleValue(), ((Number) prototype.getTo()).doubleValue(),
-                    prototype.getDocCount(), aggregations, prototype.getKeyed(), prototype.getFormat());
+            return new Bucket(prototype.getKey(), prototype.internalGetFrom(), prototype.internalGetTo(),
+                prototype.getDocCount(), aggregations, prototype.getKeyed(), prototype.getFormat());
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
@@ -28,9 +28,11 @@ import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
+import org.elasticsearch.search.aggregations.bucket.range.Range;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.joda.time.DateTime;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -42,6 +44,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.dateRange;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorBuilders.bucketScript;
@@ -58,6 +61,7 @@ public class BucketScriptIT extends ESIntegTestCase {
     private static final String FIELD_2_NAME = "field2";
     private static final String FIELD_3_NAME = "field3";
     private static final String FIELD_4_NAME = "field4";
+    private static final String FIELD_5_NAME = "field5";
 
     private static int interval;
     private static int numDocs;
@@ -142,6 +146,7 @@ public class BucketScriptIT extends ESIntegTestCase {
         jsonBuilder.field(FIELD_2_NAME, randomIntBetween(minNumber, maxNumber));
         jsonBuilder.field(FIELD_3_NAME, randomIntBetween(minNumber, maxNumber));
         jsonBuilder.field(FIELD_4_NAME, randomIntBetween(minNumber, maxNumber));
+        jsonBuilder.field(FIELD_5_NAME, DateTime.now());
         jsonBuilder.endObject();
         return jsonBuilder;
     }
@@ -234,6 +239,52 @@ public class BucketScriptIT extends ESIntegTestCase {
                 assertThat(seriesArithmetic, notNullValue());
                 double seriesArithmeticValue = seriesArithmetic.value();
                 assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue / field4SumValue));
+            }
+        }
+    }
+
+    public void testInlineScript3() {
+        SearchResponse response = client()
+            .prepareSearch("idx")
+            .addAggregation(
+                dateRange("range")
+                    .field(FIELD_5_NAME)
+                    .addRange("now-1d", "now")
+                    .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
+                    .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
+                    .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
+                    .subAggregation(
+                        bucketScript("seriesArithmetic",
+                            new Script("_value0 + _value1 + _value2", ScriptType.INLINE, CustomScriptPlugin.NAME, null)
+                            , "field2Sum", "field3Sum", "field4Sum")))
+            .execute().actionGet();
+
+        assertSearchResponse(response);
+
+        Range range = response.getAggregations().get("range");
+        assertThat(range, notNullValue());
+        assertThat(range.getName(), equalTo("range"));
+        List<? extends Range.Bucket> buckets = range.getBuckets();
+
+        for (int i = 0; i < buckets.size(); ++i) {
+            Range.Bucket bucket = buckets.get(i);
+            if (bucket.getDocCount() == 0) {
+                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                assertThat(seriesArithmetic, nullValue());
+            } else {
+                Sum field2Sum = bucket.getAggregations().get("field2Sum");
+                assertThat(field2Sum, notNullValue());
+                double field2SumValue = field2Sum.getValue();
+                Sum field3Sum = bucket.getAggregations().get("field3Sum");
+                assertThat(field3Sum, notNullValue());
+                double field3SumValue = field3Sum.getValue();
+                Sum field4Sum = bucket.getAggregations().get("field4Sum");
+                assertThat(field4Sum, notNullValue());
+                double field4SumValue = field4Sum.getValue();
+                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                assertThat(seriesArithmetic, notNullValue());
+                double seriesArithmeticValue = seriesArithmetic.value();
+                assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
@@ -243,7 +243,7 @@ public class BucketScriptIT extends ESIntegTestCase {
         }
     }
 
-    public void testInlineScript3() {
+    public void testInlineScriptWithDateRange() {
         SearchResponse response = client()
             .prepareSearch("idx")
             .addAggregation(

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
@@ -67,6 +67,7 @@ public class BucketScriptIT extends ESIntegTestCase {
     private static int numDocs;
     private static int minNumber;
     private static int maxNumber;
+    private static long date;
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
@@ -129,6 +130,7 @@ public class BucketScriptIT extends ESIntegTestCase {
         numDocs = randomIntBetween(10, 500);
         minNumber = -200;
         maxNumber = 200;
+        date = randomLong();
 
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int docs = 0; docs < numDocs; docs++) {
@@ -146,7 +148,7 @@ public class BucketScriptIT extends ESIntegTestCase {
         jsonBuilder.field(FIELD_2_NAME, randomIntBetween(minNumber, maxNumber));
         jsonBuilder.field(FIELD_3_NAME, randomIntBetween(minNumber, maxNumber));
         jsonBuilder.field(FIELD_4_NAME, randomIntBetween(minNumber, maxNumber));
-        jsonBuilder.field(FIELD_5_NAME, DateTime.now());
+        jsonBuilder.field(FIELD_5_NAME, date);
         jsonBuilder.endObject();
         return jsonBuilder;
     }
@@ -249,7 +251,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             .addAggregation(
                 dateRange("range")
                     .field(FIELD_5_NAME)
-                    .addRange("now-1d", "now")
+                    .addUnboundedFrom(date)
                     .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
                     .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
                     .subAggregation(sum("field4Sum").field(FIELD_4_NAME))


### PR DESCRIPTION
`InternalDateRange.Factory.createBucket` should use prototype's internal from/to

Fixes https://github.com/elastic/elasticsearch/issues/19364
