### PR TITLE
Remove -D handling in args for windows plugin script

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-plugin.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin.bat
@@ -17,45 +17,9 @@ for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
 
 TITLE Elasticsearch Plugin Manager ${project.version}
 
-SET properties=
-SET args=
-
-:loop
-SET "current=%~1"
-SHIFT
-IF "x!current!" == "x" GOTO breakloop
-
-IF "!current:~0,2%!" == "-D" (
-    ECHO "!current!" | FINDSTR /C:"=">nul && (
-         :: current matches -D*=*
-         IF "x!properties!" NEQ "x" (
-             SET properties=!properties! "!current!"
-         ) ELSE (
-             SET properties="!current!"
-         )
-    ) || (
-         :: current matches -D*
-         IF "x!properties!" NEQ "x" (
-            SET properties=!properties! "!current!=%~1"
-         ) ELSE (
-            SET properties="!current!=%~1"
-         )
-         SHIFT
-    )
-) ELSE (
-    :: current matches *
-    IF "x!args!" NEQ "x" (
-        SET args=!args! "!current!"
-    ) ELSE (
-        SET args="!current!"
-    )
-)
-
-GOTO loop
-:breakloop
-
+SET args=%*
 SET HOSTNAME=%COMPUTERNAME%
 
-"%JAVA%" %ES_JAVA_OPTS% -Des.path.home="%ES_HOME%" !properties! -cp "%ES_HOME%/lib/*;" "org.elasticsearch.plugins.PluginCli" !args!
+"%JAVA%" %ES_JAVA_OPTS% -Des.path.home="%ES_HOME%" -cp "%ES_HOME%/lib/*;" "org.elasticsearch.plugins.PluginCli" !args!
 
 ENDLOCAL


### PR DESCRIPTION
-D parameters used to be allowed when starting elasticsearch scripts.
However, this was removed in #18207, but the elasticsearch-plugin.bat script
was forgotten. This change removes the -D handling.
