### PR TITLE
Add ref-counting to SearchContext to prevent accessing already closed readers

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -1671,8 +1671,8 @@ public class TranslogTests extends ESTestCase {
             }
             boolean atLeastOneFailed = false;
             for (Throwable ex : threadExceptions) {
-                assertTrue(ex.toString(), ex instanceof IOException || ex instanceof AlreadyClosedException);
                 if (ex != null) {
+                    assertTrue(ex.toString(), ex instanceof IOException || ex instanceof AlreadyClosedException);
                     atLeastOneFailed = true;
                 }
             }


### PR DESCRIPTION
When a SearchContext is closed it's reader / searcher reference is closed too.
If this happens while a search is accessing it's reader reference it can lead
to an unexpected `AlreadyClosedException` or worst case, an already closed MMapDirectory
is access causing a `SIGSEV` like in #20008 (even though the window for this is very small).

SearchContext can be closed concurrently if:
- an index is deleted / removed from the node
- a search context is idle for too long and is cleaned by the reaper
- an explicit freeContext message is received

This change adds reference counting to the SearchContext base class and it's used
inside SearchService each time the context is accessed.

Relates to #20008
Backport of #20095
