### PR TITLE
Generate date ranges in a way that is more friendly to the cache.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -355,8 +355,8 @@ public class DateFieldMapper extends FieldMapper {
             // By default we split date ranges into a large static part that is
             // likely to be reused, and smaller parts that will not be cached
             // but should execute quickly since they match few docs
-            // for instance [NOW-1M TO NOW] would be rewritten to
-            // [NOW-1M TO NOW-1M+1H/H] OR [NOW-1M+1H/H TO NOW/H] OR [NOW/H TO NOW]
+            // for instance [now-1M TO now] would be rewritten to
+            // [now-1M TO  now-1M/H] OR [now-1M/H TO now/H] OR [now/H TO now]
             // This way, the middle query can be reused for one hour
             DateTimeField hour = ISOChronology.getInstanceUTC().hourOfDay();
             long l1 = l;

--- a/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.LegacyNumericRangeQuery;
 import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
@@ -329,8 +330,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 "    }\n" +
                 "}";
         Query parsedQuery = parseQuery(query).toQuery(createShardContext()).rewrite(null);
-        if (parsedQuery instanceof PointRangeQuery) {
-            // TODO what can we assert
+        if (parsedQuery instanceof PointRangeQuery || parsedQuery instanceof ConstantScoreQuery) {
+            // TODO 5.x index, what can we assert
         } else {
             assertThat(parsedQuery, instanceOf(LegacyNumericRangeQuery.class));
 


### PR DESCRIPTION
This commit uses rounding in order to improve the cacheability of date ranges.
For instance, `[now-1M TO now]` would actually be parsed as
`[now-1M TO now-1M/H] OR [now-1M/H TO now/H] OR [now/H TO now]`. The clause in
the middle of the disjunction has rounded bounds, which makes it more likely to
be cached. The two outer clauses are unlikely to get cached, but since the match
less than one hour of data each, they should execute quickly anyway.

In the case that the range query is already rounded at a granularity greater
than or equal to one hour, the query is left as-is. So for instance, this query:
`[now-2M/d TO now/d]` would be executed as-is without being split in 3
components like the previous query.

Closes #20106
