### PR TITLE
Add network types to cluster stats

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -91,7 +91,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
 
     @Override
     protected ClusterStatsNodeResponse nodeOperation(ClusterStatsNodeRequest nodeRequest) {
-        NodeInfo nodeInfo = nodeService.info(false, true, false, true, false, true, false, true, false, false);
+        NodeInfo nodeInfo = nodeService.info(true, true, false, true, false, true, false, true, false, false);
         NodeStats nodeStats = nodeService.stats(CommonStatsFlags.NONE, false, true, true, false, true, false, false, false, false, false, false);
         List<ShardStats> shardsStats = new ArrayList<>();
         for (IndexService indexService : indicesService) {

--- a/modules/transport-netty3/src/test/resources/rest-api-spec/test/10_basic.yaml
+++ b/modules/transport-netty3/src/test/resources/rest-api-spec/test/10_basic.yaml
@@ -11,3 +11,9 @@
         nodes.info: {}
 
     - match:  { nodes.$master.modules.0.name: transport-netty3  }
+
+    - do:
+        cluster.stats: {}
+
+    - match:  { nodes.network_types.transport_types.netty3: 2 }
+    - match:  { nodes.network_types.http_types.netty3: 2 }

--- a/modules/transport-netty4/src/test/resources/rest-api-spec/test/10_basic.yaml
+++ b/modules/transport-netty4/src/test/resources/rest-api-spec/test/10_basic.yaml
@@ -11,3 +11,9 @@
         nodes.info: {}
 
     - match:  { nodes.$master.modules.1.name: transport-netty4  }
+
+    - do:
+        cluster.stats: {}
+
+    - match:  { nodes.network_types.transport_types.netty4: 2 }
+    - match:  { nodes.network_types.http_types.netty4: 2 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.stats/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.stats/10_basic.yaml
@@ -23,3 +23,4 @@
   - is_true: nodes.jvm
   - is_true: nodes.fs
   - is_true: nodes.plugins
+  - is_true: nodes.network_types


### PR DESCRIPTION
The network types in use on a cluster can be useful information to have,
so this commit adds aggregate metrics for the network types in use in a
cluster to the cluster stats.
