### PR TITLE
Fix broken link reported by Twitter user

### DIFF
--- a/docs/reference/query-dsl/match-phrase-prefix-query.asciidoc
+++ b/docs/reference/query-dsl/match-phrase-prefix-query.asciidoc
@@ -59,6 +59,6 @@ for appears.
 
 For better solutions for _search-as-you-type_ see the
 <<search-suggesters-completion,completion suggester>> and
-{guide}/_index_time_search_as_you_type.html[Index-Time Search-as-You-Type].
+{defguide}/_index_time_search_as_you_type.html[Index-Time Search-as-You-Type].
 
 ===================================================


### PR DESCRIPTION
Reported by https://twitter.com/nate_smith/status/771443250766815233 and relayed by @miiiiiche. Affects https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-match-query.html#query-dsl-match-query-phrase-prefix. 

After some poking around, the link used a `{guide}` URL snippet that wasn't defined anywhere and so the link was simply omitted by the build. Changed to a snippet that is defined. 

After building, here's the output. Tested that the link works. 

![image](https://cloud.githubusercontent.com/assets/15148011/18187882/4c5da474-7062-11e6-9d95-f563a17648f7.png)

@eskibars Your LGTM, please, and a hint for what other branches this fix needs to go into. 
