### PR TITLE
Fix handling indices stats request when all shards are missing

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
@@ -97,14 +97,15 @@ public class CommonStats implements Writeable, ToXContent {
     @Nullable
     public RecoveryStats recoveryStats;
 
+    private CommonStatsFlags flags;
+
     public CommonStats() {
         this(CommonStatsFlags.NONE);
     }
 
     public CommonStats(CommonStatsFlags flags) {
-        CommonStatsFlags.Flag[] setFlags = flags.getFlags();
-
-        for (CommonStatsFlags.Flag flag : setFlags) {
+        this.flags = flags;
+        for (CommonStatsFlags.Flag flag : flags.getFlags()) {
             switch (flag) {
                 case Docs:
                     docs = new DocsStats();
@@ -164,8 +165,8 @@ public class CommonStats implements Writeable, ToXContent {
     }
 
     public CommonStats(IndicesQueryCache indicesQueryCache, IndexShard indexShard, CommonStatsFlags flags) {
-        CommonStatsFlags.Flag[] setFlags = flags.getFlags();
-        for (CommonStatsFlags.Flag flag : setFlags) {
+        this.flags = flags;
+        for (CommonStatsFlags.Flag flag : flags.getFlags()) {
             switch (flag) {
                 case Docs:
                     docs = indexShard.docStats();
@@ -225,6 +226,7 @@ public class CommonStats implements Writeable, ToXContent {
     }
 
     public CommonStats(StreamInput in) throws IOException {
+        flags = new CommonStatsFlags(in);
         if (in.readBoolean()) {
             docs = DocsStats.readDocStats(in);
         }
@@ -271,6 +273,7 @@ public class CommonStats implements Writeable, ToXContent {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        flags.writeTo(out);
         if (docs == null) {
             out.writeBoolean(false);
         } else {
@@ -484,6 +487,10 @@ public class CommonStats implements Writeable, ToXContent {
         } else {
             recoveryStats.add(stats.getRecoveryStats());
         }
+    }
+
+    public CommonStatsFlags getFlags() {
+        return this.flags;
     }
 
     @Nullable

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndexShardStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndexShardStats.java
@@ -36,11 +36,14 @@ public class IndexShardStats implements Iterable<ShardStats>, Streamable {
 
     private ShardStats[] shards;
 
+    private CommonStatsFlags flags;
+
     private IndexShardStats() {}
 
-    public IndexShardStats(ShardId shardId, ShardStats[] shards) {
+    public IndexShardStats(ShardId shardId, CommonStatsFlags flags, ShardStats[] shards) {
         this.shardId = shardId;
         this.shards = shards;
+        this.flags = flags;
     }
 
     public ShardId getShardId() {
@@ -63,31 +66,19 @@ public class IndexShardStats implements Iterable<ShardStats>, Streamable {
     private CommonStats total = null;
 
     public CommonStats getTotal() {
-        if (total != null) {
-            return total;
+        if (total == null) {
+            total = ShardStats.calculateTotalStats(shards, flags);
         }
-        CommonStats stats = new CommonStats();
-        for (ShardStats shard : shards) {
-            stats.add(shard.getStats());
-        }
-        total = stats;
-        return stats;
+        return total;
     }
 
     private CommonStats primary = null;
 
     public CommonStats getPrimary() {
-        if (primary != null) {
-            return primary;
+        if (primary == null) {
+            primary = ShardStats.calculatePrimaryStats(shards, flags);
         }
-        CommonStats stats = new CommonStats();
-        for (ShardStats shard : shards) {
-            if (shard.getShardRouting().primary()) {
-                stats.add(shard.getStats());
-            }
-        }
-        primary = stats;
-        return stats;
+        return primary;
     }
 
     @Override
@@ -98,6 +89,7 @@ public class IndexShardStats implements Iterable<ShardStats>, Streamable {
         for (int i = 0; i < shardSize; i++) {
             shards[i] = ShardStats.readShardStats(in);
         }
+        flags = new CommonStatsFlags(in);
     }
 
     @Override
@@ -107,6 +99,7 @@ public class IndexShardStats implements Iterable<ShardStats>, Streamable {
         for (ShardStats stats : shards) {
             stats.writeTo(out);
         }
+        flags.writeTo(out);
     }
 
     public static IndexShardStats readIndexShardStats(StreamInput in) throws IOException {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndexStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndexStats.java
@@ -33,9 +33,27 @@ public class IndexStats implements Iterable<IndexShardStats> {
 
     private final ShardStats shards[];
 
-    public IndexStats(String index, ShardStats[] shards) {
+    private final CommonStats total;
+
+    private final CommonStats primary;
+
+    private final Map<Integer, IndexShardStats> indexShards;
+
+    public IndexStats(String index, CommonStatsFlags flags, ShardStats[] shards) {
         this.index = index;
         this.shards = shards;
+        this.total = ShardStats.calculateTotalStats(shards, flags);
+        this.primary = ShardStats.calculatePrimaryStats(shards, flags);
+        Map<Integer, List<ShardStats>> tmpIndexShards = new HashMap<>();
+        for (ShardStats shard : shards) {
+            List<ShardStats> shardStatList = tmpIndexShards.computeIfAbsent(shard.getShardRouting().id(), integer -> new ArrayList<>());
+            shardStatList.add(shard);
+        }
+        Map<Integer, IndexShardStats> indexShardList = new HashMap<>();
+        for (Map.Entry<Integer, List<ShardStats>> entry : tmpIndexShards.entrySet()) {
+            indexShardList.put(entry.getKey(), new IndexShardStats(entry.getValue().get(0).getShardRouting().shardId(), flags, entry.getValue().toArray(new ShardStats[entry.getValue().size()])));
+        }
+        indexShards = indexShardList;
     }
 
     public String getIndex() {
@@ -46,25 +64,8 @@ public class IndexStats implements Iterable<IndexShardStats> {
         return this.shards;
     }
 
-    private Map<Integer, IndexShardStats> indexShards;
 
     public Map<Integer, IndexShardStats> getIndexShards() {
-        if (indexShards != null) {
-            return indexShards;
-        }
-        Map<Integer, List<ShardStats>> tmpIndexShards = new HashMap<>();
-        for (ShardStats shard : shards) {
-            List<ShardStats> lst = tmpIndexShards.get(shard.getShardRouting().id());
-            if (lst == null) {
-                lst = new ArrayList<>();
-                tmpIndexShards.put(shard.getShardRouting().id(), lst);
-            }
-            lst.add(shard);
-        }
-        indexShards = new HashMap<>();
-        for (Map.Entry<Integer, List<ShardStats>> entry : tmpIndexShards.entrySet()) {
-            indexShards.put(entry.getKey(), new IndexShardStats(entry.getValue().get(0).getShardRouting().shardId(), entry.getValue().toArray(new ShardStats[entry.getValue().size()])));
-        }
         return indexShards;
     }
 
@@ -73,33 +74,12 @@ public class IndexStats implements Iterable<IndexShardStats> {
         return getIndexShards().values().iterator();
     }
 
-    private CommonStats total = null;
 
     public CommonStats getTotal() {
-        if (total != null) {
-            return total;
-        }
-        CommonStats stats = new CommonStats();
-        for (ShardStats shard : shards) {
-            stats.add(shard.getStats());
-        }
-        total = stats;
-        return stats;
+        return total;
     }
 
-    private CommonStats primary = null;
-
     public CommonStats getPrimaries() {
-        if (primary != null) {
-            return primary;
-        }
-        CommonStats stats = new CommonStats();
-        for (ShardStats shard : shards) {
-            if (shard.getShardRouting().primary()) {
-                stats.add(shard.getStats());
-            }
-        }
-        primary = stats;
-        return stats;
+        return primary;
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
@@ -265,6 +265,10 @@ public class IndicesStatsRequest extends BroadcastRequest<IndicesStatsRequest> {
         return this;
     }
 
+    protected CommonStatsFlags getFlags() {
+        return flags;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
@@ -54,6 +54,30 @@ public class ShardStats implements Streamable, ToXContent {
         this.commonStats = commonStats;
     }
 
+    /** calculates primary stats for shard stats */
+    static CommonStats calculatePrimaryStats(ShardStats[] shards, CommonStatsFlags flags) {
+        CommonStats primaryStats = new CommonStats();
+        boolean primaryFound = false;
+        for (ShardStats shard : shards) {
+            if (shard.getShardRouting().primary()) {
+                primaryStats.add(shard.getStats());
+                primaryFound = true;
+            }
+        }
+        return primaryFound ? primaryStats : new CommonStats(flags);
+    }
+
+    /** calculates total stats for shard stats */
+    static CommonStats calculateTotalStats(ShardStats[] shards, CommonStatsFlags flags) {
+        CommonStats totalStats = new CommonStats();
+        boolean shardFound = false;
+        for (ShardStats shard : shards) {
+            totalStats.add(shard.getStats());
+            shardFound = true;
+        }
+        return shardFound ? totalStats : new CommonStats(flags);
+    }
+
     /**
      * The shard routing information (cluster wide shard state).
      */

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -82,7 +82,7 @@ public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
 
     @Override
     protected IndicesStatsResponse newResponse(IndicesStatsRequest request, int totalShards, int successfulShards, int failedShards, List<ShardStats> responses, List<ShardOperationFailedException> shardFailures, ClusterState clusterState) {
-        return new IndicesStatsResponse(responses.toArray(new ShardStats[responses.size()]), totalShards, successfulShards, failedShards, shardFailures);
+        return new IndicesStatsResponse(request.getFlags(), responses.toArray(new ShardStats[responses.size()]), totalShards, successfulShards, failedShards, shardFailures);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/engine/CommitStats.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/CommitStats.java
@@ -52,16 +52,9 @@ public final class CommitStats implements Streamable, ToXContent {
 
     }
 
-    public static CommitStats readCommitStatsFrom(StreamInput in) throws IOException {
-        CommitStats commitStats = new CommitStats();
-        commitStats.readFrom(in);
-        return commitStats;
-    }
-
     public static CommitStats readOptionalCommitStatsFrom(StreamInput in) throws IOException {
         return in.readOptionalStreamable(CommitStats::new);
     }
-
 
     public Map<String, String> getUserData() {
         return userData;

--- a/core/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -290,7 +290,8 @@ public class IndicesService extends AbstractLifecycleComponent
                     if (indexShard.routingEntry() == null) {
                         continue;
                     }
-                    IndexShardStats indexShardStats = new IndexShardStats(indexShard.shardId(), new ShardStats[] { new ShardStats(indexShard.routingEntry(), indexShard.shardPath(), new CommonStats(indicesQueryCache, indexShard, flags), indexShard.commitStats()) });
+                    IndexShardStats indexShardStats = new IndexShardStats(indexShard.shardId(), flags,
+                            new ShardStats[] { new ShardStats(indexShard.routingEntry(), indexShard.shardPath(), new CommonStats(indicesQueryCache, indexShard, flags), indexShard.commitStats()) });
                     if (!statsByShard.containsKey(indexService.index())) {
                         statsByShard.put(indexService.index(), arrayAsArrayList(indexShardStats));
                     } else {

--- a/core/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/core/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -230,17 +230,13 @@ public class NodeIndicesStats implements Streamable, ToXContent {
     private Map<Index, CommonStats> createStatsByIndex() {
         Map<Index, CommonStats> statsMap = new HashMap<>();
         for (Map.Entry<Index, List<IndexShardStats>> entry : statsByShard.entrySet()) {
-            if (!statsMap.containsKey(entry.getKey())) {
-                statsMap.put(entry.getKey(), new CommonStats());
-            }
-
+            CommonStats indexStats = statsMap.computeIfAbsent(entry.getKey(), index -> new CommonStats());
             for (IndexShardStats indexShardStats : entry.getValue()) {
                 for (ShardStats shardStats : indexShardStats.getShards()) {
-                    statsMap.get(entry.getKey()).add(shardStats.getStats());
+                    indexStats.add(shardStats.getStats());
                 }
             }
         }
-
         return statsMap;
     }
 

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsTests.java
@@ -114,9 +114,9 @@ public class IndicesStatsTests extends ESSingleNodeTestCase {
     /**
      * Gives access to package private IndicesStatsResponse constructor for test purpose.
      **/
-    public static IndicesStatsResponse newIndicesStatsResponse(ShardStats[] shards, int totalShards, int successfulShards,
+    public static IndicesStatsResponse newIndicesStatsResponse(CommonStatsFlags flags, ShardStats[] shards, int totalShards, int successfulShards,
                                                                int failedShards, List<ShardOperationFailedException> shardFailures) {
-        return new IndicesStatsResponse(shards, totalShards, successfulShards, failedShards, shardFailures);
+        return new IndicesStatsResponse(flags, shards, totalShards, successfulShards, failedShards, shardFailures);
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/rest/action/cat/RestIndicesActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/cat/RestIndicesActionTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.rest.action.cat;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
+import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsTests;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
@@ -143,25 +144,28 @@ public class RestIndicesActionTests extends ESTestCase {
                     );
                 shardRouting = shardRouting.initialize("node-0", null, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE);
                 shardRouting = shardRouting.moveToStarted();
-                CommonStats stats = new CommonStats();
-                stats.fieldData = new FieldDataStats();
-                stats.queryCache = new QueryCacheStats();
-                stats.docs = new DocsStats();
-                stats.store = new StoreStats();
-                stats.indexing = new IndexingStats();
-                stats.search = new SearchStats();
-                stats.segments = new SegmentsStats();
-                stats.merge = new MergeStats();
-                stats.refresh = new RefreshStats();
-                stats.completion = new CompletionStats();
-                stats.requestCache = new RequestCacheStats();
-                stats.get = new GetStats();
-                stats.flush = new FlushStats();
-                stats.warmer = new WarmerStats();
+                CommonStats stats = new CommonStats(CommonStatsFlags.ALL);
+                // rarely none of the stats fields would be initialized due to the index missing all shards for reporting stats
+                if (frequently()) {
+                    stats.fieldData = new FieldDataStats();
+                    stats.queryCache = new QueryCacheStats();
+                    stats.docs = new DocsStats();
+                    stats.store = new StoreStats();
+                    stats.indexing = new IndexingStats();
+                    stats.search = new SearchStats();
+                    stats.segments = new SegmentsStats();
+                    stats.merge = new MergeStats();
+                    stats.refresh = new RefreshStats();
+                    stats.completion = new CompletionStats();
+                    stats.requestCache = new RequestCacheStats();
+                    stats.get = new GetStats();
+                    stats.flush = new FlushStats();
+                    stats.warmer = new WarmerStats();
+                }
                 shardStats.add(new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null));
             }
         }
-        return IndicesStatsTests.newIndicesStatsResponse(
+        return IndicesStatsTests.newIndicesStatsResponse(CommonStatsFlags.ALL,
             shardStats.toArray(new ShardStats[shardStats.size()]), shardStats.size(), shardStats.size(), 0, emptyList()
         );
     }


### PR DESCRIPTION
Currently, when an index exists in the cluster state but has no shards for reporting stats,
the missing stats object cause a `NullPointerException` when requesting the indices stats.
In this commit missing stats object for an index are initialized as empty stats instead
of null, honoring the stats flags set in the stats request. The commit fixes the issue for all
APIs that use the indices stats API namely `_cat/indices`, `_cat/shards` and `_stats`.

closes #20298
