### PR TITLE
Add clusterUUID to RestMainAction output

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/main/MainResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/main/MainResponse.java
@@ -35,16 +35,18 @@ public class MainResponse extends ActionResponse implements ToXContent {
     private String nodeName;
     private Version version;
     private ClusterName clusterName;
+    private String clusterUUID;
     private Build build;
     private boolean available;
 
     MainResponse() {
     }
 
-    public MainResponse(String nodeName, Version version, ClusterName clusterName, Build build, boolean available) {
+    public MainResponse(String nodeName, Version version, ClusterName clusterName, String clusterUUID, Build build, boolean available) {
         this.nodeName = nodeName;
         this.version = version;
         this.clusterName = clusterName;
+        this.clusterUUID = clusterUUID;
         this.build = build;
         this.available = available;
     }
@@ -61,6 +63,10 @@ public class MainResponse extends ActionResponse implements ToXContent {
         return clusterName;
     }
 
+    public String getClusterUUID() {
+        return clusterUUID;
+    }
+
     public Build getBuild() {
         return build;
     }
@@ -75,6 +81,7 @@ public class MainResponse extends ActionResponse implements ToXContent {
         out.writeString(nodeName);
         Version.writeVersion(version, out);
         clusterName.writeTo(out);
+        out.writeString(clusterUUID);
         Build.writeBuild(build, out);
         out.writeBoolean(available);
     }
@@ -85,6 +92,7 @@ public class MainResponse extends ActionResponse implements ToXContent {
         nodeName = in.readString();
         version = Version.readVersion(in);
         clusterName = new ClusterName(in);
+        clusterUUID = in.readString();
         build = Build.readBuild(in);
         available = in.readBoolean();
     }
@@ -94,6 +102,7 @@ public class MainResponse extends ActionResponse implements ToXContent {
         builder.startObject();
         builder.field("name", nodeName);
         builder.field("cluster_name", clusterName.value());
+        builder.field("cluster_uuid", clusterUUID);
         builder.startObject("version")
             .field("number", version.toString())
             .field("build_hash", build.shortHash())

--- a/core/src/main/java/org/elasticsearch/action/main/MainResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/main/MainResponse.java
@@ -35,18 +35,18 @@ public class MainResponse extends ActionResponse implements ToXContent {
     private String nodeName;
     private Version version;
     private ClusterName clusterName;
-    private String clusterUUID;
+    private String clusterUuid;
     private Build build;
     private boolean available;
 
     MainResponse() {
     }
 
-    public MainResponse(String nodeName, Version version, ClusterName clusterName, String clusterUUID, Build build, boolean available) {
+    public MainResponse(String nodeName, Version version, ClusterName clusterName, String clusterUuid, Build build, boolean available) {
         this.nodeName = nodeName;
         this.version = version;
         this.clusterName = clusterName;
-        this.clusterUUID = clusterUUID;
+        this.clusterUuid = clusterUuid;
         this.build = build;
         this.available = available;
     }
@@ -63,8 +63,8 @@ public class MainResponse extends ActionResponse implements ToXContent {
         return clusterName;
     }
 
-    public String getClusterUUID() {
-        return clusterUUID;
+    public String getClusterUuid() {
+        return clusterUuid;
     }
 
     public Build getBuild() {
@@ -81,7 +81,7 @@ public class MainResponse extends ActionResponse implements ToXContent {
         out.writeString(nodeName);
         Version.writeVersion(version, out);
         clusterName.writeTo(out);
-        out.writeString(clusterUUID);
+        out.writeString(clusterUuid);
         Build.writeBuild(build, out);
         out.writeBoolean(available);
     }
@@ -92,7 +92,7 @@ public class MainResponse extends ActionResponse implements ToXContent {
         nodeName = in.readString();
         version = Version.readVersion(in);
         clusterName = new ClusterName(in);
-        clusterUUID = in.readString();
+        clusterUuid = in.readString();
         build = Build.readBuild(in);
         available = in.readBoolean();
     }
@@ -102,7 +102,7 @@ public class MainResponse extends ActionResponse implements ToXContent {
         builder.startObject();
         builder.field("name", nodeName);
         builder.field("cluster_name", clusterName.value());
-        builder.field("cluster_uuid", clusterUUID);
+        builder.field("cluster_uuid", clusterUuid);
         builder.startObject("version")
             .field("number", version.toString())
             .field("build_hash", build.shortHash())

--- a/core/src/main/java/org/elasticsearch/action/main/TransportMainAction.java
+++ b/core/src/main/java/org/elasticsearch/action/main/TransportMainAction.java
@@ -52,7 +52,7 @@ public class TransportMainAction extends HandledTransportAction<MainRequest, Mai
         assert Node.NODE_NAME_SETTING.exists(settings);
         final boolean available = clusterState.getBlocks().hasGlobalBlock(RestStatus.SERVICE_UNAVAILABLE) == false;
         listener.onResponse(
-            new MainResponse(Node.NODE_NAME_SETTING.get(settings), Version.CURRENT, clusterState.getClusterName(), Build.CURRENT,
-                available));
+            new MainResponse(Node.NODE_NAME_SETTING.get(settings), Version.CURRENT, clusterState.getClusterName(),
+                    clusterState.metaData().clusterUUID(), Build.CURRENT, available));
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/main/MainActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/main/MainActionTests.java
@@ -30,7 +30,6 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.io.stream.ByteBufferStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -42,7 +41,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -56,11 +54,12 @@ public class MainActionTests extends ESTestCase {
     public void testMainResponseSerialization() throws IOException {
         final String nodeName = "node1";
         final ClusterName clusterName = new ClusterName("cluster1");
+        final String clusterUUID = randomAsciiOfLengthBetween(10, 20);
         final boolean available = randomBoolean();
         final Version version = Version.CURRENT;
         final Build build = Build.CURRENT;
 
-        final MainResponse mainResponse = new MainResponse(nodeName, version, clusterName, build, available);
+        final MainResponse mainResponse = new MainResponse(nodeName, version, clusterName, clusterUUID, build, available);
         BytesStreamOutput streamOutput = new BytesStreamOutput();
         mainResponse.writeTo(streamOutput);
         final MainResponse serialized = new MainResponse();
@@ -74,11 +73,13 @@ public class MainActionTests extends ESTestCase {
     }
 
     public void testMainResponseXContent() throws IOException {
-        final MainResponse mainResponse = new MainResponse("node1", Version.CURRENT, new ClusterName("cluster1"), Build.CURRENT, false);
-        final String expected = "{\"name\":\"node1\",\"cluster_name\":\"cluster1\",\"version\":{\"number\":\"" + Version.CURRENT.toString()
-            + "\",\"build_hash\":\"" + Build.CURRENT.shortHash() + "\",\"build_date\":\"" + Build.CURRENT.date() + "\"," +
-            "\"build_snapshot\":" + Build.CURRENT.isSnapshot() + ",\"lucene_version\":\"" + Version.CURRENT.luceneVersion.toString() +
-            "\"},\"tagline\":\"You Know, for Search\"}";
+        String clusterUUID = randomAsciiOfLengthBetween(10, 20);
+        final MainResponse mainResponse = new MainResponse("node1", Version.CURRENT, new ClusterName("cluster1"), clusterUUID,
+                Build.CURRENT, false);
+        final String expected = "{\"name\":\"node1\",\"cluster_name\":\"cluster1\",\"cluster_uuid\":\"" + clusterUUID + "\"," +
+                "\"version\":{\"number\":\"" + Version.CURRENT.toString() + "\",\"build_hash\":\"" + Build.CURRENT.shortHash() +
+                "\",\"build_date\":\"" + Build.CURRENT.date() + "\"," + "\"build_snapshot\":" + Build.CURRENT.isSnapshot() +
+                ",\"lucene_version\":\"" + Version.CURRENT.luceneVersion.toString() + "\"},\"tagline\":\"You Know, for Search\"}";
 
         XContentBuilder builder = XContentFactory.jsonBuilder();
         mainResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);

--- a/core/src/test/java/org/elasticsearch/action/main/MainActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/main/MainActionTests.java
@@ -76,10 +76,18 @@ public class MainActionTests extends ESTestCase {
         String clusterUUID = randomAsciiOfLengthBetween(10, 20);
         final MainResponse mainResponse = new MainResponse("node1", Version.CURRENT, new ClusterName("cluster1"), clusterUUID,
                 Build.CURRENT, false);
-        final String expected = "{\"name\":\"node1\",\"cluster_name\":\"cluster1\",\"cluster_uuid\":\"" + clusterUUID + "\"," +
-                "\"version\":{\"number\":\"" + Version.CURRENT.toString() + "\",\"build_hash\":\"" + Build.CURRENT.shortHash() +
-                "\",\"build_date\":\"" + Build.CURRENT.date() + "\"," + "\"build_snapshot\":" + Build.CURRENT.isSnapshot() +
-                ",\"lucene_version\":\"" + Version.CURRENT.luceneVersion.toString() + "\"},\"tagline\":\"You Know, for Search\"}";
+        final String expected = "{" +
+                "\"name\":\"node1\"," +
+                "\"cluster_name\":\"cluster1\"," +
+                "\"cluster_uuid\":\"" + clusterUUID + "\"," +
+                "\"version\":{" +
+                "\"number\":\"" + Version.CURRENT.toString() + "\"," +
+                "\"build_hash\":\"" + Build.CURRENT.shortHash() + "\"," +
+                "\"build_date\":\"" + Build.CURRENT.date() + "\"," +
+                "\"build_snapshot\":" + Build.CURRENT.isSnapshot() +
+                ",\"lucene_version\":\"" + Version.CURRENT.luceneVersion.toString() +
+                "\"}," +
+                "\"tagline\":\"You Know, for Search\"}";
 
         XContentBuilder builder = XContentFactory.jsonBuilder();
         mainResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);

--- a/core/src/test/java/org/elasticsearch/rest/action/RestMainActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/RestMainActionTests.java
@@ -30,8 +30,6 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.rest.RestRequest.Method;
-import org.elasticsearch.rest.action.RestMainAction;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.rest.FakeRestRequest;
 
@@ -45,12 +43,13 @@ public class RestMainActionTests extends ESTestCase {
     public void testHeadResponse() throws Exception {
         final String nodeName = "node1";
         final ClusterName clusterName = new ClusterName("cluster1");
+        final String clusterUUID = randomAsciiOfLengthBetween(10, 20);
         final boolean available = randomBoolean();
         final RestStatus expectedStatus = available ? RestStatus.OK : RestStatus.SERVICE_UNAVAILABLE;
         final Version version = Version.CURRENT;
         final Build build = Build.CURRENT;
 
-        final MainResponse mainResponse = new MainResponse(nodeName, version, clusterName, build, available);
+        final MainResponse mainResponse = new MainResponse(nodeName, version, clusterName, clusterUUID, build, available);
         XContentBuilder builder = JsonXContent.contentBuilder();
         RestRequest restRequest = new FakeRestRequest() {
             @Override
@@ -70,13 +69,14 @@ public class RestMainActionTests extends ESTestCase {
     public void testGetResponse() throws Exception {
         final String nodeName = "node1";
         final ClusterName clusterName = new ClusterName("cluster1");
+        final String clusterUUID = randomAsciiOfLengthBetween(10, 20);
         final boolean available = randomBoolean();
         final RestStatus expectedStatus = available ? RestStatus.OK : RestStatus.SERVICE_UNAVAILABLE;
         final Version version = Version.CURRENT;
         final Build build = Build.CURRENT;
         final boolean prettyPrint = randomBoolean();
 
-        final MainResponse mainResponse = new MainResponse(nodeName, version, clusterName, build, available);
+        final MainResponse mainResponse = new MainResponse(nodeName, version, clusterName, clusterUUID, build, available);
         XContentBuilder builder = JsonXContent.contentBuilder();
 
         Map<String, String> params = new HashMap<>();

--- a/docs/plugins/discovery-azure-classic.asciidoc
+++ b/docs/plugins/discovery-azure-classic.asciidoc
@@ -391,6 +391,7 @@ This command should give you a JSON result:
 {
   "name" : "Cp8oag6",
   "cluster_name" : "elasticsearch",
+  "cluster_uuid" : "AT69_T_DTp-1qgIJlatQqA",
   "version" : {
     "number" : "{version}",
     "build_hash" : "f27399d",
@@ -403,6 +404,7 @@ This command should give you a JSON result:
 --------------------------------------------
 // TESTRESPONSE[s/"name" : "Cp8oag6",/"name" : "$body.name",/]
 // TESTRESPONSE[s/"cluster_name" : "elasticsearch",/"cluster_name" : "$body.cluster_name",/]
+// TESTRESPONSE[s/"cluster_uuid" : "AT69_T_DTp-1qgIJlatQqA",/"cluster_uuid" : "$body.cluster_uuid",/]
 // TESTRESPONSE[s/"build_hash" : "f27399d",/"build_hash" : "$body.version.build_hash",/]
 // TESTRESPONSE[s/"build_date" : "2016-03-30T09:51:41.449Z",/"build_date" : $body.version.build_date,/]
 // TESTRESPONSE[s/"build_snapshot" : false,/"build_snapshot" : $body.version.build_snapshot,/]

--- a/docs/reference/setup/install/check-running.asciidoc
+++ b/docs/reference/setup/install/check-running.asciidoc
@@ -16,6 +16,7 @@ which should give you a response something like this:
 {
   "name" : "Cp8oag6",
   "cluster_name" : "elasticsearch",
+  "cluster_uuid" : "AT69_T_DTp-1qgIJlatQqA",
   "version" : {
     "number" : "{version}",
     "build_hash" : "f27399d",
@@ -28,6 +29,7 @@ which should give you a response something like this:
 --------------------------------------------
 // TESTRESPONSE[s/"name" : "Cp8oag6",/"name" : "$body.name",/]
 // TESTRESPONSE[s/"cluster_name" : "elasticsearch",/"cluster_name" : "$body.cluster_name",/]
+// TESTRESPONSE[s/"cluster_uuid" : "AT69_T_DTp-1qgIJlatQqA",/"cluster_uuid" : "$body.cluster_uuid",/]
 // TESTRESPONSE[s/"build_hash" : "f27399d",/"build_hash" : "$body.version.build_hash",/]
 // TESTRESPONSE[s/"build_date" : "2016-03-30T09:51:41.449Z",/"build_date" : $body.version.build_date,/]
 // TESTRESPONSE[s/"build_snapshot" : false,/"build_snapshot" : $body.version.build_snapshot,/]

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteResponseParsers.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteResponseParsers.java
@@ -294,6 +294,7 @@ final class RemoteResponseParsers {
         MAIN_ACTION_PARSER.declareInt((p, v) -> {}, new ParseField("status"));
         MAIN_ACTION_PARSER.declareString((p, v) -> {}, new ParseField("name"));
         MAIN_ACTION_PARSER.declareString((p, v) -> {}, new ParseField("cluster_name"));
+        MAIN_ACTION_PARSER.declareString((p, v) -> {}, new ParseField("cluster_uuid"));
         MAIN_ACTION_PARSER.declareString((p, v) -> {}, new ParseField("name"));
         MAIN_ACTION_PARSER.declareString((p, v) -> {}, new ParseField("tagline"));
         MAIN_ACTION_PARSER.declareObject(constructorArg(), VERSION_PARSER, new ParseField("version"));

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/info/10_info.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/info/10_info.yaml
@@ -3,6 +3,7 @@
     - do:         {info: {}}
     - is_true:    name
     - is_true:    cluster_name
+    - is_true:    cluster_uuid
     - is_true:    tagline
     - is_true:    version
     - is_true:    version.number


### PR DESCRIPTION
`GET /` now returns the clusterUUID as well as part of its output for monitoring purposes
