### PR TITLE
Correct the description for refresh

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
@@ -39,7 +39,7 @@
         },
         "refresh": {
           "type" : "boolean",
-          "description" : "Refresh the index after performing the operation"
+          "description" : "Refresh the affected shards after performing the operation"
         },
         "routing": {
           "type" : "string",


### PR DESCRIPTION
The `refresh` description should indicate that the affected shards are refreshed as opposed to the _entire_ index.

This was raised as a discrepancy on [discuss](https://discuss.elastic.co/t/refresh-parameter-of-index-api/59008/2) on the .NET client that originates from code generated from the rest api spec. The description has been updated in master but should be updated for the 2.4.0 release.
