### PR TITLE
Samples are not working. Mapping is wrong

### DIFF
--- a/docs/reference/query-dsl/percolate-query.asciidoc
+++ b/docs/reference/query-dsl/percolate-query.asciidoc
@@ -19,7 +19,7 @@ PUT /my-index
         "doctype": {
             "properties": {
                 "message": {
-                    "type": "keyword"
+                    "type": "text"
                 }
             }
         },


### PR DESCRIPTION
Hi all, 

I was trying to run the percolate examples, but I figured that because of the "type":"keyword" , the code wasn't working.
In the saerch query the "message" : "A new bonsai tree in the office" is a pure string. 

I changed it to "text"
