### PR TITLE
Nodes don't respond to pings from stale master

### DIFF
--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -216,7 +216,6 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
 
     @Override
     protected void doStart() {
-        nodesFD.setLocalNode(clusterService.localNode());
         joinThreadControl.start();
         pingService.start();
         this.nodeJoinController = new NodeJoinController(clusterService, allocationService, electMaster, discoverySettings, settings);

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -189,7 +189,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
         this.masterFD = new MasterFaultDetection(settings, threadPool, transportService, clusterService);
         this.masterFD.addListener(new MasterNodeFailureListener());
 
-        this.nodesFD = new NodesFaultDetection(settings, threadPool, transportService, clusterService.getClusterName());
+        this.nodesFD = new NodesFaultDetection(settings, threadPool, transportService, clusterService.getClusterName(), clusterService);
         this.nodesFD.addListener(new NodeFaultDetectionListener());
 
         this.publishClusterState =

--- a/core/src/main/java/org/elasticsearch/discovery/zen/fd/FaultDetection.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/fd/FaultDetection.java
@@ -20,6 +20,7 @@ package org.elasticsearch.discovery.zen.fd;
 
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -51,6 +52,7 @@ public abstract class FaultDetection extends AbstractComponent {
     protected final ThreadPool threadPool;
     protected final ClusterName clusterName;
     protected final TransportService transportService;
+    protected final ClusterService clusterService;
 
     // used mainly for testing, should always be true
     protected final boolean registerConnectionListener;
@@ -61,11 +63,13 @@ public abstract class FaultDetection extends AbstractComponent {
     protected final TimeValue pingRetryTimeout;
     protected final int pingRetryCount;
 
-    public FaultDetection(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterName clusterName) {
+    public FaultDetection(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterName clusterName,
+                          ClusterService clusterService) {
         super(settings);
         this.threadPool = threadPool;
         this.transportService = transportService;
         this.clusterName = clusterName;
+        this.clusterService = clusterService;
 
         this.connectOnNetworkDisconnect = CONNECT_ON_NETWORK_DISCONNECT_SETTING.get(settings);
         this.pingInterval = PING_INTERVAL_SETTING.get(settings);

--- a/core/src/main/java/org/elasticsearch/discovery/zen/fd/MasterFaultDetection.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/fd/MasterFaultDetection.java
@@ -64,7 +64,6 @@ public class MasterFaultDetection extends FaultDetection {
 
     }
 
-    private final ClusterService clusterService;
     private final CopyOnWriteArrayList<Listener> listeners = new CopyOnWriteArrayList<>();
 
     private volatile MasterPinger masterPinger;
@@ -79,8 +78,7 @@ public class MasterFaultDetection extends FaultDetection {
 
     public MasterFaultDetection(Settings settings, ThreadPool threadPool, TransportService transportService,
                                 ClusterService clusterService) {
-        super(settings, threadPool, transportService, clusterService.getClusterName());
-        this.clusterService = clusterService;
+        super(settings, threadPool, transportService, clusterService.getClusterName(), clusterService);
 
         logger.debug("[master] uses ping_interval [{}], ping_timeout [{}], ping_retries [{}]", pingInterval, pingRetryTimeout,
             pingRetryCount);

--- a/core/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
@@ -98,8 +98,8 @@ public class NodesFaultDetection extends FaultDetection {
                 nodesFD.remove(monitoredNode);
             }
         }
-        // add any missing nodes
 
+        // add any missing nodes
         final DiscoveryNode localNode = clusterService.localNode();
         for (DiscoveryNode node : clusterState.nodes()) {
             if (node.equals(localNode)) {

--- a/core/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
@@ -233,9 +233,6 @@ public class NodesFaultDetection extends FaultDetection {
                                 handleTransportDisconnect(node);
                                 return;
                             }
-                            if (exp.getCause() != null && exp.getCause() instanceof IllegalStateException) {
-
-                            }
 
                             retryCount++;
                             logger.trace(

--- a/core/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
@@ -184,10 +184,8 @@ public class ZenFaultDetectionTests extends ESTestCase {
         setState(clusterServiceB, clusterStateB);
         NodesFaultDetection nodesFDA = new NodesFaultDetection(settings.build(), threadPool, serviceA, clusterStateA.getClusterName(),
                                                                   clusterServiceA);
-        nodesFDA.setLocalNode(nodeA);
         NodesFaultDetection nodesFDB = new NodesFaultDetection(settings.build(), threadPool, serviceB, clusterStateB.getClusterName(),
                                                                   clusterServiceB);
-        nodesFDB.setLocalNode(nodeB);
         final CountDownLatch pingSent = new CountDownLatch(1);
         nodesFDB.addListener(new NodesFaultDetection.Listener() {
             @Override
@@ -241,10 +239,8 @@ public class ZenFaultDetectionTests extends ESTestCase {
         setState(clusterServiceB, clusterStateB);
         NodesFaultDetection nodesFDA = new NodesFaultDetection(settings.build(), threadPool, serviceA, clusterStateA.getClusterName(),
                                                                   clusterServiceA);
-        nodesFDA.setLocalNode(nodeA);
         NodesFaultDetection nodesFDB = new NodesFaultDetection(settings.build(), threadPool, serviceB, clusterStateB.getClusterName(),
                                                                   clusterServiceB);
-        nodesFDB.setLocalNode(nodeB);
 
         final String[] failureReason = new String[1];
         final DiscoveryNode[] failureNode = new DiscoveryNode[1];


### PR DESCRIPTION
Currently, if a master gets isolated from the cluster and loses its
mastership, when it comes back to life (say, after a long GC), it will
resume sending pings to the nodes it believes to be in the cluster.
Those nodes will respond to the pings without checking to ensure its
responding to a ping from whom it believes to be master. This causes
the stale master to merrily continue believing it is the master (and
responding to requests like cluster health checks), and it won't know
it is no longer master until the next time it tries to execute a cluster
state update.

This commit makes the node receiving the ping check to ensure the
ping came from a node it believes to be master, and if not, it
throws an exception which is sent to the stale master node instead
of responding normally which is what it did before.
