### PR TITLE
Add Ubuntu-16.04 to Vagrant VMs

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -364,6 +364,7 @@ These are the linux flavors the Vagrantfile currently supports:
 * ubuntu-1204 aka precise
 * ubuntu-1404 aka trusty
 * ubuntu-1504 aka vivid
+* ubuntu-1604 aka xenial
 * debian-8 aka jessie, the current debian stable distribution
 * centos-6
 * centos-7

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,6 +37,13 @@ Vagrant.configure(2) do |config|
       [ -f /usr/share/java/jayatanaag.jar ] || install jayatana
     SHELL
   end
+  config.vm.define "ubuntu-1604" do |config|
+    config.vm.box = "elastic/ubuntu-16.04-x86_64"
+    ubuntu_common config, extra: <<-SHELL
+      # Install Jayatana so we can work around it being present.
+      [ -f /usr/share/java/jayatanaag.jar ] || install jayatana
+    SHELL
+  end
   # Wheezy's backports don't contain Openjdk 8 and the backflips required to
   # get the sun jdk on there just aren't worth it. We have jessie for testing
   # debian and it works fine.

--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -37,7 +37,8 @@ List<String> availableBoxes = [
     'sles-12',
     'ubuntu-1204',
     'ubuntu-1404',
-    'ubuntu-1504'
+    'ubuntu-1504',
+    'ubuntu-1604'
 ]
 
 String vagrantBoxes = getProperties().get('vagrant.boxes', 'sample')


### PR DESCRIPTION
Ubuntu-16.04 is gaining popularity and I think we should add a vagrant vm for it.
