### PR TITLE
Update rescoring docs in respect to sort

### DIFF
--- a/docs/reference/search/request/rescore.asciidoc
+++ b/docs/reference/search/request/rescore.asciidoc
@@ -15,9 +15,9 @@ Currently the rescore API has only one implementation: the query
 rescorer, which uses a query to tweak the scoring. In the future, 
 alternative rescorers may be made available, for example, a pair-wise rescorer.
 
-NOTE: the `rescore` phase is not executed when
+NOTE: the `rescore` phase is not executed when <<search-request-sort,`sort`>> is used or
 <<search-request-search-type,`search_type`>> is set
-to `scan` or `count`.
+to `scan` or `count`
 
 NOTE: when exposing pagination to your users, you should not change
 `window_size` as you step through each page (by passing different

--- a/docs/reference/search/request/rescore.asciidoc
+++ b/docs/reference/search/request/rescore.asciidoc
@@ -17,7 +17,7 @@ alternative rescorers may be made available, for example, a pair-wise rescorer.
 
 NOTE: the `rescore` phase is not executed when <<search-request-sort,`sort`>> is used or
 <<search-request-search-type,`search_type`>> is set
-to `scan` or `count`
+to `scan` or `count`.
 
 NOTE: when exposing pagination to your users, you should not change
 `window_size` as you step through each page (by passing different


### PR DESCRIPTION
If sort is present in a query the rescore query is not executed. As long as this feature is neither implemented (see discussion in #6788) nor the combination of sort and rescoring raises an error, we should warn the user in the documentation about this.
