### PR TITLE
Split allocator decision making from decision application 

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/UnassignedShardDecision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/UnassignedShardDecision.java
@@ -102,7 +102,6 @@ public class UnassignedShardDecision {
     public static UnassignedShardDecision throttleDecision(String explanation,
                                                            Map<String, Decision> nodeDecisions) {
         Objects.requireNonNull(explanation, "explanation must not be null");
-        Objects.requireNonNull(nodeDecisions, "nodeDecisions must not be null");
         return new UnassignedShardDecision(true, Decision.THROTTLE, AllocationStatus.DECIDERS_THROTTLED, explanation, null, null,
                                            nodeDecisions);
     }
@@ -118,7 +117,6 @@ public class UnassignedShardDecision {
                                                       Map<String, Decision> nodeDecisions) {
         Objects.requireNonNull(explanation, "explanation must not be null");
         Objects.requireNonNull(assignedNodeId, "assignedNodeId must not be null");
-        Objects.requireNonNull(nodeDecisions, "nodeDecisions must not be null");
         return new UnassignedShardDecision(true, Decision.YES, null, explanation, assignedNodeId, allocationId, nodeDecisions);
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/UnassignedShardDecision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/UnassignedShardDecision.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
+import org.elasticsearch.common.Nullable;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents the allocation decision by an allocator for an unassigned shard.
+ */
+public class UnassignedShardDecision {
+    /** a constant representing a shard decision where no decision was taken */
+    public static final UnassignedShardDecision DECISION_NOT_TAKEN =
+        new UnassignedShardDecision(false, null, null, null, null, null, null);
+
+    private final boolean decisionTaken;
+    @Nullable
+    private final Decision decision;
+    @Nullable
+    private final AllocationStatus allocationStatus;
+    @Nullable
+    private final String explanation;
+    @Nullable
+    private final String assignedNodeId;
+    @Nullable
+    private final String allocationId;
+    @Nullable
+    private final Map<String, Decision> nodeDecisions;
+
+    private UnassignedShardDecision(boolean decisionTaken,
+                                    Decision decision,
+                                    AllocationStatus allocationStatus,
+                                    String explanation,
+                                    String assignedNodeId,
+                                    String allocationId,
+                                    Map<String, Decision> nodeDecisions) {
+        assert decision != null || decisionTaken == false : "if a decision was taken, we must have the accompanying decision";
+        assert explanation != null || decisionTaken == false : "if a decision was taken, there must be an explanation for it";
+        assert assignedNodeId != null || decisionTaken == false || decision.type() != Type.YES :
+            "a yes decision must have a node to assign the shard to";
+        assert allocationStatus != null || decisionTaken == false || decision.type() == Type.YES :
+            "only a yes decision should not have an allocation status";
+        assert allocationId == null || assignedNodeId != null : "allocation id can only be null if the assigned node is null";
+        this.decisionTaken = decisionTaken;
+        this.decision = decision;
+        this.allocationStatus = allocationStatus;
+        this.explanation = explanation;
+        this.assignedNodeId = assignedNodeId;
+        this.allocationId = allocationId;
+        this.nodeDecisions = nodeDecisions != null ? Collections.unmodifiableMap(nodeDecisions) : null;
+    }
+
+    /**
+     * Creates a NO decision with the given {@link AllocationStatus} and explanation for the NO decision.
+     */
+    public static UnassignedShardDecision noDecision(AllocationStatus allocationStatus, String explanation) {
+        Objects.requireNonNull(explanation, "explanation must not be null");
+        Objects.requireNonNull(allocationStatus, "allocationStatus must not be null");
+        return new UnassignedShardDecision(true, Decision.NO, allocationStatus, explanation, null, null, null);
+    }
+
+    /**
+     * Creates a NO decision with the given {@link AllocationStatus} and explanation for the NO decision,
+     * as well as the individual node-level decisions that comprised the final NO decision.
+     */
+    public static UnassignedShardDecision noDecision(AllocationStatus allocationStatus,
+                                                     String explanation,
+                                                     Map<String, Decision> nodeDecisions) {
+        Objects.requireNonNull(explanation, "explanation must not be null");
+        Objects.requireNonNull(allocationStatus, "allocationStatus must not be null");
+        Objects.requireNonNull(nodeDecisions, "nodeDecisions must not be null");
+        return new UnassignedShardDecision(true, Decision.NO, allocationStatus, explanation, null, null, nodeDecisions);
+    }
+
+    /**
+     * Creates a THROTTLE decision with the given explanation and individual node-level decisions that
+     * comprised the final THROTTLE decision.
+     */
+    public static UnassignedShardDecision throttleDecision(String explanation,
+                                                           Map<String, Decision> nodeDecisions) {
+        Objects.requireNonNull(explanation, "explanation must not be null");
+        Objects.requireNonNull(nodeDecisions, "nodeDecisions must not be null");
+        return new UnassignedShardDecision(true, Decision.THROTTLE, AllocationStatus.DECIDERS_THROTTLED, explanation, null, null,
+                                           nodeDecisions);
+    }
+
+    /**
+     * Creates a YES decision with the given explanation and individual node-level decisions that
+     * comprised the final YES decision, along with the node id to which the shard is assigned and
+     * the allocation id for the shard, if available.
+     */
+    public static UnassignedShardDecision yesDecision(String explanation,
+                                                      String assignedNodeId,
+                                                      String allocationId,
+                                                      Map<String, Decision> nodeDecisions) {
+        Objects.requireNonNull(explanation, "explanation must not be null");
+        Objects.requireNonNull(assignedNodeId, "assignedNodeId must not be null");
+        Objects.requireNonNull(nodeDecisions, "nodeDecisions must not be null");
+        return new UnassignedShardDecision(true, Decision.YES, null, explanation, assignedNodeId, allocationId, nodeDecisions);
+    }
+
+    /**
+     * Returns <code>true</code> if a decision was taken by the allocator, {@code false} otherwise.
+     * If no decision was taken, then the rest of the fields in this object are meaningless and return {@code null}.
+     */
+    public boolean isDecisionTaken() {
+        return decisionTaken;
+    }
+
+    /**
+     * Returns the final decision made by the allocator on whether to assign the unassigned shard.
+     * This value can only be {@code null} if {@link #isDecisionTaken()} returns {@code false}.
+     */
+    @Nullable
+    public Decision getDecision() {
+        return decision;
+    }
+
+    /**
+     * Returns the status of an unsuccessful allocation attempt.  This value will be {@code null} if
+     * no decision was taken or if the decision was {@link Decision.Type#YES}.
+     */
+    @Nullable
+    public AllocationStatus getAllocationStatus() {
+        return allocationStatus;
+    }
+
+    /**
+     * Get the free-text explanation for the reason behind the decision taken in {@link #getDecision()}.
+     */
+    @Nullable
+    public String getExplanation() {
+        return explanation;
+    }
+
+    /**
+     * Get the node id that the allocator will assign the shard to, unless {@link #getDecision()} returns
+     * a value other than {@link Decision.Type#YES}, in which case this returns {@code null}.
+     */
+    @Nullable
+    public String getAssignedNodeId() {
+        return assignedNodeId;
+    }
+
+    /**
+     * Gets the allocation id for the existing shard copy that the allocator is assigning the shard to.
+     * This method returns a non-null value iff {@link #getAssignedNodeId()} returns a non-null value
+     * and the node on which the shard is assigned already has a shard copy with an in-sync allocation id
+     * that we can re-use.
+     */
+    @Nullable
+    public String getAllocationId() {
+        return allocationId;
+    }
+
+    /**
+     * Gets the individual node-level decisions that went into making the final decision as represented by
+     * {@link #getDecision()}.  The map that is returned has the node id as the key and a {@link Decision}
+     * as the decision for the given node.
+     */
+    @Nullable
+    public Map<String, Decision> getNodeDecisions() {
+        return nodeDecisions;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/UnassignedShardDecision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/UnassignedShardDecision.java
@@ -34,9 +34,8 @@ import java.util.Objects;
 public class UnassignedShardDecision {
     /** a constant representing a shard decision where no decision was taken */
     public static final UnassignedShardDecision DECISION_NOT_TAKEN =
-        new UnassignedShardDecision(false, null, null, null, null, null, null);
+        new UnassignedShardDecision(null, null, null, null, null, null);
 
-    private final boolean decisionTaken;
     @Nullable
     private final Decision finalDecision;
     @Nullable
@@ -50,24 +49,20 @@ public class UnassignedShardDecision {
     @Nullable
     private final Map<String, Decision> nodeDecisions;
 
-    private UnassignedShardDecision(boolean decisionTaken,
-                                    Decision finalDecision,
+    private UnassignedShardDecision(Decision finalDecision,
                                     AllocationStatus allocationStatus,
                                     String finalExplanation,
                                     String assignedNodeId,
                                     String allocationId,
                                     Map<String, Decision> nodeDecisions) {
-        assert finalDecision != null || decisionTaken == false :
-            "if a decision was taken, we must have the accompanying decision";
-        assert finalExplanation != null || decisionTaken == false :
+        assert finalExplanation != null || finalDecision == null :
             "if a decision was taken, there must be an explanation for it";
-        assert assignedNodeId != null || decisionTaken == false || finalDecision.type() != Type.YES :
+        assert assignedNodeId != null || finalDecision == null || finalDecision.type() != Type.YES :
             "a yes decision must have a node to assign the shard to";
-        assert allocationStatus != null || decisionTaken == false || finalDecision.type() == Type.YES :
+        assert allocationStatus != null || finalDecision == null || finalDecision.type() == Type.YES :
             "only a yes decision should not have an allocation status";
         assert allocationId == null || assignedNodeId != null :
             "allocation id can only be null if the assigned node is null";
-        this.decisionTaken = decisionTaken;
         this.finalDecision = finalDecision;
         this.allocationStatus = allocationStatus;
         this.finalExplanation = finalExplanation;
@@ -92,7 +87,7 @@ public class UnassignedShardDecision {
                                                      @Nullable Map<String, Decision> nodeDecisions) {
         Objects.requireNonNull(explanation, "explanation must not be null");
         Objects.requireNonNull(allocationStatus, "allocationStatus must not be null");
-        return new UnassignedShardDecision(true, Decision.NO, allocationStatus, explanation, null, null, nodeDecisions);
+        return new UnassignedShardDecision(Decision.NO, allocationStatus, explanation, null, null, nodeDecisions);
     }
 
     /**
@@ -102,7 +97,7 @@ public class UnassignedShardDecision {
     public static UnassignedShardDecision throttleDecision(String explanation,
                                                            Map<String, Decision> nodeDecisions) {
         Objects.requireNonNull(explanation, "explanation must not be null");
-        return new UnassignedShardDecision(true, Decision.THROTTLE, AllocationStatus.DECIDERS_THROTTLED, explanation, null, null,
+        return new UnassignedShardDecision(Decision.THROTTLE, AllocationStatus.DECIDERS_THROTTLED, explanation, null, null,
                                            nodeDecisions);
     }
 
@@ -117,7 +112,7 @@ public class UnassignedShardDecision {
                                                       Map<String, Decision> nodeDecisions) {
         Objects.requireNonNull(explanation, "explanation must not be null");
         Objects.requireNonNull(assignedNodeId, "assignedNodeId must not be null");
-        return new UnassignedShardDecision(true, Decision.YES, null, explanation, assignedNodeId, allocationId, nodeDecisions);
+        return new UnassignedShardDecision(Decision.YES, null, explanation, assignedNodeId, allocationId, nodeDecisions);
     }
 
     /**
@@ -125,7 +120,7 @@ public class UnassignedShardDecision {
      * If no decision was taken, then the rest of the fields in this object are meaningless and return {@code null}.
      */
     public boolean isDecisionTaken() {
-        return decisionTaken;
+        return finalDecision != null;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/gateway/BaseGatewayShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/BaseGatewayShardAllocator.java
@@ -43,7 +43,7 @@ public abstract class BaseGatewayShardAllocator extends AbstractComponent {
 
     /**
      * Allocate unassigned shards to nodes (if any) where valid copies of the shard already exist.
-     * It is up to the individual implementations of {@link #makeAllocationDecision(ShardRouting, RoutingAllocation, boolean, Logger)}
+     * It is up to the individual implementations of {@link #makeAllocationDecision(ShardRouting, RoutingAllocation, Logger)}
      * to make decisions on assigning shards to nodes.
      *
      * @param allocation the allocation state container object
@@ -53,7 +53,7 @@ public abstract class BaseGatewayShardAllocator extends AbstractComponent {
         final RoutingNodes.UnassignedShards.UnassignedIterator unassignedIterator = routingNodes.unassigned().iterator();
         while (unassignedIterator.hasNext()) {
             final ShardRouting shard = unassignedIterator.next();
-            final UnassignedShardDecision unassignedShardDecision = makeAllocationDecision(shard, allocation, false, logger);
+            final UnassignedShardDecision unassignedShardDecision = makeAllocationDecision(shard, allocation, logger);
 
             if (unassignedShardDecision.isDecisionTaken() == false) {
                 // no decision was taken by this allocator
@@ -79,12 +79,10 @@ public abstract class BaseGatewayShardAllocator extends AbstractComponent {
      *
      * @param unassignedShard  the unassigned shard to allocate
      * @param allocation       the current routing state
-     * @param explain          whether to explain the decision in the return object
      * @param logger           the logger
      * @return an {@link UnassignedShardDecision} with the final decision of whether to allocate and details of the decision
      */
     public abstract UnassignedShardDecision makeAllocationDecision(ShardRouting unassignedShard,
                                                                    RoutingAllocation allocation,
-                                                                   boolean explain,
                                                                    Logger logger);
 }

--- a/core/src/main/java/org/elasticsearch/gateway/BaseGatewayShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/BaseGatewayShardAllocator.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gateway;
+
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.UnassignedShardDecision;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.settings.Settings;
+
+/**
+ * An abstract class that implements basic functionality for allocating
+ * shards to nodes based on shard copies that already exist in the cluster.
+ *
+ * Individual implementations of this class are responsible for providing
+ * the logic to determine to which nodes (if any) those shards are allocated.
+ */
+public abstract class BaseGatewayShardAllocator extends AbstractComponent {
+
+    public BaseGatewayShardAllocator(Settings settings) {
+        super(settings);
+    }
+
+    /**
+     * Allocate unassigned shards to nodes (if any) where valid copies of the shard already exist.
+     * It is up to the individual implementations of {@link #makeAllocationDecision(ShardRouting, RoutingAllocation, boolean, Logger)}
+     * to make decisions on assigning shards to nodes.
+     *
+     * @param allocation the allocation state container object
+     */
+    public void allocateUnassigned(RoutingAllocation allocation) {
+        final RoutingNodes routingNodes = allocation.routingNodes();
+        final RoutingNodes.UnassignedShards.UnassignedIterator unassignedIterator = routingNodes.unassigned().iterator();
+        while (unassignedIterator.hasNext()) {
+            final ShardRouting shard = unassignedIterator.next();
+            final UnassignedShardDecision unassignedShardDecision = makeAllocationDecision(shard, allocation, false, logger);
+
+            if (unassignedShardDecision.isDecisionTaken() == false) {
+                // no decision was taken by this allocator
+                continue;
+            }
+
+            if (unassignedShardDecision.getDecision().type() == Decision.Type.YES) {
+                unassignedIterator.initialize(unassignedShardDecision.getAssignedNodeId(),
+                    unassignedShardDecision.getAllocationId(),
+                    shard.primary() ? ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE :
+                                      allocation.clusterInfo().getShardSize(shard, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE),
+                    allocation.changes());
+            } else {
+                unassignedIterator.removeAndIgnore(unassignedShardDecision.getAllocationStatus(), allocation.changes());
+            }
+        }
+    }
+
+    /**
+     * Make a decision on the allocation of an unassigned shard.  This method is used by
+     * {@link #allocateUnassigned(RoutingAllocation)} to make decisions about whether or not
+     * the shard can be allocated by this allocator and if so, to which node it will be allocated.
+     *
+     * @param unassignedShard  the unassigned shard to allocate
+     * @param allocation       the current routing state
+     * @param explain          whether to explain the decision in the return object
+     * @param logger           the logger
+     * @return an {@link UnassignedShardDecision} with the final decision of whether to allocate and details of the decision
+     */
+    public abstract UnassignedShardDecision makeAllocationDecision(ShardRouting unassignedShard,
+                                                                   RoutingAllocation allocation,
+                                                                   boolean explain,
+                                                                   Logger logger);
+}

--- a/core/src/main/java/org/elasticsearch/gateway/BaseGatewayShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/BaseGatewayShardAllocator.java
@@ -60,7 +60,7 @@ public abstract class BaseGatewayShardAllocator extends AbstractComponent {
                 continue;
             }
 
-            if (unassignedShardDecision.getDecision().type() == Decision.Type.YES) {
+            if (unassignedShardDecision.getFinalDecisionSafe().type() == Decision.Type.YES) {
                 unassignedIterator.initialize(unassignedShardDecision.getAssignedNodeId(),
                     unassignedShardDecision.getAllocationId(),
                     shard.primary() ? ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE :

--- a/core/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
@@ -203,21 +203,23 @@ public abstract class PrimaryShardAllocator extends BaseGatewayShardAllocator {
                 final NodeGatewayStartedShards nodeShardState = decidedNode.nodeShardState;
                 logger.debug("[{}][{}]: allocating [{}] to [{}] on forced primary allocation",
                              unassignedShard.index(), unassignedShard.id(), unassignedShard, nodeShardState.getNode());
-                return UnassignedShardDecision.yesDecision("",
-                    nodeShardState.getNode().getId(),
+                final String nodeId = nodeShardState.getNode().getId();
+                return UnassignedShardDecision.yesDecision(
+                    "allocating the primary shard to node [" + nodeId+ "], which has a complete copy of the shard data",
+                    nodeId,
                     nodeShardState.allocationId(),
                     (explain ? buildNodeDecisions(nodesToForceAllocate) : null));
             } else if (nodesToForceAllocate.throttleNodeShards.isEmpty() == false) {
                 logger.debug("[{}][{}]: throttling allocation [{}] to [{}] on forced primary allocation",
                              unassignedShard.index(), unassignedShard.id(), unassignedShard, nodesToForceAllocate.throttleNodeShards);
                 return UnassignedShardDecision.throttleDecision(
-                    "every node to which the shard can be force allocated is busy with other recoveries, so we are throttling allocation",
+                    "allocation throttled as all nodes to which the shard may be force allocated are busy with other recoveries",
                     (explain ? buildNodeDecisions(nodesToForceAllocate) : null));
             } else {
                 logger.debug("[{}][{}]: forced primary allocation denied [{}]",
                              unassignedShard.index(), unassignedShard.id(), unassignedShard);
                 return UnassignedShardDecision.noDecision(AllocationStatus.DECIDERS_NO,
-                    "all nodes that hold a valid shard copy received a NO decision, and force allocation was not permitted either",
+                    "all nodes that hold a valid shard copy returned a NO decision, and force allocation is not permitted",
                     (explain ? buildNodeDecisions(nodesToForceAllocate) : null));
             }
         } else {
@@ -226,7 +228,7 @@ public abstract class PrimaryShardAllocator extends BaseGatewayShardAllocator {
             logger.debug("[{}][{}]: throttling allocation [{}] to [{}] on primary allocation",
                          unassignedShard.index(), unassignedShard.id(), unassignedShard, nodesToAllocate.throttleNodeShards);
             return UnassignedShardDecision.throttleDecision(
-                "every node to which the shard can be allocated is busy with other recoveries, so we are throttling allocation",
+                "allocation throttled as all nodes to which the shard may be allocated are busy with other recoveries",
                 (explain ? buildNodeDecisions(nodesToAllocate) : null));
         }
     }

--- a/core/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
@@ -112,13 +112,13 @@ public abstract class PrimaryShardAllocator extends BaseGatewayShardAllocator {
     @Override
     public UnassignedShardDecision makeAllocationDecision(final ShardRouting unassignedShard,
                                                           final RoutingAllocation allocation,
-                                                          final boolean explain,
                                                           final Logger logger) {
         if (isResponsibleFor(unassignedShard) == false) {
             // this allocator is not responsible for allocating this shard
             return UnassignedShardDecision.DECISION_NOT_TAKEN;
         }
 
+        final boolean explain = allocation.debugDecision();
         final FetchResult<NodeGatewayStartedShards> shardState = fetchData(unassignedShard, allocation);
         if (shardState.hasData() == false) {
             allocation.setHasPendingAsyncFetch();

--- a/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -23,7 +23,7 @@ import com.carrotsearch.hppc.ObjectLongHashMap;
 import com.carrotsearch.hppc.ObjectLongMap;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectLongCursor;
-import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RoutingNode;
@@ -31,24 +31,25 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
-import org.elasticsearch.cluster.routing.RoutingChangesObserver;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.UnassignedShardDecision;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.store.StoreFileMetaData;
 import org.elasticsearch.indices.store.TransportNodesListShardStoreMetaData;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 /**
  */
-public abstract class ReplicaShardAllocator extends AbstractComponent {
+public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
 
     public ReplicaShardAllocator(Settings settings) {
         super(settings);
@@ -96,7 +97,7 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
                     continue;
                 }
 
-                MatchingNodes matchingNodes = findMatchingNodes(shard, allocation, primaryStore, shardStores);
+                MatchingNodes matchingNodes = findMatchingNodes(shard, allocation, primaryStore, shardStores, false);
                 if (matchingNodes.getNodeWithHighestMatch() != null) {
                     DiscoveryNode currentNode = allocation.nodes().get(shard.currentNodeId());
                     DiscoveryNode nodeWithHighestMatch = matchingNodes.getNodeWithHighestMatch();
@@ -128,86 +129,88 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
         }
     }
 
-    public void allocateUnassigned(RoutingAllocation allocation) {
-        final RoutingNodes routingNodes = allocation.routingNodes();
-        final RoutingNodes.UnassignedShards.UnassignedIterator unassignedIterator = routingNodes.unassigned().iterator();
-        while (unassignedIterator.hasNext()) {
-            ShardRouting shard = unassignedIterator.next();
-            if (shard.primary()) {
-                continue;
-            }
-
-            // if we are allocating a replica because of index creation, no need to go and find a copy, there isn't one...
-            if (shard.unassignedInfo().getReason() == UnassignedInfo.Reason.INDEX_CREATED) {
-                continue;
-            }
-
-            // pre-check if it can be allocated to any node that currently exists, so we won't list the store for it for nothing
-            Decision decision = canBeAllocatedToAtLeastOneNode(shard, allocation);
-            if (decision.type() != Decision.Type.YES) {
-                logger.trace("{}: ignoring allocation, can't be allocated on any node", shard);
-                unassignedIterator.removeAndIgnore(UnassignedInfo.AllocationStatus.fromDecision(decision), allocation.changes());
-                continue;
-            }
-
-            AsyncShardFetch.FetchResult<TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData> shardStores = fetchData(shard, allocation);
-            if (shardStores.hasData() == false) {
-                logger.trace("{}: ignoring allocation, still fetching shard stores", shard);
-                allocation.setHasPendingAsyncFetch();
-                unassignedIterator.removeAndIgnore(AllocationStatus.FETCHING_SHARD_DATA, allocation.changes());
-                continue; // still fetching
-            }
-
-            ShardRouting primaryShard = routingNodes.activePrimary(shard.shardId());
-            assert primaryShard != null : "the replica shard can be allocated on at least one node, so there must be an active primary";
-            TransportNodesListShardStoreMetaData.StoreFilesMetaData primaryStore = findStore(primaryShard, allocation, shardStores);
-            if (primaryStore == null) {
-                // if we can't find the primary data, it is probably because the primary shard is corrupted (and listing failed)
-                // we want to let the replica be allocated in order to expose the actual problem with the primary that the replica
-                // will try and recover from
-                // Note, this is the existing behavior, as exposed in running CorruptFileTest#testNoPrimaryData
-                logger.trace("{}: no primary shard store found or allocated, letting actual allocation figure it out", shard);
-                continue;
-            }
-
-            MatchingNodes matchingNodes = findMatchingNodes(shard, allocation, primaryStore, shardStores);
-
-            if (matchingNodes.getNodeWithHighestMatch() != null) {
-                RoutingNode nodeWithHighestMatch = allocation.routingNodes().node(matchingNodes.getNodeWithHighestMatch().getId());
-                // we only check on THROTTLE since we checked before before on NO
-                decision = allocation.deciders().canAllocate(shard, nodeWithHighestMatch, allocation);
-                if (decision.type() == Decision.Type.THROTTLE) {
-                    logger.debug("[{}][{}]: throttling allocation [{}] to [{}] in order to reuse its unallocated persistent store", shard.index(), shard.id(), shard, nodeWithHighestMatch.node());
-                    // we are throttling this, but we have enough to allocate to this node, ignore it for now
-                    unassignedIterator.removeAndIgnore(UnassignedInfo.AllocationStatus.fromDecision(decision), allocation.changes());
-                } else {
-                    logger.debug("[{}][{}]: allocating [{}] to [{}] in order to reuse its unallocated persistent store", shard.index(), shard.id(), shard, nodeWithHighestMatch.node());
-                    // we found a match
-                    unassignedIterator.initialize(nodeWithHighestMatch.nodeId(), null, allocation.clusterInfo().getShardSize(shard, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE), allocation.changes());
-                }
-            } else if (matchingNodes.hasAnyData() == false) {
-                // if we didn't manage to find *any* data (regardless of matching sizes), check if the allocation of the replica shard needs to be delayed
-                ignoreUnassignedIfDelayed(unassignedIterator, shard, allocation.changes());
-            }
-        }
+    /**
+     * Is the allocator responsible for allocating the given {@link ShardRouting}?
+     */
+    private static boolean isResponsibleFor(final ShardRouting shard) {
+        return shard.primary() == false // must be a replica
+                   && shard.unassigned() // must be unassigned
+                   // if we are allocating a replica because of index creation, no need to go and find a copy, there isn't one...
+                   && shard.unassignedInfo().getReason() != UnassignedInfo.Reason.INDEX_CREATED;
     }
 
-    /**
-     * Check if the allocation of the replica is to be delayed. Compute the delay and if it is delayed, add it to the ignore unassigned list
-     * Note: we only care about replica in delayed allocation, since if we have an unassigned primary it
-     *       will anyhow wait to find an existing copy of the shard to be allocated
-     * Note: the other side of the equation is scheduling a reroute in a timely manner, which happens in the RoutingService
-     *
-     * PUBLIC FOR TESTS!
-     *
-     * @param unassignedIterator iterator over unassigned shards
-     * @param shard the shard which might be delayed
-     */
-    public void ignoreUnassignedIfDelayed(RoutingNodes.UnassignedShards.UnassignedIterator unassignedIterator, ShardRouting shard, RoutingChangesObserver changes) {
-        if (shard.unassignedInfo().isDelayed()) {
-            logger.debug("{}: allocation of [{}] is delayed", shard.shardId(), shard);
-            unassignedIterator.removeAndIgnore(AllocationStatus.DELAYED_ALLOCATION, changes);
+    @Override
+    public UnassignedShardDecision makeAllocationDecision(final ShardRouting unassignedShard,
+                                                          final RoutingAllocation allocation,
+                                                          final boolean explain,
+                                                          final Logger logger) {
+        if (isResponsibleFor(unassignedShard) == false) {
+            // this allocator is not responsible for deciding on this shard
+            return UnassignedShardDecision.DECISION_NOT_TAKEN;
         }
+
+        final RoutingNodes routingNodes = allocation.routingNodes();
+        // pre-check if it can be allocated to any node that currently exists, so we won't list the store for it for nothing
+        Tuple<Decision, Map<String, Decision>> allocateDecision = canBeAllocatedToAtLeastOneNode(unassignedShard, allocation, explain);
+        if (allocateDecision.v1().type() != Decision.Type.YES) {
+            logger.trace("{}: ignoring allocation, can't be allocated on any node", unassignedShard);
+            return UnassignedShardDecision.noDecision(UnassignedInfo.AllocationStatus.fromDecision(allocateDecision.v1()),
+                "all nodes received a NO decision for allocating the replica shard", allocateDecision.v2());
+        }
+
+        AsyncShardFetch.FetchResult<TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData> shardStores = fetchData(unassignedShard, allocation);
+        if (shardStores.hasData() == false) {
+            logger.trace("{}: ignoring allocation, still fetching shard stores", unassignedShard);
+            allocation.setHasPendingAsyncFetch();
+            return UnassignedShardDecision.noDecision(AllocationStatus.FETCHING_SHARD_DATA,
+                "still fetching shard state from the nodes in the cluster");
+        }
+
+        ShardRouting primaryShard = routingNodes.activePrimary(unassignedShard.shardId());
+        assert primaryShard != null : "the replica shard can be allocated on at least one node, so there must be an active primary";
+        TransportNodesListShardStoreMetaData.StoreFilesMetaData primaryStore = findStore(primaryShard, allocation, shardStores);
+        if (primaryStore == null) {
+            // if we can't find the primary data, it is probably because the primary shard is corrupted (and listing failed)
+            // we want to let the replica be allocated in order to expose the actual problem with the primary that the replica
+            // will try and recover from
+            // Note, this is the existing behavior, as exposed in running CorruptFileTest#testNoPrimaryData
+            logger.trace("{}: no primary shard store found or allocated, letting actual allocation figure it out", unassignedShard);
+            return UnassignedShardDecision.DECISION_NOT_TAKEN;
+        }
+
+        MatchingNodes matchingNodes = findMatchingNodes(unassignedShard, allocation, primaryStore, shardStores, explain);
+        assert explain == false || matchingNodes.nodeDecisions != null : "in explain mode, we must have individual node decisions";
+
+        if (matchingNodes.getNodeWithHighestMatch() != null) {
+            RoutingNode nodeWithHighestMatch = allocation.routingNodes().node(matchingNodes.getNodeWithHighestMatch().getId());
+            // we only check on THROTTLE since we checked before before on NO
+            Decision decision = allocation.deciders().canAllocate(unassignedShard, nodeWithHighestMatch, allocation);
+            if (decision.type() == Decision.Type.THROTTLE) {
+                logger.debug("[{}][{}]: throttling allocation [{}] to [{}] in order to reuse its unallocated persistent store",
+                    unassignedShard.index(), unassignedShard.id(), unassignedShard, nodeWithHighestMatch.node());
+                // we are throttling this, as we have enough other shards to allocate to this node, so ignore it for now
+                return UnassignedShardDecision.throttleDecision(
+                    "received a THROTTLE decision on each node that has an unallocated copy of the shard, so waiting to re-use one " +
+                    "of those copies", matchingNodes.nodeDecisions);
+            } else {
+                logger.debug("[{}][{}]: allocating [{}] to [{}] in order to reuse its unallocated persistent store",
+                    unassignedShard.index(), unassignedShard.id(), unassignedShard, nodeWithHighestMatch.node());
+                // we found a match
+                return UnassignedShardDecision.yesDecision(
+                    "allocating to node [" + nodeWithHighestMatch.nodeId() + "] in order to re-use its unallocated persistent store",
+                    nodeWithHighestMatch.nodeId(), null, matchingNodes.nodeDecisions);
+            }
+        } else if (matchingNodes.hasAnyData() == false && unassignedShard.unassignedInfo().isDelayed()) {
+            // if we didn't manage to find *any* data (regardless of matching sizes), and the replica is
+            // unassigned due to a node leaving, so we delay allocation of this replica to see if the
+            // node with the shard copy will rejoin so we can re-use the copy it has
+            logger.debug("{}: allocation of [{}] is delayed", unassignedShard.shardId(), unassignedShard);
+            return UnassignedShardDecision.noDecision(AllocationStatus.DELAYED_ALLOCATION,
+                "delaying allocation, as the node that held the shard left the cluster, waiting to see if it returns and so " +
+                "that shard copy can be re-used");
+        }
+
+        return UnassignedShardDecision.DECISION_NOT_TAKEN;
     }
 
     /**
@@ -215,10 +218,15 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
      *
      * Returns the best allocation decision for allocating the shard on any node (i.e. YES if at least one
      * node decided YES, THROTTLE if at least one node decided THROTTLE, and NO if none of the nodes decided
-     * YES or THROTTLE.
+     * YES or THROTTLE). If the explain flag is turned on AND the decision is NO or THROTTLE, then this method
+     * also returns a map of nodes to decisions (second value in the tuple) to use for explanations; if the explain
+     * flag is off, the second value in the return tuple will be null.
      */
-    private Decision canBeAllocatedToAtLeastOneNode(ShardRouting shard, RoutingAllocation allocation) {
+    private Tuple<Decision, Map<String, Decision>> canBeAllocatedToAtLeastOneNode(ShardRouting shard,
+                                                                                  RoutingAllocation allocation,
+                                                                                  boolean explain) {
         Decision madeDecision = Decision.NO;
+        Map<String, Decision> nodeDecisions = new HashMap<>();
         for (ObjectCursor<DiscoveryNode> cursor : allocation.nodes().getDataNodes().values()) {
             RoutingNode node = allocation.routingNodes().node(cursor.value.getId());
             if (node == null) {
@@ -227,13 +235,16 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
             // if we can't allocate it on a node, ignore it, for example, this handles
             // cases for only allocating a replica after a primary
             Decision decision = allocation.deciders().canAllocate(shard, node, allocation);
+            if (explain) {
+                nodeDecisions.put(node.nodeId(), decision);
+            }
             if (decision.type() == Decision.Type.YES) {
-                return decision;
+                return Tuple.tuple(decision, null);
             } else if (madeDecision.type() == Decision.Type.NO && decision.type() == Decision.Type.THROTTLE) {
                 madeDecision = decision;
             }
         }
-        return madeDecision;
+        return Tuple.tuple(madeDecision, explain ? nodeDecisions : null);
     }
 
     /**
@@ -254,8 +265,10 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
 
     private MatchingNodes findMatchingNodes(ShardRouting shard, RoutingAllocation allocation,
                                             TransportNodesListShardStoreMetaData.StoreFilesMetaData primaryStore,
-                                            AsyncShardFetch.FetchResult<TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData> data) {
+                                            AsyncShardFetch.FetchResult<TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData> data,
+                                            boolean explain) {
         ObjectLongMap<DiscoveryNode> nodesToSize = new ObjectLongHashMap<>();
+        Map<String, Decision> nodeDecisions = new HashMap<>();
         for (Map.Entry<DiscoveryNode, TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData> nodeStoreEntry : data.getData().entrySet()) {
             DiscoveryNode discoNode = nodeStoreEntry.getKey();
             TransportNodesListShardStoreMetaData.StoreFilesMetaData storeFilesMetaData = nodeStoreEntry.getValue().storeFilesMetaData();
@@ -273,6 +286,10 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
             // we only check for NO, since if this node is THROTTLING and it has enough "same data"
             // then we will try and assign it next time
             Decision decision = allocation.deciders().canAllocate(shard, node, allocation);
+            if (explain) {
+                nodeDecisions.put(node.nodeId(), decision);
+            }
+
             if (decision.type() == Decision.Type.NO) {
                 continue;
             }
@@ -297,7 +314,8 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
             }
         }
 
-        return new MatchingNodes(nodesToSize);
+        assert explain || nodeDecisions.size() == 0 : "node decision map should not have entries if we are not in explain mode";
+        return new MatchingNodes(nodesToSize, explain ? nodeDecisions : null);
     }
 
     protected abstract AsyncShardFetch.FetchResult<TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData> fetchData(ShardRouting shard, RoutingAllocation allocation);
@@ -305,9 +323,12 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
     static class MatchingNodes {
         private final ObjectLongMap<DiscoveryNode> nodesToSize;
         private final DiscoveryNode nodeWithHighestMatch;
+        @Nullable
+        private final Map<String, Decision> nodeDecisions;
 
-        public MatchingNodes(ObjectLongMap<DiscoveryNode> nodesToSize) {
+        public MatchingNodes(ObjectLongMap<DiscoveryNode> nodesToSize, @Nullable Map<String, Decision> nodeDecisions) {
             this.nodesToSize = nodesToSize;
+            this.nodeDecisions = nodeDecisions;
 
             long highestMatchSize = 0;
             DiscoveryNode highestMatchNode = null;
@@ -339,6 +360,14 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
          */
         public boolean hasAnyData() {
             return nodesToSize.isEmpty() == false;
+        }
+
+        /**
+         * The decisions map for all nodes with a shard copy, if available.
+         */
+        @Nullable
+        public Map<String, Decision> getNodeDecisions() {
+            return nodeDecisions;
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -142,7 +142,6 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
     @Override
     public UnassignedShardDecision makeAllocationDecision(final ShardRouting unassignedShard,
                                                           final RoutingAllocation allocation,
-                                                          final boolean explain,
                                                           final Logger logger) {
         if (isResponsibleFor(unassignedShard) == false) {
             // this allocator is not responsible for deciding on this shard
@@ -150,6 +149,7 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
         }
 
         final RoutingNodes routingNodes = allocation.routingNodes();
+        final boolean explain = allocation.debugDecision();
         // pre-check if it can be allocated to any node that currently exists, so we won't list the store for it for nothing
         Tuple<Decision, Map<String, Decision>> allocateDecision = canBeAllocatedToAtLeastOneNode(unassignedShard, allocation, explain);
         if (allocateDecision.v1().type() != Decision.Type.YES) {

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/UnassignedShardDecisionTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/UnassignedShardDecisionTests.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Unit tests for the {@link UnassignedShardDecision} class.
+ */
+public class UnassignedShardDecisionTests extends ESTestCase {
+
+    public void testDecisionNotTaken() {
+        UnassignedShardDecision unassignedShardDecision = UnassignedShardDecision.DECISION_NOT_TAKEN;
+        assertFalse(unassignedShardDecision.isDecisionTaken());
+        assertNull(unassignedShardDecision.getDecision());
+        assertNull(unassignedShardDecision.getAllocationStatus());
+        assertNull(unassignedShardDecision.getAllocationId());
+        assertNull(unassignedShardDecision.getAssignedNodeId());
+        assertNull(unassignedShardDecision.getExplanation());
+        assertNull(unassignedShardDecision.getNodeDecisions());
+    }
+
+    public void testNoDecision() {
+        final AllocationStatus allocationStatus = randomFrom(
+            AllocationStatus.DELAYED_ALLOCATION, AllocationStatus.NO_VALID_SHARD_COPY, AllocationStatus.FETCHING_SHARD_DATA
+        );
+        UnassignedShardDecision noDecision = UnassignedShardDecision.noDecision(allocationStatus, "something is wrong");
+        assertTrue(noDecision.isDecisionTaken());
+        assertEquals(Decision.Type.NO, noDecision.getDecision().type());
+        assertEquals(allocationStatus, noDecision.getAllocationStatus());
+        assertEquals("something is wrong", noDecision.getExplanation());
+        assertNull(noDecision.getNodeDecisions());
+        assertNull(noDecision.getAssignedNodeId());
+        assertNull(noDecision.getAllocationId());
+
+        Map<String, Decision> nodeDecisions = new HashMap<>();
+        nodeDecisions.put("node1", Decision.NO);
+        nodeDecisions.put("node2", Decision.NO);
+        noDecision = UnassignedShardDecision.noDecision(AllocationStatus.DECIDERS_NO, "something is wrong", nodeDecisions);
+        assertTrue(noDecision.isDecisionTaken());
+        assertEquals(Decision.Type.NO, noDecision.getDecision().type());
+        assertEquals(AllocationStatus.DECIDERS_NO, noDecision.getAllocationStatus());
+        assertEquals("something is wrong", noDecision.getExplanation());
+        assertEquals(nodeDecisions, noDecision.getNodeDecisions());
+        assertNull(noDecision.getAssignedNodeId());
+        assertNull(noDecision.getAllocationId());
+
+        // test bad values
+        expectThrows(NullPointerException.class, () -> UnassignedShardDecision.noDecision(null, "a"));
+        expectThrows(NullPointerException.class, () -> UnassignedShardDecision.noDecision(AllocationStatus.DECIDERS_NO, null));
+    }
+
+    public void testThrottleDecision() {
+        Map<String, Decision> nodeDecisions = new HashMap<>();
+        nodeDecisions.put("node1", Decision.NO);
+        nodeDecisions.put("node2", Decision.THROTTLE);
+        UnassignedShardDecision throttleDecision = UnassignedShardDecision.throttleDecision("too much happening", nodeDecisions);
+        assertTrue(throttleDecision.isDecisionTaken());
+        assertEquals(Decision.Type.THROTTLE, throttleDecision.getDecision().type());
+        assertEquals(AllocationStatus.DECIDERS_THROTTLED, throttleDecision.getAllocationStatus());
+        assertEquals("too much happening", throttleDecision.getExplanation());
+        assertEquals(nodeDecisions, throttleDecision.getNodeDecisions());
+        assertNull(throttleDecision.getAssignedNodeId());
+        assertNull(throttleDecision.getAllocationId());
+
+        // test bad values
+        expectThrows(NullPointerException.class, () -> UnassignedShardDecision.throttleDecision(null, Collections.emptyMap()));
+        expectThrows(NullPointerException.class, () -> UnassignedShardDecision.throttleDecision("a", null));
+    }
+
+    public void testYesDecision() {
+        Map<String, Decision> nodeDecisions = new HashMap<>();
+        nodeDecisions.put("node1", Decision.YES);
+        nodeDecisions.put("node2", Decision.NO);
+        String allocId = randomBoolean() ? "allocId" : null;
+        UnassignedShardDecision yesDecision = UnassignedShardDecision.yesDecision(
+            "node was very kind", "node1", allocId, nodeDecisions
+        );
+        assertTrue(yesDecision.isDecisionTaken());
+        assertEquals(Decision.Type.YES, yesDecision.getDecision().type());
+        assertNull(yesDecision.getAllocationStatus());
+        assertEquals("node was very kind", yesDecision.getExplanation());
+        assertEquals(nodeDecisions, yesDecision.getNodeDecisions());
+        assertEquals("node1", yesDecision.getAssignedNodeId());
+        assertEquals(allocId, yesDecision.getAllocationId());
+
+        expectThrows(NullPointerException.class,
+            () -> UnassignedShardDecision.yesDecision(null, "a", randomBoolean() ? "a" : null, Collections.emptyMap()));
+        expectThrows(NullPointerException.class,
+            () -> UnassignedShardDecision.yesDecision("a", null, null, Collections.emptyMap()));
+        expectThrows(NullPointerException.class,
+            () -> UnassignedShardDecision.yesDecision("a", "a", randomBoolean() ? "a" : null, null));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/UnassignedShardDecisionTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/UnassignedShardDecisionTests.java
@@ -90,7 +90,6 @@ public class UnassignedShardDecisionTests extends ESTestCase {
 
         // test bad values
         expectThrows(NullPointerException.class, () -> UnassignedShardDecision.throttleDecision(null, Collections.emptyMap()));
-        expectThrows(NullPointerException.class, () -> UnassignedShardDecision.throttleDecision("a", null));
     }
 
     public void testYesDecision() {
@@ -113,7 +112,5 @@ public class UnassignedShardDecisionTests extends ESTestCase {
             () -> UnassignedShardDecision.yesDecision(null, "a", randomBoolean() ? "a" : null, Collections.emptyMap()));
         expectThrows(NullPointerException.class,
             () -> UnassignedShardDecision.yesDecision("a", null, null, Collections.emptyMap()));
-        expectThrows(NullPointerException.class,
-            () -> UnassignedShardDecision.yesDecision("a", "a", randomBoolean() ? "a" : null, null));
     }
 }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/UnassignedShardDecisionTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/UnassignedShardDecisionTests.java
@@ -35,12 +35,14 @@ public class UnassignedShardDecisionTests extends ESTestCase {
     public void testDecisionNotTaken() {
         UnassignedShardDecision unassignedShardDecision = UnassignedShardDecision.DECISION_NOT_TAKEN;
         assertFalse(unassignedShardDecision.isDecisionTaken());
-        assertNull(unassignedShardDecision.getDecision());
+        assertNull(unassignedShardDecision.getFinalDecision());
         assertNull(unassignedShardDecision.getAllocationStatus());
         assertNull(unassignedShardDecision.getAllocationId());
         assertNull(unassignedShardDecision.getAssignedNodeId());
-        assertNull(unassignedShardDecision.getExplanation());
+        assertNull(unassignedShardDecision.getFinalExplanation());
         assertNull(unassignedShardDecision.getNodeDecisions());
+        expectThrows(IllegalArgumentException.class, () -> unassignedShardDecision.getFinalDecisionSafe());
+        expectThrows(IllegalArgumentException.class, () -> unassignedShardDecision.getFinalExplanationSafe());
     }
 
     public void testNoDecision() {
@@ -49,9 +51,9 @@ public class UnassignedShardDecisionTests extends ESTestCase {
         );
         UnassignedShardDecision noDecision = UnassignedShardDecision.noDecision(allocationStatus, "something is wrong");
         assertTrue(noDecision.isDecisionTaken());
-        assertEquals(Decision.Type.NO, noDecision.getDecision().type());
+        assertEquals(Decision.Type.NO, noDecision.getFinalDecision().type());
         assertEquals(allocationStatus, noDecision.getAllocationStatus());
-        assertEquals("something is wrong", noDecision.getExplanation());
+        assertEquals("something is wrong", noDecision.getFinalExplanation());
         assertNull(noDecision.getNodeDecisions());
         assertNull(noDecision.getAssignedNodeId());
         assertNull(noDecision.getAllocationId());
@@ -61,9 +63,9 @@ public class UnassignedShardDecisionTests extends ESTestCase {
         nodeDecisions.put("node2", Decision.NO);
         noDecision = UnassignedShardDecision.noDecision(AllocationStatus.DECIDERS_NO, "something is wrong", nodeDecisions);
         assertTrue(noDecision.isDecisionTaken());
-        assertEquals(Decision.Type.NO, noDecision.getDecision().type());
+        assertEquals(Decision.Type.NO, noDecision.getFinalDecision().type());
         assertEquals(AllocationStatus.DECIDERS_NO, noDecision.getAllocationStatus());
-        assertEquals("something is wrong", noDecision.getExplanation());
+        assertEquals("something is wrong", noDecision.getFinalExplanation());
         assertEquals(nodeDecisions, noDecision.getNodeDecisions());
         assertNull(noDecision.getAssignedNodeId());
         assertNull(noDecision.getAllocationId());
@@ -79,9 +81,9 @@ public class UnassignedShardDecisionTests extends ESTestCase {
         nodeDecisions.put("node2", Decision.THROTTLE);
         UnassignedShardDecision throttleDecision = UnassignedShardDecision.throttleDecision("too much happening", nodeDecisions);
         assertTrue(throttleDecision.isDecisionTaken());
-        assertEquals(Decision.Type.THROTTLE, throttleDecision.getDecision().type());
+        assertEquals(Decision.Type.THROTTLE, throttleDecision.getFinalDecision().type());
         assertEquals(AllocationStatus.DECIDERS_THROTTLED, throttleDecision.getAllocationStatus());
-        assertEquals("too much happening", throttleDecision.getExplanation());
+        assertEquals("too much happening", throttleDecision.getFinalExplanation());
         assertEquals(nodeDecisions, throttleDecision.getNodeDecisions());
         assertNull(throttleDecision.getAssignedNodeId());
         assertNull(throttleDecision.getAllocationId());
@@ -100,9 +102,9 @@ public class UnassignedShardDecisionTests extends ESTestCase {
             "node was very kind", "node1", allocId, nodeDecisions
         );
         assertTrue(yesDecision.isDecisionTaken());
-        assertEquals(Decision.Type.YES, yesDecision.getDecision().type());
+        assertEquals(Decision.Type.YES, yesDecision.getFinalDecision().type());
         assertNull(yesDecision.getAllocationStatus());
-        assertEquals("node was very kind", yesDecision.getExplanation());
+        assertEquals("node was very kind", yesDecision.getFinalExplanation());
         assertEquals(nodeDecisions, yesDecision.getNodeDecisions());
         assertEquals("node1", yesDecision.getAssignedNodeId());
         assertEquals(allocId, yesDecision.getAllocationId());

--- a/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
@@ -236,7 +236,9 @@ public abstract class ESAllocationTestCase extends ESTestCase {
                 if (shard.primary() || shard.unassignedInfo().getReason() == UnassignedInfo.Reason.INDEX_CREATED) {
                     continue;
                 }
-                replicaShardAllocator.ignoreUnassignedIfDelayed(unassignedIterator, shard, allocation.changes());
+                if (shard.unassignedInfo().isDelayed()) {
+                    unassignedIterator.removeAndIgnore(UnassignedInfo.AllocationStatus.DELAYED_ALLOCATION, allocation.changes());
+                }
             }
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
@@ -38,10 +38,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationD
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.LocalTransportAddress;
-import org.elasticsearch.gateway.AsyncShardFetch;
 import org.elasticsearch.gateway.GatewayAllocator;
-import org.elasticsearch.gateway.ReplicaShardAllocator;
-import org.elasticsearch.indices.store.TransportNodesListShardStoreMetaData;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.gateway.NoopGatewayAllocator;
 
@@ -209,14 +206,6 @@ public abstract class ESAllocationTestCase extends ESTestCase {
      * Mocks behavior in ReplicaShardAllocator to remove delayed shards from list of unassigned shards so they don't get reassigned yet.
      */
     protected static class DelayedShardsMockGatewayAllocator extends GatewayAllocator {
-        private final ReplicaShardAllocator replicaShardAllocator = new ReplicaShardAllocator(Settings.EMPTY) {
-            @Override
-            protected AsyncShardFetch.FetchResult<TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData>
-            fetchData(ShardRouting shard, RoutingAllocation allocation) {
-                return new AsyncShardFetch.FetchResult<>(shard.shardId(), null, Collections.emptySet(), Collections.emptySet());
-            }
-        };
-
 
         public DelayedShardsMockGatewayAllocator() {
             super(Settings.EMPTY, null, null);


### PR DESCRIPTION
Splits the PrimaryShardAllocator and ReplicaShardAllocator's decision 
making for a shard from the implementation of that decision on the
routing table. This is a step toward making it easier to use the same
logic for the cluster allocation explain APIs.

A subsequent PR will split the decision making and decision application
for the BalancedShardsAllocator.
