### PR TITLE
Add rudimentary logstash and beats template BWC tests

### DIFF
--- a/core/src/test/java/org/elasticsearch/action/admin/indices/template/BWCTemplateTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/template/BWCTemplateTests.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.template;
+
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
+
+/**
+ * Rudimentary tests that the templates used by Logstash and Beats
+ * prior to their 5.x releases work for newly created indices
+ */
+public class BWCTemplateTests extends ESSingleNodeTestCase {
+    public void testBeatsTemplatesBWC() throws Exception {
+        String topBeat = copyToStringFromClasspath("/org/elasticsearch/action/admin/indices/template/topbeat-1.3.template.json");
+        String packetBeat = copyToStringFromClasspath("/org/elasticsearch/action/admin/indices/template/packetbeat-1.3.template.json");
+        String fileBeat = copyToStringFromClasspath("/org/elasticsearch/action/admin/indices/template/filebeat-1.3.template.json");
+        String winLogBeat = copyToStringFromClasspath("/org/elasticsearch/action/admin/indices/template/winlogbeat-1.3.template.json");
+        client().admin().indices().preparePutTemplate("topbeat").setSource(topBeat).get();
+        client().admin().indices().preparePutTemplate("packetbeat").setSource(packetBeat).get();
+        client().admin().indices().preparePutTemplate("filebeat").setSource(fileBeat).get();
+        client().admin().indices().preparePutTemplate("winlogbeat").setSource(winLogBeat).get();
+
+        client().prepareIndex("topbeat-foo", "doc", "1").setSource("message", "foo").get();
+        client().prepareIndex("packetbeat-foo", "doc", "1").setSource("message", "foo").get();
+        client().prepareIndex("filebeat-foo", "doc", "1").setSource("message", "foo").get();
+        client().prepareIndex("winlogbeat-foo", "doc", "1").setSource("message", "foo").get();
+    }
+
+    public void testLogstashTemplatesBWC() throws Exception {
+        String ls2x = copyToStringFromClasspath("/org/elasticsearch/action/admin/indices/template/logstash-2.x.template.json");
+        String ls5x = copyToStringFromClasspath("/org/elasticsearch/action/admin/indices/template/logstash-5.x.template.json");
+        client().admin().indices().preparePutTemplate("logstash-2x").setSource(ls2x).get();
+        client().prepareIndex("logstash-foo", "doc", "1").setSource("message", "foo").get();
+        client().admin().indices().prepareDeleteTemplate("*").get();
+
+        client().admin().indices().preparePutTemplate("logstash-5x").setSource(ls5x).get();
+        client().prepareIndex("logstash-foo", "doc", "1").setSource("message", "foo").get();
+    }
+
+}

--- a/core/src/test/resources/org/elasticsearch/action/admin/indices/template/filebeat-1.3.template.json
+++ b/core/src/test/resources/org/elasticsearch/action/admin/indices/template/filebeat-1.3.template.json
@@ -1,0 +1,42 @@
+{
+  "mappings": {
+    "_default_": {
+      "_all": {
+        "enabled": true,
+        "norms": {
+          "enabled": false
+        }
+      },
+      "dynamic_templates": [
+        {
+          "template1": {
+            "mapping": {
+              "doc_values": true,
+              "ignore_above": 1024,
+              "index": "not_analyzed",
+              "type": "{dynamic_type}"
+            },
+            "match": "*"
+          }
+        }
+      ],
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "message": {
+          "type": "string",
+          "index": "analyzed"
+        },
+        "offset": {
+          "type": "long",
+          "doc_values": "true"
+        }
+      }
+    }
+  },
+  "settings": {
+    "index.refresh_interval": "5s"
+  },
+  "template": "filebeat-*"
+}

--- a/core/src/test/resources/org/elasticsearch/action/admin/indices/template/logstash-2.x.template.json
+++ b/core/src/test/resources/org/elasticsearch/action/admin/indices/template/logstash-2.x.template.json
@@ -1,0 +1,95 @@
+{
+  "template" : "logstash-*",
+  "settings" : {
+    "index.refresh_interval" : "5s"
+  },
+  "mappings" : {
+    "_default_" : {
+      "_all" : {"enabled" : true, "omit_norms" : true},
+      "dynamic_templates" : [ {
+        "message_field" : {
+          "match" : "message",
+          "match_mapping_type" : "string",
+          "mapping" : {
+            "type" : "string", "index" : "analyzed", "omit_norms" : true,
+            "fielddata" : { "format" : "disabled" }
+          }
+        }
+      }, {
+        "string_fields" : {
+          "match" : "*",
+          "match_mapping_type" : "string",
+          "mapping" : {
+            "type" : "string", "index" : "analyzed", "omit_norms" : true,
+            "fielddata" : { "format" : "disabled" },
+            "fields" : {
+              "raw" : {"type": "string", "index" : "not_analyzed", "doc_values" : true, "ignore_above" : 256}
+            }
+          }
+        }
+      }, {
+        "float_fields" : {
+          "match" : "*",
+          "match_mapping_type" : "float",
+          "mapping" : { "type" : "float", "doc_values" : true }
+        }
+      }, {
+        "double_fields" : {
+          "match" : "*",
+          "match_mapping_type" : "double",
+          "mapping" : { "type" : "double", "doc_values" : true }
+        }
+      }, {
+        "byte_fields" : {
+          "match" : "*",
+          "match_mapping_type" : "byte",
+          "mapping" : { "type" : "byte", "doc_values" : true }
+        }
+      }, {
+        "short_fields" : {
+          "match" : "*",
+          "match_mapping_type" : "short",
+          "mapping" : { "type" : "short", "doc_values" : true }
+        }
+      }, {
+        "integer_fields" : {
+          "match" : "*",
+          "match_mapping_type" : "integer",
+          "mapping" : { "type" : "integer", "doc_values" : true }
+        }
+      }, {
+        "long_fields" : {
+          "match" : "*",
+          "match_mapping_type" : "long",
+          "mapping" : { "type" : "long", "doc_values" : true }
+        }
+      }, {
+        "date_fields" : {
+          "match" : "*",
+          "match_mapping_type" : "date",
+          "mapping" : { "type" : "date", "doc_values" : true }
+        }
+      }, {
+        "geo_point_fields" : {
+          "match" : "*",
+          "match_mapping_type" : "geo_point",
+          "mapping" : { "type" : "geo_point", "doc_values" : true }
+        }
+      } ],
+      "properties" : {
+        "@timestamp": { "type": "date", "doc_values" : true },
+        "@version": { "type": "string", "index": "not_analyzed", "doc_values" : true },
+        "geoip"  : {
+          "type" : "object",
+          "dynamic": true,
+          "properties" : {
+            "ip": { "type": "ip", "doc_values" : true },
+            "location" : { "type" : "geo_point", "doc_values" : true },
+            "latitude" : { "type" : "float", "doc_values" : true },
+            "longitude" : { "type" : "float", "doc_values" : true }
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/org/elasticsearch/action/admin/indices/template/logstash-5.x.template.json
+++ b/core/src/test/resources/org/elasticsearch/action/admin/indices/template/logstash-5.x.template.json
@@ -1,0 +1,45 @@
+{
+  "template" : "logstash-*",
+  "settings" : {
+    "index.refresh_interval" : "5s"
+  },
+  "mappings" : {
+    "_default_" : {
+      "_all" : {"enabled" : true, "norms" : false},
+      "dynamic_templates" : [ {
+        "message_field" : {
+          "match" : "message",
+          "match_mapping_type" : "string",
+          "mapping" : {
+            "type" : "string", "index" : "analyzed", "norms" : false,
+            "fielddata" : { "format" : "disabled" }
+          }
+        }
+      }, {
+        "string_fields" : {
+          "match" : "*",
+          "match_mapping_type" : "string",
+          "mapping" : {
+            "type" : "text", "norms" : false,
+            "fields" : {
+              "keyword" : { "type": "keyword" }
+            }
+          }
+        }
+      } ],
+      "properties" : {
+        "@timestamp": { "type": "date", "include_in_all": false },
+        "@version": { "type": "keyword", "include_in_all": false },
+        "geoip"  : {
+          "dynamic": true,
+          "properties" : {
+            "ip": { "type": "ip" },
+            "location" : { "type" : "geo_point" },
+            "latitude" : { "type" : "half_float" },
+            "longitude" : { "type" : "half_float" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/org/elasticsearch/action/admin/indices/template/packetbeat-1.3.template.json
+++ b/core/src/test/resources/org/elasticsearch/action/admin/indices/template/packetbeat-1.3.template.json
@@ -1,0 +1,63 @@
+{
+  "mappings": {
+    "_default_": {
+      "_all": {
+        "enabled": true,
+        "norms": {
+          "enabled": false
+        }
+      },
+      "dynamic_templates": [
+        {
+          "template1": {
+            "mapping": {
+              "doc_values": true,
+              "ignore_above": 1024,
+              "index": "not_analyzed",
+              "type": "{dynamic_type}"
+            },
+            "match": "*"
+          }
+        }
+      ],
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "client_location": {
+          "type": "geo_point"
+        },
+        "params": {
+          "index": "analyzed",
+          "norms": {
+            "enabled": false
+          },
+          "type": "string"
+        },
+        "query": {
+          "doc_values": true,
+          "index": "not_analyzed",
+          "type": "string"
+        },
+        "request": {
+          "index": "analyzed",
+          "norms": {
+            "enabled": false
+          },
+          "type": "string"
+        },
+        "response": {
+          "index": "analyzed",
+          "norms": {
+            "enabled": false
+          },
+          "type": "string"
+        }
+      }
+    }
+  },
+  "settings": {
+    "index.refresh_interval": "5s"
+  },
+  "template": "packetbeat-*"
+}

--- a/core/src/test/resources/org/elasticsearch/action/admin/indices/template/topbeat-1.3.template.json
+++ b/core/src/test/resources/org/elasticsearch/action/admin/indices/template/topbeat-1.3.template.json
@@ -1,0 +1,110 @@
+{
+  "mappings": {
+    "_default_": {
+      "_all": {
+        "enabled": true,
+        "norms": {
+          "enabled": false
+        }
+      },
+      "dynamic_templates": [
+        {
+          "template1": {
+            "mapping": {
+              "doc_values": true,
+              "ignore_above": 1024,
+              "index": "not_analyzed",
+              "type": "{dynamic_type}"
+            },
+            "match": "*"
+          }
+        }
+      ],
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "cpu": {
+          "properties": {
+            "system_p": {
+              "doc_values": "true",
+              "type": "float"
+            },
+            "user_p": {
+              "doc_values": "true",
+              "type": "float"
+            }
+          }
+        },
+        "fs": {
+          "properties": {
+            "used_p": {
+              "doc_values": "true",
+              "type": "float"
+            }
+          }
+        },
+        "load": {
+          "properties": {
+            "load1": {
+              "doc_values": "true",
+              "type": "float"
+            },
+            "load15": {
+              "doc_values": "true",
+              "type": "float"
+            },
+            "load5": {
+              "doc_values": "true",
+              "type": "float"
+            }
+          }
+        },
+        "mem": {
+          "properties": {
+            "actual_used_p": {
+              "doc_values": "true",
+              "type": "float"
+            },
+            "used_p": {
+              "doc_values": "true",
+              "type": "float"
+            }
+          }
+        },
+        "proc": {
+          "properties": {
+            "cpu": {
+              "properties": {
+                "user_p": {
+                  "doc_values": "true",
+                  "type": "float"
+                }
+              }
+            },
+            "mem": {
+              "properties": {
+                "rss_p": {
+                  "doc_values": "true",
+                  "type": "float"
+                }
+              }
+            }
+          }
+        },
+        "swap": {
+          "properties": {
+            "used_p": {
+              "doc_values": "true",
+              "type": "float"
+            }
+          }
+        }
+      }
+    }
+  },
+  "settings": {
+    "index.refresh_interval": "5s"
+  },
+  "template": "topbeat-*"
+}

--- a/core/src/test/resources/org/elasticsearch/action/admin/indices/template/winlogbeat-1.3.template.json
+++ b/core/src/test/resources/org/elasticsearch/action/admin/indices/template/winlogbeat-1.3.template.json
@@ -1,0 +1,38 @@
+{
+  "mappings": {
+    "_default_": {
+      "_all": {
+        "enabled": true,
+        "norms": {
+          "enabled": false
+        }
+      },
+      "dynamic_templates": [
+        {
+          "template1": {
+            "mapping": {
+              "doc_values": true,
+              "ignore_above": 1024,
+              "index": "not_analyzed",
+              "type": "{dynamic_type}"
+            },
+            "match": "*"
+          }
+        }
+      ],
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "message": {
+          "index": "analyzed",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "settings": {
+    "index.refresh_interval": "5s"
+  },
+  "template": "winlogbeat-*"
+}


### PR DESCRIPTION
This tests that the templates shipped with pre-5.0 versions of Logstash
and Boats still work on an Elasticsearch 5.0+ node. We need to ensure
that ES can be upgraded prior to upgrading tools dependant on it.

This is by no means an exhaustive test of all template settings but it
is a start on #17275
