### PR TITLE
Fail parsing when match query contains an array of terms

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
@@ -145,6 +145,9 @@ public class MatchQueryParser implements QueryParser {
                     } else {
                         throw new QueryParsingException(parseContext, "[match] query does not support [" + currentFieldName + "]");
                     }
+                } else {
+                    throw new QueryParsingException(parseContext,
+                            "[" + NAME + "] unknown token [" + token + "] after [" + currentFieldName + "]");
                 }
             }
             parser.nextToken();

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -2624,7 +2624,37 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
         assertThat(termQuery.getTerm(), equalTo(new Term(MetaData.ALL, queryText)));
     }
 
-    private void assertGeoDistanceRangeQuery(IndexQueryParserService queryParser, Query query, double lat, double lon, double distance, DistanceUnit distanceUnit) throws IOException {
+    @Test
+    public void testMatchQueryParseFailsWithTermsArray() throws Exception {
+        IndexQueryParserService queryParser = queryParser();
+        String json1 = "{\n" +
+                "  \"match\" : {\n" +
+                "    \"message1\" : {\n" +
+                "      \"query\" : [\"term1\", \"term2\"]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+        try {
+            queryParser.parse(json1);
+            fail("parse should have failed");
+        } catch(QueryParsingException e) {
+            //all good
+        }
+
+        String json2 = "{\n" +
+                "  \"match\" : {\n" +
+                "    \"message1\" : [\"term1\", \"term2\"]\n" +
+                "  }\n" +
+                "}";
+        try {
+            queryParser.parse(json2);
+            fail("parse should have failed");
+        } catch(QueryParsingException e) {
+            //all good
+        }
+    }
+
+    private static void assertGeoDistanceRangeQuery(IndexQueryParserService queryParser, Query query, double lat, double lon, double distance, DistanceUnit distanceUnit) throws IOException {
         if (queryParser.getIndexCreatedVersion().before(Version.V_2_2_0)) {
             assertThat(query, instanceOf(GeoDistanceRangeQuery.class));
             GeoDistanceRangeQuery q = (GeoDistanceRangeQuery) query;
@@ -2643,7 +2673,7 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
         }
     }
 
-    private void assertGeoBBoxQuery(IndexQueryParserService queryParser,  Query query, double maxLat, double minLon, double minLat, double maxLon) {
+    private static void assertGeoBBoxQuery(IndexQueryParserService queryParser,  Query query, double maxLat, double minLon, double minLat, double maxLon) {
         if (queryParser.getIndexCreatedVersion().before(Version.V_2_2_0)) {
             assertThat(query, instanceOf(InMemoryGeoBoundingBoxQuery.class));
             InMemoryGeoBoundingBoxQuery filter = (InMemoryGeoBoundingBoxQuery) query;
@@ -2671,7 +2701,7 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
         }
     }
 
-    private void assertGeoPolygonQuery(IndexQueryParserService queryParser, Query query) {
+    private static void assertGeoPolygonQuery(IndexQueryParserService queryParser, Query query) {
         if (queryParser.getIndexCreatedVersion().before(Version.V_2_2_0)) {
             assertThat(query, instanceOf(GeoPolygonQuery.class));
             GeoPolygonQuery filter = (GeoPolygonQuery) query;


### PR DESCRIPTION
Fail parsing when match query contains an array of terms. This is already the case in master and 5.0 branches, we made the change as part of the query refactoring. It is worth to backport this tiny fix and fail given that only one of the terms in the array is considered at the moment.

Closes #15741
