### PR TITLE
Only ignore gradle wrapper in root dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ nbactions.xml
 build/
 
 # gradle wrapper 
-gradle/
+/gradle/
 gradlew
 gradlew.bat
 


### PR DESCRIPTION
Otherwise we ignore the `gradle` directories in `buildSrc`.
