### PR TITLE
Automatically downgrade text and keyword to string on indexes imported from 2.x

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -722,7 +722,6 @@
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]cluster[/\\]settings[/\\]ClusterSettingsIT.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]cluster[/\\]shards[/\\]ClusterSearchShardsIT.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]cluster[/\\]structure[/\\]RoutingIteratorTests.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]codecs[/\\]CodecTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]common[/\\]BooleansTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]common[/\\]blobstore[/\\]FsBlobStoreContainerTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]common[/\\]blobstore[/\\]FsBlobStoreTests.java" checks="LineLength" />

--- a/core/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -24,6 +24,7 @@ import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -32,10 +33,14 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import static java.util.Collections.unmodifiableList;
 import static org.elasticsearch.index.mapper.TypeParsers.parseField;
 
 /**
@@ -44,6 +49,12 @@ import static org.elasticsearch.index.mapper.TypeParsers.parseField;
 public final class KeywordFieldMapper extends FieldMapper {
 
     public static final String CONTENT_TYPE = "keyword";
+
+    private static final List<String> SUPPORTED_PARAMETERS_FOR_AUTO_DOWNGRADE_TO_STRING = unmodifiableList(Arrays.asList(
+            "type",
+            // common keyword parameters, for which the upgrade is straightforward
+            "index", "store", "doc_values", "omit_norms", "norms", "boost", "fields", "copy_to",
+            "include_in_all", "ignore_above", "index_options", "similarity"));
 
     public static class Defaults {
         public static final MappedFieldType FIELD_TYPE = new KeywordFieldType();
@@ -103,6 +114,29 @@ public final class KeywordFieldMapper extends FieldMapper {
     public static class TypeParser implements Mapper.TypeParser {
         @Override
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            if (parserContext.indexVersionCreated().before(Version.V_5_0_0_alpha1)) {
+                // Downgrade "keyword" to "string" in indexes created in 2.x so you can use modern syntax against old indexes
+                Set<String> unsupportedParameters = new HashSet<>(node.keySet());
+                unsupportedParameters.removeAll(SUPPORTED_PARAMETERS_FOR_AUTO_DOWNGRADE_TO_STRING);
+                if (false == SUPPORTED_PARAMETERS_FOR_AUTO_DOWNGRADE_TO_STRING.containsAll(node.keySet())) {
+                    throw new IllegalArgumentException("Automatic downgrade from [keyword] to [string] failed because parameters "
+                            + unsupportedParameters + " are not supported for automatic downgrades.");
+                }
+                {   // Downgrade "index"
+                    Object index = node.get("index");
+                    if (index == null || Boolean.TRUE.equals(index)) {
+                        index = "not_analyzed";
+                    } else if (Boolean.FALSE.equals(index)) {
+                        index = "no";
+                    } else {
+                        throw new IllegalArgumentException(
+                                "Can't parse [index] value [" + index + "] for field [" + name + "], expected [true] or [false]");
+                    }
+                    node.put("index", index);
+                }
+                
+                return new StringFieldMapper.TypeParser().parse(name, node, parserContext);
+            }
             KeywordFieldMapper.Builder builder = new KeywordFieldMapper.Builder(name);
             parseField(builder, name, node, parserContext);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -30,11 +31,15 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
+import static java.util.Collections.unmodifiableList;
 import static org.elasticsearch.index.mapper.TypeParsers.parseTextField;
 
 /** A {@link FieldMapper} for full-text fields. */
@@ -42,6 +47,14 @@ public class TextFieldMapper extends FieldMapper {
 
     public static final String CONTENT_TYPE = "text";
     private static final int POSITION_INCREMENT_GAP_USE_ANALYZER = -1;
+
+    private static final List<String> SUPPORTED_PARAMETERS_FOR_AUTO_DOWNGRADE_TO_STRING = unmodifiableList(Arrays.asList(
+            "type",
+            // common text parameters, for which the upgrade is straightforward
+            "index", "store", "doc_values", "omit_norms", "norms", "boost", "fields", "copy_to",
+            "fielddata", "eager_global_ordinals", "fielddata_frequency_filter", "include_in_all",
+            "analyzer", "search_analyzer", "search_quote_analyzer",
+            "index_options", "position_increment_gap", "similarity"));
 
     public static class Defaults {
         public static double FIELDDATA_MIN_FREQUENCY = 0;
@@ -129,6 +142,41 @@ public class TextFieldMapper extends FieldMapper {
     public static class TypeParser implements Mapper.TypeParser {
         @Override
         public Mapper.Builder parse(String fieldName, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            if (parserContext.indexVersionCreated().before(Version.V_5_0_0_alpha1)) {
+                // Downgrade "text" to "string" in indexes created in 2.x so you can use modern syntax against old indexes
+                Set<String> unsupportedParameters = new HashSet<>(node.keySet());
+                unsupportedParameters.removeAll(SUPPORTED_PARAMETERS_FOR_AUTO_DOWNGRADE_TO_STRING);
+                if (false == SUPPORTED_PARAMETERS_FOR_AUTO_DOWNGRADE_TO_STRING.containsAll(node.keySet())) {
+                    throw new IllegalArgumentException("Automatic downgrade from [text] to [string] failed because parameters "
+                            + unsupportedParameters + " are not supported for automatic downgrades.");
+                }
+                {   // Downgrade "index"
+                    Object index = node.get("index");
+                    if (index == null || Boolean.TRUE.equals(index)) {
+                        index = "analyzed";
+                    } else if (Boolean.FALSE.equals(index)) {
+                        index = "no";
+                    } else {
+                        throw new IllegalArgumentException(
+                                "Can't parse [index] value [" + index + "] for field [" + fieldName + "], expected [true] or [false]");
+                    }
+                    node.put("index", index);
+                }
+                {   // Downgrade "fielddata" (default in string is true, default in text is false)
+                    Object fielddata = node.get("fielddata");
+                    if (fielddata == null || Boolean.FALSE.equals(fielddata)) {
+                        fielddata = false;
+                    } else if (Boolean.TRUE.equals(fielddata)) {
+                        fielddata = true;
+                    } else {
+                        throw new IllegalArgumentException("can't parse [fielddata] value for [" + fielddata + "] for field ["
+                                + fieldName + "], expected [true] or [false]");
+                    }
+                    node.put("fielddata", fielddata);
+                }
+                
+                return new StringFieldMapper.TypeParser().parse(fieldName, node, parserContext);
+            }
             TextFieldMapper.Builder builder = new TextFieldMapper.Builder(fieldName);
             builder.fieldType().setIndexAnalyzer(parserContext.analysisService().defaultIndexAnalyzer());
             builder.fieldType().setSearchAnalyzer(parserContext.analysisService().defaultSearchAnalyzer());

--- a/core/src/test/java/org/elasticsearch/codecs/CodecTests.java
+++ b/core/src/test/java/org/elasticsearch/codecs/CodecTests.java
@@ -47,18 +47,25 @@ public class CodecTests extends ESSingleNodeTestCase {
     }
 
     public void testAcceptPostingsFormat() throws IOException {
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
-                .startObject("properties").startObject("field").field("type", "keyword").field("postings_format", Codec.getDefault().postingsFormat().getName()).endObject().endObject()
-                .endObject().endObject().string();
         int i = 0;
         for (Version v : VersionUtils.allVersions()) {
             if (v.onOrAfter(Version.V_2_0_0) == false) {
                 // no need to test, we don't support upgrading from these versions
                 continue;
             }
-            IndexService indexService = createIndex("test-" + i++, Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, v).build());
+            IndexService indexService = createIndex("test-" + i++,
+                    Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, v).build());
             DocumentMapperParser parser = indexService.mapperService().documentMapperParser();
             try {
+                String mapping = XContentFactory.jsonBuilder().startObject()
+                        .startObject("type")
+                            .startObject("properties")
+                                .startObject("field")
+                                    .field("type", v.onOrAfter(Version.V_5_0_0_alpha1) ? "keyword" : "string")
+                                    .field("postings_format", Codec.getDefault().postingsFormat().getName())
+                                .endObject()
+                            .endObject()
+                        .endObject().endObject().string();
                 parser.parse("type", new CompressedXContent(mapping));
                 if (v.onOrAfter(Version.V_2_0_0_beta1)) {
                     fail("Elasticsearch 2.0 should not support custom postings formats");
@@ -74,17 +81,24 @@ public class CodecTests extends ESSingleNodeTestCase {
     }
 
     public void testAcceptDocValuesFormat() throws IOException {
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
-                .startObject("properties").startObject("field").field("type", "keyword").field("doc_values_format", Codec.getDefault().docValuesFormat().getName()).endObject().endObject()
-                .endObject().endObject().string();
         int i = 0;
         for (Version v : VersionUtils.allVersions()) {
             if (v.onOrAfter(Version.V_2_0_0) == false) {
                 // no need to test, we don't support upgrading from these versions
                 continue;
             }
-            IndexService indexService = createIndex("test-" + i++, Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, v).build());
+            IndexService indexService = createIndex("test-" + i++,
+                    Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, v).build());
             DocumentMapperParser parser = indexService.mapperService().documentMapperParser();
+            String mapping = XContentFactory.jsonBuilder().startObject()
+                    .startObject("type")
+                        .startObject("properties")
+                            .startObject("field")
+                                .field("type", v.onOrAfter(Version.V_5_0_0_alpha1) ? "keyword" : "string")
+                                .field("doc_values_format", Codec.getDefault().docValuesFormat().getName())
+                            .endObject()
+                        .endObject()
+                    .endObject().endObject().string();
             try {
                 parser.parse("type", new CompressedXContent(mapping));
                 if (v.onOrAfter(Version.V_2_0_0_beta1)) {

--- a/core/src/test/java/org/elasticsearch/index/mapper/ExternalFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ExternalFieldMapperTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.spatial.geopoint.document.GeoPointField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
@@ -27,12 +28,6 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.DocumentMapperParser;
-import org.elasticsearch.index.mapper.KeywordFieldMapper;
-import org.elasticsearch.index.mapper.Mapper;
-import org.elasticsearch.index.mapper.ParsedDocument;
-import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.indices.mapper.MapperRegistry;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -150,13 +145,21 @@ public class ExternalFieldMapperTests extends ESSingleNodeTestCase {
             assertThat(Long.parseLong(doc.rootDoc().getField("field.point").stringValue()), is(GeoPointField.encodeLatLon(42.0, 51.0)));
         }
 
-        assertThat(doc.rootDoc().getField("field.shape"), notNullValue());
+        IndexableField shape = doc.rootDoc().getField("field.shape");
+        assertThat(shape, notNullValue());
 
-        assertThat(doc.rootDoc().getField("field.field"), notNullValue());
-        assertThat(doc.rootDoc().getField("field.field").stringValue(), is("foo"));
+        IndexableField field = doc.rootDoc().getField("field.field");
+        assertThat(field, notNullValue());
+        assertThat(field.stringValue(), is("foo"));
 
-        assertThat(doc.rootDoc().getField("field.field.raw"), notNullValue());
-        assertThat(doc.rootDoc().getField("field.field.raw").binaryValue(), is(new BytesRef("foo")));
+        IndexableField raw = doc.rootDoc().getField("field.field.raw");
+
+        assertThat(raw, notNullValue());
+        if (version.before(Version.V_5_0_0_alpha1)) {
+            assertThat(raw.stringValue(), is("foo"));
+        } else {
+            assertThat(raw.binaryValue(), is(new BytesRef("foo")));
+        }
     }
 
     public void testExternalValuesWithMultifieldTwoLevels() throws Exception {

--- a/core/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -28,14 +28,8 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.DocumentMapperParser;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
@@ -279,14 +273,28 @@ public class KeywordFieldMapperTests extends ESSingleNodeTestCase {
                 Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_2_3_0).build());
         parser = indexService.mapperService().documentMapperParser();
 
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
-                .startObject("properties").startObject("field").field("type", "keyword").field("boost", 2f).endObject().endObject()
+        String mapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("type")
+                    .startObject("properties")
+                        .startObject("field")
+                            .field("type", "keyword")
+                            .field("boost", 2f)
+                        .endObject()
+                    .endObject()
                 .endObject().endObject().string();
         DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
 
-        String expectedMapping = XContentFactory.jsonBuilder().startObject().startObject("type")
-                .startObject("properties").startObject("field").field("type", "keyword")
-                .field("boost", 2f).field("norms", true).endObject().endObject()
+        String expectedMapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("type")
+                    .startObject("properties")
+                        .startObject("field")
+                            .field("type", "string")
+                            .field("boost", 2f)
+                            .field("index", "not_analyzed")
+                            .field("norms", true)
+                            .field("fielddata", false)
+                        .endObject()
+                    .endObject()
                 .endObject().endObject().string();
         assertEquals(expectedMapping, mapper.mappingSource().toString());
     }
@@ -312,23 +320,38 @@ public class KeywordFieldMapperTests extends ESSingleNodeTestCase {
     }
 
     public void testEmptyName() throws IOException {
-        // after 5.x
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
-            .startObject("properties").startObject("").field("type", "keyword").endObject().endObject()
-            .endObject().endObject().string();
+        String mapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("type")
+                    .startObject("properties")
+                        .startObject("")
+                            .field("type", "keyword")
+                        .endObject()
+                    .endObject()
+                .endObject().endObject().string();
 
+        // Empty name not allowed in index created after 5.0
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
             () -> parser.parse("type", new CompressedXContent(mapping))
         );
         assertThat(e.getMessage(), containsString("name cannot be empty string"));
 
-        // before 5.x
+        // empty name allowed in index created before 5.0
         Version oldVersion = VersionUtils.randomVersionBetween(getRandom(), Version.V_2_0_0, Version.V_2_3_5);
         Settings oldIndexSettings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, oldVersion).build();
         indexService = createIndex("test_old", oldIndexSettings);
         parser = indexService.mapperService().documentMapperParser();
 
         DocumentMapper defaultMapper = parser.parse("type", new CompressedXContent(mapping));
-        assertEquals(mapping, defaultMapper.mappingSource().string());
+        String downgradedMapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("type")
+                    .startObject("properties")
+                        .startObject("")
+                            .field("type", "string")
+                            .field("index", "not_analyzed")
+                            .field("fielddata", false)
+                        .endObject()
+                    .endObject()
+                .endObject().endObject().string();
+        assertEquals(downgradedMapping, defaultMapper.mappingSource().string());
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/LegacyDateFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/LegacyDateFieldMapperTests.java
@@ -40,15 +40,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.LegacyDateFieldMapper;
-import org.elasticsearch.index.mapper.LegacyLongFieldMapper;
-import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.ParseContext.Document;
-import org.elasticsearch.index.mapper.ParsedDocument;
-import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -114,11 +106,11 @@ public class LegacyDateFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(fieldMapper, instanceOf(LegacyDateFieldMapper.class));
 
         fieldMapper = defaultMapper.mappers().smartNameFieldMapper("wrong_date1");
-        assertThat(fieldMapper, instanceOf(TextFieldMapper.class));
+        assertThat(fieldMapper, instanceOf(StringFieldMapper.class));
         fieldMapper = defaultMapper.mappers().smartNameFieldMapper("wrong_date2");
-        assertThat(fieldMapper, instanceOf(TextFieldMapper.class));
+        assertThat(fieldMapper, instanceOf(StringFieldMapper.class));
         fieldMapper = defaultMapper.mappers().smartNameFieldMapper("wrong_date3");
-        assertThat(fieldMapper, instanceOf(TextFieldMapper.class));
+        assertThat(fieldMapper, instanceOf(StringFieldMapper.class));
     }
 
     public void testParseLocal() {

--- a/core/src/test/java/org/elasticsearch/index/mapper/LegacyStringMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/LegacyStringMappingTests.java
@@ -24,7 +24,10 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexableFieldType;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -33,18 +36,10 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.mapper.ContentPath;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.DocumentMapperParser;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.Mapper.BuilderContext;
-import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext.Document;
 import org.elasticsearch.index.mapper.StringFieldMapper.Builder;
 import org.elasticsearch.index.mapper.StringFieldMapper.StringFieldType;
-import org.elasticsearch.index.mapper.ParsedDocument;
-import org.elasticsearch.index.mapper.StringFieldMapper;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
@@ -54,9 +49,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -751,6 +749,450 @@ public class LegacyStringMappingTests extends ESSingleNodeTestCase {
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> parser.parse("type", new CompressedXContent(mapping)));
             assertEquals("Cannot set position_increment_gap on field [field] without positions enabled", e.getMessage());
+        }
+    }
+
+    public void testKeywordFieldAsStringWithUnsupportedField() throws IOException {
+        String mapping = mappingForTestField(b -> b.field("type", "keyword").field("fielddata", true)).string();
+        Exception e = expectThrows(IllegalArgumentException.class, () -> parser.parse("test_type", new CompressedXContent(mapping)));
+        assertEquals("Automatic downgrade from [keyword] to [string] failed because parameters [fielddata] are not supported for "
+                + "automatic downgrades.", e.getMessage());
+    }
+
+    public void testMergeKeywordIntoString() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("index", "not_analyzed");
+        expectedMapping.put("fielddata", false);
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("index", "not_analyzed"));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "keyword"));
+    }
+
+    public void testMergeKeywordIntoStringWithIndexFalse() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("index", "no");
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("index", "no"));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "keyword").field("index", false));
+    }
+
+    public void testMergeKeywordIntoStringWithStore() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("index", "not_analyzed");
+        expectedMapping.put("fielddata", false);
+        expectedMapping.put("store", true);
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("index", "not_analyzed").field("store", true));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "keyword").field("store", true));
+    }
+
+    public void testMergeKeywordIntoStringWithDocValues() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("index", "not_analyzed");
+        expectedMapping.put("doc_values", false);
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("index", "not_analyzed").field("doc_values", false));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "keyword").field("doc_values", false));
+    }
+
+    public void testMergeKeywordIntoStringWithNorms() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("index", "not_analyzed");
+        expectedMapping.put("fielddata", false);
+        expectedMapping.put("norms", true);
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("index", "not_analyzed").field("norms", true));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "keyword").field("norms", true));
+        // norms can be an array but it'll just get squashed into true/false
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("index", "not_analyzed")
+                .startObject("norms")
+                    .field("enabled", true)
+                    .field("loading", randomAsciiOfLength(5)) // Totally ignored even though it used to be eager/lazy
+                .endObject());
+        mergeMappingStep(expectedMapping, b -> b.field("type", "keyword")
+                .startObject("norms")
+                    .field("enabled", true)
+                    .field("loading", randomAsciiOfLength(5))
+                .endObject());
+    }
+
+    public void testMergeKeywordIntoStringWithBoost() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("index", "not_analyzed");
+        expectedMapping.put("fielddata", false);
+        expectedMapping.put("boost", 1.5);
+        expectedMapping.put("norms", true); // Implied by having a boost
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("index", "not_analyzed").field("boost", 1.5));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "keyword").field("boost", 1.5));
+        expectedMapping.put("boost", 1.4);
+        mergeMappingStep(expectedMapping, b -> b.field("type", "keyword").field("boost", 1.4));
+    }
+
+    public void testMergeKeywordIntoStringWithFields() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("index", "not_analyzed");
+        expectedMapping.put("fielddata", false);
+        Map<String, Object> expectedFields = new HashMap<>();
+        expectedMapping.put("fields", expectedFields);
+        Map<String, Object> expectedFoo = new HashMap<>();
+        expectedFields.put("foo", expectedFoo);
+        expectedFoo.put("type", "string");
+        expectedFoo.put("analyzer", "standard");
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("index", "not_analyzed")
+                .startObject("fields")
+                    .startObject("foo")
+                        .field("type", "string")
+                        .field("analyzer", "standard")
+                    .endObject()
+                .endObject());
+        mergeMappingStep(expectedMapping, b -> b.field("type", "keyword")
+                .startObject("fields")
+                    .startObject("foo")
+                        .field("type", "string")
+                        .field("analyzer", "standard")
+                    .endObject()
+                .endObject());
+
+        Map<String, Object> expectedBar = new HashMap<>();
+        expectedFields.put("bar", expectedBar);
+        expectedBar.put("type", "string");
+        expectedBar.put("analyzer", "whitespace");
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("index", "not_analyzed")
+                .startObject("fields")
+                    .startObject("foo")
+                        .field("type", "string")
+                        .field("analyzer", "standard")
+                    .endObject()
+                    .startObject("bar")
+                        .field("type", "string")
+                        .field("analyzer", "whitespace")
+                    .endObject()
+                .endObject());
+        mergeMappingStep(expectedMapping, b -> b.field("type", "keyword")
+                .startObject("fields")
+                    .startObject("foo")
+                        .field("type", "string")
+                        .field("analyzer", "standard")
+                    .endObject()
+                    .startObject("bar")
+                        .field("type", "string")
+                        .field("analyzer", "whitespace")
+                    .endObject()
+                .endObject());
+    }
+
+    public void testMergeKeywordIntoStringWithCopyTo() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("index", "not_analyzed");
+        expectedMapping.put("fielddata", false);
+        expectedMapping.put("copy_to", singletonList("another_field"));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("index", "not_analyzed").field("copy_to", "another_field"));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "keyword").field("copy_to", "another_field"));
+    }
+
+    public void testMergeKeywordIntoStringWithIncludeInAll() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("index", "not_analyzed");
+        expectedMapping.put("fielddata", false);
+        expectedMapping.put("include_in_all", false);
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("index", "not_analyzed").field("include_in_all", false));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "keyword").field("include_in_all", false));
+    }
+
+    public void testMergeKeywordIntoStringWithIgnoreAbove() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("index", "not_analyzed");
+        expectedMapping.put("fielddata", false);
+        expectedMapping.put("ignore_above", 128);
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("index", "not_analyzed").field("ignore_above", 128));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "keyword").field("ignore_above", 128));
+    }
+
+    public void testMergeKeywordIntoStringWithIndexOptions() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("index", "not_analyzed");
+        expectedMapping.put("fielddata", false);
+        expectedMapping.put("index_options", "freqs");
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("index", "not_analyzed").field("index_options", "freqs"));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "keyword").field("index_options", "freqs"));
+    }
+
+    public void testMergeKeywordIntoStringWithSimilarity() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("index", "not_analyzed");
+        expectedMapping.put("fielddata", false);
+        expectedMapping.put("similarity", "BM25");
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("index", "not_analyzed").field("similarity", "BM25"));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "keyword").field("similarity", "BM25"));
+    }
+
+    public void testTextFieldAsStringWithUnsupportedField() throws IOException {
+        String mapping = mappingForTestField(b -> b.field("type", "text").field("null_value", "kitten")).string();
+        Exception e = expectThrows(IllegalArgumentException.class, () -> parser.parse("test_type", new CompressedXContent(mapping)));
+        assertEquals("Automatic downgrade from [text] to [string] failed because parameters [null_value] are not supported for "
+                + "automatic downgrades.", e.getMessage());
+    }
+
+    public void testMergeTextIntoString() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string"));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "text").field("fielddata", true));
+    }
+
+    public void testMergeTextIntoStringWithStore() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("store", true);
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("store", true));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "text").field("store", true).field("fielddata", true));
+    }
+
+    public void testMergeTextIntoStringWithDocValues() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("doc_values", false));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "text").field("doc_values", false).field("fielddata", true));
+    }
+
+    public void testMergeTextIntoStringWithNorms() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("norms", false);
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("norms", false));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "text").field("norms", false).field("fielddata", true));
+    }
+
+    public void testMergeTextIntoStringWithBoost() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("boost", 1.5);
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("boost", 1.5));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "text").field("boost", 1.5).field("fielddata", true));
+        expectedMapping.put("boost", 1.4);
+        mergeMappingStep(expectedMapping, b -> b.field("type", "text").field("boost", 1.4).field("fielddata", true));
+    }
+
+    public void testMergeTextIntoStringWithFields() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        Map<String, Object> expectedFields = new HashMap<>();
+        expectedMapping.put("fields", expectedFields);
+        Map<String, Object> expectedFoo = new HashMap<>();
+        expectedFields.put("foo", expectedFoo);
+        expectedFoo.put("type", "string");
+        expectedFoo.put("analyzer", "standard");
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string")
+                .startObject("fields")
+                    .startObject("foo")
+                        .field("type", "string")
+                        .field("analyzer", "standard")
+                    .endObject()
+                .endObject());
+        mergeMappingStep(expectedMapping, b -> b.field("type", "text").field("fielddata", true)
+                .startObject("fields")
+                    .startObject("foo")
+                        .field("type", "string")
+                        .field("analyzer", "standard")
+                    .endObject()
+                .endObject());
+
+        Map<String, Object> expectedBar = new HashMap<>();
+        expectedFields.put("bar", expectedBar);
+        expectedBar.put("type", "string");
+        expectedBar.put("analyzer", "whitespace");
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string")
+                .startObject("fields")
+                    .startObject("foo")
+                        .field("type", "string")
+                        .field("analyzer", "standard")
+                    .endObject()
+                    .startObject("bar")
+                        .field("type", "string")
+                        .field("analyzer", "whitespace")
+                    .endObject()
+                .endObject());
+        mergeMappingStep(expectedMapping, b -> b.field("type", "text").field("fielddata", true)
+                .startObject("fields")
+                    .startObject("foo")
+                        .field("type", "string")
+                        .field("analyzer", "standard")
+                    .endObject()
+                    .startObject("bar")
+                        .field("type", "string")
+                        .field("analyzer", "whitespace")
+                    .endObject()
+                .endObject());
+    }
+
+    public void testMergeTextIntoStringWithCopyTo() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("copy_to", singletonList("another_field"));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("copy_to", "another_field"));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "text").field("copy_to", "another_field").field("fielddata", true));
+    }
+
+    public void testMergeTextIntoStringWithFileddataDisabled() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("fielddata", false);
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("fielddata", false));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "text"));
+    }
+
+    public void testMergeTextIntoStringWithEagerGlobalOrdinals() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("eager_global_ordinals", true);
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").startObject("fielddata")
+                    .field("format", "pagedbytes")
+                    .field("loading", "eager_global_ordinals")
+                .endObject());
+        mergeMappingStep(expectedMapping, b -> b.field("type", "text").field("fielddata", true).field("eager_global_ordinals", true));
+    }
+
+    public void testMergeTextIntoStringWithFielddataFrequencyFilter() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        Map<String, Object> fielddataFrequencyFilter = new HashMap<>();
+        expectedMapping.put("fielddata_frequency_filter", fielddataFrequencyFilter);
+        fielddataFrequencyFilter.put("min", 0.001);
+        fielddataFrequencyFilter.put("max", 0.1);
+        fielddataFrequencyFilter.put("min_segment_size", 100);
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").startObject("fielddata")
+                    .field("format", "pagedbytes")
+                    .startObject("filter")
+                        .startObject("frequency")
+                            .field("min", 0.001)
+                            .field("max", 0.1)
+                            .field("min_segment_size", 100)
+                        .endObject()
+                    .endObject()
+                .endObject());
+        mergeMappingStep(expectedMapping, b -> b.field("type", "text").field("fielddata", true)
+                .startObject("fielddata_frequency_filter")
+                    .field("min", 0.001)
+                    .field("max", 0.1)
+                    .field("min_segment_size", 100)
+                .endObject());
+    }
+
+    public void testMergeTextIntoStringWithIncludeInAll() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("include_in_all", false);
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("include_in_all", false));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "text").field("include_in_all", false).field("fielddata", true));
+    }
+
+    public void testMergeTextIntoStringWithSearchQuoteAnayzer() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("analyzer", "standard");
+        expectedMapping.put("search_analyzer", "whitespace");
+        expectedMapping.put("search_quote_analyzer", "keyword");
+        mergeMappingStep(expectedMapping, b -> b
+                .field("type", "string")
+                .field("analyzer", "standard")
+                .field("search_analyzer", "whitespace")
+                .field("search_quote_analyzer", "keyword"));
+        mergeMappingStep(expectedMapping, b -> b
+                .field("type", "text")
+                .field("analyzer", "standard")
+                .field("search_analyzer", "whitespace")
+                .field("search_quote_analyzer", "keyword")
+                .field("fielddata", true));
+    }
+
+    public void testMergeTextIntoStringWithIndexOptions() throws IOException {
+        String indexOptions = randomIndexOptions();
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        if (false == "positions".equals(indexOptions)) {
+            expectedMapping.put("index_options", indexOptions);
+        }
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("index_options", indexOptions));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "text").field("index_options", indexOptions).field("fielddata", true));
+    }
+
+    public void testMergeTextIntoStringWithPositionIncrementGap() throws IOException {
+        int positionIncrementGap = between(0, 10000);
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("position_increment_gap", positionIncrementGap);
+        mergeMappingStep(expectedMapping, b -> b
+                .field("type", "string")
+                .field("position_increment_gap", positionIncrementGap));
+        mergeMappingStep(expectedMapping, b -> b
+                .field("type", "text")
+                .field("position_increment_gap", positionIncrementGap)
+                .field("fielddata", true));
+    }
+
+    public void testMergeStringIntoStringWithSimilarity() throws IOException {
+        Map<String, Object> expectedMapping = new HashMap<>();
+        expectedMapping.put("type", "string");
+        expectedMapping.put("similarity", "BM25");
+        mergeMappingStep(expectedMapping, b -> b.field("type", "string").field("similarity", "BM25"));
+        mergeMappingStep(expectedMapping, b -> b.field("type", "text").field("similarity", "BM25").field("fielddata", true));
+    }
+
+    private interface FieldBuilder {
+        void populateMappingForField(XContentBuilder b) throws IOException;
+    }
+    private void mergeMappingStep(Map<String, Object> expectedMapping, FieldBuilder fieldBuilder) throws IOException {
+        XContentBuilder b = mappingForTestField(fieldBuilder);
+        if (logger.isInfoEnabled()) {
+            logger.info("--> Updating mapping to {}", b.string());
+        }
+        assertAcked(client().admin().indices().preparePutMapping("test").setType("test_type").setSource(b));
+        GetMappingsResponse response = client().admin().indices().prepareGetMappings("test").get();
+        ImmutableOpenMap<String, MappingMetaData> index = response.getMappings().get("test");
+        assertNotNull("mapping for index not found", index);
+        MappingMetaData type = index.get("test_type");
+        assertNotNull("mapping for type not found", type);
+        Map<?, ?> properties = (Map<?, ?>) type.sourceAsMap().get("properties");
+        assertEquals(expectedMapping, properties.get("test_field"));
+    }
+
+    private XContentBuilder mappingForTestField(FieldBuilder fieldBuilder) throws IOException {
+        XContentBuilder b = JsonXContent.contentBuilder();
+        b.startObject(); {
+            b.startObject("test_type"); {
+                b.startObject("properties"); {
+                    b.startObject("test_field"); {
+                        fieldBuilder.populateMappingForField(b);
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }
+        return b.endObject();
+    }
+
+    private String randomIndexOptions() {
+        IndexOptions options = randomValueOtherThan(IndexOptions.NONE, () -> randomFrom(IndexOptions.values()));
+        switch (options) {
+        case DOCS:
+            return "docs";
+        case DOCS_AND_FREQS:
+            return "freqs";
+        case DOCS_AND_FREQS_AND_POSITIONS:
+            return "positions";
+        case DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS:
+            return "offsets";
+        default:
+            throw new IllegalArgumentException("Unknown options [" + options + "]");
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
@@ -193,30 +193,37 @@ public class ObjectMapperTests extends ESSingleNodeTestCase {
     }
 
     public void testEmptyName() throws Exception {
-        String mapping = XContentFactory.jsonBuilder()
-                                        .startObject()
-                                            .startObject("")
-                                                .startObject("properties")
-                                                    .startObject("name")
-                                                        .field("type", "text")
-                                                    .endObject()
-                                                .endObject()
-                                            .endObject()
-                                        .endObject()
-                                        .string();
+        String mapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("")
+                    .startObject("properties")
+                        .startObject("name")
+                            .field("type", "text")
+                        .endObject()
+                    .endObject()
+                .endObject().endObject().string();
 
+        // Empty name not allowed in index created after 5.0
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
             createIndex("test").mapperService().documentMapperParser().parse("", new CompressedXContent(mapping));
         });
         assertThat(e.getMessage(), containsString("name cannot be empty string"));
 
-        // before 5.x
+        // empty name allowed in index created before 5.0
         Version oldVersion = VersionUtils.randomVersionBetween(getRandom(), Version.V_2_0_0, Version.V_2_3_5);
         Settings oldIndexSettings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, oldVersion).build();
         DocumentMapperParser parser = createIndex("test_old", oldIndexSettings).mapperService().documentMapperParser();
 
         DocumentMapper defaultMapper = parser.parse("", new CompressedXContent(mapping));
-        assertEquals(mapping, defaultMapper.mappingSource().string());
+        String downgradedMapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("")
+                    .startObject("properties")
+                        .startObject("name")
+                            .field("type", "string")
+                            .field("fielddata", false)
+                        .endObject()
+                    .endObject()
+                .endObject().endObject().string();
+        assertEquals(downgradedMapping, defaultMapper.mappingSource().string());
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -37,14 +37,8 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.DocumentMapperParser;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.mapper.TextFieldMapper.TextFieldType;
-import org.elasticsearch.index.mapper.ParsedDocument;
-import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -53,9 +47,9 @@ import org.elasticsearch.test.VersionUtils;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -565,23 +559,37 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
     }
 
     public void testEmptyName() throws IOException {
-        // after 5.x
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
-            .startObject("properties").startObject("").field("type", "text").endObject().endObject()
-            .endObject().endObject().string();
+        String mapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("type")
+                    .startObject("properties")
+                        .startObject("")
+                            .field("type", "text")
+                        .endObject()
+                    .endObject()
+                .endObject().endObject().string();
 
+        // Empty name not allowed in index created after 5.0
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
             () -> parser.parse("type", new CompressedXContent(mapping))
         );
         assertThat(e.getMessage(), containsString("name cannot be empty string"));
 
-        // before 5.x
+        // empty name allowed in index created before 5.0
         Version oldVersion = VersionUtils.randomVersionBetween(getRandom(), Version.V_2_0_0, Version.V_2_3_5);
         Settings oldIndexSettings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, oldVersion).build();
         indexService = createIndex("test_old", oldIndexSettings);
         parser = indexService.mapperService().documentMapperParser();
 
         DocumentMapper defaultMapper = parser.parse("type", new CompressedXContent(mapping));
-        assertEquals(mapping, defaultMapper.mappingSource().string());
+        String downgradedMapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("type")
+                    .startObject("properties")
+                        .startObject("")
+                            .field("type", "string")
+                            .field("fielddata", false)
+                        .endObject()
+                    .endObject()
+                .endObject().endObject().string();
+        assertEquals(downgradedMapping, defaultMapper.mappingSource().string());
     }
 }

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -109,3 +109,8 @@ The following parameters are accepted by `keyword` fields:
     Which scoring algorithm or _similarity_ should be used. Defaults
     to `classic`, which uses TF/IDF.
 
+NOTE: Indexes imported from 2.x do not support `keyword`. Instead they will
+attempt to downgrade `keyword` into `string`. This allows you to merge modern
+mappings with legacy mappings. Long lived indexes will have to be recreated
+before upgrading to 6.x but mapping downgrade gives you the opportunity to do
+the recreation on your own schedule.

--- a/docs/reference/mapping/types/string.asciidoc
+++ b/docs/reference/mapping/types/string.asciidoc
@@ -1,4 +1,18 @@
 [[string]]
 === String datatype
 
-NOTE: The `string` field has been removed in favor of the `text` and `keyword` fields.
+The `string` field is unsupported for indexes created in 5.x in favor of the
+`text` and `keyword` fields. Attempting to create a string field in an index
+created in 5.x will cause Elasticsearch to attempt to upgrade the `string` into
+the appropriate `text` or `keyword` field. It will return an HTTP `Warning`
+header telling you that `string` is deprecated. This upgrade process isn't
+always perfect because there are some combinations of features that are
+supported by `string` but not `text` or `keyword`. For that reason it is better
+to use `text` or `keyword`.
+
+Indexes imported from 2.x *only* support `string` and not `text` or `keyword`.
+To ease the migration from 2.x Elasticsearch will downgrade `text` and `keyword`
+mappings applied to indexes imported to 2.x into `string`. While long lived
+indexes will eventually need to be recreated against 5.x before eventually
+upgrading to 6.x, this downgrading smooths the process before you find time for
+it.

--- a/docs/reference/mapping/types/text.asciidoc
+++ b/docs/reference/mapping/types/text.asciidoc
@@ -135,3 +135,9 @@ The following parameters are accepted by `text` fields:
 
     Whether term vectors should be stored for an <<mapping-index,`analyzed`>>
     field. Defaults to `no`.
+
+NOTE: Indexes imported from 2.x do not support `text`. Instead they will
+attempt to downgrade `text` into `string`. This allows you to merge modern
+mappings with legacy mappings. Long lived indexes will have to be recreated
+before upgrading to 6.x but mapping downgrade gives you the opportunity to do
+the recreation on your own schedule.


### PR DESCRIPTION
This changes Elasticsearch to automatically downgrade `text` and `keyword` fields into appropriate string fields when changing the mapping. This allows users to use the modern, documented syntax against 2.x indexes. While we should make it clear that reindexing in order to recreate the index in 5.0 is a good idea, this is not always possible, certainly not immediately on startup while the cluster is forming.
