### PR TITLE
Improves the documentation for `cluster.routing.allocation.cluster_concurrent_rebalance`

### DIFF
--- a/docs/reference/modules/cluster/shards_allocation.asciidoc
+++ b/docs/reference/modules/cluster/shards_allocation.asciidoc
@@ -85,7 +85,11 @@ Specify when shard rebalancing is allowed:
 `cluster.routing.allocation.cluster_concurrent_rebalance`::
 
       Allow to control how many concurrent shard rebalances are
-      allowed cluster wide. Defaults to `2`.
+      allowed cluster wide. Defaults to `2`. Note that this setting
+      only controls the number of concurrent shard relocations due
+      to imbalances in the cluster. This setting does not limit shard
+      relocations due to <<allocation-filtering,allocation filtering>>
+      or <<forced-awareness,forced awareness>>.
 
 [float]
 === Shard Balancing Heuristics


### PR DESCRIPTION
Improves the documentation for the `cluster.routing.allocation.cluster_concurrent_rebalance` setting, clarifying in which shard allocation situations the rebalance limit takes effect.

Closes #20529
