### PR TITLE
skip GeoPointMultiTermQuery when highlighting

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/highlight/CustomQueryScorer.java
+++ b/core/src/main/java/org/elasticsearch/search/highlight/CustomQueryScorer.java
@@ -38,6 +38,9 @@ public final class CustomQueryScorer extends QueryScorer {
 
     static {
         try {
+            // in extract() we need to check for GeoPointMultiTermQuery and skip extraction for queries that inherit from it.
+            // But GeoPointMultiTermQuerythat is package private in Lucene hence we cannot use an instanceof check. This is why
+            // we use this rather ugly workaround to get a Class and later be able to compare with isAssignableFrom().
             unsupportedGeoQuery = Class.forName("org.apache.lucene.spatial.geopoint.search.GeoPointMultiTermQuery");
         } catch (ClassNotFoundException e) {
             throw new AssertionError(e);

--- a/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchIT.java
@@ -2735,6 +2735,46 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         assertThat(search.getHits().getAt(0).highlightFields().get("text").fragments().length, equalTo(1));
     }
 
+    public void testGeoFieldHighlightingWhenQueryGetsRewritten() throws IOException {
+        // same as above but in this example the query gets rewritten during highlighting
+        // see https://github.com/elastic/elasticsearch/issues/17537#issuecomment-244939633
+        XContentBuilder mappings = jsonBuilder();
+        mappings.startObject();
+        mappings.startObject("jobs")
+            .startObject("_all")
+            .field("enabled", false)
+            .endObject()
+            .startObject("properties")
+            .startObject("loc")
+            .field("type", "geo_point")
+            .endObject()
+            .startObject("jd")
+            .field("type", "string")
+            .endObject()
+            .endObject()
+            .endObject();
+        mappings.endObject();
+        assertAcked(prepareCreate("test")
+            .addMapping("jobs", mappings));
+        ensureYellow();
+
+        client().prepareIndex("test", "jobs", "1")
+            .setSource(jsonBuilder().startObject().field("jd", "some आवश्यकता है- आर्य समाज अनाथालय, 68 सिविल लाइन्स, बरेली को एक पुरूष रस text")
+                .field("loc", "12.934059,77.610741").endObject())
+            .get();
+        refresh();
+
+        String highlighterType = randomFrom("plain", "fvh", "postings");
+        QueryBuilder query = QueryBuilders.functionScoreQuery(QueryBuilders.boolQuery().filter(QueryBuilders.geoBoundingBoxQuery("loc")
+            .bottomRight(-23.065941, 113.610741)
+            .topLeft(48.934059, 41.610741)));
+        SearchResponse search = client().prepareSearch().setSource(
+            new SearchSourceBuilder().query(query)
+                .highlight(new HighlightBuilder().highlighterType(highlighterType).field("jd")).buildAsBytes()).get();
+        assertNoFailures(search);
+        assertThat(search.getHits().totalHits(), equalTo(1L));
+    }
+
     public void testACopyFieldWithNestedQuery() throws Exception {
         String mapping = jsonBuilder().startObject().startObject("type").startObject("properties")
                 .startObject("foo")

--- a/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchIT.java
@@ -2764,13 +2764,12 @@ public class HighlighterSearchIT extends ESIntegTestCase {
             .get();
         refresh();
 
-        String highlighterType = randomFrom("plain", "fvh", "postings");
         QueryBuilder query = QueryBuilders.functionScoreQuery(QueryBuilders.boolQuery().filter(QueryBuilders.geoBoundingBoxQuery("loc")
             .bottomRight(-23.065941, 113.610741)
             .topLeft(48.934059, 41.610741)));
         SearchResponse search = client().prepareSearch().setSource(
             new SearchSourceBuilder().query(query)
-                .highlight(new HighlightBuilder().highlighterType(highlighterType).field("jd")).buildAsBytes()).get();
+                .highlight(new HighlightBuilder().highlighterType("plain").field("jd")).buildAsBytes()).get();
         assertNoFailures(search);
         assertThat(search.getHits().totalHits(), equalTo(1L));
     }

--- a/core/src/test/java/org/elasticsearch/search/highlight/PlainHighlighterTests.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/PlainHighlighterTests.java
@@ -67,8 +67,12 @@ public class PlainHighlighterTests extends LuceneTestCase {
         String fragment = highlighter.getBestFragment(fieldNameAnalyzer.tokenStream("text", "Arbitrary text field which should not cause " +
             "a failure"), "Arbitrary text field which should not cause a failure");
         assertThat(fragment, equalTo("Arbitrary text field which should not cause a <B>failure</B>"));
-        // TODO: This test will fail if we pass in an instance of GeoPointInBBoxQueryImpl too. Should we also find a way to work around that
-        // or can the query not be rewritten before it is passed into the highlighter?
+        Query rewritten = boolQuery.rewrite(null);
+        highlighter =
+            new org.apache.lucene.search.highlight.Highlighter(new CustomQueryScorer(rewritten));
+        fragment = highlighter.getBestFragment(fieldNameAnalyzer.tokenStream("text", "Arbitrary text field which should not cause " +
+            "a failure"), "Arbitrary text field which should not cause a failure");
+        assertThat(fragment, equalTo("Arbitrary text field which should not cause a <B>failure</B>"));
     }
 
     public void testGeoPointInBBoxQueryHighlighting() throws IOException, InvalidTokenOffsetsException {


### PR DESCRIPTION
We skip GeoPointInBBoxQuery already but not when it was rewritten
it appears as GeoPointMultiTermQuery and needs to be skipped as well.

see #17537

This pull request is against the 2.4 branch and a follow up to https://github.com/elastic/elasticsearch/issues/17537#issuecomment-246112229 . Unfortunately my assumption that the highlighter never gets to see a rewritten query (see https://github.com/elastic/elasticsearch/pull/18495#issue-156019922) was wrong and so in some cases such as the example provided by @ajayar it does. We need to check for that as well and skip the highlighting in this case. 

The tests in this pull request do not reproduce the issue #17537 on the 2.4 branch for me and I believe this is due to an unrelated change in Lucene. I still think we should merge this to 2.4 anyway to be on the safe side. On 2.3 the tests reproduce the issue. In addition the discussion on #17537 is not finished so this pull request doe not close the issue yet.

On master the problem was fixed in Lucene (see https://issues.apache.org/jira/browse/LUCENE-7293) so we can remove the check in CustomQueryScorer completely. I will open a separate pull request for that.
