### PR TITLE
Add HttpHostBuilder to assist with HttpHost construction

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/HttpHostBuilder.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/HttpHostBuilder.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client;
+
+import org.apache.http.HttpHost;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Objects;
+
+/**
+ * {@code HttpHostBuilder} creates an {@link HttpHost} meant to be used with an Elasticsearch cluster. The {@code HttpHostBuilder} uses
+ * defaults that are most common for Elasticsearch, including an unspecified port defaulting to <code>9200</code> and the default scheme
+ * being <code>http</code> (as opposed to <code>https</code>).
+ * <p>
+ * The only <em>required</em> detail is the host to connect too, either via hostname or IP address.
+ * <p>
+ * This enables you to create an {@code HttpHost} directly via a builder mechanism, or indirectly by parsing a URI-like string. For example:
+ * <pre><code>
+ * HttpHost host1 = HttpHostBuilder.builder("localhost").build();               // http://localhost:9200
+ * HttpHost host2 = HttpHostBuilder.builder("localhost:9200").build();          // http://localhost:9200
+ * HttpHost host4 = HttpHostBuilder.builder("http://localhost:9200").build();   // http://localhost:9200
+ * HttpHost host5 = HttpHostBuilder.builder("https://localhost:9200").build();  // https://localhost:9200
+ * HttpHost host6 = HttpHostBuilder.builder("https://localhost:9200").build();  // https://127.0.0.1:9200 (IPv4 localhost)
+ * HttpHost host7 = HttpHostBuilder.builder("http://10.1.2.3").build();         // http://10.2.3.4:9200
+ * HttpHost host8 = HttpHostBuilder.builder("https://[::1]").build();           // http://[::1]:9200      (IPv6 localhost)
+ * HttpHost host9 = HttpHostBuilder.builder("https://[::1]:9200").build();      // http://[::1]:9200      (IPv6 localhost)
+ * HttpHost host10= HttpHostBuilder.builder("https://sub.domain").build();      // https://sub.domain
+ * </code></pre>
+ * Note: {@code HttpHost}s are the mechanism that the {@link RestClient} uses to build the base request. If you need to specify proxy
+ * settings, then use the {@link RestClientBuilder.RequestConfigCallback} to configure the {@code Proxy} settings.
+ *
+ * @see #builder(String)
+ * @see #builder()
+ */
+public class HttpHostBuilder {
+
+    /**
+     * The scheme used to connect to Elasticsearch.
+     */
+    private Scheme scheme = Scheme.HTTP;
+    /**
+     * The host is the only required portion of the supplied URI when building it. The rest can be defaulted.
+     */
+    private String host = null;
+    /**
+     * The port used to connect to Elasticsearch.
+     * <p>
+     * The default port is 9200 when unset.
+     */
+    private int port = -1;
+
+    /**
+     * Create an empty {@link HttpHostBuilder}.
+     * <p>
+     * The expectation is that you then explicitly build the {@link HttpHost} piece-by-piece.
+     * <p>
+     * For example:
+     * <pre><code>
+     * HttpHost localhost = HttpHostBuilder.builder().host("localhost").build();                            // http://localhost:9200
+     * HttpHost explicitLocalhost = HttpHostBuilder.builder.().scheme(Scheme.HTTP).host("localhost").port(9200).build();
+     *                                                                                                      // http://localhost:9200
+     * HttpHost secureLocalhost = HttpHostBuilder.builder().scheme(Scheme.HTTPS).host("localhost").build(); // https://localhost:9200
+     * HttpHost differentPort = HttpHostBuilder.builder().host("my_host").port(19200).build();              // https://my_host:19200
+     * HttpHost ipBased = HttpHostBuilder.builder().host("192.168.0.11").port(80).build();                  // https://192.168.0.11:80
+     * </code></pre>
+     *
+     * @return Never {@code null}.
+     */
+    public static HttpHostBuilder builder() {
+        return new HttpHostBuilder();
+    }
+
+    /**
+     * Create an empty {@link HttpHostBuilder}.
+     * <p>
+     * The expectation is that you then explicitly build the {@link HttpHost} piece-by-piece.
+     * <p>
+     * For example:
+     * <pre><code>
+     * HttpHost localhost = HttpHostBuilder.builder("localhost").build();                     // http://localhost:9200
+     * HttpHost explicitLocalhost = HttpHostBuilder.builder("http://localhost:9200").build(); // http://localhost:9200
+     * HttpHost secureLocalhost = HttpHostBuilder.builder("https://localhost").build();       // https://localhost:9200
+     * HttpHost differentPort = HttpHostBuilder.builder("my_host:19200").build();             // http://my_host:19200
+     * HttpHost ipBased = HttpHostBuilder.builder("192.168.0.11:80").build();                 // http://192.168.0.11:80
+     * </code></pre>
+     *
+     * @return Never {@code null}.
+     * @throws NullPointerException if {@code uri} is {@code null}.
+     * @throws IllegalArgumentException if any issue occurs while parsing the {@code uri}.
+     */
+    public static HttpHostBuilder builder(final String uri) {
+        return new HttpHostBuilder(uri);
+    }
+
+    /**
+     * Create a new {@link HttpHost} from scratch.
+     */
+    HttpHostBuilder() {
+        // everything is in the default state
+    }
+
+    /**
+     * Create a new {@link HttpHost} based on the supplied host.
+     *
+     * @param uri The [partial] URI used to build.
+     * @throws IllegalArgumentException if any issue occurs while parsing the {@code uri}.
+     */
+    HttpHostBuilder(final String uri) {
+        try {
+            String cleanedUri = uri;
+
+            if (uri.contains("://") == false) {
+                cleanedUri = "http://" + uri;
+            }
+
+            final URI parsedUri = new URI(cleanedUri);
+
+            // "localhost:9200" doesn't have a scheme
+            if (parsedUri.getScheme() != null) {
+                scheme(Scheme.fromString(parsedUri.getScheme()));
+            }
+
+            if (parsedUri.getHost() != null) {
+                host(parsedUri.getHost());
+            } else {
+                // if the host is null, then it means one of two things: we're in a broken state _or_ it had something like underscores
+                // we want the raw form so that parts of the URI are not decoded
+                final String host = parsedUri.getRawAuthority();
+
+                // they explicitly provided the port, which is unparsed when the host is null
+                if (host.contains(":")) {
+                    final String[] hostPort = host.split(":", 2);
+
+                    host(hostPort[0]);
+                    port(Integer.parseInt(hostPort[1]));
+                } else {
+                    host(host);
+                }
+            }
+
+            if (parsedUri.getPort() != -1) {
+                port(parsedUri.getPort());
+            }
+
+            // fail for proxies
+            if (parsedUri.getRawPath() != null && parsedUri.getRawPath().isEmpty() == false) {
+                throw new IllegalArgumentException(
+                    "HttpHosts do not use paths [" + parsedUri.getRawPath() +
+                        "]. see setRequestConfigCallback for proxies. value: [" + uri + "]");
+            }
+        } catch (URISyntaxException | IndexOutOfBoundsException | NullPointerException e) {
+            throw new IllegalArgumentException("error parsing host: [" + uri + "]", e);
+        }
+    }
+
+    /**
+     * Set the scheme (aka protocol) for the {@link HttpHost}.
+     *
+     * @param scheme The scheme to use.
+     * @return Always {@code this}.
+     * @throws NullPointerException if {@code scheme} is {@code null}.
+     */
+    public HttpHostBuilder scheme(final Scheme scheme) {
+        this.scheme = Objects.requireNonNull(scheme);
+
+        return this;
+    }
+
+    /**
+     * Set the host for the {@link HttpHost}.
+     * <p>
+     * This does not attempt to parse the {@code host} in any way.
+     *
+     * @param host The host to use.
+     * @return Always {@code this}.
+     * @throws NullPointerException if {@code host} is {@code null}.
+     */
+    public HttpHostBuilder host(final String host) {
+        this.host = Objects.requireNonNull(host);
+
+        return this;
+    }
+
+    /**
+     * Set the port for the {@link HttpHost}.
+     * <p>
+     * Specifying the {@code port} as -1 will cause it to be defaulted to 9200 when the {@code HttpHost} is built.
+     *
+     * @param port The port to use.
+     * @return Always {@code this}.
+     * @throws IllegalArgumentException if the {@code port} is not -1 or [1, 65535].
+     */
+    public HttpHostBuilder port(final int port) {
+        // setting a port to 0 makes no sense when you're the client; -1 allows us to use the default when we build
+        if (port != -1 && (port < 1 || port > 65535)) {
+            throw new IllegalArgumentException("port must be -1 for the default or [1, 65535]. was: " + port);
+        }
+
+        this.port = port;
+
+        return this;
+    }
+
+    /**
+     * Create a new {@link HttpHost} from the current {@code scheme}, {@code host}, and {@code port}.
+     *
+     * @return Never {@code null}.
+     * @throws IllegalStateException if {@code host} is unset.
+     */
+    public HttpHost build() {
+        if (host == null) {
+            throw new IllegalStateException("host must be set");
+        }
+
+        return new HttpHost(host, port == -1 ? 9200 : port, scheme.toString());
+    }
+
+}

--- a/client/rest/src/main/java/org/elasticsearch/client/HttpHostBuilder.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/HttpHostBuilder.java
@@ -41,7 +41,7 @@ import java.util.Objects;
  * HttpHost host7 = HttpHostBuilder.builder("http://10.1.2.3").build();         // http://10.2.3.4:9200
  * HttpHost host8 = HttpHostBuilder.builder("https://[::1]").build();           // http://[::1]:9200      (IPv6 localhost)
  * HttpHost host9 = HttpHostBuilder.builder("https://[::1]:9200").build();      // http://[::1]:9200      (IPv6 localhost)
- * HttpHost host10= HttpHostBuilder.builder("https://sub.domain").build();      // https://sub.domain
+ * HttpHost host10= HttpHostBuilder.builder("https://sub.domain").build();      // https://sub.domain:9200
  * </code></pre>
  * Note: {@code HttpHost}s are the mechanism that the {@link RestClient} uses to build the base request. If you need to specify proxy
  * settings, then use the {@link RestClientBuilder.RequestConfigCallback} to configure the {@code Proxy} settings.
@@ -120,9 +120,12 @@ public class HttpHostBuilder {
      * Create a new {@link HttpHost} based on the supplied host.
      *
      * @param uri The [partial] URI used to build.
+     * @throws NullPointerException if {@code uri} is {@code null}.
      * @throws IllegalArgumentException if any issue occurs while parsing the {@code uri}.
      */
     HttpHostBuilder(final String uri) {
+        Objects.requireNonNull(uri, "uri must not be null");
+
         try {
             String cleanedUri = uri;
 

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -80,6 +80,8 @@ import java.util.concurrent.atomic.AtomicReference;
  * Requests can be either synchronous or asynchronous. The asynchronous variants all end with {@code Async}.
  * <p>
  * Requests can be traced by enabling trace logging for "tracer". The trace logger outputs requests and responses in curl format.
+ *
+ * @see RestClientBuilder
  */
 public class RestClient implements Closeable {
 

--- a/client/rest/src/main/java/org/elasticsearch/client/Scheme.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/Scheme.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client;
+
+import java.util.Locale;
+
+/**
+ * {@code Scheme} provides the list of supported {@code URI} schemes (aka protocols) for working with Elasticsearch via the
+ * {@link RestClient}.
+ *
+ * @see HttpHostBuilder
+ */
+public enum Scheme {
+
+    /**
+     * HTTP is the default {@linkplain Scheme scheme} used by Elasticsearch.
+     */
+    HTTP("http"),
+    /**
+     * HTTPS is the secure form of {@linkplain #HTTP http}, which requires that Elasticsearch be using X-Pack Security with TLS/SSL or
+     * a similar securing mechanism.
+     */
+    HTTPS("https");
+
+    private final String scheme;
+
+    Scheme(final String scheme) {
+        this.scheme = scheme;
+    }
+
+    @Override
+    public String toString() {
+        return scheme;
+    }
+
+    /**
+     * Determine the {@link Scheme} from the {@code scheme}.
+     * <pre><code>
+     * Scheme http = Scheme.fromString("http");
+     * Scheme https = Scheme.fromString("https");
+     * Scheme httpsCaps = Scheme.fromString("HTTPS"); // same as https
+     * </code></pre>
+     *
+     * @param scheme The scheme to check.
+     * @return Never {@code null}.
+     * @throws NullPointerException if {@code scheme} is {@code null}.
+     * @throws IllegalArgumentException if the {@code scheme} is not supported.
+     */
+    public static Scheme fromString(final String scheme) {
+        switch (scheme.toLowerCase(Locale.ROOT)) {
+            case "http":
+                return HTTP;
+            case "https":
+                return HTTPS;
+        }
+
+        throw new IllegalArgumentException("unsupported scheme: [" + scheme + "]");
+    }
+
+}

--- a/client/rest/src/test/java/org/elasticsearch/client/HttpHostBuilderTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/HttpHostBuilderTests.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client;
+
+import org.apache.http.HttpHost;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests {@link HttpHostBuilder}.
+ */
+public class HttpHostBuilderTests extends RestClientTestCase {
+
+    private final Scheme scheme = randomFrom(Scheme.values());
+    private final String hostname = randomAsciiOfLengthBetween(1, 20);
+    private final int port = randomIntBetween(1, 65535);
+
+    public void testBuilder() {
+        assertHttpHost(HttpHostBuilder.builder(hostname), Scheme.HTTP, hostname, 9200);
+        assertHttpHost(HttpHostBuilder.builder(scheme.toString() + "://" + hostname), scheme, hostname, 9200);
+        assertHttpHost(HttpHostBuilder.builder(scheme.toString() + "://" + hostname + ":" + port), scheme, hostname, port);
+        // weird port, but I don't expect it to explode
+        assertHttpHost(HttpHostBuilder.builder(scheme.toString() + "://" + hostname + ":-1"), scheme, hostname, 9200);
+        // port without scheme
+        assertHttpHost(HttpHostBuilder.builder(hostname + ":" + port), Scheme.HTTP, hostname, port);
+
+        // fairly ordinary
+        assertHttpHost(HttpHostBuilder.builder("localhost"), Scheme.HTTP, "localhost", 9200);
+        assertHttpHost(HttpHostBuilder.builder("localhost:9200"), Scheme.HTTP, "localhost", 9200);
+        assertHttpHost(HttpHostBuilder.builder("http://localhost"), Scheme.HTTP, "localhost", 9200);
+        assertHttpHost(HttpHostBuilder.builder("http://localhost:9200"), Scheme.HTTP, "localhost", 9200);
+        assertHttpHost(HttpHostBuilder.builder("https://localhost:9200"), Scheme.HTTPS, "localhost", 9200);
+        assertHttpHost(HttpHostBuilder.builder("https://boaz-air.local:9200"), Scheme.HTTPS, "boaz-air.local", 9200);
+        assertHttpHost(HttpHostBuilder.builder("https://server-dash:19200"), Scheme.HTTPS, "server-dash", 19200);
+        assertHttpHost(HttpHostBuilder.builder("server-dash:19200"), Scheme.HTTP, "server-dash", 19200);
+        assertHttpHost(HttpHostBuilder.builder("server-dash"), Scheme.HTTP, "server-dash", 9200);
+        assertHttpHost(HttpHostBuilder.builder("sub.domain"), Scheme.HTTP, "sub.domain", 9200);
+        assertHttpHost(HttpHostBuilder.builder("http://sub.domain"), Scheme.HTTP, "sub.domain", 9200);
+        assertHttpHost(HttpHostBuilder.builder("http://sub.domain:9200"), Scheme.HTTP, "sub.domain", 9200);
+        assertHttpHost(HttpHostBuilder.builder("https://sub.domain:9200"), Scheme.HTTPS, "sub.domain", 9200);
+        assertHttpHost(HttpHostBuilder.builder("https://sub.domain:19200"), Scheme.HTTPS, "sub.domain", 19200);
+
+        // ipv4
+        assertHttpHost(HttpHostBuilder.builder("127.0.0.1"), Scheme.HTTP, "127.0.0.1", 9200);
+        assertHttpHost(HttpHostBuilder.builder("http://127.0.0.1"), Scheme.HTTP, "127.0.0.1", 9200);
+        assertHttpHost(HttpHostBuilder.builder("http://127.0.0.1:9200"), Scheme.HTTP, "127.0.0.1", 9200);
+        assertHttpHost(HttpHostBuilder.builder("https://127.0.0.1:9200"), Scheme.HTTPS, "127.0.0.1", 9200);
+        assertHttpHost(HttpHostBuilder.builder("https://127.0.0.1:19200"), Scheme.HTTPS, "127.0.0.1", 19200);
+
+        // ipv6
+        assertHttpHost(HttpHostBuilder.builder("[::1]"), Scheme.HTTP, "[::1]", 9200);
+        assertHttpHost(HttpHostBuilder.builder("http://[::1]"), Scheme.HTTP, "[::1]", 9200);
+        assertHttpHost(HttpHostBuilder.builder("http://[::1]:9200"), Scheme.HTTP, "[::1]", 9200);
+        assertHttpHost(HttpHostBuilder.builder("https://[::1]:9200"), Scheme.HTTPS, "[::1]", 9200);
+        assertHttpHost(HttpHostBuilder.builder("https://[::1]:19200"), Scheme.HTTPS, "[::1]", 19200);
+        assertHttpHost(HttpHostBuilder.builder("[fdda:5cc1:23:4::1f]"), Scheme.HTTP, "[fdda:5cc1:23:4::1f]", 9200);
+        assertHttpHost(HttpHostBuilder.builder("http://[fdda:5cc1:23:4::1f]"), Scheme.HTTP, "[fdda:5cc1:23:4::1f]", 9200);
+        assertHttpHost(HttpHostBuilder.builder("http://[fdda:5cc1:23:4::1f]:9200"), Scheme.HTTP, "[fdda:5cc1:23:4::1f]", 9200);
+        assertHttpHost(HttpHostBuilder.builder("https://[fdda:5cc1:23:4::1f]:9200"), Scheme.HTTPS, "[fdda:5cc1:23:4::1f]", 9200);
+        assertHttpHost(HttpHostBuilder.builder("https://[fdda:5cc1:23:4::1f]:19200"), Scheme.HTTPS, "[fdda:5cc1:23:4::1f]", 19200);
+
+        // underscores
+        assertHttpHost(HttpHostBuilder.builder("server_with_underscore"), Scheme.HTTP, "server_with_underscore", 9200);
+        assertHttpHost(HttpHostBuilder.builder("http://server_with_underscore"), Scheme.HTTP, "server_with_underscore", 9200);
+        assertHttpHost(HttpHostBuilder.builder("http://server_with_underscore:9200"), Scheme.HTTP, "server_with_underscore", 9200);
+        assertHttpHost(HttpHostBuilder.builder("http://server_with_underscore:19200"), Scheme.HTTP, "server_with_underscore", 19200);
+        assertHttpHost(HttpHostBuilder.builder("https://server_with_underscore"), Scheme.HTTPS, "server_with_underscore", 9200);
+        assertHttpHost(HttpHostBuilder.builder("https://server_with_underscore:9200"), Scheme.HTTPS, "server_with_underscore", 9200);
+        assertHttpHost(HttpHostBuilder.builder("https://server_with_underscore:19200"), Scheme.HTTPS, "server_with_underscore", 19200);
+        assertHttpHost(HttpHostBuilder.builder("_prefix.domain"), Scheme.HTTP, "_prefix.domain", 9200);
+        assertHttpHost(HttpHostBuilder.builder("http://_prefix.domain"), Scheme.HTTP, "_prefix.domain", 9200);
+        assertHttpHost(HttpHostBuilder.builder("http://_prefix.domain:9200"), Scheme.HTTP, "_prefix.domain", 9200);
+        assertHttpHost(HttpHostBuilder.builder("http://_prefix.domain:19200"), Scheme.HTTP, "_prefix.domain", 19200);
+        assertHttpHost(HttpHostBuilder.builder("https://_prefix.domain"), Scheme.HTTPS, "_prefix.domain", 9200);
+        assertHttpHost(HttpHostBuilder.builder("https://_prefix.domain:9200"), Scheme.HTTPS, "_prefix.domain", 9200);
+        assertHttpHost(HttpHostBuilder.builder("https://_prefix.domain:19200"), Scheme.HTTPS, "_prefix.domain", 19200);
+    }
+
+    public void testManualBuilder() {
+        assertHttpHost(HttpHostBuilder.builder().host(hostname), Scheme.HTTP, hostname, 9200);
+        assertHttpHost(HttpHostBuilder.builder().scheme(scheme).host(hostname), scheme, hostname, 9200);
+        assertHttpHost(HttpHostBuilder.builder().scheme(scheme).host(hostname).port(port), scheme, hostname, port);
+        // unset the port (not normal, but ensuring it works)
+        assertHttpHost(HttpHostBuilder.builder().scheme(scheme).host(hostname).port(port).port(-1), scheme, hostname, 9200);
+        // port without scheme
+        assertHttpHost(HttpHostBuilder.builder().host(hostname).port(port), Scheme.HTTP, hostname, port);
+    }
+
+    public void testUnknownScheme() {
+        assertBuilderBadSchemeThrows("htp://localhost:9200", "htp");
+        assertBuilderBadSchemeThrows("htttp://localhost:9200", "htttp");
+        assertBuilderBadSchemeThrows("httpd://localhost:9200", "httpd");
+        assertBuilderBadSchemeThrows("ws://localhost:9200", "ws");
+        assertBuilderBadSchemeThrows("wss://localhost:9200", "wss");
+        assertBuilderBadSchemeThrows("ftp://localhost:9200", "ftp");
+        assertBuilderBadSchemeThrows("gopher://localhost:9200", "gopher");
+        assertBuilderBadSchemeThrows("localhost://9200", "localhost");
+    }
+
+    public void testPathIsBlocked() {
+        assertBuilderPathThrows("http://localhost:9200/", "/");
+        assertBuilderPathThrows("http://localhost:9200/sub", "/sub");
+        assertBuilderPathThrows("http://localhost:9200/sub/path", "/sub/path");
+    }
+
+    public void testBuildWithoutHost() {
+        try {
+            HttpHostBuilder.builder().build();
+            fail("host should be required");
+        } catch (final IllegalStateException e) {
+            assertThat(e.getMessage(), equalTo("host must be set"));
+        }
+    }
+
+    public void testNullScheme() {
+        try {
+            HttpHostBuilder.builder().scheme(null);
+            fail("null scheme is malformed");
+        } catch (NullPointerException e) {
+            // success
+        }
+    }
+
+    public void testNullHost() {
+        try {
+            HttpHostBuilder.builder().host(null);
+            fail("null host is malformed");
+        } catch (NullPointerException e) {
+            // success
+        }
+    }
+
+    public void testBadPort() {
+        assertPortThrows(0);
+        assertPortThrows(65536);
+
+        assertPortThrows(randomIntBetween(Integer.MIN_VALUE, -2));
+        assertPortThrows(randomIntBetween(65537, Integer.MAX_VALUE));
+    }
+
+    private void assertHttpHost(final HttpHostBuilder host, final Scheme scheme, final String hostname, final int port) {
+        assertHttpHost(host.build(), scheme, hostname, port);
+    }
+
+    private void assertHttpHost(final HttpHost host, final Scheme scheme, final String hostname, final int port) {
+        assertThat(host.getSchemeName(), equalTo(scheme.toString()));
+        assertThat(host.getHostName(), equalTo(hostname));
+        assertThat(host.getPort(), equalTo(port));
+    }
+
+    private void assertBuilderPathThrows(final String uri, final String path) {
+        try {
+            HttpHostBuilder.builder(uri);
+            fail("path [" + path + "] should be explicitly ignored");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("[" + path + "]"));
+        }
+    }
+
+    private void assertBuilderBadSchemeThrows(final String uri, final String scheme) {
+        try {
+            HttpHostBuilder.builder(uri);
+            fail("scheme [" + scheme + "] should be unrecognized");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString(scheme));
+        }
+    }
+
+    private void assertPortThrows(final int port) {
+        try {
+            HttpHostBuilder.builder().port(port);
+            fail("port should be invalid");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString(Integer.toString(port)));
+        }
+    }
+
+}

--- a/client/rest/src/test/java/org/elasticsearch/client/HttpHostBuilderTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/HttpHostBuilderTests.java
@@ -105,6 +105,15 @@ public class HttpHostBuilderTests extends RestClientTestCase {
         assertHttpHost(HttpHostBuilder.builder().host(hostname).port(port), Scheme.HTTP, hostname, port);
     }
 
+    public void testBuilderNullUri() {
+        try {
+            HttpHostBuilder.builder(null);
+            fail("null uri should fail");
+        } catch (final NullPointerException e) {
+            assertThat(e.getMessage(), equalTo("uri must not be null"));
+        }
+    }
+
     public void testUnknownScheme() {
         assertBuilderBadSchemeThrows("htp://localhost:9200", "htp");
         assertBuilderBadSchemeThrows("htttp://localhost:9200", "htttp");

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientIntegTests.java
@@ -57,7 +57,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Integration test to check interaction between {@link RestClient} and {@link org.apache.http.client.HttpClient}.

--- a/client/rest/src/test/java/org/elasticsearch/client/SchemeTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/SchemeTests.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client;
+
+import java.util.Locale;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests {@link Scheme}.
+ */
+public class SchemeTests extends RestClientTestCase {
+
+    public void testToString() {
+        for (final Scheme scheme : Scheme.values()) {
+            assertThat(scheme.toString(), equalTo(scheme.name().toLowerCase(Locale.ROOT)));
+        }
+    }
+
+    public void testFromString() {
+        for (final Scheme scheme : Scheme.values()) {
+            assertThat(Scheme.fromString(scheme.name()), sameInstance(scheme));
+            assertThat(Scheme.fromString(scheme.name().toLowerCase(Locale.ROOT)), sameInstance(scheme));
+        }
+    }
+
+    public void testFromStringMalformed() {
+        assertIllegalScheme("htp");
+        assertIllegalScheme("htttp");
+        assertIllegalScheme("httpd");
+        assertIllegalScheme("ftp");
+        assertIllegalScheme("ws");
+        assertIllegalScheme("wss");
+        assertIllegalScheme("gopher");
+    }
+
+    private void assertIllegalScheme(final String scheme) {
+        try {
+            Scheme.fromString(scheme);
+            fail("scheme should be unknown: [" + scheme + "]");
+        } catch (final IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("[" + scheme + "]"));
+        }
+    }
+
+}

--- a/client/sniffer/src/main/java/org/elasticsearch/client/sniff/ElasticsearchHostsSniffer.java
+++ b/client/sniffer/src/main/java/org/elasticsearch/client/sniff/ElasticsearchHostsSniffer.java
@@ -28,6 +28,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.Scheme;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -63,7 +64,7 @@ public final class ElasticsearchHostsSniffer implements HostsSniffer {
      *                   client that was used to fetch them.
      */
     public ElasticsearchHostsSniffer(RestClient restClient) {
-        this(restClient, DEFAULT_SNIFF_REQUEST_TIMEOUT, ElasticsearchHostsSniffer.Scheme.HTTP);
+        this(restClient, DEFAULT_SNIFF_REQUEST_TIMEOUT, Scheme.HTTP);
     }
 
     /**
@@ -153,18 +154,4 @@ public final class ElasticsearchHostsSniffer implements HostsSniffer {
         return httpHost;
     }
 
-    public enum Scheme {
-        HTTP("http"), HTTPS("https");
-
-        private final String name;
-
-        Scheme(String name) {
-            this.name = name;
-        }
-
-        @Override
-        public String toString() {
-            return name;
-        }
-    }
 }

--- a/client/sniffer/src/test/java/org/elasticsearch/client/sniff/ElasticsearchHostsSnifferTests.java
+++ b/client/sniffer/src/test/java/org/elasticsearch/client/sniff/ElasticsearchHostsSnifferTests.java
@@ -35,6 +35,8 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientTestCase;
+import org.elasticsearch.client.Scheme;
+
 import org.junit.After;
 import org.junit.Before;
 
@@ -63,14 +65,14 @@ import static org.junit.Assert.fail;
 public class ElasticsearchHostsSnifferTests extends RestClientTestCase {
 
     private int sniffRequestTimeout;
-    private ElasticsearchHostsSniffer.Scheme scheme;
+    private Scheme scheme;
     private SniffResponse sniffResponse;
     private HttpServer httpServer;
 
     @Before
     public void startHttpServer() throws IOException {
         this.sniffRequestTimeout = RandomInts.randomIntBetween(getRandom(), 1000, 10000);
-        this.scheme = RandomPicks.randomFrom(getRandom(), ElasticsearchHostsSniffer.Scheme.values());
+        this.scheme = RandomPicks.randomFrom(getRandom(), Scheme.values());
         if (rarely()) {
             this.sniffResponse = SniffResponse.buildFailure();
         } else {
@@ -87,7 +89,7 @@ public class ElasticsearchHostsSnifferTests extends RestClientTestCase {
 
     public void testConstructorValidation() throws IOException {
         try {
-            new ElasticsearchHostsSniffer(null, 1, ElasticsearchHostsSniffer.Scheme.HTTP);
+            new ElasticsearchHostsSniffer(null, 1, Scheme.HTTP);
             fail("should have failed");
         } catch(NullPointerException e) {
             assertEquals("restClient cannot be null", e.getMessage());
@@ -101,8 +103,7 @@ public class ElasticsearchHostsSnifferTests extends RestClientTestCase {
                 assertEquals(e.getMessage(), "scheme cannot be null");
             }
             try {
-                new ElasticsearchHostsSniffer(restClient, RandomInts.randomIntBetween(getRandom(), Integer.MIN_VALUE, 0),
-                        ElasticsearchHostsSniffer.Scheme.HTTP);
+                new ElasticsearchHostsSniffer(restClient, RandomInts.randomIntBetween(getRandom(), Integer.MIN_VALUE, 0), Scheme.HTTP);
                 fail("should have failed");
             } catch (IllegalArgumentException e) {
                 assertEquals(e.getMessage(), "sniffRequestTimeoutMillis must be greater than 0");
@@ -174,7 +175,7 @@ public class ElasticsearchHostsSnifferTests extends RestClientTestCase {
         }
     }
 
-    private static SniffResponse buildSniffResponse(ElasticsearchHostsSniffer.Scheme scheme) throws IOException {
+    private static SniffResponse buildSniffResponse(Scheme scheme) throws IOException {
         int numNodes = RandomInts.randomIntBetween(getRandom(), 1, 5);
         List<HttpHost> hosts = new ArrayList<>(numNodes);
         JsonFactory jsonFactory = new JsonFactory();


### PR DESCRIPTION
This adds a new `HttpHostBuilder` that can be used to build URIs for working with Elasticsearch connections.

It is effectively a very simplified and explicit version of the `URIBuilder` provided with the `HttpClient`, except it also works around some weirdness with URI host parsing.

This makes it easier for users to handle loading ES hosts from configuration files.

Closes #20182
