### PR TITLE
Edited response structure on indexing a document

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -302,6 +302,12 @@ curl -XPUT 'localhost:9200/customer/external/1?pretty' -d '
   "_type" : "external",
   "_id" : "1",
   "_version" : 1,
+  "result" : "created",
+  "_shards" : {
+    "total" : 2,
+    "successful" : 1,
+    "failed" : 0
+  },
   "created" : true
 }
 --------------------------------------------------


### PR DESCRIPTION
I was following the `Getting Started` chapter and found out, that I had a different response structure after successfully indexing a document. With this change I added `_shards` and `result` keys to the response.
