### PR TITLE
Removes space between # and the setting in elasticsearch.yml

### DIFF
--- a/distribution/src/main/resources/config/elasticsearch.yml
+++ b/distribution/src/main/resources/config/elasticsearch.yml
@@ -14,33 +14,33 @@
 #
 # Use a descriptive name for your cluster:
 #
-# cluster.name: my-application
+#cluster.name: my-application
 #
 # ------------------------------------ Node ------------------------------------
 #
 # Use a descriptive name for the node:
 #
-# node.name: node-1
+#node.name: node-1
 #
 # Add custom attributes to the node:
 #
-# node.rack: r1
+#node.rack: r1
 #
 # ----------------------------------- Paths ------------------------------------
 #
 # Path to directory where to store the data (separate multiple locations by comma):
 #
-# path.data: /path/to/data
+#path.data: /path/to/data
 #
 # Path to log files:
 #
-# path.logs: /path/to/logs
+#path.logs: /path/to/logs
 #
 # ----------------------------------- Memory -----------------------------------
 #
 # Lock the memory on startup:
 #
-# bootstrap.memory_lock: true
+#bootstrap.memory_lock: true
 #
 # Make sure that the heap size is set to about half the memory available
 # on the system and that the owner of the process is allowed to use this
@@ -52,11 +52,11 @@
 #
 # Set the bind address to a specific IP (IPv4 or IPv6):
 #
-# network.host: 192.168.0.1
+#network.host: 192.168.0.1
 #
 # Set a custom port for HTTP:
 #
-# http.port: 9200
+#http.port: 9200
 #
 # For more information, see the documentation at:
 # <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html>
@@ -66,11 +66,11 @@
 # Pass an initial list of hosts to perform discovery when new node is started:
 # The default list of hosts is ["127.0.0.1", "[::1]"]
 #
-# discovery.zen.ping.unicast.hosts: ["host1", "host2"]
+#discovery.zen.ping.unicast.hosts: ["host1", "host2"]
 #
 # Prevent the "split brain" by configuring the majority of nodes (total number of nodes / 2 + 1):
 #
-# discovery.zen.minimum_master_nodes: 3
+#discovery.zen.minimum_master_nodes: 3
 #
 # For more information, see the documentation at:
 # <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery.html>
@@ -79,7 +79,7 @@
 #
 # Block initial recovery after a full cluster restart until N nodes are started:
 #
-# gateway.recover_after_nodes: 3
+#gateway.recover_after_nodes: 3
 #
 # For more information, see the documentation at:
 # <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html>
@@ -88,8 +88,8 @@
 #
 # Disable starting multiple nodes on a single system:
 #
-# node.max_local_storage_nodes: 1
+#node.max_local_storage_nodes: 1
 #
 # Require explicit names when deleting indices:
 #
-# action.destructive_requires_name: true
+#action.destructive_requires_name: true


### PR DESCRIPTION
Removes the whitespace between the # (to comment out) and
the setting in elasticsearch.yml, so that when a user uncomments
out a setting by just removing the #, the setting actually
takes effect. Before, it was very easy to uncomment out a
setting by just removing the #, leaving a single whitespace
character before the setting name, which would cause the
setting to not get picked up by Elasticsearch.

Closes #20090
