### PR TITLE
Warn if unsupported logging configuration present

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.config.composite.CompositeConfiguration;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfiguration;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfigurationFactory;
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.settings.Settings;
@@ -43,6 +44,7 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -63,9 +65,9 @@ public class LogConfigurator {
         final LoggerContext context = (LoggerContext) LogManager.getContext(false);
 
         if (resolveConfig) {
-            final Set<FileVisitOption> options = EnumSet.of(FileVisitOption.FOLLOW_LINKS);
             final List<AbstractConfiguration> configurations = new ArrayList<>();
             final PropertiesConfigurationFactory factory = new PropertiesConfigurationFactory();
+            final Set<FileVisitOption> options = EnumSet.of(FileVisitOption.FOLLOW_LINKS);
             Files.walkFileTree(environment.configFile(), options, Integer.MAX_VALUE, new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
@@ -87,10 +89,36 @@ public class LogConfigurator {
             final Level level = ESLoggerFactory.LOG_LEVEL_SETTING.getConcreteSetting(key).get(settings);
             Loggers.setLevel(Loggers.getLogger(key.substring("logger.".length())), level);
         }
+
+        warnIfOldConfigurationFilePresent(environment);
+    }
+
+    private static void warnIfOldConfigurationFilePresent(final Environment environment) throws IOException {
+        // TODO: the warning for unsupported logging configurations can be removed in 6.0.0
+        assert Version.CURRENT.major < 6;
+        final List<String> suffixes = Arrays.asList(".yml", ".yaml", ".json", ".properties");
+        final Set<FileVisitOption> options = EnumSet.of(FileVisitOption.FOLLOW_LINKS);
+        Files.walkFileTree(environment.configFile(), options, Integer.MAX_VALUE, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                final String fileName = file.getFileName().toString();
+                if (fileName.startsWith("logging")) {
+                    for (final String suffix : suffixes) {
+                        if (fileName.endsWith(suffix)) {
+                            Loggers.getLogger(LogConfigurator.class).warn(
+                                "ignoring unsupported logging configuration file [{}], logging is configured via [{}]",
+                                file.toString(),
+                                file.getParent().resolve("log4j2.properties"));
+                        }
+                    }
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
     }
 
     @SuppressForbidden(reason = "sets system property for logging configuration")
-    private static void setLogConfigurationSystemProperty(Environment environment, Settings settings) {
+    private static void setLogConfigurationSystemProperty(final Environment environment, final Settings settings) {
         System.setProperty("es.logs", environment.logsFile().resolve(ClusterName.CLUSTER_NAME_SETTING.get(settings).value()).toString());
     }
 

--- a/qa/evil-tests/src/test/resources/org/elasticsearch/common/logging/config/logging.yml
+++ b/qa/evil-tests/src/test/resources/org/elasticsearch/common/logging/config/logging.yml
@@ -1,0 +1,2 @@
+logger.level: INFO
+rootLogger: ${logger.level}, terminal


### PR DESCRIPTION
This commit adds a warning that an unsupported logging configuration is
present and points users to the new logging configuration file.
