### PR TITLE
Fixed naming inconsistency for fields/stored_fields in the APIs

### DIFF
--- a/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/RestNoopBulkAction.java
+++ b/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/RestNoopBulkAction.java
@@ -72,7 +72,7 @@ public class RestNoopBulkAction extends BaseRestHandler {
         }
         bulkRequest.timeout(request.paramAsTime("timeout", BulkShardRequest.DEFAULT_TIMEOUT));
         bulkRequest.setRefreshPolicy(request.param("refresh"));
-        bulkRequest.add(request.content(), defaultIndex, defaultType, defaultRouting, defaultFields, defaultPipeline, null, true);
+        bulkRequest.add(request.content(), defaultIndex, defaultType, defaultRouting, defaultFields, null, defaultPipeline, null, true);
 
         // short circuit the call to the transport layer
         BulkRestBuilderListener listener = new BulkRestBuilderListener(channel, request);

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
@@ -293,7 +293,7 @@ public class BulkProcessor implements Closeable {
     }
 
     public synchronized BulkProcessor add(BytesReference data, @Nullable String defaultIndex, @Nullable String defaultType, @Nullable String defaultPipeline, @Nullable Object payload) throws Exception {
-        bulkRequest.add(data, defaultIndex, defaultType, null, null, defaultPipeline, payload, true);
+        bulkRequest.add(data, defaultIndex, defaultType, null, null, null, defaultPipeline, payload, true);
         executeIfNeeded();
         return this;
     }

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -30,17 +30,21 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.VersionType;
+import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -57,6 +61,8 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * @see org.elasticsearch.client.Client#bulk(BulkRequest)
  */
 public class BulkRequest extends ActionRequest<BulkRequest> implements CompositeIndicesRequest, WriteRequest<BulkRequest> {
+    private static final DeprecationLogger DEPRECATION_LOGGER =
+        new DeprecationLogger(Loggers.getLogger(BulkRequest.class));
 
     private static final int REQUEST_OVERHEAD = 50;
 
@@ -257,17 +263,17 @@ public class BulkRequest extends ActionRequest<BulkRequest> implements Composite
      * Adds a framed data in binary format
      */
     public BulkRequest add(BytesReference data, @Nullable String defaultIndex, @Nullable String defaultType) throws Exception {
-        return add(data, defaultIndex, defaultType, null, null, null, null, true);
+        return add(data, defaultIndex, defaultType, null, null, null, null, null, true);
     }
 
     /**
      * Adds a framed data in binary format
      */
     public BulkRequest add(BytesReference data, @Nullable String defaultIndex, @Nullable String defaultType, boolean allowExplicitIndex) throws Exception {
-        return add(data, defaultIndex, defaultType, null, null, null, null, allowExplicitIndex);
+        return add(data, defaultIndex, defaultType, null, null, null, null, null, allowExplicitIndex);
     }
 
-    public BulkRequest add(BytesReference data, @Nullable String defaultIndex, @Nullable String defaultType, @Nullable String defaultRouting, @Nullable String[] defaultFields, @Nullable String defaultPipeline, @Nullable Object payload, boolean allowExplicitIndex) throws Exception {
+    public BulkRequest add(BytesReference data, @Nullable String defaultIndex, @Nullable String defaultType, @Nullable String defaultRouting, @Nullable String[] defaultFields, @Nullable FetchSourceContext defaultFetchSourceContext, @Nullable String defaultPipeline, @Nullable Object payload, boolean allowExplicitIndex) throws Exception {
         XContent xContent = XContentFactory.xContent(data);
         int line = 0;
         int from = 0;
@@ -301,6 +307,7 @@ public class BulkRequest extends ActionRequest<BulkRequest> implements Composite
                 String id = null;
                 String routing = defaultRouting;
                 String parent = null;
+                FetchSourceContext fetchSourceContext = defaultFetchSourceContext;
                 String[] fields = defaultFields;
                 String timestamp = null;
                 TimeValue ttl = null;
@@ -353,16 +360,21 @@ public class BulkRequest extends ActionRequest<BulkRequest> implements Composite
                                 pipeline = parser.text();
                             } else if ("fields".equals(currentFieldName)) {
                                 throw new IllegalArgumentException("Action/metadata line [" + line + "] contains a simple value for parameter [fields] while a list is expected");
+                            } else if ("_source".equals(currentFieldName)) {
+                                fetchSourceContext = FetchSourceContext.parse(parser, ParseFieldMatcher.EMPTY);
                             } else {
                                 throw new IllegalArgumentException("Action/metadata line [" + line + "] contains an unknown parameter [" + currentFieldName + "]");
                             }
                         } else if (token == XContentParser.Token.START_ARRAY) {
                             if ("fields".equals(currentFieldName)) {
+                                DEPRECATION_LOGGER.deprecated("Deprecated field [fields] used, expected [_source] instead");
                                 List<Object> values = parser.list();
                                 fields = values.toArray(new String[values.size()]);
                             } else {
                                 throw new IllegalArgumentException("Malformed action/metadata line [" + line + "], expected a simple value for field [" + currentFieldName + "] but found [" + token + "]");
                             }
+                        } else if (token == XContentParser.Token.START_OBJECT && "_source".equals(currentFieldName)) {
+                            fetchSourceContext = FetchSourceContext.parse(parser, ParseFieldMatcher.STRICT);
                         } else if (token != XContentParser.Token.VALUE_NULL) {
                             throw new IllegalArgumentException("Malformed action/metadata line [" + line + "], expected a simple value for field [" + currentFieldName + "] but found [" + token + "]");
                         }
@@ -402,7 +414,10 @@ public class BulkRequest extends ActionRequest<BulkRequest> implements Composite
                                 .version(version).versionType(versionType)
                                 .routing(routing)
                                 .parent(parent)
-                                .source(data.slice(from, nextMarker - from));
+                                .fromXContent(data.slice(from, nextMarker - from));
+                        if (fetchSourceContext != null) {
+                            updateRequest.fetchSource(fetchSourceContext);
+                        }
                         if (fields != null) {
                             updateRequest.fields(fields);
                         }

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -30,7 +30,6 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -361,7 +360,7 @@ public class BulkRequest extends ActionRequest<BulkRequest> implements Composite
                             } else if ("fields".equals(currentFieldName)) {
                                 throw new IllegalArgumentException("Action/metadata line [" + line + "] contains a simple value for parameter [fields] while a list is expected");
                             } else if ("_source".equals(currentFieldName)) {
-                                fetchSourceContext = FetchSourceContext.parse(parser, ParseFieldMatcher.EMPTY);
+                                fetchSourceContext = FetchSourceContext.parse(parser);
                             } else {
                                 throw new IllegalArgumentException("Action/metadata line [" + line + "] contains an unknown parameter [" + currentFieldName + "]");
                             }
@@ -374,7 +373,7 @@ public class BulkRequest extends ActionRequest<BulkRequest> implements Composite
                                 throw new IllegalArgumentException("Malformed action/metadata line [" + line + "], expected a simple value for field [" + currentFieldName + "] but found [" + token + "]");
                             }
                         } else if (token == XContentParser.Token.START_OBJECT && "_source".equals(currentFieldName)) {
-                            fetchSourceContext = FetchSourceContext.parse(parser, ParseFieldMatcher.STRICT);
+                            fetchSourceContext = FetchSourceContext.parse(parser);
                         } else if (token != XContentParser.Token.VALUE_NULL) {
                             throw new IllegalArgumentException("Malformed action/metadata line [" + line + "], expected a simple value for field [" + currentFieldName + "] but found [" + token + "]");
                         }

--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -251,7 +251,8 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                         // add the response
                         IndexResponse indexResponse = result.getResponse();
                         UpdateResponse updateResponse = new UpdateResponse(indexResponse.getShardInfo(), indexResponse.getShardId(), indexResponse.getType(), indexResponse.getId(), indexResponse.getVersion(), indexResponse.getResult());
-                        if (updateRequest.fields() != null && updateRequest.fields().length > 0) {
+                        if ((updateRequest.fetchSource() != null && updateRequest.fetchSource().fetchSource()) ||
+                            (updateRequest.fields() != null && updateRequest.fields().length > 0)) {
                             Tuple<XContentType, Map<String, Object>> sourceAndContent = XContentHelper.convertToMap(indexSourceAsBytes, true);
                             updateResponse.setGetResult(updateHelper.extractGetResult(updateRequest, request.index(), indexResponse.getVersion(), sourceAndContent.v2(), sourceAndContent.v1(), indexSourceAsBytes));
                         }

--- a/core/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
@@ -40,7 +40,7 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> {
     private String routing;
     private String preference;
     private QueryBuilder query;
-    private String[] fields;
+    private String[] storedFields;
     private FetchSourceContext fetchSourceContext;
 
     private String[] filteringAlias = Strings.EMPTY_ARRAY;
@@ -122,12 +122,12 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> {
     }
 
 
-    public String[] fields() {
-        return fields;
+    public String[] storedFields() {
+        return storedFields;
     }
 
-    public ExplainRequest fields(String[] fields) {
-        this.fields = fields;
+    public ExplainRequest storedFields(String[] fields) {
+        this.storedFields = fields;
         return this;
     }
 
@@ -167,7 +167,7 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> {
         preference = in.readOptionalString();
         query = in.readNamedWriteable(QueryBuilder.class);
         filteringAlias = in.readStringArray();
-        fields = in.readOptionalStringArray();
+        storedFields = in.readOptionalStringArray();
         fetchSourceContext = in.readOptionalStreamable(FetchSourceContext::new);
         nowInMillis = in.readVLong();
     }
@@ -181,7 +181,7 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> {
         out.writeOptionalString(preference);
         out.writeNamedWriteable(query);
         out.writeStringArray(filteringAlias);
-        out.writeOptionalStringArray(fields);
+        out.writeOptionalStringArray(storedFields);
         out.writeOptionalStreamable(fetchSourceContext);
         out.writeVLong(nowInMillis);
     }

--- a/core/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
@@ -168,7 +168,7 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> {
         query = in.readNamedWriteable(QueryBuilder.class);
         filteringAlias = in.readStringArray();
         storedFields = in.readOptionalStringArray();
-        fetchSourceContext = in.readOptionalStreamable(FetchSourceContext::new);
+        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::new);
         nowInMillis = in.readVLong();
     }
 
@@ -182,7 +182,7 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> {
         out.writeNamedWriteable(query);
         out.writeStringArray(filteringAlias);
         out.writeOptionalStringArray(storedFields);
-        out.writeOptionalStreamable(fetchSourceContext);
+        out.writeOptionalWriteable(fetchSourceContext);
         out.writeVLong(nowInMillis);
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/explain/ExplainRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/explain/ExplainRequestBuilder.java
@@ -88,10 +88,10 @@ public class ExplainRequestBuilder extends SingleShardOperationRequestBuilder<Ex
     }
 
     /**
-     * Explicitly specify the fields that will be returned for the explained document. By default, nothing is returned.
+     * Explicitly specify the stored fields that will be returned for the explained document. By default, nothing is returned.
      */
-    public ExplainRequestBuilder setFields(String... fields) {
-        request.fields(fields);
+    public ExplainRequestBuilder setStoredFields(String... fields) {
+        request.storedFields(fields);
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -106,12 +106,11 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
                 Rescorer rescorer = ctx.rescorer();
                 explanation = rescorer.explain(topLevelDocId, context, ctx, explanation);
             }
-            if (request.fields() != null || (request.fetchSourceContext() != null && request.fetchSourceContext().fetchSource())) {
+            if (request.storedFields() != null || (request.fetchSourceContext() != null && request.fetchSourceContext().fetchSource())) {
                 // Advantage is that we're not opening a second searcher to retrieve the _source. Also
                 // because we are working in the same searcher in engineGetResult we can be sure that a
                 // doc isn't deleted between the initial get and this call.
-                GetResult getResult = context.indexShard().getService().get(result, request.id(), request.type(), request.fields(),
-                    request.fetchSourceContext());
+                GetResult getResult = context.indexShard().getService().get(result, request.id(), request.type(), request.storedFields(), request.fetchSourceContext());
                 return new ExplainResponse(shardId.getIndexName(), request.type(), request.id(), true, explanation, getResult);
             } else {
                 return new ExplainResponse(shardId.getIndexName(), request.type(), request.id(), true, explanation);

--- a/core/src/main/java/org/elasticsearch/action/get/GetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/GetRequest.java
@@ -265,7 +265,7 @@ public class GetRequest extends SingleShardRequest<GetRequest> implements Realti
 
         this.versionType = VersionType.fromValue(in.readByte());
         this.version = in.readLong();
-        fetchSourceContext = in.readOptionalStreamable(FetchSourceContext::new);
+        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::new);
     }
 
     @Override
@@ -282,7 +282,7 @@ public class GetRequest extends SingleShardRequest<GetRequest> implements Realti
         out.writeBoolean(realtime);
         out.writeByte(versionType.getValue());
         out.writeLong(version);
-        out.writeOptionalStreamable(fetchSourceContext);
+        out.writeOptionalWriteable(fetchSourceContext);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/get/GetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/GetRequest.java
@@ -51,7 +51,7 @@ public class GetRequest extends SingleShardRequest<GetRequest> implements Realti
     private String parent;
     private String preference;
 
-    private String[] fields;
+    private String[] storedFields;
 
     private FetchSourceContext fetchSourceContext;
 
@@ -186,20 +186,20 @@ public class GetRequest extends SingleShardRequest<GetRequest> implements Realti
     }
 
     /**
-     * Explicitly specify the fields that will be returned. By default, the <tt>_source</tt>
+     * Explicitly specify the stored fields that will be returned. By default, the <tt>_source</tt>
      * field will be returned.
      */
-    public GetRequest fields(String... fields) {
-        this.fields = fields;
+    public GetRequest storedFields(String... fields) {
+        this.storedFields = fields;
         return this;
     }
 
     /**
-     * Explicitly specify the fields that will be returned. By default, the <tt>_source</tt>
+     * Explicitly specify the stored fields that will be returned. By default, the <tt>_source</tt>
      * field will be returned.
      */
-    public String[] fields() {
-        return this.fields;
+    public String[] storedFields() {
+        return this.storedFields;
     }
 
     /**
@@ -260,13 +260,7 @@ public class GetRequest extends SingleShardRequest<GetRequest> implements Realti
         parent = in.readOptionalString();
         preference = in.readOptionalString();
         refresh = in.readBoolean();
-        int size = in.readInt();
-        if (size >= 0) {
-            fields = new String[size];
-            for (int i = 0; i < size; i++) {
-                fields[i] = in.readString();
-            }
-        }
+        storedFields = in.readOptionalStringArray();
         realtime = in.readBoolean();
 
         this.versionType = VersionType.fromValue(in.readByte());
@@ -284,14 +278,7 @@ public class GetRequest extends SingleShardRequest<GetRequest> implements Realti
         out.writeOptionalString(preference);
 
         out.writeBoolean(refresh);
-        if (fields == null) {
-            out.writeInt(-1);
-        } else {
-            out.writeInt(fields.length);
-            for (String field : fields) {
-                out.writeString(field);
-            }
-        }
+        out.writeOptionalStringArray(storedFields);
         out.writeBoolean(realtime);
         out.writeByte(versionType.getValue());
         out.writeLong(version);

--- a/core/src/main/java/org/elasticsearch/action/get/GetRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/get/GetRequestBuilder.java
@@ -88,8 +88,8 @@ public class GetRequestBuilder extends SingleShardOperationRequestBuilder<GetReq
      * Explicitly specify the fields that will be returned. By default, the <tt>_source</tt>
      * field will be returned.
      */
-    public GetRequestBuilder setFields(String... fields) {
-        request.fields(fields);
+    public GetRequestBuilder setStoredFields(String... fields) {
+        request.storedFields(fields);
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/get/GetResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/get/GetResponse.java
@@ -134,14 +134,26 @@ public class GetResponse extends ActionResponse implements Iterable<GetField>, T
         return getResult.getSource();
     }
 
+    /**
+     * @deprecated Use {@link GetResponse#getSource()} instead
+     */
+    @Deprecated
     public Map<String, GetField> getFields() {
         return getResult.getFields();
     }
 
+    /**
+     * @deprecated Use {@link GetResponse#getSource()} instead
+     */
+    @Deprecated
     public GetField getField(String name) {
         return getResult.field(name);
     }
 
+    /**
+     * @deprecated Use {@link GetResponse#getSource()} instead
+     */
+    @Deprecated
     @Override
     public Iterator<GetField> iterator() {
         return getResult.iterator();

--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -192,7 +192,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
             version = in.readLong();
             versionType = VersionType.fromValue(in.readByte());
 
-            fetchSourceContext = in.readOptionalStreamable(FetchSourceContext::new);
+            fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::new);
         }
 
         @Override
@@ -206,7 +206,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
             out.writeLong(version);
             out.writeByte(versionType.getValue());
 
-            out.writeOptionalStreamable(fetchSourceContext);
+            out.writeOptionalWriteable(fetchSourceContext);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -391,7 +391,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
                         parent = parser.text();
                     } else if ("fields".equals(currentFieldName)) {
                         throw new ParsingException(parser.getTokenLocation(),
-                            "Deprecated field [fields] used, expected [stored_fields] instead");
+                            "Unsupported field [fields] used, expected [stored_fields] instead");
                     } else if ("stored_fields".equals(currentFieldName)) {
                         storedFields = new ArrayList<>();
                         storedFields.add(parser.text());
@@ -411,7 +411,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
                 } else if (token == XContentParser.Token.START_ARRAY) {
                     if ("fields".equals(currentFieldName)) {
                         throw new ParsingException(parser.getTokenLocation(),
-                            "Deprecated field [fields] used, expected [stored_fields] instead");
+                            "Unsupported field [fields] used, expected [stored_fields] instead");
                     } else if ("stored_fields".equals(currentFieldName)) {
                         storedFields = new ArrayList<>();
                         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {

--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -28,6 +28,7 @@ import org.elasticsearch.action.RealtimeRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -388,6 +389,9 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
                         routing = parser.text();
                     } else if ("_parent".equals(currentFieldName) || "parent".equals(currentFieldName)) {
                         parent = parser.text();
+                    } else if ("fields".equals(currentFieldName)) {
+                        throw new ParsingException(parser.getTokenLocation(),
+                            "Deprecated field [fields] used, expected [stored_fields] instead");
                     } else if ("stored_fields".equals(currentFieldName)) {
                         storedFields = new ArrayList<>();
                         storedFields.add(parser.text());
@@ -405,7 +409,10 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
                         }
                     }
                 } else if (token == XContentParser.Token.START_ARRAY) {
-                    if ("stored_fields".equals(currentFieldName)) {
+                    if ("fields".equals(currentFieldName)) {
+                        throw new ParsingException(parser.getTokenLocation(),
+                            "Deprecated field [fields] used, expected [stored_fields] instead");
+                    } else if ("stored_fields".equals(currentFieldName)) {
                         storedFields = new ArrayList<>();
                         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                             storedFields.add(parser.text());

--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -58,7 +58,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
         private String id;
         private String routing;
         private String parent;
-        private String[] fields;
+        private String[] storedFields;
         private long version = Versions.MATCH_ANY;
         private VersionType versionType = VersionType.INTERNAL;
         private FetchSourceContext fetchSourceContext;
@@ -136,13 +136,13 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
             return parent;
         }
 
-        public Item fields(String... fields) {
-            this.fields = fields;
+        public Item storedFields(String... fields) {
+            this.storedFields = fields;
             return this;
         }
 
-        public String[] fields() {
-            return this.fields;
+        public String[] storedFields() {
+            return this.storedFields;
         }
 
         public long version() {
@@ -188,13 +188,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
             id = in.readString();
             routing = in.readOptionalString();
             parent = in.readOptionalString();
-            int size = in.readVInt();
-            if (size > 0) {
-                fields = new String[size];
-                for (int i = 0; i < size; i++) {
-                    fields[i] = in.readString();
-                }
-            }
+            storedFields = in.readOptionalStringArray();
             version = in.readLong();
             versionType = VersionType.fromValue(in.readByte());
 
@@ -208,15 +202,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
             out.writeString(id);
             out.writeOptionalString(routing);
             out.writeOptionalString(parent);
-            if (fields == null) {
-                out.writeVInt(0);
-            } else {
-                out.writeVInt(fields.length);
-                for (String field : fields) {
-                    out.writeString(field);
-                }
-            }
-
+            out.writeOptionalStringArray(storedFields);
             out.writeLong(version);
             out.writeByte(versionType.getValue());
 
@@ -233,7 +219,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
             if (version != item.version) return false;
             if (fetchSourceContext != null ? !fetchSourceContext.equals(item.fetchSourceContext) : item.fetchSourceContext != null)
                 return false;
-            if (!Arrays.equals(fields, item.fields)) return false;
+            if (!Arrays.equals(storedFields, item.storedFields)) return false;
             if (!id.equals(item.id)) return false;
             if (!index.equals(item.index)) return false;
             if (routing != null ? !routing.equals(item.routing) : item.routing != null) return false;
@@ -251,7 +237,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
             result = 31 * result + id.hashCode();
             result = 31 * result + (routing != null ? routing.hashCode() : 0);
             result = 31 * result + (parent != null ? parent.hashCode() : 0);
-            result = 31 * result + (fields != null ? Arrays.hashCode(fields) : 0);
+            result = 31 * result + (storedFields != null ? Arrays.hashCode(storedFields) : 0);
             result = 31 * result + Long.hashCode(version);
             result = 31 * result + versionType.hashCode();
             result = 31 * result + (fetchSourceContext != null ? fetchSourceContext.hashCode() : 0);
@@ -379,7 +365,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
             String id = null;
             String routing = defaultRouting;
             String parent = null;
-            List<String> fields = null;
+            List<String> storedFields = null;
             long version = Versions.MATCH_ANY;
             VersionType versionType = VersionType.INTERNAL;
 
@@ -402,9 +388,9 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
                         routing = parser.text();
                     } else if ("_parent".equals(currentFieldName) || "parent".equals(currentFieldName)) {
                         parent = parser.text();
-                    } else if ("fields".equals(currentFieldName)) {
-                        fields = new ArrayList<>();
-                        fields.add(parser.text());
+                    } else if ("stored_fields".equals(currentFieldName)) {
+                        storedFields = new ArrayList<>();
+                        storedFields.add(parser.text());
                     } else if ("_version".equals(currentFieldName) || "version".equals(currentFieldName)) {
                         version = parser.longValue();
                     } else if ("_version_type".equals(currentFieldName) || "_versionType".equals(currentFieldName) || "version_type".equals(currentFieldName) || "versionType".equals(currentFieldName)) {
@@ -419,10 +405,10 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
                         }
                     }
                 } else if (token == XContentParser.Token.START_ARRAY) {
-                    if ("fields".equals(currentFieldName)) {
-                        fields = new ArrayList<>();
+                    if ("stored_fields".equals(currentFieldName)) {
+                        storedFields = new ArrayList<>();
                         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                            fields.add(parser.text());
+                            storedFields.add(parser.text());
                         }
                     } else if ("_source".equals(currentFieldName)) {
                         ArrayList<String> includes = new ArrayList<>();
@@ -464,12 +450,12 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
                 }
             }
             String[] aFields;
-            if (fields != null) {
-                aFields = fields.toArray(new String[fields.size()]);
+            if (storedFields != null) {
+                aFields = storedFields.toArray(new String[storedFields.size()]);
             } else {
                 aFields = defaultFields;
             }
-            items.add(new Item(index, type, id).routing(routing).fields(aFields).parent(parent).version(version).versionType(versionType)
+            items.add(new Item(index, type, id).routing(routing).storedFields(aFields).parent(parent).version(version).versionType(versionType)
                     .fetchSourceContext(fetchSourceContext == null ? defaultFetchSource : fetchSourceContext));
         }
     }
@@ -484,7 +470,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
             if (!token.isValue()) {
                 throw new IllegalArgumentException("ids array element should only contain ids");
             }
-            items.add(new Item(defaultIndex, defaultType, parser.text()).fields(defaultFields).fetchSourceContext(defaultFetchSource).routing(defaultRouting));
+            items.add(new Item(defaultIndex, defaultType, parser.text()).storedFields(defaultFields).fetchSourceContext(defaultFetchSource).routing(defaultRouting));
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
+++ b/core/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
@@ -92,7 +92,7 @@ public class TransportGetAction extends TransportSingleShardAction<GetRequest, G
             indexShard.refresh("refresh_flag_get");
         }
 
-        GetResult result = indexShard.getService().get(request.type(), request.id(), request.fields(),
+        GetResult result = indexShard.getService().get(request.type(), request.id(), request.storedFields(),
                 request.realtime(), request.version(), request.versionType(), request.fetchSourceContext());
         return new GetResponse(result);
     }

--- a/core/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
+++ b/core/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
@@ -88,7 +88,7 @@ public class TransportShardMultiGetAction extends TransportSingleShardAction<Mul
         for (int i = 0; i < request.locations.size(); i++) {
             MultiGetRequest.Item item = request.items.get(i);
             try {
-                GetResult getResult = indexShard.getService().get(item.type(), item.id(), item.fields(), request.realtime(), item.version(),
+                GetResult getResult = indexShard.getService().get(item.type(), item.id(), item.storedFields(), request.realtime(), item.version(),
                     item.versionType(), item.fetchSourceContext());
                 response.add(request.locations.get(i), new GetResponse(getResult));
             } catch (Exception e) {

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
@@ -180,7 +180,7 @@ public class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> i
         super(item.index());
         this.id = item.id();
         this.type = item.type();
-        this.selectedFields(item.fields());
+        this.selectedFields(item.storedFields());
         this.routing(item.routing());
         this.parent(item.parent());
     }

--- a/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -186,7 +186,8 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                     @Override
                     public void onResponse(IndexResponse response) {
                         UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), response.getResult());
-                        if (request.fields() != null && request.fields().length > 0) {
+                        if ((request.fetchSource() != null && request.fetchSource().fetchSource()) ||
+                            (request.fields() != null && request.fields().length > 0)) {
                             Tuple<XContentType, Map<String, Object>> sourceAndContent = XContentHelper.convertToMap(upsertSourceBytes, true);
                             update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), sourceAndContent.v2(), sourceAndContent.v1(), upsertSourceBytes));
                         } else {

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.update;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -28,9 +29,11 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.VersionType;
@@ -51,6 +54,7 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.search.lookup.SourceLookup;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -267,17 +271,19 @@ public class UpdateHelper extends AbstractComponent {
     }
 
     /**
-     * Extracts the fields from the updated document to be returned in a update response
+     * Applies {@link UpdateRequest#fetchSource()} to the _source of the updated document to be returned in a update response.
+     * For BWC this function also extracts the {@link UpdateRequest#fields()} from the updated document to be returned in a update response
      */
     public GetResult extractGetResult(final UpdateRequest request, String concreteIndex, long version, final Map<String, Object> source, XContentType sourceContentType, @Nullable final BytesReference sourceAsBytes) {
-        if (request.fields() == null || request.fields().length == 0) {
+        if ((request.fields() == null || request.fields().length == 0) &&
+            (request.fetchSource() == null || request.fetchSource().fetchSource() == false)) {
             return null;
         }
+        SourceLookup sourceLookup = new SourceLookup();
+        sourceLookup.setSource(source);
         boolean sourceRequested = false;
         Map<String, GetField> fields = null;
         if (request.fields() != null && request.fields().length > 0) {
-            SourceLookup sourceLookup = new SourceLookup();
-            sourceLookup.setSource(source);
             for (String field : request.fields()) {
                 if (field.equals("_source")) {
                     sourceRequested = true;
@@ -298,8 +304,24 @@ public class UpdateHelper extends AbstractComponent {
             }
         }
 
+        BytesReference sourceFilteredAsBytes = sourceAsBytes;
+        if (request.fetchSource() != null) {
+            sourceRequested = true;
+            Object value = sourceLookup.filter(request.fetchSource().includes(), request.fetchSource().excludes());
+            try {
+                final int initialCapacity = Math.min(1024, sourceAsBytes.length());
+                BytesStreamOutput streamOutput = new BytesStreamOutput(initialCapacity);
+                try (XContentBuilder builder = new XContentBuilder(sourceContentType.xContent(), streamOutput)) {
+                    builder.value(value);
+                    sourceFilteredAsBytes = builder.bytes();
+                }
+            } catch (IOException e) {
+                throw new ElasticsearchException("Error filtering source", e);
+            }
+        }
+
         // TODO when using delete/none, we can still return the source as bytes by generating it (using the sourceContentType)
-        return new GetResult(concreteIndex, request.type(), request.id(), version, true, sourceRequested ? sourceAsBytes : null, fields);
+        return new GetResult(concreteIndex, request.type(), request.id(), version, true, sourceRequested ? sourceFilteredAsBytes : null, fields);
     }
 
     public static class Result {

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -47,10 +47,10 @@ import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -745,22 +745,17 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
                 } else if ("detect_noop".equals(currentFieldName)) {
                     detectNoop(parser.booleanValue());
                 } else if ("fields".equals(currentFieldName)) {
+                    List<Object> fields = null;
                     if (token == XContentParser.Token.START_ARRAY) {
-                        List<String> strings = parser.list().stream()
-                            .filter((o) -> {
-                                if (o instanceof String == false) {
-                                    throw new IllegalArgumentException("");
-                                }
-                                return true;
-                            })
-                            .map(o -> o.toString())
-                            .collect(Collectors.toList());
-                        fields(strings.toArray(new String[strings.size()]));
+                        fields = (List) parser.list();
                     } else if (token.isValue()) {
-                        fields(parser.text());
+                        fields = Collections.singletonList(parser.text());
+                    }
+                    if (fields != null) {
+                        fields(fields.toArray(new String[fields.size()]));
                     }
                 } else if ("_source".equals(currentFieldName)) {
-                    fetchSourceContext = FetchSourceContext.parse(parser, ParseFieldMatcher.EMPTY);
+                    fetchSourceContext = FetchSourceContext.parse(parser);
                 }
             }
             if (script != null) {

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -32,6 +32,8 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -42,12 +44,13 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptService.ScriptType;
+import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -55,6 +58,8 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  */
 public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
         implements DocumentRequest<UpdateRequest>, WriteRequest<UpdateRequest> {
+    private static final DeprecationLogger DEPRECATION_LOGGER =
+        new DeprecationLogger(Loggers.getLogger(UpdateRequest.class));
 
     private String type;
     private String id;
@@ -68,6 +73,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
     Script script;
 
     private String[] fields;
+    private FetchSourceContext fetchSourceContext;
 
     private long version = Versions.MATCH_ANY;
     private VersionType versionType = VersionType.INTERNAL;
@@ -373,17 +379,80 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
 
     /**
      * Explicitly specify the fields that will be returned. By default, nothing is returned.
+     * @deprecated Use {@link UpdateRequest#fetchSource(String[], String[])} instead
      */
+    @Deprecated
     public UpdateRequest fields(String... fields) {
         this.fields = fields;
         return this;
     }
 
     /**
-     * Get the fields to be returned.
+     * Indicate that _source should be returned with every hit, with an
+     * "include" and/or "exclude" set which can include simple wildcard
+     * elements.
+     *
+     * @param include
+     *            An optional include (optionally wildcarded) pattern to filter
+     *            the returned _source
+     * @param exclude
+     *            An optional exclude (optionally wildcarded) pattern to filter
+     *            the returned _source
      */
+    public UpdateRequest fetchSource(@Nullable String include, @Nullable String exclude) {
+        this.fetchSourceContext = new FetchSourceContext(include, exclude);
+        return this;
+    }
+
+    /**
+     * Indicate that _source should be returned, with an
+     * "include" and/or "exclude" set which can include simple wildcard
+     * elements.
+     *
+     * @param includes
+     *            An optional list of include (optionally wildcarded) pattern to
+     *            filter the returned _source
+     * @param excludes
+     *            An optional list of exclude (optionally wildcarded) pattern to
+     *            filter the returned _source
+     */
+    public UpdateRequest fetchSource(@Nullable String[] includes, @Nullable String[] excludes) {
+        this.fetchSourceContext = new FetchSourceContext(includes, excludes);
+        return this;
+    }
+
+    /**
+     * Indicates whether the response should contain the updated _source.
+     */
+    public UpdateRequest fetchSource(boolean fetchSource) {
+        this.fetchSourceContext = new FetchSourceContext(fetchSource);
+        return this;
+    }
+
+    /**
+     * Explicitely set the fetch source context for this request
+     */
+    public UpdateRequest fetchSource(FetchSourceContext context) {
+        this.fetchSourceContext = context;
+        return this;
+    }
+
+
+    /**
+     * Get the fields to be returned.
+     * @deprecated Use {@link UpdateRequest#fetchSource()} instead
+     */
+    @Deprecated
     public String[] fields() {
-        return this.fields;
+        return fields;
+    }
+
+    /**
+     * Gets the {@link FetchSourceContext} which defines how the _source should
+     * be fetched.
+     */
+    public FetchSourceContext fetchSource() {
+        return fetchSourceContext;
     }
 
     /**
@@ -618,16 +687,16 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
         return upsertRequest;
     }
 
-    public UpdateRequest source(XContentBuilder source) throws Exception {
-        return source(source.bytes());
+    public UpdateRequest fromXContent(XContentBuilder source) throws Exception {
+        return fromXContent(source.bytes());
     }
 
-    public UpdateRequest source(byte[] source) throws Exception {
-        return source(source, 0, source.length);
+    public UpdateRequest fromXContent(byte[] source) throws Exception {
+        return fromXContent(source, 0, source.length);
     }
 
-    public UpdateRequest source(byte[] source, int offset, int length) throws Exception {
-        return source(new BytesArray(source, offset, length));
+    public UpdateRequest fromXContent(byte[] source, int offset, int length) throws Exception {
+        return fromXContent(new BytesArray(source, offset, length));
     }
 
     /**
@@ -646,7 +715,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
         return detectNoop;
     }
 
-    public UpdateRequest source(BytesReference source) throws Exception {
+    public UpdateRequest fromXContent(BytesReference source) throws Exception {
         Script script = null;
         try (XContentParser parser = XContentFactory.xContent(source).createParser(source)) {
             XContentParser.Token token = parser.nextToken();
@@ -676,15 +745,22 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
                 } else if ("detect_noop".equals(currentFieldName)) {
                     detectNoop(parser.booleanValue());
                 } else if ("fields".equals(currentFieldName)) {
-                    List<Object> fields = null;
                     if (token == XContentParser.Token.START_ARRAY) {
-                        fields = (List) parser.list();
+                        List<String> strings = parser.list().stream()
+                            .filter((o) -> {
+                                if (o instanceof String == false) {
+                                    throw new IllegalArgumentException("");
+                                }
+                                return true;
+                            })
+                            .map(o -> o.toString())
+                            .collect(Collectors.toList());
+                        fields(strings.toArray(new String[strings.size()]));
                     } else if (token.isValue()) {
-                        fields = Collections.singletonList(parser.text());
+                        fields(parser.text());
                     }
-                    if (fields != null) {
-                        fields(fields.toArray(new String[fields.size()]));
-                    }
+                } else if ("_source".equals(currentFieldName)) {
+                    fetchSourceContext = FetchSourceContext.parse(parser, ParseFieldMatcher.EMPTY);
                 }
             }
             if (script != null) {
@@ -729,13 +805,8 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
             doc = new IndexRequest();
             doc.readFrom(in);
         }
-        int size = in.readInt();
-        if (size >= 0) {
-            fields = new String[size];
-            for (int i = 0; i < size; i++) {
-                fields[i] = in.readString();
-            }
-        }
+        fields = in.readOptionalStringArray();
+        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::new);
         if (in.readBoolean()) {
             upsertRequest = new IndexRequest();
             upsertRequest.readFrom(in);
@@ -772,14 +843,8 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
             doc.id(id);
             doc.writeTo(out);
         }
-        if (fields == null) {
-            out.writeInt(-1);
-        } else {
-            out.writeInt(fields.length);
-            for (String field : fields) {
-                out.writeString(field);
-            }
-        }
+        out.writeOptionalStringArray(fields);
+        out.writeOptionalWriteable(fetchSourceContext);
         if (upsertRequest == null) {
             out.writeBoolean(false);
         } else {

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
@@ -26,7 +26,6 @@ import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.action.support.single.instance.InstanceShardOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.unit.TimeValue;
@@ -327,26 +326,6 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
      */
     public UpdateRequestBuilder setUpsert(Object... source) {
         request.upsert(source);
-        return this;
-    }
-
-    public UpdateRequestBuilder fromXContent(XContentBuilder source) throws Exception {
-        request.fromXContent(source);
-        return this;
-    }
-
-    public UpdateRequestBuilder fromXContent(byte[] source) throws Exception {
-        request.fromXContent(source);
-        return this;
-    }
-
-    public UpdateRequestBuilder fromXContent(byte[] source, int offset, int length) throws Exception {
-        request.fromXContent(source, offset, length);
-        return this;
-    }
-
-    public UpdateRequestBuilder fromXContent(BytesReference source) throws Exception {
-        request.fromXContent(source);
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
@@ -25,17 +25,23 @@ import org.elasticsearch.action.support.WriteRequestBuilder;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.action.support.single.instance.InstanceShardOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.VersionType;
+import org.elasticsearch.rest.action.document.RestUpdateAction;
 import org.elasticsearch.script.Script;
 
 import java.util.Map;
 
 public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<UpdateRequest, UpdateResponse, UpdateRequestBuilder>
         implements WriteRequestBuilder<UpdateRequestBuilder> {
+    private static final DeprecationLogger DEPRECATION_LOGGER =
+        new DeprecationLogger(Loggers.getLogger(RestUpdateAction.class));
 
     public UpdateRequestBuilder(ElasticsearchClient client, UpdateAction action) {
         super(client, action, new UpdateRequest());
@@ -90,9 +96,54 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
 
     /**
      * Explicitly specify the fields that will be returned. By default, nothing is returned.
+     * @deprecated Use {@link UpdateRequestBuilder#setFetchSource(String[], String[])} instead
      */
+    @Deprecated
     public UpdateRequestBuilder setFields(String... fields) {
+        DEPRECATION_LOGGER.deprecated("Deprecated field [fields] used, expected [_source] instead");
         request.fields(fields);
+        return this;
+    }
+
+    /**
+     * Indicate that _source should be returned with every hit, with an
+     * "include" and/or "exclude" set which can include simple wildcard
+     * elements.
+     *
+     * @param include
+     *            An optional include (optionally wildcarded) pattern to filter
+     *            the returned _source
+     * @param exclude
+     *            An optional exclude (optionally wildcarded) pattern to filter
+     *            the returned _source
+     */
+    public UpdateRequestBuilder setFetchSource(@Nullable String include, @Nullable String exclude) {
+        request.fetchSource(include, exclude);
+        return this;
+    }
+
+    /**
+     * Indicate that _source should be returned, with an
+     * "include" and/or "exclude" set which can include simple wildcard
+     * elements.
+     *
+     * @param includes
+     *            An optional list of include (optionally wildcarded) pattern to
+     *            filter the returned _source
+     * @param excludes
+     *            An optional list of exclude (optionally wildcarded) pattern to
+     *            filter the returned _source
+     */
+    public UpdateRequestBuilder setFetchSource(@Nullable String[] includes, @Nullable String[] excludes) {
+        request.fetchSource(includes, excludes);
+        return this;
+    }
+
+    /**
+     * Indicates whether the response should contain the updated _source.
+     */
+    public UpdateRequestBuilder setFetchSource(boolean fetchSource) {
+        request.fetchSource(fetchSource);
         return this;
     }
 
@@ -279,23 +330,23 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
         return this;
     }
 
-    public UpdateRequestBuilder setSource(XContentBuilder source) throws Exception {
-        request.source(source);
+    public UpdateRequestBuilder fromXContent(XContentBuilder source) throws Exception {
+        request.fromXContent(source);
         return this;
     }
 
-    public UpdateRequestBuilder setSource(byte[] source) throws Exception {
-        request.source(source);
+    public UpdateRequestBuilder fromXContent(byte[] source) throws Exception {
+        request.fromXContent(source);
         return this;
     }
 
-    public UpdateRequestBuilder setSource(byte[] source, int offset, int length) throws Exception {
-        request.source(source, offset, length);
+    public UpdateRequestBuilder fromXContent(byte[] source, int offset, int length) throws Exception {
+        request.fromXContent(source, offset, length);
         return this;
     }
 
-    public UpdateRequestBuilder setSource(BytesReference source) throws Exception {
-        request.source(source);
+    public UpdateRequestBuilder fromXContent(BytesReference source) throws Exception {
+        request.fromXContent(source);
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/get/GetResult.java
+++ b/core/src/main/java/org/elasticsearch/index/get/GetResult.java
@@ -204,6 +204,7 @@ public class GetResult implements Streamable, Iterable<GetField>, ToXContent {
         static final String _VERSION = "_version";
         static final String FOUND = "found";
         static final String FIELDS = "fields";
+        static final String _SOURCE = "_source";
     }
 
     public XContentBuilder toXContentEmbedded(XContentBuilder builder, Params params) throws IOException {
@@ -229,7 +230,7 @@ public class GetResult implements Streamable, Iterable<GetField>, ToXContent {
         builder.field(Fields.FOUND, exists);
 
         if (source != null) {
-            XContentHelper.writeRawField("_source", source, builder, params);
+            XContentHelper.writeRawField(Fields._SOURCE, source, builder, params);
         }
 
         if (!otherFields.isEmpty()) {

--- a/core/src/main/java/org/elasticsearch/index/get/GetResult.java
+++ b/core/src/main/java/org/elasticsearch/index/get/GetResult.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
@@ -204,7 +205,6 @@ public class GetResult implements Streamable, Iterable<GetField>, ToXContent {
         static final String _VERSION = "_version";
         static final String FOUND = "found";
         static final String FIELDS = "fields";
-        static final String _SOURCE = "_source";
     }
 
     public XContentBuilder toXContentEmbedded(XContentBuilder builder, Params params) throws IOException {
@@ -230,7 +230,7 @@ public class GetResult implements Streamable, Iterable<GetField>, ToXContent {
         builder.field(Fields.FOUND, exists);
 
         if (source != null) {
-            XContentHelper.writeRawField(Fields._SOURCE, source, builder, params);
+            XContentHelper.writeRawField(SourceFieldMapper.NAME, source, builder, params);
         }
 
         if (!otherFields.isEmpty()) {

--- a/core/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
@@ -94,7 +94,7 @@ public final class InnerHitBuilder extends ToXContentToBytes implements Writeabl
                 ObjectParser.ValueType.OBJECT_ARRAY);
         PARSER.declareField((p, i, c) -> {
             try {
-                i.setFetchSourceContext(FetchSourceContext.parse(c.parser(), c.getParseFieldMatcher()));
+                i.setFetchSourceContext(FetchSourceContext.parse(c.parser()));
             } catch (IOException e) {
                 throw new ParsingException(p.getTokenLocation(), "Could not parse inner _source definition", e);
             }

--- a/core/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
@@ -94,7 +94,7 @@ public final class InnerHitBuilder extends ToXContentToBytes implements Writeabl
                 ObjectParser.ValueType.OBJECT_ARRAY);
         PARSER.declareField((p, i, c) -> {
             try {
-                i.setFetchSourceContext(FetchSourceContext.parse(c));
+                i.setFetchSourceContext(FetchSourceContext.parse(c.parser(), c.getParseFieldMatcher()));
             } catch (IOException e) {
                 throw new ParsingException(p.getTokenLocation(), "Could not parse inner _source definition", e);
             }
@@ -219,7 +219,7 @@ public final class InnerHitBuilder extends ToXContentToBytes implements Writeabl
                 scriptFields.add(new ScriptField(in));
             }
         }
-        fetchSourceContext = in.readOptionalStreamable(FetchSourceContext::new);
+        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::new);
         if (in.readBoolean()) {
             int size = in.readVInt();
             sorts = new ArrayList<>(size);
@@ -258,7 +258,7 @@ public final class InnerHitBuilder extends ToXContentToBytes implements Writeabl
                 scriptField.writeTo(out);
             }
         }
-        out.writeOptionalStreamable(fetchSourceContext);
+        out.writeOptionalWriteable(fetchSourceContext);
         boolean hasSorts = sorts != null;
         out.writeBoolean(hasSorts);
         if (hasSorts) {

--- a/core/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
+++ b/core/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
@@ -258,8 +258,12 @@ public class TermVectorsService  {
         for (Map.Entry<String, Collection<Object>> entry : values.entrySet()) {
             String field = entry.getKey();
             Analyzer analyzer = getAnalyzerAtField(indexShard, field, perFieldAnalyzer);
-            for (Object text : entry.getValue()) {
-                index.addField(field, text.toString(), analyzer);
+            if (entry.getValue() instanceof List) {
+                for (Object text : entry.getValue()) {
+                    index.addField(field, text.toString(), analyzer);
+                }
+            } else {
+                index.addField(field, entry.getValue().toString(), analyzer);
             }
         }
         /* and read vectors from it */

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestGetAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestGetAction.java
@@ -59,11 +59,11 @@ public class RestGetAction extends BaseRestHandler {
         getRequest.preference(request.param("preference"));
         getRequest.realtime(request.paramAsBoolean("realtime", getRequest.realtime()));
 
-        String sField = request.param("fields");
+        String sField = request.param("stored_fields");
         if (sField != null) {
             String[] sFields = Strings.splitStringByCommaToArray(sField);
             if (sFields != null) {
-                getRequest.fields(sFields);
+                getRequest.storedFields(sFields);
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestGetAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestGetAction.java
@@ -60,7 +60,7 @@ public class RestGetAction extends BaseRestHandler {
         getRequest.realtime(request.paramAsBoolean("realtime", getRequest.realtime()));
         if (request.param("fields") != null) {
             throw new IllegalArgumentException("The parameter [fields] is no longer supported, " +
-                "please use [stored_fields] to retrieve stored fields or _source filtering if the field is not stored");
+                "please use [stored_fields] to retrieve stored fields or or [_source] to load the field from _source");
         }
         String sField = request.param("stored_fields");
         if (sField != null) {

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestGetAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestGetAction.java
@@ -58,7 +58,10 @@ public class RestGetAction extends BaseRestHandler {
         getRequest.parent(request.param("parent"));
         getRequest.preference(request.param("preference"));
         getRequest.realtime(request.paramAsBoolean("realtime", getRequest.realtime()));
-
+        if (request.param("fields") != null) {
+            throw new IllegalArgumentException("The parameter [fields] is no longer supported, " +
+                "please use [stored_fields] to retrieve stored fields or _source filtering if the field is not stored");
+        }
         String sField = request.param("stored_fields");
         if (sField != null) {
             String[] sFields = Strings.splitStringByCommaToArray(sField);

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestHeadAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestHeadAction.java
@@ -91,7 +91,7 @@ public abstract class RestHeadAction extends BaseRestHandler {
         getRequest.preference(request.param("preference"));
         getRequest.realtime(request.paramAsBoolean("realtime", getRequest.realtime()));
         // don't get any fields back...
-        getRequest.fields(Strings.EMPTY_ARRAY);
+        getRequest.storedFields(Strings.EMPTY_ARRAY);
         // TODO we can also just return the document size as Content-Length
 
         client.get(getRequest, new RestResponseListener<GetResponse>(channel) {

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestMultiGetAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestMultiGetAction.java
@@ -59,7 +59,10 @@ public class RestMultiGetAction extends BaseRestHandler {
         multiGetRequest.refresh(request.paramAsBoolean("refresh", multiGetRequest.refresh()));
         multiGetRequest.preference(request.param("preference"));
         multiGetRequest.realtime(request.paramAsBoolean("realtime", multiGetRequest.realtime()));
-
+        if (request.param("fields") != null) {
+            throw new IllegalArgumentException("The parameter [fields] is no longer supported, " +
+                "please use [stored_fields] to retrieve stored fields or _source filtering if the field is not stored");
+        }
         String[] sFields = null;
         String sField = request.param("stored_fields");
         if (sField != null) {

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestMultiGetAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestMultiGetAction.java
@@ -61,7 +61,7 @@ public class RestMultiGetAction extends BaseRestHandler {
         multiGetRequest.realtime(request.paramAsBoolean("realtime", multiGetRequest.realtime()));
 
         String[] sFields = null;
-        String sField = request.param("fields");
+        String sField = request.param("stored_fields");
         if (sField != null) {
             sFields = Strings.splitStringByCommaToArray(sField);
         }

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestUpdateAction.java
@@ -25,6 +25,8 @@ import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -33,12 +35,15 @@ import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.rest.action.RestStatusToXContentListener;
+import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 /**
  */
 public class RestUpdateAction extends BaseRestHandler {
+    private static final DeprecationLogger DEPRECATION_LOGGER =
+        new DeprecationLogger(Loggers.getLogger(RestUpdateAction.class));
 
     @Inject
     public RestUpdateAction(Settings settings, RestController controller) {
@@ -58,13 +63,19 @@ public class RestUpdateAction extends BaseRestHandler {
             updateRequest.waitForActiveShards(ActiveShardCount.parseString(waitForActiveShards));
         }
         updateRequest.docAsUpsert(request.paramAsBoolean("doc_as_upsert", updateRequest.docAsUpsert()));
+        FetchSourceContext fetchSourceContext = FetchSourceContext.parseFromRestRequest(request);
         String sField = request.param("fields");
-        if (sField != null) {
-            String[] sFields = Strings.splitStringByCommaToArray(sField);
-            if (sFields != null) {
-                updateRequest.fields(sFields);
-            }
+        if (sField != null && fetchSourceContext != null) {
+            throw new IllegalArgumentException("[fields] and [_source] cannot be used in the same request");
         }
+        if (sField != null) {
+            DEPRECATION_LOGGER.deprecated("Deprecated field [fields] used, expected [_source] instead");
+            String[] sFields = Strings.splitStringByCommaToArray(sField);
+            updateRequest.fields(sFields);
+        } else if (fetchSourceContext != null) {
+            updateRequest.fetchSource(fetchSourceContext);
+        }
+
         updateRequest.retryOnConflict(request.paramAsInt("retry_on_conflict", updateRequest.retryOnConflict()));
         updateRequest.version(RestActions.parseVersion(request));
         updateRequest.versionType(VersionType.fromString(request.param("version_type"), updateRequest.versionType()));
@@ -72,7 +83,7 @@ public class RestUpdateAction extends BaseRestHandler {
 
         // see if we have it in the body
         if (request.hasContent()) {
-            updateRequest.source(request.content());
+            updateRequest.fromXContent(request.content());
             IndexRequest upsertRequest = updateRequest.upsertRequest();
             if (upsertRequest != null) {
                 upsertRequest.routing(request.param("routing"));

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestExplainAction.java
@@ -78,6 +78,10 @@ public class RestExplainAction extends BaseRestHandler {
             explainRequest.query(query);
         }
 
+        if (request.param("fields") != null) {
+            throw new IllegalArgumentException("The parameter [fields] is no longer supported, " +
+                "please use [stored_fields] to retrieve stored fields");
+        }
         String sField = request.param("stored_fields");
         if (sField != null) {
             String[] sFields = Strings.splitStringByCommaToArray(sField);

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestExplainAction.java
@@ -78,11 +78,11 @@ public class RestExplainAction extends BaseRestHandler {
             explainRequest.query(query);
         }
 
-        String sField = request.param("fields");
+        String sField = request.param("stored_fields");
         if (sField != null) {
             String[] sFields = Strings.splitStringByCommaToArray(sField);
             if (sFields != null) {
-                explainRequest.fields(sFields);
+                explainRequest.storedFields(sFields);
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregationBuilder.java
@@ -79,7 +79,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
     public TopHitsAggregationBuilder(StreamInput in) throws IOException {
         super(in, TYPE);
         explain = in.readBoolean();
-        fetchSourceContext = in.readOptionalStreamable(FetchSourceContext::new);
+        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::new);
         if (in.readBoolean()) {
             int size = in.readVInt();
             fieldDataFields = new ArrayList<>(size);
@@ -112,7 +112,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeBoolean(explain);
-        out.writeOptionalStreamable(fetchSourceContext);
+        out.writeOptionalWriteable(fetchSourceContext);
         boolean hasFieldDataFields = fieldDataFields != null;
         out.writeBoolean(hasFieldDataFields);
         if (hasFieldDataFields) {
@@ -596,7 +596,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
                 } else if (context.getParseFieldMatcher().match(currentFieldName, SearchSourceBuilder.TRACK_SCORES_FIELD)) {
                     factory.trackScores(parser.booleanValue());
                 } else if (context.getParseFieldMatcher().match(currentFieldName, SearchSourceBuilder._SOURCE_FIELD)) {
-                    factory.fetchSource(FetchSourceContext.parse(context));
+                    factory.fetchSource(FetchSourceContext.parse(context.parser(), context.getParseFieldMatcher()));
                 } else if (context.getParseFieldMatcher().match(currentFieldName, SearchSourceBuilder.STORED_FIELDS_FIELD)) {
                     factory.storedFieldsContext =
                         StoredFieldsContext.fromXContent(SearchSourceBuilder.STORED_FIELDS_FIELD.getPreferredName(), context);
@@ -608,7 +608,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (context.getParseFieldMatcher().match(currentFieldName, SearchSourceBuilder._SOURCE_FIELD)) {
-                    factory.fetchSource(FetchSourceContext.parse(context));
+                    factory.fetchSource(FetchSourceContext.parse(context.parser(), context.getParseFieldMatcher()));
                 } else if (context.getParseFieldMatcher().match(currentFieldName, SearchSourceBuilder.SCRIPT_FIELDS_FIELD)) {
                     List<ScriptField> scriptFields = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -680,7 +680,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
                     List<SortBuilder<?>> sorts = SortBuilder.fromXContent(context);
                     factory.sorts(sorts);
                 } else if (context.getParseFieldMatcher().match(currentFieldName, SearchSourceBuilder._SOURCE_FIELD)) {
-                    factory.fetchSource(FetchSourceContext.parse(context));
+                    factory.fetchSource(FetchSourceContext.parse(context.parser(), context.getParseFieldMatcher()));
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "Unknown key for a " + token + " in [" + currentFieldName + "].",
                             parser.getTokenLocation());

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregationBuilder.java
@@ -596,7 +596,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
                 } else if (context.getParseFieldMatcher().match(currentFieldName, SearchSourceBuilder.TRACK_SCORES_FIELD)) {
                     factory.trackScores(parser.booleanValue());
                 } else if (context.getParseFieldMatcher().match(currentFieldName, SearchSourceBuilder._SOURCE_FIELD)) {
-                    factory.fetchSource(FetchSourceContext.parse(context.parser(), context.getParseFieldMatcher()));
+                    factory.fetchSource(FetchSourceContext.parse(context.parser()));
                 } else if (context.getParseFieldMatcher().match(currentFieldName, SearchSourceBuilder.STORED_FIELDS_FIELD)) {
                     factory.storedFieldsContext =
                         StoredFieldsContext.fromXContent(SearchSourceBuilder.STORED_FIELDS_FIELD.getPreferredName(), context);
@@ -608,7 +608,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (context.getParseFieldMatcher().match(currentFieldName, SearchSourceBuilder._SOURCE_FIELD)) {
-                    factory.fetchSource(FetchSourceContext.parse(context.parser(), context.getParseFieldMatcher()));
+                    factory.fetchSource(FetchSourceContext.parse(context.parser()));
                 } else if (context.getParseFieldMatcher().match(currentFieldName, SearchSourceBuilder.SCRIPT_FIELDS_FIELD)) {
                     List<ScriptField> scriptFields = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -680,7 +680,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
                     List<SortBuilder<?>> sorts = SortBuilder.fromXContent(context);
                     factory.sorts(sorts);
                 } else if (context.getParseFieldMatcher().match(currentFieldName, SearchSourceBuilder._SOURCE_FIELD)) {
-                    factory.fetchSource(FetchSourceContext.parse(context.parser(), context.getParseFieldMatcher()));
+                    factory.fetchSource(FetchSourceContext.parse(context.parser()));
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "Unknown key for a " + token + " in [" + currentFieldName + "].",
                             parser.getTokenLocation());

--- a/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -187,7 +187,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
     public SearchSourceBuilder(StreamInput in) throws IOException {
         aggregations = in.readOptionalWriteable(AggregatorFactories.Builder::new);
         explain = in.readOptionalBoolean();
-        fetchSourceContext = in.readOptionalStreamable(FetchSourceContext::new);
+        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::new);
         docValueFields = (List<String>) in.readGenericValue();
         storedFieldsContext = in.readOptionalWriteable(StoredFieldsContext::new);
         from = in.readVInt();
@@ -234,7 +234,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalWriteable(aggregations);
         out.writeOptionalBoolean(explain);
-        out.writeOptionalStreamable(fetchSourceContext);
+        out.writeOptionalWriteable(fetchSourceContext);
         out.writeGenericValue(docValueFields);
         out.writeOptionalWriteable(storedFieldsContext);
         out.writeVInt(from);
@@ -961,7 +961,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
                 } else if (context.getParseFieldMatcher().match(currentFieldName, TRACK_SCORES_FIELD)) {
                     trackScores = parser.booleanValue();
                 } else if (context.getParseFieldMatcher().match(currentFieldName, _SOURCE_FIELD)) {
-                    fetchSourceContext = FetchSourceContext.parse(context);
+                    fetchSourceContext = FetchSourceContext.parse(context.parser(), context.getParseFieldMatcher());
                 } else if (context.getParseFieldMatcher().match(currentFieldName, STORED_FIELDS_FIELD)) {
                     storedFieldsContext =
                         StoredFieldsContext.fromXContent(SearchSourceBuilder.STORED_FIELDS_FIELD.getPreferredName(), context);
@@ -983,7 +983,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
                 } else if (context.getParseFieldMatcher().match(currentFieldName, POST_FILTER_FIELD)) {
                     postQueryBuilder = context.parseInnerQueryBuilder().orElse(null);
                 } else if (context.getParseFieldMatcher().match(currentFieldName, _SOURCE_FIELD)) {
-                    fetchSourceContext = FetchSourceContext.parse(context);
+                    fetchSourceContext = FetchSourceContext.parse(context.parser(), context.getParseFieldMatcher());
                 } else if (context.getParseFieldMatcher().match(currentFieldName, SCRIPT_FIELDS_FIELD)) {
                     scriptFields = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -1068,7 +1068,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
                         }
                     }
                 } else if (context.getParseFieldMatcher().match(currentFieldName, _SOURCE_FIELD)) {
-                    fetchSourceContext = FetchSourceContext.parse(context);
+                    fetchSourceContext = FetchSourceContext.parse(context.parser(), context.getParseFieldMatcher());
                 } else if (context.getParseFieldMatcher().match(currentFieldName, SEARCH_AFTER)) {
                     searchAfterBuilder = SearchAfterBuilder.fromXContent(parser, context.getParseFieldMatcher());
                 } else if (context.getParseFieldMatcher().match(currentFieldName, FIELDS_FIELD)) {

--- a/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -961,7 +961,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
                 } else if (context.getParseFieldMatcher().match(currentFieldName, TRACK_SCORES_FIELD)) {
                     trackScores = parser.booleanValue();
                 } else if (context.getParseFieldMatcher().match(currentFieldName, _SOURCE_FIELD)) {
-                    fetchSourceContext = FetchSourceContext.parse(context.parser(), context.getParseFieldMatcher());
+                    fetchSourceContext = FetchSourceContext.parse(context.parser());
                 } else if (context.getParseFieldMatcher().match(currentFieldName, STORED_FIELDS_FIELD)) {
                     storedFieldsContext =
                         StoredFieldsContext.fromXContent(SearchSourceBuilder.STORED_FIELDS_FIELD.getPreferredName(), context);
@@ -983,7 +983,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
                 } else if (context.getParseFieldMatcher().match(currentFieldName, POST_FILTER_FIELD)) {
                     postQueryBuilder = context.parseInnerQueryBuilder().orElse(null);
                 } else if (context.getParseFieldMatcher().match(currentFieldName, _SOURCE_FIELD)) {
-                    fetchSourceContext = FetchSourceContext.parse(context.parser(), context.getParseFieldMatcher());
+                    fetchSourceContext = FetchSourceContext.parse(context.parser());
                 } else if (context.getParseFieldMatcher().match(currentFieldName, SCRIPT_FIELDS_FIELD)) {
                     scriptFields = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -1068,7 +1068,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
                         }
                     }
                 } else if (context.getParseFieldMatcher().match(currentFieldName, _SOURCE_FIELD)) {
-                    fetchSourceContext = FetchSourceContext.parse(context.parser(), context.getParseFieldMatcher());
+                    fetchSourceContext = FetchSourceContext.parse(context.parser());
                 } else if (context.getParseFieldMatcher().match(currentFieldName, SEARCH_AFTER)) {
                     searchAfterBuilder = SearchAfterBuilder.fromXContent(parser, context.getParseFieldMatcher());
                 } else if (context.getParseFieldMatcher().match(currentFieldName, FIELDS_FIELD)) {

--- a/core/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
@@ -21,15 +21,15 @@ package org.elasticsearch.search.fetch.subphase;
 
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.rest.RestRequest;
 
 import java.io.IOException;
@@ -40,7 +40,7 @@ import java.util.List;
 /**
  * Context used to fetch the {@code _source}.
  */
-public class FetchSourceContext implements Streamable, ToXContent {
+public class FetchSourceContext implements Writeable, ToXContent {
 
     public static final ParseField INCLUDES_FIELD = new ParseField("includes", "include");
     public static final ParseField EXCLUDES_FIELD = new ParseField("excludes", "exclude");
@@ -51,9 +51,10 @@ public class FetchSourceContext implements Streamable, ToXContent {
     private String[] includes;
     private String[] excludes;
 
-    public static FetchSourceContext parse(QueryParseContext context) throws IOException {
+    public static FetchSourceContext parse(XContentParser parser,
+                                           ParseFieldMatcher parseFieldMatcher) throws IOException {
         FetchSourceContext fetchSourceContext = new FetchSourceContext();
-        fetchSourceContext.fromXContent(context);
+        fetchSourceContext.fromXContent(parser, parseFieldMatcher);
         return fetchSourceContext;
     }
 
@@ -86,6 +87,19 @@ public class FetchSourceContext implements Streamable, ToXContent {
         this.fetchSource = fetchSource;
         this.includes = includes == null ? Strings.EMPTY_ARRAY : includes;
         this.excludes = excludes == null ? Strings.EMPTY_ARRAY : excludes;
+    }
+
+    public FetchSourceContext(StreamInput in) throws IOException {
+        fetchSource = in.readBoolean();
+        includes = in.readStringArray();
+        excludes = in.readStringArray();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBoolean(fetchSource);
+        out.writeStringArray(includes);
+        out.writeStringArray(excludes);
     }
 
     public boolean fetchSource() {
@@ -148,8 +162,7 @@ public class FetchSourceContext implements Streamable, ToXContent {
         return null;
     }
 
-    public void fromXContent(QueryParseContext context) throws IOException {
-        XContentParser parser = context.parser();
+    public void fromXContent(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException {
         XContentParser.Token token = parser.currentToken();
         boolean fetchSource = true;
         String[] includes = Strings.EMPTY_ARRAY;
@@ -170,7 +183,7 @@ public class FetchSourceContext implements Streamable, ToXContent {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
                 } else if (token == XContentParser.Token.START_ARRAY) {
-                    if (context.getParseFieldMatcher().match(currentFieldName, INCLUDES_FIELD)) {
+                    if (parseFieldMatcher.match(currentFieldName, INCLUDES_FIELD)) {
                         List<String> includesList = new ArrayList<>();
                         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                             if (token == XContentParser.Token.VALUE_STRING) {
@@ -181,7 +194,7 @@ public class FetchSourceContext implements Streamable, ToXContent {
                             }
                         }
                         includes = includesList.toArray(new String[includesList.size()]);
-                    } else if (context.getParseFieldMatcher().match(currentFieldName, EXCLUDES_FIELD)) {
+                    } else if (parseFieldMatcher.match(currentFieldName, EXCLUDES_FIELD)) {
                         List<String> excludesList = new ArrayList<>();
                         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                             if (token == XContentParser.Token.VALUE_STRING) {
@@ -197,10 +210,13 @@ public class FetchSourceContext implements Streamable, ToXContent {
                                 + " in [" + currentFieldName + "].", parser.getTokenLocation());
                     }
                 } else if (token == XContentParser.Token.VALUE_STRING) {
-                    if (context.getParseFieldMatcher().match(currentFieldName, INCLUDES_FIELD)) {
+                    if (parseFieldMatcher.match(currentFieldName, INCLUDES_FIELD)) {
                         includes = new String[] {parser.text()};
-                    } else if (context.getParseFieldMatcher().match(currentFieldName, EXCLUDES_FIELD)) {
+                    } else if (parseFieldMatcher.match(currentFieldName, EXCLUDES_FIELD)) {
                         excludes = new String[] {parser.text()};
+                    } else {
+                        throw new ParsingException(parser.getTokenLocation(), "Unknown key for a " + token
+                            + " in [" + currentFieldName + "].", parser.getTokenLocation());
                     }
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "Unknown key for a " + token + " in [" + currentFieldName + "].",
@@ -227,22 +243,6 @@ public class FetchSourceContext implements Streamable, ToXContent {
             builder.value(false);
         }
         return builder;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        fetchSource = in.readBoolean();
-        includes = in.readStringArray();
-        excludes = in.readStringArray();
-        in.readBoolean(); // Used to be transformSource but that was dropped in 2.1
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeBoolean(fetchSource);
-        out.writeStringArray(includes);
-        out.writeStringArray(excludes);
-        out.writeBoolean(false); // Used to be transformSource but that was dropped in 2.1
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
@@ -51,10 +51,9 @@ public class FetchSourceContext implements Writeable, ToXContent {
     private String[] includes;
     private String[] excludes;
 
-    public static FetchSourceContext parse(XContentParser parser,
-                                           ParseFieldMatcher parseFieldMatcher) throws IOException {
+    public static FetchSourceContext parse(XContentParser parser) throws IOException {
         FetchSourceContext fetchSourceContext = new FetchSourceContext();
-        fetchSourceContext.fromXContent(parser, parseFieldMatcher);
+        fetchSourceContext.fromXContent(parser, ParseFieldMatcher.STRICT);
         return fetchSourceContext;
     }
 

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkRequestTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.Requests;
+import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.script.Script;
@@ -39,6 +40,7 @@ import java.util.Map;
 
 import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -125,49 +127,34 @@ public class BulkRequestTests extends ESTestCase {
     public void testSimpleBulk6() throws Exception {
         String bulkAction = copyToStringFromClasspath("/org/elasticsearch/action/bulk/simple-bulk6.json");
         BulkRequest bulkRequest = new BulkRequest();
-        try {
-            bulkRequest.add(bulkAction.getBytes(StandardCharsets.UTF_8), 0, bulkAction.length(), null, null);
-            fail("should have thrown an exception about the wrong format of line 1");
-        } catch (IllegalArgumentException e) {
-            assertThat("message contains error about the wrong format of line 1: " + e.getMessage(),
-                    e.getMessage().contains("Malformed action/metadata line [1], expected a simple value for field [_source] but found [START_OBJECT]"), equalTo(true));
-        }
+        ParsingException exc = expectThrows(ParsingException.class,
+            () -> bulkRequest.add(bulkAction.getBytes(StandardCharsets.UTF_8), 0, bulkAction.length(), null, null));
+        assertThat(exc.getMessage(), containsString("Unknown key for a VALUE_STRING in [hello]"));
     }
 
     public void testSimpleBulk7() throws Exception {
         String bulkAction = copyToStringFromClasspath("/org/elasticsearch/action/bulk/simple-bulk7.json");
         BulkRequest bulkRequest = new BulkRequest();
-        try {
-            bulkRequest.add(bulkAction.getBytes(StandardCharsets.UTF_8), 0, bulkAction.length(), null, null);
-            fail("should have thrown an exception about the wrong format of line 5");
-        } catch (IllegalArgumentException e) {
-            assertThat("message contains error about the wrong format of line 5: " + e.getMessage(),
-                    e.getMessage().contains("Malformed action/metadata line [5], expected a simple value for field [_unkown] but found [START_ARRAY]"), equalTo(true));
-        }
+        IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
+            () -> bulkRequest.add(bulkAction.getBytes(StandardCharsets.UTF_8), 0, bulkAction.length(), null, null));
+        assertThat(exc.getMessage(),
+            containsString("Malformed action/metadata line [5], expected a simple value for field [_unkown] but found [START_ARRAY]"));
     }
 
     public void testSimpleBulk8() throws Exception {
         String bulkAction = copyToStringFromClasspath("/org/elasticsearch/action/bulk/simple-bulk8.json");
         BulkRequest bulkRequest = new BulkRequest();
-        try {
-            bulkRequest.add(bulkAction.getBytes(StandardCharsets.UTF_8), 0, bulkAction.length(), null, null);
-            fail("should have thrown an exception about the unknown parameter _foo");
-        } catch (IllegalArgumentException e) {
-            assertThat("message contains error about the unknown parameter _foo: " + e.getMessage(),
-                    e.getMessage().contains("Action/metadata line [3] contains an unknown parameter [_foo]"), equalTo(true));
-        }
+        IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
+            () -> bulkRequest.add(bulkAction.getBytes(StandardCharsets.UTF_8), 0, bulkAction.length(), null, null));
+        assertThat(exc.getMessage(), containsString("Action/metadata line [3] contains an unknown parameter [_foo]"));
     }
 
     public void testSimpleBulk9() throws Exception {
         String bulkAction = copyToStringFromClasspath("/org/elasticsearch/action/bulk/simple-bulk9.json");
         BulkRequest bulkRequest = new BulkRequest();
-        try {
-            bulkRequest.add(bulkAction.getBytes(StandardCharsets.UTF_8), 0, bulkAction.length(), null, null);
-            fail("should have thrown an exception about the wrong format of line 3");
-        } catch (IllegalArgumentException e) {
-            assertThat("message contains error about the wrong format of line 3: " + e.getMessage(),
-                    e.getMessage().contains("Malformed action/metadata line [3], expected START_OBJECT or END_OBJECT but found [START_ARRAY]"), equalTo(true));
-        }
+        IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
+            () -> bulkRequest.add(bulkAction.getBytes(StandardCharsets.UTF_8), 0, bulkAction.length(), null, null));
+        assertThat(exc.getMessage(), containsString("Malformed action/metadata line [3], expected START_OBJECT or END_OBJECT but found [START_ARRAY]"));
     }
 
     public void testSimpleBulk10() throws Exception {

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
@@ -141,18 +141,18 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
         assertThat(bulkResponse.getItems()[2].getResponse().getId(), equalTo("3"));
         assertThat(bulkResponse.getItems()[2].getResponse().getVersion(), equalTo(2L));
 
-        GetResponse getResponse = client().prepareGet().setIndex("test").setType("type1").setId("1").execute()
+        GetResponse getResponse = client().prepareGet().setIndex("test").setType("type1").setId("1").setStoredFields("field").execute()
                 .actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(2L));
         assertThat(((Number) getResponse.getSource().get("field")).longValue(), equalTo(2L));
 
-        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("2").execute().actionGet();
+        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("2").setStoredFields("field").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(2L));
         assertThat(((Number) getResponse.getSource().get("field")).longValue(), equalTo(3L));
 
-        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("3").execute().actionGet();
+        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("3").setStoredFields("field1").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(2L));
         assertThat(getResponse.getSource().get("field1").toString(), equalTo("test"));
@@ -177,15 +177,15 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
         assertThat(bulkResponse.getItems()[2].getResponse().getIndex(), equalTo("test"));
         assertThat(bulkResponse.getItems()[2].getResponse().getVersion(), equalTo(3L));
 
-        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("6").execute().actionGet();
+        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("6").setStoredFields("field").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(1L));
         assertThat(((Number) getResponse.getSource().get("field")).longValue(), equalTo(0L));
 
-        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("7").execute().actionGet();
+        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("7").setStoredFields("field").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(false));
 
-        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("2").execute().actionGet();
+        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("2").setStoredFields("field").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(3L));
         assertThat(((Number) getResponse.getSource().get("field")).longValue(), equalTo(4L));
@@ -314,7 +314,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
             assertThat(((UpdateResponse) response.getItems()[i].getResponse()).getGetResult().field("counter").getValue(), equalTo(1));
 
             for (int j = 0; j < 5; j++) {
-                GetResponse getResponse = client().prepareGet("test", "type1", Integer.toString(i)).execute()
+                GetResponse getResponse = client().prepareGet("test", "type1", Integer.toString(i)).setStoredFields("counter").execute()
                         .actionGet();
                 assertThat(getResponse.isExists(), equalTo(true));
                 assertThat(getResponse.getVersion(), equalTo(1L));
@@ -405,7 +405,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
             assertThat(response.getItems()[i].getType(), equalTo("type1"));
             assertThat(response.getItems()[i].getOpType(), equalTo("update"));
             for (int j = 0; j < 5; j++) {
-                GetResponse getResponse = client().prepareGet("test", "type1", Integer.toString(i)).setFields("counter").execute()
+                GetResponse getResponse = client().prepareGet("test", "type1", Integer.toString(i)).setStoredFields("counter").execute()
                         .actionGet();
                 assertThat(getResponse.isExists(), equalTo(false));
             }

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
@@ -141,18 +141,18 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
         assertThat(bulkResponse.getItems()[2].getResponse().getId(), equalTo("3"));
         assertThat(bulkResponse.getItems()[2].getResponse().getVersion(), equalTo(2L));
 
-        GetResponse getResponse = client().prepareGet().setIndex("test").setType("type1").setId("1").setStoredFields("field").execute()
+        GetResponse getResponse = client().prepareGet().setIndex("test").setType("type1").setId("1").execute()
                 .actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(2L));
         assertThat(((Number) getResponse.getSource().get("field")).longValue(), equalTo(2L));
 
-        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("2").setStoredFields("field").execute().actionGet();
+        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("2").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(2L));
         assertThat(((Number) getResponse.getSource().get("field")).longValue(), equalTo(3L));
 
-        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("3").setStoredFields("field1").execute().actionGet();
+        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("3").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(2L));
         assertThat(getResponse.getSource().get("field1").toString(), equalTo("test"));
@@ -177,15 +177,15 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
         assertThat(bulkResponse.getItems()[2].getResponse().getIndex(), equalTo("test"));
         assertThat(bulkResponse.getItems()[2].getResponse().getVersion(), equalTo(3L));
 
-        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("6").setStoredFields("field").execute().actionGet();
+        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("6").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(1L));
         assertThat(((Number) getResponse.getSource().get("field")).longValue(), equalTo(0L));
 
-        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("7").setStoredFields("field").execute().actionGet();
+        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("7").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(false));
 
-        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("2").setStoredFields("field").execute().actionGet();
+        getResponse = client().prepareGet().setIndex("test").setType("type1").setId("2").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(3L));
         assertThat(((Number) getResponse.getSource().get("field")).longValue(), equalTo(4L));
@@ -295,7 +295,8 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
         for (int i = 0; i < numDocs; i++) {
             builder.add(
                     client().prepareUpdate()
-                            .setIndex("test").setType("type1").setId(Integer.toString(i)).setFields("counter")
+                            .setIndex("test").setType("type1").setId(Integer.toString(i))
+                            .setFields("counter")
                             .setScript(script)
                             .setUpsert(jsonBuilder().startObject().field("counter", 1).endObject()));
         }
@@ -314,7 +315,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
             assertThat(((UpdateResponse) response.getItems()[i].getResponse()).getGetResult().field("counter").getValue(), equalTo(1));
 
             for (int j = 0; j < 5; j++) {
-                GetResponse getResponse = client().prepareGet("test", "type1", Integer.toString(i)).setStoredFields("counter").execute()
+                GetResponse getResponse = client().prepareGet("test", "type1", Integer.toString(i)).execute()
                         .actionGet();
                 assertThat(getResponse.isExists(), equalTo(true));
                 assertThat(getResponse.getVersion(), equalTo(1L));
@@ -405,7 +406,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
             assertThat(response.getItems()[i].getType(), equalTo("type1"));
             assertThat(response.getItems()[i].getOpType(), equalTo("update"));
             for (int j = 0; j < 5; j++) {
-                GetResponse getResponse = client().prepareGet("test", "type1", Integer.toString(i)).setStoredFields("counter").execute()
+                GetResponse getResponse = client().prepareGet("test", "type1", Integer.toString(i)).execute()
                         .actionGet();
                 assertThat(getResponse.isExists(), equalTo(false));
             }

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
@@ -406,8 +406,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
             assertThat(response.getItems()[i].getType(), equalTo("type1"));
             assertThat(response.getItems()[i].getOpType(), equalTo("update"));
             for (int j = 0; j < 5; j++) {
-                GetResponse getResponse = client().prepareGet("test", "type1", Integer.toString(i)).execute()
-                        .actionGet();
+                GetResponse getResponse = client().prepareGet("test", "type1", Integer.toString(i)).get();
                 assertThat(getResponse.isExists(), equalTo(false));
             }
         }

--- a/core/src/test/java/org/elasticsearch/action/get/MultiGetShardRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/get/MultiGetShardRequestTests.java
@@ -52,7 +52,7 @@ public class MultiGetShardRequestTests extends ESTestCase {
                 for (int j = 0; j < fields.length; j++) {
                     fields[j] = randomAsciiOfLength(randomIntBetween(1, 10));
                 }
-                item.fields(fields);
+                item.storedFields(fields);
             }
             if (randomBoolean()) {
                 item.version(randomIntBetween(1, Integer.MAX_VALUE));
@@ -84,7 +84,7 @@ public class MultiGetShardRequestTests extends ESTestCase {
                 assertThat(item2.index(), equalTo(item.index()));
             assertThat(item2.type(), equalTo(item.type()));
             assertThat(item2.id(), equalTo(item.id()));
-            assertThat(item2.fields(), equalTo(item.fields()));
+            assertThat(item2.storedFields(), equalTo(item.storedFields()));
             assertThat(item2.version(), equalTo(item.version()));
             assertThat(item2.versionType(), equalTo(item.versionType()));
             assertThat(item2.fetchSourceContext(), equalTo(item.fetchSourceContext()));

--- a/core/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
@@ -74,9 +74,12 @@ public class UpdateRequestTests extends ESTestCase {
         // script with params
         request = new UpdateRequest("test", "type", "1");
         request.fromXContent(XContentFactory.jsonBuilder().startObject()
-            .startObject("script").field("inline", "script1")
-            .startObject("params").field("param1", "value1")
-            .endObject().endObject().endObject());
+            .startObject("script")
+                .field("inline", "script1")
+                .startObject("params")
+                    .field("param1", "value1")
+                .endObject()
+            .endObject().endObject());
         script = request.script();
         assertThat(script, notNullValue());
         assertThat(script.getScript(), equalTo("script1"));
@@ -103,10 +106,13 @@ public class UpdateRequestTests extends ESTestCase {
 
         // script with params and upsert
         request = new UpdateRequest("test", "type", "1");
-        request.fromXContent(XContentFactory.jsonBuilder().startObject().startObject("script")
-            .startObject("params")
-                .field("param1", "value1").endObject()
-                .field("inline", "script1").endObject()
+        request.fromXContent(XContentFactory.jsonBuilder().startObject()
+            .startObject("script")
+                .startObject("params")
+                    .field("param1", "value1")
+                .endObject()
+                .field("inline", "script1")
+            .endObject()
             .startObject("upsert")
                 .field("field1", "value1")
                 .startObject("compound")
@@ -258,8 +264,8 @@ public class UpdateRequestTests extends ESTestCase {
         request.fromXContent(
             XContentFactory.jsonBuilder().startObject()
                 .startObject("_source")
-                    .field("include", "path.inner.*")
-                    .field("exclude", "another.inner.*")
+                    .field("includes", "path.inner.*")
+                    .field("excludes", "another.inner.*")
                 .endObject()
             .endObject()
         );

--- a/core/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
@@ -48,7 +48,7 @@ public class UpdateRequestTests extends ESTestCase {
     public void testUpdateRequest() throws Exception {
         UpdateRequest request = new UpdateRequest("test", "type", "1");
         // simple script
-        request.source(XContentFactory.jsonBuilder().startObject()
+        request.fromXContent(XContentFactory.jsonBuilder().startObject()
                 .field("script", "script1")
                 .endObject());
         Script script = request.script();
@@ -60,7 +60,7 @@ public class UpdateRequestTests extends ESTestCase {
         assertThat(params, nullValue());
 
         // simple verbose script
-        request.source(XContentFactory.jsonBuilder().startObject()
+        request.fromXContent(XContentFactory.jsonBuilder().startObject()
                 .startObject("script").field("inline", "script1").endObject()
                 .endObject());
         script = request.script();
@@ -73,8 +73,10 @@ public class UpdateRequestTests extends ESTestCase {
 
         // script with params
         request = new UpdateRequest("test", "type", "1");
-        request.source(XContentFactory.jsonBuilder().startObject().startObject("script").field("inline", "script1").startObject("params")
-                .field("param1", "value1").endObject().endObject().endObject());
+        request.fromXContent(XContentFactory.jsonBuilder().startObject()
+            .startObject("script").field("inline", "script1")
+            .startObject("params").field("param1", "value1")
+            .endObject().endObject().endObject());
         script = request.script();
         assertThat(script, notNullValue());
         assertThat(script.getScript(), equalTo("script1"));
@@ -86,8 +88,9 @@ public class UpdateRequestTests extends ESTestCase {
         assertThat(params.get("param1").toString(), equalTo("value1"));
 
         request = new UpdateRequest("test", "type", "1");
-        request.source(XContentFactory.jsonBuilder().startObject().startObject("script").startObject("params").field("param1", "value1")
-                .endObject().field("inline", "script1").endObject().endObject());
+        request.fromXContent(XContentFactory.jsonBuilder().startObject().startObject("script")
+            .startObject("params").field("param1", "value1").endObject()
+            .field("inline", "script1").endObject().endObject());
         script = request.script();
         assertThat(script, notNullValue());
         assertThat(script.getScript(), equalTo("script1"));
@@ -100,9 +103,16 @@ public class UpdateRequestTests extends ESTestCase {
 
         // script with params and upsert
         request = new UpdateRequest("test", "type", "1");
-        request.source(XContentFactory.jsonBuilder().startObject().startObject("script").startObject("params").field("param1", "value1")
-                .endObject().field("inline", "script1").endObject().startObject("upsert").field("field1", "value1").startObject("compound")
-                .field("field2", "value2").endObject().endObject().endObject());
+        request.fromXContent(XContentFactory.jsonBuilder().startObject().startObject("script")
+            .startObject("params")
+                .field("param1", "value1").endObject()
+                .field("inline", "script1").endObject()
+            .startObject("upsert")
+                .field("field1", "value1")
+                .startObject("compound")
+                    .field("field2", "value2")
+                .endObject()
+            .endObject().endObject());
         script = request.script();
         assertThat(script, notNullValue());
         assertThat(script.getScript(), equalTo("script1"));
@@ -117,9 +127,19 @@ public class UpdateRequestTests extends ESTestCase {
         assertThat(((Map) upsertDoc.get("compound")).get("field2").toString(), equalTo("value2"));
 
         request = new UpdateRequest("test", "type", "1");
-        request.source(XContentFactory.jsonBuilder().startObject().startObject("upsert").field("field1", "value1").startObject("compound")
-                .field("field2", "value2").endObject().endObject().startObject("script").startObject("params").field("param1", "value1")
-                .endObject().field("inline", "script1").endObject().endObject());
+        request.fromXContent(XContentFactory.jsonBuilder().startObject()
+            .startObject("upsert")
+                .field("field1", "value1")
+                .startObject("compound")
+                    .field("field2", "value2")
+                .endObject()
+            .endObject()
+            .startObject("script")
+                .startObject("params")
+                    .field("param1", "value1")
+                .endObject()
+                .field("inline", "script1")
+            .endObject().endObject());
         script = request.script();
         assertThat(script, notNullValue());
         assertThat(script.getScript(), equalTo("script1"));
@@ -135,8 +155,9 @@ public class UpdateRequestTests extends ESTestCase {
 
         // script with doc
         request = new UpdateRequest("test", "type", "1");
-        request.source(XContentFactory.jsonBuilder().startObject().startObject("doc").field("field1", "value1").startObject("compound")
-                .field("field2", "value2").endObject().endObject().endObject());
+        request.fromXContent(XContentFactory.jsonBuilder().startObject()
+            .startObject("doc").field("field1", "value1").startObject("compound")
+            .field("field2", "value2").endObject().endObject().endObject());
         Map<String, Object> doc = request.doc().sourceAsMap();
         assertThat(doc.get("field1").toString(), equalTo("value1"));
         assertThat(((Map) doc.get("compound")).get("field2").toString(), equalTo("value2"));
@@ -187,7 +208,7 @@ public class UpdateRequestTests extends ESTestCase {
     public void testInvalidBodyThrowsParseException() throws Exception {
         UpdateRequest request = new UpdateRequest("test", "type", "1");
         try {
-            request.source(new byte[] { (byte) '"' });
+            request.fromXContent(new byte[] { (byte) '"' });
             fail("Should have thrown a ElasticsearchParseException");
         } catch (ElasticsearchParseException e) {
             assertThat(e.getMessage(), equalTo("Failed to derive xcontent"));
@@ -197,13 +218,56 @@ public class UpdateRequestTests extends ESTestCase {
     // Related to issue 15338
     public void testFieldsParsing() throws Exception {
         UpdateRequest request = new UpdateRequest("test", "type1", "1")
-                .source(new BytesArray("{\"doc\": {\"field1\": \"value1\"}, \"fields\": \"_source\"}"));
+                .fromXContent(new BytesArray("{\"doc\": {\"field1\": \"value1\"}, \"fields\": \"_source\"}"));
         assertThat(request.doc().sourceAsMap().get("field1").toString(), equalTo("value1"));
         assertThat(request.fields(), arrayContaining("_source"));
 
         request = new UpdateRequest("test", "type2", "2")
-                .source(new BytesArray("{\"doc\": {\"field2\": \"value2\"}, \"fields\": [\"field1\", \"field2\"]}"));
+                .fromXContent(new BytesArray("{\"doc\": {\"field2\": \"value2\"}, \"fields\": [\"field1\", \"field2\"]}"));
         assertThat(request.doc().sourceAsMap().get("field2").toString(), equalTo("value2"));
         assertThat(request.fields(), arrayContaining("field1", "field2"));
+    }
+
+    public void testFetchSourceParsing() throws Exception {
+        UpdateRequest request = new UpdateRequest("test", "type1", "1");
+        request.fromXContent(
+            XContentFactory.jsonBuilder().startObject().field("_source", true).endObject()
+        );
+        assertThat(request.fetchSource(), notNullValue());
+        assertThat(request.fetchSource().includes().length, equalTo(0));
+        assertThat(request.fetchSource().excludes().length, equalTo(0));
+        assertThat(request.fetchSource().fetchSource(), equalTo(true));
+
+        request.fromXContent(
+            XContentFactory.jsonBuilder().startObject().field("_source", false).endObject()
+        );
+        assertThat(request.fetchSource(), notNullValue());
+        assertThat(request.fetchSource().includes().length, equalTo(0));
+        assertThat(request.fetchSource().excludes().length, equalTo(0));
+        assertThat(request.fetchSource().fetchSource(), equalTo(false));
+
+        request.fromXContent(
+            XContentFactory.jsonBuilder().startObject().field("_source", "path.inner.*").endObject()
+        );
+        assertThat(request.fetchSource(), notNullValue());
+        assertThat(request.fetchSource().fetchSource(), equalTo(true));
+        assertThat(request.fetchSource().includes().length, equalTo(1));
+        assertThat(request.fetchSource().excludes().length, equalTo(0));
+        assertThat(request.fetchSource().includes()[0], equalTo("path.inner.*"));
+
+        request.fromXContent(
+            XContentFactory.jsonBuilder().startObject()
+                .startObject("_source")
+                    .field("include", "path.inner.*")
+                    .field("exclude", "another.inner.*")
+                .endObject()
+            .endObject()
+        );
+        assertThat(request.fetchSource(), notNullValue());
+        assertThat(request.fetchSource().fetchSource(), equalTo(true));
+        assertThat(request.fetchSource().includes().length, equalTo(1));
+        assertThat(request.fetchSource().excludes().length, equalTo(1));
+        assertThat(request.fetchSource().includes()[0], equalTo("path.inner.*"));
+        assertThat(request.fetchSource().excludes()[0], equalTo("another.inner.*"));
     }
 }

--- a/core/src/test/java/org/elasticsearch/document/DocumentActionsIT.java
+++ b/core/src/test/java/org/elasticsearch/document/DocumentActionsIT.java
@@ -103,7 +103,7 @@ public class DocumentActionsIT extends ESIntegTestCase {
 
         logger.info("Get [type1/1] with script");
         for (int i = 0; i < 5; i++) {
-            getResult = client().prepareGet("test", "type1", "1").setFields("name").execute().actionGet();
+            getResult = client().prepareGet("test", "type1", "1").setStoredFields("name").execute().actionGet();
             assertThat(getResult.getIndex(), equalTo(getConcreteIndexName()));
             assertThat(getResult.isExists(), equalTo(true));
             assertThat(getResult.getSourceAsBytes(), nullValue());

--- a/core/src/test/java/org/elasticsearch/explain/ExplainActionIT.java
+++ b/core/src/test/java/org/elasticsearch/explain/ExplainActionIT.java
@@ -131,7 +131,7 @@ public class ExplainActionIT extends ESIntegTestCase {
         refresh();
         ExplainResponse response = client().prepareExplain(indexOrAlias(), "test", "1")
                 .setQuery(QueryBuilders.matchAllQuery())
-                .setFields("obj1.field1").get();
+                .setStoredFields("obj1.field1").get();
         assertNotNull(response);
         assertTrue(response.isMatch());
         assertNotNull(response.getExplanation());
@@ -148,7 +148,7 @@ public class ExplainActionIT extends ESIntegTestCase {
         refresh();
         response = client().prepareExplain(indexOrAlias(), "test", "1")
                 .setQuery(QueryBuilders.matchAllQuery())
-                .setFields("obj1.field1").setFetchSource(true).get();
+                .setStoredFields("obj1.field1").setFetchSource(true).get();
         assertNotNull(response);
         assertTrue(response.isMatch());
         assertNotNull(response.getExplanation());
@@ -164,7 +164,7 @@ public class ExplainActionIT extends ESIntegTestCase {
 
         response = client().prepareExplain(indexOrAlias(), "test", "1")
                 .setQuery(QueryBuilders.matchAllQuery())
-                .setFields("obj1.field1", "obj1.field2").get();
+                .setStoredFields("obj1.field1", "obj1.field2").get();
         assertNotNull(response);
         assertTrue(response.isMatch());
         String v1 = (String) response.getGetResult().field("obj1.field1").getValue();

--- a/core/src/test/java/org/elasticsearch/get/GetActionIT.java
+++ b/core/src/test/java/org/elasticsearch/get/GetActionIT.java
@@ -84,7 +84,7 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(response.getSourceAsMap().get("field2").toString(), equalTo("value2"));
 
         logger.info("--> realtime get 1 (no source, implicit)");
-        response = client().prepareGet(indexOrAlias(), "type1", "1").setFields(Strings.EMPTY_ARRAY).get();
+        response = client().prepareGet(indexOrAlias(), "type1", "1").setStoredFields(Strings.EMPTY_ARRAY).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getIndex(), equalTo("test"));
         Set<String> fields = new HashSet<>(response.getFields().keySet());
@@ -109,7 +109,7 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(response.getSourceAsMap().get("field2").toString(), equalTo("value2"));
 
         logger.info("--> realtime fetch of field");
-        response = client().prepareGet(indexOrAlias(), "type1", "1").setFields("field1").get();
+        response = client().prepareGet(indexOrAlias(), "type1", "1").setStoredFields("field1").get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getIndex(), equalTo("test"));
         assertThat(response.getSourceAsBytes(), nullValue());
@@ -117,7 +117,8 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(response.getField("field2"), nullValue());
 
         logger.info("--> realtime fetch of field & source");
-        response = client().prepareGet(indexOrAlias(), "type1", "1").setFields("field1").setFetchSource("field1", null).get();
+        response = client().prepareGet(indexOrAlias(), "type1", "1")
+            .setStoredFields("field1").setFetchSource("field1", null).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getIndex(), equalTo("test"));
         assertThat(response.getSourceAsMap(), hasKey("field1"));
@@ -143,7 +144,7 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(response.getSourceAsMap().get("field2").toString(), equalTo("value2"));
 
         logger.info("--> realtime fetch of field (loaded from index)");
-        response = client().prepareGet(indexOrAlias(), "type1", "1").setFields("field1").get();
+        response = client().prepareGet(indexOrAlias(), "type1", "1").setStoredFields("field1").get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getIndex(), equalTo("test"));
         assertThat(response.getSourceAsBytes(), nullValue());
@@ -151,7 +152,8 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(response.getField("field2"), nullValue());
 
         logger.info("--> realtime fetch of field & source (loaded from index)");
-        response = client().prepareGet(indexOrAlias(), "type1", "1").setFields("field1").setFetchSource(true).get();
+        response = client().prepareGet(indexOrAlias(), "type1", "1")
+            .setStoredFields("field1").setFetchSource(true).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getIndex(), equalTo("test"));
         assertThat(response.getSourceAsBytes(), not(nullValue()));
@@ -232,8 +234,8 @@ public class GetActionIT extends ESIntegTestCase {
 
         // multi get with specific field
         response = client().prepareMultiGet()
-                .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "1").fields("field"))
-                .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "3").fields("field"))
+                .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "1").storedFields("field"))
+                .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "3").storedFields("field"))
                 .get();
 
         assertThat(response.getResponses().length, equalTo(2));
@@ -269,7 +271,7 @@ public class GetActionIT extends ESIntegTestCase {
         client().prepareIndex("test", "type2", "1")
                 .setSource(jsonBuilder().startObject().array("field", "1", "2").endObject()).get();
 
-        response = client().prepareGet("test", "type1", "1").setFields("field").get();
+        response = client().prepareGet("test", "type1", "1").setStoredFields("field").get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getType(), equalTo("type1"));
@@ -281,7 +283,7 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(response.getFields().get("field").getValues().get(1).toString(), equalTo("2"));
 
 
-        response = client().prepareGet("test", "type2", "1").setFields("field").get();
+        response = client().prepareGet("test", "type2", "1").setStoredFields("field").get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getType(), equalTo("type2"));
         assertThat(response.getId(), equalTo("1"));
@@ -294,7 +296,7 @@ public class GetActionIT extends ESIntegTestCase {
 
         // Now test values being fetched from stored fields.
         refresh();
-        response = client().prepareGet("test", "type1", "1").setFields("field").get();
+        response = client().prepareGet("test", "type1", "1").setStoredFields("field").get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         fields = new HashSet<>(response.getFields().keySet());
@@ -304,7 +306,7 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(response.getFields().get("field").getValues().get(0).toString(), equalTo("1"));
         assertThat(response.getFields().get("field").getValues().get(1).toString(), equalTo("2"));
 
-        response = client().prepareGet("test", "type2", "1").setFields("field").get();
+        response = client().prepareGet("test", "type2", "1").setStoredFields("field").get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         fields = new HashSet<>(response.getFields().keySet());
@@ -546,7 +548,7 @@ public class GetActionIT extends ESIntegTestCase {
 
         GetResponse getResponse = client().prepareGet(indexOrAlias(), "my-type1", "1")
                 .setRouting("1")
-                .setFields("field1")
+                .setStoredFields("field1")
                 .get();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getField("field1").isMetadataField(), equalTo(false));
@@ -559,7 +561,7 @@ public class GetActionIT extends ESIntegTestCase {
         flush();
 
         getResponse = client().prepareGet(indexOrAlias(), "my-type1", "1")
-                .setFields("field1")
+                .setStoredFields("field1")
                 .setRouting("1")
                 .get();
         assertThat(getResponse.isExists(), equalTo(true));
@@ -585,7 +587,7 @@ public class GetActionIT extends ESIntegTestCase {
                 .get();
 
         try {
-            client().prepareGet(indexOrAlias(), "my-type1", "1").setFields("field1").get();
+            client().prepareGet(indexOrAlias(), "my-type1", "1").setStoredFields("field1").get();
             fail();
         } catch (IllegalArgumentException e) {
             //all well
@@ -594,7 +596,7 @@ public class GetActionIT extends ESIntegTestCase {
         flush();
 
         try {
-            client().prepareGet(indexOrAlias(), "my-type1", "1").setFields("field1").get();
+            client().prepareGet(indexOrAlias(), "my-type1", "1").setStoredFields("field1").get();
             fail();
         } catch (IllegalArgumentException e) {
             //all well
@@ -645,14 +647,14 @@ public class GetActionIT extends ESIntegTestCase {
         logger.info("checking real time retrieval");
 
         String field = "field1.field2.field3.field4";
-        GetResponse getResponse = client().prepareGet("my-index", "my-type1", "1").setFields(field).get();
+        GetResponse getResponse = client().prepareGet("my-index", "my-type1", "1").setStoredFields(field).get();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getField(field).isMetadataField(), equalTo(false));
         assertThat(getResponse.getField(field).getValues().size(), equalTo(2));
         assertThat(getResponse.getField(field).getValues().get(0).toString(), equalTo("value1"));
         assertThat(getResponse.getField(field).getValues().get(1).toString(), equalTo("value2"));
 
-        getResponse = client().prepareGet("my-index", "my-type2", "1").setFields(field).get();
+        getResponse = client().prepareGet("my-index", "my-type2", "1").setStoredFields(field).get();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getField(field).isMetadataField(), equalTo(false));
         assertThat(getResponse.getField(field).getValues().size(), equalTo(2));
@@ -677,14 +679,14 @@ public class GetActionIT extends ESIntegTestCase {
 
         logger.info("checking post-flush retrieval");
 
-        getResponse = client().prepareGet("my-index", "my-type1", "1").setFields(field).get();
+        getResponse = client().prepareGet("my-index", "my-type1", "1").setStoredFields(field).get();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getField(field).isMetadataField(), equalTo(false));
         assertThat(getResponse.getField(field).getValues().size(), equalTo(2));
         assertThat(getResponse.getField(field).getValues().get(0).toString(), equalTo("value1"));
         assertThat(getResponse.getField(field).getValues().get(1).toString(), equalTo("value2"));
 
-        getResponse = client().prepareGet("my-index", "my-type2", "1").setFields(field).get();
+        getResponse = client().prepareGet("my-index", "my-type2", "1").setStoredFields(field).get();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getField(field).isMetadataField(), equalTo(false));
         assertThat(getResponse.getField(field).getValues().size(), equalTo(2));
@@ -711,7 +713,7 @@ public class GetActionIT extends ESIntegTestCase {
         index("test", "my-type1", "1", "some_field", "some text");
         refresh();
 
-        GetResponse getResponse = client().prepareGet(indexOrAlias(), "my-type1", "1").setFields("_all").get();
+        GetResponse getResponse = client().prepareGet(indexOrAlias(), "my-type1", "1").setStoredFields("_all").get();
         assertNotNull(getResponse.getField("_all").getValue());
         assertThat(getResponse.getField("_all").getValue().toString(), equalTo("some text"));
     }
@@ -948,12 +950,12 @@ public class GetActionIT extends ESIntegTestCase {
 
     private void assertGetFieldException(String index, String type, String docId, String field) {
         try {
-            client().prepareGet().setIndex(index).setType(type).setId(docId).setFields(field).get();
+            client().prepareGet().setIndex(index).setType(type).setId(docId).setStoredFields(field);
             fail();
         } catch (ElasticsearchException e) {
             assertTrue(e.getMessage().contains("You can only get this field after refresh() has been called."));
         }
-        MultiGetResponse multiGetResponse = client().prepareMultiGet().add(new MultiGetRequest.Item(index, type, docId).fields(field)).get();
+        MultiGetResponse multiGetResponse = client().prepareMultiGet().add(new MultiGetRequest.Item(index, type, docId).storedFields(field)).get();
         assertNull(multiGetResponse.getResponses()[0].getResponse());
         assertTrue(multiGetResponse.getResponses()[0].getFailure().getMessage().contains("You can only get this field after refresh() has been called."));
     }
@@ -993,7 +995,7 @@ public class GetActionIT extends ESIntegTestCase {
     }
 
     private GetResponse multiGetDocument(String index, String type, String docId, String field, @Nullable String routing) {
-        MultiGetRequest.Item getItem = new MultiGetRequest.Item(index, type, docId).fields(field);
+      MultiGetRequest.Item getItem = new MultiGetRequest.Item(index, type, docId).storedFields(field);
         if (routing != null) {
             getItem.routing(routing);
         }
@@ -1002,9 +1004,9 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(multiGetResponse.getResponses().length, equalTo(1));
         return multiGetResponse.getResponses()[0].getResponse();
     }
-
+    
     private GetResponse getDocument(String index, String type, String docId, String field, @Nullable String routing) {
-        GetRequestBuilder getRequestBuilder = client().prepareGet().setIndex(index).setType(type).setId(docId).setFields(field);
+        GetRequestBuilder getRequestBuilder = client().prepareGet().setIndex(index).setType(type).setId(docId).setStoredFields(field);
         if (routing != null) {
             getRequestBuilder.setRouting(routing);
         }

--- a/core/src/test/java/org/elasticsearch/get/GetActionIT.java
+++ b/core/src/test/java/org/elasticsearch/get/GetActionIT.java
@@ -586,21 +586,18 @@ public class GetActionIT extends ESIntegTestCase {
                 .setSource(jsonBuilder().startObject().startObject("field1").field("field2", "value1").endObject().endObject())
                 .get();
 
-        try {
-            client().prepareGet(indexOrAlias(), "my-type1", "1").setStoredFields("field1").get();
-            fail();
-        } catch (IllegalArgumentException e) {
-            //all well
-        }
+
+        IllegalArgumentException exc =
+            expectThrows(IllegalArgumentException.class,
+                () -> client().prepareGet(indexOrAlias(), "my-type1", "1").setStoredFields("field1").get());
+        assertThat(exc.getMessage(), equalTo("field [field1] isn't a leaf field"));
 
         flush();
 
-        try {
-            client().prepareGet(indexOrAlias(), "my-type1", "1").setStoredFields("field1").get();
-            fail();
-        } catch (IllegalArgumentException e) {
-            //all well
-        }
+        exc =
+            expectThrows(IllegalArgumentException.class,
+                () -> client().prepareGet(indexOrAlias(), "my-type1", "1").setStoredFields("field1").get());
+        assertThat(exc.getMessage(), equalTo("field [field1] isn't a leaf field"));
     }
 
     public void testGetFieldsComplexField() throws Exception {

--- a/core/src/test/java/org/elasticsearch/get/GetActionIT.java
+++ b/core/src/test/java/org/elasticsearch/get/GetActionIT.java
@@ -1004,7 +1004,7 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(multiGetResponse.getResponses().length, equalTo(1));
         return multiGetResponse.getResponses()[0].getResponse();
     }
-    
+
     private GetResponse getDocument(String index, String type, String docId, String field, @Nullable String routing) {
         GetRequestBuilder getRequestBuilder = client().prepareGet().setIndex(index).setType(type).setId(docId).setStoredFields(field);
         if (routing != null) {

--- a/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasIT.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasIT.java
@@ -283,7 +283,6 @@ public class IndexWithShadowReplicasIT extends ESIntegTestCase {
         client().prepareIndex(IDX, "doc", "1").setSource("foo", "bar").get();
         client().prepareIndex(IDX, "doc", "2").setSource("foo", "bar").get();
 
-
         GetResponse gResp1 = client().prepareGet(IDX, "doc", "1").get();
         GetResponse gResp2 = client().prepareGet(IDX, "doc", "2").get();
         assertTrue(gResp1.isExists());

--- a/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasIT.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasIT.java
@@ -283,6 +283,7 @@ public class IndexWithShadowReplicasIT extends ESIntegTestCase {
         client().prepareIndex(IDX, "doc", "1").setSource("foo", "bar").get();
         client().prepareIndex(IDX, "doc", "2").setSource("foo", "bar").get();
 
+
         GetResponse gResp1 = client().prepareGet(IDX, "doc", "1").get();
         GetResponse gResp2 = client().prepareGet(IDX, "doc", "2").get();
         assertTrue(gResp1.isExists());

--- a/core/src/test/java/org/elasticsearch/timestamp/SimpleTimestampIT.java
+++ b/core/src/test/java/org/elasticsearch/timestamp/SimpleTimestampIT.java
@@ -69,33 +69,33 @@ public class SimpleTimestampIT extends ESIntegTestCase {
         long now2 = System.currentTimeMillis();
 
         // non realtime get (stored)
-        GetResponse getResponse = client().prepareGet("test", "type1", "1").setFields("_timestamp").setRealtime(randomBoolean()).execute().actionGet();
+        GetResponse getResponse = client().prepareGet("test", "type1", "1").setStoredFields("_timestamp").setRealtime(randomBoolean()).execute().actionGet();
         long timestamp = ((Number) getResponse.getField("_timestamp").getValue()).longValue();
         assertThat(timestamp, greaterThanOrEqualTo(now1));
         assertThat(timestamp, lessThanOrEqualTo(now2));
         // verify its the same timestamp when going the replica
-        getResponse = client().prepareGet("test", "type1", "1").setFields("_timestamp").setRealtime(randomBoolean()).execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "1").setStoredFields("_timestamp").setRealtime(randomBoolean()).execute().actionGet();
         assertThat(((Number) getResponse.getField("_timestamp").getValue()).longValue(), equalTo(timestamp));
 
         logger.info("--> check with custom timestamp (numeric)");
         client().prepareIndex("test", "type1", "1").setSource("field1", "value1").setTimestamp("10").setRefreshPolicy(IMMEDIATE).get();
 
-        getResponse = client().prepareGet("test", "type1", "1").setFields("_timestamp").setRealtime(false).execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "1").setStoredFields("_timestamp").setRealtime(false).execute().actionGet();
         timestamp = ((Number) getResponse.getField("_timestamp").getValue()).longValue();
         assertThat(timestamp, equalTo(10L));
         // verify its the same timestamp when going the replica
-        getResponse = client().prepareGet("test", "type1", "1").setFields("_timestamp").setRealtime(false).execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "1").setStoredFields("_timestamp").setRealtime(false).execute().actionGet();
         assertThat(((Number) getResponse.getField("_timestamp").getValue()).longValue(), equalTo(timestamp));
 
         logger.info("--> check with custom timestamp (string)");
         client().prepareIndex("test", "type1", "1").setSource("field1", "value1").setTimestamp("1970-01-01T00:00:00.020")
                 .setRefreshPolicy(IMMEDIATE).get();
 
-        getResponse = client().prepareGet("test", "type1", "1").setFields("_timestamp").setRealtime(false).execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "1").setStoredFields("_timestamp").setRealtime(false).execute().actionGet();
         timestamp = ((Number) getResponse.getField("_timestamp").getValue()).longValue();
         assertThat(timestamp, equalTo(20L));
         // verify its the same timestamp when going the replica
-        getResponse = client().prepareGet("test", "type1", "1").setFields("_timestamp").setRealtime(false).execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "1").setStoredFields("_timestamp").setRealtime(false).execute().actionGet();
         assertThat(((Number) getResponse.getField("_timestamp").getValue()).longValue(), equalTo(timestamp));
     }
 

--- a/core/src/test/java/org/elasticsearch/ttl/SimpleTTLIT.java
+++ b/core/src/test/java/org/elasticsearch/ttl/SimpleTTLIT.java
@@ -117,7 +117,7 @@ public class SimpleTTLIT extends ESIntegTestCase {
 
         // realtime get check
         long currentTime = System.currentTimeMillis();
-        GetResponse getResponse = client().prepareGet("test", "type1", "1").setFields("_ttl").get();
+        GetResponse getResponse = client().prepareGet("test", "type1", "1").setStoredFields("_ttl").get();
         long ttl0;
         if (getResponse.isExists()) {
             ttl0 = ((Number) getResponse.getField("_ttl").getValue()).longValue();
@@ -127,7 +127,7 @@ public class SimpleTTLIT extends ESIntegTestCase {
         }
         // verify the ttl is still decreasing when going to the replica
         currentTime = System.currentTimeMillis();
-        getResponse = client().prepareGet("test", "type1", "1").setFields("_ttl").get();
+        getResponse = client().prepareGet("test", "type1", "1").setStoredFields("_ttl").get();
         if (getResponse.isExists()) {
             ttl0 = ((Number) getResponse.getField("_ttl").getValue()).longValue();
             assertThat(ttl0, lessThanOrEqualTo(providedTTLValue - (currentTime - now)));
@@ -136,7 +136,7 @@ public class SimpleTTLIT extends ESIntegTestCase {
         }
         // non realtime get (stored)
         currentTime = System.currentTimeMillis();
-        getResponse = client().prepareGet("test", "type1", "1").setFields("_ttl").setRealtime(false).get();
+        getResponse = client().prepareGet("test", "type1", "1").setStoredFields("_ttl").setRealtime(false).get();
         if (getResponse.isExists()) {
             ttl0 = ((Number) getResponse.getField("_ttl").getValue()).longValue();
             assertThat(ttl0, lessThanOrEqualTo(providedTTLValue - (currentTime - now)));
@@ -145,7 +145,7 @@ public class SimpleTTLIT extends ESIntegTestCase {
         }
         // non realtime get going the replica
         currentTime = System.currentTimeMillis();
-        getResponse = client().prepareGet("test", "type1", "1").setFields("_ttl").setRealtime(false).get();
+        getResponse = client().prepareGet("test", "type1", "1").setStoredFields("_ttl").setRealtime(false).get();
         if (getResponse.isExists()) {
             ttl0 = ((Number) getResponse.getField("_ttl").getValue()).longValue();
             assertThat(ttl0, lessThanOrEqualTo(providedTTLValue - (currentTime - now)));
@@ -154,10 +154,10 @@ public class SimpleTTLIT extends ESIntegTestCase {
         }
 
         // no TTL provided so no TTL fetched
-        getResponse = client().prepareGet("test", "type1", "no_ttl").setFields("_ttl").setRealtime(true).execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "no_ttl").setStoredFields("_ttl").setRealtime(true).execute().actionGet();
         assertThat(getResponse.getField("_ttl"), nullValue());
         // no TTL provided make sure it has default TTL
-        getResponse = client().prepareGet("test", "type2", "default_ttl").setFields("_ttl").setRealtime(true).execute().actionGet();
+        getResponse = client().prepareGet("test", "type2", "default_ttl").setStoredFields("_ttl").setRealtime(true).execute().actionGet();
         ttl0 = ((Number) getResponse.getField("_ttl").getValue()).longValue();
         assertThat(ttl0, greaterThan(0L));
 
@@ -190,28 +190,28 @@ public class SimpleTTLIT extends ESIntegTestCase {
         ));
 
         // realtime get check
-        getResponse = client().prepareGet("test", "type1", "1").setFields("_ttl").setRealtime(true).execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "1").setStoredFields("_ttl").setRealtime(true).execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(false));
-        getResponse = client().prepareGet("test", "type1", "with_routing").setRouting("routing").setFields("_ttl").setRealtime(true).execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "with_routing").setRouting("routing").setStoredFields("_ttl").setRealtime(true).execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(false));
         // replica realtime get check
-        getResponse = client().prepareGet("test", "type1", "1").setFields("_ttl").setRealtime(true).execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "1").setStoredFields("_ttl").setRealtime(true).execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(false));
-        getResponse = client().prepareGet("test", "type1", "with_routing").setRouting("routing").setFields("_ttl").setRealtime(true).execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "with_routing").setRouting("routing").setStoredFields("_ttl").setRealtime(true).execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(false));
 
         // Need to run a refresh, in order for the non realtime get to work.
         client().admin().indices().prepareRefresh("test").execute().actionGet();
 
         // non realtime get (stored) check
-        getResponse = client().prepareGet("test", "type1", "1").setFields("_ttl").setRealtime(false).execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "1").setStoredFields("_ttl").setRealtime(false).execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(false));
-        getResponse = client().prepareGet("test", "type1", "with_routing").setRouting("routing").setFields("_ttl").setRealtime(false).execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "with_routing").setRouting("routing").setStoredFields("_ttl").setRealtime(false).execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(false));
         // non realtime get going the replica check
-        getResponse = client().prepareGet("test", "type1", "1").setFields("_ttl").setRealtime(false).execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "1").setStoredFields("_ttl").setRealtime(false).execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(false));
-        getResponse = client().prepareGet("test", "type1", "with_routing").setRouting("routing").setFields("_ttl").setRealtime(false).execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "with_routing").setRouting("routing").setStoredFields("_ttl").setRealtime(false).execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(false));
     }
 
@@ -287,7 +287,7 @@ public class SimpleTTLIT extends ESIntegTestCase {
     }
 
     private long getTtl(String type, Object id) {
-        GetResponse getResponse = client().prepareGet("test", type, id.toString()).setFields("_ttl").execute()
+        GetResponse getResponse = client().prepareGet("test", type, id.toString()).setStoredFields("_ttl").execute()
                 .actionGet();
         return ((Number) getResponse.getField("_ttl").getValue()).longValue();
     }

--- a/core/src/test/java/org/elasticsearch/update/TimestampTTLBWIT.java
+++ b/core/src/test/java/org/elasticsearch/update/TimestampTTLBWIT.java
@@ -123,12 +123,12 @@ public class TimestampTTLBWIT extends ESIntegTestCase {
 
         // check TTL is kept after an update without TTL
         client().prepareIndex("test", "type1", "2").setSource("field", 1).setTTL(86400000L).setRefreshPolicy(IMMEDIATE).get();
-        GetResponse getResponse = client().prepareGet("test", "type1", "2").setFields("_ttl").execute().actionGet();
+        GetResponse getResponse = client().prepareGet("test", "type1", "2").setStoredFields("_ttl").execute().actionGet();
         long ttl = ((Number) getResponse.getField("_ttl").getValue()).longValue();
         assertThat(ttl, greaterThan(0L));
         client().prepareUpdate(indexOrAlias(), "type1", "2")
                 .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null)).execute().actionGet();
-        getResponse = client().prepareGet("test", "type1", "2").setFields("_ttl").execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "2").setStoredFields("_ttl").execute().actionGet();
         ttl = ((Number) getResponse.getField("_ttl").getValue()).longValue();
         assertThat(ttl, greaterThan(0L));
 
@@ -136,7 +136,7 @@ public class TimestampTTLBWIT extends ESIntegTestCase {
         client().prepareUpdate(indexOrAlias(), "type1", "2")
                 .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values",
                         Collections.singletonMap("_ctx", Collections.singletonMap("_ttl", 3600000)))).execute().actionGet();
-        getResponse = client().prepareGet("test", "type1", "2").setFields("_ttl").execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "2").setStoredFields("_ttl").execute().actionGet();
         ttl = ((Number) getResponse.getField("_ttl").getValue()).longValue();
         assertThat(ttl, greaterThan(0L));
         assertThat(ttl, lessThanOrEqualTo(3600000L));
@@ -147,7 +147,7 @@ public class TimestampTTLBWIT extends ESIntegTestCase {
                 .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values",
                         Collections.singletonMap("_ctx", Collections.singletonMap("_timestamp", "2009-11-15T14:12:12")))).execute()
                 .actionGet();
-        getResponse = client().prepareGet("test", "type1", "3").setFields("_timestamp").execute().actionGet();
+        getResponse = client().prepareGet("test", "type1", "3").setStoredFields("_timestamp").execute().actionGet();
         long timestamp = ((Number) getResponse.getField("_timestamp").getValue()).longValue();
         assertThat(timestamp, equalTo(1258294332000L));
     }

--- a/core/src/test/java/org/elasticsearch/update/UpdateIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateIT.java
@@ -469,7 +469,7 @@ public class UpdateIT extends ESIntegTestCase {
         UpdateResponse updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
                 .setUpsert(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())
                 .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("extra", "foo")))
-                .setFields("_source")
+                .setFetchSource(true)
                 .execute().actionGet();
 
         assertThat(updateResponse.getIndex(), equalTo("test"));
@@ -549,7 +549,7 @@ public class UpdateIT extends ESIntegTestCase {
         UpdateResponse updateResponse = client().prepareUpdate("test", "type1", "1")
                 .setUpsert(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())
                 .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("extra", "foo")))
-                .setFields("_source")
+                .setFetchSource(true)
                 .execute().actionGet();
 
         assertThat(updateResponse.getIndex(), equalTo("test"));
@@ -624,13 +624,29 @@ public class UpdateIT extends ESIntegTestCase {
         // check fields parameter
         client().prepareIndex("test", "type1", "1").setSource("field", 1).execute().actionGet();
         updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
-                .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null)).setFields("_source", "field")
-                .execute().actionGet();
+            .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
+            .setFields("field")
+            .setFetchSource(true)
+            .execute().actionGet();
         assertThat(updateResponse.getIndex(), equalTo("test"));
         assertThat(updateResponse.getGetResult(), notNullValue());
         assertThat(updateResponse.getGetResult().getIndex(), equalTo("test"));
         assertThat(updateResponse.getGetResult().sourceRef(), notNullValue());
         assertThat(updateResponse.getGetResult().field("field").getValue(), notNullValue());
+
+        // check _source parameter
+        client().prepareIndex("test", "type1", "1").setSource("field1", 1, "field2", 2).execute().actionGet();
+        updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
+            .setScript(new Script("field1", ScriptService.ScriptType.INLINE, "field_inc", null))
+            .setFetchSource("field1", "field2")
+            .execute().actionGet();
+        assertThat(updateResponse.getIndex(), equalTo("test"));
+        assertThat(updateResponse.getGetResult(), notNullValue());
+        assertThat(updateResponse.getGetResult().getIndex(), equalTo("test"));
+        assertThat(updateResponse.getGetResult().sourceRef(), notNullValue());
+        assertThat(updateResponse.getGetResult().field("field1"), nullValue());
+        assertThat(updateResponse.getGetResult().sourceAsMap().size(), equalTo(1));
+        assertThat(updateResponse.getGetResult().sourceAsMap().get("field1"), equalTo(2));
 
         // check updates without script
         // add new field

--- a/core/src/test/java/org/elasticsearch/update/UpdateIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateIT.java
@@ -639,7 +639,7 @@ public class UpdateIT extends ESIntegTestCase {
         updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
             .setScript(new Script("field1", ScriptService.ScriptType.INLINE, "field_inc", null))
             .setFetchSource("field1", "field2")
-            .execute().actionGet();
+            .get();
         assertThat(updateResponse.getIndex(), equalTo("test"));
         assertThat(updateResponse.getGetResult(), notNullValue());
         assertThat(updateResponse.getGetResult().getIndex(), equalTo("test"));

--- a/docs/groovy-api/search.asciidoc
+++ b/docs/groovy-api/search.asciidoc
@@ -72,7 +72,7 @@ def search = node.client.search {
     source {
         query {
             query_string(
-                fields: ["test"],
+                stored_fields: ["test"],
                 query: "value1 value2")
         }
     }

--- a/docs/groovy-api/search.asciidoc
+++ b/docs/groovy-api/search.asciidoc
@@ -72,7 +72,7 @@ def search = node.client.search {
     source {
         query {
             query_string(
-                stored_fields: ["test"],
+                fields: ["test"],
                 query: "value1 value2")
         }
     }

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -154,7 +154,7 @@ times an update should be retried in the case of a version conflict.
 
 The `update` action payload, supports the following options: `doc`
 (partial document), `upsert`, `doc_as_upsert`, `script`, `params` (for
-script), `lang` (for script) and `fields`. See update documentation for details on
+script), `lang` (for script) and `_source`. See update documentation for details on
 the options. Curl example with update actions:
 
 [source,js]
@@ -165,10 +165,10 @@ the options. Curl example with update actions:
 { "script" : { "inline": "ctx._source.counter += params.param1", "lang" : "painless", "params" : {"param1" : 1}}, "upsert" : {"counter" : 1}}
 { "update" : {"_id" : "2", "_type" : "type1", "_index" : "index1", "_retry_on_conflict" : 3} }
 { "doc" : {"field" : "value"}, "doc_as_upsert" : true }
-{ "update" : {"_id" : "3", "_type" : "type1", "_index" : "index1", "fields" : ["_source"]} }
+{ "update" : {"_id" : "3", "_type" : "type1", "_index" : "index1", "_source" : true} }
 { "doc" : {"field" : "value"} }
 { "update" : {"_id" : "4", "_type" : "type1", "_index" : "index1"} }
-{ "doc" : {"field" : "value"}, "fields": ["_source"]}
+{ "doc" : {"field" : "value"}, "_source": true}
 --------------------------------------------------
 
 [float]

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -109,11 +109,11 @@ PUT twitter
          "properties": {
             "counter": {
                "type": "integer",
-               "store": "false"
+               "store": false
             },
             "tags": {
                "type": "keyword",
-               "store": "true"
+               "store": true
             }
          }
       }

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -52,9 +52,6 @@ call in-place to make the document visible. This will also make other documents
 changed since the last refresh visible. In order to disable realtime GET,
 one can set the `realtime` parameter to `false`.
 
-When getting a document, one can specify `stored_fields` to fetch from it.
-They will be simply ignored if the field is not stored (<<mapping-store,stored>> in the mapping)*[]:
-
 [float]
 [[type]]
 === Optional Type
@@ -99,17 +96,114 @@ curl -XGET 'http://localhost:9200/twitter/tweet/1?_source=*.id,retweeted'
 === Stored Fields
 
 The get operation allows specifying a set of stored fields that will be
-returned by passing the `stored_fields` parameter. For example:
+returned by passing the `stored_fields` parameter.
+If the requested fields are not stored, they will be ignored.
+Consider for instance the following mapping:
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'http://localhost:9200/twitter/tweet/1?stored_fields=title,content'
+PUT twitter
+{
+   "mappings": {
+      "tweet": {
+         "properties": {
+            "counter": {
+               "type": "integer",
+               "store": "no"
+            },
+            "tags": {
+               "type": "keyword",
+               "store": "yes"
+            }
+         }
+      }
+   }
+}
+--------------------------------------------------
+// CONSOLE
+
+Now we can add a document:
+
+[source,js]
+--------------------------------------------------
+PUT twitter/tweet/1
+{
+    "counter" : 1,
+    "tags" : ["red"]
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+... and try to retrieve it:
+
+[source,js]
+--------------------------------------------------
+GET twitter/tweet/1?stored_fields=tags,counter
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+The result of the above get operation is:
+
+[source,js]
+--------------------------------------------------
+{
+   "_index": "twitter",
+   "_type": "tweet",
+   "_id": "1",
+   "_version": 1,
+   "found": true,
+   "fields": {
+      "tags": [
+         "red"
+      ]
+   }
+}
+--------------------------------------------------
+// TESTRESPONSE
+
+
+Field values fetched from the document it self are always returned as an array.
+Since the `counter` field is not stored the get request simply ignores it when trying to get the `stored_fields.`
+
+It is also possible to retrieve metadata fields like `_routing` and `_parent` fields:
+
+[source,js]
+--------------------------------------------------
+PUT twitter/tweet/2?routing=user1
+{
+    "counter" : 1,
+    "tags" : ["white"]
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+[source,js]
+--------------------------------------------------
+GET twitter/tweet/1?routing=user1,stored_fields=tags,counter
 --------------------------------------------------
 
-If the requested fields are not stored, they will be ignored.
+The result of the above get operation is:
 
-Field values fetched from the document it self are always returned as an array. Metadata fields like `_routing` and
-`_parent` fields are never returned as an array.
+[source,js]
+--------------------------------------------------
+{
+   "_index": "twitter",
+   "_type": "tweet",
+   "_id": "1",
+   "_version": 1,
+   "_routing": "user1",
+   "found": true,
+   "fields": {
+      "tags": [
+         "red"
+      ]
+   }
+}
+--------------------------------------------------
+// TESTRESPONSE
 
 Also only leaf fields can be returned via the `stored_field` option. So object fields can't be returned and such requests
 will fail.

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -109,11 +109,11 @@ PUT twitter
          "properties": {
             "counter": {
                "type": "integer",
-               "store": "no"
+               "store": "false"
             },
             "tags": {
                "type": "keyword",
-               "store": "yes"
+               "store": "true"
             }
          }
       }
@@ -182,8 +182,10 @@ PUT twitter/tweet/2?routing=user1
 
 [source,js]
 --------------------------------------------------
-GET twitter/tweet/1?routing=user1,stored_fields=tags,counter
+GET twitter/tweet/2?routing=user1&stored_fields=tags,counter
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
 
 The result of the above get operation is:
 
@@ -192,13 +194,13 @@ The result of the above get operation is:
 {
    "_index": "twitter",
    "_type": "tweet",
-   "_id": "1",
+   "_id": "2",
    "_version": 1,
    "_routing": "user1",
    "found": true,
    "fields": {
       "tags": [
-         "red"
+         "white"
       ]
    }
 }

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -52,9 +52,8 @@ call in-place to make the document visible. This will also make other documents
 changed since the last refresh visible. In order to disable realtime GET,
 one can set the `realtime` parameter to `false`.
 
-When getting a document, one can specify `fields` to fetch from it. They
-will, when possible, be fetched as stored fields (fields mapped as
-<<mapping-store,stored>> in the mapping).
+When getting a document, one can specify `stored_fields` to fetch from it.
+They will be simply ignored if the field is not stored (<<mapping-store,stored>> in the mapping)*[]:
 
 [float]
 [[type]]
@@ -69,7 +68,7 @@ to fetch the first document matching the id across all types.
 === Source filtering
 
 By default, the get operation returns the contents of the `_source` field unless
-you have used the `fields` parameter or if the `_source` field is disabled. 
+you have used the `stored_fields` parameter or if the `_source` field is disabled.
 You can turn off `_source` retrieval by using the `_source` parameter:
 
 [source,js]
@@ -96,25 +95,23 @@ curl -XGET 'http://localhost:9200/twitter/tweet/1?_source=*.id,retweeted'
 
 
 [float]
-[[get-fields]]
-=== Fields
+[[get-stored-fields]]
+=== Stored Fields
 
 The get operation allows specifying a set of stored fields that will be
-returned by passing the `fields` parameter. For example:
+returned by passing the `stored_fields` parameter. For example:
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'http://localhost:9200/twitter/tweet/1?fields=title,content'
+curl -XGET 'http://localhost:9200/twitter/tweet/1?stored_fields=title,content'
 --------------------------------------------------
 
-For backward compatibility, if the requested fields are not stored, they will be fetched
-from the `_source` (parsed and extracted). This functionality has been replaced by the
-<<get-source-filtering,source filtering>> parameter.
+If the requested fields are not stored, they will be ignored.
 
 Field values fetched from the document it self are always returned as an array. Metadata fields like `_routing` and
 `_parent` fields are never returned as an array.
 
-Also only leaf fields can be returned via the `field` option. So object fields can't be returned and such requests
+Also only leaf fields can be returned via the `stored_field` option. So object fields can't be returned and such requests
 will fail.
 
 [float]

--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -155,7 +155,7 @@ curl 'localhost:9200/_mget' -d '{
 [[mget-fields]]
 === Fields
 
-Specific stored fields can be specified to be retrieved per document to get, similar to the <<get-fields,fields>> parameter of the Get API.
+Specific stored fields can be specified to be retrieved per document to get, similar to the <<get-stored-fields,stored_fields>> parameter of the Get API.
 For example:
 
 [source,js]
@@ -166,31 +166,31 @@ curl 'localhost:9200/_mget' -d '{
             "_index" : "test",
             "_type" : "type",
             "_id" : "1",
-            "fields" : ["field1", "field2"]
+            "stored_fields" : ["field1", "field2"]
         },
         {
             "_index" : "test",
             "_type" : "type",
             "_id" : "2",
-            "fields" : ["field3", "field4"]
+            "stored_fields" : ["field3", "field4"]
         }
     ]
 }'
 --------------------------------------------------
 
-Alternatively, you can specify the `fields` parameter in the query string
+Alternatively, you can specify the `stored_fields` parameter in the query string
 as a default to be applied to all documents.
 
 [source,js]
 --------------------------------------------------
-curl 'localhost:9200/test/type/_mget?fields=field1,field2' -d '{
+curl 'localhost:9200/test/type/_mget?stored_fields=field1,field2' -d '{
     "docs" : [
         {
             "_id" : "1" <1>
         },
         {
             "_id" : "2",
-            "fields" : ["field3", "field4"] <2>
+            "stored_fields" : ["field3", "field4"] <2>
         }
     ]
 }'
@@ -201,7 +201,7 @@ curl 'localhost:9200/test/type/_mget?fields=field1,field2' -d '{
 [float]
 === Generated fields
 
-See <<generated-fields>> for fields are generated only when indexing. 
+See <<generated-fields>> for fields generated only when indexing.
 
 [float]
 [[mget-routing]]

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -94,7 +94,7 @@ POST test/type1/1/_update
 // TEST[continued]
 
 And, we can even change the operation that is executed.  This example deletes
-the doc if the `tags` field contain `blue`, otherwise it does nothing
+the doc if the `tags` field contain `green`, otherwise it does nothing
 (`noop`):
 
 [source,js]

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -17,11 +17,13 @@ For example, lets index a simple doc:
 
 [source,js]
 --------------------------------------------------
-curl -XPUT localhost:9200/test/type1/1 -d '{
+PUT test/type1/1
+{
     "counter" : 1,
     "tags" : ["red"]
-}'
+}
 --------------------------------------------------
+// CONSOLE
 
 [float]
 === Scripted updates
@@ -30,7 +32,8 @@ Now, we can execute a script that would increment the counter:
 
 [source,js]
 --------------------------------------------------
-curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
+POST test/type1/1/_update
+{
     "script" : {
         "inline": "ctx._source.counter += params.count",
         "lang": "painless",
@@ -38,15 +41,18 @@ curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
             "count" : 4
         }
     }
-}'
+}
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
 
 We can add a tag to the list of tags (note, if the tag exists, it
 will still add it, since its a list):
 
 [source,js]
 --------------------------------------------------
-curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
+POST test/type1/1/_update
+{
     "script" : {
         "inline": "ctx._source.tags.add(params.tag)",
         "lang": "painless",
@@ -54,8 +60,10 @@ curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
             "tag" : "blue"
         }
     }
-}'
+}
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
 
 In addition to `_source`, the following variables are available through
 the `ctx` map: `_index`, `_type`, `_id`, `_version`, `_routing`,
@@ -65,19 +73,25 @@ We can also add a new field to the document:
 
 [source,js]
 --------------------------------------------------
-curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
-    "script" : "ctx._source.name_of_new_field = \"value_of_new_field\""
-}'
+POST test/type1/1/_update
+{
+    "script" : "ctx._source.new_field = \"value_of_new_field\""
+}
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
 
 Or remove a field from the document:
 
 [source,js]
 --------------------------------------------------
-curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
-    "script" : "ctx._source.remove(\"name_of_field\")"
-}'
+POST test/type1/1/_update
+{
+    "script" : "ctx._source.remove(\"new_field\")"
+}
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
 
 And, we can even change the operation that is executed.  This example deletes
 the doc if the `tags` field contain `blue`, otherwise it does nothing
@@ -85,16 +99,19 @@ the doc if the `tags` field contain `blue`, otherwise it does nothing
 
 [source,js]
 --------------------------------------------------
-curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
+POST test/type1/1/_update
+{
     "script" : {
-        "inline": "ctx._source.tags.contains(params.tag) ? ctx.op = \"delete\" : ctx.op = \"none\"",
+        "inline": "if (ctx._source.tags.contains(params.tag)) { ctx.op = \"delete\" } else { ctx.op = \"none\" }",
         "lang": "painless",
         "params" : {
-            "tag" : "blue"
+            "tag" : "green"
         }
     }
-}'
+}
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
 
 [float]
 === Updates with a partial document
@@ -106,12 +123,15 @@ example:
 
 [source,js]
 --------------------------------------------------
-curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
+POST test/type1/1/_update
+{
     "doc" : {
         "name" : "new_name"
     }
-}'
+}
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
 
 If both `doc` and `script` are specified, then `doc` is ignored. Best is
 to put your field pairs of the partial document in the script itself.
@@ -124,13 +144,16 @@ the old. Setting `detect_noop` to `false` will cause Elasticsearch to always
 update the document even if it hasn't changed. For example:
 [source,js]
 --------------------------------------------------
-curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
+POST test/type1/1/_update
+{
     "doc" : {
         "name" : "new_name"
     },
-    "detect_noop": false
-}'
+    "detect_noop": true
+}
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
 
 If `name` was `new_name` before the request was sent then the entire update
 request is ignored. The `result` element in the response returns `noop` if
@@ -139,13 +162,19 @@ the request was ignored.
 [source,js]
 --------------------------------------------------
 {
+   "_shards": {
+        "total": 0,
+        "successful": 0,
+        "failed": 0
+   },
    "_index": "test",
    "_type": "type1",
    "_id": "1",
-   "_version": 1,
+   "_version": 6,
    "result": noop
 }
 --------------------------------------------------
+// TESTRESPONSE
 
 [[upserts]]
 [float]
@@ -157,7 +186,8 @@ will be inserted as a new document.  If the document does exist, then the
 
 [source,js]
 --------------------------------------------------
-curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
+POST test/type1/1/_update
+{
     "script" : {
         "inline": "ctx._source.counter += params.count",
         "lang": "painless",
@@ -168,8 +198,10 @@ curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
     "upsert" : {
         "counter" : 1
     }
-}'
+}
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
 
 [float]
 ==== `scripted_upsert`
@@ -180,7 +212,8 @@ or not -- i.e. the script handles initializing the document instead of the
 
 [source,js]
 --------------------------------------------------
-curl -XPOST 'localhost:9200/sessions/session/dh3sgudg8gsrgl/_update' -d '{
+POST sessions/session/dh3sgudg8gsrgl/_update
+{
     "scripted_upsert":true,
     "script" : {
         "id": "my_web_session_summariser",
@@ -193,7 +226,7 @@ curl -XPOST 'localhost:9200/sessions/session/dh3sgudg8gsrgl/_update' -d '{
         }
     },
     "upsert" : {}
-}'
+}
 --------------------------------------------------
 
 [float]
@@ -205,13 +238,16 @@ value:
 
 [source,js]
 --------------------------------------------------
-curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
+POST test/type1/1/_update
+{
     "doc" : {
         "name" : "new_name"
     },
     "doc_as_upsert" : true
-}'
+}
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
 
 
 [float]
@@ -255,10 +291,12 @@ See <<index-wait-for-active-shards,here>> for details.
 Control when the changes made by this request are visible to search. See
 <<docs-refresh>>.
 
-`fields`::
+`_source`::
 
-Return the relevant fields from the updated document. Specify `_source` to
-return the full updated source.
+Allows to control if and how the updated source should be returned in the response.
+By default the updated source is not returned.
+See <<search-request-source-filtering, `source filtering`>> for details.
+
 
 `version` & `version_type`::
 

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -138,18 +138,17 @@ to put your field pairs of the partial document in the script itself.
 
 [float]
 === Detecting noop updates
-If `doc` is specified its value is merged with the existing `_source`. By
-default the document is only reindexed if the new `_source` field differs from
-the old. Setting `detect_noop` to `false` will cause Elasticsearch to always
-update the document even if it hasn't changed. For example:
+
+If `doc` is specified its value is merged with the existing `_source`.
+By default updates that don't change anything detect that they don't change anything and return "result": "noop" like this:
+
 [source,js]
 --------------------------------------------------
 POST test/type1/1/_update
 {
     "doc" : {
         "name" : "new_name"
-    },
-    "detect_noop": true
+    }
 }
 --------------------------------------------------
 // CONSOLE
@@ -175,6 +174,21 @@ the request was ignored.
 }
 --------------------------------------------------
 // TESTRESPONSE
+
+You can disable this behavior by setting "detect_noop": false like this:
+
+[source,js]
+--------------------------------------------------
+POST test/type1/1/_update
+{
+    "doc" : {
+        "name" : "new_name"
+    },
+    "detect_noop": true
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
 
 [[upserts]]
 [float]

--- a/docs/reference/search/explain.asciidoc
+++ b/docs/reference/search/explain.asciidoc
@@ -66,7 +66,7 @@ This will yield the same result as the previous request.
     Set to `true` to retrieve the `_source` of the document explained. You can also
     retrieve part of the document by using `_source_include` & `_source_exclude` (see <<get-source-filtering,Get API>> for more details)
 
-`fields`::
+`stored_fields`::
     Allows to control which stored fields to return as part of the
     document explained.
 

--- a/docs/reference/search/request/source-filtering.asciidoc
+++ b/docs/reference/search/request/source-filtering.asciidoc
@@ -5,7 +5,7 @@
 Allows to control how the `_source` field is returned with every hit.
 
 By default operations return the contents of the `_source` field unless
-you have used the `fields` parameter or if the `_source` field is disabled.
+you have used the `stored_fields` parameter or if the `_source` field is disabled.
 
 You can turn off `_source` retrieval by using the `_source` parameter:
 

--- a/docs/reference/search/request/stored-fields.asciidoc
+++ b/docs/reference/search/request/stored-fields.asciidoc
@@ -25,7 +25,7 @@ GET /_search
 
 An empty array will cause only the `_id` and `_type` for each hit to be
 returned, for example:
-
+t
 [source,js]
 --------------------------------------------------
 GET /_search
@@ -38,10 +38,7 @@ GET /_search
 --------------------------------------------------
 // CONSOLE
 
-
-For backwards compatibility, if the fields parameter specifies fields which are not stored (`store` mapping set to
-`false`), it will load the `_source` and extract it from it. This functionality has been replaced by the
-<<search-request-source-filtering,source filtering>> parameter.
+If the requested fields are not stored (`store` mapping set to `false`), they will be ignored.
 
 Field values fetched from the document it self are always returned as an array. Metadata fields like `_routing` and
 `_parent` fields are never returned as an array.

--- a/docs/reference/search/request/stored-fields.asciidoc
+++ b/docs/reference/search/request/stored-fields.asciidoc
@@ -25,7 +25,7 @@ GET /_search
 
 An empty array will cause only the `_id` and `_type` for each hit to be
 returned, for example:
-t
+
 [source,js]
 --------------------------------------------------
 GET /_search

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateRequest.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateRequest.java
@@ -242,8 +242,8 @@ public class PercolateRequest extends ActionRequest<PercolateRequest> implements
         if (source == null && getRequest == null) {
             validationException = addValidationError("source or get is missing", validationException);
         }
-        if (getRequest != null && getRequest.fields() != null) {
-            validationException = addValidationError("get fields option isn't supported via percolate request", validationException);
+        if (getRequest != null && getRequest.storedFields() != null) {
+            validationException = addValidationError("get stored fields option isn't supported via percolate request", validationException);
         }
         return validationException;
     }

--- a/plugins/mapper-size/src/test/java/org/elasticsearch/index/mapper/size/SizeMappingIT.java
+++ b/plugins/mapper-size/src/test/java/org/elasticsearch/index/mapper/size/SizeMappingIT.java
@@ -108,7 +108,7 @@ public class SizeMappingIT extends ESIntegTestCase {
         final String source = "{\"f\":10}";
         indexRandom(true,
                 client().prepareIndex("test", "type", "1").setSource(source));
-        GetResponse getResponse = client().prepareGet("test", "type", "1").setFields("_size").get();
+        GetResponse getResponse = client().prepareGet("test", "type", "1").setStoredFields("_size").get();
         assertNotNull(getResponse.getField("_size"));
         assertEquals(source.length(), getResponse.getField("_size").getValue());
     }

--- a/plugins/mapper-size/src/test/resources/rest-api-spec/test/mapper_size/10_basic.yaml
+++ b/plugins/mapper-size/src/test/resources/rest-api-spec/test/mapper_size/10_basic.yaml
@@ -26,7 +26,7 @@
             index: test
             type: type1
             id: 1
-            fields: "_size"
+            stored_fields: "_size"
 
     - match: { _size: 13 }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
@@ -41,6 +41,18 @@
           "type": "list",
           "description" : "Default comma-separated list of fields to return in the response for updates"
         },
+        "_source": {
+          "type" : "list",
+          "description" : "True or false to return the _source field or not, or default list of fields to return"
+        },
+        "_source_exclude": {
+          "type" : "list",
+          "description" : "Default list of fields to exclude from the returned _source field"
+        },
+        "_source_include": {
+          "type" : "list",
+          "description" : "Default list of fields to extract and return from the _source field"
+        },
         "pipeline" : {
           "type" : "string",
           "description" : "The pipeline id to preprocess incoming documents with"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
@@ -39,19 +39,19 @@
         },
         "fields": {
           "type": "list",
-          "description" : "Default comma-separated list of fields to return in the response for updates"
+          "description" : "Default comma-separated list of fields to return in the response for updates, can be overridden on each sub-request"
         },
         "_source": {
           "type" : "list",
-          "description" : "True or false to return the _source field or not, or default list of fields to return"
+          "description" : "True or false to return the _source field or not, or default list of fields to return, can be overridden on each sub-request"
         },
         "_source_exclude": {
           "type" : "list",
-          "description" : "Default list of fields to exclude from the returned _source field"
+          "description" : "Default list of fields to exclude from the returned _source field, can be overridden on each sub-request"
         },
         "_source_include": {
           "type" : "list",
-          "description" : "Default list of fields to extract and return from the _source field"
+          "description" : "Default list of fields to extract and return from the _source field, can be overridden on each sub-request"
         },
         "pipeline" : {
           "type" : "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -42,7 +42,7 @@
         },
         "stored_fields": {
           "type" : "list",
-          "description" : "A comma-separated list of fields to return as part of a hit"
+          "description" : "A comma-separated list of stored fields to return as part of a hit"
         },
         "docvalue_fields": {
           "type" : "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -40,13 +40,17 @@
           "type" : "boolean",
           "description" : "Specify whether to return detailed information about score computation as part of a hit"
         },
-        "fields": {
+        "stored_fields": {
           "type" : "list",
           "description" : "A comma-separated list of fields to return as part of a hit"
         },
+        "docvalue_fields": {
+          "type" : "list",
+          "description" : "A comma-separated list of fields to return as the docvalue representation of a field for each hit"
+        },
         "fielddata_fields": {
           "type" : "list",
-          "description" : "A comma-separated list of fields to return as the field data representation of a field for each hit"
+          "description" : "A comma-separated list of fields to return as the docvalue representation of a field for each hit"
         },
         "from": {
           "type" : "number",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -48,10 +48,6 @@
           "type" : "list",
           "description" : "A comma-separated list of fields to return as the docvalue representation of a field for each hit"
         },
-        "fielddata_fields": {
-          "type" : "list",
-          "description" : "A comma-separated list of fields to return as the docvalue representation of a field for each hit"
-        },
         "from": {
           "type" : "number",
           "description" : "Starting offset (default: 0)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json
@@ -41,9 +41,9 @@
           "type" : "string",
           "description" : "The default field for query string query (default: _all)"
         },
-        "fields": {
+        "stored_fields": {
           "type": "list",
-          "description" : "A comma-separated list of fields to return in the response"
+          "description" : "A comma-separated list of stored fields to return in the response"
         },
         "lenient": {
           "type" : "boolean",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
@@ -23,9 +23,9 @@
         }
       },
       "params": {
-        "fields": {
+        "stored_fields": {
           "type": "list",
-          "description" : "A comma-separated list of fields to return in the response"
+          "description" : "A comma-separated list of stored fields to return in the response"
         },
         "parent": {
           "type" : "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json
@@ -16,7 +16,7 @@
         }
       },
       "params": {
-        "fields": {
+        "stored_fields": {
           "type": "list",
           "description" : "A comma-separated list of fields to return in the response"
         },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json
@@ -18,7 +18,7 @@
       "params": {
         "stored_fields": {
           "type": "list",
-          "description" : "A comma-separated list of fields to return in the response"
+          "description" : "A comma-separated list of stored fields to return in the response"
         },
         "preference": {
           "type" : "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
@@ -31,6 +31,18 @@
           "type": "list",
           "description": "A comma-separated list of fields to return in the response"
         },
+        "_source": {
+          "type" : "list",
+          "description" : "True or false to return the _source field or not, or a list of fields to return"
+        },
+        "_source_exclude": {
+          "type" : "list",
+          "description" : "A list of fields to exclude from the returned _source field"
+        },
+        "_source_include": {
+          "type" : "list",
+          "description" : "A list of fields to extract and return from the _source field"
+        },
         "lang": {
           "type": "string",
           "description": "The script language (default: groovy)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -42,7 +42,7 @@
         },
         "stored_fields": {
           "type" : "list",
-          "description" : "A comma-separated list of fields to return as part of a hit"
+          "description" : "A comma-separated list of stored fields to return as part of a hit"
         },
         "docvalue_fields": {
           "type" : "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -40,13 +40,17 @@
           "type" : "boolean",
           "description" : "Specify whether to return detailed information about score computation as part of a hit"
         },
-        "fields": {
+        "stored_fields": {
           "type" : "list",
           "description" : "A comma-separated list of fields to return as part of a hit"
         },
+        "docvalue_fields": {
+          "type" : "list",
+          "description" : "A comma-separated list of fields to return as the docvalue representation of a field for each hit"
+        },
         "fielddata_fields": {
           "type" : "list",
-          "description" : "A comma-separated list of fields to return as the field data representation of a field for each hit"
+          "description" : "A comma-separated list of fields to return as the docvalue representation of a field for each hit"
         },
         "from": {
           "type" : "number",

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/40_fields.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/40_fields.yaml
@@ -29,10 +29,10 @@
       bulk:
         refresh: true
         body: |
-          { "update": { "_index": "test_index", "_type": "test_type", "_id": "test_id_1", "fields": ["_source"] } }
+          { "update": { "_index": "test_index", "_type": "test_type", "_id": "test_id_1", "_source": true } }
           { "doc": { "foo": "baz" } }
           { "update": { "_index": "test_index", "_type": "test_type", "_id": "test_id_2" } }
-          { "fields": ["_source"], "doc": { "foo": "quux" } }
+          { "_source": true, "doc": { "foo": "quux" } }
 
   - match: { items.0.update.get._source.foo: baz }
   - match: { items.1.update.get._source.foo: quux }
@@ -41,7 +41,7 @@
       bulk:
         index: test_index
         type: test_type
-        fields: _source
+        _source: true
         body: |
           { "update": { "_id": "test_id_3" } }
           { "doc": { "foo": "garply" } }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/40_source.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/40_source.yaml
@@ -1,12 +1,12 @@
 ---
-"Fields":
+"Source filtering":
   - do:
       index:
         refresh: true
         index: test_index
         type: test_type
         id: test_id_1
-        body: { "foo": "bar" }
+        body: { "foo": "bar", "bar": "foo" }
 
   - do:
       index:
@@ -14,7 +14,7 @@
         index: test_index
         type: test_type
         id: test_id_2
-        body: { "foo": "qux" }
+        body: { "foo": "qux", "bar": "pux" }
 
   - do:
       index:
@@ -22,7 +22,7 @@
         index: test_index
         type: test_type
         id: test_id_3
-        body: { "foo": "corge" }
+        body: { "foo": "corge", "bar": "forge" }
 
 
   - do:
@@ -47,3 +47,30 @@
           { "doc": { "foo": "garply" } }
 
   - match: { items.0.update.get._source.foo: garply }
+
+  - do:
+      bulk:
+        refresh: true
+        body: |
+          { "update": { "_index": "test_index", "_type": "test_type", "_id": "test_id_1", "_source": {"includes": "bar"} } }
+          { "doc": { "foo": "baz" } }
+          { "update": { "_index": "test_index", "_type": "test_type", "_id": "test_id_2" } }
+          { "_source": {"includes": "foo"}, "doc": { "foo": "quux" } }
+
+  - match: { items.0.update.get._source.bar: foo }
+  - is_false: items.0.update.get._source.foo
+  - match: { items.1.update.get._source.foo: quux }
+  - is_false: items.1.update.get._source.bar
+
+  - do:
+      bulk:
+        index: test_index
+        type: test_type
+        _source_include: foo
+        body: |
+          { "update": { "_id": "test_id_3" } }
+          { "doc": { "foo": "garply" } }
+
+  - match: { items.0.update.get._source.foo: garply }
+  - is_false: items.0.update.get._source.bar
+

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/create/40_routing.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/create/40_routing.yaml
@@ -28,7 +28,7 @@
           type:    test
           id:      1
           routing: 5
-          fields:  [_routing]
+          stored_fields:  [_routing]
 
  - match:   { _id:              "1"}
  - match:   { _routing:  "5"}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/create/50_parent.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/create/50_parent.yaml
@@ -31,7 +31,7 @@
           type:    test
           id:      1
           parent:  5
-          fields:  [_parent, _routing]
+          stored_fields:  [_parent, _routing]
 
  - match:   { _id:      "1"}
  - match:   { _parent: "5"}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/create/55_parent_with_routing.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/create/55_parent_with_routing.yaml
@@ -32,7 +32,7 @@
           id:      1
           parent:  5
           routing: 4
-          fields:  [_parent, _routing]
+          stored_fields:  [_parent, _routing]
 
  - match:   { _id:      "1"}
  - match:   { _parent: "5"}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get/20_fields.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get/20_fields.yaml
@@ -26,7 +26,7 @@
         index:  test_1
         type:   test
         id:     1
-        fields: foo
+        stored_fields: foo
 
   - match:   { _index:   test_1  }
   - match:   { _type:    test    }
@@ -39,7 +39,7 @@
         index:  test_1
         type:   test
         id:     1
-        fields: [foo, count]
+        stored_fields: [foo, count]
 
   - match:   { fields.foo:  [bar] }
   - match:   { fields.count:  [1] }
@@ -50,7 +50,7 @@
         index:  test_1
         type:   test
         id:     1
-        fields: [foo, count, _source]
+        stored_fields: [foo, count, _source]
 
   - match: { fields.foo:  [bar] }
   - match: { fields.count:  [1] }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get/20_stored_fields.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get/20_stored_fields.yaml
@@ -1,5 +1,5 @@
 ---
-"Fields":
+"Stored fields":
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get/30_parent.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get/30_parent.yaml
@@ -25,7 +25,7 @@ setup:
           type:    test
           id:      1
           parent:  中文
-          fields:  [_parent, _routing]
+          stored_fields:  [_parent, _routing]
 
  - match:   { _id:      "1"}
  - match:   { _parent: 中文 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get/40_routing.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get/40_routing.yaml
@@ -28,7 +28,7 @@
           type:    test
           id:      1
           routing: 5
-          fields:  [_routing]
+          stored_fields:  [_routing]
 
  - match:   { _id:              "1"}
  - match:   { _routing:  "5"}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get/55_parent_with_routing.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get/55_parent_with_routing.yaml
@@ -32,7 +32,7 @@
           id:      1
           parent:  5
           routing: 4
-          fields:  [_parent, _routing]
+          stored_fields:  [_parent, _routing]
 
  - match:   { _id:      "1"}
  - match:   { _parent: "5"}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get/70_source_filtering.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get/70_source_filtering.yaml
@@ -58,7 +58,7 @@
         index:  test_1
         type:   test
         id:     1
-        fields: count
+        stored_fields: count
         _source: true
 
   - match:   { _index:   test_1  }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/40_routing.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/40_routing.yaml
@@ -28,7 +28,7 @@
           type:    test
           id:      1
           routing: 5
-          fields:  [_routing]
+          stored_fields:  [_routing]
 
  - match:   { _id:       "1"}
  - match:   { _routing:  "5"}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/50_parent.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/50_parent.yaml
@@ -31,7 +31,7 @@
           type:    test
           id:      1
           parent:  5
-          fields:  [_parent, _routing]
+          stored_fields:  [_parent, _routing]
 
  - match:   { _id:      "1"}
  - match:   { _parent: "5"}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/55_parent_with_routing.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/55_parent_with_routing.yaml
@@ -32,7 +32,7 @@
           id:      1
           parent:  5
           routing: 4
-          fields:  [_parent, _routing]
+          stored_fields:  [_parent, _routing]
 
  - match:   { _id:      "1"}
  - match:   { _parent: "5"}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/20_fields.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/20_fields.yaml
@@ -29,9 +29,9 @@
         body:
           docs:
             - { _id: 1                         }
-            - { _id: 1, fields: foo            }
-            - { _id: 1, fields: [foo]          }
-            - { _id: 1, fields: [foo, _source] }
+            - { _id: 1, stored_fields: foo            }
+            - { _id: 1, stored_fields: [foo]          }
+            - { _id: 1, stored_fields: [foo, _source] }
 
   - is_false: docs.0.fields
   - match:  { docs.0._source: { foo: bar }}
@@ -49,13 +49,13 @@
       mget:
         index: test_1
         type:  test
-        fields: foo
+        stored_fields: foo
         body:
           docs:
             - { _id: 1                         }
-            - { _id: 1, fields: foo            }
-            - { _id: 1, fields: [foo]          }
-            - { _id: 1, fields: [foo, _source] }
+            - { _id: 1, stored_fields: foo            }
+            - { _id: 1, stored_fields: [foo]          }
+            - { _id: 1, stored_fields: [foo, _source] }
 
   - match:  { docs.0.fields.foo: [bar] }
   - is_false: docs.0._source
@@ -73,13 +73,13 @@
       mget:
         index:  test_1
         type:   test
-        fields: [foo]
+        stored_fields: [foo]
         body:
           docs:
             - { _id: 1                         }
-            - { _id: 1, fields: foo            }
-            - { _id: 1, fields: [foo]          }
-            - { _id: 1, fields: [foo, _source] }
+            - { _id: 1, stored_fields: foo            }
+            - { _id: 1, stored_fields: [foo]          }
+            - { _id: 1, stored_fields: [foo, _source] }
 
   - match:  { docs.0.fields.foo: [bar] }
   - is_false: docs.0._source
@@ -97,13 +97,13 @@
       mget:
         index:  test_1
         type:   test
-        fields: [foo, _source]
+        stored_fields: [foo, _source]
         body:
           docs:
             - { _id: 1                         }
-            - { _id: 1, fields: foo            }
-            - { _id: 1, fields: [foo]          }
-            - { _id: 1, fields: [foo, _source] }
+            - { _id: 1, stored_fields: foo            }
+            - { _id: 1, stored_fields: [foo]          }
+            - { _id: 1, stored_fields: [foo, _source] }
 
   - match:  { docs.0.fields.foo: [bar] }
   - match:  { docs.0._source: { foo: bar }}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/20_stored_fields.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/20_stored_fields.yaml
@@ -1,5 +1,5 @@
 ---
-"Fields":
+"Stored fields":
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/30_parent.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/30_parent.yaml
@@ -34,9 +34,9 @@
         body:
           docs:
             - { _id: 1 }
-            - { _id: 1, parent: 5, fields: [ _parent, _routing ] }
-            - { _id: 1, parent: 4, fields: [ _parent, _routing ] }
-            - { _id: 2, parent: 5, fields: [ _parent, _routing ] }
+            - { _id: 1, parent: 5, stored_fields: [ _parent, _routing ] }
+            - { _id: 1, parent: 4, stored_fields: [ _parent, _routing ] }
+            - { _id: 2, parent: 5, stored_fields: [ _parent, _routing ] }
 
  - is_false:  docs.0.found
  - is_false:  docs.1.found

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/40_routing.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/40_routing.yaml
@@ -26,7 +26,7 @@
       mget:
           index:   test_1
           type:    test
-          fields:  [_routing]
+          stored_fields:  [_routing]
           body:
             docs:
               - { _id: 1 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/55_parent_with_routing.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/55_parent_with_routing.yaml
@@ -29,7 +29,7 @@
       mget:
         index:  test_1
         type:   test
-        fields:  [ _routing , _parent]
+        stored_fields:  [ _routing , _parent]
         body:
           docs:
             - { _id: 1 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/40_routing.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/40_routing.yaml
@@ -49,9 +49,9 @@
           type:    test
           id:      1
           routing: 5
-          fields:  foo
+          _source:  foo
           body:
             doc:        { foo: baz }
 
- - match: { get.fields.foo: [baz] }
+ - match: { get._source.foo: baz }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/40_routing.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/40_routing.yaml
@@ -30,7 +30,7 @@
           type:    test
           id:      1
           routing: 5
-          fields:  _routing
+          stored_fields:  _routing
 
  - match: { _routing:  "5"}
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/40_routing.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/40_routing.yaml
@@ -49,7 +49,7 @@
           type:    test
           id:      1
           routing: 5
-          _source:  foo
+          _source: foo
           body:
             doc:        { foo: baz }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/50_parent.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/50_parent.yaml
@@ -36,7 +36,7 @@ setup:
           type:    test
           id:      1
           parent:  5
-          fields:  [_parent, _routing]
+          stored_fields:  [_parent, _routing]
 
  - match: { _parent:  "5"}
  - match: { _routing: "5"}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/50_parent.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/50_parent.yaml
@@ -47,11 +47,11 @@ setup:
           type:    test
           id:      1
           parent:  5
-          fields:  foo
+          _source:  foo
           body:
             doc:        { foo: baz }
 
- - match: { get.fields.foo: [baz] }
+ - match: { get._source.foo: baz }
 
 ---
 "Parent omitted":

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/55_parent_with_routing.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/55_parent_with_routing.yaml
@@ -56,9 +56,9 @@
           id:      1
           parent:  5
           routing: 4
-          fields:  foo
+          _source:  foo
           body:
             doc:        { foo: baz }
 
- - match: { get.fields.foo: [baz] }
+ - match: { get._source.foo: baz }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/55_parent_with_routing.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/55_parent_with_routing.yaml
@@ -34,7 +34,7 @@
           id:      1
           routing: 4
           parent:  5
-          fields:  [_parent, _routing]
+          stored_fields:  [_parent, _routing]
 
  - match: { _parent:  "5"}
  - match: { _routing: "4"}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/80_fields.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/80_fields.yaml
@@ -6,14 +6,13 @@
           index:  test_1
           type:   test
           id:     1
-          fields: foo,bar,_source
+          _source: [foo, bar]
           body:
             doc:    { foo: baz }
             upsert: { foo: bar }
 
   - match:   { get._source.foo: bar }
-  - match:   { get.fields.foo:  [bar] }
-  - is_false:  get.fields.bar
+  - is_false:  get._source.bar
 
 # TODO:
 #

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/80_source_filtering.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/80_source_filtering.yaml
@@ -1,5 +1,5 @@
 ---
-"Fields":
+"Source filtering":
 
   - do:
       update:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/85_fields_meta.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/85_fields_meta.yaml
@@ -33,6 +33,6 @@
           type:   test
           id:     1
           parent: 5
-          fields: [ _parent, _routing ]
+          stored_fields: [ _parent, _routing ]
 
 


### PR DESCRIPTION
This change replaces the fields parameter with stored_fields when it makes sense.
This is dictated by the renaming we made in #18943 for the search API.

The following list of endpoint has been changed to use `stored_fields` instead of `fields`:
- get
- mget
- explain

The documentation and the rest API spec has been updated to cope with the changes for the following APIs:
- delete_by_query
- get
- mget
- explain

The `fields` parameter has been deprecated for the following APIs:
- update
- bulk

These APIs now support `_source` as a parameter to filter the _source of the updated document to be returned. 

Some APIs still have the `fields` parameter for various reasons:
- cat.fielddata: the fields paramaters relates to the fielddata fields that should be printed.
- indices.clear_cache: used to indicate which fielddata fields should be cleared.
- indices.get_field_mapping: used to filter fields in the mapping.
- indices.stats: get stats on fields (stored or not stored).
- termvectors: fields are retrieved from the stored fields if possible and extracted from the _source otherwise.
- mtermvectors:
- nodes.stats: the fields parameter is used to concatenate completion_fields and fielddata_fields so it's not related to stored_fields at all.

Fixes #20155
