### PR TITLE
Don't allow XContentBuilder#writeValue(TimeValue)

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -886,6 +886,7 @@ public final class XContentBuilder implements BytesStream, Releasable {
             generator.writeNull();
             return;
         }
+        assert false == value instanceof TimeValue : "Use timeValueField instead";
         Class<?> type = value.getClass();
         Writer writer = MAP.get(type);
         if (writer != null) {


### PR DESCRIPTION
We have specific support for writing `TimeValue`s in the form of
`XContentBuilder#timeValueField`. Writing a `TimeValue` using
`XContentBuilder#writeValue` is a bug waiting to happen.
