### PR TITLE
Correct path.conf for integ-test-zip distribution

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -490,6 +490,7 @@ Map<String, String> expansionsForDistribution(distributionType) {
     'path.conf': [
       'tar': '$ES_HOME/config',
       'zip': '$ES_HOME/config',
+      'integ-test-zip': '$ES_HOME/config',
       'def': '/etc/elasticsearch',
     ],
     'path.env': [


### PR DESCRIPTION
The integ-test-zip distribution did not specify a value for
path.conf. As such, it picked up the default value of
/etc/elasticsearch. This means that on machines that have this
directory, integration tests could fail because they would try to pick
up configuration from that directory rather than from the home directory
of the exploded distribution. This commit fixes this issue by specifying
a value of path.conf for the integ-test-zip distribution.

Supersedes #20256
