### PR TITLE
Add search ingest processor

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -1335,6 +1335,182 @@ Renames an existing field. If the field doesn't exist or the new name is already
 }
 --------------------------------------------------
 
+[[ingest-search-processor]]
+=== Search Processor
+
+Allows running elasticsearch queries against a cluster (external or local) and extract data from the response.
+The size of the request is defined to `1` so you get the first more relevant document.
+
+[[ingest-search-options]]
+.Search Options
+[options="header"]
+|======
+| Name                   | Required  | Default                   | Description
+| `target_field`         | no        | -                         | The field to set. If empty, the result is merged from the root level.
+| `host`                 | no        | address of the local node | Elasticsearch node. For example: http://127.0.0.1:9200
+| `username`             | no        | -                         | The username is the cluster is secured
+| `password`             | no        | -                         | The password is the cluster is secured
+| `index`                | no        | -                         | Index name
+| `type`                 | no        | -                         | Type name
+| `query`                | no        |{"query":{"match_all":{}}} | Query to run.
+| `path`                 | no        | hits.hits._source         | defines a path to apply on the response to extract the object to be merged.
+|======
+
+Assume you have already indexed the following document in index `index` with type `type`:
+
+[source,js]
+--------------------------------------------------
+{
+  "foo" : "bar"
+}
+--------------------------------------------------
+
+And that you have a sample document like this one:
+
+[source,js]
+--------------------------------------------------
+{
+  "one" : 1
+}
+--------------------------------------------------
+
+
+When this `search` processor operates on this sample document:
+
+[source,js]
+--------------------------------------------------
+{
+  "search" : {
+    "index" : "index",
+    "type" : "type"
+  }
+}
+--------------------------------------------------
+
+Then the document will look like this after preprocessing:
+
+[source,js]
+--------------------------------------------------
+{
+  "one" : 1,
+  "foo" : "bar"
+}
+--------------------------------------------------
+
+Another example with the same source document. If you want to copy the result in another field:
+
+[source,js]
+--------------------------------------------------
+{
+  "search" : {
+    "index" : "index",
+    "type" : "type",
+    "target_field" : "target"
+  }
+}
+--------------------------------------------------
+
+Then the document will look like this after preprocessing:
+
+[source,js]
+--------------------------------------------------
+{
+  "one" : 1,
+  "target": {
+    "foo" : "bar"
+  }
+}
+--------------------------------------------------
+
+[[ingest-search-query]]
+==== Changing the query
+
+You can easily change the query using elasticsearch Query DSL:
+
+[source,js]
+--------------------------------------------------
+{
+  "search" : {
+    "index" : "index",
+    "type" : "type",
+    "query" : "{\"query\":{\"match\":{\"foo\":\"bar\"}}}"
+  }
+}
+--------------------------------------------------
+
+By default, it runs a `match_all` query. Note that only the first hit is fetch by the search processor.
+Remember that can always sort the result set in order to get first other results.
+
+
+[[ingest-search-path]]
+==== Extracting specific content
+
+Using `path` parameter, you can specify which field you want to actually extract from the result set.
+If the result is:
+
+[source,js]
+--------------------------------------------------
+{
+  "took" : 2,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 5,
+    "successful" : 5,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : 1,
+    "max_score" : 0.2876821,
+    "hits" : [
+      {
+        "_index" : "foo",
+        "_type" : "bar",
+        "_id" : "1",
+        "_score" : 0.2876821,
+        "_source" : {
+          "foo" : "bar"
+        }
+      }
+    ]
+  }
+}
+--------------------------------------------------
+
+You can define `path` to be `_shards.total` if you want to add the number of total shards to your document.
+You can also define it to `hits.hits._source.foo` to index directly `bar`. Note that if the path returns a
+core datatype, you will need to define the `target_field` to put this value in.
+
+You can also imagine running an aggregation and extract any field from the aggregation result.
+
+
+[[ingest-search-target-field]]
+==== Target field behavior
+
+Depending on the value extracted by the `path` and the source document, you might have the following behavior.
+
+If `path` extracts an object and `target_field` is not defined, the object is merged as is within the source.
+
+[[ingest-search-target-field-examples]]
+.Target field examples
+[options="header"]
+|======
+| Extracted with `path` | Source object                | `target_field`                   | Generated document
+| `{ "foo": "bar" }`    | `{ }`                        | -                                | `{ "foo": "bar" }`
+| `{ "foo": "bar" }`    | `{ }`                        | `target`                         | `{ "target": { "foo": "bar" } }`
+| `{ "foo": "bar" }`    | `{ "target": "baz" }`        | `target`                         | `{ "target": { "foo": "bar" } }`
+| `{ "foo": "bar" }`    | `{ "target": { "a": "b" } }` | `target`                         | `{ "target": { "a": "b", "foo": "bar" } }`
+| `"bar"`               | `{ }`                        | -                                | Will be rejected
+| `"bar"`               | `{ }`                        | `target`                         | `{ "target": "bar" }`
+| `"bar"`               | `{ "target": "baz" }`        | `target`                         | `{ "target": "bar" }`
+| `"bar"`               | `{ "target": { "a": "b" } }` | `target`                         | `{ "target": "bar" }`
+|======
+
+Note that your documents could be rejected if they don't match the existing mapping.
+
+For example, if you have previously indexed a document like `{ "target": "baz" }`, so `target` is defined as a
+`string`, search ingest won't be able to generate a document like `{ "target": { "foo": "bar" } }` because
+`target` would become an `Object`.
+
 [[script-processor]]
 === Script Processor
 

--- a/modules/ingest-common/build.gradle
+++ b/modules/ingest-common/build.gradle
@@ -23,6 +23,7 @@ esplugin {
 }
 
 dependencies {
+    compile "org.elasticsearch.client:rest:${version}"
     compile 'org.jruby.joni:joni:2.1.6'
     // joni dependencies:
     compile 'org.jruby.jcodings:jcodings:1.0.12'
@@ -37,3 +38,10 @@ thirdPartyAudit.excludes = [
         'org.objectweb.asm.MethodVisitor',
         'org.objectweb.asm.Opcodes',
 ]
+
+dependencyLicenses {
+    // Don't check the client's license. We know it.
+    dependencies = project.configurations.runtime.fileCollection {
+        it.group.startsWith('org.elasticsearch') == false
+    } - project.configurations.provided
+}

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/SearchProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/SearchProcessor.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.ingest.common;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.common.logging.ESLoggerFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.ingest.AbstractProcessor;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.Processor;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.ingest.ConfigurationUtils.newConfigurationException;
+import static org.elasticsearch.ingest.ConfigurationUtils.readOptionalStringProperty;
+import static org.elasticsearch.ingest.ConfigurationUtils.readStringProperty;
+
+/**
+ * Processor that adds new fields with their corresponding values based on the result of search request
+ * against an elasticsearch cluster. It can use an external cluster using REST protocol.
+ */
+public final class SearchProcessor extends AbstractProcessor {
+
+    private static Logger logger = ESLoggerFactory.getLogger("ingest.common");
+
+    public static final String TYPE = "search";
+
+    private final RestClient client;
+    private final String endpoint;
+    private final String query;
+    private final String path;
+    private final String targetField;
+
+    /**
+     * Create a SearchProcessor instance
+     * @param tag Tag
+     * @param client REST Client
+     * @param index index (null if not set)
+     * @param type type (null if not set). If set, index must be set.
+     * @param query JSON query. Defaults to { "query" : { "match_all": {} } }
+     * @param path defines a path to apply on the response to extract the object to be merged in the target field.
+     *             Defaults to hits.hits[0]._source
+     * @param targetField target field. If it does not exist, it will be created. If it exists as an object, the response
+     *               content will be merged. If it exists as a simple value like "foo": "bar", "foo" will become an object
+     *               containing the response.
+     *               If not set, the result will be merged on the root level.
+     */
+    SearchProcessor(String tag, RestClient client, String index, String type, String query, String path, String targetField)  {
+        super(tag);
+        this.client = client;
+        this.query = query;
+        this.path = path;
+        this.targetField = targetField;
+
+        String localEndpoint = "/";
+        if (index != null) {
+            localEndpoint += index + "/";
+        }
+        if (type != null) {
+            localEndpoint += type + "/";
+        }
+        localEndpoint += "_search";
+        this.endpoint = localEndpoint;
+    }
+
+    @Override
+    public void execute(IngestDocument document) {
+
+        try {
+            StringEntity entity = new StringEntity(query, ContentType.APPLICATION_JSON);
+
+            Response response = client.performRequest("GET", endpoint, Collections.singletonMap("size", "1"), entity);
+            XContentType xContentType = XContentType.JSON;
+            XContentParser parser = xContentType.xContent().createParser(response.getEntity().getContent());
+            Map<String, Object> map = parser.map();
+            int total = (int) XContentMapValues.extractValue("hits.total", map);
+
+            logger.trace("Got {}", map);
+
+            if (total > 0) {
+                Object oSource = XContentMapValues.extractValue(path, map);
+
+                if (oSource == null) {
+                    // We found no document
+                    logger.debug("No document found for [{}] with path [{}]. Got {}", query, path, map);
+                } else {
+                    // We add what we found to our ingest document
+                    logger.debug("Enriching document with [{}]", oSource);
+
+                    // If source is an array, we get the first one
+                    if (oSource instanceof List) {
+                        List source = (List) oSource;
+                        if (!source.isEmpty()) {
+                            oSource = source.get(0);
+                        }
+                    }
+
+                    logger.debug("oSource is [{}]", oSource);
+
+                    if (targetField != null) {
+                        if (document.hasField(targetField)) {
+                            // The target field already exists.
+                            Object oTarget = document.getFieldValue(targetField, Object.class);
+
+                            logger.debug("oTarget is [{}]", oTarget);
+
+                            if (oTarget instanceof Map && oSource instanceof Map) {
+                                // If it's an object (Map), we can merge the new values
+                                // and if we have an object in oSource, like { "foo": "bar" }
+                                // We merge objects
+                                Map<String, Object> source = (Map<String, Object>) oSource;
+                                for (Map.Entry<String, Object> entry : source.entrySet()) {
+                                    document.setFieldValue(targetField + "." + entry.getKey(), entry.getValue());
+                                }
+                            }
+                            else {
+                                // We are going to overwrite any existing value
+                                document.setFieldValue(targetField, oSource);
+                            }
+                        } else {
+                            logger.debug("writing [{}] at [{}]", oSource, targetField);
+                            document.setFieldValue(targetField, oSource);
+                        }
+                    } else {
+                        // We merge the result directly on the top level
+                        if (oSource instanceof Map) {
+                            // If it's an object (Map), we can merge the new values
+                            // and if we have an object in oSource, like { "foo": "bar" }
+                            // We merge objects
+                            Map<String, Object> source = (Map<String, Object>) oSource;
+                            for (Map.Entry<String, Object> entry : source.entrySet()) {
+                                document.setFieldValue(entry.getKey(), entry.getValue());
+                            }
+                        } else {
+                            throw new ElasticsearchException("We can not merge top level values without a field name");
+                        }
+                    }
+                }
+            } else {
+                // No hit found
+                logger.debug("No hits found for query [{}]. Got {}", query, map);
+            }
+
+        } catch (IOException e) {
+            throw new ElasticsearchException("Error while executing search", e);
+        }
+
+        logger.debug("Document generated [{}]", document);
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    /**
+     * The Factory helps to create a SearchProcessor instance.
+     * It supports the following settings:
+     * <ul>
+     *     <li>host: the elasticsearch server we want to run the search requests on, defaults to "http://127.0.0.1:9200"
+     *     <li>username: elasticsearch username (for plain text auth)
+     *     <li>password: elasticsearch password (for plain text auth)
+     *     <li>index: index we want to run the query on
+     *     <li>type: type we want to run the query on
+     *     <li>query: elasticsearch query to run, defaults to { "query" : { "match_all": {} } }
+     *     <li>path: defines a path to apply on the response to extract the object to be merged in the target field.
+     *         Defaults to hits.hits.0._source
+     *     <li>target_field: destination field. Defaults to "target".
+     * </ul>
+     */
+    public static final class Factory implements Closeable, Processor.Factory {
+
+        public static final String DEFAULT_HOST = "http://127.0.0.1:9200";
+        public static final String DEFAULT_QUERY = "{ \"query\" : { \"match_all\": {} } }";
+        public static final String DEFAULT_PATH = "hits.hits._source";
+
+        protected final Map<String, RestClient> clients;
+
+        public Factory() {
+            clients = new HashMap<>();
+        }
+
+        @Override
+        public SearchProcessor create(Map<String, Processor.Factory> registry,
+                                      String processorTag,
+                                      Map<String, Object> config) throws Exception {
+            // TODO we should default to the current node http layer if available
+            String host = readStringProperty(TYPE, processorTag, config, "host", DEFAULT_HOST);
+            String username = readOptionalStringProperty(TYPE, processorTag, config, "username");
+            // TODO probably a bad idea to have that in clear
+            String password = readOptionalStringProperty(TYPE, processorTag, config, "password");
+            String index = readOptionalStringProperty(TYPE, processorTag, config, "index");
+            String type = readOptionalStringProperty(TYPE, processorTag, config, "type");
+            String query = readStringProperty(TYPE, processorTag, config, "query", DEFAULT_QUERY);
+            String path = readStringProperty(TYPE, processorTag, config, "path", DEFAULT_PATH);
+            String targetField = readOptionalStringProperty(TYPE, processorTag, config, "target_field");
+
+            if (index != null && index.isEmpty()) {
+                throw newConfigurationException(TYPE, processorTag, "index", "when set can't be empty");
+            }
+
+            if (type != null && type.isEmpty()) {
+                throw newConfigurationException(TYPE, processorTag, "type", "when set can't be empty");
+            }
+
+            // If type is defined, index must be set
+            if (type != null && index == null) {
+                throw newConfigurationException(TYPE, processorTag, "index/type", ": if [type] is set, [index] must be set as well");
+            }
+
+            // We reuse the same connection to the same server instead of building a new instance every time
+            RestClient client = clients.get(host);
+
+            if (client == null) {
+                logger.debug("creating REST client for host [{}]", host);
+                HttpHost httpHost = HttpHost.create(host);
+
+                RestClientBuilder builder = RestClient.builder(httpHost);
+
+
+                if (username != null) {
+                    CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                    credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+                    builder.setHttpClientConfigCallback(httpClientBuilder ->
+                        httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+                }
+
+                client = builder.build();
+                clients.put(host, client);
+            }
+
+            return new SearchProcessor(processorTag, client, index, type, query, path, targetField);
+        }
+
+        @Override
+        public void close() throws IOException {
+            for (Map.Entry<String, RestClient> clientEntry : clients.entrySet()) {
+                logger.debug("closing REST client for host [{}]", clientEntry.getKey());
+                clientEntry.getValue().close();
+            }
+        }
+    }
+}

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SearchProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SearchProcessorFactoryTests.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.ingest.common;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+public class SearchProcessorFactoryTests extends ESTestCase {
+
+    private SearchProcessor.Factory factory;
+
+    @Before
+    public void createFactory() {
+        factory = new SearchProcessor.Factory();
+    }
+
+    @After
+    public void closeFactory() throws IOException {
+        factory.close();
+    }
+
+    public void testRestClientInstances() throws Exception {
+        // Create the first processor instance
+        factory.create(null, randomAsciiOfLength(10), Collections.emptyMap());
+        // We should have only one client (the default one)
+        assertThat(factory.clients.size(), is(1));
+        assertThat(factory.clients, hasKey("http://127.0.0.1:9200"));
+
+        // Create the second processor instance
+        factory.create(null, randomAsciiOfLength(10), Collections.emptyMap());
+        // We should have only one client (the default one)
+        assertThat(factory.clients.size(), is(1));
+
+        // Create the third processor instance which defines another server
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("host", "http://127.0.0.1:9250");
+        factory.create(null, randomAsciiOfLength(10), configMap);
+        // We should have two clients (the default one and the new one)
+        assertThat(factory.clients.size(), is(2));
+        assertThat(factory.clients, hasKey("http://127.0.0.1:9250"));
+    }
+
+    public void testFactoryIndexEmptyValidation() throws Exception {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("index", "");
+
+        ElasticsearchException exception = expectThrows(ElasticsearchException.class,
+            () -> factory.create(null, randomAsciiOfLength(10), configMap));
+
+        assertThat(exception.getMessage(), is("[index] when set can't be empty"));
+    }
+
+    public void testFactoryTypeEmptyValidation() throws Exception {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("type", "");
+
+        ElasticsearchException exception = expectThrows(ElasticsearchException.class,
+            () -> factory.create(null, randomAsciiOfLength(10), configMap));
+
+        assertThat(exception.getMessage(), is("[type] when set can't be empty"));
+    }
+
+    public void testFactoryIndexTypeValidation() throws Exception {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("type", "my_type");
+
+        ElasticsearchException exception = expectThrows(ElasticsearchException.class,
+            () -> factory.create(null, randomAsciiOfLength(10), configMap));
+
+        assertThat(exception.getMessage(), is("[index/type] : if [type] is set, [index] must be set as well"));
+    }
+}

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SearchProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SearchProcessorTests.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.ingest.common;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.RequestLine;
+import org.apache.http.StatusLine;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.XContentGenerator;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.RandomDocumentPicks;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isOneOf;
+import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SearchProcessorTests extends ESTestCase {
+
+    private static final String EMPTY = "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":0,\"successful\":0,\"failed\":0}," +
+        "\"hits\":{\"total\":0,\"max_score\":0.0,\"hits\":[]}}";
+
+    private static final String BAR = "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":5,\"successful\":5,\"failed\":0}," +
+        "\"hits\":{\"total\":1,\"max_score\":1.0,\"hits\":[{\"_index\":\"foo\",\"_type\":\"bar\",\"_id\":\"1\",\"_score\":1.0," +
+        "\"_source\":{ \"foo\" : \"bar\" }}]}}";
+
+    private static final String BAZ = "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":5,\"successful\":5,\"failed\":0}," +
+        "\"hits\":{\"total\":1,\"max_score\":1.0,\"hits\":[{\"_index\":\"foo\",\"_type\":\"bar\",\"_id\":\"2\",\"_score\":1.0," +
+        "\"_source\":{ \"foo\" : \"baz\" }}]}}";
+
+    private static final String BAR_BAZ = "{\"took\":2,\"timed_out\":false,\"_shards\":{\"total\":5,\"successful\":5,\"failed\":0}," +
+        "\"hits\":{\"total\":2,\"max_score\":1.0,\"hits\":[{\"_index\":\"foo\",\"_type\":\"bar\",\"_id\":\"2\",\"_score\":1.0," +
+        "\"_source\":{ \"foo\" : \"baz\" }},{\"_index\":\"foo\",\"_type\":\"bar\",\"_id\":\"1\",\"_score\":1.0,\"_source\":{ \"foo\" : " +
+        "\"bar\" }}]}}";
+
+    public void testSearchNoResult() throws Exception {
+        SearchProcessor processor = mockSearchEngine(SearchProcessor.Factory.DEFAULT_QUERY, EMPTY,
+            SearchProcessor.Factory.DEFAULT_PATH, "target");
+
+        Map<String, Object> document = new HashMap<>();
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        processor.execute(ingestDocument);
+
+        assertThat(ingestDocument.hasField("target.foo"), is(false));
+    }
+
+    public void testSearchOneResult() throws Exception {
+        SearchProcessor processor = mockSearchEngine(SearchProcessor.Factory.DEFAULT_QUERY, randomFrom(BAR, BAZ),
+            SearchProcessor.Factory.DEFAULT_PATH, "target");
+
+        Map<String, Object> document = new HashMap<>();
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        processor.execute(ingestDocument);
+
+        assertThat(ingestDocument.getFieldValue("target.foo", String.class), isOneOf("bar", "baz"));
+    }
+
+    public void testSearchTwoResult() throws Exception {
+        SearchProcessor processor = mockSearchEngine(SearchProcessor.Factory.DEFAULT_QUERY, BAR_BAZ,
+            SearchProcessor.Factory.DEFAULT_PATH, "target");
+
+        Map<String, Object> document = new HashMap<>();
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        processor.execute(ingestDocument);
+
+        assertThat(ingestDocument.getFieldValue("target.foo", String.class), is("baz"));
+    }
+
+    public void testSearchDeeperPath() throws Exception {
+        SearchProcessor processor = mockSearchEngine(SearchProcessor.Factory.DEFAULT_QUERY, randomFrom(BAR, BAZ),
+            SearchProcessor.Factory.DEFAULT_PATH, "target.something");
+
+        Map<String, Object> document = new HashMap<>();
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        processor.execute(ingestDocument);
+
+        assertThat(ingestDocument.getFieldValue("target.something.foo", String.class), isOneOf("bar", "baz"));
+    }
+
+    public void testMergingObjectsInDocument() throws Exception {
+        SearchProcessor processor = mockSearchEngine(SearchProcessor.Factory.DEFAULT_QUERY, randomFrom(BAR, BAZ),
+            SearchProcessor.Factory.DEFAULT_PATH, "origin");
+
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> origin = new HashMap<>();
+        origin.put("my_foo", "my_bar");
+        document.put("origin", origin);
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        processor.execute(ingestDocument);
+
+        assertThat(ingestDocument.getFieldValue("origin.foo", String.class), isOneOf("bar", "baz"));
+        assertThat(ingestDocument.getFieldValue("origin.my_foo", String.class), is("my_bar"));
+    }
+
+    public void testOverwritingValueInDocument() throws Exception {
+        SearchProcessor processor = mockSearchEngine(SearchProcessor.Factory.DEFAULT_QUERY, randomFrom(BAR, BAZ),
+            SearchProcessor.Factory.DEFAULT_PATH, "origin");
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("origin", "my_origin");
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        processor.execute(ingestDocument);
+
+        assertThat(ingestDocument.getFieldValue("origin.foo", String.class), isOneOf("bar", "baz"));
+    }
+
+    public void testSearchTopLevelMerge() throws Exception {
+        SearchProcessor processor = mockSearchEngine(SearchProcessor.Factory.DEFAULT_QUERY, randomFrom(BAR, BAZ),
+            SearchProcessor.Factory.DEFAULT_PATH, null);
+
+        Map<String, Object> document = new HashMap<>();
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        processor.execute(ingestDocument);
+
+        assertThat(ingestDocument.getFieldValue("foo", String.class), isOneOf("bar", "baz"));
+    }
+
+    protected SearchProcessor mockSearchEngine(String query, String jsonResponse, String path, String target) throws IOException {
+        RestClient restClient = mock(RestClient.class);
+        final Response response = response("GET", "/_search", RestStatus.OK);
+        final StringEntity entity = new StringEntity(jsonResponse, ContentType.APPLICATION_JSON);
+        when(response.getEntity()).thenReturn(entity);
+        when(restClient.performRequest(eq("GET"), eq("/_search"), anyMapOf(String.class, String.class), any(HttpEntity.class)))
+            .thenReturn(response);
+
+        return new SearchProcessor(randomAsciiOfLength(10), restClient, null, null, query, path, target);
+    }
+
+    protected Response response(final String method, final String endpoint, final RestStatus status) {
+        final Response response = mock(Response.class);
+        final RequestLine requestLine = mock(RequestLine.class);
+        when(requestLine.getMethod()).thenReturn(method);
+        when(requestLine.getUri()).thenReturn(endpoint);
+        final StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(status.getStatus());
+
+        when(response.getRequestLine()).thenReturn(requestLine);
+        when(response.getStatusLine()).thenReturn(statusLine);
+
+        return response;
+    }
+
+}

--- a/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/10_basic.yaml
+++ b/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/10_basic.yaml
@@ -23,8 +23,9 @@
     - match:  { nodes.$master.ingest.processors.11.type: remove }
     - match:  { nodes.$master.ingest.processors.12.type: rename }
     - match:  { nodes.$master.ingest.processors.13.type: script }
-    - match:  { nodes.$master.ingest.processors.14.type: set }
-    - match:  { nodes.$master.ingest.processors.15.type: sort }
-    - match:  { nodes.$master.ingest.processors.16.type: split }
-    - match:  { nodes.$master.ingest.processors.17.type: trim }
-    - match:  { nodes.$master.ingest.processors.18.type: uppercase }
+    - match:  { nodes.$master.ingest.processors.14.type: search }
+    - match:  { nodes.$master.ingest.processors.15.type: set }
+    - match:  { nodes.$master.ingest.processors.16.type: sort }
+    - match:  { nodes.$master.ingest.processors.17.type: split }
+    - match:  { nodes.$master.ingest.processors.18.type: trim }
+    - match:  { nodes.$master.ingest.processors.19.type: uppercase }

--- a/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/140_search.yaml
+++ b/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/140_search.yaml
@@ -1,0 +1,248 @@
+---
+teardown:
+  - do:
+      ingest.delete_pipeline:
+        id: "1"
+        ignore: 404
+
+---
+"Test search processor default values":
+  - do:
+      index:
+        index: index
+        type: type
+        id: 1
+        body: {
+          foo: "bar"
+        }
+  - do:
+      index:
+        index: index
+        type: type
+        id: 2
+        body: {
+          foo: "baz"
+        }
+
+  - do:
+      indices.refresh: {}
+
+  # Fetch the http host. We use the host of the master because we know there will always be a master.
+  - do:
+      cluster.state: {}
+  - set: { master_node: master }
+  - do:
+      nodes.info:
+        metric: [ http ]
+  - is_true: nodes.$master.http.publish_address
+  - set: {nodes.$master.http.publish_address: host}
+
+  - do:
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "search" : {
+                  "host": "http://${host}",
+                  "index": "index",
+                  "type": "type"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        type: test
+        id: 1
+        pipeline: "1"
+        body: {
+        }
+
+  - do:
+      get:
+        index: test
+        type: test
+        id: 1
+  - match: { _source.foo: "/ba.+/" }
+
+---
+"Test search processor with query":
+  - do:
+      index:
+        index: index
+        type: type
+        id: 1
+        body: {
+          foo: "bar"
+        }
+
+  - do:
+      index:
+        index: index
+        type: type
+        id: 2
+        body: {
+          foo: "baz"
+        }
+
+  - do:
+      indices.refresh: {}
+
+  # Fetch the http host. We use the host of the master because we know there will always be a master.
+  - do:
+      cluster.state: {}
+  - set: { master_node: master }
+  - do:
+      nodes.info:
+        metric: [ http ]
+  - is_true: nodes.$master.http.publish_address
+  - set: {nodes.$master.http.publish_address: host}
+
+  # PIPELINE 1
+  - do:
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "search" : {
+                  "host": "http://${host}",
+                  "index": "index",
+                  "type": "type",
+                  "query": "{ \"query\" : { \"match\" : { \"foo\" : \"bar\" } } }"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        type: test
+        id: 1
+        pipeline: "1"
+        body: {
+        }
+
+  - do:
+      get:
+        index: test
+        type: test
+        id: 1
+  - match: { _source.foo: "bar" }
+
+  - do:
+      index:
+        index: test
+        type: test
+        id: 2
+        pipeline: "1"
+        body: {
+          foo: "something"
+        }
+
+  - do:
+      get:
+        index: test
+        type: test
+        id: 2
+  - match: { _source.foo: "bar" }
+
+  - do:
+      index:
+        index: test
+        type: test
+        id: 3
+        pipeline: "1"
+        body: {
+          foo: {
+            inner: "something"
+          }
+        }
+
+  - do:
+      get:
+        index: test
+        type: test
+        id: 3
+  - match: { _source.foo: "bar" }
+
+  # PIPELINE 2
+  - do:
+      ingest.put_pipeline:
+        id: "2"
+        body:  >
+          {
+            "processors": [
+              {
+                "search" : {
+                  "host": "http://${host}",
+                  "index": "index",
+                  "type": "type",
+                  "query": "{ \"query\" : { \"match\" : { \"foo\" : \"bar\" } } }",
+                  "target_field": "foo"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test2
+        type: test
+        id: 1
+        pipeline: "2"
+        body: {
+        }
+
+  - do:
+      get:
+        index: test2
+        type: test
+        id: 1
+  - match: { _source.foo.foo: "bar" }
+
+  - do:
+      index:
+        index: test2
+        type: test
+        id: 2
+        pipeline: "2"
+        body: {
+          foo: "something"
+        }
+
+  - do:
+      get:
+        index: test2
+        type: test
+        id: 2
+  - match: { _source.foo.foo: "bar" }
+
+  - do:
+      index:
+        index: test2
+        type: test
+        id: 3
+        pipeline: "2"
+        body: {
+          foo: {
+            inner: "something"
+          }
+        }
+
+  - do:
+      get:
+        index: test2
+        type: test
+        id: 3
+  - match: { _source.foo.foo: "bar" }
+  - match: { _source.foo.inner: "something" }


### PR DESCRIPTION
Search ingest processor helps to get information by running a search query against an elasticsearch cluster.
The elasticsearch cluster can be internal or external. It uses REST layer to communicate.

The search request is sent with `size: 1` as we basically want to get only data from the more relevant hit.

| Name | Required | Default | Description |
| --- | --- | --- | --- |
| `target_field` | no | - | The field to set. If empty, the result is merged from the root level. |
| `host` | no | address of the local node | Elasticsearch node. For example: http://127.0.0.1:9200 |
| `username` | no | - | The username is the cluster is secured |
| `password` | no | - | The password is the cluster is secured |
| `index` | no | - | Index name |
| `type` | no | - | Type name |
| `query` | no | {"query":{"match_all":{}}} | Query to run. |
| `path` | no | hits.hits._source | defines a path to apply on the response to extract the object to be merged. |

Assume you have already indexed the following document in index `index` with type `type`:

``` js
{
  "foo" : "bar"
}
```

And that you have a sample document like this one:

``` js
{
  "one" : 1
}
```

When this `search` processor operates on this sample document:

``` js
{
  "search" : {
    "index" : "index",
    "type" : "type"
  }
}
```

Then the document will look like this after preprocessing:

``` js
{
  "one" : 1,
  "foo" : "bar"
}
```

Another example with the same source document. If you want to copy the result in another field:

``` js
{
  "search" : {
    "index" : "index",
    "type" : "type",
    "target_field" : "target"
  }
}
```

Then the document will look like this after preprocessing:

``` js
{
  "one" : 1,
  "target": {
    "foo" : "bar"
  }
}
```

You can easily change the query using elasticsearch Query DSL:

``` js
{
  "search" : {
    "index" : "index",
    "type" : "type",
    "query" : "{\"query\":{\"match\":{\"foo\":\"bar\"}}}"
  }
}
```

By default, it runs a `match_all` query. Note that only the first hit is fetch by the search processor.
Remember that can always sort the result set in order to get first other results.

Using `path` parameter, you can specify which field you want to actually extract from the result set.
If the result is:

``` js
{
  "took" : 2,
  "timed_out" : false,
  "_shards" : {
    "total" : 5,
    "successful" : 5,
    "failed" : 0
  },
  "hits" : {
    "total" : 1,
    "max_score" : 0.2876821,
    "hits" : [
      {
        "_index" : "foo",
        "_type" : "bar",
        "_id" : "1",
        "_score" : 0.2876821,
        "_source" : {
          "foo" : "bar"
        }
      }
    ]
  }
}
```

You can define `path` to be `_shards.total` if you want to add the number of total shards to your document.
You can also define it to `hits.hits._source.foo` to index directly `bar`. Note that if the path returns a
core datatype, you will need to define the `target_field` to put this value in.

You can also imagine running an aggregation and extract any field from the aggregation result.

Depending on the value extracted by the `path` and the source document, you might have the following behavior.

If `path` extracts an object and `target_field` is not defined, the object is merged as is within the source.

| Extracted with `path` | Source object | `target_field` | Generated document |
| --- | --- | --- | --- |
| `{ "foo": "bar" }` | `{ }` | - | `{ "foo": "bar" }` |
| `{ "foo": "bar" }` | `{ }` | `target` | `{ "target": { "foo": "bar" } }` |
| `{ "foo": "bar" }` | `{ "target": "baz" }` | `target` | `{ "target": { "foo": "bar" } }` |
| `{ "foo": "bar" }` | `{ "target": { "a": "b" } }` | `target` | `{ "target": { "a": "b", "foo": "bar" } }` |
| `"bar"` | `{ }` | - | Will be rejected |
| `"bar"` | `{ }` | `target` | `{ "target": "bar" }` |
| `"bar"` | `{ "target": "baz" }` | `target` | `{ "target": "bar" }` |
| `"bar"` | `{ "target": { "a": "b" } }` | `target` | `{ "target": "bar" }` |

Note that your documents could be rejected if they don't match the existing mapping.

For example, if you have previously indexed a document like `{ "target": "baz" }`, so `target` is defined as a
`string`, search ingest won't be able to generate a document like `{ "target": { "foo": "bar" } }` because
`target` would become an `Object`.
## TODO
- [ ] Need to autodetect the current http address. For now it's hard coded to http://127.0.0.1:9200
- [ ] Test with X-Pack / Security
- [ ] Password for X-Pack is in clear text for now and stored in the pipeline. We need to fix that.
- [ ] Support for multiple nodes?
- [ ] Support for cluster sniffing?
- [ ] Add a possibility to use a mustache template for the query and fill the template based on the content of the ingest source document.
- [ ] Read a full query from an ingest source field
- [ ] Use a real query object instead of String for the query and validate it when creating the pipeline? 

Closes #14617.
