### PR TITLE
Remove logging configuration warning

### DIFF
--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
@@ -77,14 +77,14 @@ public class EvilLoggerTests extends ESTestCase {
         testLogger.trace("This is a trace message");
         final String path = System.getProperty("es.logs") + ".log";
         final List<String> events = Files.readAllLines(PathUtils.get(path));
-        assertThat(events.size(), equalTo(6)); // the five messages me log plus a warning for unsupported configuration files
+        assertThat(events.size(), equalTo(5));
         final String location = "org.elasticsearch.common.logging.EvilLoggerTests.testLocationInfoTest";
         // the first message is a warning for unsupported configuration files
-        assertLogLine(events.get(1), Level.ERROR, location, "This is an error message");
-        assertLogLine(events.get(2), Level.WARN, location, "This is a warning message");
-        assertLogLine(events.get(3), Level.INFO, location, "This is an info message");
-        assertLogLine(events.get(4), Level.DEBUG, location, "This is a debug message");
-        assertLogLine(events.get(5), Level.TRACE, location, "This is a trace message");
+        assertLogLine(events.get(0), Level.ERROR, location, "This is an error message");
+        assertLogLine(events.get(1), Level.WARN, location, "This is a warning message");
+        assertLogLine(events.get(2), Level.INFO, location, "This is an info message");
+        assertLogLine(events.get(3), Level.DEBUG, location, "This is a debug message");
+        assertLogLine(events.get(4), Level.TRACE, location, "This is a trace message");
     }
 
     private void assertLogLine(final String logLine, final Level level, final String location, final String message) {

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
@@ -107,17 +107,4 @@ public class EvilLoggerTests extends ESTestCase {
             "This is a deprecation message");
     }
 
-    public void testUnsupportedLoggingConfigurationFiles() throws IOException {
-        // TODO: the warning for unsupported logging configurations can be removed in 6.0.0
-        assert Version.CURRENT.major < 6;
-        final String path = System.getProperty("es.logs") + ".log";
-        final List<String> events = Files.readAllLines(PathUtils.get(path));
-        assertThat(events.size(), equalTo(1));
-        assertLogLine(
-            events.get(0),
-            Level.WARN,
-            "org\\.elasticsearch\\.common\\.logging\\.LogConfigurator.*",
-            "ignoring unsupported logging configuration file \\[.*\\], logging is configured via \\[.*\\]");
-    }
-
 }


### PR DESCRIPTION
The 5.x series of Elasticsearch emits a warning if any of the old
logging configuration formats are present. This commit removes that
warning.

Relates #20309
