### PR TITLE
Specify configuration directory while running setup command during integrations tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -175,7 +175,7 @@ class ClusterFormationTasks {
             // the first argument is the actual script name, relative to home
             Object[] args = command.getValue().clone()
             args[0] = new File(node.homeDir, args[0].toString())
-            setup = configureExecTask(taskName(task, node, command.getKey()), project, setup, node, args)
+            setup = configureExecTask(taskName(task, node, command.getKey()), project, setup, node, args, [CONF_DIR: node.confDir])
         }
 
         Task start = configureStartTask(taskName(task, node, 'start'), project, setup, node)
@@ -379,7 +379,7 @@ class ClusterFormationTasks {
         // delay reading the file location until execution time by wrapping in a closure within a GString
         Object file = "${-> new File(node.pluginsTmpDir, pluginZip.singleFile.getName()).toURI().toURL().toString()}"
         Object[] args = [new File(node.homeDir, 'bin/elasticsearch-plugin'), 'install', file]
-        return configureExecTask(name, project, setup, node, args)
+        return configureExecTask(name, project, setup, node, args, [CONF_DIR: node.confDir])
     }
 
     /** Wrapper for command line argument: surrounds comma with double quotes **/
@@ -399,7 +399,7 @@ class ClusterFormationTasks {
     }
 
     /** Adds a task to execute a command to help setup the cluster */
-    static Task configureExecTask(String name, Project project, Task setup, NodeInfo node, Object[] execArgs) {
+    static Task configureExecTask(String name, Project project, Task setup, NodeInfo node, Object[] execArgs, Map<String, ?> env) {
         return project.tasks.create(name: name, type: LoggedExec, dependsOn: setup) {
             workingDir node.cwd
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
@@ -409,6 +409,7 @@ class ClusterFormationTasks {
                 // argument are wrapped in an ExecArgWrapper that escapes commas
                 args execArgs.collect { a -> new EscapeCommaWrapper(arg: a) }
             } else {
+                environment env
                 commandLine execArgs
             }
         }


### PR DESCRIPTION
Currently integration tests are running commands with default configuration directory pointing to `/etc/elasticsearch`. It makes `ingest-geoip`and many `x-pack` tests to fail during integration tests if `/etc/elasticsearch` exists.

Not sure if this is the right way to fix it and this is a good place for the environment to be specified, but it fixes the issue for me.

Reproduction:

```
$ mkdir /etc/elasticsearch
$ gradle :plugins:ingest-geoip:integTest#installIngestGeoipPlugin
```
