### PR TITLE
filter_keys should be a list

### DIFF
--- a/rest-api-spec/api/indices.clear_cache.json
+++ b/rest-api-spec/api/indices.clear_cache.json
@@ -33,7 +33,7 @@
           "description" : "Clear filter caches"
         },
         "filter_keys": {
-          "type" : "boolean",
+          "type" : "list",
           "description" : "A comma-separated list of keys to clear when using the `filter_cache` parameter (default: all)"
         },
         "id": {


### PR DESCRIPTION
[`filter_keys` should be a `list` type](https://github.com/elastic/elasticsearch/blob/1.7/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java#L93).

See https://github.com/elastic/elasticsearch-net/issues/2229
