### PR TITLE
Use `refresh=true` in mapping/fields examples

### DIFF
--- a/docs/reference/mapping/fields/field-names-field.asciidoc
+++ b/docs/reference/mapping/fields/field-names-field.asciidoc
@@ -6,7 +6,7 @@ contains any value other than `null`.  This field is used by the
 <<query-dsl-exists-query,`exists`>> query to find documents that
 either have or don't have any non-+null+ value for a particular field.
 
-The value of the `_field_name` field is accessible in queries and scripts:
+The value of the `_field_name` field is accessible in queries:
 
 [source,js]
 --------------------------
@@ -16,7 +16,7 @@ PUT my_index/my_type/1
   "title": "This is a document"
 }
 
-PUT my_index/my_type/1
+PUT my_index/my_type/2?refresh=true
 {
   "title": "This is another document",
   "body": "This document has a body"
@@ -28,14 +28,6 @@ GET my_index/_search
     "terms": {
       "_field_names": [ "title" ] <1>
     }
-  },
-  "script_fields": {
-    "Field names": {
-      "script": {
-        "lang": "painless",
-        "inline": "doc['_field_names']" <2>
-      }
-    }
   }
 }
 
@@ -43,4 +35,3 @@ GET my_index/_search
 // CONSOLE
 
 <1> Querying on the `_field_names` field (also see the <<query-dsl-exists-query,`exists`>> query)
-<2> Accessing the `_field_names` field in scripts

--- a/docs/reference/mapping/fields/id-field.asciidoc
+++ b/docs/reference/mapping/fields/id-field.asciidoc
@@ -19,7 +19,7 @@ PUT my_index/my_type/1
   "text": "Document with ID 1"
 }
 
-PUT my_index/my_type/2
+PUT my_index/my_type/2&refresh=true
 {
   "text": "Document with ID 2"
 }

--- a/docs/reference/mapping/fields/index-field.asciidoc
+++ b/docs/reference/mapping/fields/index-field.asciidoc
@@ -21,7 +21,7 @@ PUT index_1/my_type/1
   "text": "Document in index 1"
 }
 
-PUT index_2/my_type/2
+PUT index_2/my_type/2?refresh=true
 {
   "text": "Document in index 2"
 }

--- a/docs/reference/mapping/fields/parent-field.asciidoc
+++ b/docs/reference/mapping/fields/parent-field.asciidoc
@@ -28,7 +28,7 @@ PUT my_index/my_child/2?parent=1 <3>
   "text": "This is a child document"
 }
 
-PUT my_index/my_child/3?parent=1 <3>
+PUT my_index/my_child/3?parent=1&refresh=true <3>
 {
   "text": "This is another child document"
 }

--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -14,7 +14,7 @@ value per document.  For instance:
 
 [source,js]
 ------------------------------
-PUT my_index/my_type/1?routing=user1 <1>
+PUT my_index/my_type/1?routing=user1&refresh=true <1>
 {
   "title": "This is a document"
 }
@@ -29,7 +29,7 @@ GET my_index/my_type/1?routing=user1 <2>
     <<docs-get,getting>>, <<docs-delete,deleting>>, or <<docs-update,updating>>
     the document.
 
-The value of the `_routing` field is accessible in queries and scripts:
+The value of the `_routing` field is accessible in queries:
 
 [source,js]
 --------------------------
@@ -39,22 +39,12 @@ GET my_index/_search
     "terms": {
       "_routing": [ "user1" ] <1>
     }
-  },
-  "script_fields": {
-    "Routing value": {
-      "script": {
-        "lang": "painless",
-        "inline": "doc['_routing']" <2>
-      }
-    }
   }
 }
 --------------------------
 // CONSOLE
 
 <1> Querying on the `_routing` field (also see the <<query-dsl-ids-query,`ids` query>>)
-<2> Accessing the `_routing` field in scripts
-
 
 ==== Searching with custom routing
 

--- a/docs/reference/mapping/fields/type-field.asciidoc
+++ b/docs/reference/mapping/fields/type-field.asciidoc
@@ -16,7 +16,7 @@ PUT my_index/type_1/1
   "text": "Document with type 1"
 }
 
-PUT my_index/type_2/2
+PUT my_index/type_2/2?refresh=true
 {
   "text": "Document with type 2"
 }

--- a/docs/reference/mapping/fields/uid-field.asciidoc
+++ b/docs/reference/mapping/fields/uid-field.asciidoc
@@ -16,7 +16,7 @@ PUT my_index/my_type/1
   "text": "Document with ID 1"
 }
 
-PUT my_index/my_type/2
+PUT my_index/my_type/2?refresh=true
 {
   "text": "Document with ID 2"
 }


### PR DESCRIPTION
Fix field examples to make documents actually visible

This commit adds refresh calls to field examples an removes not working
`_routing` and `_field_names` script access.

Closes #20118

fix docs
