### PR TITLE
RankEval: Add toXContent method to classes used in ranking request

### DIFF
--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/DiscountedCumulativeGainAt.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/DiscountedCumulativeGainAt.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.ParseFieldMatcherSupplier;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchHit;
 
@@ -179,5 +180,17 @@ public class DiscountedCumulativeGainAt extends RankedListQualityMetric {
 
     public static DiscountedCumulativeGainAt fromXContent(XContentParser parser, ParseFieldMatcherSupplier matcher) {
         return PARSER.apply(parser, matcher);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        builder.field(SIZE_FIELD.getPreferredName(), this.position);
+        builder.field(NORMALIZE_FIELD.getPreferredName(), this.normalize);
+        if (unknownDocRating != null) {
+            builder.field(UNKNOWN_DOC_RATING_FIELD.getPreferredName(), this.unknownDocRating);
+        }
+        builder.endObject();
+        return builder;
     }
 }

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/PrecisionAtN.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/PrecisionAtN.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.ParseFieldMatcherSupplier;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchHit;
 
@@ -148,6 +149,14 @@ public class PrecisionAtN extends RankedListQualityMetric {
             }
             return Rating.IRRELEVANT;
         }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        builder.field(SIZE_FIELD.getPreferredName(), this.n);
+        builder.endObject();
+        return builder;
     }
 
 }

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankedListQualityMetric.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankedListQualityMetric.java
@@ -19,9 +19,11 @@
 
 package org.elasticsearch.index.rankeval;
 
+import org.elasticsearch.action.support.ToXContentToBytes;
 import org.elasticsearch.common.ParseFieldMatcherSupplier;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.search.SearchHit;
@@ -36,7 +38,7 @@ import java.util.List;
  *
  * RelevancyLevel specifies the type of object determining the relevancy level of some known docid.
  * */
-public abstract class RankedListQualityMetric implements NamedWriteable {
+public abstract class RankedListQualityMetric extends ToXContentToBytes implements NamedWriteable {
 
     /**
      * Returns a single metric representing the ranking quality of a set of returned documents
@@ -79,4 +81,7 @@ public abstract class RankedListQualityMetric implements NamedWriteable {
     double combine(Collection<EvalQueryQuality> partialResults) {
         return partialResults.stream().mapToDouble(EvalQueryQuality::getQualityLevel).sum() / partialResults.size();
     }
+
+    @Override
+    public abstract XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException;
 }

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/ReciprocalRank.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/ReciprocalRank.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.ParseFieldMatcherSupplier;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.rankeval.PrecisionAtN.Rating;
 import org.elasticsearch.index.rankeval.PrecisionAtN.RatingMapping;
@@ -141,5 +142,15 @@ public class ReciprocalRank extends RankedListQualityMetric {
 
     public static ReciprocalRank fromXContent(XContentParser parser, ParseFieldMatcherSupplier matcher) {
         return PARSER.apply(parser, matcher);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.startObject(NAME);
+        builder.field(MAX_RANK_FIELD.getPreferredName(), this.maxAcceptableRank);
+        builder.endObject();
+        builder.endObject();
+        return builder;
     }
 }


### PR DESCRIPTION
Working on some helper classes to generate example requests from rated documents we realized it would be good to have the ability to build the ranking evaluation requests in java and output them to Json.This change adds `toXContent()` methods to the relevant classes.
