### PR TITLE
Update logger names in docs

### DIFF
--- a/docs/reference/modules/cluster/misc.asciidoc
+++ b/docs/reference/modules/cluster/misc.asciidoc
@@ -46,7 +46,7 @@ The settings which control logging can be updated dynamically with the
 PUT /_cluster/settings
 {
   "transient": {
-    "logger.indices.recovery": "DEBUG"
+    "logger.org.elasticsearch.indices.recovery": "DEBUG"
   }
 }
 -------------------------------

--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -91,13 +91,13 @@ the JVM. It is automatically enabled when using
 === Transport Tracer
 
 The transport module has a dedicated tracer logger which, when activated, logs incoming and out going requests. The log can be dynamically activated
-by settings the level of the `transport.tracer` logger to `TRACE`:
+by settings the level of the `org.elasticsearch.transport.TransportService.tracer` logger to `TRACE`:
 
 [source,js]
 --------------------------------------------------
 curl -XPUT localhost:9200/_cluster/settings -d '{
     "transient" : {
-        "logger.transport.tracer" : "TRACE"
+        "logger.org.elasticsearch.transport.TransportService.tracer" : "TRACE"
     }
 }'
 --------------------------------------------------

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -148,10 +148,10 @@ will be compressed as they are rolled.
 Multiple configuration files can be loaded (in which case they will get merged)
 as long as they are named `log4j2.properties` and have the Elasticsearch config
 directory as an ancestor; this is useful for plugins that expose additional
-loggers.  The logger section contains the java packages and their corresponding
-log level, where it is possible to omit the `org.elasticsearch` prefix. The
-appender section contains the destinations for the logs. Extensive information
-on how to customize logging and all the supported appenders can be found on the
+loggers. The logger section contains the java packages and their corresponding
+log level. The appender section contains the destinations for the logs.
+Extensive information on how to customize logging and all the supported
+appenders can be found on the
 http://logging.apache.org/log4j/2.x/manual/configuration.html[Log4j
 documentation].
 


### PR DESCRIPTION
In 7560101ec73331acb39a042bde6130e59e4bb630, the Elasticsearch logger
names were modified to be their fully-qualified class name (with some
exceptions for special loggers like the slow logs and the transport
tracer). This commit updates the docs accordingly.

Relates #20457
