### PR TITLE
Explicitly disable Netty key set replacement

### DIFF
--- a/distribution/src/main/resources/config/jvm.options
+++ b/distribution/src/main/resources/config/jvm.options
@@ -59,8 +59,9 @@
 # use our provided JNA always versus the system one
 -Djna.nosys=true
 
-# flag to explicitly tell Netty to not use unsafe
+# flags to keep Netty from being unsafe
 -Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
 
 ## heap dumps
 


### PR DESCRIPTION
Netty replaces the backing set for the selector implementation. The
value of doing this is questionable, and doing this requires permissions
that we are not going to grant. This commit explicitly disables this
optimization rather than relying on it failing due to lack of
permissions.
