### PR TITLE
Build: Add pom building and associated files to rest api spec jar

### DIFF
--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -1,8 +1,7 @@
-apply plugin: 'java'
-apply plugin: 'com.bmuschko.nexus'
+apply plugin: 'elasticsearch.build'
+apply plugin: 'nebula.maven-base-publish'
+apply plugin: 'nebula.maven-scm'
 
-extraArchive {
-  sources = false
-  javadoc = false
-  tests = false
-}
+test.enabled = false
+jarHell.enabled = false
+licenseHeaders.enabled = false

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.upgrade.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.upgrade.json
@@ -29,7 +29,7 @@
         "wait_for_completion": {
            "type" : "boolean",
            "description" : "Specify whether the request should block until the all segments are upgraded (default: false)"
-	},
+  },
         "only_ancient_segments": {
           "type" : "boolean",
           "description" : "If true, only ancient (an older Lucene major release) segments will be upgraded"


### PR DESCRIPTION
We put the rest api spec into a jar for upload to maven, so that we can
use within external rest tests. This change adds making a pom for maven
(as well as producing sources and javadoc jars, even though they will be
empty, because maven central requires them).
