### PR TITLE
[Doc] Update plugins intro about categories of plugins core/community

### DIFF
--- a/docs/plugins/index.asciidoc
+++ b/docs/plugins/index.asciidoc
@@ -11,13 +11,27 @@ manner. They range from adding custom mapping types, custom analyzers, native
 scripts, custom discovery and more.
 
 Plugins contain JAR files, but may also contain scripts and config files, and
-must be installed on every node in the cluster.  After installation, each
+must be installed on every node in the cluster. After installation, each
 node must be restarted before the plugin becomes visible.
+
+This documentation distinguishes two category of plugins:
+
+Core Plugins::    This category identifies plugins that are part of Elasticsearch
+project. Delivered at the same time as Elasticsearch, their version number always
+match the version number of the search engine. These plugins are maintained by the
+Elastic team with the appreciated help of amazing community members (for open
+source plugins). Issues and bug reports can be reported on the
+https://github.com/elastic/elasticsearch[Github project page].
+
+Community contributed::    This category identifies plugins that are external to
+the Elasticsearch project. They are provided by individual developers or private
+companies and have their own licenses as well as their own versioning system.
+Issues and bug reports can usually be reported on the community plugin's web site.
+
+For advice on writing your own plugin, see <<plugin-authors>>.
 
 IMPORTANT: Site plugins -- plugins containing HTML, CSS and Javascript -- are
 no longer supported.
-
-For advice on writing your own plugin, see <<plugin-authors>>.
 
 include::plugin-script.asciidoc[]
 


### PR DESCRIPTION
Difference between core and community can be obvious for some people but not everybody. Since the plugins documentation always presents plugins as _Core_ and _Community contributed_ maybe we could add a small note in the intro.
