### PR TITLE
Replace usage of LuceneTestCase#getBaseTempDirForTestClass

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/common/io/PathUtilsForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/io/PathUtilsForTesting.java
@@ -30,7 +30,7 @@ public class PathUtilsForTesting {
 
     /** Sets a new default filesystem for testing */
     public static void setup() {
-        installMock(LuceneTestCase.getBaseTempDirForTestClass().getFileSystem());
+        installMock(LuceneTestCase.createTempDir().getFileSystem());
     }
 
     /** Installs a mock filesystem for testing */


### PR DESCRIPTION
`LuceneTestCase#getBaseTempDirForTestClass` is deprecated, we should not use it.

Closes #15845
