### PR TITLE
Default reindex to return first 50 bulk failures

### DIFF
--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -144,7 +144,8 @@ POST twitter/_delete_by_query?scroll_size=5000
 === URL Parameters
 
 In addition to the standard parameters like `pretty`, the Delete By Query API
-also supports `refresh`, `wait_for_completion`, `wait_for_active_shards`, and `timeout`.
+also supports `refresh`, `wait_for_completion`, `wait_for_active_shards`,
+`timeout`, `requests_per_second`, and `max_reported_bulk_failures`.
 
 Sending the `refresh` will refresh all shards involved in the delete by query
 once the request completes. This is different than the Delete API's `refresh`
@@ -160,7 +161,7 @@ to keep or remove as you see fit. When you are done with it, delete it so
 Elasticsearch can reclaim the space it uses.
 
 `wait_for_active_shards` controls how many copies of a shard must be active
-before proceeding with the request. See <<index-wait-for-active-shards,here>> 
+before proceeding with the request. See <<index-wait-for-active-shards,here>>
 for details. `timeout` controls how long each write request waits for unavailable
 shards to become available. Both work exactly how they work in the
 <<docs-bulk,Bulk API>>.
@@ -174,6 +175,13 @@ the time `requests_per_second * requests_in_the_batch`. Since the batch isn't
 broken into multiple bulk requests large batch sizes will cause Elasticsearch
 to create many requests and then wait for a while before starting the next set.
 This is "bursty" instead of "smooth". The default is `-1`.
+
+`max_reported_bulk_failures` is the maximum number of indexing error that
+are returned when a bulk operation fails. This defaults to `50` to prevent
+interactive users of `_delete_by_query` from being buried under an avalanche
+of errors if the entire request fails. Extra errors are logged. Clients should
+set this to a `-1` to have all errors returned if they can handle as many
+errors as the request batch size which defaults to `1000`.
 
 [float]
 === Response body

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -419,8 +419,8 @@ is sent directly to the remote host without validation or modification.
 === URL Parameters
 
 In addition to the standard parameters like `pretty`, the Reindex API also
-supports `refresh`, `wait_for_completion`, `wait_for_active_shards`, `timeout`, and
-`requests_per_second`.
+supports `refresh`, `wait_for_completion`, `wait_for_active_shards`, `timeout`,
+`requests_per_second`, and `max_reported_indexing_failures`.
 
 Sending the `refresh` url parameter will cause all indexes to which the request
 wrote to be refreshed. This is different than the Index API's `refresh`
@@ -449,6 +449,13 @@ the time `requests_per_second * requests_in_the_batch`. Since the batch isn't
 broken into multiple bulk requests large batch sizes will cause Elasticsearch
 to create many requests and then wait for a while before starting the next set.
 This is "bursty" instead of "smooth". The default is `-1`.
+
+`max_reported_bulk_failures` is the maximum number of indexing error that
+are returned when a bulk operation fails. This defaults to `50` to prevent
+interactive users of `_reindex` from being buried under an avalanche
+of errors if the entire request fails. Extra errors are logged. Clients should
+set this to a `-1` to have all errors returned if they can handle as many
+errors as the request batch size which defaults to `1000`.
 
 [float]
 [[docs-reindex-response-body]]

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -202,7 +202,8 @@ POST twitter/_update_by_query?pipeline=set-foo
 === URL Parameters
 
 In addition to the standard parameters like `pretty`, the Update By Query API
-also supports `refresh`, `wait_for_completion`, `wait_for_active_shards`, and `timeout`.
+also supports `refresh`, `wait_for_completion`, `wait_for_active_shards`,
+`timeout`, `requests_per_second`, and `max_reported_bulk_failures`.
 
 Sending the `refresh` will update all shards in the index being updated when
 the request completes. This is different than the Index API's `refresh`
@@ -217,7 +218,7 @@ to keep or remove as you see fit. When you are done with it, delete it so
 Elasticsearch can reclaim the space it uses.
 
 `wait_for_active_shards` controls how many copies of a shard must be active
-before proceeding with the request. See <<index-wait-for-active-shards,here>> 
+before proceeding with the request. See <<index-wait-for-active-shards,here>>
 for details. `timeout` controls how long each write request waits for unavailable
 shards to become available. Both work exactly how they work in the
 <<docs-bulk,Bulk API>>.
@@ -231,6 +232,13 @@ the time `requests_per_second * requests_in_the_batch`. Since the batch isn't
 broken into multiple bulk requests large batch sizes will cause Elasticsearch
 to create many requests and then wait for a while before starting the next set.
 This is "bursty" instead of "smooth". The default is `-1`.
+
+`max_reported_bulk_failures` is the maximum number of indexing error that
+are returned when a bulk operation fails. This defaults to `50` to prevent
+interactive users of `_update_by_query` from being buried under an avalanche
+of errors if the entire request fails. Extra errors are logged. Clients should
+set this to a `-1` to have all errors returned if they can handle as many
+errors as the request batch size which defaults to `1000`.
 
 [float]
 [[docs-update-by-query-response-body]]

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBaseReindexRestHandler.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBaseReindexRestHandler.java
@@ -26,15 +26,12 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.indices.query.IndicesQueriesRegistry;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchRequestParsers;
-import org.elasticsearch.search.aggregations.AggregatorParsers;
-import org.elasticsearch.search.suggest.Suggesters;
 import org.elasticsearch.tasks.LoggingTaskListener;
 import org.elasticsearch.tasks.Task;
 
@@ -103,6 +100,7 @@ public abstract class AbstractBaseReindexRestHandler<
 
         request.setRefresh(restRequest.paramAsBoolean("refresh", request.isRefresh()));
         request.setTimeout(restRequest.paramAsTime("timeout", request.getTimeout()));
+        request.setMaxReportedBulkFailures(restRequest.paramAsInt("max_reported_bulk_failures", request.getMaxReportedBulkFailures()));
 
         String waitForActiveShards = restRequest.param("wait_for_active_shards");
         if (waitForActiveShards != null) {

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -98,6 +98,11 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
      */
     private boolean shouldStoreResult;
 
+    /**
+     * How many bulk failures should this return by default? Defaults to {@link Integer#MAX_VALUE} to return as many as it finds.
+     */
+    private int maxReportedBulkFailures = Integer.MAX_VALUE;
+
     public AbstractBulkByScrollRequest() {
     }
 
@@ -313,6 +318,26 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
         return shouldStoreResult;
     }
 
+    /**
+     * How many bulk failures should this return by default? Defaults to {@link Integer#MAX_VALUE} to return as many as it finds.
+     */
+    public Self setMaxReportedBulkFailures(int maxReportedBulkFailures) {
+        if (maxReportedBulkFailures == -1) {
+            maxReportedBulkFailures = Integer.MAX_VALUE;
+        } else if (maxReportedBulkFailures < 0) {
+            throw new IllegalArgumentException("[max_reported_bulk_failures] must be >= -1 but was [" + maxReportedBulkFailures + "]");
+        }
+        this.maxReportedBulkFailures = maxReportedBulkFailures;
+        return self();
+    }
+
+    /**
+     * How many bulk failures should this return by default? Defaults to {@link Integer#MAX_VALUE} to return as many as it finds.
+     */
+    public int getMaxReportedBulkFailures() {
+        return maxReportedBulkFailures;
+    }
+
     @Override
     public Task createTask(long id, String type, String action, TaskId parentTaskId) {
         return new BulkByScrollTask(id, type, action, getDescription(), parentTaskId, requestsPerSecond);
@@ -331,6 +356,7 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
         retryBackoffInitialTime = new TimeValue(in);
         maxRetries = in.readVInt();
         requestsPerSecond = in.readFloat();
+        maxReportedBulkFailures = in.readInt();
     }
 
     @Override
@@ -345,6 +371,7 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
         retryBackoffInitialTime.writeTo(out);
         out.writeVInt(maxRetries);
         out.writeFloat(requestsPerSecond);
+        out.writeInt(maxReportedBulkFailures);
     }
 
     /**

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequestBuilder.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequestBuilder.java
@@ -141,4 +141,12 @@ public abstract class AbstractBulkByScrollRequestBuilder<
         request.setShouldStoreResult(shouldStoreResult);
         return self();
     }
+
+    /**
+     * How many bulk failures should this return by default? Defaults to {@link Integer#MAX_VALUE} to return as many as it finds.
+     */
+    public Self setMaxReportedBulkFailures(int maxReportedBulkFailures) {
+        request.setMaxReportedBulkFailures(maxReportedBulkFailures);
+        return self();
+    }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/AsyncBulkByScrollActionTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.reindex;
 
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
@@ -111,6 +112,9 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class AsyncBulkByScrollActionTests extends ESTestCase {
     private MyMockClient client;
@@ -357,14 +361,37 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
      * Mimicks bulk indexing failures.
      */
     public void testBulkFailuresAbortRequest() throws Exception {
-        Failure failure = new Failure("index", "type", "id", new RuntimeException("test"));
-        DummyAbstractAsyncBulkByScrollAction action = new DummyAbstractAsyncBulkByScrollAction();
-        BulkResponse bulkResponse = new BulkResponse(new BulkItemResponse[] {new BulkItemResponse(0, "index", failure)}, randomLong());
+        testRequest.setMaxReportedBulkFailures(randomBoolean() ? Integer.MAX_VALUE : between(3, 10));
+        int failureCount = between(1, 10);
+        BulkItemResponse[] responses = new BulkItemResponse[failureCount + between(1, 5)];
+        List<Failure> expectedReturnedFailures = new ArrayList<>();
+        List<Failure> expectedLoggedFailures = new ArrayList<>();
+        for (int i = 0; i < responses.length; i++) {
+            if (i < failureCount) {
+                Failure failure = new Failure("index", "type", Integer.toString(i), new RuntimeException("test"));
+                if (i < testRequest.getMaxReportedBulkFailures()) {
+                    expectedReturnedFailures.add(failure);
+                } else {
+                    expectedLoggedFailures.add(failure);
+                }
+                responses[i] = new BulkItemResponse(0, "index", failure);
+            } else {
+                ShardId shardId = new ShardId(new Index("name", "uid"), 0);
+                responses[i] = new BulkItemResponse(0, "index", new IndexResponse(shardId, "type", Integer.toString(i), 1, false));
+            }
+        }
+        Logger logger = mock(Logger.class);
+        DummyAbstractAsyncBulkByScrollAction action = new DummyAbstractAsyncBulkByScrollAction(logger);
+        BulkResponse bulkResponse = new BulkResponse(responses, randomLong());
         action.onBulkResponse(timeValueNanos(System.nanoTime()), bulkResponse);
         BulkIndexByScrollResponse response = listener.get();
-        assertThat(response.getBulkFailures(), contains(failure));
+        assertEquals(expectedReturnedFailures, response.getBulkFailures());
         assertThat(response.getSearchFailures(), empty());
         assertNull(response.getReasonCancelled());
+        for (Failure failure : expectedLoggedFailures) {
+            verify(logger).warn("Reindexing failure that can't be returned for [{}] {}", testTask.getId(), failure);
+        }
+        verifyNoMoreInteractions(logger);
     }
 
     /**
@@ -654,9 +681,13 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
 
     private class DummyAbstractAsyncBulkByScrollAction
             extends AbstractAsyncBulkByScrollAction<DummyAbstractBulkByScrollRequest> {
-        public DummyAbstractAsyncBulkByScrollAction() {
-            super(testTask, AsyncBulkByScrollActionTests.this.logger, new ParentTaskAssigningClient(client, localNode, testTask),
+        public DummyAbstractAsyncBulkByScrollAction(Logger logger) {
+            super(testTask, logger, new ParentTaskAssigningClient(client, localNode, testTask),
                     AsyncBulkByScrollActionTests.this.threadPool, testRequest, listener);
+        }
+
+        public DummyAbstractAsyncBulkByScrollAction() {
+            this(AsyncBulkByScrollActionTests.this.logger);
         }
 
         @Override

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RoundTripTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RoundTripTests.java
@@ -110,6 +110,7 @@ public class RoundTripTests extends ESTestCase {
         request.setWaitForActiveShards(randomIntBetween(0, 10));
         request.setScript(random().nextBoolean() ? null : randomScript());
         request.setRequestsPerSecond(between(0, Integer.MAX_VALUE));
+        request.setMaxReportedBulkFailures(randomBoolean() ? Integer.MAX_VALUE : between(1, Integer.MAX_VALUE));
     }
 
     private void assertRequestEquals(AbstractBulkIndexByScrollRequest<?> request,
@@ -124,6 +125,7 @@ public class RoundTripTests extends ESTestCase {
         assertEquals(request.getRetryBackoffInitialTime(), tripped.getRetryBackoffInitialTime());
         assertEquals(request.getMaxRetries(), tripped.getMaxRetries());
         assertEquals(request.getRequestsPerSecond(), tripped.getRequestsPerSecond(), 0d);
+        assertEquals(request.getMaxReportedBulkFailures(), tripped.getMaxReportedBulkFailures());
     }
 
     public void testBulkByTaskStatus() throws IOException {

--- a/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/20_validation.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/20_validation.yaml
@@ -109,3 +109,14 @@
         body:
           query:
             match_all: {}
+
+---
+"max_reported_bulk_failures >= 0":
+  - do:
+      catch: /\[max_reported_bulk_failures\] must be >= -1 but was \[-12\]/
+      delete_by_query:
+        max_reported_bulk_failures: -12
+        index: test
+        body:
+          query:
+            match_all: {}

--- a/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/25_max_reported_bulk_failures.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/25_max_reported_bulk_failures.yaml
@@ -1,0 +1,121 @@
+---
+"max_reported_bulk_failures limits number of returned failures":
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            index.refresh_interval: -1
+  - do:
+      index:
+        index:   test
+        type:    foo
+        id:      1
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   test
+        type:    foo
+        id:      2
+        body:    { "text": "test" }
+  - do:
+      indices.refresh: {}
+  # Creates a new version for reindex to miss on scan.
+  - do:
+      index:
+        index:   test
+        type:    foo
+        id:      1
+        body:    { "text": "test2" }
+  - do:
+      index:
+        index:   test
+        type:    foo
+        id:      2
+        body:    { "text": "test2" }
+
+
+  - do:
+      catch: conflict
+      delete_by_query:
+        max_reported_bulk_failures: 1
+        index: test
+        body:
+          query:
+            match_all: {}
+  - length: {failures: 1}
+  - match: {failures.0.index:  test}
+  - match: {failures.0.type:   foo}
+  - match: {failures.0.id:     /\d+/}
+  - match: {failures.0.status: 409}
+  - match: {failures.0.cause.type:   version_conflict_engine_exception}
+  # Use a regex so we don't mind if the version isn't always 1. Sometimes it comes out 2.
+  - match: {failures.0.cause.reason: "/\\[foo\\]\\[\\d+\\]:.version.conflict,.current.version.\\[\\d+\\].is.different.than.the.one.provided.\\[\\d+\\]/"}
+  - match: {failures.0.cause.shard:  /\d+/}
+  - match: {failures.0.cause.index:  test}
+
+
+---
+"max_reported_bulk_failures=-1 means all failures":
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            index.refresh_interval: -1
+  - do:
+      index:
+        index:   test
+        type:    foo
+        id:      1
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   test
+        type:    foo
+        id:      2
+        body:    { "text": "test" }
+  - do:
+      indices.refresh: {}
+  # Creates a new version for reindex to miss on scan.
+  - do:
+      index:
+        index:   test
+        type:    foo
+        id:      1
+        body:    { "text": "test2" }
+  - do:
+      index:
+        index:   test
+        type:    foo
+        id:      2
+        body:    { "text": "test2" }
+
+
+  - do:
+      catch: conflict
+      delete_by_query:
+        max_reported_bulk_failures: -1
+        index: test
+        body:
+          query:
+            match_all: {}
+  - length: {failures: 2}
+  - match: {failures.0.index:  test}
+  - match: {failures.0.type:   foo}
+  - match: {failures.0.id:     /\d+/}
+  - match: {failures.0.status: 409}
+  - match: {failures.0.cause.type:   version_conflict_engine_exception}
+  # Use a regex so we don't mind if the version isn't always 1. Sometimes it comes out 2.
+  - match: {failures.0.cause.reason: "/\\[foo\\]\\[\\d+\\]:.version.conflict,.current.version.\\[\\d+\\].is.different.than.the.one.provided.\\[\\d+\\]/"}
+  - match: {failures.0.cause.shard:  /\d+/}
+  - match: {failures.0.cause.index:  test}
+  - match: {failures.1.index:  test}
+  - match: {failures.1.type:   foo}
+  - match: {failures.1.id:     /\d+/}
+  - match: {failures.1.status: 409}
+  - match: {failures.1.cause.type:   version_conflict_engine_exception}
+  # Use a regex so we don't mind if the version isn't always 1. Sometimes it comes out 2.
+  - match: {failures.1.cause.reason: "/\\[foo\\]\\[\\d+\\]:.version.conflict,.current.version.\\[\\d+\\].is.different.than.the.one.provided.\\[\\d+\\]/"}
+  - match: {failures.1.cause.shard:  /\d+/}
+  - match: {failures.1.cause.index:  test}

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/20_validation.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/20_validation.yaml
@@ -198,6 +198,18 @@
             index: dest
 
 ---
+"max_reported_bulk_failures >= -1":
+  - do:
+      catch: /\[max_reported_bulk_failures\] must be >= -1 but was \[-12\]/
+      reindex:
+        max_reported_bulk_failures: -12
+        body:
+          source:
+            index: test
+          dest:
+            index: dest
+
+---
 "reindex without source gives useful error message":
   - do:
       indices.create:

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/25_max_reported_bulk_failures.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/25_max_reported_bulk_failures.yaml
@@ -1,0 +1,110 @@
+---
+"max_reported_bulk_failures limits number of returned failures":
+  - do:
+      index:
+        index:   source
+        type:    foo
+        id:      1
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   dest
+        type:    foo
+        id:      1
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        type:    foo
+        id:      2
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   dest
+        type:    foo
+        id:      2
+        body:    { "text": "test" }
+  - do:
+      indices.refresh: {}
+
+
+  - do:
+      catch: conflict
+      reindex:
+        max_reported_bulk_failures: 1
+        body:
+          source:
+            index: source
+          dest:
+            index: dest
+            op_type: create
+  - length: {failures: 1}
+  - match: {failures.0.index:  dest}
+  - match: {failures.0.type:   foo}
+  - match: {failures.0.id:     /\d+/}
+  - match: {failures.0.status: 409}
+  - match: {failures.0.cause.type:   version_conflict_engine_exception}
+  # Use a regex so we don't mind if the version isn't always 1. Sometimes it comes out 2.
+  - match: {failures.0.cause.reason: "/\\[foo\\]\\[\\d+\\]:.version.conflict,.document.already.exists.\\(current.version.\\[\\d+\\]\\)/"}
+  - match: {failures.0.cause.shard:  /\d+/}
+  - match: {failures.0.cause.index:  dest}
+
+---
+"max_reported_bulk_failures=-1 means all failures":
+  - do:
+      index:
+        index:   source
+        type:    foo
+        id:      1
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   dest
+        type:    foo
+        id:      1
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   source
+        type:    foo
+        id:      2
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   dest
+        type:    foo
+        id:      2
+        body:    { "text": "test" }
+  - do:
+      indices.refresh: {}
+
+
+  - do:
+      catch: conflict
+      reindex:
+        max_reported_bulk_failures: -1
+        body:
+          source:
+            index: source
+          dest:
+            index: dest
+            op_type: create
+  - length: {failures: 2}
+  - match: {failures.0.index:  dest}
+  - match: {failures.0.type:   foo}
+  - match: {failures.0.id:     /\d+/}
+  - match: {failures.0.status: 409}
+  - match: {failures.0.cause.type:   version_conflict_engine_exception}
+  # Use a regex so we don't mind if the version isn't always 1. Sometimes it comes out 2.
+  - match: {failures.0.cause.reason: "/\\[foo\\]\\[\\d+\\]:.version.conflict,.document.already.exists.\\(current.version.\\[\\d+\\]\\)/"}
+  - match: {failures.0.cause.shard:  /\d+/}
+  - match: {failures.0.cause.index:  dest}
+  - match: {failures.1.index:  dest}
+  - match: {failures.1.type:   foo}
+  - match: {failures.1.id:     /\d+/}
+  - match: {failures.1.status: 409}
+  - match: {failures.1.cause.type:   version_conflict_engine_exception}
+  # Use a regex so we don't mind if the version isn't always 1. Sometimes it comes out 2.
+  - match: {failures.1.cause.reason: "/\\[foo\\]\\[\\d+\\]:.version.conflict,.document.already.exists.\\(current.version.\\[\\d+\\]\\)/"}
+  - match: {failures.1.cause.shard:  /\d+/}
+  - match: {failures.1.cause.index:  dest}

--- a/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/20_validation.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/20_validation.yaml
@@ -102,5 +102,16 @@
   - do:
       catch: /\[requests_per_second\] must be a float greater than 0. Use -1 to disable throttling./
       update_by_query:
-        requests_per_second: 0
+        requests_per_second: unlimited
         index: test
+
+---
+"max_reported_bulk_failures >= 0":
+  - do:
+      catch: /\[max_reported_bulk_failures\] must be >= -1 but was \[-12\]/
+      update_by_query:
+        max_reported_bulk_failures: -12
+        index: test
+        body:
+          query:
+            match_all: {}

--- a/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/25_max_reported_bulk_failures.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/25_max_reported_bulk_failures.yaml
@@ -1,0 +1,112 @@
+---
+"max_reported_bulk_failures limits number of returned failures":
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            index.refresh_interval: -1
+  - do:
+      index:
+        index:   test
+        type:    foo
+        id:      1
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   test
+        type:    foo
+        id:      2
+        body:    { "text": "test" }
+  - do:
+      indices.refresh: {}
+  # Creates a new version for reindex to miss on scan.
+  - do:
+      index:
+        index:   test
+        type:    foo
+        id:      1
+        body:    { "text": "test2" }
+  - do:
+      index:
+        index:   test
+        type:    foo
+        id:      2
+        body:    { "text": "test2" }
+
+  - do:
+      catch: conflict
+      update_by_query:
+        max_reported_bulk_failures: 1
+        index: test
+  - length: {failures: 1}
+  - match: {failures.0.index:  test}
+  - match: {failures.0.type:   foo}
+  - match: {failures.0.id:     /\d+/}
+  - match: {failures.0.status: 409}
+  - match: {failures.0.cause.type:   version_conflict_engine_exception}
+  # Use a regex so we don't mind if the version isn't always 1. Sometimes it comes out 2.
+  - match: {failures.0.cause.reason: "/\\[foo\\]\\[\\d+\\]:.version.conflict,.current.version.\\[\\d+\\].is.different.than.the.one.provided.\\[\\d+\\]/"}
+  - match: {failures.0.cause.shard:  /\d+/}
+  - match: {failures.0.cause.index:  test}
+
+---
+"max_reported_bulk_failures=-1 means all failures":
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            index.refresh_interval: -1
+  - do:
+      index:
+        index:   test
+        type:    foo
+        id:      1
+        body:    { "text": "test" }
+  - do:
+      index:
+        index:   test
+        type:    foo
+        id:      2
+        body:    { "text": "test" }
+  - do:
+      indices.refresh: {}
+  # Creates a new version for reindex to miss on scan.
+  - do:
+      index:
+        index:   test
+        type:    foo
+        id:      1
+        body:    { "text": "test2" }
+  - do:
+      index:
+        index:   test
+        type:    foo
+        id:      2
+        body:    { "text": "test2" }
+
+  - do:
+      catch: conflict
+      update_by_query:
+        max_reported_bulk_failures: -1
+        index: test
+  - length: {failures: 2}
+  - match: {failures.0.index:  test}
+  - match: {failures.0.type:   foo}
+  - match: {failures.0.id:     /\d+/}
+  - match: {failures.0.status: 409}
+  - match: {failures.0.cause.type:   version_conflict_engine_exception}
+  # Use a regex so we don't mind if the version isn't always 1. Sometimes it comes out 2.
+  - match: {failures.0.cause.reason: "/\\[foo\\]\\[\\d+\\]:.version.conflict,.current.version.\\[\\d+\\].is.different.than.the.one.provided.\\[\\d+\\]/"}
+  - match: {failures.0.cause.shard:  /\d+/}
+  - match: {failures.0.cause.index:  test}
+  - match: {failures.1.index:  test}
+  - match: {failures.1.type:   foo}
+  - match: {failures.1.id:     /\d+/}
+  - match: {failures.1.status: 409}
+  - match: {failures.1.cause.type:   version_conflict_engine_exception}
+  # Use a regex so we don't mind if the version isn't always 1. Sometimes it comes out 2.
+  - match: {failures.1.cause.reason: "/\\[foo\\]\\[\\d+\\]:.version.conflict,.current.version.\\[\\d+\\].is.different.than.the.one.provided.\\[\\d+\\]/"}
+  - match: {failures.1.cause.shard:  /\d+/}
+  - match: {failures.1.cause.index:  test}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -194,7 +194,12 @@
         "requests_per_second": {
           "type": "float",
           "default": 0,
-          "description": "The throttle for this request in sub-requests per second. -1 means set no throttle."
+          "description": "The throttle to set on this request in sub-requests per second. -1 means set no throttle."
+        },
+        "max_reported_bulk_failures": {
+          "type": "integer",
+          "default": 50,
+          "description": "The maximum number of bulk deleting failures that are returned with the response in the case of failure. Additional failures are logged but not returned so the client isn't overwhelmed with failures."
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
@@ -28,7 +28,12 @@
         "requests_per_second": {
           "type": "float",
           "default": 0,
-          "description": "The throttle to set on this request in sub-requests per second. -1 means set no throttle as does \"unlimited\" which is the only non-float this accepts."
+          "description": "The throttle to set on this request in sub-requests per second. -1 means set no throttle."
+        },
+        "max_reported_bulk_failures": {
+          "type": "integer",
+          "default": 50,
+          "description": "The maximum number of bulk indexing failures that are returned with the response in the case of failure. Additional failures are logged but not returned so the client isn't overwhelmed with failures."
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -202,7 +202,12 @@
         "requests_per_second": {
           "type": "float",
           "default": 0,
-          "description": "The throttle to set on this request in sub-requests per second. -1 means set no throttle as does \"unlimited\" which is the only non-float this accepts."
+          "description": "The throttle to set on this request in sub-requests per second. -1 means set no throttle."
+        },
+        "max_reported_bulk_failures": {
+          "type": "integer",
+          "default": 50,
+          "description": "The maximum number of bulk update failures that are returned with the response in the case of failure. Additional failures are logged but not returned so the client isn't overwhelmed with failures."
         }
       }
     },


### PR DESCRIPTION
Reindex, update_by_query, and delete_by_query work in batches based
on the scroll size of their source query, defaulting to 1000 documents
at a time. If all 1000 of those documents fail this returns an
avalanche of errors which is just fine over the Java API and, probably,
fine for any programatic consumers over the REST API as well. But for
interactive users the size of the response can be devestating.

So this commit creates a URL parameter to control the number of
indexing failures returned in the response,
`max_reported_bulk_failures`, which defaults to 50. The option
also exists in the Transport Client for completeness sake but
defaults to `Integer.MAX_VALUE` because transport client users are
unlikely to suffer if the response is large. Even though the
default is `Integer.MAX_VALUE`, not more than `batch_size` errors
are ever returned because a single error causes reindex to abort
after processing the current batch.

Closes #20199
