### PR TITLE
[DOC] Add note requiring full cluster restart for installing plugins with custom metadata

### DIFF
--- a/docs/plugins/index.asciidoc
+++ b/docs/plugins/index.asciidoc
@@ -16,6 +16,10 @@ Plugins contain JAR files, but may also contain scripts and config files, and
 must be installed on every node in the cluster. After installation, each
 node must be restarted before the plugin becomes visible.
 
+NOTE: A full cluster restart is required for installing plugins that have
+custom cluster state metadata, such as X-Pack. It is still possible to upgrade
+such plugins with a rolling restart.
+
 This documentation distinguishes two categories of plugins:
 
 Core Plugins::    This category identifies plugins that are part of Elasticsearch


### PR DESCRIPTION
Currently, we check if a node has the same set of custom metadata 
as the master before joining the cluster. This implies freshly installing 
a plugin that has its custom metadata requires a full cluster restart.
