### PR TITLE
Don't generate html outputs from checkstyle

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
@@ -148,6 +148,9 @@ class PrecommitTasks {
                 checkstyleTask.dependsOn(task)
                 task.dependsOn(copyCheckstyleConf)
                 task.inputs.file(checkstyleSuppressions)
+                task.reports {
+                    html.enabled false
+                }
             }
         }
         return checkstyleTask


### PR DESCRIPTION
We run our builds with `gradle --info` and that ends up generating horrific long dumps of xslt.

This is what we're trying to avoid:

```
[ant:xslt] Loading stylesheet <xsl:stylesheet   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
<!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

<xsl:output method="html" indent="yes"/>
<xsl:decimal-format decimal-separator="." grouping-separator="," />

<xsl:key name="files" match="file" use="@name" />

<!-- Checkstyle XML Style Sheet by Stephane Bailliez <sbailliez@apache.org>         -->
<!-- Part of the Checkstyle distribution found at http://checkstyle.sourceforge.net -->
<!-- Usage (generates checkstyle_report.html):                                      -->
<!--    <checkstyle failonviolation="false" config="${check.config}">               -->
<!--      <fileset dir="${src.dir}" includes="**/*.java"/>                          -->
<!--      <formatter type="xml" toFile="${doc.dir}/checkstyle_report.xml"/>         -->
<!--    </checkstyle>
```
