### PR TITLE
Remove allow unquoted JSON

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContent.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContent.java
@@ -47,30 +47,10 @@ public class JsonXContent implements XContent {
     }
 
     private static final JsonFactory jsonFactory;
-    public static final String JSON_ALLOW_UNQUOTED_FIELD_NAMES = "elasticsearch.json.allow_unquoted_field_names";
     public static final JsonXContent jsonXContent;
-    public static final boolean unquotedFieldNamesSet;
 
     static {
         jsonFactory = new JsonFactory();
-        // TODO: Remove the system property configuration for this in Elasticsearch 6.0.0
-        String jsonUnquoteProp = System.getProperty(JSON_ALLOW_UNQUOTED_FIELD_NAMES);
-        if (jsonUnquoteProp == null) {
-            unquotedFieldNamesSet = false;
-            jsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, false);
-        } else {
-            unquotedFieldNamesSet = true;
-            switch (jsonUnquoteProp) {
-                case "true":
-                    jsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
-                    break;
-                case "false":
-                    jsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, false);
-                    break;
-                default:
-                    throw new IllegalArgumentException("invalid value for [" + JSON_ALLOW_UNQUOTED_FIELD_NAMES + "]: " + jsonUnquoteProp);
-            }
-        }
         jsonFactory.configure(JsonGenerator.Feature.QUOTE_FIELD_NAMES, true);
         jsonFactory.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
         jsonFactory.configure(JsonFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW, false); // this trips on many mappings now...

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -269,12 +269,6 @@ public class Node implements Closeable {
                 logger.debug("using config [{}], data [{}], logs [{}], plugins [{}]",
                     environment.configFile(), Arrays.toString(environment.dataFiles()), environment.logsFile(), environment.pluginsFile());
             }
-            // TODO: Remove this in Elasticsearch 6.0.0
-            if (JsonXContent.unquotedFieldNamesSet) {
-                DeprecationLogger dLogger = new DeprecationLogger(logger);
-                dLogger.deprecated("[{}] has been set, but will be removed in Elasticsearch 6.0.0",
-                    JsonXContent.JSON_ALLOW_UNQUOTED_FIELD_NAMES);
-            }
 
             this.pluginsService = new PluginsService(tmpSettings, environment.modulesFile(), environment.pluginsFile(), classpathPlugins);
             this.settings = pluginsService.updatedSettings();

--- a/distribution/src/main/resources/config/jvm.options
+++ b/distribution/src/main/resources/config/jvm.options
@@ -90,11 +90,3 @@
 # log GC status to a file with time stamps
 # ensure the directory exists
 #-Xloggc:${loggc}
-
-# Elasticsearch 5.0.0 will throw an exception on unquoted field names in JSON.
-# If documents were already indexed with unquoted fields in a previous version
-# of Elasticsearch, some operations may throw errors.
-#
-# WARNING: This option will be removed in Elasticsearch 6.0.0 and is provided
-# only for migration purposes.
-#-Delasticsearch.json.allow_unquoted_field_names=true

--- a/docs/reference/migration/migrate_6_0.asciidoc
+++ b/docs/reference/migration/migrate_6_0.asciidoc
@@ -24,10 +24,12 @@ way to reindex old indices is to use the `reindex` API.
 [float]
 === Also see:
 
-* <<breaking_60_search_changes>>
 * <<breaking_60_mapping_changes>>
-
-include::migrate_6_0/search.asciidoc[]
+* <<breaking_60_rest_changes>>
+* <<breaking_60_search_changes>>
 
 include::migrate_6_0/mapping.asciidoc[]
 
+include::migrate_6_0/rest.asciidoc[]
+
+include::migrate_6_0/search.asciidoc[]

--- a/docs/reference/migration/migrate_6_0/rest.asciidoc
+++ b/docs/reference/migration/migrate_6_0/rest.asciidoc
@@ -1,0 +1,9 @@
+[[breaking_60_rest_changes]]
+=== REST changes
+
+==== Unquoted JSON
+
+In previous versions of Elasticsearch, JSON documents were allowed to contain unquoted field names.
+This feature was removed in the 5.x series, but a backwards-compability layer was added via the
+system property `elasticsearch.json.allow_unquoted_field_names`. This backwards-compability layer
+has been removed in Elasticsearch 6.0.0.

--- a/qa/vagrant/src/test/resources/packaging/scripts/20_tar_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/20_tar_package.bats
@@ -115,24 +115,6 @@ setup() {
     export ES_JAVA_OPTS=$es_java_opts
 }
 
-@test "[TAR] start Elasticsearch with unquoted JSON option" {
-    local es_java_opts=$ES_JAVA_OPTS
-    local es_jvm_options=$ES_JVM_OPTIONS
-    local temp=`mktemp -d`
-    touch "$temp/jvm.options"
-    chown -R elasticsearch:elasticsearch "$temp"
-    echo "-Delasticsearch.json.allow_unquoted_field_names=true" >> "$temp/jvm.options"
-    export ES_JVM_OPTIONS="$temp/jvm.options"
-    start_elasticsearch_service
-    # unquoted field name
-    curl -s -XPOST localhost:9200/i/d/1 -d'{foo: "bar"}'
-    [ "$?" -eq 0 ]
-    curl -s -XDELETE localhost:9200/i
-    stop_elasticsearch_service
-    export ES_JVM_OPTIONS=$es_jvm_options
-    export ES_JAVA_OPTS=$es_java_opts
-}
-
 @test "[TAR] remove tar" {
     rm -rf "/tmp/elasticsearch"
 }


### PR DESCRIPTION
Previous versions of Elasticsearch permitted unquoted JSON field names even though this is against the JSON spec. This leniency was disabled by default in the 5.x series of Elasticsearch but a backwards compatibility layer was added via a system property with the intention of removing this layer in 6.0.0. This commit removes this backwards compatibility layer.

Relates #17801, relates #17674
