### PR TITLE
Similarity should accept dynamic settings when possible

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -55,7 +55,7 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
     private final Map<String, Setting<?>> keySettings;
     private final Setting.Property scope;
     private static final Pattern KEY_PATTERN = Pattern.compile("^(?:[-\\w]+[.])*[-\\w]+$");
-    private static final Pattern GROUP_KEY_PATTERN = Pattern.compile("^(?:[-\\w]+[.])+$");
+    private static final Pattern GROUP_KEY_PATTERN = Pattern.compile("^(?:[-\\w\\*]+[.])+$");
 
     protected AbstractScopedSettings(Settings settings, Set<Setting<?>> settingsSet, Setting.Property scope) {
         super(settings);
@@ -182,7 +182,7 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
      *                  This is useful to add additional validation to settings at runtime compared to at startup time.
      */
     public synchronized <T> void addSettingsUpdateConsumer(Setting<T> setting, Consumer<T> consumer, Consumer<T> validator) {
-        if (setting != get(setting.getKey())) {
+        if (setting.equals(get(setting.getKey())) == false) {
             throw new IllegalArgumentException("Setting is not registered for key [" + setting.getKey() + "]");
         }
         addSettingsUpdater(setting.newUpdater(consumer, logger, validator));

--- a/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -150,7 +150,6 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS,
         SimilarityService.TYPE_SETTING,
         BaseSimilarityProvider.DISCOUNT_OVERLAPS_SETTING,
-        BaseSimilarityProvider.NORMALIZATION_MODE_SETTING,
         BaseSimilarityProvider.NORMALIZATION_SETTING,
         BM25SimilarityProvider.B_SETTING,
         BM25SimilarityProvider.K1_SETTING,

--- a/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -36,6 +36,13 @@ import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.similarity.BM25SimilarityProvider;
+import org.elasticsearch.index.similarity.BaseSimilarityProvider;
+import org.elasticsearch.index.similarity.DFISimilarityProvider;
+import org.elasticsearch.index.similarity.DFRSimilarityProvider;
+import org.elasticsearch.index.similarity.IBSimilarityProvider;
+import org.elasticsearch.index.similarity.LMDirichletSimilarityProvider;
+import org.elasticsearch.index.similarity.LMJelinekMercerSimilarityProvider;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.index.store.FsDirectoryService;
 import org.elasticsearch.index.store.IndexStore;
@@ -45,7 +52,6 @@ import org.elasticsearch.indices.IndicesRequestCache;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -142,16 +148,19 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         EngineConfig.INDEX_CODEC_SETTING,
         EngineConfig.INDEX_OPTIMIZE_AUTO_GENERATED_IDS,
         IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS,
-        // validate that built-in similarities don't get redefined
-        Setting.groupSetting("index.similarity.", (s) -> {
-            Map<String, Settings> groups = s.getAsGroups();
-            for (String key : SimilarityService.BUILT_IN.keySet()) {
-                if (groups.containsKey(key)) {
-                    throw new IllegalArgumentException("illegal value for [index.similarity." + key +
-                            "] cannot redefine built-in similarity");
-                }
-            }
-        }, Property.IndexScope), // this allows similarity settings to be passed
+        SimilarityService.TYPE_SETTING,
+        BaseSimilarityProvider.DISCOUNT_OVERLAPS_SETTING,
+        BaseSimilarityProvider.NORMALIZATION_MODE_SETTING,
+        BaseSimilarityProvider.NORMALIZATION_SETTING,
+        BM25SimilarityProvider.B_SETTING,
+        BM25SimilarityProvider.K1_SETTING,
+        DFISimilarityProvider.INDEPENDENCE_MEASURE_SETTING,
+        DFRSimilarityProvider.BASIC_MODEL_SETTING,
+        DFRSimilarityProvider.AFTER_EFFECT_SETTING,
+        IBSimilarityProvider.DISTRIBUTION_SETTING,
+        IBSimilarityProvider.COLLECTION_MODEL_SETTING,
+        LMDirichletSimilarityProvider.MU_SETTING,
+        LMJelinekMercerSimilarityProvider.LAMBDA_SETTING,
         Setting.groupSetting("index.analysis.", Property.IndexScope) // this allows analysis settings to be passed
 
     )));

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -61,7 +61,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.unit.ByteSizeValue.parseBytesSizeValue;
 import static org.elasticsearch.common.unit.SizeValue.parseSizeValue;
@@ -186,6 +185,10 @@ public final class Settings implements ToXContent {
      * A settings that are filtered (and key is removed) with the specified prefix.
      */
     public Settings getByPrefix(String prefix) {
+        return getByPrefix(prefix, false);
+    }
+
+    public Settings getByPrefix(String prefix, boolean keepExactMatch) {
         Builder builder = new Builder();
         for (Map.Entry<String, String> entry : getAsMap().entrySet()) {
             if (entry.getKey().startsWith(prefix)) {
@@ -194,6 +197,10 @@ public final class Settings implements ToXContent {
                     continue;
                 }
                 builder.put(entry.getKey().substring(prefix.length()), entry.getValue());
+            } else if (keepExactMatch && prefix.endsWith(".") &&
+                entry.getKey().equals(prefix.substring(0, prefix.length()-1))) {
+                // Exact match without the trailing '.'
+                builder.put(entry.getKey().substring(prefix.length()-1), entry.getValue());
             }
         }
         return builder.build();
@@ -216,7 +223,7 @@ public final class Settings implements ToXContent {
      * Returns the settings mapped to the given setting name.
      */
     public Settings getAsSettings(String setting) {
-        return getByPrefix(setting + ".");
+        return getByPrefix(setting + ".", false);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/similarity/ClassicSimilarityProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/similarity/ClassicSimilarityProvider.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.similarity;
 
 import org.apache.lucene.search.similarities.ClassicSimilarity;
+import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 
 /**
@@ -31,21 +32,21 @@ import org.elasticsearch.common.settings.Settings;
  * </ul>
  * @see ClassicSimilarity For more information about configuration
  */
-public class ClassicSimilarityProvider extends AbstractSimilarityProvider {
+public class ClassicSimilarityProvider extends BaseSimilarityProvider {
 
     private final ClassicSimilarity similarity = new ClassicSimilarity();
 
     public ClassicSimilarityProvider(String name, Settings settings) {
         super(name);
-        boolean discountOverlaps = settings.getAsBoolean("discount_overlaps", true);
+        boolean discountOverlaps = getConcreteSetting(DISCOUNT_OVERLAPS_SETTING).get(settings);
         this.similarity.setDiscountOverlaps(discountOverlaps);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public ClassicSimilarity get() {
         return similarity;
     }
+
+    @Override
+    public void addSettingsUpdateConsumer(IndexScopedSettings scopedSettings) {}
 }

--- a/core/src/main/java/org/elasticsearch/index/similarity/DFRSimilarityProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/similarity/DFRSimilarityProvider.java
@@ -102,20 +102,21 @@ public class DFRSimilarityProvider extends BaseSimilarityProvider {
     private final boolean discountOverlaps;
     private volatile BasicModel basicModel;
     private volatile AfterEffect afterEffect;
-    private final Normalization normalization;
+    private volatile Normalization normalization;
 
     public DFRSimilarityProvider(String name, Settings settings) {
         super(name);
         this.discountOverlaps = getConcreteSetting(DISCOUNT_OVERLAPS_SETTING).get(settings);
         this.basicModel = getConcreteSetting(BASIC_MODEL_SETTING).get(settings);
         this.afterEffect = getConcreteSetting(AFTER_EFFECT_SETTING).get(settings);
-        this.normalization = parseNormalization(settings);
+        this.normalization = parseNormalization(getConcreteSetting(NORMALIZATION_SETTING).get(settings));
     }
 
     @Override
     public void addSettingsUpdateConsumer(IndexScopedSettings scopedSettings) {
         scopedSettings.addSettingsUpdateConsumer(getConcreteSetting(BASIC_MODEL_SETTING), this::setBasicModel);
         scopedSettings.addSettingsUpdateConsumer(getConcreteSetting(AFTER_EFFECT_SETTING), this::setAfterEffect);
+        scopedSettings.addSettingsUpdateConsumer(getConcreteSetting(NORMALIZATION_SETTING), this::setNormalization);
     }
 
     private void setBasicModel(BasicModel model) {
@@ -124,6 +125,10 @@ public class DFRSimilarityProvider extends BaseSimilarityProvider {
 
     private void setAfterEffect(AfterEffect effect) {
         this.afterEffect = effect;
+    }
+
+    private void setNormalization(Settings innerSettings) {
+        this.normalization = parseNormalization(innerSettings);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/similarity/IBSimilarityProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/similarity/IBSimilarityProvider.java
@@ -27,7 +27,8 @@ import org.apache.lucene.search.similarities.Lambda;
 import org.apache.lucene.search.similarities.LambdaDF;
 import org.apache.lucene.search.similarities.LambdaTTF;
 import org.apache.lucene.search.similarities.Normalization;
-import org.apache.lucene.search.similarities.Similarity;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 
 import java.util.HashMap;
@@ -46,8 +47,7 @@ import static java.util.Collections.unmodifiableMap;
  * </ul>
  * @see IBSimilarity For more information about configuration
  */
-public class IBSimilarityProvider extends AbstractSimilarityProvider {
-
+public class IBSimilarityProvider extends BaseSimilarityProvider {
     private static final Map<String, Distribution> DISTRIBUTIONS;
     private static final Map<String, Lambda> LAMBDAS;
 
@@ -63,51 +63,61 @@ public class IBSimilarityProvider extends AbstractSimilarityProvider {
         LAMBDAS = unmodifiableMap(lamdas);
     }
 
-    private final IBSimilarity similarity;
+    public static final Setting<Distribution> DISTRIBUTION_SETTING =
+        Setting.affixKeySetting("index.similarity.", ".distribution",
+            (s) -> "ll",
+            (name) -> {
+                Distribution distrib = DISTRIBUTIONS.get(name);
+                if (distrib == null) {
+                    throw new IllegalArgumentException("Unsupported Distribution [" + name + "]");
+                }
+                return distrib;
+            },
+            Setting.Property.IndexScope, Setting.Property.Dynamic);
+
+    public static final Setting<Lambda> COLLECTION_MODEL_SETTING =
+        Setting.affixKeySetting("index.similarity.", ".collection_model",
+            (s) -> "df",
+            (name) -> {
+                Lambda lambda = LAMBDAS.get(name);
+                if (lambda == null) {
+                    throw new IllegalArgumentException("Unsupported CollectionModel [" + name + "]");
+                }
+                return lambda;
+            },
+            Setting.Property.IndexScope, Setting.Property.Dynamic);
+
+    private final boolean discountOverlaps;
+    private final Normalization normalization;
+    private volatile Distribution distribution;
+    private volatile Lambda lambda;
 
     public IBSimilarityProvider(String name, Settings settings) {
         super(name);
-        Distribution distribution = parseDistribution(settings);
-        Lambda lambda = parseLambda(settings);
-        Normalization normalization = parseNormalization(settings);
-        this.similarity = new IBSimilarity(distribution, lambda, normalization);
+        this.discountOverlaps = getConcreteSetting(DISCOUNT_OVERLAPS_SETTING).get(settings);
+        this.distribution = getConcreteSetting(DISTRIBUTION_SETTING).get(settings);
+        this.lambda = getConcreteSetting(COLLECTION_MODEL_SETTING).get(settings);
+        this.normalization = parseNormalization(settings);
     }
 
-    /**
-     * Parses the given Settings and creates the appropriate {@link Distribution}
-     *
-     * @param settings Settings to parse
-     * @return {@link Normalization} referred to in the Settings
-     */
-    protected Distribution parseDistribution(Settings settings) {
-        String rawDistribution = settings.get("distribution");
-        Distribution distribution = DISTRIBUTIONS.get(rawDistribution);
-        if (distribution == null) {
-            throw new IllegalArgumentException("Unsupported Distribution [" + rawDistribution + "]");
-        }
-        return distribution;
-    }
-
-    /**
-     * Parses the given Settings and creates the appropriate {@link Lambda}
-     *
-     * @param settings Settings to parse
-     * @return {@link Normalization} referred to in the Settings
-     */
-    protected Lambda parseLambda(Settings settings) {
-        String rawLambda = settings.get("lambda");
-        Lambda lambda = LAMBDAS.get(rawLambda);
-        if (lambda == null) {
-            throw new IllegalArgumentException("Unsupported Lambda [" + rawLambda + "]");
-        }
-        return lambda;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public Similarity get() {
-        return similarity;
+    public void addSettingsUpdateConsumer(IndexScopedSettings scopedSettings) {
+        scopedSettings.addSettingsUpdateConsumer(getConcreteSetting(DISTRIBUTION_SETTING), this::setDistribution);
+        scopedSettings.addSettingsUpdateConsumer(getConcreteSetting(COLLECTION_MODEL_SETTING), this::setCollectionModel);
+    }
+
+    private void setDistribution(Distribution distribution) {
+        this.distribution = distribution;
+    }
+
+    private void setCollectionModel(Lambda lambda) {
+        this.lambda = lambda;
+    }
+
+    @Override
+    public IBSimilarity get() {
+        IBSimilarity sim = new IBSimilarity(distribution, lambda, normalization);
+        sim.setDiscountOverlaps(discountOverlaps);
+        return sim;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/similarity/IBSimilarityProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/similarity/IBSimilarityProvider.java
@@ -88,7 +88,7 @@ public class IBSimilarityProvider extends BaseSimilarityProvider {
             Setting.Property.IndexScope, Setting.Property.Dynamic);
 
     private final boolean discountOverlaps;
-    private final Normalization normalization;
+    private volatile Normalization normalization;
     private volatile Distribution distribution;
     private volatile Lambda lambda;
 
@@ -97,13 +97,14 @@ public class IBSimilarityProvider extends BaseSimilarityProvider {
         this.discountOverlaps = getConcreteSetting(DISCOUNT_OVERLAPS_SETTING).get(settings);
         this.distribution = getConcreteSetting(DISTRIBUTION_SETTING).get(settings);
         this.lambda = getConcreteSetting(COLLECTION_MODEL_SETTING).get(settings);
-        this.normalization = parseNormalization(settings);
+        this.normalization =  parseNormalization(getConcreteSetting(NORMALIZATION_SETTING).get(settings));
     }
 
     @Override
     public void addSettingsUpdateConsumer(IndexScopedSettings scopedSettings) {
         scopedSettings.addSettingsUpdateConsumer(getConcreteSetting(DISTRIBUTION_SETTING), this::setDistribution);
         scopedSettings.addSettingsUpdateConsumer(getConcreteSetting(COLLECTION_MODEL_SETTING), this::setCollectionModel);
+        scopedSettings.addSettingsUpdateConsumer(getConcreteSetting(NORMALIZATION_SETTING), this::setNormalization);
     }
 
     private void setDistribution(Distribution distribution) {
@@ -112,6 +113,10 @@ public class IBSimilarityProvider extends BaseSimilarityProvider {
 
     private void setCollectionModel(Lambda lambda) {
         this.lambda = lambda;
+    }
+
+    private void setNormalization(Settings settings) {
+        this.normalization = parseNormalization(settings);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/similarity/SimilarityProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/similarity/SimilarityProvider.java
@@ -20,23 +20,44 @@
 package org.elasticsearch.index.similarity;
 
 import org.apache.lucene.search.similarities.Similarity;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Setting;
 
 /**
  * Provider for {@link Similarity} instances
  */
-public interface SimilarityProvider {
-
+public abstract class SimilarityProvider {
     /**
      * Returns the name associated with the Provider
      *
      * @return Name of the Provider
      */
-    String name();
+    public abstract String name();
 
     /**
      * Returns the {@link Similarity} the Provider is for
      *
      * @return Provided {@link Similarity}
      */
-    Similarity get();
+    public abstract Similarity get();
+
+
+    /**
+     * Allows to add update consumer for the settings of the similarity provider
+     */
+    public abstract void addSettingsUpdateConsumer(IndexScopedSettings scopedSettings);
+
+    /**
+     * Returns the concrete setting translated from the provided {@link Setting}
+     *
+     * @return The concrete setting for the provided {@link Setting}
+     */
+    protected <T> Setting<T> getConcreteSetting(Setting<T> setting) {
+        if (setting.getRawKey() instanceof Setting.AffixKey == false) {
+            throw new IllegalArgumentException("setting must be an affix setting");
+        }
+        Setting.AffixKey k = (Setting.AffixKey) setting.getRawKey();
+        String fullKey = k.toConcreteKey(name()).toString();
+        return setting.getConcreteSetting(fullKey);
+    }
 }

--- a/core/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -235,13 +235,6 @@ public class ScopedSettingsTests extends ESTestCase {
         } catch (IllegalArgumentException e) {
             assertEquals("Failed to parse value [true] for setting [index.number_of_replicas]", e.getMessage());
         }
-
-        try {
-            settings.validate("index.similarity.classic.type", Settings.builder().put("index.similarity.classic.type", "mine").build());
-            fail();
-        } catch (IllegalArgumentException e) {
-            assertEquals("illegal value for [index.similarity.classic] cannot redefine built-in similarity", e.getMessage());
-        }
     }
 
 

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class SettingTests extends ESTestCase {
@@ -52,7 +53,6 @@ public class SettingTests extends ESTestCase {
         byteSizeValueSetting = Setting.byteSizeSetting("a.byte.size", s -> "2048b", Property.Dynamic, Property.NodeScope);
         byteSizeValue = byteSizeValueSetting.get(Settings.EMPTY);
         assertEquals(byteSizeValue.bytes(), 2048);
-
 
         AtomicReference<ByteSizeValue> value = new AtomicReference<>(null);
         ClusterSettings.SettingUpdater<ByteSizeValue> settingUpdater = byteSizeValueSetting.newUpdater(value::set, logger);
@@ -402,9 +402,9 @@ public class SettingTests extends ESTestCase {
         }
     }
 
-    public void testAdfixKeySetting() {
+    public void testAffixKeySetting() {
         Setting<Boolean> setting =
-            Setting.adfixKeySetting("foo", "enable", "false", Boolean::parseBoolean, Property.NodeScope);
+            Setting.affixKeySetting("foo.", ".enable", "false", Boolean::parseBoolean, Property.NodeScope);
         assertTrue(setting.hasComplexMatcher());
         assertTrue(setting.match("foo.bar.enable"));
         assertTrue(setting.match("foo.baz.enable"));
@@ -416,12 +416,25 @@ public class SettingTests extends ESTestCase {
         assertTrue(concreteSetting.get(Settings.builder().put("foo.bar.enable", "true").build()));
         assertFalse(concreteSetting.get(Settings.builder().put("foo.baz.enable", "true").build()));
 
-        try {
-            setting.getConcreteSetting("foo");
-            fail();
-        } catch (IllegalArgumentException ex) {
-            assertEquals("key [foo] must match [foo*enable.] but didn't.", ex.getMessage());
-        }
+        IllegalArgumentException ex =
+            expectThrows(IllegalArgumentException.class, () -> setting.getConcreteSetting("foo"));
+        assertThat(ex.getMessage(), equalTo("key [foo] must match [foo.*.enable.] but didn't."));
+    }
+
+    public void testAffixKeyGroupSetting() {
+        Setting<Settings> setting =
+            Setting.affixKeyGroupSetting("foo.", ".group", Property.NodeScope);
+        assertTrue(setting.hasComplexMatcher());
+        assertFalse(setting.match("foo.bar.group"));
+        assertTrue(setting.match("foo.baz.group.value1"));
+        assertTrue(setting.match("foo.bar.group.value2"));
+        assertFalse(setting.match("foo.bar"));
+        assertFalse(setting.match("foo.bar.baz.groups"));
+        assertFalse(setting.match("foo"));
+
+        IllegalArgumentException ex =
+            expectThrows(IllegalArgumentException.class, () -> setting.getConcreteSetting("foo"));
+        assertThat(ex.getMessage(), equalTo("key [foo] must match [foo.*.group.*.] but didn't."));
     }
 
     public void testMinMaxInt() {

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -425,11 +425,10 @@ public class SettingTests extends ESTestCase {
         Setting<Settings> setting =
             Setting.affixKeyGroupSetting("foo.", ".group", Property.NodeScope);
         assertTrue(setting.hasComplexMatcher());
-        assertFalse(setting.match("foo.bar.group"));
+        assertTrue(setting.match("foo.bar.group"));
         assertTrue(setting.match("foo.baz.group.value1"));
         assertTrue(setting.match("foo.bar.group.value2"));
         assertFalse(setting.match("foo.bar"));
-        assertFalse(setting.match("foo.bar.baz.groups"));
         assertFalse(setting.match("foo"));
 
         IllegalArgumentException ex =

--- a/core/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/core/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -428,7 +428,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         ensureGreen(metaData.getIndex().getName());
         state = client().admin().cluster().prepareState().get().getState();
         assertEquals(IndexMetaData.State.CLOSE, state.getMetaData().index(metaData.getIndex()).getState());
-        assertEquals("classic", state.getMetaData().index(metaData.getIndex()).getSettings().get("archived.index.similarity.BM25.type"));
+        assertEquals("classic", state.getMetaData().index(metaData.getIndex()).getSettings().get("index.similarity.BM25.type"));
         // try to open it with the broken setting - fail again!
         ElasticsearchException ex = expectThrows(ElasticsearchException.class, () -> client().admin().indices().prepareOpen("test").get());
         assertEquals(ex.getMessage(), "Failed to verify index " + metaData.getIndex());

--- a/core/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -20,7 +20,6 @@ package org.elasticsearch.index;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.cluster.metadata.MetaDataIndexUpgradeService;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
@@ -29,12 +28,10 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.translog.Translog;
-import org.elasticsearch.indices.mapper.MapperRegistry;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;

--- a/core/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
+++ b/core/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
@@ -19,22 +19,22 @@
 
 package org.elasticsearch.index.similarity;
 
-import org.apache.lucene.search.similarities.ClassicSimilarity;
-import org.apache.lucene.search.similarities.DFISimilarity;
+import org.apache.lucene.search.similarities.AfterEffectB;
 import org.apache.lucene.search.similarities.AfterEffectL;
 import org.apache.lucene.search.similarities.BM25Similarity;
 import org.apache.lucene.search.similarities.BasicModelG;
-import org.apache.lucene.search.similarities.DFRSimilarity;
+import org.apache.lucene.search.similarities.BasicModelIn;
+import org.apache.lucene.search.similarities.ClassicSimilarity;
+import org.apache.lucene.search.similarities.DistributionLL;
 import org.apache.lucene.search.similarities.DistributionSPL;
-import org.apache.lucene.search.similarities.IBSimilarity;
 import org.apache.lucene.search.similarities.IndependenceChiSquared;
-import org.apache.lucene.search.similarities.LMDirichletSimilarity;
-import org.apache.lucene.search.similarities.LMJelinekMercerSimilarity;
+import org.apache.lucene.search.similarities.IndependenceSaturated;
+import org.apache.lucene.search.similarities.LambdaDF;
 import org.apache.lucene.search.similarities.LambdaTTF;
 import org.apache.lucene.search.similarities.NormalizationH2;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.IndexService;
@@ -52,6 +52,7 @@ import java.util.Collection;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.startsWith;
 
 public class SimilarityTests extends ESSingleNodeTestCase {
 
@@ -82,8 +83,31 @@ public class SimilarityTests extends ESSingleNodeTestCase {
         DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
         assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(), instanceOf(ClassicSimilarityProvider.class));
 
-        ClassicSimilarity similarity = (ClassicSimilarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
-        assertThat(similarity.getDiscountOverlaps(), equalTo(false));
+        ClassicSimilarityProvider provider =
+            (ClassicSimilarityProvider) documentMapper.mappers().getMapper("field1").fieldType().similarity();
+        assertThat(provider.get().getDiscountOverlaps(), equalTo(false));
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.type", "BM25")
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(),
+                startsWith("Can't update non dynamic settings [[index.similarity.my_similarity.type]]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(false));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.discount_overlaps", true)
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(),
+                startsWith("Can't update non dynamic settings [[index.similarity.my_similarity.discount_overlaps]]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(false));
+        }
     }
 
     public void testResolveSimilaritiesFromMapping_bm25() throws IOException {
@@ -103,10 +127,64 @@ public class SimilarityTests extends ESSingleNodeTestCase {
         DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
         assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(), instanceOf(BM25SimilarityProvider.class));
 
-        BM25Similarity similarity = (BM25Similarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
-        assertThat(similarity.getK1(), equalTo(2.0f));
-        assertThat(similarity.getB(), equalTo(0.5f));
-        assertThat(similarity.getDiscountOverlaps(), equalTo(false));
+        BM25SimilarityProvider provider =
+            (BM25SimilarityProvider) documentMapper.mappers().getMapper("field1").fieldType().similarity();
+        assertThat(provider.get().getK1(), equalTo(2.0f));
+        assertThat(provider.get().getB(), equalTo(0.5f));
+        assertThat(provider.get().getDiscountOverlaps(), equalTo(false));
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.type", "classic")
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(),
+                startsWith("Can't update non dynamic settings [[index.similarity.my_similarity.type]]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(false));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.discount_overlaps", true)
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(),
+                startsWith("Can't update non dynamic settings [[index.similarity.my_similarity.discount_overlaps]]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(false));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.b", 0.7f)
+                .put("index.similarity.my_similarity.k1", 2.7f)
+                .build();
+            client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet();
+            assertThat(provider.get().getB(), equalTo(0.7f));
+            assertThat(provider.get().getK1(), equalTo(2.7f));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(false));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.b", 2.0f)
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(),
+                startsWith("illegal b value: 2.0, must be between 0 and 1"));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.k1", -1.0f)
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(),
+                startsWith("illegal k1 value: -1.0, must be a non-negative finite value"));
+        }
     }
 
     public void testResolveSimilaritiesFromMapping_DFR() throws IOException {
@@ -127,11 +205,64 @@ public class SimilarityTests extends ESSingleNodeTestCase {
         DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
         assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(), instanceOf(DFRSimilarityProvider.class));
 
-        DFRSimilarity similarity = (DFRSimilarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
-        assertThat(similarity.getBasicModel(), instanceOf(BasicModelG.class));
-        assertThat(similarity.getAfterEffect(), instanceOf(AfterEffectL.class));
-        assertThat(similarity.getNormalization(), instanceOf(NormalizationH2.class));
-        assertThat(((NormalizationH2) similarity.getNormalization()).getC(), equalTo(3f));
+        DFRSimilarityProvider provider =
+            (DFRSimilarityProvider) documentMapper.mappers().getMapper("field1").fieldType().similarity();
+        assertThat(provider.get().getBasicModel(), instanceOf(BasicModelG.class));
+        assertThat(provider.get().getAfterEffect(), instanceOf(AfterEffectL.class));
+        assertThat(provider.get().getNormalization(), instanceOf(NormalizationH2.class));
+        assertThat(((NormalizationH2) provider.get().getNormalization()).getC(), equalTo(3f));
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.type", "classic")
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(),
+                startsWith("Can't update non dynamic settings [[index.similarity.my_similarity.type]]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.discount_overlaps", false)
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(),
+                startsWith("Can't update non dynamic settings [[index.similarity.my_similarity.discount_overlaps]]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.basic_model", "foo")
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(), startsWith("Unsupported BasicModel [foo]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.after_effect", "foo")
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(), startsWith("Unsupported AfterEffect [foo]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.basic_model", "in")
+                .put("index.similarity.my_similarity.after_effect", "b")
+                .build();
+            client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet();
+            assertThat(provider.get().getBasicModel(), instanceOf(BasicModelIn.class));
+            assertThat(provider.get().getAfterEffect(), instanceOf(AfterEffectB.class));
+        }
     }
 
     public void testResolveSimilaritiesFromMapping_IB() throws IOException {
@@ -144,7 +275,7 @@ public class SimilarityTests extends ESSingleNodeTestCase {
         Settings indexSettings = Settings.builder()
             .put("index.similarity.my_similarity.type", "IB")
             .put("index.similarity.my_similarity.distribution", "spl")
-            .put("index.similarity.my_similarity.lambda", "ttf")
+            .put("index.similarity.my_similarity.collection_model", "ttf")
             .put("index.similarity.my_similarity.normalization", "h2")
             .put("index.similarity.my_similarity.normalization.h2.c", 3f)
             .build();
@@ -152,11 +283,64 @@ public class SimilarityTests extends ESSingleNodeTestCase {
         DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
         assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(), instanceOf(IBSimilarityProvider.class));
 
-        IBSimilarity similarity = (IBSimilarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
-        assertThat(similarity.getDistribution(), instanceOf(DistributionSPL.class));
-        assertThat(similarity.getLambda(), instanceOf(LambdaTTF.class));
-        assertThat(similarity.getNormalization(), instanceOf(NormalizationH2.class));
-        assertThat(((NormalizationH2) similarity.getNormalization()).getC(), equalTo(3f));
+        IBSimilarityProvider provider =
+            (IBSimilarityProvider) documentMapper.mappers().getMapper("field1").fieldType().similarity();
+        assertThat(provider.get().getDistribution(), instanceOf(DistributionSPL.class));
+        assertThat(provider.get().getLambda(), instanceOf(LambdaTTF.class));
+        assertThat(provider.get().getNormalization(), instanceOf(NormalizationH2.class));
+        assertThat(((NormalizationH2) provider.get().getNormalization()).getC(), equalTo(3f));
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.type", "classic")
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(),
+                startsWith("Can't update non dynamic settings [[index.similarity.my_similarity.type]]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.discount_overlaps", false)
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(),
+                startsWith("Can't update non dynamic settings [[index.similarity.my_similarity.discount_overlaps]]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.distribution", "foo")
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(), startsWith("Unsupported Distribution [foo]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.collection_model", "foo")
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(), startsWith("Unsupported CollectionModel [foo]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.distribution", "ll")
+                .put("index.similarity.my_similarity.collection_model", "df")
+                .build();
+            client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet();
+            assertThat(provider.get().getDistribution(), instanceOf(DistributionLL.class));
+            assertThat(provider.get().getLambda(), instanceOf(LambdaDF.class));
+        }
     }
 
     public void testResolveSimilaritiesFromMapping_DFI() throws IOException {
@@ -174,8 +358,48 @@ public class SimilarityTests extends ESSingleNodeTestCase {
         DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
         MappedFieldType fieldType = documentMapper.mappers().getMapper("field1").fieldType();
         assertThat(fieldType.similarity(), instanceOf(DFISimilarityProvider.class));
-        DFISimilarity similarity = (DFISimilarity) fieldType.similarity().get();
-        assertThat(similarity.getIndependence(), instanceOf(IndependenceChiSquared.class));
+        DFISimilarityProvider provider = (DFISimilarityProvider) fieldType.similarity();
+        assertThat(provider.get().getIndependence(), instanceOf(IndependenceChiSquared.class));
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.type", "classic")
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(),
+                startsWith("Can't update non dynamic settings [[index.similarity.my_similarity.type]]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.discount_overlaps", false)
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(),
+                startsWith("Can't update non dynamic settings [[index.similarity.my_similarity.discount_overlaps]]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.independence_measure", "foo")
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(), startsWith("Unsupported IndependenceMeasure [foo]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.independence_measure", "saturated")
+                .build();
+            client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet();
+            assertThat(provider.get().getIndependence(), instanceOf(IndependenceSaturated.class));
+        }
     }
 
     public void testResolveSimilaritiesFromMapping_LMDirichlet() throws IOException {
@@ -193,8 +417,49 @@ public class SimilarityTests extends ESSingleNodeTestCase {
         DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
         assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(), instanceOf(LMDirichletSimilarityProvider.class));
 
-        LMDirichletSimilarity similarity = (LMDirichletSimilarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
-        assertThat(similarity.getMu(), equalTo(3000f));
+        LMDirichletSimilarityProvider provider =
+            (LMDirichletSimilarityProvider) documentMapper.mappers().getMapper("field1").fieldType().similarity();
+        assertThat(provider.get().getMu(), equalTo(3000f));
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.type", "classic")
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(),
+                startsWith("Can't update non dynamic settings [[index.similarity.my_similarity.type]]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.discount_overlaps", false)
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(),
+                startsWith("Can't update non dynamic settings [[index.similarity.my_similarity.discount_overlaps]]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.mu", "foo")
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(), startsWith("Failed to parse value [foo] for setting [index.similarity.my_similarity.mu]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.mu", 2000f)
+                .build();
+            client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet();
+            assertThat(provider.get().getMu(), equalTo(2000f));
+        }
     }
 
     public void testResolveSimilaritiesFromMapping_LMJelinekMercer() throws IOException {
@@ -212,8 +477,49 @@ public class SimilarityTests extends ESSingleNodeTestCase {
         DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
         assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(), instanceOf(LMJelinekMercerSimilarityProvider.class));
 
-        LMJelinekMercerSimilarity similarity = (LMJelinekMercerSimilarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
-        assertThat(similarity.getLambda(), equalTo(0.7f));
+        LMJelinekMercerSimilarityProvider provider =
+            (LMJelinekMercerSimilarityProvider) documentMapper.mappers().getMapper("field1").fieldType().similarity();
+        assertThat(provider.get().getLambda(), equalTo(0.7f));
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.type", "classic")
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(),
+                startsWith("Can't update non dynamic settings [[index.similarity.my_similarity.type]]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.discount_overlaps", false)
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(),
+                startsWith("Can't update non dynamic settings [[index.similarity.my_similarity.discount_overlaps]]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.lambda", "foo")
+                .build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet());
+            assertThat(e.getMessage(), startsWith("Failed to parse value [foo] for setting [index.similarity.my_similarity.lambda]"));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(true));
+        }
+
+        {
+            Settings newSettings = Settings.builder()
+                .put("index.similarity.my_similarity.lambda", 0.9f)
+                .build();
+            client().admin().indices().prepareUpdateSettings("foo").setSettings(newSettings).execute().actionGet();
+            assertThat(provider.get().getLambda(), equalTo(0.9f));
+        }
     }
 
     public void testResolveSimilaritiesFromMapping_Unknown() throws IOException {
@@ -257,6 +563,111 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             fail("Expected MappingParsingException");
         } catch (MapperParsingException e) {
             assertThat(e.getMessage(), equalTo("Unknown Similarity type [default] for field [field1]"));
+        }
+    }
+
+    public void testMultipleSimilarities() throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties")
+            .startObject("field1").field("type", "text").field("similarity", "my_similarity1").endObject()
+            .startObject("field2").field("type", "text").field("similarity", "my_similarity2").endObject()
+            .startObject("field3").field("type", "text").field("similarity", "my_similarity3").endObject()
+            .startObject("field4").field("type", "text").field("similarity", "my_similarity4").endObject()
+            .startObject("field5").field("type", "text").field("similarity", "my_similarity5").endObject()
+            .startObject("field6").field("type", "text").field("similarity", "my_similarity6").endObject()
+            .startObject("field7").field("type", "text").field("similarity", "my_similarity7").endObject()
+            .endObject()
+            .endObject().endObject().string();
+
+        Settings indexSettings = Settings.builder()
+            .put("index.similarity.my_similarity1.type", "classic")
+            .put("index.similarity.my_similarity1.discount_overlaps", false)
+            .put("index.similarity.my_similarity2.type", "BM25")
+            .put("index.similarity.my_similarity2.k1", 2.0f)
+            .put("index.similarity.my_similarity2.b", 0.5f)
+            .put("index.similarity.my_similarity2.discount_overlaps", false)
+            .put("index.similarity.my_similarity3.type", "DFR")
+            .put("index.similarity.my_similarity3.basic_model", "g")
+            .put("index.similarity.my_similarity3.after_effect", "l")
+            .put("index.similarity.my_similarity3.normalization", "h2")
+            .put("index.similarity.my_similarity3.normalization.h2.c", 3f)
+            .put("index.similarity.my_similarity4.type", "IB")
+            .put("index.similarity.my_similarity4.distribution", "spl")
+            .put("index.similarity.my_similarity4.collection_model", "ttf")
+            .put("index.similarity.my_similarity4.normalization", "h2")
+            .put("index.similarity.my_similarity4.normalization.h2.c", 3f)
+            .put("index.similarity.my_similarity5.type", "DFI")
+            .put("index.similarity.my_similarity5.independence_measure", "chisquared")
+            .put("index.similarity.my_similarity6.type", "LMDirichlet")
+            .put("index.similarity.my_similarity6.mu", 3000f)
+            .put("index.similarity.my_similarity7.type", "LMJelinekMercer")
+            .put("index.similarity.my_similarity7.lambda", 0.7f)
+            .build();
+        IndexService indexService = createIndex("foo", indexSettings);
+        DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
+        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(),
+            instanceOf(ClassicSimilarityProvider.class));
+        assertThat(documentMapper.mappers().getMapper("field2").fieldType().similarity(),
+            instanceOf(BM25SimilarityProvider.class));
+        assertThat(documentMapper.mappers().getMapper("field3").fieldType().similarity(),
+            instanceOf(DFRSimilarityProvider.class));
+        assertThat(documentMapper.mappers().getMapper("field4").fieldType().similarity(),
+            instanceOf(IBSimilarityProvider.class));
+        assertThat(documentMapper.mappers().getMapper("field5").fieldType().similarity(),
+            instanceOf(DFISimilarityProvider.class));
+        assertThat(documentMapper.mappers().getMapper("field6").fieldType().similarity(),
+            instanceOf(LMDirichletSimilarityProvider.class));
+        assertThat(documentMapper.mappers().getMapper("field7").fieldType().similarity(),
+            instanceOf(LMJelinekMercerSimilarityProvider.class));
+
+        {
+            ClassicSimilarityProvider provider =
+                (ClassicSimilarityProvider) documentMapper.mappers().getMapper("field1").fieldType().similarity();
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(false));
+        }
+
+        {
+            BM25SimilarityProvider provider =
+                (BM25SimilarityProvider) documentMapper.mappers().getMapper("field2").fieldType().similarity();
+            assertThat(provider.get().getK1(), equalTo(2.0f));
+            assertThat(provider.get().getB(), equalTo(0.5f));
+            assertThat(provider.get().getDiscountOverlaps(), equalTo(false));
+        }
+
+        {
+            DFRSimilarityProvider provider =
+                (DFRSimilarityProvider) documentMapper.mappers().getMapper("field3").fieldType().similarity();
+            assertThat(provider.get().getBasicModel(), instanceOf(BasicModelG.class));
+            assertThat(provider.get().getAfterEffect(), instanceOf(AfterEffectL.class));
+            assertThat(provider.get().getNormalization(), instanceOf(NormalizationH2.class));
+            assertThat(((NormalizationH2) provider.get().getNormalization()).getC(), equalTo(3f));
+        }
+
+        {
+            IBSimilarityProvider provider =
+                (IBSimilarityProvider) documentMapper.mappers().getMapper("field4").fieldType().similarity();
+            assertThat(provider.get().getDistribution(), instanceOf(DistributionSPL.class));
+            assertThat(provider.get().getLambda(), instanceOf(LambdaTTF.class));
+            assertThat(provider.get().getNormalization(), instanceOf(NormalizationH2.class));
+            assertThat(((NormalizationH2) provider.get().getNormalization()).getC(), equalTo(3f));
+        }
+
+        {
+            DFISimilarityProvider provider =
+                (DFISimilarityProvider) documentMapper.mappers().getMapper("field5").fieldType().similarity();
+            assertThat(provider.get().getIndependence(), instanceOf(IndependenceChiSquared.class));
+        }
+
+        {
+            LMDirichletSimilarityProvider provider =
+                (LMDirichletSimilarityProvider) documentMapper.mappers().getMapper("field6").fieldType().similarity();
+            assertThat(provider.get().getMu(), equalTo(3000f));
+        }
+
+        {
+            LMJelinekMercerSimilarityProvider provider =
+                (LMJelinekMercerSimilarityProvider) documentMapper.mappers().getMapper("field7").fieldType().similarity();
+            assertThat(provider.get().getLambda(), equalTo(0.7f));
         }
     }
 }

--- a/docs/reference/index-modules/similarity.asciidoc
+++ b/docs/reference/index-modules/similarity.asciidoc
@@ -47,6 +47,20 @@ Here we configure the DFRSimilarity so it can be referenced as
 [float]
 === Available similarities
 
+Similarity options marked with *dynamic* are dynamically updatable.
+Here we update the option `normalization.h2.c` of the similarity `my_similarity`:
+
+[source,js]
+--------------------------------------------------
+"similarity" : {
+  "my_similarity" : {
+    "normalization.h2.c" : "4.0"
+  }
+}
+--------------------------------------------------
+
+Note that it is not possible to update the type of an already defined similarity.
+
 [float]
 [[bm25]]
 ==== BM25 similarity (*default*)
@@ -57,11 +71,11 @@ http://en.wikipedia.org/wiki/Okapi_BM25[Okapi_BM25] for more details.
 This similarity has the following options:
 
 [horizontal]
-`k1`::
+`k1` (*dynamic*)::
     Controls non-linear term frequency normalization
     (saturation). The default value is `1.2`.
 
-`b`::
+`b` (*dynamic*)::
     Controls to what degree document length normalizes tf values.
     The default value is `0.75`.
 
@@ -95,14 +109,19 @@ http://lucene.apache.org/core/5_2_1/core/org/apache/lucene/search/similarities/D
 from randomness] framework. This similarity has the following options:
 
 [horizontal]
-`basic_model`::
+`basic_model` (*dynamic*)::
     Possible values: `be`, `d`, `g`, `if`, `in`, `ine` and `p`.
 
-`after_effect`::
+`after_effect` (*dynamic*)::
     Possible values: `no`, `b` and `l`.
 
-`normalization`::
+`normalization` (*dynamic*)::
     Possible values: `no`, `h1`, `h2`, `h3` and `z`.
+
+`discount_overlaps`::
+    Determines whether overlap tokens (Tokens with
+    0 position increment) are ignored when computing norm. By default this
+    is true, meaning overlap tokens do not count when computing norms.
 
 All options but the first option need a normalization value.
 
@@ -112,12 +131,17 @@ Type name: `DFR`
 [[dfi]]
 ==== DFI similarity
 
-Similarity that implements the http://trec.nist.gov/pubs/trec21/papers/irra.web.nb.pdf[divergence from independence] 
+Similarity that implements the http://trec.nist.gov/pubs/trec21/papers/irra.web.nb.pdf[divergence from independence]
 model.
 This similarity has the following options:
 
 [horizontal]
-`independence_measure`:: Possible values `standardized`, `saturated`, `chisquared`.
+`independence_measure` (*dynamic*):: Possible values `standardized`, `saturated`, `chisquared`.
+
+`discount_overlaps`::
+    Determines whether overlap tokens (Tokens with
+    0 position increment) are ignored when computing norm. By default this
+    is true, meaning overlap tokens do not count when computing norms.
 
 Type name: `DFI`
 
@@ -132,9 +156,19 @@ For written texts this challenge would correspond to comparing the writing style
 This similarity has the following options:
 
 [horizontal]
-`distribution`::  Possible values: `ll` and `spl`.
-`lambda`::        Possible values: `df` and `ttf`.
-`normalization`:: Same as in `DFR` similarity.
+`distribution` (*dynamic*)::
+    Possible values: `ll` and `spl`.
+
+`collection_model` (*dynamic*)::
+    Possible values: `df` and `ttf`.
+
+`normalization` (*dynamic*)::
+    Same as in `DFR` similarity.
+
+`discount_overlaps`::
+    Determines whether overlap tokens (Tokens with
+    0 position increment) are ignored when computing norm. By default this
+    is true, meaning overlap tokens do not count when computing norms.
 
 Type name: `IB`
 
@@ -146,7 +180,13 @@ http://lucene.apache.org/core/5_2_1/core/org/apache/lucene/search/similarities/L
 Dirichlet similarity] . This similarity has the following options:
 
 [horizontal]
-`mu`::  Default to `2000`.
+`mu` (*dynamic*)::
+    Default to `2000`.
+
+`discount_overlaps`::
+    Determines whether overlap tokens (Tokens with
+    0 position increment) are ignored when computing norm. By default this
+    is true, meaning overlap tokens do not count when computing norms.
 
 Type name: `LMDirichlet`
 
@@ -158,8 +198,13 @@ http://lucene.apache.org/core/5_2_1/core/org/apache/lucene/search/similarities/L
 Jelinek Mercer similarity] . The algorithm attempts to capture important patterns in the text, while leaving out noise. This similarity has the following options:
 
 [horizontal]
-`lambda`::  The optimal value depends on both the collection and the query. The optimal value is around `0.1`
+`lambda` (*dynamic*)::  The optimal value depends on both the collection and the query. The optimal value is around `0.1`
 for title queries and `0.7` for long queries. Default to `0.1`. When value approaches `0`, documents that match more query terms will be ranked higher than those that match fewer terms.
+
+`discount_overlaps`::
+    Determines whether overlap tokens (Tokens with
+    0 position increment) are ignored when computing norm. By default this
+    is true, meaning overlap tokens do not count when computing norms.
 
 Type name: `LMJelinekMercer`
 

--- a/docs/reference/migration/migrate_5_0/search.asciidoc
+++ b/docs/reference/migration/migrate_5_0/search.asciidoc
@@ -210,3 +210,7 @@ also supports specifying multiple nodes.
 ==== Default similarity
 
 The default similarity has been changed to `BM25`.
+
+==== IB Similarity
+
+The parameter `lambda` has been renamed to `collection_model`.

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageSettings.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageSettings.java
@@ -34,10 +34,10 @@ import java.util.Map;
 import java.util.function.Function;
 
 public final class AzureStorageSettings {
-    private static final String TIMEOUT_SUFFIX = "timeout";
-    private static final String ACCOUNT_SUFFIX = "account";
-    private static final String KEY_SUFFIX = "key";
-    private static final String DEFAULT_SUFFIX = "default";
+    private static final String TIMEOUT_SUFFIX = ".timeout";
+    private static final String ACCOUNT_SUFFIX = ".account";
+    private static final String KEY_SUFFIX = ".key";
+    private static final String DEFAULT_SUFFIX = ".default";
 
     private static final Setting.AffixKey TIMEOUT_KEY = Setting.AffixKey.withAdfix(Storage.PREFIX, TIMEOUT_SUFFIX);
 
@@ -47,11 +47,11 @@ public final class AzureStorageSettings {
         (s) -> Setting.parseTimeValue(s, TimeValue.timeValueSeconds(-1), TIMEOUT_KEY.toString()),
         Setting.Property.NodeScope);
     private static final Setting<String> ACCOUNT_SETTING =
-        Setting.adfixKeySetting(Storage.PREFIX, ACCOUNT_SUFFIX, "", Function.identity(), Setting.Property.NodeScope);
+        Setting.affixKeySetting(Storage.PREFIX, ACCOUNT_SUFFIX, "", Function.identity(), Setting.Property.NodeScope);
     private static final Setting<String> KEY_SETTING =
-        Setting.adfixKeySetting(Storage.PREFIX, KEY_SUFFIX, "", Function.identity(), Setting.Property.NodeScope);
+        Setting.affixKeySetting(Storage.PREFIX, KEY_SUFFIX, "", Function.identity(), Setting.Property.NodeScope);
     private static final Setting<Boolean> DEFAULT_SETTING =
-        Setting.adfixKeySetting(Storage.PREFIX, DEFAULT_SUFFIX, "false", Boolean::valueOf, Setting.Property.NodeScope);
+        Setting.affixKeySetting(Storage.PREFIX, DEFAULT_SUFFIX, "false", Boolean::valueOf, Setting.Property.NodeScope);
 
 
     private final String name;


### PR DESCRIPTION
This is a spin off for https://github.com/elastic/elasticsearch/pull/19046

This change allows to dynamically change options for any existing similarities on an open index.
It uses the affix setting to register all the similarity settings.
It does not allow to change the type of an existing similarity, to change the similarity of a field or to add a new similarity on an open index.
Options are updatable only if they don't change the way the similarity encodes the norm on disk.
The non-updatable options can't be changed if the index is opened nor closed.
This change adds validation to the similarity settings and throws an exception with a detailed message if a setting is unknown or not parseable.
Since it uses affix settings to register non-concrete setting, similarity settings that share the same suffix have been renamed:
`lambda` has been renamed to `collection_model` for the IBSimilarity (clashes with the lambda setting in LM Jelinek Mercer similarity).

The downside of using the affix setting is that each setting is registered as a global setting for any similarity type even though some settings are available for a certain similarity type only. Another solution could be to change the way the settings are registered, so instead of:

```
index.similarity.my_similarity.type: "BM25"
index.similarity.my_similarity.k1: 0.5

```

... we could do:

```
index.similarity.my_similarity.BM25.k1: 0.5
```

This would solve the problem of the global settings but it would also break the settings framework which does not accept settings without value:

```
index.similarity.my_similarity.BM25
```

Relates #6727
