### PR TITLE
Switch indices.exists_type from `{index}/{type}` to `{index}/_mapping/{type}`.

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestTypesExistsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestTypesExistsAction.java
@@ -46,7 +46,9 @@ public class RestTypesExistsAction extends BaseRestHandler {
     @Inject
     public RestTypesExistsAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(HEAD, "/{index}/{type}", this);
+        controller.registerWithDeprecatedHandler(
+                HEAD, "/{index}/_mapping/{type}", this,
+                HEAD, "/{index}/{type}", deprecationLogger);
     }
 
     @Override

--- a/docs/reference/indices/indices-exists.asciidoc
+++ b/docs/reference/indices/indices-exists.asciidoc
@@ -5,8 +5,10 @@ Used to check if the index (indices) exists or not. For example:
 
 [source,js]
 --------------------------------------------------
-curl -XHEAD -i 'http://localhost:9200/twitter'
+HEAD twitter
 --------------------------------------------------
+// CONSOLE
+// TEST[setup:twitter]
 
 The HTTP status code indicates if the index exists or not. A `404` means
 it does not exist, and `200` means it does.

--- a/docs/reference/indices/types-exists.asciidoc
+++ b/docs/reference/indices/types-exists.asciidoc
@@ -5,8 +5,10 @@ Used to check if a type/types exists in an index/indices.
 
 [source,js]
 --------------------------------------------------
-curl -XHEAD -i 'http://localhost:9200/twitter/tweet'
+HEAD twitter/_mapping/tweet
 --------------------------------------------------
+// CONSOLE
+// TEST[setup:twitter]
 
 The HTTP status code indicates if the type exists or not. A `404` means
 it does not exist, and `200` means it does.

--- a/docs/reference/migration/migrate_5_0/rest.asciidoc
+++ b/docs/reference/migration/migrate_5_0/rest.asciidoc
@@ -20,6 +20,13 @@ The `GET` HTTP verb for `/_forcemerge` is no longer supported, please use the
 It used to be possible to create an index by either calling `PUT index_name`
 or `POST index_name`. Only the former is now supported.
 
+==== `HEAD {index}/{type}` replaced with `HEAD {index}/_mapping/{type}`
+
+The endpoint for checking whether a type exists has been changed from
+`{index}/{type}` to `{index}/_mapping/{type}` in order to prepare for the
+removal of types when `HEAD {index}/{id}` will be used to check whether a
+document exists in an index. The old endpoint will keep working until 6.0.
+
 ==== Removed `mem` section from `/_cluster/stats` response
 
 The `mem` section contained only one value, the total memory available

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_type.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_type.json
@@ -3,8 +3,8 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html",
     "methods": ["HEAD"],
     "url": {
-      "path": "/{index}/{type}",
-      "paths": ["/{index}/{type}"],
+      "path": "/{index}/_mapping/{type}",
+      "paths": ["/{index}/_mapping/{type}"],
       "parts": {
         "index": {
           "type" : "list",


### PR DESCRIPTION
This will help remove types as we will need `{index}/{id}` to tell whether a
document exists.

Relates #15613
