### PR TITLE
Fixes free/used memory stats check in cluster stats tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.stats/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.stats/10_basic.yaml
@@ -22,8 +22,8 @@
   - is_true: nodes.os.mem.total_in_bytes
   - is_true: nodes.os.mem.free_in_bytes
   - is_true: nodes.os.mem.used_in_bytes
-  - is_true: nodes.os.mem.free_percent
-  - is_true: nodes.os.mem.used_percent
+  - gte: { nodes.os.mem.free_percent: 0 }
+  - gte: { nodes.os.mem.used_percent: 0 }
   - is_true: nodes.process
   - is_true: nodes.jvm
   - is_true: nodes.fs


### PR DESCRIPTION
For the REST cluster stats test, if free or used
memory are much less than the total memory, the percentage
returned could be 0%. The yaml tests check that the free/used
percentage are valid values by asserting `is_true`, but it
turns out that `is_true` returns false if the value is
assigned but it is 0 or even the string "0". This commit
changes the assertion in the yaml test to ensure the value
is greater than or equal to 0 instead.

Before this commit, the error could be tripped by running the test
with this reproduce line: 

```
gradle :modules:transport-netty4:integTest -Dtests.seed=F71A7059D7DD9C20 -Dtests.class=org.elasticsearch.http.netty4.Netty4ClientYamlTestSuiteIT -Dtests.method="test {yaml=cluster.stats/10_basic/cluster stats test}" -Dtests.security.manager=true -Dtests.locale=ms-MY -Dtests.timezone=PRT
```

Which resulted in:

```
 > Throwable #1: java.lang.AssertionError: Failure at [cluster.stats/10_basic:25]: field [nodes.os.mem.free_percent] doesn't have a true value
   > Expected: not "0"
   >      but: was "0"
   >    at __randomizedtesting.SeedInfo.seed([F71A7059D7DD9C20:7F4E4F837921F1D8]:0)
   >    at org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase.executeSection(ESClientYamlSuiteTestCase.java:329)
   >    at org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase.test(ESClientYamlSuiteTestCase.java:309)
   >    at java.lang.Thread.run(Thread.java:745)
   > Caused by: java.lang.AssertionError: field [nodes.os.mem.free_percent] doesn't have a true value
   > Expected: not "0"
   >      but: was "0"
```
