### PR TITLE
Skip loading of jansi from log4j2

### DIFF
--- a/distribution/src/main/resources/config/jvm.options
+++ b/distribution/src/main/resources/config/jvm.options
@@ -66,6 +66,7 @@
 # log4j 2
 -Dlog4j.shutdownHookEnabled=false
 -Dlog4j2.disable.jmx=true
+-Dlog4j.skipJansi=true
 
 ## heap dumps
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -134,6 +134,7 @@ public abstract class ESTestCase extends LuceneTestCase {
         // this will fail
         System.setProperty("es.log4j.shutdownEnabled", "false");
         System.setProperty("log4j2.disable.jmx", "true");
+        System.setProperty("log4j.skipJansi", "true"); // jython has this crazy shaded Jansi version that log4j2 tries to load
         BootstrapForTesting.ensureInitialized();
     }
 


### PR DESCRIPTION
Jython shades `jansi` into it's classpath without changing it's package or
anything like that. This causes attempts to load native code on windows which
blows up tests. This change adds `log4j.skipJansi=true` system property to our
tests as well as to the JVM properties we set.

@jasontedor  can you take a look
