### PR TITLE
Increase the size of the history that the query cache tracks.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -266,7 +266,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         if (IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.get(settings)) {
             cachingPolicy = QueryCachingPolicy.ALWAYS_CACHE;
         } else {
-            cachingPolicy = new UsageTrackingQueryCachingPolicy();
+            // track the 1024 most recently seen filters, this requires about
+            // 22kb of memory
+            cachingPolicy = new UsageTrackingQueryCachingPolicy(1024);
         }
         indexShardOperationsLock = new IndexShardOperationsLock(shardId, logger, threadPool);
         searcherWrapper = indexSearcherWrapper;


### PR DESCRIPTION
The current value is 256 which is conservative. There have been a couple cases
that indicated that it might be too low to allow caching at all in the case of
queries that are composed of tens of filters, so I would like to experiment
with a slightly higher value: 1024.
