### PR TITLE
Remove specialized timeValueField() methods in XContentBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanation.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanation.java
@@ -181,8 +181,8 @@ public final class ClusterAllocationExplanation implements ToXContent, Writeable
             // If we have unassigned info, show that
             if (unassignedInfo != null) {
                 unassignedInfo.toXContent(builder, params);
-                builder.timeValueField("allocation_delay_in_millis", "allocation_delay", TimeValue.timeValueMillis(allocationDelayMillis));
-                builder.timeValueField("remaining_delay_in_millis", "remaining_delay", TimeValue.timeValueMillis(remainingDelayMillis));
+                builder.field("allocation_delay", TimeValue.timeValueMillis(allocationDelayMillis));
+                builder.field("remaining_delay", TimeValue.timeValueMillis(remainingDelayMillis));
             }
             builder.startObject("nodes"); {
                 for (NodeExplanation explanation : nodeExplanations.values()) {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -231,7 +231,6 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
     private static final String NUMBER_OF_IN_FLIGHT_FETCH = "number_of_in_flight_fetch";
     private static final String DELAYED_UNASSIGNED_SHARDS = "delayed_unassigned_shards";
     private static final String TASK_MAX_WAIT_TIME_IN_QUEUE = "task_max_waiting_in_queue";
-    private static final String TASK_MAX_WAIT_TIME_IN_QUEUE_IN_MILLIS = "task_max_waiting_in_queue_millis";
     private static final String ACTIVE_SHARDS_PERCENT_AS_NUMBER = "active_shards_percent_as_number";
     private static final String ACTIVE_SHARDS_PERCENT = "active_shards_percent";
     private static final String ACTIVE_PRIMARY_SHARDS = "active_primary_shards";
@@ -256,7 +255,7 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
         builder.field(DELAYED_UNASSIGNED_SHARDS, getDelayedUnassignedShards());
         builder.field(NUMBER_OF_PENDING_TASKS, getNumberOfPendingTasks());
         builder.field(NUMBER_OF_IN_FLIGHT_FETCH, getNumberOfInFlightFetch());
-        builder.timeValueField(TASK_MAX_WAIT_TIME_IN_QUEUE_IN_MILLIS, TASK_MAX_WAIT_TIME_IN_QUEUE, getTaskMaxWaitingTime());
+        builder.field(TASK_MAX_WAIT_TIME_IN_QUEUE, getTaskMaxWaitingTime());
         builder.percentageField(ACTIVE_SHARDS_PERCENT_AS_NUMBER, ACTIVE_SHARDS_PERCENT, getActiveShardsPercent());
 
         String level = params.param("level", "cluster");

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStats.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.cluster.snapshots.status;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.snapshots.IndexShardSnapshotStatus;
@@ -137,7 +138,6 @@ public class SnapshotStats implements Streamable, ToXContent {
         static final String PROCESSED_SIZE_IN_BYTES = "processed_size_in_bytes";
         static final String PROCESSED_SIZE = "processed_size";
         static final String START_TIME_IN_MILLIS = "start_time_in_millis";
-        static final String TIME_IN_MILLIS = "time_in_millis";
         static final String TIME = "time";
     }
 
@@ -149,7 +149,7 @@ public class SnapshotStats implements Streamable, ToXContent {
         builder.byteSizeField(Fields.TOTAL_SIZE_IN_BYTES, Fields.TOTAL_SIZE, getTotalSize());
         builder.byteSizeField(Fields.PROCESSED_SIZE_IN_BYTES, Fields.PROCESSED_SIZE, getProcessedSize());
         builder.field(Fields.START_TIME_IN_MILLIS, getStartTime());
-        builder.timeValueField(Fields.TIME_IN_MILLIS, Fields.TIME, getTime());
+        builder.field(Fields.TIME, TimeValue.timeValueMillis(getTime()));
         builder.endObject();
         return builder;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -474,7 +474,6 @@ public class ClusterStatsNodes implements ToXContent {
             static final String COUNT = "count";
             static final String THREADS = "threads";
             static final String MAX_UPTIME = "max_uptime";
-            static final String MAX_UPTIME_IN_MILLIS = "max_uptime_in_millis";
             static final String MEM = "mem";
             static final String HEAP_USED = "heap_used";
             static final String HEAP_USED_IN_BYTES = "heap_used_in_bytes";
@@ -484,7 +483,7 @@ public class ClusterStatsNodes implements ToXContent {
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.timeValueField(Fields.MAX_UPTIME_IN_MILLIS, Fields.MAX_UPTIME, maxUptime);
+            builder.field(Fields.MAX_UPTIME, TimeValue.timeValueMillis(maxUptime));
             builder.startArray(Fields.VERSIONS);
             for (ObjectIntCursor<JvmVersion> v : versions) {
                 builder.startObject();

--- a/core/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/core/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.ClusterState.Custom;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.shard.ShardId;
@@ -432,7 +433,6 @@ public class SnapshotsInProgress extends AbstractDiffable<Custom> implements Cus
     private static final String PARTIAL = "partial";
     private static final String STATE = "state";
     private static final String INDICES = "indices";
-    private static final String START_TIME_MILLIS = "start_time_millis";
     private static final String START_TIME = "start_time";
     private static final String SHARDS = "shards";
     private static final String INDEX = "index";
@@ -464,7 +464,7 @@ public class SnapshotsInProgress extends AbstractDiffable<Custom> implements Cus
             }
         }
         builder.endArray();
-        builder.timeValueField(START_TIME_MILLIS, START_TIME, entry.startTime());
+        builder.field(START_TIME, TimeValue.timeValueMillis(entry.startTime()));
         builder.startArray(SHARDS);
         {
             for (ObjectObjectCursor<ShardId, ShardSnapshotStatus> shardEntry : entry.shards) {

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -438,7 +439,8 @@ public final class IndexGraveyard implements MetaData.Custom {
             builder.startObject();
             builder.field(INDEX_KEY);
             index.toXContent(builder, params);
-            builder.timeValueField(DELETE_DATE_IN_MILLIS_KEY, DELETE_DATE_KEY, deleteDateInMillis, TimeUnit.MILLISECONDS);
+            // We force the output format because it is parsed later on
+            builder.field(DELETE_DATE_KEY, TimeValue.timeValueMillis(deleteDateInMillis), TimeUnit.MILLISECONDS);
             return builder.endObject();
         }
 

--- a/core/src/main/java/org/elasticsearch/index/flush/FlushStats.java
+++ b/core/src/main/java/org/elasticsearch/index/flush/FlushStats.java
@@ -91,7 +91,7 @@ public class FlushStats implements Streamable, ToXContent {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.FLUSH);
         builder.field(Fields.TOTAL, total);
-        builder.timeValueField(Fields.TOTAL_TIME_IN_MILLIS, Fields.TOTAL_TIME, totalTimeInMillis);
+        builder.field(Fields.TOTAL_TIME, TimeValue.timeValueMillis(totalTimeInMillis));
         builder.endObject();
         return builder;
     }
@@ -100,7 +100,6 @@ public class FlushStats implements Streamable, ToXContent {
         static final String FLUSH = "flush";
         static final String TOTAL = "total";
         static final String TOTAL_TIME = "total_time";
-        static final String TOTAL_TIME_IN_MILLIS = "total_time_in_millis";
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/get/GetStats.java
+++ b/core/src/main/java/org/elasticsearch/index/get/GetStats.java
@@ -112,11 +112,11 @@ public class GetStats implements Streamable, ToXContent {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.GET);
         builder.field(Fields.TOTAL, getCount());
-        builder.timeValueField(Fields.TIME_IN_MILLIS, Fields.TIME, getTimeInMillis());
+        builder.field(Fields.TIME, TimeValue.timeValueMillis(getTimeInMillis()));
         builder.field(Fields.EXISTS_TOTAL, existsCount);
-        builder.timeValueField(Fields.EXISTS_TIME_IN_MILLIS, Fields.EXISTS_TIME, existsTimeInMillis);
+        builder.field(Fields.EXISTS_TIME, TimeValue.timeValueMillis(existsTimeInMillis));
         builder.field(Fields.MISSING_TOTAL, missingCount);
-        builder.timeValueField(Fields.MISSING_TIME_IN_MILLIS, Fields.MISSING_TIME, missingTimeInMillis);
+        builder.field(Fields.MISSING_TIME, TimeValue.timeValueMillis(missingTimeInMillis));
         builder.field(Fields.CURRENT, current);
         builder.endObject();
         return builder;
@@ -124,15 +124,12 @@ public class GetStats implements Streamable, ToXContent {
 
     static final class Fields {
         static final String GET = "get";
-        static final String TOTAL = "total";
-        static final String TIME = "getTime";
-        static final String TIME_IN_MILLIS = "time_in_millis";
+        static final String TOTAL = "get_total";
+        static final String TIME = "get_time";
         static final String EXISTS_TOTAL = "exists_total";
         static final String EXISTS_TIME = "exists_time";
-        static final String EXISTS_TIME_IN_MILLIS = "exists_time_in_millis";
         static final String MISSING_TOTAL = "missing_total";
         static final String MISSING_TIME = "missing_time";
-        static final String MISSING_TIME_IN_MILLIS = "missing_time_in_millis";
         static final String CURRENT = "current";
     }
 

--- a/core/src/main/java/org/elasticsearch/index/merge/MergeStats.java
+++ b/core/src/main/java/org/elasticsearch/index/merge/MergeStats.java
@@ -198,11 +198,11 @@ public class MergeStats implements Streamable, ToXContent {
         builder.field(Fields.CURRENT_DOCS, currentNumDocs);
         builder.byteSizeField(Fields.CURRENT_SIZE_IN_BYTES, Fields.CURRENT_SIZE, currentSizeInBytes);
         builder.field(Fields.TOTAL, total);
-        builder.timeValueField(Fields.TOTAL_TIME_IN_MILLIS, Fields.TOTAL_TIME, totalTimeInMillis);
+        builder.field(Fields.TOTAL_TIME, TimeValue.timeValueMillis(totalTimeInMillis));
         builder.field(Fields.TOTAL_DOCS, totalNumDocs);
         builder.byteSizeField(Fields.TOTAL_SIZE_IN_BYTES, Fields.TOTAL_SIZE, totalSizeInBytes);
-        builder.timeValueField(Fields.TOTAL_STOPPED_TIME_IN_MILLIS, Fields.TOTAL_STOPPED_TIME, totalStoppedTimeInMillis);
-        builder.timeValueField(Fields.TOTAL_THROTTLED_TIME_IN_MILLIS, Fields.TOTAL_THROTTLED_TIME, totalThrottledTimeInMillis);
+        builder.field(Fields.TOTAL_STOPPED_TIME, TimeValue.timeValueMillis(totalStoppedTimeInMillis));
+        builder.field(Fields.TOTAL_THROTTLED_TIME, TimeValue.timeValueMillis(totalThrottledTimeInMillis));
         builder.byteSizeField(Fields.TOTAL_THROTTLE_BYTES_PER_SEC_IN_BYTES, Fields.TOTAL_THROTTLE_BYTES_PER_SEC, totalBytesPerSecAutoThrottle);
         builder.endObject();
         return builder;
@@ -216,11 +216,8 @@ public class MergeStats implements Streamable, ToXContent {
         static final String CURRENT_SIZE_IN_BYTES = "current_size_in_bytes";
         static final String TOTAL = "total";
         static final String TOTAL_TIME = "total_time";
-        static final String TOTAL_TIME_IN_MILLIS = "total_time_in_millis";
         static final String TOTAL_STOPPED_TIME = "total_stopped_time";
-        static final String TOTAL_STOPPED_TIME_IN_MILLIS = "total_stopped_time_in_millis";
         static final String TOTAL_THROTTLED_TIME = "total_throttled_time";
-        static final String TOTAL_THROTTLED_TIME_IN_MILLIS = "total_throttled_time_in_millis";
         static final String TOTAL_DOCS = "total_docs";
         static final String TOTAL_SIZE = "total_size";
         static final String TOTAL_SIZE_IN_BYTES = "total_size_in_bytes";

--- a/core/src/main/java/org/elasticsearch/index/recovery/RecoveryStats.java
+++ b/core/src/main/java/org/elasticsearch/index/recovery/RecoveryStats.java
@@ -102,7 +102,7 @@ public class RecoveryStats implements ToXContent, Streamable {
         builder.startObject(Fields.RECOVERY);
         builder.field(Fields.CURRENT_AS_SOURCE, currentAsSource());
         builder.field(Fields.CURRENT_AS_TARGET, currentAsTarget());
-        builder.timeValueField(Fields.THROTTLE_TIME_IN_MILLIS, Fields.THROTTLE_TIME, throttleTime());
+        builder.field(Fields.THROTTLE_TIME, throttleTime());
         builder.endObject();
         return builder;
     }
@@ -118,7 +118,6 @@ public class RecoveryStats implements ToXContent, Streamable {
         static final String CURRENT_AS_SOURCE = "current_as_source";
         static final String CURRENT_AS_TARGET = "current_as_target";
         static final String THROTTLE_TIME = "throttle_time";
-        static final String THROTTLE_TIME_IN_MILLIS = "throttle_time_in_millis";
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/refresh/RefreshStats.java
+++ b/core/src/main/java/org/elasticsearch/index/refresh/RefreshStats.java
@@ -91,7 +91,7 @@ public class RefreshStats implements Streamable, ToXContent {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.REFRESH);
         builder.field(Fields.TOTAL, total);
-        builder.timeValueField(Fields.TOTAL_TIME_IN_MILLIS, Fields.TOTAL_TIME, totalTimeInMillis);
+        builder.field(Fields.TOTAL_TIME, TimeValue.timeValueMillis(totalTimeInMillis));
         builder.endObject();
         return builder;
     }
@@ -100,7 +100,6 @@ public class RefreshStats implements Streamable, ToXContent {
         static final String REFRESH = "refresh";
         static final String TOTAL = "total";
         static final String TOTAL_TIME = "total_time";
-        static final String TOTAL_TIME_IN_MILLIS = "total_time_in_millis";
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
+++ b/core/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
@@ -220,19 +220,19 @@ public class SearchStats implements Streamable, ToXContent {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.field(Fields.QUERY_TOTAL, queryCount);
-            builder.timeValueField(Fields.QUERY_TIME_IN_MILLIS, Fields.QUERY_TIME, queryTimeInMillis);
+            builder.field(Fields.QUERY_TIME, TimeValue.timeValueMillis(queryTimeInMillis));
             builder.field(Fields.QUERY_CURRENT, queryCurrent);
 
             builder.field(Fields.FETCH_TOTAL, fetchCount);
-            builder.timeValueField(Fields.FETCH_TIME_IN_MILLIS, Fields.FETCH_TIME, fetchTimeInMillis);
+            builder.field(Fields.FETCH_TIME, TimeValue.timeValueMillis(fetchTimeInMillis));
             builder.field(Fields.FETCH_CURRENT, fetchCurrent);
 
             builder.field(Fields.SCROLL_TOTAL, scrollCount);
-            builder.timeValueField(Fields.SCROLL_TIME_IN_MILLIS, Fields.SCROLL_TIME, scrollTimeInMillis);
+            builder.field(Fields.SCROLL_TIME, TimeValue.timeValueMillis(scrollTimeInMillis));
             builder.field(Fields.SCROLL_CURRENT, scrollCurrent);
 
             builder.field(Fields.SUGGEST_TOTAL, suggestCount);
-            builder.timeValueField(Fields.SUGGEST_TIME_IN_MILLIS, Fields.SUGGEST_TIME, suggestTimeInMillis);
+            builder.field(Fields.SUGGEST_TIME, TimeValue.timeValueMillis(suggestTimeInMillis));
             builder.field(Fields.SUGGEST_CURRENT, suggestCurrent);
 
             return builder;
@@ -324,19 +324,15 @@ public class SearchStats implements Streamable, ToXContent {
         static final String GROUPS = "groups";
         static final String QUERY_TOTAL = "query_total";
         static final String QUERY_TIME = "query_time";
-        static final String QUERY_TIME_IN_MILLIS = "query_time_in_millis";
         static final String QUERY_CURRENT = "query_current";
         static final String FETCH_TOTAL = "fetch_total";
         static final String FETCH_TIME = "fetch_time";
-        static final String FETCH_TIME_IN_MILLIS = "fetch_time_in_millis";
         static final String FETCH_CURRENT = "fetch_current";
         static final String SCROLL_TOTAL = "scroll_total";
         static final String SCROLL_TIME = "scroll_time";
-        static final String SCROLL_TIME_IN_MILLIS = "scroll_time_in_millis";
         static final String SCROLL_CURRENT = "scroll_current";
         static final String SUGGEST_TOTAL = "suggest_total";
         static final String SUGGEST_TIME = "suggest_time";
-        static final String SUGGEST_TIME_IN_MILLIS = "suggest_time_in_millis";
         static final String SUGGEST_CURRENT = "suggest_current";
     }
 

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexingStats.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexingStats.java
@@ -180,18 +180,18 @@ public class IndexingStats implements Streamable, ToXContent {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.field(Fields.INDEX_TOTAL, indexCount);
-            builder.timeValueField(Fields.INDEX_TIME_IN_MILLIS, Fields.INDEX_TIME, indexTimeInMillis);
+            builder.field(Fields.INDEX_TIME, TimeValue.timeValueMillis(indexTimeInMillis));
             builder.field(Fields.INDEX_CURRENT, indexCurrent);
             builder.field(Fields.INDEX_FAILED, indexFailedCount);
 
             builder.field(Fields.DELETE_TOTAL, deleteCount);
-            builder.timeValueField(Fields.DELETE_TIME_IN_MILLIS, Fields.DELETE_TIME, deleteTimeInMillis);
+            builder.field(Fields.DELETE_TIME, TimeValue.timeValueMillis(deleteTimeInMillis));
             builder.field(Fields.DELETE_CURRENT, deleteCurrent);
 
             builder.field(Fields.NOOP_UPDATE_TOTAL, noopUpdateCount);
 
             builder.field(Fields.IS_THROTTLED, isThrottled);
-            builder.timeValueField(Fields.THROTTLED_TIME_IN_MILLIS, Fields.THROTTLED_TIME, throttleTimeInMillis);
+            builder.field(Fields.THROTTLED_TIME, TimeValue.timeValueMillis(throttleTimeInMillis));
             return builder;
         }
     }
@@ -272,16 +272,13 @@ public class IndexingStats implements Streamable, ToXContent {
         static final String TYPES = "types";
         static final String INDEX_TOTAL = "index_total";
         static final String INDEX_TIME = "index_time";
-        static final String INDEX_TIME_IN_MILLIS = "index_time_in_millis";
         static final String INDEX_CURRENT = "index_current";
         static final String INDEX_FAILED = "index_failed";
         static final String DELETE_TOTAL = "delete_total";
         static final String DELETE_TIME = "delete_time";
-        static final String DELETE_TIME_IN_MILLIS = "delete_time_in_millis";
         static final String DELETE_CURRENT = "delete_current";
         static final String NOOP_UPDATE_TOTAL = "noop_update_total";
         static final String IS_THROTTLED = "is_throttled";
-        static final String THROTTLED_TIME_IN_MILLIS = "throttle_time_in_millis";
         static final String THROTTLED_TIME = "throttle_time";
     }
 

--- a/core/src/main/java/org/elasticsearch/index/store/StoreStats.java
+++ b/core/src/main/java/org/elasticsearch/index/store/StoreStats.java
@@ -101,7 +101,7 @@ public class StoreStats implements Streamable, ToXContent {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.STORE);
         builder.byteSizeField(Fields.SIZE_IN_BYTES, Fields.SIZE, sizeInBytes);
-        builder.timeValueField(Fields.THROTTLE_TIME_IN_MILLIS, Fields.THROTTLE_TIME, throttleTime());
+        builder.field(Fields.THROTTLE_TIME, throttleTime());
         builder.endObject();
         return builder;
     }
@@ -111,6 +111,5 @@ public class StoreStats implements Streamable, ToXContent {
         static final String SIZE = "size";
         static final String SIZE_IN_BYTES = "size_in_bytes";
         static final String THROTTLE_TIME = "throttle_time";
-        static final String THROTTLE_TIME_IN_MILLIS = "throttle_time_in_millis";
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/warmer/WarmerStats.java
+++ b/core/src/main/java/org/elasticsearch/index/warmer/WarmerStats.java
@@ -97,7 +97,7 @@ public class WarmerStats implements Streamable, ToXContent {
         builder.startObject(Fields.WARMER);
         builder.field(Fields.CURRENT, current);
         builder.field(Fields.TOTAL, total);
-        builder.timeValueField(Fields.TOTAL_TIME_IN_MILLIS, Fields.TOTAL_TIME, totalTimeInMillis);
+        builder.field(Fields.TOTAL_TIME, TimeValue.timeValueMillis(totalTimeInMillis));
         builder.endObject();
         return builder;
     }
@@ -107,7 +107,6 @@ public class WarmerStats implements Streamable, ToXContent {
         static final String CURRENT = "current";
         static final String TOTAL = "total";
         static final String TOTAL_TIME = "total_time";
-        static final String TOTAL_TIME_IN_MILLIS = "total_time_in_millis";
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -264,7 +264,7 @@ public class RecoveryState implements ToXContent, Streamable {
         if (timer.stopTime > 0) {
             builder.dateValueField(Fields.STOP_TIME_IN_MILLIS, Fields.STOP_TIME, timer.stopTime);
         }
-        builder.timeValueField(Fields.TOTAL_TIME_IN_MILLIS, Fields.TOTAL_TIME, timer.time());
+        builder.field(Fields.TOTAL_TIME, TimeValue.timeValueMillis(timer.time()));
 
         if (recoverySource.getType() == RecoverySource.Type.PEER) {
             builder.startObject(Fields.SOURCE);
@@ -313,7 +313,6 @@ public class RecoveryState implements ToXContent, Streamable {
         static final String STOP_TIME = "stop_time";
         static final String STOP_TIME_IN_MILLIS = "stop_time_in_millis";
         static final String TOTAL_TIME = "total_time";
-        static final String TOTAL_TIME_IN_MILLIS = "total_time_in_millis";
         static final String SOURCE = "source";
         static final String HOST = "host";
         static final String TRANSPORT_ADDRESS = "transport_address";
@@ -327,7 +326,6 @@ public class RecoveryState implements ToXContent, Streamable {
         static final String RECOVERED = "recovered";
         static final String RECOVERED_IN_BYTES = "recovered_in_bytes";
         static final String CHECK_INDEX_TIME = "check_index_time";
-        static final String CHECK_INDEX_TIME_IN_MILLIS = "check_index_time_in_millis";
         static final String LENGTH = "length";
         static final String LENGTH_IN_BYTES = "length_in_bytes";
         static final String FILES = "files";
@@ -339,9 +337,7 @@ public class RecoveryState implements ToXContent, Streamable {
         static final String DETAILS = "details";
         static final String SIZE = "size";
         static final String SOURCE_THROTTLE_TIME = "source_throttle_time";
-        static final String SOURCE_THROTTLE_TIME_IN_MILLIS = "source_throttle_time_in_millis";
         static final String TARGET_THROTTLE_TIME = "target_throttle_time";
-        static final String TARGET_THROTTLE_TIME_IN_MILLIS = "target_throttle_time_in_millis";
     }
 
     public static class Timer implements Streamable {
@@ -442,8 +438,8 @@ public class RecoveryState implements ToXContent, Streamable {
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.timeValueField(Fields.CHECK_INDEX_TIME_IN_MILLIS, Fields.CHECK_INDEX_TIME, checkIndexTime);
-            builder.timeValueField(Fields.TOTAL_TIME_IN_MILLIS, Fields.TOTAL_TIME, time());
+            builder.field(Fields.CHECK_INDEX_TIME, TimeValue.timeValueMillis(checkIndexTime));
+            builder.field(Fields.TOTAL_TIME, TimeValue.timeValueMillis(time()));
             return builder;
         }
     }
@@ -542,7 +538,7 @@ public class RecoveryState implements ToXContent, Streamable {
             builder.field(Fields.TOTAL, total);
             builder.field(Fields.PERCENT, String.format(Locale.ROOT, "%1.1f%%", recoveredPercent()));
             builder.field(Fields.TOTAL_ON_START, totalOnStart);
-            builder.timeValueField(Fields.TOTAL_TIME_IN_MILLIS, Fields.TOTAL_TIME, time());
+            builder.field(Fields.TOTAL_TIME, TimeValue.timeValueMillis(time()));
             return builder;
         }
     }
@@ -917,9 +913,9 @@ public class RecoveryState implements ToXContent, Streamable {
                 builder.endArray();
             }
             builder.endObject();
-            builder.timeValueField(Fields.TOTAL_TIME_IN_MILLIS, Fields.TOTAL_TIME, time());
-            builder.timeValueField(Fields.SOURCE_THROTTLE_TIME_IN_MILLIS, Fields.SOURCE_THROTTLE_TIME, sourceThrottling());
-            builder.timeValueField(Fields.TARGET_THROTTLE_TIME_IN_MILLIS, Fields.TARGET_THROTTLE_TIME, targetThrottling());
+            builder.field(Fields.TOTAL_TIME, TimeValue.timeValueMillis(time()));
+            builder.field(Fields.SOURCE_THROTTLE_TIME, sourceThrottling());
+            builder.field(Fields.TARGET_THROTTLE_TIME, targetThrottling());
             return builder;
         }
 

--- a/core/src/main/java/org/elasticsearch/ingest/IngestStats.java
+++ b/core/src/main/java/org/elasticsearch/ingest/IngestStats.java
@@ -22,6 +22,7 @@ package org.elasticsearch.ingest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -157,7 +158,7 @@ public class IngestStats implements Writeable, ToXContent {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.field("count", ingestCount);
-            builder.timeValueField("time_in_millis", "time", ingestTimeInMillis, TimeUnit.MILLISECONDS);
+            builder.field("time", TimeValue.timeValueMillis(ingestTimeInMillis));
             builder.field("current", ingestCurrent);
             builder.field("failed", ingestFailedCount);
             return builder;

--- a/core/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/core/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -177,7 +177,7 @@ public class JvmStats implements Streamable, ToXContent {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.JVM);
         builder.field(Fields.TIMESTAMP, timestamp);
-        builder.timeValueField(Fields.UPTIME_IN_MILLIS, Fields.UPTIME, uptime);
+        builder.field(Fields.UPTIME, TimeValue.timeValueMillis(uptime));
         if (mem != null) {
             builder.startObject(Fields.MEM);
 
@@ -218,7 +218,7 @@ public class JvmStats implements Streamable, ToXContent {
             for (GarbageCollector collector : gc) {
                 builder.startObject(collector.getName());
                 builder.field(Fields.COLLECTION_COUNT, collector.getCollectionCount());
-                builder.timeValueField(Fields.COLLECTION_TIME_IN_MILLIS, Fields.COLLECTION_TIME, collector.collectionTime);
+                builder.field(Fields.COLLECTION_TIME, TimeValue.timeValueMillis(collector.collectionTime));
                 builder.endObject();
             }
             builder.endObject();
@@ -254,7 +254,6 @@ public class JvmStats implements Streamable, ToXContent {
         static final String JVM = "jvm";
         static final String TIMESTAMP = "timestamp";
         static final String UPTIME = "uptime";
-        static final String UPTIME_IN_MILLIS = "uptime_in_millis";
 
         static final String MEM = "mem";
         static final String HEAP_USED = "heap_used";
@@ -288,7 +287,6 @@ public class JvmStats implements Streamable, ToXContent {
         static final String COLLECTORS = "collectors";
         static final String COLLECTION_COUNT = "collection_count";
         static final String COLLECTION_TIME = "collection_time";
-        static final String COLLECTION_TIME_IN_MILLIS = "collection_time_in_millis";
 
         static final String BUFFER_POOLS = "buffer_pools";
         static final String NAME = "name";

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsInfo.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsInfo.java
@@ -22,6 +22,7 @@ package org.elasticsearch.monitor.os;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -94,7 +95,6 @@ public class OsInfo implements Writeable, ToXContent {
         static final String ARCH = "arch";
         static final String VERSION = "version";
         static final String REFRESH_INTERVAL = "refresh_interval";
-        static final String REFRESH_INTERVAL_IN_MILLIS = "refresh_interval_in_millis";
         static final String AVAILABLE_PROCESSORS = "available_processors";
         static final String ALLOCATED_PROCESSORS = "allocated_processors";
     }
@@ -102,7 +102,7 @@ public class OsInfo implements Writeable, ToXContent {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.OS);
-        builder.timeValueField(Fields.REFRESH_INTERVAL_IN_MILLIS, Fields.REFRESH_INTERVAL, refreshInterval);
+        builder.field(Fields.REFRESH_INTERVAL, TimeValue.timeValueMillis(refreshInterval));
         if (name != null) {
             builder.field(Fields.NAME, name);
         }

--- a/core/src/main/java/org/elasticsearch/monitor/process/ProcessInfo.java
+++ b/core/src/main/java/org/elasticsearch/monitor/process/ProcessInfo.java
@@ -22,6 +22,7 @@ package org.elasticsearch.monitor.process;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -74,7 +75,6 @@ public class ProcessInfo implements Writeable, ToXContent {
     static final class Fields {
         static final String PROCESS = "process";
         static final String REFRESH_INTERVAL = "refresh_interval";
-        static final String REFRESH_INTERVAL_IN_MILLIS = "refresh_interval_in_millis";
         static final String ID = "id";
         static final String MLOCKALL = "mlockall";
     }
@@ -82,7 +82,7 @@ public class ProcessInfo implements Writeable, ToXContent {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.PROCESS);
-        builder.timeValueField(Fields.REFRESH_INTERVAL_IN_MILLIS, Fields.REFRESH_INTERVAL, refreshInterval);
+        builder.field(Fields.REFRESH_INTERVAL, TimeValue.timeValueMillis(refreshInterval));
         builder.field(Fields.ID, id);
         builder.field(Fields.MLOCKALL, mlockall);
         builder.endObject();

--- a/core/src/main/java/org/elasticsearch/monitor/process/ProcessStats.java
+++ b/core/src/main/java/org/elasticsearch/monitor/process/ProcessStats.java
@@ -72,7 +72,6 @@ public class ProcessStats implements Streamable, ToXContent {
         static final String CPU = "cpu";
         static final String PERCENT = "percent";
         static final String TOTAL = "total";
-        static final String TOTAL_IN_MILLIS = "total_in_millis";
 
         static final String MEM = "mem";
         static final String TOTAL_VIRTUAL = "total_virtual";
@@ -88,7 +87,7 @@ public class ProcessStats implements Streamable, ToXContent {
         if (cpu != null) {
             builder.startObject(Fields.CPU);
             builder.field(Fields.PERCENT, cpu.percent);
-            builder.timeValueField(Fields.TOTAL_IN_MILLIS, Fields.TOTAL, cpu.total);
+            builder.field(Fields.TOTAL, TimeValue.timeValueMillis(cpu.total));
             builder.endObject();
         }
         if (mem != null) {

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.joda.FormatDateTimeFormatter;
 import org.elasticsearch.common.joda.Joda;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.FromXContentBuilder;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -58,7 +59,6 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
     private static final String END_TIME = "end_time";
     private static final String END_TIME_IN_MILLIS = "end_time_in_millis";
     private static final String DURATION = "duration";
-    private static final String DURATION_IN_MILLIS = "duration_in_millis";
     private static final String FAILURES = "failures";
     private static final String SHARDS = "shards";
     private static final String TOTAL = "total";
@@ -326,7 +326,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         if (endTime != 0) {
             builder.field(END_TIME, DATE_TIME_FORMATTER.printer().print(endTime));
             builder.field(END_TIME_IN_MILLIS, endTime);
-            builder.timeValueField(DURATION_IN_MILLIS, DURATION, endTime - startTime);
+            builder.field(DURATION, TimeValue.timeValueMillis(endTime - startTime));
         }
         builder.startArray(FAILURES);
         for (SnapshotShardFailure shardFailure : shardFailures) {

--- a/core/src/main/java/org/elasticsearch/tasks/TaskInfo.java
+++ b/core/src/main/java/org/elasticsearch/tasks/TaskInfo.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -181,7 +182,8 @@ public final class TaskInfo implements Writeable, ToXContent {
             builder.field("description", description);
         }
         builder.dateValueField("start_time_in_millis", "start_time", startTime);
-        builder.timeValueField("running_time_in_nanos", "running_time", runningTimeNanos, TimeUnit.NANOSECONDS);
+        // Force the time unit because tasks might run under a millisecond
+        builder.field("running_time", TimeValue.timeValueNanos(runningTimeNanos), TimeUnit.NANOSECONDS);
         builder.field("cancellable", cancellable);
         if (parentTaskId.isSet()) {
             builder.field("parent_task_id", parentTaskId.toString());

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
@@ -216,12 +216,12 @@ public class BulkByScrollTask extends CancellableTask {
                 builder.field("search", searchRetries);
             }
             builder.endObject();
-            builder.timeValueField("throttled_millis", "throttled", throttled);
+            builder.field("throttled", throttled);
             builder.field("requests_per_second", requestsPerSecond == Float.POSITIVE_INFINITY ? -1 : requestsPerSecond);
             if (reasonCancelled != null) {
                 builder.field("canceled", reasonCancelled);
             }
-            builder.timeValueField("throttled_until_millis", "throttled_until", throttledUntil);
+            builder.field("throttled_until", throttledUntil);
             return builder;
         }
 


### PR DESCRIPTION
This PR renames some specialized method like 

`timeValueField(String rawFieldName, String readableFieldName, TimeValue timeValue)`

in favor of a bit more concise method:

`field(String name, TimeValue timeValue)`

The method takes care of writing the human readable field and also the time value field using a default `TimeUnit` configured at the `XContentBuilder` level. This ensures that human readable field and time value fields share the exact same prefix and allows to build objects using a specific time unit.

Note: this PR breaks some field names that were not fully coherent. If agreed, I'll document them as breaking change before merging.
