### PR TITLE
Fix NPE when running a range query on a `scaled_float` with no upper bound.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -244,7 +244,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                 lo = Math.round(Math.ceil(dValue * scalingFactor));
             }
             Long hi = null;
-            if (lowerTerm != null) {
+            if (upperTerm != null) {
                 double dValue = NumberFieldMapper.NumberType.DOUBLE.parse(upperTerm).doubleValue();
                 if (includeUpper == false) {
                     dValue = Math.nextDown(dValue);

--- a/core/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
@@ -117,8 +117,8 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
         IndexSearcher searcher = newSearcher(reader);
         final int numQueries = 1000;
         for (int i = 0; i < numQueries; ++i) {
-            double l = (randomDouble() * 2 - 1) * 10000;
-            double u = (randomDouble() * 2 - 1) * 10000;
+            Double l = randomBoolean() ? null : (randomDouble() * 2 - 1) * 10000;
+            Double u = randomBoolean() ? null : (randomDouble() * 2 - 1) * 10000;
             boolean includeLower = randomBoolean();
             boolean includeUpper = randomBoolean();
             Query doubleQ = NumberFieldMapper.NumberType.DOUBLE.rangeQuery("double", l, u, includeLower, includeUpper);


### PR DESCRIPTION
The null check was there, but on the wrong variable.
