### PR TITLE
Added gradle wrapper files to gitignore, to ease updating the repo du…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@ nbactions.xml
 .gradle/
 build/
 
+# gradle wrapper 
+gradle/
+gradlew
+gradlew.bat
+
 # maven stuff (to be removed when trunk becomes 4.x)
 *-execution-hints.log
 target/


### PR DESCRIPTION
Added gradle wrapper files to gitignore, to ease updating the repo during private usage of gradle wrapper.

Creating private gradle wrapper is easy. Just run:

```
gradle wrapper --gradle-version 2.13
```

It was mentioned in https://github.com/elastic/elasticsearch/issues/18935#issuecomment-232503962 by @rjernst 
