### PR TITLE
If an inline script is specified as plain string don't turn it into an object when serializing to xcontent.

### DIFF
--- a/core/src/main/java/org/elasticsearch/script/Script.java
+++ b/core/src/main/java/org/elasticsearch/script/Script.java
@@ -57,10 +57,10 @@ public final class Script implements ToXContent, Writeable {
      * @param script The inline script to execute.
      */
     public Script(String script) {
-        this(script, ScriptType.INLINE, null, null);
+        this(script, null, null, null);
     }
 
-    public Script(String script, ScriptType type, @Nullable String lang, @Nullable Map<String, ?> params) {
+    public Script(String script, @Nullable ScriptType type, @Nullable String lang, @Nullable Map<String, ?> params) {
         this(script, type, lang, params, null);
     }
 
@@ -78,13 +78,13 @@ public final class Script implements ToXContent, Writeable {
      *                      when serializing the script back to xcontent.
      */
     @SuppressWarnings("unchecked")
-    public Script(String script, ScriptType type, @Nullable String lang, @Nullable Map<String, ?> params,
+    public Script(String script, @Nullable ScriptType type, @Nullable String lang, @Nullable Map<String, ?> params,
                   @Nullable XContentType  contentType) {
         if (contentType != null && type != ScriptType.INLINE) {
             throw new IllegalArgumentException("The parameter contentType only makes sense for inline scripts");
         }
         this.script = Objects.requireNonNull(script);
-        this.type = Objects.requireNonNull(type);
+        this.type = type;
         this.lang = lang;
         this.params = (Map<String, Object>) params;
         this.contentType = contentType;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/AbstractValuesSourceParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/AbstractValuesSourceParser.java
@@ -118,7 +118,9 @@ public abstract class AbstractValuesSourceParser<VS extends ValuesSource>
                 } else if (formattable && "format".equals(currentFieldName)) {
                     format = parser.text();
                 } else if (scriptable) {
-                    if ("value_type".equals(currentFieldName) || "valueType".equals(currentFieldName)) {
+                    if (context.getParseFieldMatcher().match(currentFieldName, ScriptField.SCRIPT)) {
+                        script = Script.parse(parser, context.getParseFieldMatcher());
+                    } else if ("value_type".equals(currentFieldName) || "valueType".equals(currentFieldName)) {
                         valueType = ValueType.resolveForScript(parser.text());
                         if (targetValueType != null && valueType.isNotA(targetValueType)) {
                             throw new ParsingException(parser.getTokenLocation(),

--- a/core/src/test/java/org/elasticsearch/script/ScriptTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.script;
 
 import org.elasticsearch.common.ParseFieldMatcher;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -36,6 +37,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ScriptTests extends ESTestCase {
@@ -49,6 +51,21 @@ public class ScriptTests extends ESTestCase {
                 Script actualScript = Script.parse(parser, ParseFieldMatcher.STRICT);
                 assertThat(actualScript, equalTo(expectedScript));
             }
+        }
+    }
+
+    public void testScriptSimpleParsing() throws IOException {
+        String simpleScript = "{\"script\":\"_score + doc['field']\"}";
+        try (XContentParser parser = XContentHelper.createParser(new BytesArray(simpleScript))) {
+            parser.nextToken();
+            parser.nextToken();
+            parser.nextToken();
+            Script script = Script.parse(parser, ParseFieldMatcher.STRICT);
+            XContentBuilder builder = jsonBuilder().startObject();
+            builder.field("script");
+            script.toXContent(builder, null);
+            builder.endObject();
+            assertThat(builder.string(), equalTo(simpleScript));
         }
     }
 


### PR DESCRIPTION
If someone specified: `_score + doc['count']` then after it was parsed and serialized back it would turned into: `{ "script" : "_score + doc['count']", "type" : "inline" }`
