### PR TITLE
NodeStats classes to implement Writeable rather then Streamable

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -215,7 +215,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
             os = new OsStats(in);
         }
         if (in.readBoolean()) {
-            process = ProcessStats.readProcessStats(in);
+            process = new ProcessStats(in);
         }
         if (in.readBoolean()) {
             jvm = JvmStats.readJvmStats(in);

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -218,7 +218,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
             process = new ProcessStats(in);
         }
         if (in.readBoolean()) {
-            jvm = JvmStats.readJvmStats(in);
+            jvm = new JvmStats(in);
         }
         if (in.readBoolean()) {
             threadPool = ThreadPoolStats.readThreadPoolStats(in);

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -219,7 +219,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         transport = in.readOptionalWriteable(TransportStats::new);
         http = in.readOptionalWriteable(HttpStats::new);
         breaker = AllCircuitBreakerStats.readOptionalAllCircuitBreakerStats(in);
-        scriptStats = in.readOptionalStreamable(ScriptStats::new);
+        scriptStats = in.readOptionalWriteable(ScriptStats::new);
         discoveryStats = in.readOptionalStreamable(() -> new DiscoveryStats(null));
         ingestStats = in.readOptionalWriteable(IngestStats::new);
     }
@@ -242,7 +242,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         out.writeOptionalWriteable(transport);
         out.writeOptionalWriteable(http);
         out.writeOptionalStreamable(breaker);
-        out.writeOptionalStreamable(scriptStats);
+        out.writeOptionalWriteable(scriptStats);
         out.writeOptionalStreamable(discoveryStats);
         out.writeOptionalWriteable(ingestStats);
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -218,7 +218,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         fs = in.readOptionalWriteable(FsInfo::new);
         transport = in.readOptionalWriteable(TransportStats::new);
         http = in.readOptionalWriteable(HttpStats::new);
-        breaker = AllCircuitBreakerStats.readOptionalAllCircuitBreakerStats(in);
+        breaker = in.readOptionalWriteable(AllCircuitBreakerStats::new);
         scriptStats = in.readOptionalWriteable(ScriptStats::new);
         discoveryStats = in.readOptionalWriteable(DiscoveryStats::new);
         ingestStats = in.readOptionalWriteable(IngestStats::new);
@@ -241,7 +241,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         out.writeOptionalWriteable(fs);
         out.writeOptionalWriteable(transport);
         out.writeOptionalWriteable(http);
-        out.writeOptionalStreamable(breaker);
+        out.writeOptionalWriteable(breaker);
         out.writeOptionalWriteable(scriptStats);
         out.writeOptionalWriteable(discoveryStats);
         out.writeOptionalWriteable(ingestStats);

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -220,7 +220,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         http = in.readOptionalWriteable(HttpStats::new);
         breaker = AllCircuitBreakerStats.readOptionalAllCircuitBreakerStats(in);
         scriptStats = in.readOptionalWriteable(ScriptStats::new);
-        discoveryStats = in.readOptionalStreamable(() -> new DiscoveryStats(null));
+        discoveryStats = in.readOptionalWriteable(DiscoveryStats::new);
         ingestStats = in.readOptionalWriteable(IngestStats::new);
     }
 
@@ -243,7 +243,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         out.writeOptionalWriteable(http);
         out.writeOptionalStreamable(breaker);
         out.writeOptionalWriteable(scriptStats);
-        out.writeOptionalStreamable(discoveryStats);
+        out.writeOptionalWriteable(discoveryStats);
         out.writeOptionalWriteable(ingestStats);
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -215,12 +215,8 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         process = in.readOptionalWriteable(ProcessStats::new);
         jvm = in.readOptionalWriteable(JvmStats::new);
         threadPool = in.readOptionalWriteable(ThreadPoolStats::new);
-        if (in.readBoolean()) {
-            fs = new FsInfo(in);
-        }
-        if (in.readBoolean()) {
-            transport = TransportStats.readTransportStats(in);
-        }
+        fs = in.readOptionalWriteable(FsInfo::new);
+        transport = in.readOptionalWriteable(TransportStats::new);
         if (in.readBoolean()) {
             http = HttpStats.readHttpStats(in);
         }
@@ -244,18 +240,8 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         out.writeOptionalWriteable(process);
         out.writeOptionalWriteable(jvm);
         out.writeOptionalWriteable(threadPool);
-        if (fs == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            fs.writeTo(out);
-        }
-        if (transport == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            transport.writeTo(out);
-        }
+        out.writeOptionalWriteable(fs);
+        out.writeOptionalWriteable(transport);
         if (http == null) {
             out.writeBoolean(false);
         } else {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -217,9 +217,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         threadPool = in.readOptionalWriteable(ThreadPoolStats::new);
         fs = in.readOptionalWriteable(FsInfo::new);
         transport = in.readOptionalWriteable(TransportStats::new);
-        if (in.readBoolean()) {
-            http = HttpStats.readHttpStats(in);
-        }
+        http = in.readOptionalWriteable(HttpStats::new);
         breaker = AllCircuitBreakerStats.readOptionalAllCircuitBreakerStats(in);
         scriptStats = in.readOptionalStreamable(ScriptStats::new);
         discoveryStats = in.readOptionalStreamable(() -> new DiscoveryStats(null));
@@ -242,12 +240,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         out.writeOptionalWriteable(threadPool);
         out.writeOptionalWriteable(fs);
         out.writeOptionalWriteable(transport);
-        if (http == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            http.writeTo(out);
-        }
+        out.writeOptionalWriteable(http);
         out.writeOptionalStreamable(breaker);
         out.writeOptionalStreamable(scriptStats);
         out.writeOptionalStreamable(discoveryStats);

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -269,11 +269,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
                 builder.endObject();
             }
         }
-
         if (getIndices() != null) {
             getIndices().toXContent(builder, params);
         }
-
         if (getOs() != null) {
             getOs().toXContent(builder, params);
         }
@@ -301,15 +299,12 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         if (getScriptStats() != null) {
             getScriptStats().toXContent(builder, params);
         }
-
         if (getDiscoveryStats() != null) {
             getDiscoveryStats().toXContent(builder, params);
         }
-
         if (getIngestStats() != null) {
             getIngestStats().toXContent(builder, params);
         }
-
         return builder;
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -211,18 +211,10 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         if (in.readBoolean()) {
             indices = NodeIndicesStats.readIndicesStats(in);
         }
-        if (in.readBoolean()) {
-            os = new OsStats(in);
-        }
-        if (in.readBoolean()) {
-            process = new ProcessStats(in);
-        }
-        if (in.readBoolean()) {
-            jvm = new JvmStats(in);
-        }
-        if (in.readBoolean()) {
-            threadPool = ThreadPoolStats.readThreadPoolStats(in);
-        }
+        os = in.readOptionalWriteable(OsStats::new);
+        process = in.readOptionalWriteable(ProcessStats::new);
+        jvm = in.readOptionalWriteable(JvmStats::new);
+        threadPool = in.readOptionalWriteable(ThreadPoolStats::new);
         if (in.readBoolean()) {
             fs = new FsInfo(in);
         }
@@ -248,30 +240,10 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
             out.writeBoolean(true);
             indices.writeTo(out);
         }
-        if (os == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            os.writeTo(out);
-        }
-        if (process == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            process.writeTo(out);
-        }
-        if (jvm == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            jvm.writeTo(out);
-        }
-        if (threadPool == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            threadPool.writeTo(out);
-        }
+        out.writeOptionalWriteable(os);
+        out.writeOptionalWriteable(process);
+        out.writeOptionalWriteable(jvm);
+        out.writeOptionalWriteable(threadPool);
         if (fs == null) {
             out.writeBoolean(false);
         } else {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -268,7 +268,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        indices = CommonStatsFlags.readCommonStatsFlags(in);
+        indices = new CommonStatsFlags(in);
         os = in.readBoolean();
         process = in.readBoolean();
         jvm = in.readBoolean();
@@ -298,5 +298,4 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         out.writeBoolean(discovery);
         out.writeBoolean(ingest);
     }
-
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -83,7 +83,7 @@ public class ClusterStatsNodes implements ToXContent {
                 continue;
             }
             if (nodeResponse.nodeStats().getFs() != null) {
-                this.fs.add(nodeResponse.nodeStats().getFs().total());
+                this.fs.add(nodeResponse.nodeStats().getFs().getTotal());
             }
         }
         this.counts = new Counts(nodeInfos);

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.admin.indices.stats;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -32,13 +32,13 @@ import org.elasticsearch.index.engine.SegmentsStats;
 import org.elasticsearch.index.fielddata.FieldDataStats;
 import org.elasticsearch.index.flush.FlushStats;
 import org.elasticsearch.index.get.GetStats;
-import org.elasticsearch.index.shard.IndexingStats;
 import org.elasticsearch.index.merge.MergeStats;
 import org.elasticsearch.index.recovery.RecoveryStats;
 import org.elasticsearch.index.refresh.RefreshStats;
 import org.elasticsearch.index.search.stats.SearchStats;
 import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexingStats;
 import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.index.translog.TranslogStats;
 import org.elasticsearch.index.warmer.WarmerStats;
@@ -47,9 +47,55 @@ import org.elasticsearch.search.suggest.completion.CompletionStats;
 
 import java.io.IOException;
 
-/**
- */
-public class CommonStats implements Streamable, ToXContent {
+public class CommonStats implements Writeable, ToXContent {
+
+    @Nullable
+    public DocsStats docs;
+
+    @Nullable
+    public StoreStats store;
+
+    @Nullable
+    public IndexingStats indexing;
+
+    @Nullable
+    public GetStats get;
+
+    @Nullable
+    public SearchStats search;
+
+    @Nullable
+    public MergeStats merge;
+
+    @Nullable
+    public RefreshStats refresh;
+
+    @Nullable
+    public FlushStats flush;
+
+    @Nullable
+    public WarmerStats warmer;
+
+    @Nullable
+    public QueryCacheStats queryCache;
+
+    @Nullable
+    public FieldDataStats fieldData;
+
+    @Nullable
+    public CompletionStats completion;
+
+    @Nullable
+    public SegmentsStats segments;
+
+    @Nullable
+    public TranslogStats translog;
+
+    @Nullable
+    public RequestCacheStats requestCache;
+
+    @Nullable
+    public RecoveryStats recoveryStats;
 
     public CommonStats() {
         this(CommonStatsFlags.NONE);
@@ -117,11 +163,8 @@ public class CommonStats implements Streamable, ToXContent {
         }
     }
 
-
     public CommonStats(IndicesQueryCache indicesQueryCache, IndexShard indexShard, CommonStatsFlags flags) {
-
         CommonStatsFlags.Flag[] setFlags = flags.getFlags();
-
         for (CommonStatsFlags.Flag flag : setFlags) {
             switch (flag) {
                 case Docs:
@@ -181,53 +224,135 @@ public class CommonStats implements Streamable, ToXContent {
         }
     }
 
-    @Nullable
-    public DocsStats docs;
+    public CommonStats(StreamInput in) throws IOException {
+        if (in.readBoolean()) {
+            docs = DocsStats.readDocStats(in);
+        }
+        if (in.readBoolean()) {
+            store = StoreStats.readStoreStats(in);
+        }
+        if (in.readBoolean()) {
+            indexing = IndexingStats.readIndexingStats(in);
+        }
+        if (in.readBoolean()) {
+            get = GetStats.readGetStats(in);
+        }
+        if (in.readBoolean()) {
+            search = SearchStats.readSearchStats(in);
+        }
+        if (in.readBoolean()) {
+            merge = MergeStats.readMergeStats(in);
+        }
+        if (in.readBoolean()) {
+            refresh = RefreshStats.readRefreshStats(in);
+        }
+        if (in.readBoolean()) {
+            flush = FlushStats.readFlushStats(in);
+        }
+        if (in.readBoolean()) {
+            warmer = WarmerStats.readWarmerStats(in);
+        }
+        if (in.readBoolean()) {
+            queryCache = QueryCacheStats.readQueryCacheStats(in);
+        }
+        if (in.readBoolean()) {
+            fieldData = FieldDataStats.readFieldDataStats(in);
+        }
+        if (in.readBoolean()) {
+            completion = CompletionStats.readCompletionStats(in);
+        }
+        if (in.readBoolean()) {
+            segments = SegmentsStats.readSegmentsStats(in);
+        }
+        translog = in.readOptionalStreamable(TranslogStats::new);
+        requestCache = in.readOptionalStreamable(RequestCacheStats::new);
+        recoveryStats = in.readOptionalStreamable(RecoveryStats::new);
+    }
 
-    @Nullable
-    public StoreStats store;
-
-    @Nullable
-    public IndexingStats indexing;
-
-    @Nullable
-    public GetStats get;
-
-    @Nullable
-    public SearchStats search;
-
-    @Nullable
-    public MergeStats merge;
-
-    @Nullable
-    public RefreshStats refresh;
-
-    @Nullable
-    public FlushStats flush;
-
-    @Nullable
-    public WarmerStats warmer;
-
-    @Nullable
-    public QueryCacheStats queryCache;
-
-    @Nullable
-    public FieldDataStats fieldData;
-
-    @Nullable
-    public CompletionStats completion;
-
-    @Nullable
-    public SegmentsStats segments;
-
-    @Nullable
-    public TranslogStats translog;
-
-    @Nullable
-    public RequestCacheStats requestCache;
-
-    @Nullable
-    public RecoveryStats recoveryStats;
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        if (docs == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            docs.writeTo(out);
+        }
+        if (store == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            store.writeTo(out);
+        }
+        if (indexing == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            indexing.writeTo(out);
+        }
+        if (get == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            get.writeTo(out);
+        }
+        if (search == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            search.writeTo(out);
+        }
+        if (merge == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            merge.writeTo(out);
+        }
+        if (refresh == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            refresh.writeTo(out);
+        }
+        if (flush == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            flush.writeTo(out);
+        }
+        if (warmer == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            warmer.writeTo(out);
+        }
+        if (queryCache == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            queryCache.writeTo(out);
+        }
+        if (fieldData == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            fieldData.writeTo(out);
+        }
+        if (completion == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            completion.writeTo(out);
+        }
+        if (segments == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            segments.writeTo(out);
+        }
+        out.writeOptionalStreamable(translog);
+        out.writeOptionalStreamable(requestCache);
+        out.writeOptionalStreamable(recoveryStats);
+    }
 
     public void add(CommonStats stats) {
         if (docs == null) {
@@ -441,12 +566,6 @@ public class CommonStats implements Streamable, ToXContent {
         return recoveryStats;
     }
 
-    public static CommonStats readCommonStats(StreamInput in) throws IOException {
-        CommonStats stats = new CommonStats();
-        stats.readFrom(in);
-        return stats;
-    }
-
     /**
      * Utility method which computes total memory by adding
      * FieldData, PercolatorCache, Segments (memory, index writer, version map)
@@ -466,137 +585,6 @@ public class CommonStats implements Streamable, ToXContent {
         }
 
         return new ByteSizeValue(size);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        if (in.readBoolean()) {
-            docs = DocsStats.readDocStats(in);
-        }
-        if (in.readBoolean()) {
-            store = StoreStats.readStoreStats(in);
-        }
-        if (in.readBoolean()) {
-            indexing = IndexingStats.readIndexingStats(in);
-        }
-        if (in.readBoolean()) {
-            get = GetStats.readGetStats(in);
-        }
-        if (in.readBoolean()) {
-            search = SearchStats.readSearchStats(in);
-        }
-        if (in.readBoolean()) {
-            merge = MergeStats.readMergeStats(in);
-        }
-        if (in.readBoolean()) {
-            refresh = RefreshStats.readRefreshStats(in);
-        }
-        if (in.readBoolean()) {
-            flush = FlushStats.readFlushStats(in);
-        }
-        if (in.readBoolean()) {
-            warmer = WarmerStats.readWarmerStats(in);
-        }
-        if (in.readBoolean()) {
-            queryCache = QueryCacheStats.readQueryCacheStats(in);
-        }
-        if (in.readBoolean()) {
-            fieldData = FieldDataStats.readFieldDataStats(in);
-        }
-        if (in.readBoolean()) {
-            completion = CompletionStats.readCompletionStats(in);
-        }
-        if (in.readBoolean()) {
-            segments = SegmentsStats.readSegmentsStats(in);
-        }
-        translog = in.readOptionalStreamable(TranslogStats::new);
-        requestCache = in.readOptionalStreamable(RequestCacheStats::new);
-        recoveryStats = in.readOptionalStreamable(RecoveryStats::new);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        if (docs == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            docs.writeTo(out);
-        }
-        if (store == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            store.writeTo(out);
-        }
-        if (indexing == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            indexing.writeTo(out);
-        }
-        if (get == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            get.writeTo(out);
-        }
-        if (search == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            search.writeTo(out);
-        }
-        if (merge == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            merge.writeTo(out);
-        }
-        if (refresh == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            refresh.writeTo(out);
-        }
-        if (flush == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            flush.writeTo(out);
-        }
-        if (warmer == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            warmer.writeTo(out);
-        }
-        if (queryCache == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            queryCache.writeTo(out);
-        }
-        if (fieldData == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            fieldData.writeTo(out);
-        }
-        if (completion == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            completion.writeTo(out);
-        }
-        if (segments == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            segments.writeTo(out);
-        }
-        out.writeOptionalStreamable(translog);
-        out.writeOptionalStreamable(requestCache);
-        out.writeOptionalStreamable(recoveryStats);
     }
 
     // note, requires a wrapping object

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.EnumSet;
 
 public class CommonStatsFlags implements Writeable, Cloneable {
@@ -44,9 +45,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
     public CommonStatsFlags(Flag... flags) {
         if (flags.length > 0) {
             clear();
-            for (Flag f : flags) {
-                this.flags.add(f);
-            }
+            Collections.addAll(this.flags, flags);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.stats;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -63,11 +62,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         groups = in.readStringArray();
         fieldDataFields = in.readStringArray();
         completionDataFields = in.readStringArray();
-        if (in.getVersion().onOrAfter(Version.V_5_0_0_alpha1)) {
-            includeSegmentFileSizes = in.readBoolean();
-        } else {
-            includeSegmentFileSizes = false;
-        }
+        includeSegmentFileSizes = in.readBoolean();
     }
 
     @Override
@@ -82,9 +77,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         out.writeStringArrayNullable(groups);
         out.writeStringArrayNullable(fieldDataFields);
         out.writeStringArrayNullable(completionDataFields);
-        if (out.getVersion().onOrAfter(Version.V_5_0_0_alpha1)) {
-            out.writeBoolean(includeSegmentFileSizes);
-        }
+        out.writeBoolean(includeSegmentFileSizes);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
@@ -274,6 +274,6 @@ public class IndicesStatsRequest extends BroadcastRequest<IndicesStatsRequest> {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        flags = CommonStatsFlags.readCommonStatsFlags(in);
+        flags = new CommonStatsFlags(in);
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
@@ -90,7 +90,7 @@ public class ShardStats implements Streamable, ToXContent {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         shardRouting = new ShardRouting(in);
-        commonStats = CommonStats.readCommonStats(in);
+        commonStats = new CommonStats(in);
         commitStats = CommitStats.readOptionalCommitStatsFrom(in);
         statePath = in.readString();
         dataPath = in.readString();

--- a/core/src/main/java/org/elasticsearch/discovery/DiscoveryStats.java
+++ b/core/src/main/java/org/elasticsearch/discovery/DiscoveryStats.java
@@ -22,49 +22,39 @@ package org.elasticsearch.discovery;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.discovery.zen.publish.PendingClusterStateStats;
 
 import java.io.IOException;
 
-public class DiscoveryStats implements Streamable, ToXContent {
+public class DiscoveryStats implements Writeable, ToXContent {
 
     @Nullable
-    private PendingClusterStateStats queueStats;
+    private final PendingClusterStateStats queueStats;
 
     public DiscoveryStats(PendingClusterStateStats queueStats) {
         this.queueStats = queueStats;
     }
 
+    public DiscoveryStats(StreamInput in) throws IOException {
+        queueStats = in.readOptionalWriteable(PendingClusterStateStats::new);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalWriteable(queueStats);
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.DISCOVERY);
-
         if (queueStats != null ){
             queueStats.toXContent(builder, params);
         }
         builder.endObject();
         return builder;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        if (in.readBoolean()) {
-            queueStats = new PendingClusterStateStats();
-            queueStats.readFrom(in);
-        }
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        if (queueStats != null ) {
-            out.writeBoolean(true);
-            queueStats.writeTo(out);
-        }else{
-            out.writeBoolean(false);
-        }
     }
 
     static final class Fields {

--- a/core/src/main/java/org/elasticsearch/discovery/local/LocalDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/local/LocalDiscovery.java
@@ -47,6 +47,7 @@ import org.elasticsearch.discovery.BlockingClusterStatePublishResponseHandler;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.DiscoveryStats;
+import org.elasticsearch.discovery.zen.publish.PendingClusterStateStats;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -281,7 +282,7 @@ public class LocalDiscovery extends AbstractLifecycleComponent implements Discov
 
     @Override
     public DiscoveryStats stats() {
-        return new DiscoveryStats(null);
+        return new DiscoveryStats((PendingClusterStateStats)null);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/discovery/zen/publish/PendingClusterStateStats.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/publish/PendingClusterStateStats.java
@@ -21,7 +21,7 @@ package org.elasticsearch.discovery.zen.publish;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -30,20 +30,29 @@ import java.io.IOException;
 /**
  * Class encapsulating stats about the PendingClusterStatsQueue
  */
-public class PendingClusterStateStats implements Streamable, ToXContent {
+public class PendingClusterStateStats implements Writeable, ToXContent {
 
-    private int total;
-    private int pending;
-    private int committed;
-
-    public PendingClusterStateStats() {
-
-    }
+    private final int total;
+    private final int pending;
+    private final int committed;
 
     public PendingClusterStateStats(int total, int pending, int committed) {
         this.total = total;
         this.pending = pending;
         this.committed = committed;
+    }
+
+    public PendingClusterStateStats(StreamInput in) throws IOException {
+        total = in.readVInt();
+        pending = in.readVInt();
+        committed = in.readVInt();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(total);
+        out.writeVInt(pending);
+        out.writeVInt(committed);
     }
 
     public int getCommitted() {
@@ -66,20 +75,6 @@ public class PendingClusterStateStats implements Streamable, ToXContent {
         builder.field(Fields.COMMITTED, committed);
         builder.endObject();
         return builder;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        total = in.readVInt();
-        pending = in.readVInt();
-        committed = in.readVInt();
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeVInt(total);
-        out.writeVInt(pending);
-        out.writeVInt(committed);
     }
 
     static final class Fields {

--- a/core/src/main/java/org/elasticsearch/http/HttpStats.java
+++ b/core/src/main/java/org/elasticsearch/http/HttpStats.java
@@ -21,42 +21,23 @@ package org.elasticsearch.http;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class HttpStats implements Streamable, ToXContent {
+public class HttpStats implements Writeable, ToXContent {
 
-    private long serverOpen;
-    private long totalOpen;
-
-    HttpStats() {
-
-    }
+    private final long serverOpen;
+    private final long totalOpen;
 
     public HttpStats(long serverOpen, long totalOpen) {
         this.serverOpen = serverOpen;
         this.totalOpen = totalOpen;
     }
 
-    public long getServerOpen() {
-        return this.serverOpen;
-    }
-
-    public long getTotalOpen() {
-        return this.totalOpen;
-    }
-
-    public static HttpStats readHttpStats(StreamInput in) throws IOException {
-        HttpStats stats = new HttpStats();
-        stats.readFrom(in);
-        return stats;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
+    public HttpStats(StreamInput in) throws IOException {
         serverOpen = in.readVLong();
         totalOpen = in.readVLong();
     }
@@ -65,6 +46,14 @@ public class HttpStats implements Streamable, ToXContent {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(serverOpen);
         out.writeVLong(totalOpen);
+    }
+
+    public long getServerOpen() {
+        return this.serverOpen;
+    }
+
+    public long getTotalOpen() {
+        return this.totalOpen;
     }
 
     static final class Fields {

--- a/core/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/core/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -35,12 +35,12 @@ import org.elasticsearch.index.engine.SegmentsStats;
 import org.elasticsearch.index.fielddata.FieldDataStats;
 import org.elasticsearch.index.flush.FlushStats;
 import org.elasticsearch.index.get.GetStats;
-import org.elasticsearch.index.shard.IndexingStats;
 import org.elasticsearch.index.merge.MergeStats;
 import org.elasticsearch.index.recovery.RecoveryStats;
 import org.elasticsearch.index.refresh.RefreshStats;
 import org.elasticsearch.index.search.stats.SearchStats;
 import org.elasticsearch.index.shard.DocsStats;
+import org.elasticsearch.index.shard.IndexingStats;
 import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.search.suggest.completion.CompletionStats;
 
@@ -154,7 +154,7 @@ public class NodeIndicesStats implements Streamable, ToXContent {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        stats = CommonStats.readCommonStats(in);
+        stats = new CommonStats(in);
         if (in.readBoolean()) {
             int entries = in.readVInt();
             statsByShard = new HashMap<>();

--- a/core/src/main/java/org/elasticsearch/indices/breaker/AllCircuitBreakerStats.java
+++ b/core/src/main/java/org/elasticsearch/indices/breaker/AllCircuitBreakerStats.java
@@ -21,7 +21,7 @@ package org.elasticsearch.indices.breaker;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -30,16 +30,21 @@ import java.io.IOException;
 /**
  * Stats class encapsulating all of the different circuit breaker stats
  */
-public class AllCircuitBreakerStats implements Streamable, ToXContent {
+public class AllCircuitBreakerStats implements Writeable, ToXContent {
 
-    private CircuitBreakerStats[] allStats = new CircuitBreakerStats[0];
-
-    public AllCircuitBreakerStats() {
-
-    }
+    private final CircuitBreakerStats[] allStats;
 
     public AllCircuitBreakerStats(CircuitBreakerStats[] allStats) {
         this.allStats = allStats;
+    }
+
+    public AllCircuitBreakerStats(StreamInput in) throws IOException {
+        allStats = in.readArray(CircuitBreakerStats::new, CircuitBreakerStats[]::new);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeArray(allStats);
     }
 
     public CircuitBreakerStats[] getAllStats() {
@@ -53,33 +58,6 @@ public class AllCircuitBreakerStats implements Streamable, ToXContent {
             }
         }
         return null;
-    }
-
-    public static AllCircuitBreakerStats readOptionalAllCircuitBreakerStats(StreamInput in) throws IOException {
-        AllCircuitBreakerStats stats = in.readOptionalStreamable(AllCircuitBreakerStats::new);
-        return stats;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        int statCount = in.readVInt();
-        CircuitBreakerStats[] newStats = new CircuitBreakerStats[statCount];
-        for (int i = 0; i < statCount; i++) {
-            CircuitBreakerStats stats = new CircuitBreakerStats();
-            stats.readFrom(in);
-            newStats[i] = stats;
-        }
-        allStats = newStats;
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeVInt(allStats.length);
-        for (CircuitBreakerStats stats : allStats) {
-            if (stats != null) {
-                stats.writeTo(out);
-            }
-        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerStats.java
+++ b/core/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerStats.java
@@ -49,7 +49,6 @@ public class CircuitBreakerStats implements Writeable, ToXContent {
     }
 
     public CircuitBreakerStats(StreamInput in) throws IOException {
-        // limit is the maximum from the old circuit breaker stats for backwards compatibility
         limit = in.readLong();
         estimated = in.readLong();
         overhead = in.readDouble();

--- a/core/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerStats.java
+++ b/core/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerStats.java
@@ -21,7 +21,7 @@ package org.elasticsearch.indices.breaker;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -32,17 +32,13 @@ import java.util.Locale;
 /**
  * Class encapsulating stats about the circuit breaker
  */
-public class CircuitBreakerStats implements Streamable, ToXContent {
+public class CircuitBreakerStats implements Writeable, ToXContent {
 
-    private String name;
-    private long limit;
-    private long estimated;
-    private long trippedCount;
-    private double overhead;
-
-    CircuitBreakerStats() {
-
-    }
+    private final String name;
+    private final long limit;
+    private final long estimated;
+    private final long trippedCount;
+    private final double overhead;
 
     public CircuitBreakerStats(String name, long limit, long estimated, double overhead, long trippedCount) {
         this.name = name;
@@ -50,6 +46,24 @@ public class CircuitBreakerStats implements Streamable, ToXContent {
         this.estimated = estimated;
         this.trippedCount = trippedCount;
         this.overhead = overhead;
+    }
+
+    public CircuitBreakerStats(StreamInput in) throws IOException {
+        // limit is the maximum from the old circuit breaker stats for backwards compatibility
+        limit = in.readLong();
+        estimated = in.readLong();
+        overhead = in.readDouble();
+        this.trippedCount = in.readLong();
+        this.name = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeLong(limit);
+        out.writeLong(estimated);
+        out.writeDouble(overhead);
+        out.writeLong(trippedCount);
+        out.writeString(name);
     }
 
     public String getName() {
@@ -70,30 +84,6 @@ public class CircuitBreakerStats implements Streamable, ToXContent {
 
     public double getOverhead() {
         return this.overhead;
-    }
-
-    public static CircuitBreakerStats readOptionalCircuitBreakerStats(StreamInput in) throws IOException {
-        CircuitBreakerStats stats = in.readOptionalStreamable(CircuitBreakerStats::new);
-        return stats;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        // limit is the maximum from the old circuit breaker stats for backwards compatibility
-        limit = in.readLong();
-        estimated = in.readLong();
-        overhead = in.readDouble();
-        this.trippedCount = in.readLong();
-        this.name = in.readString();
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeLong(limit);
-        out.writeLong(estimated);
-        out.writeDouble(overhead);
-        out.writeLong(trippedCount);
-        out.writeString(name);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
+++ b/core/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
@@ -386,6 +386,30 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContent {
             out.writeLong(totalWriteKilobytes);
         }
 
+        public DeviceStats[] getDevicesStats() {
+            return devicesStats;
+        }
+
+        public long getTotalOperations() {
+            return totalOperations;
+        }
+
+        public long getTotalReadOperations() {
+            return totalReadOperations;
+        }
+
+        public long getTotalWriteOperations() {
+            return totalWriteOperations;
+        }
+
+        public long getTotalReadKilobytes() {
+            return totalReadKilobytes;
+        }
+
+        public long getTotalWriteKilobytes() {
+            return totalWriteKilobytes;
+        }
+
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             if (devicesStats.length > 0) {

--- a/core/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
+++ b/core/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
@@ -410,16 +410,16 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContent {
 
     }
 
-    final long timestamp;
-    final Path[] paths;
-    final IoStats ioStats;
-    Path total;
+    private final long timestamp;
+    private final Path[] paths;
+    private final IoStats ioStats;
+    private final Path total;
 
     public FsInfo(long timestamp, IoStats ioStats, Path[] paths) {
         this.timestamp = timestamp;
         this.ioStats = ioStats;
         this.paths = paths;
-        this.total = null;
+        this.total = total();
     }
 
     /**
@@ -432,6 +432,7 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContent {
         for (int i = 0; i < paths.length; i++) {
             paths[i] = new Path(in);
         }
+        this.total = total();
     }
 
     @Override
@@ -445,13 +446,10 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContent {
     }
 
     public Path getTotal() {
-        return total();
+        return total;
     }
 
-    public Path total() {
-        if (total != null) {
-            return total;
-        }
+    private Path total() {
         Path res = new Path();
         Set<String> seenDevices = new HashSet<>(paths.length);
         for (Path subPath : paths) {
@@ -462,7 +460,6 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContent {
             }
             res.add(subPath);
         }
-        total = res;
         return res;
     }
 
@@ -506,5 +503,4 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContent {
         static final String TOTAL = "total";
         static final String IO_STATS = "io_stats";
     }
-
 }

--- a/core/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/core/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -19,9 +19,10 @@
 
 package org.elasticsearch.monitor.jvm;
 
+import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -39,14 +40,12 @@ import java.lang.management.RuntimeMXBean;
 import java.lang.management.ThreadMXBean;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-/**
- *
- */
-public class JvmStats implements Streamable, ToXContent {
+public class JvmStats implements Writeable, ToXContent {
 
     private static final RuntimeMXBean runtimeMXBean;
     private static final MemoryMXBean memoryMXBean;
@@ -61,21 +60,17 @@ public class JvmStats implements Streamable, ToXContent {
     }
 
     public static JvmStats jvmStats() {
-        JvmStats stats = new JvmStats(System.currentTimeMillis(), runtimeMXBean.getUptime());
-        stats.mem = new Mem();
         MemoryUsage memUsage = memoryMXBean.getHeapMemoryUsage();
-        stats.mem.heapUsed = memUsage.getUsed() < 0 ? 0 : memUsage.getUsed();
-        stats.mem.heapCommitted = memUsage.getCommitted() < 0 ? 0 : memUsage.getCommitted();
-        stats.mem.heapMax = memUsage.getMax() < 0 ? 0 : memUsage.getMax();
+        long heapUsed = memUsage.getUsed() < 0 ? 0 : memUsage.getUsed();
+        long heapCommitted = memUsage.getCommitted() < 0 ? 0 : memUsage.getCommitted();
+        long heapMax = memUsage.getMax() < 0 ? 0 : memUsage.getMax();
         memUsage = memoryMXBean.getNonHeapMemoryUsage();
-        stats.mem.nonHeapUsed = memUsage.getUsed() < 0 ? 0 : memUsage.getUsed();
-        stats.mem.nonHeapCommitted = memUsage.getCommitted() < 0 ? 0 : memUsage.getCommitted();
-
+        long nonHeapUsed = memUsage.getUsed() < 0 ? 0 : memUsage.getUsed();
+        long nonHeapCommitted = memUsage.getCommitted() < 0 ? 0 : memUsage.getCommitted();
         List<MemoryPoolMXBean> memoryPoolMXBeans = ManagementFactory.getMemoryPoolMXBeans();
         List<MemoryPool> pools = new ArrayList<>();
-        for (int i = 0; i < memoryPoolMXBeans.size(); i++) {
+        for (MemoryPoolMXBean memoryPoolMXBean : memoryPoolMXBeans) {
             try {
-                MemoryPoolMXBean memoryPoolMXBean = memoryPoolMXBeans.get(i);
                 MemoryUsage usage = memoryPoolMXBean.getUsage();
                 MemoryUsage peakUsage = memoryPoolMXBean.getPeakUsage();
                 String name = GcNames.getByMemoryPoolName(memoryPoolMXBean.getName(), null);
@@ -94,55 +89,84 @@ public class JvmStats implements Streamable, ToXContent {
                  * we just omit the pool in that case!*/
             }
         }
-        stats.mem.pools = pools.toArray(new MemoryPool[pools.size()]);
-
-        stats.threads = new Threads();
-        stats.threads.count = threadMXBean.getThreadCount();
-        stats.threads.peakCount = threadMXBean.getPeakThreadCount();
+        MemoryPool[] memoryPools = pools.toArray(new MemoryPool[pools.size()]);
+        Mem mem = new Mem(heapCommitted, heapUsed, heapMax, nonHeapCommitted, nonHeapUsed, memoryPools);
+        Threads threads = new Threads(threadMXBean.getThreadCount(), threadMXBean.getPeakThreadCount());
 
         List<GarbageCollectorMXBean> gcMxBeans = ManagementFactory.getGarbageCollectorMXBeans();
-        stats.gc = new GarbageCollectors();
-        stats.gc.collectors = new GarbageCollector[gcMxBeans.size()];
-        for (int i = 0; i < stats.gc.collectors.length; i++) {
+        GarbageCollector[] collectors = new GarbageCollector[gcMxBeans.size()];
+        for (int i = 0; i < collectors.length; i++) {
             GarbageCollectorMXBean gcMxBean = gcMxBeans.get(i);
-            stats.gc.collectors[i] = new GarbageCollector();
-            stats.gc.collectors[i].name = GcNames.getByGcName(gcMxBean.getName(), gcMxBean.getName());
-            stats.gc.collectors[i].collectionCount = gcMxBean.getCollectionCount();
-            stats.gc.collectors[i].collectionTime = gcMxBean.getCollectionTime();
+            collectors[i] = new GarbageCollector(GcNames.getByGcName(gcMxBean.getName(), gcMxBean.getName()),
+                    gcMxBean.getCollectionCount(), gcMxBean.getCollectionTime());
         }
-
+        GarbageCollectors garbageCollectors = new GarbageCollectors(collectors);
+        List<BufferPool> bufferPoolsList = null;
         try {
             List<BufferPoolMXBean> bufferPools = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class);
-            stats.bufferPools = new ArrayList<>(bufferPools.size());
+            bufferPoolsList = new ArrayList<>(bufferPools.size());
             for (BufferPoolMXBean bufferPool : bufferPools) {
-                stats.bufferPools.add(new BufferPool(bufferPool.getName(), bufferPool.getCount(), bufferPool.getTotalCapacity(), bufferPool.getMemoryUsed()));
+                bufferPoolsList.add(new BufferPool(bufferPool.getName(), bufferPool.getCount(),
+                        bufferPool.getTotalCapacity(), bufferPool.getMemoryUsed()));
             }
         } catch (Exception e) {
             // buffer pools are not available
         }
 
-        stats.classes = new Classes();
-        stats.classes.loadedClassCount = classLoadingMXBean.getLoadedClassCount();
-        stats.classes.totalLoadedClassCount = classLoadingMXBean.getTotalLoadedClassCount();
-        stats.classes.unloadedClassCount = classLoadingMXBean.getUnloadedClassCount();
+        Classes classes = new Classes(classLoadingMXBean.getLoadedClassCount(), classLoadingMXBean.getTotalLoadedClassCount(),
+                classLoadingMXBean.getUnloadedClassCount());
 
-        return stats;
+        return new JvmStats(System.currentTimeMillis(), runtimeMXBean.getUptime(), mem, threads,
+                garbageCollectors, bufferPoolsList, classes);
     }
 
-    long timestamp = -1;
-    long uptime;
-    Mem mem;
-    Threads threads;
-    GarbageCollectors gc;
-    List<BufferPool> bufferPools;
-    Classes classes;
+    private final long timestamp;
+    private final long uptime;
+    private final Mem mem;
+    private final Threads threads;
+    private final GarbageCollectors gc;
+    private final List<BufferPool> bufferPools;
+    private final Classes classes;
 
-    private JvmStats() {
-    }
-
-    public JvmStats(long timestamp, long uptime) {
+    public JvmStats(long timestamp, long uptime, Mem mem, Threads threads, GarbageCollectors gc,
+                    @Nullable List<BufferPool> bufferPools, Classes classes) {
         this.timestamp = timestamp;
         this.uptime = uptime;
+        this.mem = mem;
+        this.threads = threads;
+        this.gc = gc;
+        this.bufferPools = bufferPools;
+        this.classes = classes;
+    }
+
+    public JvmStats(StreamInput in) throws IOException {
+        timestamp = in.readVLong();
+        uptime = in.readVLong();
+        mem = new Mem(in);
+        threads = new Threads(in);
+        gc = new GarbageCollectors(in);
+        if (in.readBoolean()) {
+            bufferPools = in.readList(BufferPool::new);
+        } else {
+            bufferPools = Collections.emptyList();
+        }
+        classes = new Classes(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(timestamp);
+        out.writeVLong(uptime);
+        mem.writeTo(out);
+        threads.writeTo(out);
+        gc.writeTo(out);
+        if (bufferPools == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeList(bufferPools);
+        }
+        classes.writeTo(out);
     }
 
     public long getTimestamp() {
@@ -178,53 +202,50 @@ public class JvmStats implements Streamable, ToXContent {
         builder.startObject(Fields.JVM);
         builder.field(Fields.TIMESTAMP, timestamp);
         builder.timeValueField(Fields.UPTIME_IN_MILLIS, Fields.UPTIME, uptime);
-        if (mem != null) {
-            builder.startObject(Fields.MEM);
 
-            builder.byteSizeField(Fields.HEAP_USED_IN_BYTES, Fields.HEAP_USED, mem.heapUsed);
-            if (mem.getHeapUsedPercent() >= 0) {
-                builder.field(Fields.HEAP_USED_PERCENT, mem.getHeapUsedPercent());
-            }
-            builder.byteSizeField(Fields.HEAP_COMMITTED_IN_BYTES, Fields.HEAP_COMMITTED, mem.heapCommitted);
-            builder.byteSizeField(Fields.HEAP_MAX_IN_BYTES, Fields.HEAP_MAX, mem.heapMax);
-            builder.byteSizeField(Fields.NON_HEAP_USED_IN_BYTES, Fields.NON_HEAP_USED, mem.nonHeapUsed);
-            builder.byteSizeField(Fields.NON_HEAP_COMMITTED_IN_BYTES, Fields.NON_HEAP_COMMITTED, mem.nonHeapCommitted);
+        builder.startObject(Fields.MEM);
 
-            builder.startObject(Fields.POOLS);
-            for (MemoryPool pool : mem) {
-                builder.startObject(pool.getName());
-                builder.byteSizeField(Fields.USED_IN_BYTES, Fields.USED, pool.used);
-                builder.byteSizeField(Fields.MAX_IN_BYTES, Fields.MAX, pool.max);
+        builder.byteSizeField(Fields.HEAP_USED_IN_BYTES, Fields.HEAP_USED, mem.heapUsed);
+        if (mem.getHeapUsedPercent() >= 0) {
+            builder.field(Fields.HEAP_USED_PERCENT, mem.getHeapUsedPercent());
+        }
+        builder.byteSizeField(Fields.HEAP_COMMITTED_IN_BYTES, Fields.HEAP_COMMITTED, mem.heapCommitted);
+        builder.byteSizeField(Fields.HEAP_MAX_IN_BYTES, Fields.HEAP_MAX, mem.heapMax);
+        builder.byteSizeField(Fields.NON_HEAP_USED_IN_BYTES, Fields.NON_HEAP_USED, mem.nonHeapUsed);
+        builder.byteSizeField(Fields.NON_HEAP_COMMITTED_IN_BYTES, Fields.NON_HEAP_COMMITTED, mem.nonHeapCommitted);
 
-                builder.byteSizeField(Fields.PEAK_USED_IN_BYTES, Fields.PEAK_USED, pool.peakUsed);
-                builder.byteSizeField(Fields.PEAK_MAX_IN_BYTES, Fields.PEAK_MAX, pool.peakMax);
+        builder.startObject(Fields.POOLS);
+        for (MemoryPool pool : mem) {
+            builder.startObject(pool.getName());
+            builder.byteSizeField(Fields.USED_IN_BYTES, Fields.USED, pool.used);
+            builder.byteSizeField(Fields.MAX_IN_BYTES, Fields.MAX, pool.max);
 
-                builder.endObject();
-            }
-            builder.endObject();
+            builder.byteSizeField(Fields.PEAK_USED_IN_BYTES, Fields.PEAK_USED, pool.peakUsed);
+            builder.byteSizeField(Fields.PEAK_MAX_IN_BYTES, Fields.PEAK_MAX, pool.peakMax);
 
             builder.endObject();
         }
-        if (threads != null) {
-            builder.startObject(Fields.THREADS);
-            builder.field(Fields.COUNT, threads.getCount());
-            builder.field(Fields.PEAK_COUNT, threads.getPeakCount());
+        builder.endObject();
+
+        builder.endObject();
+
+        builder.startObject(Fields.THREADS);
+        builder.field(Fields.COUNT, threads.getCount());
+        builder.field(Fields.PEAK_COUNT, threads.getPeakCount());
+        builder.endObject();
+
+        builder.startObject(Fields.GC);
+
+        builder.startObject(Fields.COLLECTORS);
+        for (GarbageCollector collector : gc) {
+            builder.startObject(collector.getName());
+            builder.field(Fields.COLLECTION_COUNT, collector.getCollectionCount());
+            builder.timeValueField(Fields.COLLECTION_TIME_IN_MILLIS, Fields.COLLECTION_TIME, collector.collectionTime);
             builder.endObject();
         }
-        if (gc != null) {
-            builder.startObject(Fields.GC);
+        builder.endObject();
 
-            builder.startObject(Fields.COLLECTORS);
-            for (GarbageCollector collector : gc) {
-                builder.startObject(collector.getName());
-                builder.field(Fields.COLLECTION_COUNT, collector.getCollectionCount());
-                builder.timeValueField(Fields.COLLECTION_TIME_IN_MILLIS, Fields.COLLECTION_TIME, collector.collectionTime);
-                builder.endObject();
-            }
-            builder.endObject();
-
-            builder.endObject();
-        }
+        builder.endObject();
 
         if (bufferPools != null) {
             builder.startObject(Fields.BUFFER_POOLS);
@@ -238,13 +259,11 @@ public class JvmStats implements Streamable, ToXContent {
             builder.endObject();
         }
 
-        if (classes != null) {
-            builder.startObject(Fields.CLASSES);
-            builder.field(Fields.CURRENT_LOADED_COUNT, classes.getLoadedClassCount());
-            builder.field(Fields.TOTAL_LOADED_COUNT, classes.getTotalLoadedClassCount());
-            builder.field(Fields.TOTAL_UNLOADED_COUNT, classes.getUnloadedClassCount());
-            builder.endObject();
-        }
+        builder.startObject(Fields.CLASSES);
+        builder.field(Fields.CURRENT_LOADED_COUNT, classes.getLoadedClassCount());
+        builder.field(Fields.TOTAL_LOADED_COUNT, classes.getTotalLoadedClassCount());
+        builder.field(Fields.TOTAL_UNLOADED_COUNT, classes.getUnloadedClassCount());
+        builder.endObject();
 
         builder.endObject();
         return builder;
@@ -291,7 +310,6 @@ public class JvmStats implements Streamable, ToXContent {
         static final String COLLECTION_TIME_IN_MILLIS = "collection_time_in_millis";
 
         static final String BUFFER_POOLS = "buffer_pools";
-        static final String NAME = "name";
         static final String TOTAL_CAPACITY = "total_capacity";
         static final String TOTAL_CAPACITY_IN_BYTES = "total_capacity_in_bytes";
 
@@ -301,80 +319,21 @@ public class JvmStats implements Streamable, ToXContent {
         static final String TOTAL_UNLOADED_COUNT = "total_unloaded_count";
     }
 
+    public static class GarbageCollectors implements Writeable, Iterable<GarbageCollector> {
 
-    public static JvmStats readJvmStats(StreamInput in) throws IOException {
-        JvmStats jvmStats = new JvmStats();
-        jvmStats.readFrom(in);
-        return jvmStats;
-    }
+        private final GarbageCollector[] collectors;
 
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        timestamp = in.readVLong();
-        uptime = in.readVLong();
-
-        mem = Mem.readMem(in);
-        threads = Threads.readThreads(in);
-        gc = GarbageCollectors.readGarbageCollectors(in);
-
-        if (in.readBoolean()) {
-            int size = in.readVInt();
-            bufferPools = new ArrayList<>(size);
-            for (int i = 0; i < size; i++) {
-                BufferPool bufferPool = new BufferPool();
-                bufferPool.readFrom(in);
-                bufferPools.add(bufferPool);
-            }
-        }
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeVLong(timestamp);
-        out.writeVLong(uptime);
-
-        mem.writeTo(out);
-        threads.writeTo(out);
-        gc.writeTo(out);
-
-        if (bufferPools == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            out.writeVInt(bufferPools.size());
-            for (BufferPool bufferPool : bufferPools) {
-                bufferPool.writeTo(out);
-            }
-        }
-    }
-
-    public static class GarbageCollectors implements Streamable, Iterable<GarbageCollector> {
-
-        GarbageCollector[] collectors;
-
-        GarbageCollectors() {
+        public GarbageCollectors(GarbageCollector[] collectors) {
+            this.collectors = collectors;
         }
 
-        public static GarbageCollectors readGarbageCollectors(StreamInput in) throws IOException {
-            GarbageCollectors collectors = new GarbageCollectors();
-            collectors.readFrom(in);
-            return collectors;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            collectors = new GarbageCollector[in.readVInt()];
-            for (int i = 0; i < collectors.length; i++) {
-                collectors[i] = GarbageCollector.readGarbageCollector(in);
-            }
+        public GarbageCollectors(StreamInput in) throws IOException {
+            collectors = in.readArray(GarbageCollector::new, GarbageCollector[]::new);
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeVInt(collectors.length);
-            for (GarbageCollector gc : collectors) {
-                gc.writeTo(out);
-            }
+            out.writeArray(collectors);
         }
 
         public GarbageCollector[] getCollectors() {
@@ -387,23 +346,19 @@ public class JvmStats implements Streamable, ToXContent {
         }
     }
 
-    public static class GarbageCollector implements Streamable {
+    public static class GarbageCollector implements Writeable {
 
-        String name;
-        long collectionCount;
-        long collectionTime;
+        private final String name;
+        private final long collectionCount;
+        private final long collectionTime;
 
-        GarbageCollector() {
+        public GarbageCollector(String name, long collectionCount, long collectionTime) {
+            this.name = name;
+            this.collectionCount = collectionCount;
+            this.collectionTime = collectionTime;
         }
 
-        public static GarbageCollector readGarbageCollector(StreamInput in) throws IOException {
-            GarbageCollector gc = new GarbageCollector();
-            gc.readFrom(in);
-            return gc;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
+        public GarbageCollector(StreamInput in) throws IOException {
             name = in.readString();
             collectionCount = in.readVLong();
             collectionTime = in.readVLong();
@@ -429,30 +384,17 @@ public class JvmStats implements Streamable, ToXContent {
         }
     }
 
-    public static class Threads implements Streamable {
+    public static class Threads implements Writeable {
 
-        int count;
-        int peakCount;
+        private final int count;
+        private final int peakCount;
 
-        Threads() {
+        public Threads(int count, int peakCount) {
+            this.count = count;
+            this.peakCount = peakCount;
         }
 
-        public int getCount() {
-            return count;
-        }
-
-        public int getPeakCount() {
-            return peakCount;
-        }
-
-        public static Threads readThreads(StreamInput in) throws IOException {
-            Threads threads = new Threads();
-            threads.readFrom(in);
-            return threads;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
+        public Threads(StreamInput in) throws IOException {
             count = in.readVInt();
             peakCount = in.readVInt();
         }
@@ -462,20 +404,23 @@ public class JvmStats implements Streamable, ToXContent {
             out.writeVInt(count);
             out.writeVInt(peakCount);
         }
+
+        public int getCount() {
+            return count;
+        }
+
+        public int getPeakCount() {
+            return peakCount;
+        }
     }
 
-    public static class MemoryPool implements Streamable {
+    public static class MemoryPool implements Writeable {
 
-        String name;
-        long used;
-        long max;
-
-        long peakUsed;
-        long peakMax;
-
-        MemoryPool() {
-
-        }
+        private final String name;
+        private final long used;
+        private final long max;
+        private final long peakUsed;
+        private final long peakMax;
 
         public MemoryPool(String name, long used, long max, long peakUsed, long peakMax) {
             this.name = name;
@@ -485,10 +430,21 @@ public class JvmStats implements Streamable, ToXContent {
             this.peakMax = peakMax;
         }
 
-        public static MemoryPool readMemoryPool(StreamInput in) throws IOException {
-            MemoryPool pool = new MemoryPool();
-            pool.readFrom(in);
-            return pool;
+        public MemoryPool(StreamInput in) throws IOException {
+            name = in.readString();
+            used = in.readVLong();
+            max = in.readVLong();
+            peakUsed = in.readVLong();
+            peakMax = in.readVLong();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(name);
+            out.writeVLong(used);
+            out.writeVLong(max);
+            out.writeVLong(peakUsed);
+            out.writeVLong(peakMax);
         }
 
         public String getName() {
@@ -510,61 +466,33 @@ public class JvmStats implements Streamable, ToXContent {
         public ByteSizeValue getPeakMax() {
             return new ByteSizeValue(peakMax);
         }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            name = in.readString();
-            used = in.readVLong();
-            max = in.readVLong();
-            peakUsed = in.readVLong();
-            peakMax = in.readVLong();
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeString(name);
-            out.writeVLong(used);
-            out.writeVLong(max);
-            out.writeVLong(peakUsed);
-            out.writeVLong(peakMax);
-        }
     }
 
-    public static class Mem implements Streamable, Iterable<MemoryPool> {
+    public static class Mem implements Writeable, Iterable<MemoryPool> {
 
-        long heapCommitted;
-        long heapUsed;
-        long heapMax;
-        long nonHeapCommitted;
-        long nonHeapUsed;
+        private final long heapCommitted;
+        private final long heapUsed;
+        private final long heapMax;
+        private final long nonHeapCommitted;
+        private final long nonHeapUsed;
+        private final MemoryPool[] pools;
 
-        MemoryPool[] pools = new MemoryPool[0];
-
-        Mem() {
+        public Mem(long heapCommitted, long heapUsed, long heapMax, long nonHeapCommitted, long nonHeapUsed, MemoryPool[] pools) {
+            this.heapCommitted = heapCommitted;
+            this.heapUsed = heapUsed;
+            this.heapMax = heapMax;
+            this.nonHeapCommitted = nonHeapCommitted;
+            this.nonHeapUsed = nonHeapUsed;
+            this.pools = pools;
         }
 
-        public static Mem readMem(StreamInput in) throws IOException {
-            Mem mem = new Mem();
-            mem.readFrom(in);
-            return mem;
-        }
-
-        @Override
-        public Iterator<MemoryPool> iterator() {
-            return Arrays.stream(pools).iterator();
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
+        public Mem(StreamInput in) throws IOException {
             heapCommitted = in.readVLong();
             heapUsed = in.readVLong();
             nonHeapCommitted = in.readVLong();
             nonHeapUsed = in.readVLong();
             heapMax = in.readVLong();
-            pools = new MemoryPool[in.readVInt()];
-            for (int i = 0; i < pools.length; i++) {
-                pools[i] = MemoryPool.readMemoryPool(in);
-            }
+            pools = in.readArray(MemoryPool::new, MemoryPool[]::new);
         }
 
         @Override
@@ -574,10 +502,12 @@ public class JvmStats implements Streamable, ToXContent {
             out.writeVLong(nonHeapCommitted);
             out.writeVLong(nonHeapUsed);
             out.writeVLong(heapMax);
-            out.writeVInt(pools.length);
-            for (MemoryPool pool : pools) {
-                pool.writeTo(out);
-            }
+            out.writeArray(pools);
+        }
+
+        @Override
+        public Iterator<MemoryPool> iterator() {
+            return Arrays.stream(pools).iterator();
         }
 
         public ByteSizeValue getHeapCommitted() {
@@ -614,21 +544,33 @@ public class JvmStats implements Streamable, ToXContent {
         }
     }
 
-    public static class BufferPool implements Streamable {
+    public static class BufferPool implements Writeable {
 
-        String name;
-        long count;
-        long totalCapacity;
-        long used;
-
-        BufferPool() {
-        }
+        private final String name;
+        private final long count;
+        private final long totalCapacity;
+        private final long used;
 
         public BufferPool(String name, long count, long totalCapacity, long used) {
             this.name = name;
             this.count = count;
             this.totalCapacity = totalCapacity;
             this.used = used;
+        }
+
+        public BufferPool(StreamInput in) throws IOException {
+            name = in.readString();
+            count = in.readLong();
+            totalCapacity = in.readLong();
+            used = in.readLong();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(name);
+            out.writeLong(count);
+            out.writeLong(totalCapacity);
+            out.writeLong(used);
         }
 
         public String getName() {
@@ -646,37 +588,31 @@ public class JvmStats implements Streamable, ToXContent {
         public ByteSizeValue getUsed() {
             return new ByteSizeValue(used);
         }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            name = in.readString();
-            count = in.readLong();
-            totalCapacity = in.readLong();
-            used = in.readLong();
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeString(name);
-            out.writeLong(count);
-            out.writeLong(totalCapacity);
-            out.writeLong(used);
-        }
     }
 
-    public static class Classes implements Streamable {
+    public static class Classes implements Writeable {
 
-        long loadedClassCount;
-        long totalLoadedClassCount;
-        long unloadedClassCount;
-
-        Classes() {
-        }
+        private final long loadedClassCount;
+        private final long totalLoadedClassCount;
+        private final long unloadedClassCount;
 
         public Classes(long loadedClassCount, long totalLoadedClassCount, long unloadedClassCount) {
             this.loadedClassCount = loadedClassCount;
             this.totalLoadedClassCount = totalLoadedClassCount;
             this.unloadedClassCount = unloadedClassCount;
+        }
+
+        public Classes(StreamInput in) throws IOException {
+            loadedClassCount = in.readLong();
+            totalLoadedClassCount = in.readLong();
+            unloadedClassCount = in.readLong();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeLong(loadedClassCount);
+            out.writeLong(totalLoadedClassCount);
+            out.writeLong(unloadedClassCount);
         }
 
         public long getLoadedClassCount() {
@@ -689,20 +625,6 @@ public class JvmStats implements Streamable, ToXContent {
 
         public long getUnloadedClassCount() {
             return unloadedClassCount;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            loadedClassCount = in.readLong();
-            totalLoadedClassCount = in.readLong();
-            unloadedClassCount = in.readLong();
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeLong(loadedClassCount);
-            out.writeLong(totalLoadedClassCount);
-            out.writeLong(unloadedClassCount);
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/core/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.monitor.jvm;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -100,7 +99,7 @@ public class JvmStats implements Writeable, ToXContent {
                     gcMxBean.getCollectionCount(), gcMxBean.getCollectionTime());
         }
         GarbageCollectors garbageCollectors = new GarbageCollectors(collectors);
-        List<BufferPool> bufferPoolsList = null;
+        List<BufferPool> bufferPoolsList = Collections.emptyList();
         try {
             List<BufferPoolMXBean> bufferPools = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class);
             bufferPoolsList = new ArrayList<>(bufferPools.size());
@@ -128,7 +127,7 @@ public class JvmStats implements Writeable, ToXContent {
     private final Classes classes;
 
     public JvmStats(long timestamp, long uptime, Mem mem, Threads threads, GarbageCollectors gc,
-                    @Nullable List<BufferPool> bufferPools, Classes classes) {
+                    List<BufferPool> bufferPools, Classes classes) {
         this.timestamp = timestamp;
         this.uptime = uptime;
         this.mem = mem;
@@ -144,11 +143,7 @@ public class JvmStats implements Writeable, ToXContent {
         mem = new Mem(in);
         threads = new Threads(in);
         gc = new GarbageCollectors(in);
-        if (in.readBoolean()) {
-            bufferPools = in.readList(BufferPool::new);
-        } else {
-            bufferPools = null;
-        }
+        bufferPools = in.readList(BufferPool::new);
         classes = new Classes(in);
     }
 
@@ -159,12 +154,7 @@ public class JvmStats implements Writeable, ToXContent {
         mem.writeTo(out);
         threads.writeTo(out);
         gc.writeTo(out);
-        if (bufferPools == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            out.writeList(bufferPools);
-        }
+        out.writeList(bufferPools);
         classes.writeTo(out);
     }
 

--- a/core/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/core/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -40,7 +40,6 @@ import java.lang.management.RuntimeMXBean;
 import java.lang.management.ThreadMXBean;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -148,7 +147,7 @@ public class JvmStats implements Writeable, ToXContent {
         if (in.readBoolean()) {
             bufferPools = in.readList(BufferPool::new);
         } else {
-            bufferPools = Collections.emptyList();
+            bufferPools = null;
         }
         classes = new Classes(in);
     }

--- a/core/src/main/java/org/elasticsearch/monitor/process/ProcessProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/process/ProcessProbe.java
@@ -131,21 +131,9 @@ public class ProcessProbe {
     }
 
     public ProcessStats processStats() {
-        ProcessStats stats = new ProcessStats();
-        stats.timestamp = System.currentTimeMillis();
-        stats.openFileDescriptors = getOpenFileDescriptorCount();
-        stats.maxFileDescriptors = getMaxFileDescriptorCount();
-
-        ProcessStats.Cpu cpu = new ProcessStats.Cpu();
-        cpu.percent = getProcessCpuPercent();
-        cpu.total = getProcessCpuTotalTime();
-        stats.cpu = cpu;
-
-        ProcessStats.Mem mem = new ProcessStats.Mem();
-        mem.totalVirtual = getTotalVirtualMemorySize();
-        stats.mem = mem;
-
-        return stats;
+        ProcessStats.Cpu cpu = new ProcessStats.Cpu(getProcessCpuPercent(), getProcessCpuTotalTime());
+        ProcessStats.Mem mem = new ProcessStats.Mem(getTotalVirtualMemorySize());
+        return new ProcessStats(System.currentTimeMillis(), getOpenFileDescriptorCount(), getMaxFileDescriptorCount(), cpu, mem);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/monitor/process/ProcessStats.java
+++ b/core/src/main/java/org/elasticsearch/monitor/process/ProcessStats.java
@@ -21,7 +21,7 @@ package org.elasticsearch.monitor.process;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -29,18 +29,37 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class ProcessStats implements Streamable, ToXContent {
+public class ProcessStats implements Writeable, ToXContent {
 
-    long timestamp = -1;
+    private final long timestamp;
+    private final long openFileDescriptors;
+    private final long maxFileDescriptors;
+    private final Cpu cpu;
+    private final Mem mem;
 
-    long openFileDescriptors = -1;
-    long maxFileDescriptors = -1;
+    public ProcessStats(long timestamp, long openFileDescriptors, long maxFileDescriptors, Cpu cpu, Mem mem) {
+        this.timestamp = timestamp;
+        this.openFileDescriptors = openFileDescriptors;
+        this.maxFileDescriptors = maxFileDescriptors;
+        this.cpu = cpu;
+        this.mem = mem;
+    }
 
-    Cpu cpu = null;
+    public ProcessStats(StreamInput in) throws IOException {
+        timestamp = in.readVLong();
+        openFileDescriptors = in.readLong();
+        maxFileDescriptors = in.readLong();
+        cpu = in.readOptionalWriteable(Cpu::new);
+        mem = in.readOptionalWriteable(Mem::new);
+    }
 
-    Mem mem = null;
-
-    ProcessStats() {
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(timestamp);
+        out.writeLong(openFileDescriptors);
+        out.writeLong(maxFileDescriptors);
+        out.writeOptionalWriteable(cpu);
+        out.writeOptionalWriteable(mem);
     }
 
     public long getTimestamp() {
@@ -100,59 +119,15 @@ public class ProcessStats implements Streamable, ToXContent {
         return builder;
     }
 
-    public static ProcessStats readProcessStats(StreamInput in) throws IOException {
-        ProcessStats stats = new ProcessStats();
-        stats.readFrom(in);
-        return stats;
-    }
+    public static class Mem implements Writeable {
 
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        timestamp = in.readVLong();
-        openFileDescriptors = in.readLong();
-        maxFileDescriptors = in.readLong();
-        if (in.readBoolean()) {
-            cpu = Cpu.readCpu(in);
-        }
-        if (in.readBoolean()) {
-            mem = Mem.readMem(in);
-        }
-    }
+        private final long totalVirtual;
 
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeVLong(timestamp);
-        out.writeLong(openFileDescriptors);
-        out.writeLong(maxFileDescriptors);
-        if (cpu == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            cpu.writeTo(out);
-        }
-        if (mem == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            mem.writeTo(out);
-        }
-    }
-
-    public static class Mem implements Streamable {
-
-        long totalVirtual = -1;
-
-        Mem() {
+        public Mem(long totalVirtual) {
+            this.totalVirtual = totalVirtual;
         }
 
-        public static Mem readMem(StreamInput in) throws IOException {
-            Mem mem = new Mem();
-            mem.readFrom(in);
-            return mem;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
+        public Mem(StreamInput in) throws IOException {
             totalVirtual = in.readLong();
         }
 
@@ -166,23 +141,17 @@ public class ProcessStats implements Streamable, ToXContent {
         }
     }
 
-    public static class Cpu implements Streamable {
+    public static class Cpu implements Writeable {
 
-        short percent = -1;
-        long total = -1;
+        private final short percent;
+        private final long total;
 
-        Cpu() {
-
+        public Cpu(short percent, long total) {
+            this.percent = percent;
+            this.total = total;
         }
 
-        public static Cpu readCpu(StreamInput in) throws IOException {
-            Cpu cpu = new Cpu();
-            cpu.readFrom(in);
-            return cpu;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
+        public Cpu(StreamInput in) throws IOException {
             percent = in.readShort();
             total = in.readLong();
         }

--- a/core/src/main/java/org/elasticsearch/script/ScriptStats.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptStats.java
@@ -21,39 +21,22 @@ package org.elasticsearch.script;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class ScriptStats implements Streamable, ToXContent {
-    private long compilations;
-    private long cacheEvictions;
-
-    public ScriptStats() {
-    }
+public class ScriptStats implements Writeable, ToXContent {
+    private final long compilations;
+    private final long cacheEvictions;
 
     public ScriptStats(long compilations, long cacheEvictions) {
         this.compilations = compilations;
         this.cacheEvictions = cacheEvictions;
     }
 
-    public void add(ScriptStats stats) {
-        this.compilations += stats.compilations;
-        this.cacheEvictions += stats.cacheEvictions;
-    }
-
-    public long getCompilations() {
-        return compilations;
-    }
-
-    public long getCacheEvictions() {
-        return cacheEvictions;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
+    public ScriptStats(StreamInput in) throws IOException {
         compilations = in.readVLong();
         cacheEvictions = in.readVLong();
     }
@@ -62,6 +45,14 @@ public class ScriptStats implements Streamable, ToXContent {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(compilations);
         out.writeVLong(cacheEvictions);
+    }
+
+    public long getCompilations() {
+        return compilations;
+    }
+
+    public long getCacheEvictions() {
+        return cacheEvictions;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/threadpool/ThreadPoolStats.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ThreadPoolStats.java
@@ -21,33 +21,26 @@ package org.elasticsearch.threadpool;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-/**
- */
-public class ThreadPoolStats implements Streamable, ToXContent, Iterable<ThreadPoolStats.Stats> {
+public class ThreadPoolStats implements Writeable, ToXContent, Iterable<ThreadPoolStats.Stats> {
 
-    public static class Stats implements Streamable, ToXContent, Comparable<Stats> {
+    public static class Stats implements Writeable, ToXContent, Comparable<Stats> {
 
-        private String name;
-        private int threads;
-        private int queue;
-        private int active;
-        private long rejected;
-        private int largest;
-        private long completed;
-
-        Stats() {
-
-        }
+        private final String name;
+        private final int threads;
+        private final int queue;
+        private final int active;
+        private final long rejected;
+        private final int largest;
+        private final long completed;
 
         public Stats(String name, int threads, int queue, int active, long rejected, int largest, long completed) {
             this.name = name;
@@ -57,6 +50,27 @@ public class ThreadPoolStats implements Streamable, ToXContent, Iterable<ThreadP
             this.rejected = rejected;
             this.largest = largest;
             this.completed = completed;
+        }
+
+        public Stats(StreamInput in) throws IOException {
+            name = in.readString();
+            threads = in.readInt();
+            queue = in.readInt();
+            active = in.readInt();
+            rejected = in.readLong();
+            largest = in.readInt();
+            completed = in.readLong();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(name);
+            out.writeInt(threads);
+            out.writeInt(queue);
+            out.writeInt(active);
+            out.writeLong(rejected);
+            out.writeInt(largest);
+            out.writeLong(completed);
         }
 
         public String getName() {
@@ -85,28 +99,6 @@ public class ThreadPoolStats implements Streamable, ToXContent, Iterable<ThreadP
 
         public long getCompleted() {
             return this.completed;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            name = in.readString();
-            threads = in.readInt();
-            queue = in.readInt();
-            active = in.readInt();
-            rejected = in.readLong();
-            largest = in.readInt();
-            completed = in.readLong();
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeString(name);
-            out.writeInt(threads);
-            out.writeInt(queue);
-            out.writeInt(active);
-            out.writeLong(rejected);
-            out.writeInt(largest);
-            out.writeLong(completed);
         }
 
         @Override
@@ -154,43 +146,23 @@ public class ThreadPoolStats implements Streamable, ToXContent, Iterable<ThreadP
 
     private List<Stats> stats;
 
-    ThreadPoolStats() {
-
-    }
-
     public ThreadPoolStats(List<Stats> stats) {
         Collections.sort(stats);
         this.stats = stats;
     }
 
-    @Override
-    public Iterator<Stats> iterator() {
-        return stats.iterator();
-    }
-
-    public static ThreadPoolStats readThreadPoolStats(StreamInput in) throws IOException {
-        ThreadPoolStats stats = new ThreadPoolStats();
-        stats.readFrom(in);
-        return stats;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        int size = in.readVInt();
-        stats = new ArrayList<>(size);
-        for (int i = 0; i < size; i++) {
-            Stats stats1 = new Stats();
-            stats1.readFrom(in);
-            stats.add(stats1);
-        }
+    public ThreadPoolStats(StreamInput in) throws IOException {
+        stats = in.readList(Stats::new);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeVInt(stats.size());
-        for (Stats stat : stats) {
-            stat.writeTo(out);
-        }
+        out.writeList(stats);
+    }
+
+    @Override
+    public Iterator<Stats> iterator() {
+        return stats.iterator();
     }
 
     static final class Fields {

--- a/core/src/main/java/org/elasticsearch/transport/TransportStats.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportStats.java
@@ -21,24 +21,20 @@ package org.elasticsearch.transport;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class TransportStats implements Streamable, ToXContent {
+public class TransportStats implements Writeable, ToXContent {
 
-    private long serverOpen;
-    private long rxCount;
-    private long rxSize;
-    private long txCount;
-    private long txSize;
-
-    TransportStats() {
-
-    }
+    private final long serverOpen;
+    private final long rxCount;
+    private final long rxSize;
+    private final long txCount;
+    private final long txSize;
 
     public TransportStats(long serverOpen, long rxCount, long rxSize, long txCount, long txSize) {
         this.serverOpen = serverOpen;
@@ -46,6 +42,23 @@ public class TransportStats implements Streamable, ToXContent {
         this.rxSize = rxSize;
         this.txCount = txCount;
         this.txSize = txSize;
+    }
+
+    public TransportStats(StreamInput in) throws IOException {
+        serverOpen = in.readVLong();
+        rxCount = in.readVLong();
+        rxSize = in.readVLong();
+        txCount = in.readVLong();
+        txSize = in.readVLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(serverOpen);
+        out.writeVLong(rxCount);
+        out.writeVLong(rxSize);
+        out.writeVLong(txCount);
+        out.writeVLong(txSize);
     }
 
     public long serverOpen() {
@@ -86,30 +99,6 @@ public class TransportStats implements Streamable, ToXContent {
 
     public ByteSizeValue getTxSize() {
         return txSize();
-    }
-
-    public static TransportStats readTransportStats(StreamInput in) throws IOException {
-        TransportStats stats = new TransportStats();
-        stats.readFrom(in);
-        return stats;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        serverOpen = in.readVLong();
-        rxCount = in.readVLong();
-        rxSize = in.readVLong();
-        txCount = in.readVLong();
-        txSize = in.readVLong();
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeVLong(serverOpen);
-        out.writeVLong(rxCount);
-        out.writeVLong(rxSize);
-        out.writeVLong(txCount);
-        out.writeVLong(txSize);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.stats;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.transport.LocalTransportAddress;
+import org.elasticsearch.discovery.DiscoveryStats;
+import org.elasticsearch.discovery.zen.publish.PendingClusterStateStats;
+import org.elasticsearch.http.HttpStats;
+import org.elasticsearch.indices.breaker.AllCircuitBreakerStats;
+import org.elasticsearch.indices.breaker.CircuitBreakerStats;
+import org.elasticsearch.ingest.IngestStats;
+import org.elasticsearch.monitor.fs.FsInfo;
+import org.elasticsearch.monitor.jvm.JvmStats;
+import org.elasticsearch.monitor.os.OsStats;
+import org.elasticsearch.monitor.process.ProcessStats;
+import org.elasticsearch.script.ScriptStats;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.threadpool.ThreadPoolStats;
+import org.elasticsearch.transport.TransportStats;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+
+public class NodeStatsTests extends ESTestCase {
+
+    public void testSerialization() throws IOException {
+        NodeStats nodeStats = createNodeStats();
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            nodeStats.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                NodeStats deserializedNodeStats = NodeStats.readNodeStats(in);
+                assertEquals(nodeStats.getNode(), deserializedNodeStats.getNode());
+                assertEquals(nodeStats.getTimestamp(), deserializedNodeStats.getTimestamp());
+                if (nodeStats.getOs() == null) {
+                    assertNull(deserializedNodeStats.getOs());
+                } else {
+                    assertEquals(nodeStats.getOs().getTimestamp(), deserializedNodeStats.getOs().getTimestamp());
+                    assertEquals(nodeStats.getOs().getSwap().getFree(), deserializedNodeStats.getOs().getSwap().getFree());
+                    assertEquals(nodeStats.getOs().getSwap().getTotal(), deserializedNodeStats.getOs().getSwap().getTotal());
+                    assertEquals(nodeStats.getOs().getSwap().getUsed(), deserializedNodeStats.getOs().getSwap().getUsed());
+                    assertEquals(nodeStats.getOs().getMem().getFree(), deserializedNodeStats.getOs().getMem().getFree());
+                    assertEquals(nodeStats.getOs().getMem().getTotal(), deserializedNodeStats.getOs().getMem().getTotal());
+                    assertEquals(nodeStats.getOs().getMem().getUsed(), deserializedNodeStats.getOs().getMem().getUsed());
+                    assertEquals(nodeStats.getOs().getMem().getFreePercent(), deserializedNodeStats.getOs().getMem().getFreePercent());
+                    assertEquals(nodeStats.getOs().getMem().getUsedPercent(), deserializedNodeStats.getOs().getMem().getUsedPercent());
+                    assertEquals(nodeStats.getOs().getCpu().getPercent(), deserializedNodeStats.getOs().getCpu().getPercent());
+                    assertArrayEquals(nodeStats.getOs().getCpu().getLoadAverage(),
+                            deserializedNodeStats.getOs().getCpu().getLoadAverage(), 0);
+                }
+                if (nodeStats.getProcess() == null) {
+                    assertNull(deserializedNodeStats.getProcess());
+                } else {
+                    assertEquals(nodeStats.getProcess().getTimestamp(), deserializedNodeStats.getProcess().getTimestamp());
+                    assertEquals(nodeStats.getProcess().getCpu().getTotal(), deserializedNodeStats.getProcess().getCpu().getTotal());
+                    assertEquals(nodeStats.getProcess().getCpu().getPercent(), deserializedNodeStats.getProcess().getCpu().getPercent());
+                    assertEquals(nodeStats.getProcess().getMem().getTotalVirtual(),
+                            deserializedNodeStats.getProcess().getMem().getTotalVirtual());
+                    assertEquals(nodeStats.getProcess().getMaxFileDescriptors(),
+                            deserializedNodeStats.getProcess().getMaxFileDescriptors());
+                    assertEquals(nodeStats.getProcess().getOpenFileDescriptors(),
+                            deserializedNodeStats.getProcess().getOpenFileDescriptors());
+                }
+                if (nodeStats.getJvm() == null) {
+                    assertNull(deserializedNodeStats.getJvm());
+                } else {
+                    assertEquals(nodeStats.getJvm().getTimestamp(), deserializedNodeStats.getJvm().getTimestamp());
+                    assertEquals(nodeStats.getJvm().getMem().getHeapUsedPercent(),
+                            deserializedNodeStats.getJvm().getMem().getHeapUsedPercent());
+                    assertEquals(nodeStats.getJvm().getMem().getHeapUsed(), deserializedNodeStats.getJvm().getMem().getHeapUsed());
+                    assertEquals(nodeStats.getJvm().getMem().getHeapCommitted(),
+                            deserializedNodeStats.getJvm().getMem().getHeapCommitted());
+                    assertEquals(nodeStats.getJvm().getMem().getNonHeapCommitted(),
+                            deserializedNodeStats.getJvm().getMem().getNonHeapCommitted());
+                    assertEquals(nodeStats.getJvm().getMem().getNonHeapUsed(), deserializedNodeStats.getJvm().getMem().getNonHeapUsed());
+                    assertEquals(nodeStats.getJvm().getMem().getHeapMax(), deserializedNodeStats.getJvm().getMem().getHeapMax());
+                    assertEquals(nodeStats.getJvm().getClasses().getLoadedClassCount(),
+                            deserializedNodeStats.getJvm().getClasses().getLoadedClassCount());
+                    assertEquals(nodeStats.getJvm().getClasses().getTotalLoadedClassCount(),
+                            deserializedNodeStats.getJvm().getClasses().getTotalLoadedClassCount());
+                    assertEquals(nodeStats.getJvm().getClasses().getUnloadedClassCount(),
+                            deserializedNodeStats.getJvm().getClasses().getUnloadedClassCount());
+                    assertEquals(nodeStats.getJvm().getGc().getCollectors().length,
+                            deserializedNodeStats.getJvm().getGc().getCollectors().length);
+                    for (int i = 0; i < nodeStats.getJvm().getGc().getCollectors().length; i++) {
+                        JvmStats.GarbageCollector garbageCollector = nodeStats.getJvm().getGc().getCollectors()[i];
+                        JvmStats.GarbageCollector deserializedGarbageCollector = deserializedNodeStats.getJvm().getGc().getCollectors()[i];
+                        assertEquals(garbageCollector.getName(), deserializedGarbageCollector.getName());
+                        assertEquals(garbageCollector.getCollectionCount(), deserializedGarbageCollector.getCollectionCount());
+                        assertEquals(garbageCollector.getCollectionTime(), deserializedGarbageCollector.getCollectionTime());
+                    }
+                    assertEquals(nodeStats.getJvm().getThreads().getCount(), deserializedNodeStats.getJvm().getThreads().getCount());
+                    assertEquals(nodeStats.getJvm().getThreads().getPeakCount(),
+                            deserializedNodeStats.getJvm().getThreads().getPeakCount());
+                    assertEquals(nodeStats.getJvm().getUptime(), deserializedNodeStats.getJvm().getUptime());
+                    if (nodeStats.getJvm().getBufferPools() == null) {
+                        assertNull(deserializedNodeStats.getJvm().getBufferPools());
+                    } else {
+                        assertEquals(nodeStats.getJvm().getBufferPools().size(), deserializedNodeStats.getJvm().getBufferPools().size());
+                        for (int i = 0; i < nodeStats.getJvm().getBufferPools().size(); i++) {
+                            JvmStats.BufferPool bufferPool = nodeStats.getJvm().getBufferPools().get(i);
+                            JvmStats.BufferPool deserializedBufferPool = deserializedNodeStats.getJvm().getBufferPools().get(i);
+                            assertEquals(bufferPool.getName(), deserializedBufferPool.getName());
+                            assertEquals(bufferPool.getCount(), deserializedBufferPool.getCount());
+                            assertEquals(bufferPool.getTotalCapacity(), deserializedBufferPool.getTotalCapacity());
+                            assertEquals(bufferPool.getUsed(), deserializedBufferPool.getUsed());
+                        }
+                    }
+                }
+                if (nodeStats.getThreadPool() == null) {
+                    assertNull(deserializedNodeStats.getThreadPool());
+                } else {
+                    Iterator<ThreadPoolStats.Stats> threadPoolIterator = nodeStats.getThreadPool().iterator();
+                    Iterator<ThreadPoolStats.Stats> deserializedThreadPoolIterator = deserializedNodeStats.getThreadPool().iterator();
+                    while (threadPoolIterator.hasNext()) {
+                        ThreadPoolStats.Stats stats = threadPoolIterator.next();
+                        ThreadPoolStats.Stats deserializedStats = deserializedThreadPoolIterator.next();
+                        assertEquals(stats.getName(), deserializedStats.getName());
+                        assertEquals(stats.getThreads(), deserializedStats.getThreads());
+                        assertEquals(stats.getActive(), deserializedStats.getActive());
+                        assertEquals(stats.getLargest(), deserializedStats.getLargest());
+                        assertEquals(stats.getCompleted(), deserializedStats.getCompleted());
+                        assertEquals(stats.getQueue(), deserializedStats.getQueue());
+                        assertEquals(stats.getRejected(), deserializedStats.getRejected());
+                    }
+                }
+                if (nodeStats.getFs() == null) {
+                    assertNull(deserializedNodeStats.getFs());
+                } else {
+                    assertEquals(nodeStats.getFs().getTimestamp(), deserializedNodeStats.getFs().getTimestamp());
+                    assertEquals(nodeStats.getFs().getTotal().getAvailable(), deserializedNodeStats.getFs().getTotal().getAvailable());
+                    assertEquals(nodeStats.getFs().getTotal().getTotal(), deserializedNodeStats.getFs().getTotal().getTotal());
+                    assertEquals(nodeStats.getFs().getTotal().getFree(), deserializedNodeStats.getFs().getTotal().getFree());
+                    assertEquals(nodeStats.getFs().getTotal().getMount(), deserializedNodeStats.getFs().getTotal().getMount());
+                    assertEquals(nodeStats.getFs().getTotal().getPath(), deserializedNodeStats.getFs().getTotal().getPath());
+                    assertEquals(nodeStats.getFs().getTotal().getSpins(), deserializedNodeStats.getFs().getTotal().getSpins());
+                    assertEquals(nodeStats.getFs().getTotal().getType(), deserializedNodeStats.getFs().getTotal().getType());
+                    assertEquals(nodeStats.getFs().getIoStats().getTotalOperations(),
+                            deserializedNodeStats.getFs().getIoStats().getTotalOperations());
+                    assertEquals(nodeStats.getFs().getIoStats().getTotalReadKilobytes(),
+                            deserializedNodeStats.getFs().getIoStats().getTotalReadKilobytes());
+                    assertEquals(nodeStats.getFs().getIoStats().getTotalReadOperations(),
+                            deserializedNodeStats.getFs().getIoStats().getTotalReadOperations());
+                    assertEquals(nodeStats.getFs().getIoStats().getTotalWriteKilobytes(),
+                            deserializedNodeStats.getFs().getIoStats().getTotalWriteKilobytes());
+                    assertEquals(nodeStats.getFs().getIoStats().getTotalWriteOperations(),
+                            deserializedNodeStats.getFs().getIoStats().getTotalWriteOperations());
+                    assertEquals(nodeStats.getFs().getIoStats().getDevicesStats().length,
+                            deserializedNodeStats.getFs().getIoStats().getDevicesStats().length);
+                    for (int i = 0; i < nodeStats.getFs().getIoStats().getDevicesStats().length; i++) {
+                        FsInfo.DeviceStats deviceStats = nodeStats.getFs().getIoStats().getDevicesStats()[i];
+                        FsInfo.DeviceStats deserializedDeviceStats = deserializedNodeStats.getFs().getIoStats().getDevicesStats()[i];
+                        assertEquals(deviceStats.operations(), deserializedDeviceStats.operations());
+                        assertEquals(deviceStats.readKilobytes(), deserializedDeviceStats.readKilobytes());
+                        assertEquals(deviceStats.readOperations(), deserializedDeviceStats.readOperations());
+                        assertEquals(deviceStats.writeKilobytes(), deserializedDeviceStats.writeKilobytes());
+                        assertEquals(deviceStats.writeOperations(), deserializedDeviceStats.writeOperations());
+                    }
+                }
+                if (nodeStats.getTransport() == null) {
+                    assertNull(deserializedNodeStats.getTransport());
+                } else {
+                    assertEquals(nodeStats.getTransport().getRxCount(), deserializedNodeStats.getTransport().getRxCount());
+                    assertEquals(nodeStats.getTransport().getRxSize(), deserializedNodeStats.getTransport().getRxSize());
+                    assertEquals(nodeStats.getTransport().getServerOpen(), deserializedNodeStats.getTransport().getServerOpen());
+                    assertEquals(nodeStats.getTransport().getTxCount(), deserializedNodeStats.getTransport().getTxCount());
+                    assertEquals(nodeStats.getTransport().getTxSize(), deserializedNodeStats.getTransport().getTxSize());
+                }
+                if (nodeStats.getHttp() == null) {
+                    assertNull(deserializedNodeStats.getHttp());
+                } else {
+                    assertEquals(nodeStats.getHttp().getServerOpen(), deserializedNodeStats.getHttp().getServerOpen());
+                    assertEquals(nodeStats.getHttp().getTotalOpen(), deserializedNodeStats.getHttp().getTotalOpen());
+                }
+                if (nodeStats.getBreaker() == null) {
+                    assertNull(deserializedNodeStats.getBreaker());
+                } else {
+                    assertEquals(nodeStats.getBreaker().getAllStats().length, deserializedNodeStats.getBreaker().getAllStats().length);
+                    for (int i = 0; i < nodeStats.getBreaker().getAllStats().length; i++) {
+                        CircuitBreakerStats circuitBreakerStats = nodeStats.getBreaker().getAllStats()[i];
+                        CircuitBreakerStats deserializedCircuitBreakerStats = deserializedNodeStats.getBreaker().getAllStats()[i];
+                        assertEquals(circuitBreakerStats.getEstimated(), deserializedCircuitBreakerStats.getEstimated());
+                        assertEquals(circuitBreakerStats.getLimit(), deserializedCircuitBreakerStats.getLimit());
+                        assertEquals(circuitBreakerStats.getName(), deserializedCircuitBreakerStats.getName());
+                        assertEquals(circuitBreakerStats.getOverhead(), deserializedCircuitBreakerStats.getOverhead(), 0);
+                        assertEquals(circuitBreakerStats.getTrippedCount(), deserializedCircuitBreakerStats.getTrippedCount(), 0);
+                    }
+                }
+                if (nodeStats.getScriptStats() == null) {
+                    assertNull(deserializedNodeStats.getScriptStats());
+                } else {
+                    assertEquals(nodeStats.getScriptStats().getCacheEvictions(),
+                            deserializedNodeStats.getScriptStats().getCacheEvictions());
+                    assertEquals(nodeStats.getScriptStats().getCompilations(), deserializedNodeStats.getScriptStats().getCompilations());
+                }
+                if (nodeStats.getDiscoveryStats() == null) {
+                    assertNull(deserializedNodeStats.getDiscoveryStats());
+                } else {
+                    if (nodeStats.getDiscoveryStats().getQueueStats() == null) {
+                        assertNull(deserializedNodeStats.getDiscoveryStats().getQueueStats());
+                    } else {
+                        assertEquals(nodeStats.getDiscoveryStats().getQueueStats().getCommitted(),
+                                deserializedNodeStats.getDiscoveryStats().getQueueStats().getCommitted());
+                        assertEquals(nodeStats.getDiscoveryStats().getQueueStats().getTotal(),
+                                deserializedNodeStats.getDiscoveryStats().getQueueStats().getTotal());
+                        assertEquals(nodeStats.getDiscoveryStats().getQueueStats().getPending(),
+                                deserializedNodeStats.getDiscoveryStats().getQueueStats().getPending());
+                    }
+                }
+                if (nodeStats.getIngestStats() == null) {
+                    assertNull(deserializedNodeStats.getIngestStats());
+                } else {
+                    assertEquals(nodeStats.getIngestStats().getTotalStats().getIngestCount(),
+                            deserializedNodeStats.getIngestStats().getTotalStats().getIngestCount());
+                    assertEquals(nodeStats.getIngestStats().getTotalStats().getIngestCurrent(),
+                            deserializedNodeStats.getIngestStats().getTotalStats().getIngestCurrent());
+                    assertEquals(nodeStats.getIngestStats().getTotalStats().getIngestFailedCount(),
+                            deserializedNodeStats.getIngestStats().getTotalStats().getIngestFailedCount());
+                    assertEquals(nodeStats.getIngestStats().getTotalStats().getIngestTimeInMillis(),
+                            deserializedNodeStats.getIngestStats().getTotalStats().getIngestTimeInMillis());
+                    assertEquals(nodeStats.getIngestStats().getStatsPerPipeline().size(),
+                            deserializedNodeStats.getIngestStats().getStatsPerPipeline().size());
+                    for (Map.Entry<String, IngestStats.Stats> entry : nodeStats.getIngestStats().getStatsPerPipeline().entrySet()) {
+                        IngestStats.Stats stats = entry.getValue();
+                        IngestStats.Stats deserializedStats = deserializedNodeStats.getIngestStats()
+                                .getStatsPerPipeline().get(entry.getKey());
+                        assertEquals(stats.getIngestFailedCount(), deserializedStats.getIngestFailedCount());
+                        assertEquals(stats.getIngestTimeInMillis(), deserializedStats.getIngestTimeInMillis());
+                        assertEquals(stats.getIngestCurrent(), deserializedStats.getIngestCurrent());
+                        assertEquals(stats.getIngestCount(), deserializedStats.getIngestCount());
+                    }
+                }
+            }
+        }
+    }
+
+    private static NodeStats createNodeStats() {
+        DiscoveryNode node = new DiscoveryNode("test_node", LocalTransportAddress.buildUnique(),
+                emptyMap(), emptySet(), VersionUtils.randomVersion(random()));
+        OsStats osStats = null;
+        if (frequently()) {
+            double loadAverages[] = new double[3];
+            for (int i = 0; i < 3; i++) {
+                loadAverages[i] = randomBoolean() ? randomDouble() : -1;
+            }
+            osStats = new OsStats(System.currentTimeMillis(), new OsStats.Cpu(randomShort(), loadAverages),
+                    new OsStats.Mem(randomLong(), randomLong()),
+                    new OsStats.Swap(randomLong(), randomLong()));
+        }
+        ProcessStats processStats = frequently() ? new ProcessStats(randomPositiveLong(), randomPositiveLong(), randomPositiveLong(),
+                new ProcessStats.Cpu(randomShort(), randomPositiveLong()),
+                new ProcessStats.Mem(randomPositiveLong())) : null;
+        JvmStats jvmStats = null;
+        if (frequently()) {
+            int numMemoryPools = randomIntBetween(0, 10);
+            JvmStats.MemoryPool[] memoryPools = new JvmStats.MemoryPool[numMemoryPools];
+            for (int i = 0; i < numMemoryPools; i++) {
+                memoryPools[i] = new JvmStats.MemoryPool(randomAsciiOfLengthBetween(3, 10), randomPositiveLong(),
+                        randomPositiveLong(), randomPositiveLong(), randomPositiveLong());
+            }
+            JvmStats.Threads threads = new JvmStats.Threads(randomIntBetween(1, 1000), randomIntBetween(1, 1000));
+            int numGarbageCollectors = randomIntBetween(0, 10);
+            JvmStats.GarbageCollector[] garbageCollectorsArray = new JvmStats.GarbageCollector[numGarbageCollectors];
+            for (int i = 0; i < numGarbageCollectors; i++) {
+                garbageCollectorsArray[i] = new JvmStats.GarbageCollector(randomAsciiOfLengthBetween(3, 10),
+                        randomPositiveLong(), randomPositiveLong());
+            }
+            JvmStats.GarbageCollectors garbageCollectors = new JvmStats.GarbageCollectors(garbageCollectorsArray);
+            int numBufferPools = randomIntBetween(0, 10);
+            List<JvmStats.BufferPool> bufferPoolList = new ArrayList<>();
+            for (int i = 0; i < numBufferPools; i++) {
+                bufferPoolList.add(new JvmStats.BufferPool(randomAsciiOfLengthBetween(3, 10), randomPositiveLong(), randomPositiveLong(),
+                        randomPositiveLong()));
+            }
+            JvmStats.Classes classes = new JvmStats.Classes(randomPositiveLong(), randomPositiveLong(), randomPositiveLong());
+            jvmStats = frequently() ? new JvmStats(randomPositiveLong(), randomPositiveLong(), new JvmStats.Mem(randomPositiveLong(),
+                    randomPositiveLong(), randomPositiveLong(), randomPositiveLong(), randomPositiveLong(), memoryPools), threads,
+                    garbageCollectors, randomBoolean() ? null : bufferPoolList, classes) : null;
+        }
+        ThreadPoolStats threadPoolStats = null;
+        if (frequently()) {
+            int numThreadPoolStats = randomIntBetween(0, 10);
+            List<ThreadPoolStats.Stats> threadPoolStatsList = new ArrayList<>();
+            for (int i = 0; i < numThreadPoolStats; i++) {
+                threadPoolStatsList.add(new ThreadPoolStats.Stats(randomAsciiOfLengthBetween(3, 10), randomIntBetween(1, 1000),
+                        randomIntBetween(1, 1000), randomIntBetween(1, 1000), randomPositiveLong(),
+                        randomIntBetween(1, 1000), randomIntBetween(1, 1000)));
+            }
+            threadPoolStats = new ThreadPoolStats(threadPoolStatsList);
+        }
+        FsInfo fsInfo = null;
+        if (frequently()) {
+            int numDeviceStats = randomIntBetween(0, 10);
+            FsInfo.DeviceStats[] deviceStatsArray = new FsInfo.DeviceStats[numDeviceStats];
+            for (int i = 0; i < numDeviceStats; i++) {
+                FsInfo.DeviceStats previousDeviceStats = randomBoolean() ? null :
+                        new FsInfo.DeviceStats(randomInt(), randomInt(), randomAsciiOfLengthBetween(3, 10),
+                                randomPositiveLong(), randomPositiveLong(), randomPositiveLong(), randomPositiveLong(), null);
+                deviceStatsArray[i] = new FsInfo.DeviceStats(randomInt(), randomInt(), randomAsciiOfLengthBetween(3, 10),
+                        randomPositiveLong(), randomPositiveLong(), randomPositiveLong(), randomPositiveLong(), previousDeviceStats);
+            }
+            FsInfo.IoStats ioStats = new FsInfo.IoStats(deviceStatsArray);
+            int numPaths = randomIntBetween(0, 10);
+            FsInfo.Path[] paths = new FsInfo.Path[numPaths];
+            for (int i = 0; i < numPaths; i++) {
+                paths[i] = new FsInfo.Path(randomAsciiOfLengthBetween(3, 10), randomBoolean() ? randomAsciiOfLengthBetween(3, 10) : null,
+                        randomPositiveLong(), randomPositiveLong(), randomPositiveLong());
+            }
+            fsInfo = new FsInfo(randomPositiveLong(), ioStats, paths);
+        }
+        TransportStats transportStats = frequently() ? new TransportStats(randomPositiveLong(), randomPositiveLong(),
+                randomPositiveLong(), randomPositiveLong(), randomPositiveLong()) : null;
+        HttpStats httpStats = frequently() ? new HttpStats(randomPositiveLong(), randomPositiveLong()) : null;
+        AllCircuitBreakerStats allCircuitBreakerStats = null;
+        if (frequently()) {
+            int numCircuitBreakerStats = randomIntBetween(0, 10);
+            CircuitBreakerStats[] circuitBreakerStatsArray = new CircuitBreakerStats[numCircuitBreakerStats];
+            for (int i = 0; i < numCircuitBreakerStats; i++) {
+                circuitBreakerStatsArray[i] = new CircuitBreakerStats(randomAsciiOfLengthBetween(3, 10), randomPositiveLong(),
+                        randomPositiveLong(), randomDouble(), randomPositiveLong());
+            }
+            allCircuitBreakerStats = new AllCircuitBreakerStats(circuitBreakerStatsArray);
+        }
+        ScriptStats scriptStats = frequently() ? new ScriptStats(randomPositiveLong(), randomPositiveLong()) : null;
+        DiscoveryStats discoveryStats = frequently() ? new DiscoveryStats(randomBoolean() ? new PendingClusterStateStats(randomInt(),
+                randomInt(), randomInt()) : null) : null;
+        IngestStats ingestStats = null;
+        if (frequently()) {
+            IngestStats.Stats totalStats = new IngestStats.Stats(randomPositiveLong(), randomPositiveLong(), randomPositiveLong(),
+                    randomPositiveLong());
+
+            int numStatsPerPipeline = randomIntBetween(0, 10);
+            Map<String, IngestStats.Stats> statsPerPipeline = new HashMap<>();
+            for (int i = 0; i < numStatsPerPipeline; i++) {
+                statsPerPipeline.put(randomAsciiOfLengthBetween(3, 10), new IngestStats.Stats(randomPositiveLong(),
+                        randomPositiveLong(), randomPositiveLong(), randomPositiveLong()));
+            }
+            ingestStats = new IngestStats(totalStats, statsPerPipeline);
+        }
+        //TODO NodeIndicesStats are not tested here, way too complicated to create, also they need to be migrated to Writeable yet
+        return new NodeStats(node, randomPositiveLong(), null, osStats, processStats, jvmStats, threadPoolStats, fsInfo,
+                transportStats, httpStats, allCircuitBreakerStats, scriptStats, discoveryStats, ingestStats);
+    }
+}

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -41,6 +41,7 @@ import org.elasticsearch.transport.TransportStats;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -294,7 +295,7 @@ public class NodeStatsTests extends ESTestCase {
             JvmStats.Classes classes = new JvmStats.Classes(randomPositiveLong(), randomPositiveLong(), randomPositiveLong());
             jvmStats = frequently() ? new JvmStats(randomPositiveLong(), randomPositiveLong(), new JvmStats.Mem(randomPositiveLong(),
                     randomPositiveLong(), randomPositiveLong(), randomPositiveLong(), randomPositiveLong(), memoryPools), threads,
-                    garbageCollectors, randomBoolean() ? null : bufferPoolList, classes) : null;
+                    garbageCollectors, randomBoolean() ? Collections.emptyList() : bufferPoolList, classes) : null;
         }
         ThreadPoolStats threadPoolStats = null;
         if (frequently()) {

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -280,10 +280,10 @@ public class NodeStatsTests extends ESTestCase {
         JvmStats jvmStats = null;
         if (frequently()) {
             int numMemoryPools = randomIntBetween(0, 10);
-            JvmStats.MemoryPool[] memoryPools = new JvmStats.MemoryPool[numMemoryPools];
+            List<JvmStats.MemoryPool> memoryPools = new ArrayList<>(numMemoryPools);
             for (int i = 0; i < numMemoryPools; i++) {
-                memoryPools[i] = new JvmStats.MemoryPool(randomAsciiOfLengthBetween(3, 10), randomPositiveLong(),
-                        randomPositiveLong(), randomPositiveLong(), randomPositiveLong());
+                memoryPools.add(new JvmStats.MemoryPool(randomAsciiOfLengthBetween(3, 10), randomPositiveLong(),
+                        randomPositiveLong(), randomPositiveLong(), randomPositiveLong()));
             }
             JvmStats.Threads threads = new JvmStats.Threads(randomIntBetween(1, 1000), randomIntBetween(1, 1000));
             int numGarbageCollectors = randomIntBetween(0, 10);

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -88,45 +88,42 @@ public class NodeStatsTests extends ESTestCase {
                     assertEquals(nodeStats.getProcess().getOpenFileDescriptors(),
                             deserializedNodeStats.getProcess().getOpenFileDescriptors());
                 }
-                if (nodeStats.getJvm() == null) {
-                    assertNull(deserializedNodeStats.getJvm());
+                JvmStats jvm = nodeStats.getJvm();
+                JvmStats deserializedJvm = deserializedNodeStats.getJvm();
+                if (jvm == null) {
+                    assertNull(deserializedJvm);
                 } else {
-                    assertEquals(nodeStats.getJvm().getTimestamp(), deserializedNodeStats.getJvm().getTimestamp());
-                    assertEquals(nodeStats.getJvm().getMem().getHeapUsedPercent(),
-                            deserializedNodeStats.getJvm().getMem().getHeapUsedPercent());
-                    assertEquals(nodeStats.getJvm().getMem().getHeapUsed(), deserializedNodeStats.getJvm().getMem().getHeapUsed());
-                    assertEquals(nodeStats.getJvm().getMem().getHeapCommitted(),
-                            deserializedNodeStats.getJvm().getMem().getHeapCommitted());
-                    assertEquals(nodeStats.getJvm().getMem().getNonHeapCommitted(),
-                            deserializedNodeStats.getJvm().getMem().getNonHeapCommitted());
-                    assertEquals(nodeStats.getJvm().getMem().getNonHeapUsed(), deserializedNodeStats.getJvm().getMem().getNonHeapUsed());
-                    assertEquals(nodeStats.getJvm().getMem().getHeapMax(), deserializedNodeStats.getJvm().getMem().getHeapMax());
-                    assertEquals(nodeStats.getJvm().getClasses().getLoadedClassCount(),
-                            deserializedNodeStats.getJvm().getClasses().getLoadedClassCount());
-                    assertEquals(nodeStats.getJvm().getClasses().getTotalLoadedClassCount(),
-                            deserializedNodeStats.getJvm().getClasses().getTotalLoadedClassCount());
-                    assertEquals(nodeStats.getJvm().getClasses().getUnloadedClassCount(),
-                            deserializedNodeStats.getJvm().getClasses().getUnloadedClassCount());
-                    assertEquals(nodeStats.getJvm().getGc().getCollectors().length,
-                            deserializedNodeStats.getJvm().getGc().getCollectors().length);
-                    for (int i = 0; i < nodeStats.getJvm().getGc().getCollectors().length; i++) {
-                        JvmStats.GarbageCollector garbageCollector = nodeStats.getJvm().getGc().getCollectors()[i];
-                        JvmStats.GarbageCollector deserializedGarbageCollector = deserializedNodeStats.getJvm().getGc().getCollectors()[i];
+                    JvmStats.Mem mem = jvm.getMem();
+                    JvmStats.Mem deserializedMem = deserializedJvm.getMem();
+                    assertEquals(jvm.getTimestamp(), deserializedJvm.getTimestamp());
+                    assertEquals(mem.getHeapUsedPercent(), deserializedMem.getHeapUsedPercent());
+                    assertEquals(mem.getHeapUsed(), deserializedMem.getHeapUsed());
+                    assertEquals(mem.getHeapCommitted(), deserializedMem.getHeapCommitted());
+                    assertEquals(mem.getNonHeapCommitted(), deserializedMem.getNonHeapCommitted());
+                    assertEquals(mem.getNonHeapUsed(), deserializedMem.getNonHeapUsed());
+                    assertEquals(mem.getHeapMax(), deserializedMem.getHeapMax());
+                    JvmStats.Classes classes = jvm.getClasses();
+                    assertEquals(classes.getLoadedClassCount(), deserializedJvm.getClasses().getLoadedClassCount());
+                    assertEquals(classes.getTotalLoadedClassCount(), deserializedJvm.getClasses().getTotalLoadedClassCount());
+                    assertEquals(classes.getUnloadedClassCount(), deserializedJvm.getClasses().getUnloadedClassCount());
+                    assertEquals(jvm.getGc().getCollectors().length, deserializedJvm.getGc().getCollectors().length);
+                    for (int i = 0; i < jvm.getGc().getCollectors().length; i++) {
+                        JvmStats.GarbageCollector garbageCollector = jvm.getGc().getCollectors()[i];
+                        JvmStats.GarbageCollector deserializedGarbageCollector = deserializedJvm.getGc().getCollectors()[i];
                         assertEquals(garbageCollector.getName(), deserializedGarbageCollector.getName());
                         assertEquals(garbageCollector.getCollectionCount(), deserializedGarbageCollector.getCollectionCount());
                         assertEquals(garbageCollector.getCollectionTime(), deserializedGarbageCollector.getCollectionTime());
                     }
-                    assertEquals(nodeStats.getJvm().getThreads().getCount(), deserializedNodeStats.getJvm().getThreads().getCount());
-                    assertEquals(nodeStats.getJvm().getThreads().getPeakCount(),
-                            deserializedNodeStats.getJvm().getThreads().getPeakCount());
-                    assertEquals(nodeStats.getJvm().getUptime(), deserializedNodeStats.getJvm().getUptime());
-                    if (nodeStats.getJvm().getBufferPools() == null) {
-                        assertNull(deserializedNodeStats.getJvm().getBufferPools());
+                    assertEquals(jvm.getThreads().getCount(), deserializedJvm.getThreads().getCount());
+                    assertEquals(jvm.getThreads().getPeakCount(), deserializedJvm.getThreads().getPeakCount());
+                    assertEquals(jvm.getUptime(), deserializedJvm.getUptime());
+                    if (jvm.getBufferPools() == null) {
+                        assertNull(deserializedJvm.getBufferPools());
                     } else {
-                        assertEquals(nodeStats.getJvm().getBufferPools().size(), deserializedNodeStats.getJvm().getBufferPools().size());
-                        for (int i = 0; i < nodeStats.getJvm().getBufferPools().size(); i++) {
-                            JvmStats.BufferPool bufferPool = nodeStats.getJvm().getBufferPools().get(i);
-                            JvmStats.BufferPool deserializedBufferPool = deserializedNodeStats.getJvm().getBufferPools().get(i);
+                        assertEquals(jvm.getBufferPools().size(), deserializedJvm.getBufferPools().size());
+                        for (int i = 0; i < jvm.getBufferPools().size(); i++) {
+                            JvmStats.BufferPool bufferPool = jvm.getBufferPools().get(i);
+                            JvmStats.BufferPool deserializedBufferPool = deserializedJvm.getBufferPools().get(i);
                             assertEquals(bufferPool.getName(), deserializedBufferPool.getName());
                             assertEquals(bufferPool.getCount(), deserializedBufferPool.getCount());
                             assertEquals(bufferPool.getTotalCapacity(), deserializedBufferPool.getTotalCapacity());
@@ -151,32 +148,30 @@ public class NodeStatsTests extends ESTestCase {
                         assertEquals(stats.getRejected(), deserializedStats.getRejected());
                     }
                 }
-                if (nodeStats.getFs() == null) {
-                    assertNull(deserializedNodeStats.getFs());
+                FsInfo fs = nodeStats.getFs();
+                FsInfo deserializedFs = deserializedNodeStats.getFs();
+                if (fs == null) {
+                    assertNull(deserializedFs);
                 } else {
-                    assertEquals(nodeStats.getFs().getTimestamp(), deserializedNodeStats.getFs().getTimestamp());
-                    assertEquals(nodeStats.getFs().getTotal().getAvailable(), deserializedNodeStats.getFs().getTotal().getAvailable());
-                    assertEquals(nodeStats.getFs().getTotal().getTotal(), deserializedNodeStats.getFs().getTotal().getTotal());
-                    assertEquals(nodeStats.getFs().getTotal().getFree(), deserializedNodeStats.getFs().getTotal().getFree());
-                    assertEquals(nodeStats.getFs().getTotal().getMount(), deserializedNodeStats.getFs().getTotal().getMount());
-                    assertEquals(nodeStats.getFs().getTotal().getPath(), deserializedNodeStats.getFs().getTotal().getPath());
-                    assertEquals(nodeStats.getFs().getTotal().getSpins(), deserializedNodeStats.getFs().getTotal().getSpins());
-                    assertEquals(nodeStats.getFs().getTotal().getType(), deserializedNodeStats.getFs().getTotal().getType());
-                    assertEquals(nodeStats.getFs().getIoStats().getTotalOperations(),
-                            deserializedNodeStats.getFs().getIoStats().getTotalOperations());
-                    assertEquals(nodeStats.getFs().getIoStats().getTotalReadKilobytes(),
-                            deserializedNodeStats.getFs().getIoStats().getTotalReadKilobytes());
-                    assertEquals(nodeStats.getFs().getIoStats().getTotalReadOperations(),
-                            deserializedNodeStats.getFs().getIoStats().getTotalReadOperations());
-                    assertEquals(nodeStats.getFs().getIoStats().getTotalWriteKilobytes(),
-                            deserializedNodeStats.getFs().getIoStats().getTotalWriteKilobytes());
-                    assertEquals(nodeStats.getFs().getIoStats().getTotalWriteOperations(),
-                            deserializedNodeStats.getFs().getIoStats().getTotalWriteOperations());
-                    assertEquals(nodeStats.getFs().getIoStats().getDevicesStats().length,
-                            deserializedNodeStats.getFs().getIoStats().getDevicesStats().length);
-                    for (int i = 0; i < nodeStats.getFs().getIoStats().getDevicesStats().length; i++) {
-                        FsInfo.DeviceStats deviceStats = nodeStats.getFs().getIoStats().getDevicesStats()[i];
-                        FsInfo.DeviceStats deserializedDeviceStats = deserializedNodeStats.getFs().getIoStats().getDevicesStats()[i];
+                    assertEquals(fs.getTimestamp(), deserializedFs.getTimestamp());
+                    assertEquals(fs.getTotal().getAvailable(), deserializedFs.getTotal().getAvailable());
+                    assertEquals(fs.getTotal().getTotal(), deserializedFs.getTotal().getTotal());
+                    assertEquals(fs.getTotal().getFree(), deserializedFs.getTotal().getFree());
+                    assertEquals(fs.getTotal().getMount(), deserializedFs.getTotal().getMount());
+                    assertEquals(fs.getTotal().getPath(), deserializedFs.getTotal().getPath());
+                    assertEquals(fs.getTotal().getSpins(), deserializedFs.getTotal().getSpins());
+                    assertEquals(fs.getTotal().getType(), deserializedFs.getTotal().getType());
+                    FsInfo.IoStats ioStats = fs.getIoStats();
+                    FsInfo.IoStats deserializedIoStats = deserializedFs.getIoStats();
+                    assertEquals(ioStats.getTotalOperations(), deserializedIoStats.getTotalOperations());
+                    assertEquals(ioStats.getTotalReadKilobytes(), deserializedIoStats.getTotalReadKilobytes());
+                    assertEquals(ioStats.getTotalReadOperations(), deserializedIoStats.getTotalReadOperations());
+                    assertEquals(ioStats.getTotalWriteKilobytes(), deserializedIoStats.getTotalWriteKilobytes());
+                    assertEquals(ioStats.getTotalWriteOperations(), deserializedIoStats.getTotalWriteOperations());
+                    assertEquals(ioStats.getDevicesStats().length, deserializedIoStats.getDevicesStats().length);
+                    for (int i = 0; i < ioStats.getDevicesStats().length; i++) {
+                        FsInfo.DeviceStats deviceStats = ioStats.getDevicesStats()[i];
+                        FsInfo.DeviceStats deserializedDeviceStats = deserializedIoStats.getDevicesStats()[i];
                         assertEquals(deviceStats.operations(), deserializedDeviceStats.operations());
                         assertEquals(deviceStats.readKilobytes(), deserializedDeviceStats.readKilobytes());
                         assertEquals(deviceStats.readOperations(), deserializedDeviceStats.readOperations());
@@ -213,44 +208,41 @@ public class NodeStatsTests extends ESTestCase {
                         assertEquals(circuitBreakerStats.getTrippedCount(), deserializedCircuitBreakerStats.getTrippedCount(), 0);
                     }
                 }
-                if (nodeStats.getScriptStats() == null) {
+                ScriptStats scriptStats = nodeStats.getScriptStats();
+                if (scriptStats == null) {
                     assertNull(deserializedNodeStats.getScriptStats());
                 } else {
-                    assertEquals(nodeStats.getScriptStats().getCacheEvictions(),
-                            deserializedNodeStats.getScriptStats().getCacheEvictions());
-                    assertEquals(nodeStats.getScriptStats().getCompilations(), deserializedNodeStats.getScriptStats().getCompilations());
+                    assertEquals(scriptStats.getCacheEvictions(), deserializedNodeStats.getScriptStats().getCacheEvictions());
+                    assertEquals(scriptStats.getCompilations(), deserializedNodeStats.getScriptStats().getCompilations());
                 }
-                if (nodeStats.getDiscoveryStats() == null) {
-                    assertNull(deserializedNodeStats.getDiscoveryStats());
+                DiscoveryStats discoveryStats = nodeStats.getDiscoveryStats();
+                DiscoveryStats deserializedDiscoveryStats = deserializedNodeStats.getDiscoveryStats();
+                if (discoveryStats == null) {
+                    assertNull(deserializedDiscoveryStats);
                 } else {
-                    if (nodeStats.getDiscoveryStats().getQueueStats() == null) {
-                        assertNull(deserializedNodeStats.getDiscoveryStats().getQueueStats());
+                    PendingClusterStateStats queueStats = discoveryStats.getQueueStats();
+                    if (queueStats == null) {
+                        assertNull(deserializedDiscoveryStats.getQueueStats());
                     } else {
-                        assertEquals(nodeStats.getDiscoveryStats().getQueueStats().getCommitted(),
-                                deserializedNodeStats.getDiscoveryStats().getQueueStats().getCommitted());
-                        assertEquals(nodeStats.getDiscoveryStats().getQueueStats().getTotal(),
-                                deserializedNodeStats.getDiscoveryStats().getQueueStats().getTotal());
-                        assertEquals(nodeStats.getDiscoveryStats().getQueueStats().getPending(),
-                                deserializedNodeStats.getDiscoveryStats().getQueueStats().getPending());
+                        assertEquals(queueStats.getCommitted(), deserializedDiscoveryStats.getQueueStats().getCommitted());
+                        assertEquals(queueStats.getTotal(), deserializedDiscoveryStats.getQueueStats().getTotal());
+                        assertEquals(queueStats.getPending(), deserializedDiscoveryStats.getQueueStats().getPending());
                     }
                 }
-                if (nodeStats.getIngestStats() == null) {
-                    assertNull(deserializedNodeStats.getIngestStats());
+                IngestStats ingestStats = nodeStats.getIngestStats();
+                IngestStats deserializedIngestStats = deserializedNodeStats.getIngestStats();
+                if (ingestStats == null) {
+                    assertNull(deserializedIngestStats);
                 } else {
-                    assertEquals(nodeStats.getIngestStats().getTotalStats().getIngestCount(),
-                            deserializedNodeStats.getIngestStats().getTotalStats().getIngestCount());
-                    assertEquals(nodeStats.getIngestStats().getTotalStats().getIngestCurrent(),
-                            deserializedNodeStats.getIngestStats().getTotalStats().getIngestCurrent());
-                    assertEquals(nodeStats.getIngestStats().getTotalStats().getIngestFailedCount(),
-                            deserializedNodeStats.getIngestStats().getTotalStats().getIngestFailedCount());
-                    assertEquals(nodeStats.getIngestStats().getTotalStats().getIngestTimeInMillis(),
-                            deserializedNodeStats.getIngestStats().getTotalStats().getIngestTimeInMillis());
-                    assertEquals(nodeStats.getIngestStats().getStatsPerPipeline().size(),
-                            deserializedNodeStats.getIngestStats().getStatsPerPipeline().size());
-                    for (Map.Entry<String, IngestStats.Stats> entry : nodeStats.getIngestStats().getStatsPerPipeline().entrySet()) {
+                    IngestStats.Stats totalStats = ingestStats.getTotalStats();
+                    assertEquals(totalStats.getIngestCount(), deserializedIngestStats.getTotalStats().getIngestCount());
+                    assertEquals(totalStats.getIngestCurrent(), deserializedIngestStats.getTotalStats().getIngestCurrent());
+                    assertEquals(totalStats.getIngestFailedCount(), deserializedIngestStats.getTotalStats().getIngestFailedCount());
+                    assertEquals(totalStats.getIngestTimeInMillis(), deserializedIngestStats.getTotalStats().getIngestTimeInMillis());
+                    assertEquals(ingestStats.getStatsPerPipeline().size(), deserializedIngestStats.getStatsPerPipeline().size());
+                    for (Map.Entry<String, IngestStats.Stats> entry : ingestStats.getStatsPerPipeline().entrySet()) {
                         IngestStats.Stats stats = entry.getValue();
-                        IngestStats.Stats deserializedStats = deserializedNodeStats.getIngestStats()
-                                .getStatsPerPipeline().get(entry.getKey());
+                        IngestStats.Stats deserializedStats = deserializedIngestStats.getStatsPerPipeline().get(entry.getKey());
                         assertEquals(stats.getIngestFailedCount(), deserializedStats.getIngestFailedCount());
                         assertEquals(stats.getIngestTimeInMillis(), deserializedStats.getIngestTimeInMillis());
                         assertEquals(stats.getIngestCurrent(), deserializedStats.getIngestCurrent());

--- a/core/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
@@ -647,7 +647,7 @@ public class IndexStatsIT extends ESIntegTestCase {
             flags.writeTo(out);
             out.close();
             BytesReference bytes = out.bytes();
-            CommonStatsFlags readStats = CommonStatsFlags.readCommonStatsFlags(bytes.streamInput());
+            CommonStatsFlags readStats = new CommonStatsFlags(bytes.streamInput());
             for (Flag flag : values) {
                 assertThat(flags.isSet(flag), equalTo(readStats.isSet(flag)));
             }
@@ -661,7 +661,7 @@ public class IndexStatsIT extends ESIntegTestCase {
             flags.writeTo(out);
             out.close();
             BytesReference bytes = out.bytes();
-            CommonStatsFlags readStats = CommonStatsFlags.readCommonStatsFlags(bytes.streamInput());
+            CommonStatsFlags readStats = new CommonStatsFlags(bytes.streamInput());
             for (Flag flag : values) {
                 assertThat(flags.isSet(flag), equalTo(readStats.isSet(flag)));
             }

--- a/core/src/test/java/org/elasticsearch/monitor/fs/FsProbeTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/fs/FsProbeTests.java
@@ -141,7 +141,7 @@ public class FsProbeTests extends ESTestCase {
                 " 253       1 dm-1 112 0 4624 13 0 0 0 0 0 5 13",
                 " 253       2 dm-2 48045 0 714866 49369 1372291 0 64128568 33730766 0 1058347 33782056"));
 
-        final FsInfo previous = new FsInfo(System.currentTimeMillis(), first, null);
+        final FsInfo previous = new FsInfo(System.currentTimeMillis(), first, new FsInfo.Path[0]);
         final FsInfo.IoStats second = probe.ioStats(devicesNumbers, previous);
         assertNotNull(second);
         assertThat(second.devicesStats[0].majorDeviceNumber, equalTo(253));

--- a/core/src/test/java/org/elasticsearch/monitor/process/ProcessProbeTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/process/ProcessProbeTests.java
@@ -65,11 +65,11 @@ public class ProcessProbeTests extends ESTestCase {
         assertThat(cpu.getPercent(), anyOf(lessThan((short) 0), allOf(greaterThanOrEqualTo((short) 0), lessThanOrEqualTo((short) 100))));
 
         // CPU time can return -1 if the platform does not support this operation, let's see which platforms fail
-        assertThat(cpu.total, greaterThan(0L));
+        assertThat(cpu.getTotal().millis(), greaterThan(0L));
 
         ProcessStats.Mem mem = stats.getMem();
         assertNotNull(mem);
         // Commited total virtual memory can return -1 if not supported, let's see which platforms fail
-        assertThat(mem.totalVirtual, greaterThan(0L));
+        assertThat(mem.getTotalVirtual().bytes(), greaterThan(0L));
     }
 }


### PR DESCRIPTION
This allows to make all the instance members final , which also prevents silly errors from happening (e.g. missing assignment when reading from the stream). 

Added also an extensive serialization test that was missing before.
