### PR TITLE
Remove unsupported environment variables check

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -54,35 +54,6 @@ EOF
     exit 1
 fi
 
-# TODO: remove for Elasticsearch 6.x
-unsupported_environment_variable() {
-    if test -n "$1"; then
-        echo "$2=$1: $3"
-    fi
-}
-
-if test -n "$ES_MIN_MEM" ||
-   test -n "$ES_MAX_MEM" ||
-   test -n "$ES_HEAP_SIZE" ||
-   test -n "$ES_HEAP_NEWSIZE" ||
-   test -n "$ES_DIRECT_SIZE" ||
-   test -n "$ES_USE_IPV4" ||
-   test -n "$ES_GC_OPTS" ||
-   test -n "$ES_GC_LOG_FILE"; then
-    echo "Error: encountered environment variables that are no longer supported"
-    echo "Use jvm.options or ES_JAVA_OPTS to configure the JVM"
-    unsupported_environment_variable "$ES_MIN_MEM" ES_MIN_MEM "set -Xms$ES_MIN_MEM in jvm.options or add \"-Xms$ES_MIN_MEM\" to ES_JAVA_OPTS"
-    unsupported_environment_variable "$ES_MAX_MEM" ES_MAX_MEM "set -Xmx$ES_MAX_MEM in jvm.options or add \"-Xmx$ES_MAX_MEM\" to ES_JAVA_OPTS"
-    unsupported_environment_variable "$ES_HEAP_SIZE" ES_HEAP_SIZE "set -Xms$ES_HEAP_SIZE and -Xmx$ES_HEAP_SIZE in jvm.options or add \"-Xms$ES_HEAP_SIZE -Xmx$ES_HEAP_SIZE\" to ES_JAVA_OPTS"
-    unsupported_environment_variable "$ES_HEAP_NEWSIZE" ES_HEAP_NEWSIZE "set -Xmn$ES_HEAP_NEWSIZE in jvm.options or add \"-Xmn$ES_HEAP_SIZE\" to ES_JAVA_OPTS"
-    unsupported_environment_variable "$ES_DIRECT_SIZE" ES_DIRECT_SIZE "set -XX:MaxDirectMemorySize=$ES_DIRECT_SIZE in jvm.options or add \"-XX:MaxDirectMemorySize=$ES_DIRECT_SIZE\" to ES_JAVA_OPTS"
-    unsupported_environment_variable "$ES_USE_IPV4" ES_USE_IPV4 "set -Djava.net.preferIPv4Stack=true in jvm.options or add \"-Djava.net.preferIPv4Stack=true\" to ES_JAVA_OPTS"
-    unsupported_environment_variable "$ES_GC_OPTS" ES_GC_OPTS "set ${ES_GC_OPTS// / and } in jvm.options or add \"$ES_GC_OPTS\" to ES_JAVA_OPTS"
-    unsupported_environment_variable "$ES_GC_LOG_FILE" ES_GC_LOG_FILE "set -Xloggc:$ES_GC_LOG_FILE in jvm.options or add \"-Xloggc:$ES_GC_LOG_FILE\" to ES_JAVA_OPTS"
-    exit 1
-fi
-# end TODO: remove for Elasticsearch 6.x
-
 parse_jvm_options() {
   if [ -f "$1" ]; then
     echo "$(grep "^-" "$1" | tr '\n' ' ')"

--- a/distribution/src/main/resources/bin/elasticsearch.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.bat
@@ -5,31 +5,6 @@ TITLE Elasticsearch ${project.version}
 
 SET params='%*'
 
-rem TODO: remove for Elasticsearch 6.x
-set bad_env_var=0
-if not "%ES_MIN_MEM%" == "" set bad_env_var=1
-if not "%ES_MAX_MEM%" == "" set bad_env_var=1
-if not "%ES_HEAP_SIZE%" == "" set bad_env_var=1
-if not "%ES_HEAP_NEWSIZE%" == "" set bad_env_var=1
-if not "%ES_DIRECT_SIZE%" == "" set bad_env_var=1
-if not "%ES_USE_IPV4%" == "" set bad_env_var=1
-if not "%ES_GC_OPTS%" == "" set bad_env_var=1
-if not "%ES_GC_LOG_FILE%" == "" set bad_env_var=1
-if %bad_env_var% == 1 (
-    echo Error: encountered environment variables that are no longer supported
-    echo Use jvm.options or ES_JAVA_OPTS to configure the JVM
-    if not "%ES_MIN_MEM%" == "" echo ES_MIN_MEM=%ES_MIN_MEM%: set -Xms%ES_MIN_MEM% in jvm.options or add "-Xms%ES_MIN_MEM%" to ES_JAVA_OPTS
-    if not "%ES_MAX_MEM%" == "" echo ES_MAX_MEM=%ES_MAX_MEM%: set -Xmx%ES_MAX_MEM% in jvm.options or add "-Xmx%ES_MAX_MEM%" to ES_JAVA_OPTS
-    if not "%ES_HEAP_SIZE%" == "" echo ES_HEAP_SIZE=%ES_HEAP_SIZE%: set -Xms%ES_HEAP_SIZE% and -Xmx%ES_HEAP_SIZE% in jvm.options or add "-Xms%ES_HEAP_SIZE% -Xmx%ES_HEAP_SIZE%" to ES_JAVA_OPTS
-    if not "%ES_HEAP_NEWSIZE%" == "" echo ES_HEAP_NEWSIZE=%ES_HEAP_NEWSIZE%: set -Xmn%ES_HEAP_NEWSIZE% in jvm.options or add "-Xmn%ES_HEAP_SIZE%" to ES_JAVA_OPTS
-    if not "%ES_DIRECT_SIZE%" == "" echo ES_DIRECT_SIZE=%ES_DIRECT_SIZE%: set -XX:MaxDirectMemorySize=%ES_DIRECT_SIZE% in jvm.options or add "-XX:MaxDirectMemorySize=%ES_DIRECT_SIZE%" to ES_JAVA_OPTS
-    if not "%ES_USE_IPV4%" == "" echo ES_USE_IPV4=%ES_USE_IPV4%: set -Djava.net.preferIPv4Stack=true in jvm.options or add "-Djava.net.preferIPv4Stack=true" to ES_JAVA_OPTS
-    if not "%ES_GC_OPTS%" == "" echo ES_GC_OPTS=%ES_GC_OPTS%: set %ES_GC_OPTS: = and % in jvm.options or add "%ES_GC_OPTS%" to ES_JAVA_OPTS
-    if not "%ES_GC_LOG_FILE%" == "" echo ES_GC_LOG_FILE=%ES_GC_LOG_FILE%: set -Xloggc:%ES_GC_LOG_FILE% in jvm.options or add "-Xloggc:%ES_GC_LOG_FILE%" to ES_JAVA_OPTS"
-    exit /b 1
-)
-rem end TODO: remove for Elasticsearch 6.x
-
 :loop
 FOR /F "usebackq tokens=1* delims= " %%A IN (!params!) DO (
     SET current=%%A

--- a/distribution/src/main/resources/bin/service.bat
+++ b/distribution/src/main/resources/bin/service.bat
@@ -3,31 +3,6 @@ SETLOCAL enabledelayedexpansion
 
 TITLE Elasticsearch Service ${project.version}
 
-rem TODO: remove for Elasticsearch 6.x
-set bad_env_var=0
-if not "%ES_MIN_MEM%" == "" set bad_env_var=1
-if not "%ES_MAX_MEM%" == "" set bad_env_var=1
-if not "%ES_HEAP_SIZE%" == "" set bad_env_var=1
-if not "%ES_HEAP_NEWSIZE%" == "" set bad_env_var=1
-if not "%ES_DIRECT_SIZE%" == "" set bad_env_var=1
-if not "%ES_USE_IPV4%" == "" set bad_env_var=1
-if not "%ES_GC_OPTS%" == "" set bad_env_var=1
-if not "%ES_GC_LOG_FILE%" == "" set bad_env_var=1
-if %bad_env_var% == 1 (
-    echo Error: encountered environment variables that are no longer supported
-    echo Use jvm.options or ES_JAVA_OPTS to configure the JVM
-    if not "%ES_MIN_MEM%" == "" echo ES_MIN_MEM=%ES_MIN_MEM%: set -Xms%ES_MIN_MEM% in jvm.options or add "-Xms%ES_MIN_MEM%" to ES_JAVA_OPTS
-    if not "%ES_MAX_MEM%" == "" echo ES_MAX_MEM=%ES_MAX_MEM%: set -Xms%ES_MAX_MEM% in jvm.options or add "-Xmx%ES_MAX_MEM%" to ES_JAVA_OPTS
-    if not "%ES_HEAP_SIZE%" == "" echo ES_HEAP_SIZE=%ES_HEAP_SIZE%: set -Xms%ES_HEAP_SIZE% and -Xmx%ES_HEAP_SIZE% in jvm.options or add "-Xms%ES_HEAP_SIZE% -Xmx%ES_HEAP_SIZE%" to ES_JAVA_OPTS
-    if not "%ES_HEAP_NEWSIZE%" == "" echo ES_HEAP_NEWSIZE=%ES_HEAP_NEWSIZE%: set -Xmn%ES_HEAP_NEWSIZE% in jvm.options or add "-Xmn%ES_HEAP_SIZE%" to ES_JAVA_OPTS
-    if not "%ES_DIRECT_SIZE%" == "" echo ES_DIRECT_SIZE=%ES_DIRECT_SIZE%: set -XX:MaxDirectMemorySize=%ES_DIRECT_SIZE% in jvm.options or add "-XX:MaxDirectMemorySize=%ES_DIRECT_SIZE%" to ES_JAVA_OPTS
-    if not "%ES_USE_IPV4%" == "" echo ES_USE_IPV4=%ES_USE_IPV4%: set -Djava.net.preferIPv4Stack=true in jvm.options or add "-Djava.net.preferIPv4Stack=true" to ES_JAVA_OPTS
-    if not "%ES_GC_OPTS%" == "" echo ES_GC_OPTS=%ES_GC_OPTS%: set %ES_GC_OPTS: = and % in jvm.options or add "%ES_GC_OPTS%" to ES_JAVA_OPTS
-    if not "%ES_GC_LOG_FILE%" == "" echo ES_GC_LOG_FILE=%ES_GC_LOG_FILE%: set -Xloggc:%ES_GC_LOG_FILE% in jvm.options or add "-Xloggc:%ES_GC_LOG_FILE%" to ES_JAVA_OPTS"
-    exit /b 1
-)
-rem end TODO: remove for Elasticsearch 6.x
-
 IF DEFINED JAVA_HOME (
   SET JAVA=%JAVA_HOME%\bin\java.exe
 ) ELSE (


### PR DESCRIPTION
The Elasticsearch startup scripts contain checks for the presence of
support for environment variables that were removed in the 5.x
series. These checks warn the user and fail the script if any of the
unsupported environment variables are present. This was provided as
migration step from 2.x to 5.x so that we were not just silently
ignoring environment variables that were previously set. This commit
removes these checks, as upgrades from 2.x to 6.x are not supported.

Relates #17675, relates bdfa063946d4c5f3ab30918b9c628442c21be27c
