### PR TITLE
Set LimitMEMLOCK=infinity as default for systemd

### DIFF
--- a/distribution/src/main/packaging/systemd/elasticsearch.service
+++ b/distribution/src/main/packaging/systemd/elasticsearch.service
@@ -34,7 +34,7 @@ LimitNOFILE=65536
 # Specifies the maximum number of bytes of memory that may be locked into RAM
 # Set to "infinity" if you use the 'bootstrap.memory_lock: true' option
 # in elasticsearch.yml and 'MAX_LOCKED_MEMORY=unlimited' in ${path.env}
-#LimitMEMLOCK=infinity
+LimitMEMLOCK=infinity
 
 # Disable timeout logic and wait until process is stopped
 TimeoutStopSec=0


### PR DESCRIPTION
Since in 5.x the "production" checks require `bootstrap.memory_lock: true`, I think it would be nice to have `LimitMEMLOCK=infinity` on as default. It would make things easier to configure.
