### PR TITLE
Fix logging hierarchy configs

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -30,7 +30,6 @@ import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.config.composite.CompositeConfiguration;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfiguration;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfigurationFactory;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.settings.Settings;
@@ -44,7 +43,6 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -81,13 +79,14 @@ public class LogConfigurator {
         }
 
         if (ESLoggerFactory.LOG_DEFAULT_LEVEL_SETTING.exists(settings)) {
-            Loggers.setLevel(ESLoggerFactory.getRootLogger(), ESLoggerFactory.LOG_DEFAULT_LEVEL_SETTING.get(settings));
+            final Level level = ESLoggerFactory.LOG_DEFAULT_LEVEL_SETTING.get(settings);
+            Loggers.setLevel(ESLoggerFactory.getRootLogger(), level);
         }
 
         final Map<String, String> levels = settings.filter(ESLoggerFactory.LOG_LEVEL_SETTING::match).getAsMap();
         for (String key : levels.keySet()) {
             final Level level = ESLoggerFactory.LOG_LEVEL_SETTING.getConcreteSetting(key).get(settings);
-            Loggers.setLevel(Loggers.getLogger(key.substring("logger.".length())), level);
+            Loggers.setLevel(ESLoggerFactory.getLogger(key.substring("logger.".length())), level);
         }
     }
 

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerConfigurationTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerConfigurationTests.java
@@ -96,7 +96,7 @@ public class EvilLoggerConfigurationTests extends ESTestCase {
         final Environment environment = new Environment(settings);
         LogConfigurator.configure(environment, true);
 
-        final String loggerName = Loggers.commonPrefix + "test";
+        final String loggerName = "test";
         final Logger logger = ESLoggerFactory.getLogger(loggerName);
         assertThat(logger.getLevel().toString(), equalTo(level));
     }
@@ -113,9 +113,28 @@ public class EvilLoggerConfigurationTests extends ESTestCase {
         LogConfigurator.configure(environment, true);
 
         // args should overwrite whatever is in the config
-        final String loggerName = Loggers.commonPrefix + "test_resolve_order";
+        final String loggerName = "test_resolve_order";
         final Logger logger = ESLoggerFactory.getLogger(loggerName);
         assertTrue(logger.isTraceEnabled());
+    }
+
+    public void testHierarchy() throws Exception {
+        final Path configDir = getDataPath("hierarchy");
+        final Settings settings = Settings.builder()
+                .put(Environment.PATH_CONF_SETTING.getKey(), configDir.toAbsolutePath())
+                .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
+                .build();
+        final Environment environment = new Environment(settings);
+        LogConfigurator.configure(environment, true);
+
+        assertThat(ESLoggerFactory.getLogger("x").getLevel(), equalTo(Level.TRACE));
+        assertThat(ESLoggerFactory.getLogger("x.y").getLevel(), equalTo(Level.DEBUG));
+
+        final Level level = randomFrom(Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR);
+        Loggers.setLevel(ESLoggerFactory.getLogger("x"), level);
+
+        assertThat(ESLoggerFactory.getLogger("x").getLevel(), equalTo(level));
+        assertThat(ESLoggerFactory.getLogger("x.y").getLevel(), equalTo(level));
     }
 
 }

--- a/qa/evil-tests/src/test/resources/org/elasticsearch/common/logging/hierarchy/log4j2.properties
+++ b/qa/evil-tests/src/test/resources/org/elasticsearch/common/logging/hierarchy/log4j2.properties
@@ -1,0 +1,20 @@
+status = error
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console
+rootLogger.appenderRef.file.ref = file
+
+logger.x.name = x
+logger.x.level = trace
+logger.x.appenderRef.console.ref = console
+logger.x.additivity = false
+
+logger.x_y.name = x.y
+logger.x_y.level = debug
+logger.x_y.appenderRef.console.ref = console
+logger.x_y.additivity = false


### PR DESCRIPTION
Today when setting the logging level via the command-line or an API
call, the expectation is that the logging level should trickle down the
hiearchy to descendant loggers. However, this is not necessarily the
case. For example, if loggers x and x.y are already configured then
setting the logging level on x will not descend to x.y. This is because
the logging config for x.y has already been forked from the logging
config for x. Therefore, we must explicitly descend the hierarchy when
setting the logging level and that is what this commit does.
