### PR TITLE
Tests: Improve rest suite names and generated test names for docs tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
@@ -117,7 +117,7 @@ public class RestTestsFromSnippetsTask extends SnippetsTask {
 
             if (false == test.continued) {
                 current.println('---')
-                current.println("\"$test.start\":")
+                current.println("\"line_$test.start\":")
             }
             if (test.skipTest) {
                 current.println("  - skip:")

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/FileUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/FileUtils.java
@@ -155,7 +155,7 @@ public final class FileUtils {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                 if (file.toString().endsWith(fileSuffix)) {
-                    String groupName = file.toAbsolutePath().getParent().getFileName().toString();
+                    String groupName = dir.relativize(file.getParent()).toString();
                     Set<Path> filesSet = files.get(groupName);
                     if (filesSet == null) {
                         filesSet = new HashSet<>();


### PR DESCRIPTION
Rest test suites are currently only the directory above the yaml test
file. That is confusing when there are more than one directory level
which contain yaml tests, as there are in generated docs tests. This
change makes rest tests use the full relative path to the rest test root
as the suite name, and also makes the test names for docs tests a little
clearer (that they are testing an example from a specific line number,
instead of just the line number as an opaque test name).
