### PR TITLE
[SPEC] Change type of wait_for_active_shards from number to string

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
@@ -31,7 +31,7 @@
           "description" : "Explicit operation timeout"
         },
         "wait_for_active_shards": {
-          "type" : "number",
+          "type" : "string",
           "description" : "Wait until the specified number of shards is active"
         },
         "wait_for_nodes": {


### PR DESCRIPTION
Fixed all (most) instances where `wait_for_active_shards` was incorrectly typed as a string instead of number.
