### PR TITLE
Add "Async" to the end of each Async RestClient method

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -65,16 +65,20 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Client that connects to an elasticsearch cluster through http.
+ * Client that connects to an Elasticsearch cluster through HTTP.
+ * <p>
  * Must be created using {@link RestClientBuilder}, which allows to set all the different options or just rely on defaults.
  * The hosts that are part of the cluster need to be provided at creation time, but can also be replaced later
  * by calling {@link #setHosts(HttpHost...)}.
+ * <p>
  * The method {@link #performRequest(String, String, Map, HttpEntity, Header...)} allows to send a request to the cluster. When
  * sending a request, a host gets selected out of the provided ones in a round-robin fashion. Failing hosts are marked dead and
  * retried after a certain amount of time (minimum 1 minute, maximum 30 minutes), depending on how many times they previously
  * failed (the more failures, the later they will be retried). In case of failures all of the alive nodes (or dead nodes that
  * deserve a retry) are retried until one responds or none of them does, in which case an {@link IOException} will be thrown.
- *
+ * <p>
+ * Requests can be either synchronous or asynchronous. The asynchronous variants all end with {@code Async}.
+ * <p>
  * Requests can be traced by enabling trace logging for "tracer". The trace logger outputs requests and responses in curl format.
  */
 public class RestClient implements Closeable {
@@ -124,41 +128,41 @@ public class RestClient implements Closeable {
     }
 
     /**
-     * Sends a request to the elasticsearch cluster that the client points to and waits for the corresponding response
+     * Sends a request to the Elasticsearch cluster that the client points to and waits for the corresponding response
      * to be returned. Shortcut to {@link #performRequest(String, String, Map, HttpEntity, Header...)} but without parameters
      * and request body.
      *
      * @param method the http method
      * @param endpoint the path of the request (without host and port)
      * @param headers the optional request headers
-     * @return the response returned by elasticsearch
+     * @return the response returned by Elasticsearch
      * @throws IOException in case of a problem or the connection was aborted
      * @throws ClientProtocolException in case of an http protocol error
-     * @throws ResponseException in case elasticsearch responded with a status code that indicated an error
+     * @throws ResponseException in case Elasticsearch responded with a status code that indicated an error
      */
     public Response performRequest(String method, String endpoint, Header... headers) throws IOException {
         return performRequest(method, endpoint, Collections.<String, String>emptyMap(), (HttpEntity)null, headers);
     }
 
     /**
-     * Sends a request to the elasticsearch cluster that the client points to and waits for the corresponding response
+     * Sends a request to the Elasticsearch cluster that the client points to and waits for the corresponding response
      * to be returned. Shortcut to {@link #performRequest(String, String, Map, HttpEntity, Header...)} but without request body.
      *
      * @param method the http method
      * @param endpoint the path of the request (without host and port)
      * @param params the query_string parameters
      * @param headers the optional request headers
-     * @return the response returned by elasticsearch
+     * @return the response returned by Elasticsearch
      * @throws IOException in case of a problem or the connection was aborted
      * @throws ClientProtocolException in case of an http protocol error
-     * @throws ResponseException in case elasticsearch responded with a status code that indicated an error
+     * @throws ResponseException in case Elasticsearch responded with a status code that indicated an error
      */
     public Response performRequest(String method, String endpoint, Map<String, String> params, Header... headers) throws IOException {
         return performRequest(method, endpoint, params, (HttpEntity)null, headers);
     }
 
     /**
-     * Sends a request to the elasticsearch cluster that the client points to and waits for the corresponding response
+     * Sends a request to the Elasticsearch cluster that the client points to and waits for the corresponding response
      * to be returned. Shortcut to {@link #performRequest(String, String, Map, HttpEntity, HttpAsyncResponseConsumer, Header...)}
      * which doesn't require specifying an {@link HttpAsyncResponseConsumer} instance, {@link HeapBufferedAsyncResponseConsumer}
      * will be used to consume the response body.
@@ -168,10 +172,10 @@ public class RestClient implements Closeable {
      * @param params the query_string parameters
      * @param entity the body of the request, null if not applicable
      * @param headers the optional request headers
-     * @return the response returned by elasticsearch
+     * @return the response returned by Elasticsearch
      * @throws IOException in case of a problem or the connection was aborted
      * @throws ClientProtocolException in case of an http protocol error
-     * @throws ResponseException in case elasticsearch responded with a status code that indicated an error
+     * @throws ResponseException in case Elasticsearch responded with a status code that indicated an error
      */
     public Response performRequest(String method, String endpoint, Map<String, String> params,
                                    HttpEntity entity, Header... headers) throws IOException {
@@ -180,7 +184,7 @@ public class RestClient implements Closeable {
     }
 
     /**
-     * Sends a request to the elasticsearch cluster that the client points to. Blocks until the request is completed and returns
+     * Sends a request to the Elasticsearch cluster that the client points to. Blocks until the request is completed and returns
      * its response or fails by throwing an exception. Selects a host out of the provided ones in a round-robin fashion. Failing hosts
      * are marked dead and retried after a certain amount of time (minimum 1 minute, maximum 30 minutes), depending on how many times
      * they previously failed (the more failures, the later they will be retried). In case of failures all of the alive nodes (or dead
@@ -193,37 +197,37 @@ public class RestClient implements Closeable {
      * @param responseConsumer the {@link HttpAsyncResponseConsumer} callback. Controls how the response
      * body gets streamed from a non-blocking HTTP connection on the client side.
      * @param headers the optional request headers
-     * @return the response returned by elasticsearch
+     * @return the response returned by Elasticsearch
      * @throws IOException in case of a problem or the connection was aborted
      * @throws ClientProtocolException in case of an http protocol error
-     * @throws ResponseException in case elasticsearch responded with a status code that indicated an error
+     * @throws ResponseException in case Elasticsearch responded with a status code that indicated an error
      */
     public Response performRequest(String method, String endpoint, Map<String, String> params,
                                    HttpEntity entity, HttpAsyncResponseConsumer<HttpResponse> responseConsumer,
                                    Header... headers) throws IOException {
         SyncResponseListener listener = new SyncResponseListener(maxRetryTimeoutMillis);
-        performRequest(method, endpoint, params, entity, responseConsumer, listener, headers);
+        performRequestAsync(method, endpoint, params, entity, responseConsumer, listener, headers);
         return listener.get();
     }
 
     /**
-     * Sends a request to the elasticsearch cluster that the client points to. Doesn't wait for the response, instead
+     * Sends a request to the Elasticsearch cluster that the client points to. Doesn't wait for the response, instead
      * the provided {@link ResponseListener} will be notified upon completion or failure. Shortcut to
-     * {@link #performRequest(String, String, Map, HttpEntity, ResponseListener, Header...)} but without parameters and  request body.
+     * {@link #performRequestAsync(String, String, Map, HttpEntity, ResponseListener, Header...)} but without parameters and  request body.
      *
      * @param method the http method
      * @param endpoint the path of the request (without host and port)
      * @param responseListener the {@link ResponseListener} to notify when the request is completed or fails
      * @param headers the optional request headers
      */
-    public void performRequest(String method, String endpoint, ResponseListener responseListener, Header... headers) {
-        performRequest(method, endpoint, Collections.<String, String>emptyMap(), null, responseListener, headers);
+    public void performRequestAsync(String method, String endpoint, ResponseListener responseListener, Header... headers) {
+        performRequestAsync(method, endpoint, Collections.<String, String>emptyMap(), null, responseListener, headers);
     }
 
     /**
-     * Sends a request to the elasticsearch cluster that the client points to. Doesn't wait for the response, instead
+     * Sends a request to the Elasticsearch cluster that the client points to. Doesn't wait for the response, instead
      * the provided {@link ResponseListener} will be notified upon completion or failure. Shortcut to
-     * {@link #performRequest(String, String, Map, HttpEntity, ResponseListener, Header...)} but without request body.
+     * {@link #performRequestAsync(String, String, Map, HttpEntity, ResponseListener, Header...)} but without request body.
      *
      * @param method the http method
      * @param endpoint the path of the request (without host and port)
@@ -231,15 +235,15 @@ public class RestClient implements Closeable {
      * @param responseListener the {@link ResponseListener} to notify when the request is completed or fails
      * @param headers the optional request headers
      */
-    public void performRequest(String method, String endpoint, Map<String, String> params,
-                               ResponseListener responseListener, Header... headers) {
-        performRequest(method, endpoint, params, null, responseListener, headers);
+    public void performRequestAsync(String method, String endpoint, Map<String, String> params,
+                                    ResponseListener responseListener, Header... headers) {
+        performRequestAsync(method, endpoint, params, null, responseListener, headers);
     }
 
     /**
-     * Sends a request to the elasticsearch cluster that the client points to. Doesn't wait for the response, instead
+     * Sends a request to the Elasticsearch cluster that the client points to. Doesn't wait for the response, instead
      * the provided {@link ResponseListener} will be notified upon completion or failure.
-     * Shortcut to {@link #performRequest(String, String, Map, HttpEntity, HttpAsyncResponseConsumer, ResponseListener, Header...)}
+     * Shortcut to {@link #performRequestAsync(String, String, Map, HttpEntity, HttpAsyncResponseConsumer, ResponseListener, Header...)}
      * which doesn't require specifying an {@link HttpAsyncResponseConsumer} instance, {@link HeapBufferedAsyncResponseConsumer}
      * will be used to consume the response body.
      *
@@ -250,14 +254,14 @@ public class RestClient implements Closeable {
      * @param responseListener the {@link ResponseListener} to notify when the request is completed or fails
      * @param headers the optional request headers
      */
-    public void performRequest(String method, String endpoint, Map<String, String> params,
-                               HttpEntity entity, ResponseListener responseListener, Header... headers) {
+    public void performRequestAsync(String method, String endpoint, Map<String, String> params,
+                                    HttpEntity entity, ResponseListener responseListener, Header... headers) {
         HttpAsyncResponseConsumer<HttpResponse> responseConsumer = new HeapBufferedAsyncResponseConsumer();
-        performRequest(method, endpoint, params, entity, responseConsumer, responseListener, headers);
+        performRequestAsync(method, endpoint, params, entity, responseConsumer, responseListener, headers);
     }
 
     /**
-     * Sends a request to the elasticsearch cluster that the client points to. The request is executed asynchronously
+     * Sends a request to the Elasticsearch cluster that the client points to. The request is executed asynchronously
      * and the provided {@link ResponseListener} gets notified upon request completion or failure.
      * Selects a host out of the provided ones in a round-robin fashion. Failing hosts are marked dead and retried after a certain
      * amount of time (minimum 1 minute, maximum 30 minutes), depending on how many times they previously failed (the more failures,
@@ -273,20 +277,20 @@ public class RestClient implements Closeable {
      * @param responseListener the {@link ResponseListener} to notify when the request is completed or fails
      * @param headers the optional request headers
      */
-    public void performRequest(String method, String endpoint, Map<String, String> params,
-                               HttpEntity entity, HttpAsyncResponseConsumer<HttpResponse> responseConsumer,
-                               ResponseListener responseListener, Header... headers) {
+    public void performRequestAsync(String method, String endpoint, Map<String, String> params,
+                                    HttpEntity entity, HttpAsyncResponseConsumer<HttpResponse> responseConsumer,
+                                    ResponseListener responseListener, Header... headers) {
         URI uri = buildUri(endpoint, params);
         HttpRequestBase request = createHttpRequest(method, uri, entity);
         setHeaders(request, headers);
         FailureTrackingResponseListener failureTrackingResponseListener = new FailureTrackingResponseListener(responseListener);
         long startTime = System.nanoTime();
-        performRequest(startTime, nextHost().iterator(), request, responseConsumer, failureTrackingResponseListener);
+        performRequestAsync(startTime, nextHost().iterator(), request, responseConsumer, failureTrackingResponseListener);
     }
 
-    private void performRequest(final long startTime, final Iterator<HttpHost> hosts, final HttpRequestBase request,
-                                final HttpAsyncResponseConsumer<HttpResponse> responseConsumer,
-                                final FailureTrackingResponseListener listener) {
+    private void performRequestAsync(final long startTime, final Iterator<HttpHost> hosts, final HttpRequestBase request,
+                                     final HttpAsyncResponseConsumer<HttpResponse> responseConsumer,
+                                     final FailureTrackingResponseListener listener) {
         final HttpHost host = hosts.next();
         //we stream the request body if the entity allows for it
         HttpAsyncRequestProducer requestProducer = HttpAsyncMethods.create(host, request);
@@ -340,7 +344,7 @@ public class RestClient implements Closeable {
                     } else {
                         listener.trackFailure(exception);
                         request.reset();
-                        performRequest(startTime, hosts, request, responseConsumer, listener);
+                        performRequestAsync(startTime, hosts, request, responseConsumer, listener);
                     }
                 } else {
                     listener.onDefinitiveFailure(exception);

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientIntegTests.java
@@ -226,7 +226,7 @@ public class RestClientIntegTests extends RestClientTestCase {
         for (int i = 0; i < numRequests; i++) {
             final String method = RestClientTestUtil.randomHttpMethod(getRandom());
             final int statusCode = randomStatusCode(getRandom());
-            restClient.performRequest(method, "/" + statusCode, new ResponseListener() {
+            restClient.performRequestAsync(method, "/" + statusCode, new ResponseListener() {
                 @Override
                 public void onSuccess(Response response) {
                     responses.add(new TestResponse(method, statusCode, response));

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSource.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSource.java
@@ -98,7 +98,6 @@ public class RemoteScrollableHitSource extends ScrollableHitSource {
 
     void lookupRemoteVersion(Consumer<Version> onVersion) {
         execute("GET", "", emptyMap(), null, MAIN_ACTION_PARSER, onVersion);
-        
     }
 
     private void onStartResponse(Consumer<? super Response> onResponse, Response response) {
@@ -119,7 +118,7 @@ public class RemoteScrollableHitSource extends ScrollableHitSource {
     @Override
     protected void clearScroll(String scrollId) {
         // Need to throw out response....
-        client.performRequest("DELETE", scrollPath(), emptyMap(), scrollEntity(scrollId), new ResponseListener() {
+        client.performRequestAsync("DELETE", scrollPath(), emptyMap(), scrollEntity(scrollId), new ResponseListener() {
             @Override
             public void onSuccess(org.elasticsearch.client.Response response) {
                 logger.debug("Successfully cleared [{}]", scrollId);
@@ -141,7 +140,7 @@ public class RemoteScrollableHitSource extends ScrollableHitSource {
 
             @Override
             protected void doRun() throws Exception {
-                client.performRequest(method, uri, params, entity, new ResponseListener() {
+                client.performRequestAsync(method, uri, params, entity, new ResponseListener() {
                     @Override
                     public void onSuccess(org.elasticsearch.client.Response response) {
                         // Restore the thread context to get the precious headers


### PR DESCRIPTION
This makes it much harder to accidentally miss the `Response`.

Closes #20168
