### PR TITLE
Add CONSOLE tests for snippets in get and bulk API docs

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -66,17 +66,97 @@ example of a correct sequence of bulk commands:
 
 [source,js]
 --------------------------------------------------
+POST _bulk
 { "index" : { "_index" : "test", "_type" : "type1", "_id" : "1" } }
 { "field1" : "value1" }
 { "delete" : { "_index" : "test", "_type" : "type1", "_id" : "2" } }
 { "create" : { "_index" : "test", "_type" : "type1", "_id" : "3" } }
 { "field1" : "value3" }
-{ "update" : {"_id" : "1", "_type" : "type1", "_index" : "index1"} }
+{ "update" : {"_id" : "4", "_type" : "type1", "_index" : "index1"} }
 { "doc" : {"field2" : "value2"} }
 --------------------------------------------------
+// CONSOLE
 
-In the above example `doc` for the `update` action is a partial
-document, that will be merged with the already stored document.
+The result of this bulk operation is:
+
+[source,js]
+--------------------------------------------------
+{
+   "took": ...,
+   "errors": true, <1>
+   "items": [
+      {
+         "index": { <2>
+            "_index": "test",
+            "_type": "type1",
+            "_id": "1",
+            "_version": 1,
+            "result": "created",
+            "_shards": {
+               "total": 2,
+               "successful": 1,
+               "failed": 0
+            },
+            "created": true,
+            "status": 201
+         }
+      },
+      {
+         "delete": { <3>
+            "found": false,
+            "_index": "test",
+            "_type": "type1",
+            "_id": "2",
+            "_version": 1,
+            "result": "not_found",
+            "_shards": {
+               "total": 2,
+               "successful": 1,
+               "failed": 0
+            },
+            "status": 404
+         }
+      },
+      {
+         "create": { <4>
+            "_index": "test",
+            "_type": "type1",
+            "_id": "3",
+            "_version": 1,
+            "result": "created",
+            "_shards": {
+               "total": 2,
+               "successful": 1,
+               "failed": 0
+            },
+            "created": true,
+            "status": 201
+         }
+      },
+      {
+         "update": { <5>
+            "_index": "index1",
+            "_type": "type1",
+            "_id": "4",
+            "status": 404,
+            "error": {
+               "type": "document_missing_exception",
+               "reason": "[type1][4]: document missing",
+               "index_uuid": ...,
+               "shard": "2",
+               "index": "index1"
+            }
+         }
+      }
+   ]
+}
+--------------------------------------------------
+// TESTRESPONSE[s/"took": .../"took": $body.took/ s/"index_uuid": .../"index_uuid": $body.items.3.update.error.index_uuid/]
+<1> Some operation(s) in the _bulk request failed
+<2> The first operation succeeded with 201 status
+<3> The delete operation failed because the targeted document does not exist
+<4> The create operation succeeded with 201 status
+<5> The update operation failed because the targeted document is missing (create and update the same document in a single _bulk request does not work)
 
 The endpoints are `/_bulk`, `/{index}/_bulk`, and `{index}/{type}/_bulk`.
 When the index or the index/type are provided, they will be used by
@@ -155,10 +235,11 @@ times an update should be retried in the case of a version conflict.
 The `update` action payload, supports the following options: `doc`
 (partial document), `upsert`, `doc_as_upsert`, `script`, `params` (for
 script), `lang` (for script) and `_source`. See update documentation for details on
-the options. Curl example with update actions:
+the options. Example with update actions:
 
 [source,js]
 --------------------------------------------------
+POST _bulk
 { "update" : {"_id" : "1", "_type" : "type1", "_index" : "index1", "_retry_on_conflict" : 3} }
 { "doc" : {"field" : "value"} }
 { "update" : { "_id" : "0", "_type" : "type1", "_index" : "index1", "_retry_on_conflict" : 3} }
@@ -170,6 +251,8 @@ the options. Curl example with update actions:
 { "update" : {"_id" : "4", "_type" : "type1", "_index" : "index1"} }
 { "doc" : {"field" : "value"}, "_source": true}
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
 
 [float]
 [[bulk-security]]

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -72,7 +72,7 @@ POST _bulk
 { "delete" : { "_index" : "test", "_type" : "type1", "_id" : "2" } }
 { "create" : { "_index" : "test", "_type" : "type1", "_id" : "3" } }
 { "field1" : "value3" }
-{ "update" : {"_id" : "4", "_type" : "type1", "_index" : "index1"} }
+{ "update" : {"_id" : "1", "_type" : "type1", "_index" : "test"} }
 { "doc" : {"field2" : "value2"} }
 --------------------------------------------------
 // CONSOLE
@@ -82,11 +82,11 @@ The result of this bulk operation is:
 [source,js]
 --------------------------------------------------
 {
-   "took": ...,
-   "errors": true, <1>
+   "took": 30,
+   "errors": false,
    "items": [
       {
-         "index": { <2>
+         "index": {
             "_index": "test",
             "_type": "type1",
             "_id": "1",
@@ -102,7 +102,7 @@ The result of this bulk operation is:
          }
       },
       {
-         "delete": { <3>
+         "delete": {
             "found": false,
             "_index": "test",
             "_type": "type1",
@@ -118,7 +118,7 @@ The result of this bulk operation is:
          }
       },
       {
-         "create": { <4>
+         "create": {
             "_index": "test",
             "_type": "type1",
             "_id": "3",
@@ -134,29 +134,24 @@ The result of this bulk operation is:
          }
       },
       {
-         "update": { <5>
-            "_index": "index1",
+         "update": {
+            "_index": "test",
             "_type": "type1",
-            "_id": "4",
-            "status": 404,
-            "error": {
-               "type": "document_missing_exception",
-               "reason": "[type1][4]: document missing",
-               "index_uuid": ...,
-               "shard": "2",
-               "index": "index1"
-            }
+            "_id": "1",
+            "_version": 2,
+            "result": "updated",
+            "_shards": {
+                "total": 2,
+                "successful": 1,
+                "failed": 0
+            },
+            "status": 200
          }
       }
    ]
 }
 --------------------------------------------------
-// TESTRESPONSE[s/"took": .../"took": $body.took/ s/"index_uuid": .../"index_uuid": $body.items.3.update.error.index_uuid/]
-<1> Some operation(s) in the _bulk request failed
-<2> The first operation succeeded with 201 status
-<3> The delete operation failed because the targeted document does not exist
-<4> The create operation succeeded with 201 status
-<5> The update operation failed because the targeted document is missing (create and update the same document in a single _bulk request does not work)
+// TESTRESPONSE[s/"took": 30/"took": $body.took/ s/"index_uuid": .../"index_uuid": $body.items.3.update.error.index_uuid/]
 
 The endpoints are `/_bulk`, `/{index}/_bulk`, and `{index}/{type}/_bulk`.
 When the index or the index/type are provided, they will be used by

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -3,12 +3,14 @@
 
 The get API allows to get a typed JSON document from the index based on
 its id. The following example gets a JSON document from an index called
-twitter, under a type called tweet, with id valued 1:
+twitter, under a type called tweet, with id valued 0:
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'http://localhost:9200/twitter/tweet/1'
+GET twitter/tweet/0
 --------------------------------------------------
+// CONSOLE
+// TEST[setup:twitter]
 
 The result of the above get operation is:
 
@@ -17,16 +19,18 @@ The result of the above get operation is:
 {
     "_index" : "twitter",
     "_type" : "tweet",
-    "_id" : "1",
+    "_id" : "0",
     "_version" : 1,
     "found": true,
     "_source" : {
         "user" : "kimchy",
-        "postDate" : "2009-11-15T14:12:12",
+        "date" : "2009-11-15T14:12:12",
+        "likes": 0,
         "message" : "trying out Elasticsearch"
     }
 }
 --------------------------------------------------
+// TESTRESPONSE
 
 The above result includes the `_index`, `_type`, `_id` and `_version`
 of the document we wish to retrieve, including the actual `_source`
@@ -38,8 +42,10 @@ The API also allows to check for the existence of a document using
 
 [source,js]
 --------------------------------------------------
-curl -XHEAD -i 'http://localhost:9200/twitter/tweet/1'
+HEAD twitter/tweet/0
 --------------------------------------------------
+// CONSOLE
+// TEST[setup:twitter]
 
 [float]
 [[realtime]]
@@ -70,8 +76,10 @@ You can turn off `_source` retrieval by using the `_source` parameter:
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'http://localhost:9200/twitter/tweet/1?_source=false'
+GET twitter/tweet/0?_source=false
 --------------------------------------------------
+// CONSOLE
+// TEST[setup:twitter]
 
 If you only need one or two fields from the complete `_source`, you can use the `_source_include`
 & `_source_exclude` parameters to include or filter out that parts you need. This can be especially helpful
@@ -80,16 +88,19 @@ of fields or wildcard expressions. Example:
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'http://localhost:9200/twitter/tweet/1?_source_include=*.id&_source_exclude=entities'
+GET twitter/tweet/0?_source_include=*.id&_source_exclude=entities
 --------------------------------------------------
+// CONSOLE
+// TEST[setup:twitter]
 
 If you only want to specify includes, you can use a shorter notation:
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'http://localhost:9200/twitter/tweet/1?_source=*.id,retweeted'
+GET twitter/tweet/0?_source=*.id,retweeted
 --------------------------------------------------
-
+// CONSOLE
+// TEST[setup:twitter]
 
 [float]
 [[get-stored-fields]]
@@ -227,24 +238,29 @@ without any additional content around it. For example:
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'http://localhost:9200/twitter/tweet/1/_source'
+GET twitter/tweet/1/_source
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
 
 You can also use the same source filtering parameters to control which parts of the `_source` will be returned:
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'http://localhost:9200/twitter/tweet/1/_source?_source_include=*.id&_source_exclude=entities'
+GET twitter/tweet/1/_source?_source_include=*.id&_source_exclude=entities'
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
 
 Note, there is also a HEAD variant for the _source endpoint to efficiently test for document _source existence.
 An existing document will not have a _source if it is disabled in the <<mapping-source-field,mapping>>.
-Curl example:
 
 [source,js]
 --------------------------------------------------
-curl -XHEAD -i 'http://localhost:9200/twitter/tweet/1/_source'
+HEAD twitter/tweet/1/_source
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
 
 [float]
 [[get-routing]]
@@ -255,10 +271,12 @@ a document, the routing value should also be provided. For example:
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'http://localhost:9200/twitter/tweet/1?routing=kimchy'
+GET twitter/tweet/2?routing=user1
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
 
-The above will get a tweet with id 1, but will be routed based on the
+The above will get a tweet with id 2, but will be routed based on the
 user. Note, issuing a get without the correct routing, will cause the
 document not to be fetched.
 


### PR DESCRIPTION
This change adds tests for the snippets in the get and bulk API documentation.
