### PR TITLE
[Packaging] Do not remove scripts directory on upgrade

### DIFF
--- a/distribution/src/main/packaging/scripts/prerm
+++ b/distribution/src/main/packaging/scripts/prerm
@@ -79,12 +79,13 @@ if [ "$REMOVE_SERVICE" = "true" ]; then
     if command -v update-rc.d >/dev/null; then
         update-rc.d elasticsearch remove >/dev/null || true
     fi
+
+    SCRIPTS_DIR="/etc/elasticsearch/scripts"
+    # delete the scripts directory if and only if empty
+    if [ -d "$SCRIPTS_DIR" ]; then
+        rmdir --ignore-fail-on-non-empty "$SCRIPTS_DIR"
+    fi
 fi
 
-SCRIPTS_DIR="/etc/elasticsearch/scripts"
-# delete the scripts directory if and only if empty
-if [ -d "$SCRIPTS_DIR" ]; then
-    rmdir --ignore-fail-on-non-empty "$SCRIPTS_DIR"
-fi
 
 ${scripts.footer}

--- a/qa/vagrant/src/test/resources/packaging/scripts/30_deb_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/30_deb_package.bats
@@ -131,6 +131,7 @@ setup() {
 
     # The configuration files are still here
     assert_file_exist "/etc/elasticsearch"
+    assert_file_exist "/etc/elasticsearch/scripts"
     assert_file_exist "/etc/elasticsearch/elasticsearch.yml"
     assert_file_exist "/etc/elasticsearch/jvm.options"
     assert_file_exist "/etc/elasticsearch/log4j2.properties"
@@ -152,6 +153,7 @@ setup() {
 @test "[DEB] verify package purge" {
     # all remaining files are deleted by the purge
     assert_file_not_exist "/etc/elasticsearch"
+    assert_file_not_exist "/etc/elasticsearch/scripts"
     assert_file_not_exist "/etc/elasticsearch/elasticsearch.yml"
     assert_file_not_exist "/etc/elasticsearch/jvm.options"
     assert_file_not_exist "/etc/elasticsearch/log4j2.properties"

--- a/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
@@ -119,6 +119,7 @@ setup() {
     assert_file_not_exist "/var/run/elasticsearch"
 
     assert_file_not_exist "/etc/elasticsearch"
+    assert_file_not_exist "/etc/elasticsearch/scripts"
     assert_file_not_exist "/etc/elasticsearch/elasticsearch.yml"
     assert_file_not_exist "/etc/elasticsearch/jvm.options"
     assert_file_not_exist "/etc/elasticsearch/log4j2.properties"


### PR DESCRIPTION
When upgrading elasticsearch using the RPM package, the scripts directory is removed if it's empty but it won't be recreated by the upgraded package. After that the service will not start because the `scripts` dir is missing.

I think we must remove the scripts directory only if it's empty **and** if it's not an upgrade.
