### PR TITLE
Increase visibility of deprecation logger

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -131,9 +131,9 @@ public class DeprecationLogger {
                 }
             }
 
-            logger.debug(formattedMsg);
+            logger.warn(formattedMsg);
         } else {
-            logger.debug(msg, params);
+            logger.warn(msg, params);
         }
 
     }

--- a/core/src/test/java/org/elasticsearch/common/logging/ESLoggerTests.java
+++ b/core/src/test/java/org/elasticsearch/common/logging/ESLoggerTests.java
@@ -138,7 +138,7 @@ public class ESLoggerTests extends ESTestCase {
         List<LoggingEvent> deprecationEvents = deprecationAppender.getEvents();
         LoggingEvent event = deprecationEvents.get(0);
         assertThat(event, notNullValue());
-        assertThat(event.getLevel(), equalTo(Level.DEBUG));
+        assertThat(event.getLevel(), equalTo(Level.WARN));
         assertThat(event.getRenderedMessage(), equalTo("This is a deprecation message"));
     }
 

--- a/distribution/src/main/resources/config/logging.yml
+++ b/distribution/src/main/resources/config/logging.yml
@@ -6,8 +6,8 @@ logger:
   # log action execution errors for easier debugging
   action: DEBUG
 
-  # deprecation logging, turn to DEBUG to see them
-  deprecation: INFO, deprecation_log_file
+  # deprecation logging, turn to INFO to disable them
+  deprecation: WARN, deprecation_log_file
 
   # reduce the logging for aws, too much is logged under the default INFO
   com.amazonaws: WARN

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -136,14 +136,17 @@ out of the box.
 In addition to regular logging, Elasticsearch allows you to enable logging
 of deprecated actions. For example this allows you to determine early, if
 you need to migrate certain functionality in the future. By default,
-deprecation logging is disabled. You can enable it in the `config/logging.yml`
-file by setting the deprecation log level to `DEBUG`.
+deprecation logging is enabled at the WARN level, the level at which all
+deprecation log messages will be emitted.
 
 [source,yaml]
 --------------------------------------------------
-deprecation: DEBUG, deprecation_log_file
+deprecation: WARN, deprecation_log_file
 --------------------------------------------------
 
 This will create a daily rolling deprecation log file in your log directory.
 Check this file regularly, especially when you intend to upgrade to a new
 major version.
+
+You can disable it in the `config/logging.yml` file by setting the deprecation
+log level to `INFO`.


### PR DESCRIPTION
The deprecation logger is an important way to make visible features of
Elasticsearch that are deprecated. Yet, the default logging makes the
log messages for the deprecation logger invisible. We want these log
messages to be visible, so the default logging for the deprecation
logger should enable these log messages. This commit changes the log
level of deprecation log message to warn, and configures the deprecation
logger so that these log messages are visible out of the box.

Relates #11033
