### PR TITLE
Adds nodes usage API to monitor usages of actions

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/ClearNodeUsageResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/ClearNodeUsageResponse.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.usage;
+
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+public class ClearNodeUsageResponse extends BaseNodeResponse implements ToXContent {
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field("acknowledged", true);
+        return builder;
+    }
+
+    public static ClearNodeUsageResponse readNodeStats(StreamInput in) throws IOException {
+        ClearNodeUsageResponse noderesponse = new ClearNodeUsageResponse();
+        noderesponse.readFrom(in);
+        return noderesponse;
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/ClearNodesUsageAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/ClearNodesUsageAction.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.usage;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.client.ElasticsearchClient;
+
+public class ClearNodesUsageAction extends Action<ClearNodesUsageRequest, ClearNodesUsageResponse, ClearNodesUsageRequestBuilder> {
+
+    public static final ClearNodesUsageAction INSTANCE = new ClearNodesUsageAction();
+    public static final String NAME = "cluster:monitor/nodes/usage/clear";
+
+    protected ClearNodesUsageAction() {
+        super(NAME);
+    }
+
+    @Override
+    public ClearNodesUsageRequestBuilder newRequestBuilder(ElasticsearchClient client) {
+        return new ClearNodesUsageRequestBuilder(client, this);
+    }
+
+    @Override
+    public ClearNodesUsageResponse newResponse() {
+        return new ClearNodesUsageResponse();
+    }
+
+
+}

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/ClearNodesUsageRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/ClearNodesUsageRequest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.usage;
+
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+
+public class ClearNodesUsageRequest extends BaseNodesRequest<ClearNodesUsageRequest> {
+
+    public ClearNodesUsageRequest() {
+        super();
+    }
+
+    /**
+     * Get usage from nodes based on the nodes ids specified. If none are
+     * passed, usage for all nodes will be returned.
+     */
+    public ClearNodesUsageRequest(String... nodesIds) {
+        super(nodesIds);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/ClearNodesUsageRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/ClearNodesUsageRequestBuilder.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.usage;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.action.support.nodes.NodesOperationRequestBuilder;
+import org.elasticsearch.client.ElasticsearchClient;
+
+public class ClearNodesUsageRequestBuilder
+        extends NodesOperationRequestBuilder<ClearNodesUsageRequest, ClearNodesUsageResponse, ClearNodesUsageRequestBuilder> {
+
+    public ClearNodesUsageRequestBuilder(ElasticsearchClient client,
+            Action<ClearNodesUsageRequest, ClearNodesUsageResponse, ClearNodesUsageRequestBuilder> action) {
+        super(client, action, new ClearNodesUsageRequest());
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/ClearNodesUsageResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/ClearNodesUsageResponse.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.usage;
+
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+public class ClearNodesUsageResponse extends BaseNodesResponse<ClearNodeUsageResponse> implements ToXContent {
+
+    ClearNodesUsageResponse() {
+        super();
+    }
+
+    public ClearNodesUsageResponse(ClusterName clusterName, List<ClearNodeUsageResponse> nodes, List<FailedNodeException> failures) {
+        super(clusterName, nodes, failures);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder;
+    }
+
+    @Override
+    protected List<ClearNodeUsageResponse> readNodesFrom(StreamInput in) throws IOException {
+        return in.readList(ClearNodeUsageResponse::readNodeStats);
+    }
+
+    @Override
+    protected void writeNodesTo(StreamOutput out, List<ClearNodeUsageResponse> nodes) throws IOException {
+        out.writeStreamableList(nodes);
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodeUsage.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodeUsage.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.usage;
+
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class NodeUsage extends BaseNodeResponse implements ToXContent {
+
+    private long timestamp;
+    private long sinceTime;
+    private Map<String, Long> restUsage;
+
+    NodeUsage() {
+    }
+
+    public static NodeUsage readNodeStats(StreamInput in) throws IOException {
+        NodeUsage nodeInfo = new NodeUsage();
+        nodeInfo.readFrom(in);
+        return nodeInfo;
+    }
+
+    /**
+     * @param node
+     *            the node these statistics were collected from
+     * @param timestamp
+     *            the timestamp for when these statistics were collected
+     * @param sinceTime
+     *            the timestamp for when the collection of these statistics
+     *            started
+     * @param restUsage
+     *            a map containing the counts of the number of times each REST
+     *            endpoint has been called
+     */
+    public NodeUsage(DiscoveryNode node, long timestamp, long sinceTime, Map<String, Long> restUsage) {
+        super(node);
+        this.timestamp = timestamp;
+        this.sinceTime = sinceTime;
+        this.restUsage = restUsage;
+    }
+
+    /**
+     * @return the timestamp for when these statistics were collected
+     */
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * @return the timestamp for when the collection of these statistics started
+     */
+    public long getSinceTime() {
+        return sinceTime;
+    }
+
+    /**
+     * @return a map containing the counts of the number of times each REST
+     *         endpoint has been called
+     */
+    public Map<String, Long> getRestUsage() {
+        return restUsage;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field("since", sinceTime);
+        if (restUsage != null) {
+            builder.field("rest_actions");
+            builder.map(restUsage);
+        }
+        return builder;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        timestamp = in.readLong();
+        sinceTime = in.readLong();
+        restUsage = (Map<String, Long>) in.readGenericValue();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeLong(timestamp);
+        out.writeLong(sinceTime);
+        out.writeGenericValue(restUsage);
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageAction.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.usage;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.client.ElasticsearchClient;
+
+public class NodesUsageAction extends Action<NodesUsageRequest, NodesUsageResponse, NodesUsageRequestBuilder> {
+
+    public static final NodesUsageAction INSTANCE = new NodesUsageAction();
+    public static final String NAME = "cluster:monitor/nodes/usage";
+
+    protected NodesUsageAction() {
+        super(NAME);
+    }
+
+    @Override
+    public NodesUsageRequestBuilder newRequestBuilder(ElasticsearchClient client) {
+        return new NodesUsageRequestBuilder(client, this);
+    }
+
+    @Override
+    public NodesUsageResponse newResponse() {
+        return new NodesUsageResponse();
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageRequest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.usage;
+
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+public class NodesUsageRequest extends BaseNodesRequest<NodesUsageRequest> {
+
+    private boolean restActions;
+
+    public NodesUsageRequest() {
+        super();
+    }
+
+    /**
+     * Get usage from nodes based on the nodes ids specified. If none are
+     * passed, usage for all nodes will be returned.
+     */
+    public NodesUsageRequest(String... nodesIds) {
+        super(nodesIds);
+    }
+
+    /**
+     * Sets all the request flags.
+     */
+    public NodesUsageRequest all() {
+        this.restActions = true;
+        return this;
+    }
+
+    /**
+     * Clears all the request flags.
+     */
+    public NodesUsageRequest clear() {
+        this.restActions = false;
+        return this;
+    }
+
+    /**
+     * Should the node rest actions usage statistics be returned.
+     */
+    public boolean restActions() {
+        return this.restActions;
+    }
+
+    /**
+     * Should the node rest actions usage statistics be returned.
+     */
+    public NodesUsageRequest restActions(boolean restActions) {
+        this.restActions = restActions;
+        return this;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        this.restActions = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeBoolean(restActions);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageRequestBuilder.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.usage;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.action.support.nodes.NodesOperationRequestBuilder;
+import org.elasticsearch.client.ElasticsearchClient;
+
+public class NodesUsageRequestBuilder
+        extends NodesOperationRequestBuilder<NodesUsageRequest, NodesUsageResponse, NodesUsageRequestBuilder> {
+
+    public NodesUsageRequestBuilder(ElasticsearchClient client,
+            Action<NodesUsageRequest, NodesUsageResponse, NodesUsageRequestBuilder> action) {
+        super(client, action, new NodesUsageRequest());
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageResponse.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.usage;
+
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * The response for the nodes usage api which contains the individual usage
+ * statistics for all nodes queried.
+ */
+public class NodesUsageResponse extends BaseNodesResponse<NodeUsage> implements ToXContent {
+
+    NodesUsageResponse() {
+    }
+
+    public NodesUsageResponse(ClusterName clusterName, List<NodeUsage> nodes, List<FailedNodeException> failures) {
+        super(clusterName, nodes, failures);
+    }
+
+    @Override
+    protected List<NodeUsage> readNodesFrom(StreamInput in) throws IOException {
+        return in.readList(NodeUsage::readNodeStats);
+    }
+
+    @Override
+    protected void writeNodesTo(StreamOutput out, List<NodeUsage> nodes) throws IOException {
+        out.writeStreamableList(nodes);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("nodes");
+        for (NodeUsage nodeUsage : getNodes()) {
+            builder.startObject(nodeUsage.getNode().getId());
+            builder.field("timestamp", nodeUsage.getTimestamp());
+            nodeUsage.toXContent(builder, params);
+
+            builder.endObject();
+        }
+        builder.endObject();
+
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        try {
+            XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
+            builder.startObject();
+            toXContent(builder, EMPTY_PARAMS);
+            builder.endObject();
+            return builder.string();
+        } catch (IOException e) {
+            return "{ \"error\" : \"" + e.getMessage() + "\"}";
+        }
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/TransportClearNodesUsageAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/TransportClearNodesUsageAction.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.usage;
+
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.nodes.BaseNodeRequest;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.node.service.NodeService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.usage.UsageService;
+
+import java.io.IOException;
+import java.util.List;
+
+public class TransportClearNodesUsageAction extends
+        TransportNodesAction<ClearNodesUsageRequest, ClearNodesUsageResponse, TransportClearNodesUsageAction.ClearNodeUsageRequest, 
+        ClearNodeUsageResponse> {
+
+    private UsageService usageService;
+
+    @Inject
+    public TransportClearNodesUsageAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
+            TransportService transportService, NodeService nodeService, ActionFilters actionFilters,
+            IndexNameExpressionResolver indexNameExpressionResolver, UsageService usageService) {
+        super(settings, ClearNodesUsageAction.NAME, threadPool, clusterService, transportService, actionFilters,
+                indexNameExpressionResolver, ClearNodesUsageRequest::new, ClearNodeUsageRequest::new, ThreadPool.Names.MANAGEMENT,
+                ClearNodeUsageResponse.class);
+        this.usageService = usageService;
+    }
+
+    @Override
+    protected ClearNodesUsageResponse newResponse(ClearNodesUsageRequest request, List<ClearNodeUsageResponse> responses,
+            List<FailedNodeException> failures) {
+        return new ClearNodesUsageResponse(clusterService.getClusterName(), responses, failures);
+    }
+
+    @Override
+    protected ClearNodeUsageRequest newNodeRequest(String nodeId, ClearNodesUsageRequest request) {
+        return new ClearNodeUsageRequest(nodeId, request);
+    }
+
+    @Override
+    protected ClearNodeUsageResponse newNodeResponse() {
+        return new ClearNodeUsageResponse();
+    }
+
+    @Override
+    protected ClearNodeUsageResponse nodeOperation(ClearNodeUsageRequest nodeUsageRequest) {
+        usageService.clear();
+        return new ClearNodeUsageResponse();
+    }
+
+    @Override
+    protected boolean accumulateExceptions() {
+        return false;
+    }
+
+    public static class ClearNodeUsageRequest extends BaseNodeRequest {
+
+        ClearNodesUsageRequest request;
+
+        public ClearNodeUsageRequest() {
+        }
+
+        ClearNodeUsageRequest(String nodeId, ClearNodesUsageRequest request) {
+            super(nodeId);
+            this.request = request;
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            request = new ClearNodesUsageRequest();
+            request.readFrom(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            request.writeTo(out);
+        }
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/TransportNodesUsageAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/TransportNodesUsageAction.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.usage;
+
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.nodes.BaseNodeRequest;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.node.service.NodeService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.usage.UsageService;
+
+import java.io.IOException;
+import java.util.List;
+
+public class TransportNodesUsageAction
+        extends TransportNodesAction<NodesUsageRequest, NodesUsageResponse, TransportNodesUsageAction.NodeUsageRequest, NodeUsage> {
+
+    private UsageService usageService;
+
+    @Inject
+    public TransportNodesUsageAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
+            TransportService transportService, NodeService nodeService, ActionFilters actionFilters,
+            IndexNameExpressionResolver indexNameExpressionResolver, UsageService usageService) {
+        super(settings, NodesUsageAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
+                NodesUsageRequest::new, NodeUsageRequest::new, ThreadPool.Names.MANAGEMENT, NodeUsage.class);
+        this.usageService = usageService;
+    }
+
+    @Override
+    protected NodesUsageResponse newResponse(NodesUsageRequest request, List<NodeUsage> responses, List<FailedNodeException> failures) {
+        return new NodesUsageResponse(clusterService.getClusterName(), responses, failures);
+    }
+
+    @Override
+    protected NodeUsageRequest newNodeRequest(String nodeId, NodesUsageRequest request) {
+        return new NodeUsageRequest(nodeId, request);
+    }
+
+    @Override
+    protected NodeUsage newNodeResponse() {
+        return new NodeUsage();
+    }
+
+    @Override
+    protected NodeUsage nodeOperation(NodeUsageRequest nodeUsageRequest) {
+        NodesUsageRequest request = nodeUsageRequest.request;
+        return usageService.getUsageStats(request.restActions());
+    }
+
+    @Override
+    protected boolean accumulateExceptions() {
+        return false;
+    }
+
+    public static class NodeUsageRequest extends BaseNodeRequest {
+
+        NodesUsageRequest request;
+
+        public NodeUsageRequest() {
+        }
+
+        NodeUsageRequest(String nodeId, NodesUsageRequest request) {
+            super(nodeId);
+            this.request = request;
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            request = new NodesUsageRequest();
+            request.readFrom(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            request.writeTo(out);
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
+++ b/core/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
@@ -45,6 +45,12 @@ import org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskResponse;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequestBuilder;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
+import org.elasticsearch.action.admin.cluster.node.usage.ClearNodesUsageRequest;
+import org.elasticsearch.action.admin.cluster.node.usage.ClearNodesUsageRequestBuilder;
+import org.elasticsearch.action.admin.cluster.node.usage.ClearNodesUsageResponse;
+import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageRequest;
+import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageRequestBuilder;
+import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageResponse;
 import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteRepositoryRequest;
 import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteRepositoryRequestBuilder;
 import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteRepositoryResponse;
@@ -264,8 +270,60 @@ public interface ClusterAdminClient extends ElasticsearchClient {
     NodesStatsRequestBuilder prepareNodesStats(String... nodesIds);
 
     /**
-     * Returns top N hot-threads samples per node. The hot-threads are only sampled
-     * for the node ids specified in the request.
+     * Nodes usage of the cluster.
+     *
+     * @param request
+     *            The nodes usage request
+     * @return The result future
+     * @see org.elasticsearch.client.Requests#nodesUsageRequest(String...)
+     */
+    ActionFuture<NodesUsageResponse> nodesUsage(NodesUsageRequest request);
+
+    /**
+     * Nodes usage of the cluster.
+     *
+     * @param request
+     *            The nodes usage request
+     * @param listener
+     *            A listener to be notified with a result
+     * @see org.elasticsearch.client.Requests#nodesUsageRequest(String...)
+     */
+    void nodesUsage(NodesUsageRequest request, ActionListener<NodesUsageResponse> listener);
+
+    /**
+     * Nodes usage of the cluster.
+     */
+    NodesUsageRequestBuilder prepareNodesUsage(String... nodesIds);
+
+    /**
+     * Clear Nodes Usage statistics.
+     *
+     * @param request
+     *            The clear nodes usage request
+     * @return The result future
+     * @see org.elasticsearch.client.Requests#clearNodesUsageRequest(String...)
+     */
+    ActionFuture<ClearNodesUsageResponse> clearNodesUsage(ClearNodesUsageRequest request);
+
+    /**
+     * Clear Nodes Usage statistics.
+     *
+     * @param request
+     *            The clear nodes usage request
+     * @param listener
+     *            A listener to be notified with a result
+     * @see org.elasticsearch.client.Requests#clearNodesUsageRequest(String...)
+     */
+    void clearNodesUsage(ClearNodesUsageRequest request, ActionListener<ClearNodesUsageResponse> listener);
+
+    /**
+     * Clear Nodes Usage statistics.
+     */
+    ClearNodesUsageRequestBuilder prepareClearNodesUsage(String... nodesIds);
+
+    /**
+     * Returns top N hot-threads samples per node. The hot-threads are only
+     * sampled for the node ids specified in the request.
      */
     ActionFuture<NodesHotThreadsResponse> nodesHotThreads(NodesHotThreadsRequest request);
 

--- a/core/src/main/java/org/elasticsearch/client/Requests.java
+++ b/core/src/main/java/org/elasticsearch/client/Requests.java
@@ -25,6 +25,8 @@ import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
+import org.elasticsearch.action.admin.cluster.node.usage.ClearNodesUsageRequest;
+import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageRequest;
 import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteRepositoryRequest;
 import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesRequest;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
@@ -385,6 +387,32 @@ public class Requests {
      */
     public static NodesStatsRequest nodesStatsRequest(String... nodesIds) {
         return new NodesStatsRequest(nodesIds);
+    }
+
+    /**
+     * Creates a nodes usage request against one or more nodes. Pass
+     * <tt>null</tt> or an empty array for all nodes.
+     *
+     * @param nodesIds
+     *            The nodes ids to get the usage for
+     * @return The nodes usage request
+     * @see org.elasticsearch.client.ClusterAdminClient#nodesUsage(org.elasticsearch.action.admin.cluster.node.usage.NodesUsageRequest)
+     */
+    public static NodesUsageRequest nodesUsageRequest(String... nodesIds) {
+        return new NodesUsageRequest(nodesIds);
+    }
+
+    /**
+     * Creates a clear nodes usage request against one or more nodes. Pass
+     * <tt>null</tt> or an empty array for all nodes.
+     *
+     * @param nodesIds
+     *            The nodes ids to clear the usage for
+     * @return The clear nodes usage request
+     * @see ClusterAdminClient#clearNodesUsage(org.elasticsearch.action.admin.cluster.node.usage.ClearNodesUsageRequest)
+     */
+    public static ClearNodesUsageRequest clearNodesUsageRequest(String... nodesIds) {
+        return new ClearNodesUsageRequest(nodesIds);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/core/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -57,6 +57,14 @@ import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksAction;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequestBuilder;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
+import org.elasticsearch.action.admin.cluster.node.usage.ClearNodesUsageAction;
+import org.elasticsearch.action.admin.cluster.node.usage.ClearNodesUsageRequest;
+import org.elasticsearch.action.admin.cluster.node.usage.ClearNodesUsageRequestBuilder;
+import org.elasticsearch.action.admin.cluster.node.usage.ClearNodesUsageResponse;
+import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageAction;
+import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageRequest;
+import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageRequestBuilder;
+import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageResponse;
 import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteRepositoryAction;
 import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteRepositoryRequest;
 import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteRepositoryRequestBuilder;
@@ -809,6 +817,36 @@ public abstract class AbstractClient extends AbstractComponent implements Client
         @Override
         public NodesStatsRequestBuilder prepareNodesStats(String... nodesIds) {
             return new NodesStatsRequestBuilder(this, NodesStatsAction.INSTANCE).setNodesIds(nodesIds);
+        }
+
+        @Override
+        public ActionFuture<NodesUsageResponse> nodesUsage(final NodesUsageRequest request) {
+            return execute(NodesUsageAction.INSTANCE, request);
+        }
+
+        @Override
+        public void nodesUsage(final NodesUsageRequest request, final ActionListener<NodesUsageResponse> listener) {
+            execute(NodesUsageAction.INSTANCE, request, listener);
+        }
+
+        @Override
+        public NodesUsageRequestBuilder prepareNodesUsage(String... nodesIds) {
+            return new NodesUsageRequestBuilder(this, NodesUsageAction.INSTANCE).setNodesIds(nodesIds);
+        }
+
+        @Override
+        public ActionFuture<ClearNodesUsageResponse> clearNodesUsage(final ClearNodesUsageRequest request) {
+            return execute(ClearNodesUsageAction.INSTANCE, request);
+        }
+
+        @Override
+        public void clearNodesUsage(final ClearNodesUsageRequest request, final ActionListener<ClearNodesUsageResponse> listener) {
+            execute(ClearNodesUsageAction.INSTANCE, request, listener);
+        }
+
+        @Override
+        public ClearNodesUsageRequestBuilder prepareClearNodesUsage(String... nodesIds) {
+            return new ClearNodesUsageRequestBuilder(this, ClearNodesUsageAction.INSTANCE).setNodesIds(nodesIds);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -53,7 +53,6 @@ import org.elasticsearch.threadpool.ExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TcpTransport;
 import org.elasticsearch.transport.TransportService;
-
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -138,7 +137,7 @@ public abstract class TransportClient extends AbstractClient {
             modules.add(b -> b.bind(ThreadPool.class).toInstance(threadPool));
             modules.add(searchModule);
             ActionModule actionModule = new ActionModule(false, true, settings, null, settingsModule.getClusterSettings(),
-                pluginsService.filterPlugins(ActionPlugin.class));
+                    pluginsService.filterPlugins(ActionPlugin.class), null);
             modules.add(actionModule);
 
             pluginsService.processModules(modules);

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -120,6 +120,7 @@ import org.elasticsearch.threadpool.ExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.tribe.TribeService;
+import org.elasticsearch.usage.UsageService;
 import org.elasticsearch.watcher.ResourceWatcherService;
 
 import javax.management.MBeanServerPermission;
@@ -318,6 +319,7 @@ public class Node implements Closeable {
             resourcesToClose.add(tribeService);
             final IngestService ingestService = new IngestService(settings, threadPool, this.environment,
                 scriptModule.getScriptService(), analysisModule.getAnalysisRegistry(), pluginsService.filterPlugins(IngestPlugin.class));
+            final UsageService usageService = new UsageService(clusterService::localNode, settings);
 
             ModulesBuilder modules = new ModulesBuilder();
             // plugin modules must be added here, before others or we can get crazy injection errors...
@@ -338,7 +340,7 @@ public class Node implements Closeable {
             modules.add(searchModule);
             modules.add(new ActionModule(DiscoveryNode.isIngestNode(settings), false, settings,
                 clusterModule.getIndexNameExpressionResolver(), settingsModule.getClusterSettings(),
-                pluginsService.filterPlugins(ActionPlugin.class)));
+                    pluginsService.filterPlugins(ActionPlugin.class), usageService));
             modules.add(new GatewayModule());
             modules.add(new RepositoriesModule(this.environment, pluginsService.filterPlugins(RepositoryPlugin.class)));
             pluginsService.processModules(modules);
@@ -386,6 +388,7 @@ public class Node implements Closeable {
                     b.bind(AnalysisRegistry.class).toInstance(analysisModule.getAnalysisRegistry());
                     b.bind(IngestService.class).toInstance(ingestService);
                     b.bind(NamedWriteableRegistry.class).toInstance(namedWriteableRegistry);
+                    b.bind(UsageService.class).toInstance(usageService);
                     b.bind(MetaDataUpgrader.class).toInstance(metaDataUpgrader);
                     b.bind(MetaStateService.class).toInstance(metaStateService);
                     b.bind(IndicesService.class).toInstance(indicesService);

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClearNodesUsageAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClearNodesUsageAction.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.cluster;
+
+import org.elasticsearch.action.admin.cluster.node.usage.ClearNodesUsageRequest;
+import org.elasticsearch.action.admin.cluster.node.usage.ClearNodesUsageResponse;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.action.RestActions;
+import org.elasticsearch.rest.action.RestBuilderListener;
+
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
+public class RestClearNodesUsageAction extends BaseRestHandler {
+
+    @Inject
+    public RestClearNodesUsageAction(Settings settings, RestController controller) {
+        super(settings);
+        controller.registerHandler(POST, "/_nodes/usage/_clear", this);
+        controller.registerHandler(POST, "/_nodes/{nodeId}/usage/_clear", this);
+    }
+
+    @Override
+    public void handleRequest(final RestRequest request, final RestChannel channel, final NodeClient client) {
+        String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
+
+        ClearNodesUsageRequest nodesUsageRequest = new ClearNodesUsageRequest(nodesIds);
+        nodesUsageRequest.timeout(request.param("timeout"));
+
+        client.admin().cluster().clearNodesUsage(nodesUsageRequest, new RestBuilderListener<ClearNodesUsageResponse>(channel) {
+
+            @Override
+            public RestResponse buildResponse(ClearNodesUsageResponse response, XContentBuilder builder) throws Exception {
+                builder.startObject();
+                RestActions.buildNodesHeader(builder, channel.request(), response);
+                builder.field("cluster_name", response.getClusterName().value());
+                response.toXContent(builder, channel.request());
+                builder.endObject();
+
+                return new BytesRestResponse(RestStatus.OK, builder);
+            }
+        });
+    }
+
+    @Override
+    public boolean canTripCircuitBreaker() {
+        return false;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesUsageAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesUsageAction.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.cluster;
+
+import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageRequest;
+import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageResponse;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.action.RestActions;
+import org.elasticsearch.rest.action.RestBuilderListener;
+
+import java.util.Set;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+
+public class RestNodesUsageAction extends BaseRestHandler {
+
+    @Inject
+    public RestNodesUsageAction(Settings settings, RestController controller) {
+        super(settings);
+        controller.registerHandler(GET, "/_nodes/usage", this);
+        controller.registerHandler(GET, "/_nodes/{nodeId}/usage", this);
+
+        controller.registerHandler(GET, "/_nodes/usage/{metric}", this);
+        controller.registerHandler(GET, "/_nodes/{nodeId}/usage/{metric}", this);
+    }
+
+    @Override
+    public void handleRequest(final RestRequest request, final RestChannel channel, final NodeClient client) {
+        String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
+        Set<String> metrics = Strings.splitStringByCommaToSet(request.param("metric", "_all"));
+
+        NodesUsageRequest nodesUsageRequest = new NodesUsageRequest(nodesIds);
+        nodesUsageRequest.timeout(request.param("timeout"));
+
+        if (metrics.size() == 1 && metrics.contains("_all")) {
+            nodesUsageRequest.all();
+        } else {
+            nodesUsageRequest.clear();
+            nodesUsageRequest.restActions(metrics.contains("rest_actions"));
+        }
+
+        client.admin().cluster().nodesUsage(nodesUsageRequest, new RestBuilderListener<NodesUsageResponse>(channel) {
+
+            @Override
+            public RestResponse buildResponse(NodesUsageResponse response, XContentBuilder builder) throws Exception {
+                builder.startObject();
+                RestActions.buildNodesHeader(builder, channel.request(), response);
+                builder.field("cluster_name", response.getClusterName().value());
+                response.toXContent(builder, channel.request());
+                builder.endObject();
+
+                return new BytesRestResponse(RestStatus.OK, builder);
+            }
+        });
+    }
+
+    @Override
+    public boolean canTripCircuitBreaker() {
+        return false;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/usage/UsageService.java
+++ b/core/src/main/java/org/elasticsearch/usage/UsageService.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.usage;
+
+import org.elasticsearch.action.admin.cluster.node.usage.NodeUsage;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+/**
+ * A service to monitor usage of Elasticsearch features.
+ */
+public class UsageService extends AbstractComponent {
+
+    private final Supplier<DiscoveryNode> localNodeSupplier;
+    private final Map<String, AtomicLong> restUsage;
+    private long sinceTime;
+
+    @Inject
+    public UsageService(Supplier<DiscoveryNode> localNodeSupplier, Settings settings) {
+        super(settings);
+        this.localNodeSupplier = localNodeSupplier;
+        this.restUsage = new ConcurrentHashMap<>();
+        this.sinceTime = System.currentTimeMillis();
+    }
+
+    /**
+     * record a call to a REST endpoint.
+     *
+     * @param actionName
+     *            the class name of the {@link RestHandler} called for this
+     *            endpoint.
+     */
+    public void addRestCall(String actionName) {
+        AtomicLong counter = restUsage.computeIfAbsent(actionName, key -> new AtomicLong());
+        counter.getAndIncrement();
+    }
+
+    public void clear() {
+        this.sinceTime = System.currentTimeMillis();
+        this.restUsage.clear();
+    }
+
+    /**
+     * Get the current usage statistics for this node.
+     *
+     * @param restActions
+     *            whether to include rest action usage in the returned
+     *            statistics
+     * @return the {@link NodeUsage} representing the usage statistics for this
+     *         node
+     */
+    public NodeUsage getUsageStats(boolean restActions) {
+        Map<String, Long> restUsageMap;
+        if (restActions) {
+            restUsageMap = new HashMap<>();
+            restUsage.forEach((key, value) -> {
+                restUsageMap.put(key, value.get());
+            });
+        } else {
+            restUsageMap = null;
+        }
+        return new NodeUsage(localNodeSupplier.get(), System.currentTimeMillis(), sinceTime, restUsageMap);
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/usage/UsageService.java
+++ b/core/src/main/java/org/elasticsearch/usage/UsageService.java
@@ -29,7 +29,7 @@ import org.elasticsearch.rest.RestHandler;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Supplier;
 
 /**
@@ -38,7 +38,7 @@ import java.util.function.Supplier;
 public class UsageService extends AbstractComponent {
 
     private final Supplier<DiscoveryNode> localNodeSupplier;
-    private final Map<String, AtomicLong> restUsage;
+    private final Map<String, LongAdder> restUsage;
     private long sinceTime;
 
     @Inject
@@ -57,8 +57,8 @@ public class UsageService extends AbstractComponent {
      *            endpoint.
      */
     public void addRestCall(String actionName) {
-        AtomicLong counter = restUsage.computeIfAbsent(actionName, key -> new AtomicLong());
-        counter.getAndIncrement();
+        LongAdder counter = restUsage.computeIfAbsent(actionName, key -> new LongAdder());
+        counter.increment();
     }
 
     public void clear() {
@@ -80,7 +80,7 @@ public class UsageService extends AbstractComponent {
         if (restActions) {
             restUsageMap = new HashMap<>();
             restUsage.forEach((key, value) -> {
-                restUsageMap.put(key, value.get());
+                restUsageMap.put(key, value.longValue());
             });
         } else {
             restUsageMap = null;

--- a/core/src/test/java/org/elasticsearch/http/HttpServerTests.java
+++ b/core/src/test/java/org/elasticsearch/http/HttpServerTests.java
@@ -21,6 +21,8 @@ package org.elasticsearch.http;
 import java.util.Collections;
 import java.util.Map;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -41,6 +43,7 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.usage.UsageService;
 import org.junit.Before;
 
 public class HttpServerTests extends ESTestCase {
@@ -60,7 +63,9 @@ public class HttpServerTests extends ESTestCase {
         inFlightRequestsBreaker = circuitBreakerService.getBreaker(CircuitBreaker.IN_FLIGHT_REQUESTS);
 
         HttpServerTransport httpServerTransport = new TestHttpServerTransport();
-        RestController restController = new RestController(settings, Collections.emptySet());
+        DiscoveryNode discoveryNode = new DiscoveryNode("foo", new LocalTransportAddress("bar"), Version.CURRENT);
+        UsageService usageService = new UsageService(() -> discoveryNode, settings);
+        RestController restController = new RestController(settings, Collections.emptySet(), usageService);
         restController.registerHandler(RestRequest.Method.GET, "/",
             (request, channel, client) -> channel.sendResponse(
                 new BytesRestResponse(RestStatus.OK, BytesRestResponse.TEXT_CONTENT_TYPE, BytesArray.EMPTY)));

--- a/core/src/test/java/org/elasticsearch/rest/RestFilterChainTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/RestFilterChainTests.java
@@ -19,13 +19,17 @@
 
 package org.elasticsearch.rest;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.LocalTransportAddress;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.rest.FakeRestChannel;
 import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.usage.UsageService;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,7 +44,9 @@ import static org.hamcrest.CoreMatchers.equalTo;
 public class RestFilterChainTests extends ESTestCase {
     public void testRestFilters() throws Exception {
 
-        RestController restController = new RestController(Settings.EMPTY, Collections.emptySet());
+        DiscoveryNode discoveryNode = new DiscoveryNode("foo", new LocalTransportAddress("bar"), Version.CURRENT);
+        UsageService usageService = new UsageService(() -> discoveryNode, Settings.EMPTY);
+        RestController restController = new RestController(Settings.EMPTY, Collections.emptySet(), usageService);
 
         int numFilters = randomInt(10);
         Set<Integer> orders = new HashSet<>(numFilters);
@@ -121,7 +127,9 @@ public class RestFilterChainTests extends ESTestCase {
             }
         });
 
-        RestController restController = new RestController(Settings.EMPTY, Collections.emptySet());
+        DiscoveryNode discoveryNode = new DiscoveryNode("foo", new LocalTransportAddress("bar"), Version.CURRENT);
+        UsageService usageService = new UsageService(() -> discoveryNode, Settings.EMPTY);
+        RestController restController = new RestController(Settings.EMPTY, Collections.emptySet(), usageService);
         restController.registerFilter(testFilter);
 
         restController.registerHandler(RestRequest.Method.GET, "/", new RestHandler() {

--- a/core/src/test/java/org/elasticsearch/rest/action/cat/RestIndicesActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/cat/RestIndicesActionTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RecoverySource.PeerRecoverySource;
 import org.elasticsearch.cluster.routing.RecoverySource.StoreRecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -37,6 +38,7 @@ import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.LocalTransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.cache.query.QueryCacheStats;
@@ -57,6 +59,7 @@ import org.elasticsearch.index.warmer.WarmerStats;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.search.suggest.completion.CompletionStats;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.usage.UsageService;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -73,7 +76,9 @@ public class RestIndicesActionTests extends ESTestCase {
 
     public void testBuildTable() {
         final Settings settings = Settings.EMPTY;
-        final RestController restController = new RestController(settings, Collections.emptySet());
+        DiscoveryNode discoveryNode = new DiscoveryNode("foo", new LocalTransportAddress("bar"), Version.CURRENT);
+        UsageService usageService = new UsageService(() -> discoveryNode, settings);
+        final RestController restController = new RestController(settings, Collections.emptySet(), usageService);
         final RestIndicesAction action = new RestIndicesAction(settings, restController, new IndexNameExpressionResolver(settings));
 
         // build a (semi-)random table

--- a/core/src/test/java/org/elasticsearch/rest/action/cat/RestRecoveryActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/cat/RestRecoveryActionTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.rest.action.cat;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -28,12 +29,14 @@ import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.LocalTransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.usage.UsageService;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -50,7 +53,9 @@ public class RestRecoveryActionTests extends ESTestCase {
 
     public void testRestRecoveryAction() {
         final Settings settings = Settings.EMPTY;
-        final RestController restController = new RestController(settings, Collections.emptySet());
+        DiscoveryNode discoveryNode = new DiscoveryNode("foo", new LocalTransportAddress("bar"), Version.CURRENT);
+        UsageService usageService = new UsageService(() -> discoveryNode, settings);
+        final RestController restController = new RestController(settings, Collections.emptySet(), usageService);
         final RestRecoveryAction action = new RestRecoveryAction(settings, restController, restController);
         final int totalShards = randomIntBetween(1, 32);
         final int successfulShards = Math.max(0, totalShards - randomIntBetween(1, 2));

--- a/core/src/test/java/org/elasticsearch/usage/UsageServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/usage/UsageServiceTests.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.usage;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.node.usage.NodeUsage;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.LocalTransportAddress;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class UsageServiceTests extends ESTestCase {
+
+    public void testRestUsage() {
+        DiscoveryNode discoveryNode = new DiscoveryNode("foo", new LocalTransportAddress("bar"), Version.CURRENT);
+        UsageService usageService = new UsageService(() -> discoveryNode, Settings.EMPTY);
+        usageService.addRestCall("a");
+        usageService.addRestCall("b");
+        usageService.addRestCall("a");
+        usageService.addRestCall("a");
+        usageService.addRestCall("b");
+        usageService.addRestCall("c");
+        usageService.addRestCall("c");
+        usageService.addRestCall("d");
+        usageService.addRestCall("a");
+        usageService.addRestCall("b");
+        usageService.addRestCall("e");
+        usageService.addRestCall("f");
+        usageService.addRestCall("c");
+        usageService.addRestCall("d");
+        NodeUsage usage = usageService.getUsageStats(true);
+        assertThat(usage.getNode(), sameInstance(discoveryNode));
+        Map<String, Long> restUsage = usage.getRestUsage();
+        assertThat(restUsage, notNullValue());
+        assertThat(restUsage.size(), equalTo(6));
+        assertThat(restUsage.get("a"), equalTo(4L));
+        assertThat(restUsage.get("b"), equalTo(3L));
+        assertThat(restUsage.get("c"), equalTo(3L));
+        assertThat(restUsage.get("d"), equalTo(2L));
+        assertThat(restUsage.get("e"), equalTo(1L));
+        assertThat(restUsage.get("f"), equalTo(1L));
+
+        usage = usageService.getUsageStats(false);
+        assertThat(usage.getNode(), sameInstance(discoveryNode));
+        assertThat(usage.getRestUsage(), nullValue());
+    }
+
+    public void testClearUsage() {
+        DiscoveryNode discoveryNode = new DiscoveryNode("foo", new LocalTransportAddress("bar"), Version.CURRENT);
+        UsageService usageService = new UsageService(() -> discoveryNode, Settings.EMPTY);
+        usageService.addRestCall("a");
+        usageService.addRestCall("b");
+        usageService.addRestCall("c");
+        usageService.addRestCall("d");
+        usageService.addRestCall("e");
+        usageService.addRestCall("f");
+        NodeUsage usage = usageService.getUsageStats(true);
+        assertThat(usage.getNode(), sameInstance(discoveryNode));
+        Map<String, Long> restUsage = usage.getRestUsage();
+        assertThat(restUsage, notNullValue());
+        assertThat(restUsage.size(), equalTo(6));
+        assertThat(restUsage.get("a"), equalTo(1L));
+        assertThat(restUsage.get("b"), equalTo(1L));
+        assertThat(restUsage.get("c"), equalTo(1L));
+        assertThat(restUsage.get("d"), equalTo(1L));
+        assertThat(restUsage.get("e"), equalTo(1L));
+        assertThat(restUsage.get("f"), equalTo(1L));
+
+        usageService.clear();
+        usage = usageService.getUsageStats(true);
+        assertThat(usage.getNode(), sameInstance(discoveryNode));
+        assertThat(usage.getRestUsage(), notNullValue());
+        assertThat(usage.getRestUsage().size(), equalTo(0));
+    }
+
+}

--- a/distribution/integ-test-zip/src/test/java/org/elasticsearch/test/rest/NodeRestUsageIT.java
+++ b/distribution/integ-test-zip/src/test/java/org/elasticsearch/test/rest/NodeRestUsageIT.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.rest;
+
+import org.apache.http.entity.StringEntity;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.rest.action.admin.cluster.RestNodesInfoAction;
+import org.elasticsearch.rest.action.admin.cluster.RestNodesStatsAction;
+import org.elasticsearch.rest.action.admin.cluster.RestNodesUsageAction;
+import org.elasticsearch.rest.action.admin.indices.RestCreateIndexAction;
+import org.elasticsearch.rest.action.admin.indices.RestDeleteIndexAction;
+import org.elasticsearch.rest.action.admin.indices.RestRefreshAction;
+import org.elasticsearch.rest.action.cat.RestIndicesAction;
+import org.elasticsearch.rest.action.document.RestIndexAction;
+import org.elasticsearch.rest.action.search.RestSearchAction;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class NodeRestUsageIT extends ESRestTestCase {
+
+    @SuppressWarnings("unchecked")
+    public void testNoRestUsage() throws IOException {
+        Response response = client().performRequest("GET", "_nodes/usage");
+        Map<String, Object> responseBodyMap = entityAsMap(response);
+        assertThat(responseBodyMap, notNullValue());
+        Map<String, Object> _nodesMap = (Map<String, Object>) responseBodyMap.get("_nodes");
+        assertThat(_nodesMap, notNullValue());
+        Integer total = (Integer) _nodesMap.get("total");
+        Integer successful = (Integer) _nodesMap.get("successful");
+        Integer failed = (Integer) _nodesMap.get("failed");
+        assertThat(total, greaterThan(0));
+        assertThat(successful, equalTo(total));
+        assertThat(failed, equalTo(0));
+
+        Map<String, Object> nodesMap = (Map<String, Object>) responseBodyMap.get("nodes");
+        assertThat(nodesMap, notNullValue());
+        assertThat(nodesMap.size(), equalTo(successful));
+        Map<String, Integer> combinedRestUsage = new HashMap<>();
+        for (Map.Entry<String, Object> nodeEntry : nodesMap.entrySet()) {
+            Map<String, Object> restActionUsage = (Map<String, Object>) ((Map<String, Object>) nodeEntry.getValue()).get("rest_actions");
+            assertThat(restActionUsage, notNullValue());
+            for (Map.Entry<String, Object> restActionEntry : restActionUsage.entrySet()) {
+                Integer currentUsage = combinedRestUsage.get(restActionEntry.getKey());
+                if (currentUsage == null) {
+                    combinedRestUsage.put(restActionEntry.getKey(), (Integer) restActionEntry.getValue());
+                } else {
+                    combinedRestUsage.put(restActionEntry.getKey(), currentUsage + (Integer) restActionEntry.getValue());
+                }
+            }
+        }
+        // The call to the nodes usage api counts in the stats so it should be
+        // the only thing returned in the response
+        assertThat(combinedRestUsage.size(), equalTo(1));
+        assertThat(combinedRestUsage.get(RestNodesUsageAction.class.getName()), equalTo(1));
+
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testWithRestUsage() throws IOException {
+        // Do some requests to get some rest usage stats
+        client().performRequest("PUT", "/test");
+        client().performRequest("POST", "/test/doc/1", Collections.emptyMap(), new StringEntity("{ \"foo\": \"bar\"}"));
+        client().performRequest("POST", "/test/doc/2", Collections.emptyMap(), new StringEntity("{ \"foo\": \"bar\"}"));
+        client().performRequest("POST", "/test/doc/3", Collections.emptyMap(), new StringEntity("{ \"foo\": \"bar\"}"));
+        client().performRequest("GET", "/test/_search");
+        client().performRequest("POST", "/test/doc/4", Collections.emptyMap(), new StringEntity("{ \"foo\": \"bar\"}"));
+        client().performRequest("POST", "/test/_refresh");
+        client().performRequest("GET", "/_cat/indices");
+        client().performRequest("GET", "/_nodes");
+        client().performRequest("GET", "/test/_search");
+        client().performRequest("GET", "/_nodes/stats");
+        client().performRequest("DELETE", "/test");
+
+        Response response = client().performRequest("GET", "_nodes/usage");
+        Map<String, Object> responseBodyMap = entityAsMap(response);
+        assertThat(responseBodyMap, notNullValue());
+        Map<String, Object> _nodesMap = (Map<String, Object>) responseBodyMap.get("_nodes");
+        assertThat(_nodesMap, notNullValue());
+        Integer total = (Integer) _nodesMap.get("total");
+        Integer successful = (Integer) _nodesMap.get("successful");
+        Integer failed = (Integer) _nodesMap.get("failed");
+        assertThat(total, greaterThan(0));
+        assertThat(successful, equalTo(total));
+        assertThat(failed, equalTo(0));
+
+        Map<String, Object> nodesMap = (Map<String, Object>) responseBodyMap.get("nodes");
+        assertThat(nodesMap, notNullValue());
+        assertThat(nodesMap.size(), equalTo(successful));
+        Map<String, Integer> combinedRestUsage = new HashMap<>();
+        for (Map.Entry<String, Object> nodeEntry : nodesMap.entrySet()) {
+            Map<String, Object> restActionUsage = (Map<String, Object>) ((Map<String, Object>) nodeEntry.getValue()).get("rest_actions");
+            assertThat(restActionUsage, notNullValue());
+            for (Map.Entry<String, Object> restActionEntry : restActionUsage.entrySet()) {
+                Integer currentUsage = combinedRestUsage.get(restActionEntry.getKey());
+                if (currentUsage == null) {
+                    combinedRestUsage.put(restActionEntry.getKey(), (Integer) restActionEntry.getValue());
+                } else {
+                    combinedRestUsage.put(restActionEntry.getKey(), currentUsage + (Integer) restActionEntry.getValue());
+                }
+            }
+        }
+        // The call to the nodes usage api counts in the stats so it should be
+        // the only thing returned in the response
+        assertThat(combinedRestUsage.size(), equalTo(9));
+        assertThat(combinedRestUsage.get(RestNodesUsageAction.class.getName()), equalTo(1));
+        assertThat(combinedRestUsage.get(RestCreateIndexAction.class.getName()), equalTo(1));
+        assertThat(combinedRestUsage.get(RestIndexAction.class.getName()), equalTo(4));
+        assertThat(combinedRestUsage.get(RestSearchAction.class.getName()), equalTo(2));
+        assertThat(combinedRestUsage.get(RestRefreshAction.class.getName()), equalTo(1));
+        assertThat(combinedRestUsage.get(RestIndicesAction.class.getName()), equalTo(1));
+        assertThat(combinedRestUsage.get(RestNodesInfoAction.class.getName()), equalTo(1));
+        assertThat(combinedRestUsage.get(RestNodesStatsAction.class.getName()), equalTo(1));
+        assertThat(combinedRestUsage.get(RestDeleteIndexAction.class.getName()), equalTo(1));
+
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testClearRestUsage() throws IOException {
+        // Do some requests to get some rest usage stats
+        client().performRequest("GET", "/_cat/indices");
+        client().performRequest("GET", "/_nodes");
+        client().performRequest("GET", "/_nodes/stats");
+
+        Response response = client().performRequest("GET", "_nodes/usage");
+        Map<String, Object> responseBodyMap = entityAsMap(response);
+        assertThat(responseBodyMap, notNullValue());
+        Map<String, Object> _nodesMap = (Map<String, Object>) responseBodyMap.get("_nodes");
+        assertThat(_nodesMap, notNullValue());
+        Integer total = (Integer) _nodesMap.get("total");
+        Integer successful = (Integer) _nodesMap.get("successful");
+        Integer failed = (Integer) _nodesMap.get("failed");
+        assertThat(total, greaterThan(0));
+        assertThat(successful, equalTo(total));
+        assertThat(failed, equalTo(0));
+
+        Map<String, Object> nodesMap = (Map<String, Object>) responseBodyMap.get("nodes");
+        assertThat(nodesMap, notNullValue());
+        assertThat(nodesMap.size(), equalTo(successful));
+        Map<String, Integer> combinedRestUsage = new HashMap<>();
+        for (Map.Entry<String, Object> nodeEntry : nodesMap.entrySet()) {
+            Map<String, Object> restActionUsage = (Map<String, Object>) ((Map<String, Object>) nodeEntry.getValue()).get("rest_actions");
+            assertThat(restActionUsage, notNullValue());
+            for (Map.Entry<String, Object> restActionEntry : restActionUsage.entrySet()) {
+                Integer currentUsage = combinedRestUsage.get(restActionEntry.getKey());
+                if (currentUsage == null) {
+                    combinedRestUsage.put(restActionEntry.getKey(), (Integer) restActionEntry.getValue());
+                } else {
+                    combinedRestUsage.put(restActionEntry.getKey(), currentUsage + (Integer) restActionEntry.getValue());
+                }
+            }
+        }
+        // The call to the nodes usage api counts in the stats so it should be
+        // the only thing returned in the response
+        assertThat(combinedRestUsage.size(), equalTo(4));
+        assertThat(combinedRestUsage.get(RestNodesUsageAction.class.getName()), equalTo(1));
+        assertThat(combinedRestUsage.get(RestIndicesAction.class.getName()), equalTo(1));
+        assertThat(combinedRestUsage.get(RestNodesInfoAction.class.getName()), equalTo(1));
+        assertThat(combinedRestUsage.get(RestNodesStatsAction.class.getName()), equalTo(1));
+
+        response = client().performRequest("GET", "_nodes/usage/_clear");
+        responseBodyMap = entityAsMap(response);
+        assertThat(responseBodyMap, notNullValue());
+        _nodesMap = (Map<String, Object>) responseBodyMap.get("_nodes");
+        assertThat(_nodesMap, notNullValue());
+        total = (Integer) _nodesMap.get("total");
+        successful = (Integer) _nodesMap.get("successful");
+        failed = (Integer) _nodesMap.get("failed");
+        assertThat(total, greaterThan(0));
+        assertThat(successful, equalTo(total));
+        assertThat(failed, equalTo(0));
+
+        nodesMap = (Map<String, Object>) responseBodyMap.get("nodes");
+        assertThat(nodesMap, notNullValue());
+        assertThat(nodesMap.size(), equalTo(successful));
+        for (Map.Entry<String, Object> nodeEntry : nodesMap.entrySet()) {
+            Map<String, Object> restActionUsage = (Map<String, Object>) ((Map<String, Object>) nodeEntry.getValue()).get("rest_actions");
+            assertThat(restActionUsage, nullValue());
+        }
+    }
+
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json
@@ -1,0 +1,38 @@
+{
+  "nodes.usage": {
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html",
+    "methods": ["GET"],
+    "url": {
+      "path": "/_nodes/usage",
+      "paths": [
+        "/_nodes/usage",
+        "/_nodes/{node_id}/usage",
+        "/_nodes/usage/{metric}",
+        "/_nodes/{node_id}/usage/{metric}"
+      ],
+      "parts": {
+        "metric" : {
+          "type" : "list",
+          "options" : ["_all", "rest_actions"],
+          "description" : "Limit the information returned to the specified metrics"
+        },
+        "node_id": {
+          "type" : "list",
+          "description" : "A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"
+        }
+      },
+      "params": {
+        "human": {
+            "type": "boolean",
+            "description": "Whether to return time and byte values in human-readable format.",
+            "default": false
+        },
+        "timeout": {
+          "type" : "time",
+          "description" : "Explicit operation timeout"
+        }
+      }
+    },
+    "body": null
+  }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -120,7 +120,14 @@ public class ESRestTestCase extends ESTestCase {
     public final void after() throws Exception {
         wipeCluster();
         logIfThereAreRunningTasks();
+        // Need to wipe usage stats here as logIfThereAreRunningTasks performs
+        // requests
+        wipeUsageStats();
         closeClients();
+    }
+
+    private void wipeUsageStats() throws IOException {
+        adminClient().performRequest("POST", "_nodes/usage/_clear");
     }
 
     /**


### PR DESCRIPTION
The nodes usage API has 2 main endpoints

`/_nodes/usage` and `/_nodes/{nodeIds}/usage` return the usage statistics
for all nodes and the specified node(s) respectively.

`/_nodes/usage/_clear` and `_nodes/{nodeIds}/usage/_clear` clear the usage
statistics for all node and the specified node(s) respectively.

At the moment only one type of usage statistics is available, the REST
actions usage. This records the number of times each REST action class is
called and when the nodes usage api is called will return a map of rest
action class name to long representing the number of times each of the action
classes has been called.

In following PRs I want to add usage statistics for the query types and
aggregation types and this PR leaves open the ability to add other usage
statistics and filter which stats are returned.

Still to do:
- Documentation
