### PR TITLE
Add dotexpander processor

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -1495,3 +1495,115 @@ Converts a string to its uppercase equivalent.
   }
 }
 --------------------------------------------------
+
+[[dot-expand-processor]]
+=== Dot Expander Processor
+
+Expands a field with dots into an object field. This processor allows fields
+with dots in the name to be accessible by other processors in the pipeline.
+Otherwise these <<accessing-data-in-pipelines,fields> can't be accessed by any processor.
+
+[[dot-expender-options]]
+.Dot Expand Options
+[options="header"]
+|======
+| Name     | Required  | Default  | Description
+| `field`  | yes       | -        | The field to expand into an object field
+| `path`   | no        | -        | The field that contains the field to expand. Only required if the field to expand is part another object field, because the `field` option can only understand leaf fields.
+|======
+
+[source,js]
+--------------------------------------------------
+{
+  "dot_expander": {
+    "field": "foo.bar"
+  }
+}
+--------------------------------------------------
+
+For example the dot expand processor would turn this document:
+
+[source,js]
+--------------------------------------------------
+{
+  "foo.bar" : "value"
+}
+--------------------------------------------------
+
+into:
+
+[source,js]
+--------------------------------------------------
+{
+  "foo" : {
+     "bar" : "value"
+  }
+}
+--------------------------------------------------
+
+If there is already a `bar` field nested under `foo` then
+this processor merges the the `foo.bar` field into it. If the field is
+a scalar value then it will turn that field into an array field.
+
+For example, the following document:
+
+[source,js]
+--------------------------------------------------
+{
+  "foo.bar" : "value2",
+  "foo" : {
+    "bar" : "value1"
+  }
+}
+--------------------------------------------------
+
+is transformed by the `dot_expander` processor into:
+
+[source,js]
+--------------------------------------------------
+{
+  "foo" : {
+    "bar" : ["value1", "value2"]
+  }
+}
+--------------------------------------------------
+
+If any field outside of the leaf field conflicts with a pre-existing field of the same name,
+then that field needs to be renamed first.
+
+Consider the following document:
+
+[source,js]
+--------------------------------------------------
+{
+  "foo": "value1",
+  "foo.bar": "value2"
+}
+--------------------------------------------------
+
+Then the the `foo` needs to be renamed first before the `dot_expander`
+processor is applied. So in order for the `foo.bar` field to properly
+be expanded into the `bar` field under the `foo` field the following
+pipeline should be used:
+
+[source,js]
+--------------------------------------------------
+{
+  "processors" : [
+    {
+      "rename" : {
+        "field" : "foo",
+        "target_field" : "foo.bar""
+      }
+    },
+    {
+      "dot_expander": {
+        "field": "foo.bar"
+      }
+    }
+  ]
+}
+--------------------------------------------------
+
+The reason for this is that Ingest doesn't know how to automatically cast
+a scalar field to an object field.

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DotExpanderProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DotExpanderProcessor.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.ingest.common;
+
+import org.elasticsearch.ingest.AbstractProcessor;
+import org.elasticsearch.ingest.ConfigurationUtils;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.Processor;
+
+import java.util.Map;
+
+public final class DotExpanderProcessor extends AbstractProcessor {
+
+    static final String TYPE = "dot_expander";
+
+    private final String path;
+    private final String field;
+
+    DotExpanderProcessor(String tag, String path, String field) {
+        super(tag);
+        this.path = path;
+        this.field = field;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void execute(IngestDocument ingestDocument) throws Exception {
+        String path;
+        Map<String, Object> map;
+        if (this.path != null) {
+            path = this.path + "." + field;
+            map = ingestDocument.getFieldValue(this.path, Map.class);
+        } else {
+            path = field;
+            map = ingestDocument.getSourceAndMetadata();
+        }
+
+        if (ingestDocument.hasField(path)) {
+            Object value = map.remove(field);
+            ingestDocument.appendFieldValue(path, value);
+        } else {
+            // check whether we actually can expand the field in question into an object field.
+            // part of the path may already exist and if part of it would be a value field (string, integer etc.)
+            // then we can't override it with an object field and we should fail with a good reason.
+            // IngestDocument#setFieldValue(...) would fail too, but the error isn't very understandable
+            for (int index = path.indexOf('.'); index != -1; index = path.indexOf('.', index + 1)) {
+                String partialPath = path.substring(0, index);
+                if (ingestDocument.hasField(partialPath)) {
+                    Object val = ingestDocument.getFieldValue(partialPath, Object.class);
+                    if ((val instanceof Map) == false) {
+                        throw new IllegalArgumentException("cannot expend [" + path + "], because [" + partialPath +
+                                "] is not an object field, but a value field");
+                    }
+                } else {
+                    break;
+                }
+            }
+            Object value = map.remove(field);
+            ingestDocument.setFieldValue(path, value);
+        }
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    String getPath() {
+        return path;
+    }
+
+    String getField() {
+        return field;
+    }
+
+    public static final class Factory implements Processor.Factory {
+
+        @Override
+        public Processor create(Map<String, Processor.Factory> processorFactories, String tag,
+                                Map<String, Object> config) throws Exception {
+            String field = ConfigurationUtils.readStringProperty(TYPE, tag, config, "field");
+            if (field.contains(".") == false) {
+                throw ConfigurationUtils.newConfigurationException(ConfigurationUtils.TAG_KEY, tag, "field",
+                        "field does not contain a dot");
+            }
+            if (field.indexOf('.') == 0 || field.lastIndexOf('.') == field.length() - 1) {
+                throw ConfigurationUtils.newConfigurationException(ConfigurationUtils.TAG_KEY, tag, "field",
+                        "Field can't start or end with a dot");
+            }
+            int firstIndex = -1;
+            for (int index = field.indexOf('.'); index != -1; index = field.indexOf('.', index + 1)) {
+                if (index - firstIndex == 1) {
+                    throw ConfigurationUtils.newConfigurationException(ConfigurationUtils.TAG_KEY, tag, "field",
+                            "No space between dots");
+                }
+                firstIndex = index;
+            }
+
+            String path = ConfigurationUtils.readOptionalStringProperty(TYPE, tag, config, "path");
+            return new DotExpanderProcessor(tag, path, field);
+        }
+    }
+}

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/IngestCommonPlugin.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/IngestCommonPlugin.java
@@ -61,6 +61,7 @@ public class IngestCommonPlugin extends Plugin implements IngestPlugin {
         processors.put(SortProcessor.TYPE, new SortProcessor.Factory());
         processors.put(GrokProcessor.TYPE, new GrokProcessor.Factory(builtinPatterns));
         processors.put(ScriptProcessor.TYPE, new ScriptProcessor.Factory(parameters.scriptService));
+        processors.put(DotExpanderProcessor.TYPE, new DotExpanderProcessor.Factory());
         return Collections.unmodifiableMap(processors);
     }
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DotExpanderProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DotExpanderProcessorFactoryTests.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.ingest.common;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class DotExpanderProcessorFactoryTests extends ESTestCase {
+
+    public void testCreate() throws Exception {
+        DotExpanderProcessor.Factory factory = new DotExpanderProcessor.Factory();
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "_field.field");
+        config.put("path", "_path");
+        DotExpanderProcessor processor = (DotExpanderProcessor) factory.create(null, "_tag", config);
+        assertThat(processor.getField(), equalTo("_field.field"));
+        assertThat(processor.getPath(), equalTo("_path"));
+
+        config = new HashMap<>();
+        config.put("field", "_field.field");
+        processor = (DotExpanderProcessor) factory.create(null, "_tag", config);
+        assertThat(processor.getField(), equalTo("_field.field"));
+        assertThat(processor.getPath(), nullValue());
+    }
+
+    public void testValidFields() throws Exception {
+        DotExpanderProcessor.Factory factory = new DotExpanderProcessor.Factory();
+
+        String[] fields = new String[] {"a.b", "a.b.c", "a.b.c.d", "ab.cd"};
+        for (String field : fields) {
+            Map<String, Object> config = new HashMap<>();
+            config.put("field", field);
+            config.put("path", "_path");
+            DotExpanderProcessor processor = (DotExpanderProcessor) factory.create(null, "_tag", config);
+            assertThat(processor.getField(), equalTo(field));
+            assertThat(processor.getPath(), equalTo("_path"));
+        }
+    }
+
+    public void testCreate_fieldMissing() throws Exception {
+        DotExpanderProcessor.Factory factory = new DotExpanderProcessor.Factory();
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("path", "_path");
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> factory.create(null, "_tag", config));
+        assertThat(e.getMessage(), equalTo("[field] required property is missing"));
+    }
+
+    public void testCreate_invalidFields() throws Exception {
+        DotExpanderProcessor.Factory factory = new DotExpanderProcessor.Factory();
+        String[] fields = new String[] {"a", "abc"};
+        for (String field : fields) {
+            Map<String, Object> config = new HashMap<>();
+            config.put("field", field);
+            Exception e = expectThrows(ElasticsearchParseException.class, () -> factory.create(null, "_tag", config));
+            assertThat(e.getMessage(), equalTo("[field] field does not contain a dot"));
+        }
+
+        fields = new String[] {".a", "a.", "."};
+        for (String field : fields) {
+            Map<String, Object> config = new HashMap<>();
+            config.put("field", field);
+            Exception e = expectThrows(ElasticsearchParseException.class, () -> factory.create(null, "_tag", config));
+            assertThat(e.getMessage(), equalTo("[field] Field can't start or end with a dot"));
+        }
+
+        fields = new String[] {"a..b", "a...b", "a.b..c", "abc.def..hij"};
+        for (String field : fields) {
+            Map<String, Object> config = new HashMap<>();
+            config.put("field", field);
+            Exception e = expectThrows(ElasticsearchParseException.class, () -> factory.create(null, "_tag", config));
+            assertThat(e.getMessage(), equalTo("[field] No space between dots"));
+        }
+    }
+
+}

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DotExpanderProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DotExpanderProcessorTests.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.ingest.common;
+
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.Processor;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class DotExpanderProcessorTests extends ESTestCase {
+
+    public void testEscapeFields() throws Exception {
+        Map<String, Object> source = new HashMap<>();
+        source.put("foo.bar", "baz1");
+        IngestDocument document = new IngestDocument(source, Collections.emptyMap());
+        DotExpanderProcessor processor = new DotExpanderProcessor("_tag", null, "foo.bar");
+        processor.execute(document);
+        assertThat(document.getFieldValue("foo", Map.class).size(), equalTo(1));
+        assertThat(document.getFieldValue("foo.bar", String.class), equalTo("baz1"));
+
+        source = new HashMap<>();
+        source.put("foo.bar.baz", "value");
+        document = new IngestDocument(source, Collections.emptyMap());
+        processor = new DotExpanderProcessor("_tag", null, "foo.bar.baz");
+        processor.execute(document);
+        assertThat(document.getFieldValue("foo", Map.class).size(), equalTo(1));
+        assertThat(document.getFieldValue("foo.bar", Map.class).size(), equalTo(1));
+        assertThat(document.getFieldValue("foo.bar.baz", String.class), equalTo("value"));
+
+        source = new HashMap<>();
+        source.put("foo.bar", "baz1");
+        source.put("foo", new HashMap<>(Collections.singletonMap("bar", "baz2")));
+        document = new IngestDocument(source, Collections.emptyMap());
+        processor = new DotExpanderProcessor("_tag", null, "foo.bar");
+        processor.execute(document);
+        assertThat(document.getSourceAndMetadata().size(), equalTo(1));
+        assertThat(document.getFieldValue("foo.bar", List.class).size(), equalTo(2));
+        assertThat(document.getFieldValue("foo.bar.0", String.class), equalTo("baz2"));
+        assertThat(document.getFieldValue("foo.bar.1", String.class), equalTo("baz1"));
+
+        source = new HashMap<>();
+        source.put("foo.bar", "2");
+        source.put("foo", new HashMap<>(Collections.singletonMap("bar", 1)));
+        document = new IngestDocument(source, Collections.emptyMap());
+        processor = new DotExpanderProcessor("_tag", null, "foo.bar");
+        processor.execute(document);
+        assertThat(document.getSourceAndMetadata().size(), equalTo(1));
+        assertThat(document.getFieldValue("foo.bar", List.class).size(), equalTo(2));
+        assertThat(document.getFieldValue("foo.bar.0", Integer.class), equalTo(1));
+        assertThat(document.getFieldValue("foo.bar.1", String.class), equalTo("2"));
+    }
+
+    public void testEscapeFields_valueField() throws Exception {
+        Map<String, Object> source = new HashMap<>();
+        source.put("foo.bar", "baz1");
+        source.put("foo", "baz2");
+        IngestDocument document1 = new IngestDocument(source, Collections.emptyMap());
+        Processor processor1 = new DotExpanderProcessor("_tag", null, "foo.bar");
+        // foo already exists and if a leaf field and therefor can't be replaced by a map field:
+        Exception e = expectThrows(IllegalArgumentException.class, () -> processor1.execute(document1));
+        assertThat(e.getMessage(), equalTo("cannot expend [foo.bar], because [foo] is not an object field, but a value field"));
+
+        // so because foo is no branch field but a value field the `foo.bar` field can't be expanded
+        // into [foo].[bar], so foo should be renamed first into `[foo].[bar]:
+        IngestDocument document = new IngestDocument(source, Collections.emptyMap());
+        Processor processor = new RenameProcessor("_tag", "foo", "foo.bar");
+        processor.execute(document);
+        processor = new DotExpanderProcessor("_tag", null, "foo.bar");
+        processor.execute(document);
+        assertThat(document.getFieldValue("foo", Map.class).size(), equalTo(1));
+        assertThat(document.getFieldValue("foo.bar.0", String.class), equalTo("baz2"));
+        assertThat(document.getFieldValue("foo.bar.1", String.class), equalTo("baz1"));
+
+        source = new HashMap<>();
+        source.put("foo.bar", "baz1");
+        document = new IngestDocument(source, Collections.emptyMap());
+        processor = new DotExpanderProcessor("_tag", null, "foo.bar");
+        processor.execute(document);
+        assertThat(document.getFieldValue("foo", Map.class).size(), equalTo(1));
+        assertThat(document.getFieldValue("foo.bar", String.class), equalTo("baz1"));
+
+        source = new HashMap<>();
+        source.put("foo.bar.baz", "baz1");
+        source.put("foo", new HashMap<>(Collections.singletonMap("bar", new HashMap<>())));
+        document = new IngestDocument(source, Collections.emptyMap());
+        processor = new DotExpanderProcessor("_tag", null, "foo.bar.baz");
+        processor.execute(document);
+        assertThat(document.getFieldValue("foo", Map.class).size(), equalTo(1));
+        assertThat(document.getFieldValue("foo.bar", Map.class).size(), equalTo(1));
+        assertThat(document.getFieldValue("foo.bar.baz", String.class), equalTo("baz1"));
+
+        source = new HashMap<>();
+        source.put("foo.bar.baz", "baz1");
+        source.put("foo", new HashMap<>(Collections.singletonMap("bar", "baz2")));
+        IngestDocument document2 = new IngestDocument(source, Collections.emptyMap());
+        Processor processor2 = new DotExpanderProcessor("_tag", null, "foo.bar.baz");
+        e = expectThrows(IllegalArgumentException.class, () -> processor2.execute(document2));
+        assertThat(e.getMessage(), equalTo("cannot expend [foo.bar.baz], because [foo.bar] is not an object field, but a value field"));
+    }
+
+    public void testEscapeFields_path() throws Exception {
+        Map<String, Object> source = new HashMap<>();
+        source.put("foo", new HashMap<>(Collections.singletonMap("bar.baz", "value")));
+        IngestDocument document = new IngestDocument(source, Collections.emptyMap());
+        DotExpanderProcessor processor = new DotExpanderProcessor("_tag", "foo", "bar.baz");
+        processor.execute(document);
+        assertThat(document.getFieldValue("foo", Map.class).size(), equalTo(1));
+        assertThat(document.getFieldValue("foo.bar", Map.class).size(), equalTo(1));
+        assertThat(document.getFieldValue("foo.bar.baz", String.class), equalTo("value"));
+
+        source = new HashMap<>();
+        source.put("field", new HashMap<>(Collections.singletonMap("foo.bar.baz", "value")));
+        document = new IngestDocument(source, Collections.emptyMap());
+        processor = new DotExpanderProcessor("_tag", "field", "foo.bar.baz");
+        processor.execute(document);
+        assertThat(document.getFieldValue("field.foo", Map.class).size(), equalTo(1));
+        assertThat(document.getFieldValue("field.foo.bar", Map.class).size(), equalTo(1));
+        assertThat(document.getFieldValue("field.foo.bar.baz", String.class), equalTo("value"));
+    }
+
+}

--- a/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/10_basic.yaml
+++ b/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/10_basic.yaml
@@ -13,17 +13,18 @@
     - match:  { nodes.$master.ingest.processors.1.type: convert }
     - match:  { nodes.$master.ingest.processors.2.type: date }
     - match:  { nodes.$master.ingest.processors.3.type: date_index_name }
-    - match:  { nodes.$master.ingest.processors.4.type: fail }
-    - match:  { nodes.$master.ingest.processors.5.type: foreach }
-    - match:  { nodes.$master.ingest.processors.6.type: grok }
-    - match:  { nodes.$master.ingest.processors.7.type: gsub }
-    - match:  { nodes.$master.ingest.processors.8.type: join }
-    - match:  { nodes.$master.ingest.processors.9.type: lowercase }
-    - match:  { nodes.$master.ingest.processors.10.type: remove }
-    - match:  { nodes.$master.ingest.processors.11.type: rename }
-    - match:  { nodes.$master.ingest.processors.12.type: script }
-    - match:  { nodes.$master.ingest.processors.13.type: set }
-    - match:  { nodes.$master.ingest.processors.14.type: sort }
-    - match:  { nodes.$master.ingest.processors.15.type: split }
-    - match:  { nodes.$master.ingest.processors.16.type: trim }
-    - match:  { nodes.$master.ingest.processors.17.type: uppercase }
+    - match:  { nodes.$master.ingest.processors.4.type: dot_expander }
+    - match:  { nodes.$master.ingest.processors.5.type: fail }
+    - match:  { nodes.$master.ingest.processors.6.type: foreach }
+    - match:  { nodes.$master.ingest.processors.7.type: grok }
+    - match:  { nodes.$master.ingest.processors.8.type: gsub }
+    - match:  { nodes.$master.ingest.processors.9.type: join }
+    - match:  { nodes.$master.ingest.processors.10.type: lowercase }
+    - match:  { nodes.$master.ingest.processors.11.type: remove }
+    - match:  { nodes.$master.ingest.processors.12.type: rename }
+    - match:  { nodes.$master.ingest.processors.13.type: script }
+    - match:  { nodes.$master.ingest.processors.14.type: set }
+    - match:  { nodes.$master.ingest.processors.15.type: sort }
+    - match:  { nodes.$master.ingest.processors.16.type: split }
+    - match:  { nodes.$master.ingest.processors.17.type: trim }
+    - match:  { nodes.$master.ingest.processors.18.type: uppercase }

--- a/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/130_escape_dot.yaml
+++ b/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/130_escape_dot.yaml
@@ -1,0 +1,40 @@
+---
+teardown:
+  - do:
+      ingest.delete_pipeline:
+        id: "1"
+        ignore: 404
+
+---
+"Test escape_dot processor":
+  - do:
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "dot_expander" : {
+                  "field" : "foo.bar"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        type: test
+        id: 1
+        pipeline: "1"
+        body: {
+          foo.bar: "baz"
+        }
+
+  - do:
+      get:
+        index: test
+        type: test
+        id: 1
+  - match: { _source.foo.bar: "baz" }


### PR DESCRIPTION
Adds a processor the turns fields with dots into object fields, so that other processors can clean the data up before indexing.
