### PR TITLE
Adding extra = to make minhash docs appear in the correct level of the documentation table of contents.

### DIFF
--- a/docs/reference/analysis/tokenfilters/minhash-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/minhash-tokenfilter.asciidoc
@@ -1,5 +1,5 @@
 [[analysis-minhash-tokenfilter]]
-== Minhash Token Filter
+=== Minhash Token Filter
 
 A token filter of type `min_hash` hashes each token of the token stream and divides
 the resulting hashes into buckets, keeping the lowest-valued hashes per


### PR DESCRIPTION
The file [minhash-tokenfilter.asciidoc](https://github.com/elastic/elasticsearch/blame/f825e8f4cb557f3abc724647b4f760f2a0a35ffc/docs/reference/analysis/tokenfilters/minhash-tokenfilter.asciidoc#L2) uses == instead of ===, and thus appears (incorrectly) on the same level as 'analyzers' and 'tokenizers' in the documentation table of contents. This PR swaps that to '==='.

I verified the fix by building the documentation with:
`./build_docs.pl --doc /path/to/elasticsearch/docs/reference/index.asciidoc --chunk 1`

Sorry for messing this up in #20206, and sorry for the trivial PR :(
