### PR TITLE
Fix RAM usage estimation of LiveVersionMap.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/engine/DeleteVersionValue.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/DeleteVersionValue.java
@@ -19,11 +19,15 @@
 
 package org.elasticsearch.index.engine;
 
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.index.translog.Translog;
 
 /** Holds a deleted version, which just adds a timestamp to {@link VersionValue} so we know when we can expire the deletion. */
 
 class DeleteVersionValue extends VersionValue {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(DeleteVersionValue.class);
+
     private final long time;
 
     public DeleteVersionValue(long version, long time, Translog.Location translogLocation) {
@@ -43,6 +47,7 @@ class DeleteVersionValue extends VersionValue {
 
     @Override
     public long ramBytesUsed() {
-        return super.ramBytesUsed() + Long.BYTES;
+        Translog.Location translogLocation = translogLocation();
+        return BASE_RAM_BYTES_USED + (translogLocation != null ? translogLocation.ramBytesUsed() : 0);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
@@ -59,26 +59,37 @@ class LiveVersionMap implements ReferenceManager.RefreshListener, Accountable {
 
     private volatile Maps maps = new Maps();
 
-    private ReferenceManager mgr;
+    private ReferenceManager<?> mgr;
 
     /** Bytes consumed for each BytesRef UID:
-     *
-     *  NUM_BYTES_OBJECT_HEADER + 2*NUM_BYTES_INT + NUM_BYTES_OBJECT_REF + NUM_BYTES_ARRAY_HEADER [ + bytes.length] */
-    private static final int BASE_BYTES_PER_BYTESREF = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER +
-        2*Integer.BYTES +
-        RamUsageEstimator.NUM_BYTES_OBJECT_REF + 
-        RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+     * In this base value, we account for the {@link BytesRef} object itself as
+     * well as the header of the byte[] array it holds, and some lost bytes due
+     * to object alignment. So consumers of this constant just have to add the
+     * length of the byte[] (assuming it is not shared between multiple
+     * instances). */
+    private static final long BASE_BYTES_PER_BYTESREF =
+            // shallow memory usage of the BytesRef object
+            RamUsageEstimator.shallowSizeOfInstance(BytesRef.class) +
+            // header of the byte[] array
+            RamUsageEstimator.NUM_BYTES_ARRAY_HEADER +
+            // with an alignment size (-XX:ObjectAlignmentInBytes) of 8 (default),
+            // there could be between 0 and 7 lost bytes, so we account for 3
+            // lost bytes on average
+            3;
 
-    /** Bytes used by having CHM point to a key/value:
-     *
-     *  CHM.Entry:
-     *     + NUM_BYTES_OBJECT_HEADER + 3*NUM_BYTES_OBJECT_REF + NUM_BYTES_INT
-     *
-     *  CHM's pointer to CHM.Entry, double for approx load factor:
-     *     + 2*NUM_BYTES_OBJECT_REF */
-    private static final int BASE_BYTES_PER_CHM_ENTRY = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER +
-        Integer.BYTES +
-        5*RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+    /** Bytes used by having CHM point to a key/value. */
+    private static final long BASE_BYTES_PER_CHM_ENTRY;
+    static {
+        // use the same impl as the Maps does
+        Map<Integer, Integer> map = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+        map.put(0, 0);
+        long chmEntryShallowSize = RamUsageEstimator.shallowSizeOf(map.entrySet().iterator().next());
+        // assume a load factor of 50%
+        // for each entry, we need two object refs, one for the entry itself
+        // and one for the free space that is due to the fact hash tables can
+        // not be fully loaded
+        BASE_BYTES_PER_CHM_ENTRY = chmEntryShallowSize + 2 * RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+    }
 
     /** Tracks bytes used by current map, i.e. what is freed on refresh. For deletes, which are also added to tombstones, we only account
      *  for the CHM entry here, and account for BytesRef/VersionValue against the tombstones, since refresh would not clear this RAM. */
@@ -88,7 +99,7 @@ class LiveVersionMap implements ReferenceManager.RefreshListener, Accountable {
     final AtomicLong ramBytesUsedTombstones = new AtomicLong();
 
     /** Sync'd because we replace old mgr. */
-    synchronized void setManager(ReferenceManager newMgr) {
+    synchronized void setManager(ReferenceManager<?> newMgr) {
         if (mgr != null) {
             mgr.removeListener(this);
         }
@@ -146,7 +157,7 @@ class LiveVersionMap implements ReferenceManager.RefreshListener, Accountable {
 
     /** Adds this uid/version to the pending adds map. */
     void putUnderLock(BytesRef uid, VersionValue version) {
-
+        assert uid.bytes.length == uid.length : "Oversized _uid! UID length: " + uid.length + ", bytes length: " + uid.bytes.length;
         long uidRAMBytesUsed = BASE_BYTES_PER_BYTESREF + uid.bytes.length;
 
         final VersionValue prev = maps.current.put(uid, version);

--- a/core/src/main/java/org/elasticsearch/index/engine/VersionValue.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/VersionValue.java
@@ -28,6 +28,8 @@ import java.util.Collections;
 
 class VersionValue implements Accountable {
 
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(VersionValue.class);
+
     private final long version;
     private final Translog.Location translogLocation;
 
@@ -54,8 +56,7 @@ class VersionValue implements Accountable {
 
     @Override
     public long ramBytesUsed() {
-        return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Long.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF +
-            (translogLocation != null ? translogLocation.size : 0);
+        return BASE_RAM_BYTES_USED + (translogLocation != null ? translogLocation.ramBytesUsed() : 0);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.Field;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.index.mapper.ParseContext.Document;
 
@@ -32,7 +33,8 @@ public class ParsedDocument {
 
     private final Field version;
 
-    private final String uid, id, type;
+    private final String id, type;
+    private final BytesRef uid;
 
     private final String routing;
 
@@ -52,7 +54,7 @@ public class ParsedDocument {
         this.version = version;
         this.id = id;
         this.type = type;
-        this.uid = Uid.createUid(type, id);
+        this.uid = Uid.createUidAsBytes(type, id);
         this.routing = routing;
         this.timestamp = timestamp;
         this.ttl = ttl;
@@ -64,7 +66,7 @@ public class ParsedDocument {
         return version;
     }
 
-    public String uid() {
+    public BytesRef uid() {
         return uid;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -657,6 +657,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
     public static class Location implements Accountable, Comparable<Location> {
 
+        private static final long RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Location.class);
+
         public final long generation;
         public final long translogLocation;
         public final int size;
@@ -669,7 +671,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
         @Override
         public long ramBytesUsed() {
-            return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + 2 * Long.BYTES + Integer.BYTES;
+            return RAM_BYTES_USED;
         }
 
         @Override

--- a/core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
@@ -38,6 +38,8 @@ grant codeBase "${codebase.lucene-test-framework-6.1.0.jar}" {
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   // needed for testing hardlinks in StoreRecoveryTests since we install MockFS
   permission java.nio.file.LinkPermission "hard";
+  // needed for RAMUsageTester
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
 };
 
 grant codeBase "${codebase.randomizedtesting-runner-2.3.2.jar}" {

--- a/core/src/test/java/org/elasticsearch/index/engine/LiveVersionMapTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/LiveVersionMapTests.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.engine;
+
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.RamUsageTester;
+import org.apache.lucene.util.TestUtil;
+import org.elasticsearch.test.ESTestCase;
+
+public class LiveVersionMapTests extends ESTestCase {
+
+    public void testRamBytesUsed() throws Exception {
+        LiveVersionMap map = new LiveVersionMap();
+        for (int i = 0; i < 100000; ++i) {
+            BytesRefBuilder uid = new BytesRefBuilder();
+            uid.copyChars(TestUtil.randomSimpleString(random(), 10, 20));
+            VersionValue version = new VersionValue(randomLong(), null);
+            map.putUnderLock(uid.toBytesRef(), version);
+        }
+        long actualRamBytesUsed = RamUsageTester.sizeOf(map);
+        long estimatedRamBytesUsed = map.ramBytesUsed();
+        // less than 25% off
+        assertEquals(actualRamBytesUsed, estimatedRamBytesUsed, actualRamBytesUsed / 4);
+
+        // now refresh
+        map.beforeRefresh();
+        map.afterRefresh(true);
+
+        for (int i = 0; i < 100000; ++i) {
+            BytesRefBuilder uid = new BytesRefBuilder();
+            uid.copyChars(TestUtil.randomSimpleString(random(), 10, 20));
+            VersionValue version = new VersionValue(randomLong(), null);
+            map.putUnderLock(uid.toBytesRef(), version);
+        }
+        actualRamBytesUsed = RamUsageTester.sizeOf(map);
+        estimatedRamBytesUsed = map.ramBytesUsed();
+        // less than 25% off
+        assertEquals(actualRamBytesUsed, estimatedRamBytesUsed, actualRamBytesUsed / 4);
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/index/engine/VersionValueTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/VersionValueTests.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.engine;
+
+import org.apache.lucene.util.RamUsageTester;
+import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.index.translog.TranslogTests;
+import org.elasticsearch.test.ESTestCase;
+
+public class VersionValueTests extends ESTestCase {
+
+    public void testRamBytesUsed() {
+        VersionValue versionValue = new VersionValue(randomLong(), null);
+        assertEquals(RamUsageTester.sizeOf(versionValue), versionValue.ramBytesUsed());
+        Translog.Location location = TranslogTests.randomTranslogLocation();
+        versionValue = new VersionValue(randomLong(), location);
+        assertEquals(RamUsageTester.sizeOf(versionValue), versionValue.ramBytesUsed());
+    }
+
+    public void testDeleteRamBytesUsed() {
+        DeleteVersionValue versionValue = new DeleteVersionValue(randomLong(), randomLong(), null);
+        assertEquals(RamUsageTester.sizeOf(versionValue), versionValue.ramBytesUsed());
+        Translog.Location location = TranslogTests.randomTranslogLocation();
+        versionValue = new DeleteVersionValue(randomLong(), randomLong(), location);
+        assertEquals(RamUsageTester.sizeOf(versionValue), versionValue.ramBytesUsed());
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -29,6 +29,7 @@ import org.apache.lucene.store.MockDirectoryWrapper;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LineFileDocs;
 import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.RamUsageTester;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -1924,5 +1925,14 @@ public class TranslogTests extends ESTestCase {
         translog.close();
         IOUtils.close(view);
         translog = new Translog(config, generation);
+    }
+
+    public static Translog.Location randomTranslogLocation() {
+        return new Translog.Location(randomLong(), randomLong(), randomInt());
+    }
+
+    public void testLocationRamBytesUsed() {
+        Translog.Location location = randomTranslogLocation();
+        assertEquals(RamUsageTester.sizeOf(location), location.ramBytesUsed());
     }
 }


### PR DESCRIPTION
I was writing tests for RAM usage estimation of LiveVersionMap and found a
couple issues:
- The BytesRef objects used as uids were oversized since they were created
  via `new BytesRef(CharSequence)` which creates a `byte[]` whose size is 3x
  the length of the provided char sequence. Given that our uids are most of
  times ASCII sequences, this is a waste of memory.
- `VersionValue` was using `translogLocation.size` instead of
  `translogLocation.ramBytesUsed()` for RAM estimation, which is completely
  unrelated to the memory footprint of the `Translog.Location` object.

In particular, the latter issue could cause RAM usage estimation to be
significantly overestimated, especially on large documents.

I also added tests for ram accounting.

Relates #19787
