### PR TITLE
Unguice Transport and friends

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -663,4 +663,8 @@ public class ActionModule extends AbstractModule {
             }
         }
     }
+
+    public RestController getRestController() {
+        return restController;
+    }
 }

--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -45,6 +45,7 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.internal.InternalSettingsPreparer;
 import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.plugins.SearchPlugin;
@@ -52,6 +53,7 @@ import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.threadpool.ExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TcpTransport;
+import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.Closeable;
@@ -119,7 +121,9 @@ public abstract class TransportClient extends AbstractClient {
             }
             SettingsModule settingsModule = new SettingsModule(settings, additionalSettings, additionalSettingsFilter);
 
-            NetworkModule networkModule = new NetworkModule(networkService, settings, true);
+            NetworkModule networkModule = new NetworkModule(settings, true);
+            networkModule.processPlugins(pluginsService.filterPlugins(NetworkPlugin.class));
+
             SearchModule searchModule = new SearchModule(settings, true, pluginsService.filterPlugins(SearchPlugin.class));
             List<NamedWriteableRegistry.Entry> entries = new ArrayList<>();
             entries.addAll(networkModule.getNamedWriteables());
@@ -134,7 +138,6 @@ public abstract class TransportClient extends AbstractClient {
             for (Module pluginModule : pluginsService.createGuiceModules()) {
                 modules.add(pluginModule);
             }
-            modules.add(networkModule);
             modules.add(b -> b.bind(ThreadPool.class).toInstance(threadPool));
             ActionModule actionModule = new ActionModule(false, true, settings, null, settingsModule.getClusterSettings(),
                 pluginsService.filterPlugins(ActionPlugin.class));
@@ -147,15 +150,21 @@ public abstract class TransportClient extends AbstractClient {
             BigArrays bigArrays = new BigArrays(settings, circuitBreakerService);
             resourcesToClose.add(bigArrays);
             modules.add(settingsModule);
+            final Transport transport = networkModule.getTransportFactory().createTransport(settings, threadPool, bigArrays,
+                circuitBreakerService, namedWriteableRegistry, networkService);
+            final TransportService transportService = new TransportService(settings, transport, threadPool,
+                networkModule.getTransportInterceptor());
             modules.add((b -> {
                 b.bind(BigArrays.class).toInstance(bigArrays);
                 b.bind(PluginsService.class).toInstance(pluginsService);
                 b.bind(CircuitBreakerService.class).toInstance(circuitBreakerService);
                 b.bind(NamedWriteableRegistry.class).toInstance(namedWriteableRegistry);
+                b.bind(Transport.class).toInstance(transport);
+                b.bind(TransportService.class).toInstance(transportService);
+                b.bind(NetworkService.class).toInstance(networkService);
             }));
 
             Injector injector = modules.createInjector();
-            final TransportService transportService = injector.getInstance(TransportService.class);
             final TransportClientNodesService nodesService =
                 new TransportClientNodesService(settings, transportService, threadPool);
             final TransportProxyClient proxy = new TransportProxyClient(settings, transportService, nodesService,

--- a/core/src/main/java/org/elasticsearch/common/network/NetworkModule.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkModule.java
@@ -171,7 +171,13 @@ public final class NetworkModule {
     }
 
     public NetworkPlugin.TransportFactory<HttpServerTransport> getHttpServerTransportFactory() {
-        NetworkPlugin.TransportFactory<HttpServerTransport> factory = transportHttpFactories.get(HTTP_TYPE_SETTING.get(settings));
+        final String name;
+        if (HTTP_TYPE_SETTING.exists(settings)) {
+            name = HTTP_TYPE_SETTING.get(settings);
+        } else {
+            name = HTTP_DEFAULT_TYPE_SETTING.get(settings);
+        }
+        final NetworkPlugin.TransportFactory<HttpServerTransport> factory = transportHttpFactories.get(name);
         if (factory == null) {
             throw new IllegalStateException("No http.type: " + HTTP_TYPE_SETTING.get(settings) + " configured");
         }
@@ -183,13 +189,13 @@ public final class NetworkModule {
     }
 
     public NetworkPlugin.TransportFactory<Transport> getTransportFactory() {
-        String name;
+        final String name;
         if (TRANSPORT_TYPE_SETTING.exists(settings)) {
             name = TRANSPORT_TYPE_SETTING.get(settings);
         } else {
             name = TRANSPORT_DEFAULT_TYPE_SETTING.get(settings);
         }
-        NetworkPlugin.TransportFactory<Transport> factory = transportFactories.get(name);
+        final NetworkPlugin.TransportFactory<Transport> factory = transportFactories.get(name);
         if (factory == null) {
             throw new IllegalStateException("No transport.type: " + name + " configured");
         }

--- a/core/src/main/java/org/elasticsearch/http/HttpServer.java
+++ b/core/src/main/java/org/elasticsearch/http/HttpServer.java
@@ -25,14 +25,12 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
-import org.elasticsearch.node.service.NodeService;
 import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
@@ -60,7 +58,6 @@ public class HttpServer extends AbstractLifecycleComponent implements HttpServer
 
     private final CircuitBreakerService circuitBreakerService;
 
-    @Inject
     public HttpServer(Settings settings, HttpServerTransport transport, RestController restController,
                       NodeClient client, CircuitBreakerService circuitBreakerService) {
         super(settings);

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -44,14 +44,17 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RoutingService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.routing.allocation.command.AllocationCommandRegistry;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.StopWatch;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.component.LifecycleComponent;
+import org.elasticsearch.common.inject.Binder;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.Key;
 import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.inject.ModulesBuilder;
+import org.elasticsearch.common.inject.util.Providers;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.logging.DeprecationLogger;
@@ -68,7 +71,6 @@ import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.discovery.DiscoverySettings;
@@ -102,6 +104,7 @@ import org.elasticsearch.plugins.ClusterPlugin;
 import org.elasticsearch.plugins.DiscoveryPlugin;
 import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.plugins.MapperPlugin;
+import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.MetaDataUpgrader;
 import org.elasticsearch.plugins.PluginsService;
@@ -122,6 +125,8 @@ import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.tasks.TaskResultsService;
 import org.elasticsearch.threadpool.ExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportInterceptor;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.tribe.TribeService;
 import org.elasticsearch.watcher.ResourceWatcherService;
@@ -144,6 +149,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -321,8 +327,8 @@ public class Node implements Closeable {
             }
             final MonitorService monitorService = new MonitorService(settings, nodeEnvironment, threadPool);
             modules.add(new NodeModule(this, monitorService));
-            NetworkModule networkModule = createNetworkModule(settings, networkService);
-            modules.add(networkModule);
+            NetworkModule networkModule = new NetworkModule(settings, false);
+            networkModule.processPlugins(pluginsService.filterPlugins(NetworkPlugin.class));
             modules.add(new DiscoveryModule(this.settings));
             ClusterModule clusterModule = new ClusterModule(settings, clusterService,
                 pluginsService.filterPlugins(ClusterPlugin.class));
@@ -330,9 +336,10 @@ public class Node implements Closeable {
             IndicesModule indicesModule = new IndicesModule(pluginsService.filterPlugins(MapperPlugin.class));
             modules.add(indicesModule);
             SearchModule searchModule = new SearchModule(settings, false, pluginsService.filterPlugins(SearchPlugin.class));
-            modules.add(new ActionModule(DiscoveryNode.isIngestNode(settings), false, settings,
+            ActionModule actionModule = new ActionModule(DiscoveryNode.isIngestNode(settings), false, settings,
                 clusterModule.getIndexNameExpressionResolver(), settingsModule.getClusterSettings(),
-                pluginsService.filterPlugins(ActionPlugin.class)));
+                pluginsService.filterPlugins(ActionPlugin.class));
+            modules.add(actionModule);
             modules.add(new GatewayModule());
             modules.add(new RepositoriesModule(this.environment, pluginsService.filterPlugins(RepositoryPlugin.class)));
             pluginsService.processModules(modules);
@@ -365,7 +372,26 @@ public class Node implements Closeable {
                 .map(Plugin::getCustomMetaDataUpgrader)
                 .collect(Collectors.toList());
             final MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(customMetaDataUpgraders);
-
+            final Transport transport = networkModule.getTransportFactory().createTransport(settings, threadPool, bigArrays,
+                circuitBreakerService, namedWriteableRegistry, networkService);
+            final TransportService transportService = newTransportService(settings, transport, threadPool,
+                networkModule.getTransportInterceptor());
+            final Consumer<Binder> httpBind;
+            if (networkModule.isHttpEnabled()) {
+                NetworkPlugin.TransportFactory<HttpServerTransport> httpTransportFactory = networkModule.getHttpServerTransportFactory();
+                HttpServerTransport httpServerTransport = httpTransportFactory.createTransport(settings, threadPool, bigArrays,
+                    circuitBreakerService, namedWriteableRegistry, networkService);
+                HttpServer httpServer = new HttpServer(settings, httpServerTransport, actionModule.getRestController(), client,
+                    circuitBreakerService);
+                httpBind = b -> {
+                    b.bind(HttpServer.class).toInstance(httpServer);
+                    b.bind(HttpServerTransport.class).toInstance(httpServerTransport);
+                };
+            } else {
+                httpBind = b -> {
+                    b.bind(HttpServer.class).toProvider(Providers.of(null));
+                };
+            }
             modules.add(b -> {
                     b.bind(IndicesQueriesRegistry.class).toInstance(searchModule.getQueryParserRegistry());
                     b.bind(SearchRequestParsers.class).toInstance(searchModule.getSearchRequestParsers());
@@ -389,8 +415,12 @@ public class Node implements Closeable {
                     b.bind(IndicesService.class).toInstance(indicesService);
                     b.bind(SearchService.class).toInstance(newSearchService(clusterService, indicesService,
                         threadPool, scriptModule.getScriptService(), bigArrays, searchModule.getFetchPhase()));
+                    b.bind(Transport.class).toInstance(transport);
+                    b.bind(TransportService.class).toInstance(transportService);
+                    b.bind(NetworkService.class).toInstance(networkService);
+                    b.bind(AllocationCommandRegistry.class).toInstance(networkModule.getAllocationCommandRegistry());
+                    httpBind.accept(b);
                     pluginComponents.stream().forEach(p -> b.bind((Class) p.getClass()).toInstance(p));
-
                 }
             );
             injector = modules.createInjector();
@@ -417,8 +447,9 @@ public class Node implements Closeable {
         }
     }
 
-    protected NetworkModule createNetworkModule(Settings settings, NetworkService networkService) {
-        return new NetworkModule(networkService, settings, false);
+    protected TransportService newTransportService(Settings settings, Transport transport, ThreadPool threadPool,
+                                                   TransportInterceptor interceptor) {
+        return new TransportService(settings, transport, threadPool, interceptor);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/plugins/NetworkPlugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/NetworkPlugin.java
@@ -30,6 +30,8 @@ import org.elasticsearch.transport.TransportInterceptor;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Plugin for extending network and transport related classes
@@ -45,43 +47,23 @@ public interface NetworkPlugin {
     }
 
     /**
-     * Returns a list of {@link TransportFactory} instances that are used to create the nodes {@link Transport} implementation.
+     * Returns a map of {@link Transport} suppliers.
      * See {@link org.elasticsearch.common.network.NetworkModule#TRANSPORT_TYPE_KEY} to configure a specific implementation.
      */
-    default List<TransportFactory<Transport>> getTransportFactory() {
-        return Collections.emptyList();
+    default Map<String, Supplier<Transport>> getTransports(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                                           CircuitBreakerService circuitBreakerService,
+                                                           NamedWriteableRegistry namedWriteableRegistry,
+                                                           NetworkService networkService) {
+        return Collections.emptyMap();
     }
-
     /**
-     * Returns a list of {@link TransportFactory} instances that are used to create the nodes {@link HttpServerTransport} implementation.
+     * Returns a map of {@link HttpServerTransport} suppliers.
      * See {@link org.elasticsearch.common.network.NetworkModule#HTTP_TYPE_SETTING} to configure a specific implementation.
      */
-    default List<TransportFactory<HttpServerTransport>> getHttpTransportFactory() {
-        return Collections.emptyList();
-    }
-
-    abstract class TransportFactory<Transport> {
-        private final String type;
-
-        protected TransportFactory(String type) {
-            this.type = type;
-        }
-
-        /**
-         * The transport type name that use used to configure the transport implementation.
-         * @see org.elasticsearch.common.network.NetworkModule#HTTP_TYPE_SETTING
-         * @see org.elasticsearch.common.network.NetworkModule#TRANSPORT_TYPE_SETTING
-         */
-        public final String getType() {
-            return this.type;
-        }
-
-        /**
-         * Creates a new transport implementation. This method is only invoked for the configure transport type.
-         */
-        public abstract Transport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
-                                                  CircuitBreakerService circuitBreakerService,
-                                                  NamedWriteableRegistry namedWriteableRegistry,
-                                                  NetworkService networkService);
+    default Map<String, Supplier<HttpServerTransport>> getHttpTransports(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                                               CircuitBreakerService circuitBreakerService,
+                                                               NamedWriteableRegistry namedWriteableRegistry,
+                                                               NetworkService networkService) {
+        return Collections.emptyMap();
     }
 }

--- a/core/src/main/java/org/elasticsearch/plugins/NetworkPlugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/NetworkPlugin.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.plugins;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.network.NetworkService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportInterceptor;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Plugin for extending network and transport related classes
+ */
+public interface NetworkPlugin {
+
+    /**
+     * Returns a list of {@link TransportInterceptor} instances that are used to intercept incoming and outgoing
+     * transport (inter-node) requests. This must not return <code>null</code>
+     */
+    default List<TransportInterceptor> getTransportInterceptors() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns a list of {@link TransportFactory} instances that are used to create the nodes {@link Transport} implementation.
+     * See {@link org.elasticsearch.common.network.NetworkModule#TRANSPORT_TYPE_KEY} to configure a specific implementation.
+     */
+    default List<TransportFactory<Transport>> getTransportFactory() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns a list of {@link TransportFactory} instances that are used to create the nodes {@link HttpServerTransport} implementation.
+     * See {@link org.elasticsearch.common.network.NetworkModule#HTTP_TYPE_SETTING} to configure a specific implementation.
+     */
+    default List<TransportFactory<HttpServerTransport>> getHttpTransportFactory() {
+        return Collections.emptyList();
+    }
+
+    abstract class TransportFactory<Transport> {
+        private final String type;
+
+        protected TransportFactory(String type) {
+            this.type = type;
+        }
+
+        /**
+         * The transport type name that use used to configure the transport implementation.
+         * @see org.elasticsearch.common.network.NetworkModule#HTTP_TYPE_SETTING
+         * @see org.elasticsearch.common.network.NetworkModule#TRANSPORT_TYPE_SETTING
+         */
+        public final String getType() {
+            return this.type;
+        }
+
+        /**
+         * Creates a new transport implementation. This method is only invoked for the configure transport type.
+         */
+        public abstract Transport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                                  CircuitBreakerService circuitBreakerService,
+                                                  NamedWriteableRegistry namedWriteableRegistry,
+                                                  NetworkService networkService);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/plugins/Plugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/Plugin.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
@@ -188,6 +189,14 @@ public abstract class Plugin {
      */
     @Deprecated
     public final void onModule(SearchModule module) {}
+
+    /**
+     * Old-style action extension point.
+     *
+     * @deprecated implement {@link NetworkPlugin} instead
+     */
+    @Deprecated
+    public final void onModule(NetworkModule module) {}
 
     /**
      * Provides the list of this plugin's custom thread pools, empty if

--- a/core/src/main/java/org/elasticsearch/transport/local/LocalTransport.java
+++ b/core/src/main/java/org/elasticsearch/transport/local/LocalTransport.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.component.Lifecycle;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -91,7 +90,6 @@ public class LocalTransport extends AbstractLifecycleComponent implements Transp
     public static final String TRANSPORT_LOCAL_WORKERS = "transport.local.workers";
     public static final String TRANSPORT_LOCAL_QUEUE = "transport.local.queue";
 
-    @Inject
     public LocalTransport(Settings settings, ThreadPool threadPool,
                           NamedWriteableRegistry namedWriteableRegistry, CircuitBreakerService circuitBreakerService) {
         super(settings);

--- a/core/src/test/java/org/elasticsearch/action/IndicesRequestIT.java
+++ b/core/src/test/java/org/elasticsearch/action/IndicesRequestIT.java
@@ -78,9 +78,9 @@ import org.elasticsearch.action.update.UpdateAction;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.script.MockScriptPlugin;
@@ -739,10 +739,11 @@ public class IndicesRequestIT extends ESIntegTestCase {
 
     public static class InterceptingTransportService implements TransportInterceptor {
 
-        public static class TestPlugin extends Plugin {
+        public static class TestPlugin extends Plugin implements NetworkPlugin {
             public final InterceptingTransportService instance = new InterceptingTransportService();
-            public void onModule(NetworkModule module) {
-                module.addTransportInterceptor(instance);
+            @Override
+            public List<TransportInterceptor> getTransportInterceptors() {
+                return Collections.singletonList(instance);
             }
         }
 

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteRequestTests.java
@@ -73,9 +73,8 @@ public class ClusterRerouteRequestTests extends ESTestCase {
     private final AllocationCommandRegistry allocationCommandRegistry;
 
     public ClusterRerouteRequestTests() {
-        NetworkModule networkModule = new NetworkModule(null, true);
-        allocationCommandRegistry = networkModule.getAllocationCommandRegistry();
-        namedWriteableRegistry = new NamedWriteableRegistry(networkModule.getNamedWriteables());
+        allocationCommandRegistry = NetworkModule.getAllocationCommandRegistry();
+        namedWriteableRegistry = new NamedWriteableRegistry(NetworkModule.getNamedWriteables());
     }
 
     private ClusterRerouteRequest randomRequest() {

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteRequestTests.java
@@ -45,7 +45,6 @@ import org.elasticsearch.test.rest.FakeRestRequest;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,7 +73,7 @@ public class ClusterRerouteRequestTests extends ESTestCase {
     private final AllocationCommandRegistry allocationCommandRegistry;
 
     public ClusterRerouteRequestTests() {
-        NetworkModule networkModule = new NetworkModule(null, null, true);
+        NetworkModule networkModule = new NetworkModule(null, true);
         allocationCommandRegistry = networkModule.getAllocationCommandRegistry();
         namedWriteableRegistry = new NamedWriteableRegistry(networkModule.getNamedWriteables());
     }

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
@@ -64,7 +64,7 @@ public class ClusterRerouteTests extends ESAllocationTestCase {
         BytesStreamOutput out = new BytesStreamOutput();
         req.writeTo(out);
         BytesReference bytes = out.bytes();
-        NetworkModule networkModule = new NetworkModule(null, Settings.EMPTY, true);
+        NetworkModule networkModule = new NetworkModule(Settings.EMPTY, true);
         NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(networkModule.getNamedWriteables());
         StreamInput wrap = new NamedWriteableAwareStreamInput(bytes.streamInput(),
             namedWriteableRegistry);

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
@@ -64,8 +64,7 @@ public class ClusterRerouteTests extends ESAllocationTestCase {
         BytesStreamOutput out = new BytesStreamOutput();
         req.writeTo(out);
         BytesReference bytes = out.bytes();
-        NetworkModule networkModule = new NetworkModule(Settings.EMPTY, true);
-        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(networkModule.getNamedWriteables());
+        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(NetworkModule.getNamedWriteables());
         StreamInput wrap = new NamedWriteableAwareStreamInput(bytes.streamInput(),
             namedWriteableRegistry);
         ClusterRerouteRequest deserializedReq = new ClusterRerouteRequest();

--- a/core/src/test/java/org/elasticsearch/client/transport/TransportClientHeadersTests.java
+++ b/core/src/test/java/org/elasticsearch/client/transport/TransportClientHeadersTests.java
@@ -31,10 +31,10 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -49,6 +49,7 @@ import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportResponseHandler;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -115,11 +116,12 @@ public class TransportClientHeadersTests extends AbstractClientHeadersTestCase {
         TransportAddress address;
 
 
-        public static class TestPlugin extends Plugin {
+        public static class TestPlugin extends Plugin implements NetworkPlugin {
             private InternalTransportServiceInterceptor instance = new InternalTransportServiceInterceptor();
 
-            public void onModule(NetworkModule transportModule) {
-                transportModule.addTransportInterceptor(new TransportInterceptor() {
+            @Override
+            public List<TransportInterceptor> getTransportInterceptors() {
+                return Collections.singletonList(new TransportInterceptor() {
                     @Override
                     public <T extends TransportRequest> TransportRequestHandler<T> interceptHandler(String action,
                                                                                 TransportRequestHandler<T> actualHandler) {

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
@@ -445,8 +445,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         StreamInput in = bytes.bytes().streamInput();
 
         // Since the commands are named writeable we need to register them and wrap the input stream
-        NetworkModule networkModule = new NetworkModule(Settings.EMPTY, true);
-        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(networkModule.getNamedWriteables());
+        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(NetworkModule.getNamedWriteables());
         in = new NamedWriteableAwareStreamInput(in, namedWriteableRegistry);
 
         // Now we can read them!
@@ -492,7 +491,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         // move two tokens, parser expected to be "on" `commands` field
         parser.nextToken();
         parser.nextToken();
-        AllocationCommandRegistry registry = new NetworkModule(Settings.EMPTY, true).getAllocationCommandRegistry();
+        AllocationCommandRegistry registry = NetworkModule.getAllocationCommandRegistry();
         AllocationCommands sCommands = AllocationCommands.fromXContent(parser, ParseFieldMatcher.STRICT, registry);
 
         assertThat(sCommands.commands().size(), equalTo(5));

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
@@ -445,7 +445,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         StreamInput in = bytes.bytes().streamInput();
 
         // Since the commands are named writeable we need to register them and wrap the input stream
-        NetworkModule networkModule = new NetworkModule(null, Settings.EMPTY, true);
+        NetworkModule networkModule = new NetworkModule(Settings.EMPTY, true);
         NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(networkModule.getNamedWriteables());
         in = new NamedWriteableAwareStreamInput(in, namedWriteableRegistry);
 
@@ -492,7 +492,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         // move two tokens, parser expected to be "on" `commands` field
         parser.nextToken();
         parser.nextToken();
-        AllocationCommandRegistry registry = new NetworkModule(null, Settings.EMPTY, true).getAllocationCommandRegistry();
+        AllocationCommandRegistry registry = new NetworkModule(Settings.EMPTY, true).getAllocationCommandRegistry();
         AllocationCommands sCommands = AllocationCommands.fromXContent(parser, ParseFieldMatcher.STRICT, registry);
 
         assertThat(sCommands.commands().size(), equalTo(5));

--- a/core/src/test/java/org/elasticsearch/common/network/NetworkModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/common/network/NetworkModuleTests.java
@@ -175,6 +175,38 @@ public class NetworkModuleTests extends ModuleTestCase {
         expectThrows(IllegalStateException.class, () -> newModule.getHttpServerTransportFactory());
     }
 
+    public void testOverrideDefault() {
+        Settings settings = Settings.builder()
+            .put(NetworkModule.HTTP_TYPE_SETTING.getKey(), "custom")
+            .put(NetworkModule.HTTP_DEFAULT_TYPE_SETTING.getKey(), "default_custom")
+            .put(NetworkModule.TRANSPORT_DEFAULT_TYPE_SETTING.getKey(), "local")
+            .put(NetworkModule.TRANSPORT_TYPE_KEY, "default_custom").build();
+        NetworkModule module = new NetworkModule(settings, false);
+        FakeHttpTransportFactory custom = new FakeHttpTransportFactory("custom");
+        FakeHttpTransportFactory def = new FakeHttpTransportFactory("default_custom");
+        FakeTransportFactory customTransport = new FakeTransportFactory("default_custom");
+        module.registerHttpTransport(custom);
+        module.registerHttpTransport(def);
+        module.registerTransport(customTransport);
+        assertSame(custom, module.getHttpServerTransportFactory());
+        assertSame(customTransport, module.getTransportFactory());
+    }
+
+    public void testDefaultKeys() {
+        Settings settings = Settings.builder()
+            .put(NetworkModule.HTTP_DEFAULT_TYPE_SETTING.getKey(), "default_custom")
+            .put(NetworkModule.TRANSPORT_DEFAULT_TYPE_SETTING.getKey(), "default_custom").build();
+        NetworkModule module = new NetworkModule(settings, false);
+        FakeHttpTransportFactory custom = new FakeHttpTransportFactory("custom");
+        FakeHttpTransportFactory def = new FakeHttpTransportFactory("default_custom");
+        FakeTransportFactory customTransport = new FakeTransportFactory("default_custom");
+        module.registerHttpTransport(custom);
+        module.registerHttpTransport(def);
+        module.registerTransport(customTransport);
+        assertSame(def, module.getHttpServerTransportFactory());
+        assertSame(customTransport, module.getTransportFactory());
+    }
+
     public void testRegisterInterceptor() {
         Settings settings = Settings.builder()
             .put(NetworkModule.HTTP_ENABLED.getKey(), false)

--- a/core/src/test/java/org/elasticsearch/common/network/NetworkModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/common/network/NetworkModuleTests.java
@@ -23,27 +23,44 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.ModuleTestCase;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.http.HttpInfo;
 import org.elasticsearch.http.HttpServerAdapter;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.http.HttpStats;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.cat.AbstractCatAction;
 import org.elasticsearch.test.transport.AssertingLocalTransport;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportInterceptor;
-
-import java.util.Collections;
 
 public class NetworkModuleTests extends ModuleTestCase {
 
     static class FakeTransport extends AssertingLocalTransport {
         public FakeTransport() {
             super(null, null, null, null);
+        }
+    }
+
+    static class FakeTransportFactory extends NetworkPlugin.TransportFactory<Transport> {
+
+        public FakeTransportFactory(String name) {
+            super(name);
+        }
+
+        @Override
+        public FakeTransport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                             CircuitBreakerService circuitBreakerService, NamedWriteableRegistry namedWriteableRegistry,
+                                             NetworkService networkService) {
+            return new FakeTransport();
         }
     }
 
@@ -73,6 +90,20 @@ public class NetworkModuleTests extends ModuleTestCase {
         public void httpServerAdapter(HttpServerAdapter httpServerAdapter) {}
     }
 
+    static class FakeHttpTransportFactory extends NetworkPlugin.TransportFactory<HttpServerTransport> {
+
+        public FakeHttpTransportFactory(String name) {
+            super(name);
+        }
+
+        @Override
+        public FakeHttpTransport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                             CircuitBreakerService circuitBreakerService, NamedWriteableRegistry namedWriteableRegistry,
+                                             NetworkService networkService) {
+            return new FakeHttpTransport();
+        }
+    }
+
     static class FakeRestHandler extends BaseRestHandler {
         public FakeRestHandler() {
             super(null);
@@ -99,44 +130,49 @@ public class NetworkModuleTests extends ModuleTestCase {
         Settings settings = Settings.builder().put(NetworkModule.TRANSPORT_TYPE_KEY, "custom")
             .put(NetworkModule.HTTP_ENABLED.getKey(), false)
             .build();
-        NetworkModule module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, false);
-        module.registerTransport("custom", FakeTransport.class);
-        assertBinding(module, Transport.class, FakeTransport.class);
+        NetworkModule module = new NetworkModule(settings, false);
+        FakeTransportFactory custom = new FakeTransportFactory("custom");
+        module.registerTransport(custom);
         assertFalse(module.isTransportClient());
+        assertFalse(module.isHttpEnabled());
+        assertSame(custom, module.getTransportFactory());
 
         // check it works with transport only as well
-        module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, true);
-        module.registerTransport("custom", FakeTransport.class);
-        assertBinding(module, Transport.class, FakeTransport.class);
+        module = new NetworkModule(settings, true);
+        module.registerTransport(custom);
+        assertSame(custom, module.getTransportFactory());
         assertTrue(module.isTransportClient());
+        assertFalse(module.isHttpEnabled());
     }
 
     public void testRegisterHttpTransport() {
         Settings settings = Settings.builder()
             .put(NetworkModule.HTTP_TYPE_SETTING.getKey(), "custom")
             .put(NetworkModule.TRANSPORT_TYPE_KEY, "local").build();
-        NetworkModule module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, false);
-        module.registerHttpTransport("custom", FakeHttpTransport.class);
-        assertBinding(module, HttpServerTransport.class, FakeHttpTransport.class);
+        NetworkModule module = new NetworkModule(settings, false);
+        FakeHttpTransportFactory custom = new FakeHttpTransportFactory("custom");
+        module.registerHttpTransport(custom);
+        assertSame(custom, module.getHttpServerTransportFactory());
         assertFalse(module.isTransportClient());
+        assertTrue(module.isHttpEnabled());
 
         // check registration not allowed for transport only
-        module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, true);
+        module = new NetworkModule(settings, true);
         assertTrue(module.isTransportClient());
         try {
-            module.registerHttpTransport("custom", FakeHttpTransport.class);
+            module.registerHttpTransport(custom);
             fail();
         } catch (IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("Cannot register http transport"));
             assertTrue(e.getMessage().contains("for transport client"));
         }
 
-        // not added if http is disabled
         settings = Settings.builder().put(NetworkModule.HTTP_ENABLED.getKey(), false)
             .put(NetworkModule.TRANSPORT_TYPE_KEY, "local").build();
-        module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, false);
-        assertNotBound(module, HttpServerTransport.class);
-        assertFalse(module.isTransportClient());
+        NetworkModule newModule = new NetworkModule(settings, false);
+        assertFalse(newModule.isTransportClient());
+        assertFalse(newModule.isHttpEnabled());
+        expectThrows(IllegalStateException.class, () -> newModule.getHttpServerTransportFactory());
     }
 
     public void testRegisterInterceptor() {
@@ -144,19 +180,18 @@ public class NetworkModuleTests extends ModuleTestCase {
             .put(NetworkModule.HTTP_ENABLED.getKey(), false)
             .put(NetworkModule.TRANSPORT_TYPE_KEY, "local").build();
 
-        NetworkModule module = new NetworkModule(new NetworkService(settings, Collections.emptyList()), settings, false);
-        TransportInterceptor interceptor = new TransportInterceptor() {};
-        module.addTransportInterceptor(interceptor);
-        assertInstanceBinding(module, TransportInterceptor.class, i -> {
-            if (i instanceof NetworkModule.CompositeTransportInterceptor) {
-                assertEquals(((NetworkModule.CompositeTransportInterceptor)i).transportInterceptors.size(), 1);
-                return ((NetworkModule.CompositeTransportInterceptor)i).transportInterceptors.get(0) == interceptor;
-            }
-            return false;
-        });
+        NetworkModule module = new NetworkModule(settings, false);
+
+        TransportInterceptor interceptor = new TransportInterceptor() {
+        };
+        module.registerTransportInterceptor(interceptor);
+        TransportInterceptor transportInterceptor = module.getTransportInterceptor();
+        assertTrue(transportInterceptor instanceof  NetworkModule.CompositeTransportInterceptor);
+        assertEquals(((NetworkModule.CompositeTransportInterceptor)transportInterceptor).transportInterceptors.size(), 1);
+        assertSame(((NetworkModule.CompositeTransportInterceptor)transportInterceptor).transportInterceptors.get(0), interceptor);
 
         NullPointerException nullPointerException = expectThrows(NullPointerException.class, () -> {
-            module.addTransportInterceptor(null);
+            module.registerTransportInterceptor(null);
         });
         assertEquals("interceptor must not be null", nullPointerException.getMessage());
 

--- a/modules/transport-netty3/src/main/java/org/elasticsearch/http/netty3/Netty3HttpServerTransport.java
+++ b/modules/transport-netty3/src/main/java/org/elasticsearch/http/netty3/Netty3HttpServerTransport.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Setting;
@@ -218,7 +217,6 @@ public class Netty3HttpServerTransport extends AbstractLifecycleComponent implem
 
     private final Netty3CorsConfig corsConfig;
 
-    @Inject
     public Netty3HttpServerTransport(Settings settings, NetworkService networkService, BigArrays bigArrays, ThreadPool threadPool) {
         super(settings);
         this.networkService = networkService;

--- a/modules/transport-netty3/src/main/java/org/elasticsearch/transport/Netty3Plugin.java
+++ b/modules/transport-netty3/src/main/java/org/elasticsearch/transport/Netty3Plugin.java
@@ -19,19 +19,27 @@
 
 package org.elasticsearch.transport;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkModule;
+import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.http.netty3.Netty3HttpServerTransport;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.netty3.Netty3Transport;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
-public class Netty3Plugin extends Plugin {
+public class Netty3Plugin extends Plugin implements NetworkPlugin{
     public static final String NETTY_TRANSPORT_NAME = "netty3";
     public static final String NETTY_HTTP_TRANSPORT_NAME = "netty3";
 
@@ -57,11 +65,27 @@ public class Netty3Plugin extends Plugin {
         );
     }
 
-    public void onModule(NetworkModule networkModule) {
-        if (networkModule.canRegisterHttpExtensions()) {
-            networkModule.registerHttpTransport(NETTY_HTTP_TRANSPORT_NAME, Netty3HttpServerTransport.class);
-        }
-        networkModule.registerTransport(NETTY_TRANSPORT_NAME, Netty3Transport.class);
+    @Override
+    public List<TransportFactory<Transport>> getTransportFactory() {
+        return Collections.singletonList(new TransportFactory<Transport>(NETTY_TRANSPORT_NAME) {
+            @Override
+            public Transport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                             CircuitBreakerService circuitBreakerService, NamedWriteableRegistry namedWriteableRegistry,
+                                             NetworkService networkService) {
+                return new Netty3Transport(settings, threadPool, networkService, bigArrays, namedWriteableRegistry, circuitBreakerService);
+            }
+        });
     }
 
+    @Override
+    public List<TransportFactory<HttpServerTransport>> getHttpTransportFactory() {
+        return Collections.singletonList(new TransportFactory<HttpServerTransport>(NETTY_HTTP_TRANSPORT_NAME) {
+            @Override
+            public HttpServerTransport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                                       CircuitBreakerService circuitBreakerService,
+                                                       NamedWriteableRegistry namedWriteableRegistry, NetworkService networkService) {
+                return new Netty3HttpServerTransport(settings, networkService, bigArrays, threadPool);
+            }
+        });
+    }
 }

--- a/modules/transport-netty3/src/main/java/org/elasticsearch/transport/Netty3Plugin.java
+++ b/modules/transport-netty3/src/main/java/org/elasticsearch/transport/Netty3Plugin.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.transport;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -33,13 +32,13 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.netty3.Netty3Transport;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 
-public class Netty3Plugin extends Plugin implements NetworkPlugin{
+public class Netty3Plugin extends Plugin implements NetworkPlugin {
     public static final String NETTY_TRANSPORT_NAME = "netty3";
     public static final String NETTY_HTTP_TRANSPORT_NAME = "netty3";
 
@@ -66,26 +65,19 @@ public class Netty3Plugin extends Plugin implements NetworkPlugin{
     }
 
     @Override
-    public List<TransportFactory<Transport>> getTransportFactory() {
-        return Collections.singletonList(new TransportFactory<Transport>(NETTY_TRANSPORT_NAME) {
-            @Override
-            public Transport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
-                                             CircuitBreakerService circuitBreakerService, NamedWriteableRegistry namedWriteableRegistry,
-                                             NetworkService networkService) {
-                return new Netty3Transport(settings, threadPool, networkService, bigArrays, namedWriteableRegistry, circuitBreakerService);
-            }
-        });
+    public Map<String, Supplier<Transport>> getTransports(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                                          CircuitBreakerService circuitBreakerService,
+                                                          NamedWriteableRegistry namedWriteableRegistry, NetworkService networkService) {
+        return Collections.singletonMap(NETTY_TRANSPORT_NAME, () -> new Netty3Transport(settings, threadPool, networkService, bigArrays,
+            namedWriteableRegistry, circuitBreakerService));
     }
 
     @Override
-    public List<TransportFactory<HttpServerTransport>> getHttpTransportFactory() {
-        return Collections.singletonList(new TransportFactory<HttpServerTransport>(NETTY_HTTP_TRANSPORT_NAME) {
-            @Override
-            public HttpServerTransport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
-                                                       CircuitBreakerService circuitBreakerService,
-                                                       NamedWriteableRegistry namedWriteableRegistry, NetworkService networkService) {
-                return new Netty3HttpServerTransport(settings, networkService, bigArrays, threadPool);
-            }
-        });
+    public Map<String, Supplier<HttpServerTransport>> getHttpTransports(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                                                        CircuitBreakerService circuitBreakerService,
+                                                                        NamedWriteableRegistry namedWriteableRegistry,
+                                                                        NetworkService networkService) {
+        return Collections.singletonMap(NETTY_HTTP_TRANSPORT_NAME, () -> new Netty3HttpServerTransport(settings, networkService,
+            bigArrays, threadPool));
     }
 }

--- a/modules/transport-netty3/src/main/java/org/elasticsearch/transport/netty3/Netty3Transport.java
+++ b/modules/transport-netty3/src/main/java/org/elasticsearch/transport/netty3/Netty3Transport.java
@@ -25,7 +25,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.network.NetworkService;
@@ -138,7 +137,6 @@ public class Netty3Transport extends TcpTransport<Channel> {
     protected volatile ClientBootstrap clientBootstrap;
     protected final Map<String, ServerBootstrap> serverBootstraps = newConcurrentMap();
 
-    @Inject
     public Netty3Transport(Settings settings, ThreadPool threadPool, NetworkService networkService, BigArrays bigArrays,
                            NamedWriteableRegistry namedWriteableRegistry, CircuitBreakerService circuitBreakerService) {
         super("netty3", settings, threadPool, bigArrays, circuitBreakerService, namedWriteableRegistry, networkService);

--- a/modules/transport-netty3/src/test/java/org/elasticsearch/transport/netty3/Netty3TransportIT.java
+++ b/modules/transport-netty3/src/test/java/org/elasticsearch/transport/netty3/Netty3TransportIT.java
@@ -46,6 +46,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -85,17 +87,15 @@ public class Netty3TransportIT extends ESNetty3IntegTestCase {
     public static final class ExceptionThrowingNetty3Transport extends Netty3Transport {
 
         public static class TestPlugin extends Plugin implements NetworkPlugin {
+
             @Override
-            public List<TransportFactory<Transport>> getTransportFactory() {
-                return Collections.singletonList(new TransportFactory<Transport>("exception-throwing") {
-                    @Override
-                    public Transport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
-                                                     CircuitBreakerService circuitBreakerService,
-                                                     NamedWriteableRegistry namedWriteableRegistry, NetworkService networkService) {
-                        return new ExceptionThrowingNetty3Transport(settings, threadPool, networkService, bigArrays,
-                            namedWriteableRegistry, circuitBreakerService);
-                    }
-                });
+            public Map<String, Supplier<Transport>> getTransports(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                                                  CircuitBreakerService circuitBreakerService,
+                                                                  NamedWriteableRegistry namedWriteableRegistry,
+                                                                  NetworkService networkService) {
+                return Collections.singletonMap("exception-throwing", () ->
+                    new ExceptionThrowingNetty3Transport(settings, threadPool, networkService, bigArrays,
+                        namedWriteableRegistry, circuitBreakerService));
             }
         }
 

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -47,7 +47,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Setting;
@@ -220,7 +219,6 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
 
     private final Netty4CorsConfig corsConfig;
 
-    @Inject
     public Netty4HttpServerTransport(Settings settings, NetworkService networkService, BigArrays bigArrays, ThreadPool threadPool) {
         super(settings);
         this.networkService = networkService;

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
@@ -36,6 +36,8 @@ import org.elasticsearch.transport.netty4.Netty4Transport;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 
 public class Netty4Plugin extends Plugin implements NetworkPlugin {
 
@@ -75,27 +77,20 @@ public class Netty4Plugin extends Plugin implements NetworkPlugin {
     }
 
     @Override
-    public List<TransportFactory<Transport>> getTransportFactory() {
-        return Collections.singletonList(new TransportFactory<Transport>(NETTY_TRANSPORT_NAME) {
-            @Override
-            public Transport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
-                                             CircuitBreakerService circuitBreakerService, NamedWriteableRegistry namedWriteableRegistry,
-                                             NetworkService networkService) {
-                return new Netty4Transport(settings, threadPool, networkService, bigArrays, namedWriteableRegistry, circuitBreakerService);
-            }
-        });
+    public Map<String, Supplier<Transport>> getTransports(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                                          CircuitBreakerService circuitBreakerService,
+                                                          NamedWriteableRegistry namedWriteableRegistry,
+                                                          NetworkService networkService) {
+        return Collections.singletonMap(NETTY_TRANSPORT_NAME, () -> new Netty4Transport(settings, threadPool, networkService, bigArrays,
+            namedWriteableRegistry, circuitBreakerService));
     }
 
     @Override
-    public List<TransportFactory<HttpServerTransport>> getHttpTransportFactory() {
-        return Collections.singletonList(new TransportFactory<HttpServerTransport>(NETTY_HTTP_TRANSPORT_NAME) {
-            @Override
-            public HttpServerTransport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
-                                                       CircuitBreakerService circuitBreakerService,
-                                                       NamedWriteableRegistry namedWriteableRegistry, NetworkService networkService) {
-                return new Netty4HttpServerTransport(settings, networkService, bigArrays, threadPool);
-            }
-        });
+    public Map<String, Supplier<HttpServerTransport>> getHttpTransports(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                                                        CircuitBreakerService circuitBreakerService,
+                                                                        NamedWriteableRegistry namedWriteableRegistry,
+                                                                        NetworkService networkService) {
+        return Collections.singletonMap(NETTY_HTTP_TRANSPORT_NAME,
+            () -> new Netty4HttpServerTransport(settings, networkService, bigArrays, threadPool));
     }
-
 }

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4TransportIT.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4TransportIT.java
@@ -25,7 +25,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.network.NetworkModule;
@@ -33,14 +32,17 @@ import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportSettings;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -83,13 +85,21 @@ public class Netty4TransportIT extends ESNetty4IntegTestCase {
 
     public static final class ExceptionThrowingNetty4Transport extends Netty4Transport {
 
-        public static class TestPlugin extends Plugin {
-            public void onModule(NetworkModule module) {
-                module.registerTransport("exception-throwing", ExceptionThrowingNetty4Transport.class);
+        public static class TestPlugin extends Plugin implements NetworkPlugin {
+            @Override
+            public List<TransportFactory<Transport>> getTransportFactory() {
+                return Collections.singletonList(new TransportFactory<Transport>("exception-throwing") {
+                    @Override
+                    public Transport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                                     CircuitBreakerService circuitBreakerService,
+                                                     NamedWriteableRegistry namedWriteableRegistry, NetworkService networkService) {
+                        return new ExceptionThrowingNetty4Transport(settings, threadPool, networkService, bigArrays,
+                            namedWriteableRegistry, circuitBreakerService);
+                    }
+                });
             }
         }
 
-        @Inject
         public ExceptionThrowingNetty4Transport(
                 Settings settings,
                 ThreadPool threadPool,

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4TransportIT.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4TransportIT.java
@@ -42,11 +42,12 @@ import org.elasticsearch.transport.TransportSettings;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -86,17 +87,15 @@ public class Netty4TransportIT extends ESNetty4IntegTestCase {
     public static final class ExceptionThrowingNetty4Transport extends Netty4Transport {
 
         public static class TestPlugin extends Plugin implements NetworkPlugin {
+
             @Override
-            public List<TransportFactory<Transport>> getTransportFactory() {
-                return Collections.singletonList(new TransportFactory<Transport>("exception-throwing") {
-                    @Override
-                    public Transport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
-                                                     CircuitBreakerService circuitBreakerService,
-                                                     NamedWriteableRegistry namedWriteableRegistry, NetworkService networkService) {
-                        return new ExceptionThrowingNetty4Transport(settings, threadPool, networkService, bigArrays,
-                            namedWriteableRegistry, circuitBreakerService);
-                    }
-                });
+            public Map<String, Supplier<Transport>> getTransports(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                                                  CircuitBreakerService circuitBreakerService,
+                                                                  NamedWriteableRegistry namedWriteableRegistry,
+                                                                  NetworkService networkService) {
+                return Collections.singletonMap("exception-throwing",
+                    () -> new ExceptionThrowingNetty4Transport(settings, threadPool, networkService, bigArrays,
+                    namedWriteableRegistry, circuitBreakerService));
             }
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/AssertingLocalTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/AssertingLocalTransport.java
@@ -48,7 +48,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.function.Supplier;
 
 public class AssertingLocalTransport extends LocalTransport {
 
@@ -62,15 +64,12 @@ public class AssertingLocalTransport extends LocalTransport {
         }
 
         @Override
-        public List<TransportFactory<Transport>> getTransportFactory() {
-            return Collections.singletonList(new TransportFactory<Transport>(ASSERTING_TRANSPORT_NAME) {
-                @Override
-                public Transport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
-                                                 CircuitBreakerService circuitBreakerService, NamedWriteableRegistry namedWriteableRegistry,
-                                                 NetworkService networkService) {
-                    return new AssertingLocalTransport(settings, circuitBreakerService, threadPool, namedWriteableRegistry);
-                }
-            });
+        public Map<String, Supplier<Transport>> getTransports(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                                              CircuitBreakerService circuitBreakerService,
+                                                              NamedWriteableRegistry namedWriteableRegistry,
+                                                              NetworkService networkService) {
+            return Collections.singletonMap(ASSERTING_TRANSPORT_NAME,
+                () -> new AssertingLocalTransport(settings, circuitBreakerService, threadPool, namedWriteableRegistry));
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/AssertingLocalTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/AssertingLocalTransport.java
@@ -24,15 +24,19 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkModule;
+import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestOptions;
@@ -42,6 +46,7 @@ import org.elasticsearch.transport.local.LocalTransport;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
@@ -49,14 +54,23 @@ public class AssertingLocalTransport extends LocalTransport {
 
     public static final String ASSERTING_TRANSPORT_NAME = "asserting_local";
 
-    public static class TestPlugin extends Plugin {
-        public void onModule(NetworkModule module) {
-            module.registerTransport(ASSERTING_TRANSPORT_NAME, AssertingLocalTransport.class);
-        }
+    public static class TestPlugin extends Plugin implements NetworkPlugin {
 
         @Override
         public List<Setting<?>> getSettings() {
             return Arrays.asList(ASSERTING_TRANSPORT_MIN_VERSION_KEY, ASSERTING_TRANSPORT_MAX_VERSION_KEY);
+        }
+
+        @Override
+        public List<TransportFactory<Transport>> getTransportFactory() {
+            return Collections.singletonList(new TransportFactory<Transport>(ASSERTING_TRANSPORT_NAME) {
+                @Override
+                public Transport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                                 CircuitBreakerService circuitBreakerService, NamedWriteableRegistry namedWriteableRegistry,
+                                                 NetworkService networkService) {
+                    return new AssertingLocalTransport(settings, circuitBreakerService, threadPool, namedWriteableRegistry);
+                }
+            });
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/transport/MockTcpTransportPlugin.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/MockTcpTransportPlugin.java
@@ -30,19 +30,18 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 
 public class MockTcpTransportPlugin extends Plugin implements NetworkPlugin {
     public static final String MOCK_TCP_TRANSPORT_NAME = "mock-socket-network";
 
     @Override
-    public List<TransportFactory<Transport>> getTransportFactory() {
-        return Collections.singletonList(new TransportFactory<Transport>(MOCK_TCP_TRANSPORT_NAME) {
-            @Override
-            public Transport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
-                                             CircuitBreakerService circuitBreakerService, NamedWriteableRegistry namedWriteableRegistry,
-                                             NetworkService networkService) {
-                return new MockTcpTransport(settings, threadPool, bigArrays, circuitBreakerService, namedWriteableRegistry, networkService);
-            }
-        });
+    public Map<String, Supplier<Transport>> getTransports(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                                          CircuitBreakerService circuitBreakerService,
+                                                          NamedWriteableRegistry namedWriteableRegistry,
+                                                          NetworkService networkService) {
+        return Collections.singletonMap(MOCK_TCP_TRANSPORT_NAME,
+            () -> new MockTcpTransport(settings, threadPool, bigArrays, circuitBreakerService, namedWriteableRegistry, networkService));
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/transport/MockTcpTransportPlugin.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/MockTcpTransportPlugin.java
@@ -18,14 +18,31 @@
  */
 package org.elasticsearch.transport;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkModule;
+import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.threadpool.ThreadPool;
 
-public class MockTcpTransportPlugin extends Plugin {
+import java.util.Collections;
+import java.util.List;
+
+public class MockTcpTransportPlugin extends Plugin implements NetworkPlugin {
     public static final String MOCK_TCP_TRANSPORT_NAME = "mock-socket-network";
 
-    public void onModule(NetworkModule module) {
-        module.registerTransport(MOCK_TCP_TRANSPORT_NAME, MockTcpTransport.class);
+    @Override
+    public List<TransportFactory<Transport>> getTransportFactory() {
+        return Collections.singletonList(new TransportFactory<Transport>(MOCK_TCP_TRANSPORT_NAME) {
+            @Override
+            public Transport createTransport(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+                                             CircuitBreakerService circuitBreakerService, NamedWriteableRegistry namedWriteableRegistry,
+                                             NetworkService networkService) {
+                return new MockTcpTransport(settings, threadPool, bigArrays, circuitBreakerService, namedWriteableRegistry, networkService);
+            }
+        });
     }
 }


### PR DESCRIPTION
This change removes all guice interaction from Transport, HttpServerTransport,
HttpServer and TransportService. All these classes as well as their subclasses
or extended version configured via plugins are now created by using plain old
bloody java constructors. YAY!
