### PR TITLE
Fix Javascript OOM build Failure

### DIFF
--- a/plugins/lang-javascript/src/test/java/org/elasticsearch/script/javascript/JavaScriptScriptMultiThreadedTests.java
+++ b/plugins/lang-javascript/src/test/java/org/elasticsearch/script/javascript/JavaScriptScriptMultiThreadedTests.java
@@ -41,7 +41,7 @@ public class JavaScriptScriptMultiThreadedTests extends ESTestCase {
         final Object compiled = se.compile(null, "x + y", Collections.emptyMap());
         final AtomicBoolean failed = new AtomicBoolean();
 
-        Thread[] threads = new Thread[50];
+        Thread[] threads = new Thread[between(3, 12)];
         final CountDownLatch latch = new CountDownLatch(threads.length);
         final CyclicBarrier barrier = new CyclicBarrier(threads.length + 1);
         for (int i = 0; i < threads.length; i++) {
@@ -57,7 +57,7 @@ public class JavaScriptScriptMultiThreadedTests extends ESTestCase {
                         vars.put("x", x);
                         vars.put("y", y);
                         ExecutableScript script = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testExecutableNoRuntimeParams", "js", compiled), vars);
-                        for (int i = 0; i < 100000; i++) {
+                        for (int i = 0; i < between(100, 1000); i++) {
                             long result = ((Number) script.run()).longValue();
                             assertThat(result, equalTo(addition));
                         }
@@ -83,7 +83,7 @@ public class JavaScriptScriptMultiThreadedTests extends ESTestCase {
         final Object compiled = se.compile(null, "x + y", Collections.emptyMap());
         final AtomicBoolean failed = new AtomicBoolean();
 
-        Thread[] threads = new Thread[50];
+        Thread[] threads = new Thread[between(3, 12)];
         final CountDownLatch latch = new CountDownLatch(threads.length);
         final CyclicBarrier barrier = new CyclicBarrier(threads.length + 1);
         for (int i = 0; i < threads.length; i++) {
@@ -96,7 +96,7 @@ public class JavaScriptScriptMultiThreadedTests extends ESTestCase {
                         Map<String, Object> vars = new HashMap<String, Object>();
                         vars.put("x", x);
                         ExecutableScript script = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testExecutableNoRuntimeParams", "js", compiled), vars);
-                        for (int i = 0; i < 100000; i++) {
+                        for (int i = 0; i < between(100, 1000); i++) {
                             long y = Randomness.get().nextInt();
                             long addition = x + y;
                             script.setNextVar("y", y);
@@ -125,7 +125,7 @@ public class JavaScriptScriptMultiThreadedTests extends ESTestCase {
         final Object compiled = se.compile(null, "x + y", Collections.emptyMap());
         final AtomicBoolean failed = new AtomicBoolean();
 
-        Thread[] threads = new Thread[50];
+        Thread[] threads = new Thread[between(3, 12)];
         final CountDownLatch latch = new CountDownLatch(threads.length);
         final CyclicBarrier barrier = new CyclicBarrier(threads.length + 1);
         for (int i = 0; i < threads.length; i++) {
@@ -135,7 +135,7 @@ public class JavaScriptScriptMultiThreadedTests extends ESTestCase {
                     try {
                         barrier.await();
                         Map<String, Object> runtimeVars = new HashMap<String, Object>();
-                        for (int i = 0; i < 100000; i++) {
+                        for (int i = 0; i < between(100, 1000); i++) {
                             long x = Randomness.get().nextInt();
                             long y = Randomness.get().nextInt();
                             long addition = x + y;


### PR DESCRIPTION
@nik9000 noticed several build failures related to a OOM error during the multithreaded test cases for JavaScript scripting.  As it turned out the cause was millions of deprecation warnings being logged for each script run during this test.  We reduced the number of potential scripts to the thousands, and the tests stopped running out of memory while still covering the original cases in question.
