### PR TITLE
Mapping updates on objects should propagate `include_an_all`.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -430,6 +430,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
             }
         }
 
+        this.includeInAll = mergeWith.includeInAll;
         if (mergeWith.dynamic != null) {
             this.dynamic = mergeWith.dynamic;
         }


### PR DESCRIPTION
Today you can't update `include_an_all` on an existing object. The bug affects
2.x too.
