### PR TITLE
Skip smoke test client on JDK 9

### DIFF
--- a/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/SmokeTestClientIT.java
+++ b/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/SmokeTestClientIT.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.smoketest;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
@@ -27,10 +28,19 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.greaterThan;
 
 public class SmokeTestClientIT extends ESSmokeClientTestCase {
+
+    // needed to avoid the test suite from failing for having no tests
+    // TODO: remove when Netty 4.1.5 is upgraded to Netty 4.1.6 including https://github.com/netty/netty/pull/5778
+    public void testSoThatTestsDoNotFail() {
+
+    }
+
     /**
      * Check that we are connected to a cluster named "elasticsearch".
      */
     public void testSimpleClient() {
+        // TODO: remove when Netty 4.1.5 is upgraded to Netty 4.1.6 including https://github.com/netty/netty/pull/5778
+        assumeFalse("JDK is JDK 9", Constants.JRE_IS_MINIMUM_JAVA9);
         Client client = getClient();
 
         // START SNIPPET: java-doc-admin-cluster-health
@@ -45,6 +55,8 @@ public class SmokeTestClientIT extends ESSmokeClientTestCase {
      * Create an index and index some docs
      */
     public void testPutDocument() {
+        // TODO: remove when Netty 4.1.5 is upgraded to Netty 4.1.6 including https://github.com/netty/netty/pull/5778
+        assumeFalse("JDK is JDK 9", Constants.JRE_IS_MINIMUM_JAVA9);
         Client client = getClient();
 
         // START SNIPPET: java-doc-index-doc-simple
@@ -63,5 +75,6 @@ public class SmokeTestClientIT extends ESSmokeClientTestCase {
         assertThat(searchResponse.getHits().getTotalHits(), is(1L));
         // END SNIPPET: java-doc-search-simple
     }
+
 }
 


### PR DESCRIPTION
This commit adds an assumption to SmokeTestClientIT tests on JDK 9. The
underlying issue is that Netty attempts to access sun.nio.ch but this
package is not exported from java.base on JDK 9. This throws an uncaught
InaccessibleObjectException causing the test to fail. This assumption
can be removed when Netty 4.1.6 is released as it will include a fix for
this scenario.

Relates #20251, netty/netty#5778
