### PR TITLE
Avoid prematurely triggering logger initialization

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.common.settings;
 
-import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.support.ToXContentToBytes;

--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -107,8 +107,6 @@ public class Setting<T> extends ToXContentToBytes {
         IndexScope
     }
 
-    private static DeprecationLogger deprecationLogger;
-
     private final Key key;
     protected final Function<Settings, String> defaultValue;
     @Nullable
@@ -320,11 +318,8 @@ public class Setting<T> extends ToXContentToBytes {
     public String getRaw(Settings settings) {
         // They're using the setting, so we need to tell them to stop
         if (this.isDeprecated() && this.exists(settings)) {
-            // it does not matter if this is set twice
-            if (deprecationLogger == null) {
-                deprecationLogger = new DeprecationLogger(Loggers.getLogger(Setting.class));
-            }
             // It would be convenient to show its replacement key, but replacement is often not so simple
+            final DeprecationLogger deprecationLogger = new DeprecationLogger(Loggers.getLogger(getClass()));
             deprecationLogger.deprecated("[{}] setting was deprecated in Elasticsearch and it will be removed in a future release! " +
                     "See the breaking changes lists in the documentation for details", getKey());
         }

--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -108,7 +108,7 @@ public class Setting<T> extends ToXContentToBytes {
         IndexScope
     }
 
-    private final static SetOnce<DeprecationLogger> deprecationLogger = new SetOnce<>();
+    private static DeprecationLogger deprecationLogger;
 
     private final Key key;
     protected final Function<Settings, String> defaultValue;
@@ -321,11 +321,12 @@ public class Setting<T> extends ToXContentToBytes {
     public String getRaw(Settings settings) {
         // They're using the setting, so we need to tell them to stop
         if (this.isDeprecated() && this.exists(settings)) {
-            if (deprecationLogger.get() == null) {
-                deprecationLogger.set(new DeprecationLogger(Loggers.getLogger(Setting.class)));
+            // it does not matter if this is set twice
+            if (deprecationLogger == null) {
+                deprecationLogger = new DeprecationLogger(Loggers.getLogger(Setting.class));
             }
             // It would be convenient to show its replacement key, but replacement is often not so simple
-            deprecationLogger.get().deprecated("[{}] setting was deprecated in Elasticsearch and it will be removed in a future release! " +
+            deprecationLogger.deprecated("[{}] setting was deprecated in Elasticsearch and it will be removed in a future release! " +
                     "See the breaking changes lists in the documentation for details", getKey());
         }
         return settings.get(getKey(), defaultValue.apply(settings));


### PR DESCRIPTION
The class Setting holds a static reference to a deprecation logger
instance. When the class initializer for Setting runs, it starts
triggering log4j initialization. There is a chain of initializations
from InternalSettingsPreparer to Environment to Setting that triggers
this initialization before log4j configuration has occurred. This commit
modifies this initialization so that initialization is not done eagerly.
