### PR TITLE
AllTermQuery must implement equals/hashCode.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
@@ -227,4 +227,17 @@ public final class AllTermQuery extends Query {
         return new TermQuery(term).toString(field) + ToStringUtils.boost(getBoost());
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (super.equals(obj) == false) {
+            return false;
+        }
+        AllTermQuery that = (AllTermQuery) obj;
+        return term.equals(that.term);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * super.hashCode() + term.hashCode();
+    }
 }

--- a/core/src/test/java/org/elasticsearch/common/lucene/all/SimpleAllTests.java
+++ b/core/src/test/java/org/elasticsearch/common/lucene/all/SimpleAllTests.java
@@ -374,4 +374,13 @@ public class SimpleAllTests extends ESTestCase {
         assertThat(docs.totalHits, equalTo(1));
         assertThat(docs.scoreDocs[0].doc, equalTo(0));
     }
+
+    public void testEquals() {
+        Term bar = new Term("foo", "bar");
+        Term baz = new Term("foo", "baz");
+        assertEquals(new AllTermQuery(bar), new AllTermQuery(bar));
+        assertNotEquals(new AllTermQuery(bar), new AllTermQuery(baz));
+        assertEquals(new AllTermQuery(bar).hashCode(), new AllTermQuery(bar).hashCode());
+        assertNotEquals(new AllTermQuery(bar).hashCode(), new AllTermQuery(baz).hashCode());
+    }
 }


### PR DESCRIPTION
This is required as queries are used as keys in the filter cache. Currently
all AllTermQuery instances are considered equals.

Closes #20161
Closes #13662
