### PR TITLE
Un-final Core REST Client classes

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/Response.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/Response.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * Holds an elasticsearch response. It wraps the {@link HttpResponse} returned and associates it with
  * its corresponding {@link RequestLine} and {@link HttpHost}.
  */
-public final class Response {
+public class Response {
 
     private final RequestLine requestLine;
     private final HttpHost host;

--- a/client/rest/src/main/java/org/elasticsearch/client/ResponseException.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/ResponseException.java
@@ -33,7 +33,7 @@ public final class ResponseException extends IOException {
 
     private Response response;
 
-    ResponseException(Response response) throws IOException {
+    public ResponseException(Response response) throws IOException {
         super(buildMessage(response));
         this.response = response;
     }

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -77,7 +77,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * Requests can be traced by enabling trace logging for "tracer". The trace logger outputs requests and responses in curl format.
  */
-public final class RestClient implements Closeable {
+public class RestClient implements Closeable {
 
     private static final Log logger = LogFactory.getLog(RestClient.class);
 

--- a/client/sniffer/src/main/java/org/elasticsearch/client/sniff/Sniffer.java
+++ b/client/sniffer/src/main/java/org/elasticsearch/client/sniff/Sniffer.java
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * {@link RestClientBuilder#setFailureListener(RestClient.FailureListener)}. The Sniffer implementation needs to be lazily set to the
  * previously created SniffOnFailureListener through {@link SniffOnFailureListener#setSniffer(Sniffer)}.
  */
-public final class Sniffer implements Closeable {
+public class Sniffer implements Closeable {
 
     private static final Log logger = LogFactory.getLog(Sniffer.class);
 


### PR DESCRIPTION
This removes `final` from the `RestClient`, `Response`, and `Sniffer` classes so that outside code can mock them. Their constructors are already package private, so there's not much that can go wrong.
