### PR TITLE
Size limit deprecation logs

### DIFF
--- a/distribution/src/main/resources/config/log4j2.properties
+++ b/distribution/src/main/resources/config/log4j2.properties
@@ -29,11 +29,12 @@ appender.deprecation_rolling.name = deprecation_rolling
 appender.deprecation_rolling.fileName = ${sys:es.logs}_deprecation.log
 appender.deprecation_rolling.layout.type = PatternLayout
 appender.deprecation_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %.10000m%n
-appender.deprecation_rolling.filePattern = ${sys:es.logs}_deprecation-%d{yyyy-MM-dd}.log
+appender.deprecation_rolling.filePattern = ${sys:es.logs}_deprecation-%i.log.gz
 appender.deprecation_rolling.policies.type = Policies
-appender.deprecation_rolling.policies.time.type = TimeBasedTriggeringPolicy
-appender.deprecation_rolling.policies.time.interval = 1
-appender.deprecation_rolling.policies.time.modulate = true
+appender.deprecation_rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.deprecation_rolling.policies.size.size = 1GB
+appender.deprecation_rolling.strategy.type = DefaultRolloverStrategy
+appender.deprecation_rolling.strategy.max = 4
 
 logger.deprecation.name = deprecation
 logger.deprecation.level = warn

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -174,5 +174,9 @@ This will create a daily rolling deprecation log file in your log directory.
 Check this file regularly, especially when you intend to upgrade to a new
 major version.
 
+The default logging configuration has set the roll policy for the deprecation
+logs to roll and compress after 1 GB, and to preserve a maximum of five log
+files (four rolled logs, and the active log).
+
 You can disable it in the `config/log4j2.properties` file by setting the deprecation
 log level to `info`.


### PR DESCRIPTION
This commit configures the deprecation logs to be size-limited to 1 GB,
and compress these logs when they roll. The default configuration will
preserve up to four rolled logs.

Relates #20235, relates #20254
