### PR TITLE
Don't rebuild pipeline on every cluster state update

### DIFF
--- a/core/src/main/java/org/elasticsearch/ingest/PipelineStore.java
+++ b/core/src/main/java/org/elasticsearch/ingest/PipelineStore.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ExceptionsHelper;
@@ -62,12 +63,13 @@ public class PipelineStore extends AbstractComponent implements ClusterStateList
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
-        innerUpdatePipelines(event.state());
+        innerUpdatePipelines(event.previousState(), event.state());
     }
 
-    void innerUpdatePipelines(ClusterState state) {
+    void innerUpdatePipelines(ClusterState previousState, ClusterState state) {
         IngestMetadata ingestMetadata = state.getMetaData().custom(IngestMetadata.TYPE);
-        if (ingestMetadata == null) {
+        IngestMetadata previousIngestMetadata = previousState.getMetaData().custom(IngestMetadata.TYPE);
+        if (Objects.equals(ingestMetadata, previousIngestMetadata)) {
             return;
         }
 


### PR DESCRIPTION
Currently, after at least one pipeline is registered it is getting rebuilt on every single cluster state update, even when this update is not related to ingest metadata. This change adds a check that the ingest metadata changed before trying to rebuild all pipelines.
