### PR TITLE
Clean up snapshots where possible after each REST test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get/10_basic.yaml
@@ -10,13 +10,6 @@ setup:
             location: "test_repo_get_1_loc"
 
 ---
-teardown:
-
-  - do:
-      snapshot.delete_repository:
-        repository: test_repo_get_1
-
----
 "Get snapshot info":
 
   - do:
@@ -39,7 +32,7 @@ teardown:
         snapshot: test_snapshot
 
   - is_true: snapshots
-  
+
 ---
 "Get missing snapshot info throws an exception":
 
@@ -48,7 +41,7 @@ teardown:
       snapshot.get:
         repository: test_repo_get_1
         snapshot: test_nonexistent_snapshot
-   
+
 ---
 "Get missing snapshot info succeeds when ignoreUnavailable is true":
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.status/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.status/10_basic.yaml
@@ -10,13 +10,6 @@ setup:
             location: "test_repo_status_1_loc"
 
 ---
-teardown:
-
-  - do:
-      snapshot.delete_repository:
-        repository: test_repo_status_1
-
----
 "Get snapshot status":
 
   - do:
@@ -39,7 +32,7 @@ teardown:
         snapshot: test_snapshot
 
   - is_true: snapshots
-  
+
 ---
 "Get missing snapshot status throws an exception":
 
@@ -48,7 +41,7 @@ teardown:
       snapshot.status:
         repository: test_repo_status_1
         snapshot: test_nonexistent_snapshot
-   
+
 ---
 "Get missing snapshot status succeeds when ignoreUnavailable is true":
 


### PR DESCRIPTION
The only repository we can be sure is safe to clean is `fs` so we clean
any snapshots in those repositories after each test. Other repositories
like url and azure tend to throw exceptions rather than let us fetch
their contents during the REST test. So we clean what we can....

Closes #18159
