### PR TITLE
Add threshold for document ratings for PrecisionAtN and ReciprocalRank

### DIFF
--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/PrecisionAtN.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/PrecisionAtN.java
@@ -37,15 +37,29 @@ import javax.naming.directory.SearchResult;
 
 /**
  * Evaluate Precision at N, N being the number of search results to consider for precision calculation.
- *
  * Documents of unkonwn quality are ignored in the precision at n computation and returned by document id.
+ * By default documents with a rating equal or bigger than 1 are considered to be "relevant" for the precision
+ * calculation. This value can be changes using the "relevant_rating_threshold" parameter.
  * */
 public class PrecisionAtN extends RankedListQualityMetric {
 
     /** Number of results to check against a given set of relevant results. */
     private int n;
 
+    /** ratings equal or above this value will be considered relevant. */
+    private int relevantRatingThreshhold = 1;
+
     public static final String NAME = "precisionatn";
+
+    private static final ParseField SIZE_FIELD = new ParseField("size");
+    private static final ParseField RELEVANT_RATING_FIELD = new ParseField("relevant_rating_threshold");
+    private static final ConstructingObjectParser<PrecisionAtN, ParseFieldMatcherSupplier> PARSER = new ConstructingObjectParser<>(
+            "precision_at", a -> new PrecisionAtN((Integer) a[0]));
+
+    static {
+        PARSER.declareInt(ConstructingObjectParser.constructorArg(), SIZE_FIELD);
+        PARSER.declareInt(PrecisionAtN::setRelevantRatingThreshhold, RELEVANT_RATING_FIELD);
+    }
 
     public PrecisionAtN(StreamInput in) throws IOException {
         n = in.readInt();
@@ -82,12 +96,19 @@ public class PrecisionAtN extends RankedListQualityMetric {
         return n;
     }
 
-    private static final ParseField SIZE_FIELD = new ParseField("size");
-    private static final ConstructingObjectParser<PrecisionAtN, ParseFieldMatcherSupplier> PARSER = new ConstructingObjectParser<>(
-            "precision_at", a -> new PrecisionAtN((Integer) a[0]));
+    /**
+     * Sets the rating threshold above which ratings are considered to be "relevant" for this metric.
+     * */
+    public void setRelevantRatingThreshhold(int threshold) {
+        this.relevantRatingThreshhold = threshold;
+    }
 
-    static {
-        PARSER.declareInt(ConstructingObjectParser.constructorArg(), SIZE_FIELD);
+    /**
+     * Return the rating threshold above which ratings are considered to be "relevant" for this metric.
+     * Defaults to 1.
+     * */
+    public int getRelevantRatingThreshold() {
+        return relevantRatingThreshhold ;
     }
 
     public static PrecisionAtN fromXContent(XContentParser parser, ParseFieldMatcherSupplier matcher) {
@@ -103,9 +124,9 @@ public class PrecisionAtN extends RankedListQualityMetric {
         Collection<RatedDocumentKey> relevantDocIds = new ArrayList<>();
         Collection<RatedDocumentKey> irrelevantDocIds = new ArrayList<>();
         for (RatedDocument doc : ratedDocs) {
-            if (Rating.RELEVANT.equals(RatingMapping.mapTo(doc.getRating()))) {
+            if (doc.getRating() >= this.relevantRatingThreshhold) {
                 relevantDocIds.add(doc.getKey());
-            } else if (Rating.IRRELEVANT.equals(RatingMapping.mapTo(doc.getRating()))) {
+            } else {
                 irrelevantDocIds.add(doc.getKey());
             }
         }

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/ReciprocalRankTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/ReciprocalRankTests.java
@@ -26,10 +26,12 @@ import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.InternalSearchHit;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
+import java.util.concurrent.ExecutionException;
 
 import static java.util.Collections.emptyList;
 
@@ -101,6 +103,29 @@ public class ReciprocalRankTests extends ESTestCase {
 
         EvalQueryQuality evaluation = reciprocalRank.evaluate(hits, ratedDocs);
         assertEquals(1.0 / (relevantAt + 1), evaluation.getQualityLevel(), Double.MIN_VALUE);
+    }
+
+    /**
+     * test that the relevant rating threshold can be set to something larger than 1.
+     * e.g. we set it to 2 here and expect dics 0-2 to be not relevant, so first relevant doc has
+     * third ranking position, so RR should be 1/3
+     */
+    public void testPrecisionAtFiveRelevanceThreshold() throws IOException, InterruptedException, ExecutionException {
+        List<RatedDocument> rated = new ArrayList<>();
+        rated.add(new RatedDocument(new RatedDocumentKey("test", "testtype", "0"), 0));
+        rated.add(new RatedDocument(new RatedDocumentKey("test", "testtype", "1"), 1));
+        rated.add(new RatedDocument(new RatedDocumentKey("test", "testtype", "2"), 2));
+        rated.add(new RatedDocument(new RatedDocumentKey("test", "testtype", "3"), 3));
+        rated.add(new RatedDocument(new RatedDocumentKey("test", "testtype", "4"), 4));
+        InternalSearchHit[] hits = new InternalSearchHit[5];
+        for (int i = 0; i < 5; i++) {
+            hits[i] = new InternalSearchHit(i, i+"", new Text("testtype"), Collections.emptyMap());
+            hits[i].shard(new SearchShardTarget("testnode", new Index("test", "uuid"), 0));
+        }
+
+        ReciprocalRank reciprocalRank = new ReciprocalRank();
+        reciprocalRank.setRelevantRatingThreshhold(2);
+        assertEquals((double) 1 / 3, reciprocalRank.evaluate(hits, rated).getQualityLevel(), 0.00001);
     }
 
     public void testCombine() {


### PR DESCRIPTION
PrecisionAtN and ReciprocalRank are binary evaluation metrics by default that only distiguish between relevant/irrelevant search results. So far we assumed that relevant documents are labaled with 1 (irrelevant docs with 0) in the evaluation request, but this is cumbersome if the ratings are provided on a larger integer scale and would need to get mapped to a 0/1 value.

This change introduces a threshold parameter on the PrecisionAtN and ReciprocalRank metric than can be used to set the threshold from which on a document is considered "relevant". It defaults to 1, so in case of 0/1 ratings the threshold doesn't have to be set and only ratings with value 0 are considered to be irrelevant.

This PR is against a WIP feature-branch.
