### PR TITLE
Cherry pick: Fix broken link reported by Twitter user #20311

### DIFF
--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -232,6 +232,6 @@ for appears.
 
 For better solutions for _search-as-you-type_ see the
 <<search-suggesters-completion,completion suggester>> and
-{guide}/_index_time_search_as_you_type.html[Index-Time Search-as-You-Type].
+{defguide}/_index_time_search_as_you_type.html[Index-Time Search-as-You-Type].
 
 ===================================================


### PR DESCRIPTION
From #20311: Apply the same fix to the 2.4 branch already applied to master. The file names are different between branches, so there's no cherry-pick (which also explain my previous commit/revert, as I didn't realize this at first).

Built ES docs locally, tested link, works.
