### PR TITLE
[Test] Improve AbstractQueryTestCase.unknownObjectExceptionTest()

### DIFF
--- a/test/framework/src/test/java/org/elasticsearch/test/AbstractQueryTestCaseTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/AbstractQueryTestCaseTests.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.util.set.Sets;
+import org.hamcrest.Matcher;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.singleton;
+import static org.elasticsearch.test.AbstractQueryTestCase.alterateQueries;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Various test for {@link org.elasticsearch.test.AbstractQueryTestCase}
+ */
+public class AbstractQueryTestCaseTests extends ESTestCase {
+
+    public void testAlterateQueries() throws IOException {
+        List<Tuple<String, Boolean>> alterations = alterateQueries(singleton("{\"field\": \"value\"}"), null);
+        assertAlterations(alterations, allOf(notNullValue(), hasEntry("{\"newField\":{\"field\":\"value\"}}", true)));
+
+        alterations = alterateQueries(singleton("{\"term\":{\"field\": \"value\"}}"), null);
+        assertAlterations(alterations, allOf(
+            hasEntry("{\"newField\":{\"term\":{\"field\":\"value\"}}}", true),
+            hasEntry("{\"term\":{\"newField\":{\"field\":\"value\"}}}", true))
+        );
+
+        alterations = alterateQueries(singleton("{\"bool\":{\"must\": [{\"match\":{\"field\":\"value\"}}]}}"), null);
+        assertAlterations(alterations, allOf(
+                hasEntry("{\"newField\":{\"bool\":{\"must\":[{\"match\":{\"field\":\"value\"}}]}}}", true),
+                hasEntry("{\"bool\":{\"newField\":{\"must\":[{\"match\":{\"field\":\"value\"}}]}}}", true),
+                hasEntry("{\"bool\":{\"must\":[{\"newField\":{\"match\":{\"field\":\"value\"}}}]}}", true),
+                hasEntry("{\"bool\":{\"must\":[{\"match\":{\"newField\":{\"field\":\"value\"}}}]}}", true)
+        ));
+    }
+
+    public void testAlterateQueriesWithArbitraryContent() throws IOException {
+        Set<String> arbitraryContentHolders = Sets.newHashSet("params", "doc");
+        Set<String> queries = Sets.newHashSet(
+                "{\"query\":{\"script\":\"test\",\"params\":{\"foo\":\"bar\"}}}",
+                "{\"query\":{\"more_like_this\":{\"fields\":[\"a\",\"b\"],\"like\":{\"doc\":{\"c\":\"d\"}}}}}"
+        );
+
+        List<Tuple<String, Boolean>> alterations = alterateQueries(queries, arbitraryContentHolders);
+        assertAlterations(alterations, allOf(
+            hasEntry("{\"newField\":{\"query\":{\"script\":\"test\",\"params\":{\"foo\":\"bar\"}}}}", true),
+            hasEntry("{\"query\":{\"newField\":{\"script\":\"test\",\"params\":{\"foo\":\"bar\"}}}}", true),
+            hasEntry("{\"query\":{\"script\":\"test\",\"params\":{\"newField\":{\"foo\":\"bar\"}}}}", false)
+        ));
+        assertAlterations(alterations, allOf(
+            hasEntry("{\"newField\":{\"query\":{\"more_like_this\":{\"fields\":[\"a\",\"b\"],\"like\":{\"doc\":{\"c\":\"d\"}}}}}}", true),
+            hasEntry("{\"query\":{\"newField\":{\"more_like_this\":{\"fields\":[\"a\",\"b\"],\"like\":{\"doc\":{\"c\":\"d\"}}}}}}", true),
+            hasEntry("{\"query\":{\"more_like_this\":{\"newField\":{\"fields\":[\"a\",\"b\"],\"like\":{\"doc\":{\"c\":\"d\"}}}}}}", true),
+            hasEntry("{\"query\":{\"more_like_this\":{\"fields\":[\"a\",\"b\"],\"like\":{\"newField\":{\"doc\":{\"c\":\"d\"}}}}}}", true),
+            hasEntry("{\"query\":{\"more_like_this\":{\"fields\":[\"a\",\"b\"],\"like\":{\"doc\":{\"newField\":{\"c\":\"d\"}}}}}}", false)
+        ));
+    }
+
+    private static <K, V> void assertAlterations(List<Tuple<K, V>> alterations, Matcher<Map<K, V>> matcher) {
+        assertThat(alterations.stream().collect(Collectors.toMap(Tuple::v1, Tuple::v2)), matcher);
+    }
+}


### PR DESCRIPTION
The method `AbstractQueryTestCase.unknownObjectExceptionTest()` uses heavy string concatenation to modify and insert new field in a valid query. Unfortunately it fails when a randomized string value contains a `"`. Since the test method is hard to understand and maintain, this PR changes it to a XContent based parsing and generating.

This has been detected by CI:

> REPRODUCE WITH: gradle :core:test -Dtests.seed=5284243AD94E27EC -Dtests.class=org.elasticsearch.index.query.SpanOrQueryBuilderTests -Dtests.method="testUnknownObjectException" -Dtests.security.manager=true -Dtests.locale=lv -Dtests.timezone=Canada/Yukon
> Suite: org.elasticsearch.index.query.SpanOrQueryBuilderTests
>   1> [2016-08-19 09:20:55,894][INFO ][org.elasticsearch.cluster.service] new_master {node}{vb3qT855T--Ej-ybWKgRsw}{local}{local[816]}, reason: test setting state
>   1> [2016-08-19 09:20:55,895][INFO ][org.elasticsearch.plugins] [class org.elasticsearch.test.AbstractQueryTestCase] no modules loaded
>   1> [2016-08-19 09:20:55,895][INFO ][org.elasticsearch.plugins] [class org.elasticsearch.test.AbstractQueryTestCase] no plugins loaded
> ERROR   0.01s J1 | SpanOrQueryBuilderTests.testUnknownObjectException <<< FAILURES!
> Throwable #1: com.fasterxml.jackson.core.io.JsonEOFException: Unexpected end-of-input within/between Object entries
>  at [Source: { "newField" : ; line: 1, column: 31]
>    at __randomizedtesting.SeedInfo.seed([5284243AD94E27EC:FA9AD57BE440E8EE]:0)
>    at com.fasterxml.jackson.core.base.ParserMinimalBase._reportInvalidEOF(ParserMinimalBase.java:483)
>    at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._skipColon2(ReaderBasedJsonParser.java:2229)
>    at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._skipColon(ReaderBasedJsonParser.java:2141)
>   2> NOTE: leaving temporary files on disk at: /usr/share/elasticsearch/escheckout/core/build/testrun/test/J1/temp/org.elasticsearch.index.query.SpanOrQueryBuilderTests_5284243AD94E27EC-001
>    at com.fasterxml.jackson.core.json.ReaderBasedJsonParser.nextToken(ReaderBasedJsonParser.java:687)
>    at org.elasticsearch.common.xcontent.json.JsonXContentParser.nextToken(JsonXContentParser.java:52)
>    at org.elasticsearch.index.query.QueryParseContext.parseInnerQueryBuilder(QueryParseContext.java:96)
>   2> NOTE: test params are: codec=Asserting(Lucene60): {}, docValues:{}, maxPointsInLeafNode=1463, maxMBSortInHeap=7.289747265721868, sim=ClassicSimilarity, locale=lv, timezone=Canada/Yukon
>   2> NOTE: Linux 4.4.0-31-generic amd64/Oracle Corporation 1.8.0_92-internal (64-bit)/cpus=4,threads=1,free=451550800,total=530055168
>    at org.elasticsearch.test.AbstractQueryTestCase.parseQuery(AbstractQueryTestCase.java:566)
>    at org.elasticsearch.test.AbstractQueryTestCase.parseQuery(AbstractQueryTestCase.java:552)
>    at org.elasticsearch.test.AbstractQueryTestCase.parseQuery(AbstractQueryTestCase.java:547)
>    at org.elasticsearch.test.AbstractQueryTestCase.unknownObjectExceptionTest(AbstractQueryTestCase.java:436)
>    at org.elasticsearch.test.AbstractQueryTestCase.testUnknownObjectException(AbstractQueryTestCase.java:321)
>    at java.lang.Thread.run(Thread.java:745) 

Related to #19864
