### PR TITLE
XContentBuilder: Avoid building self-referencing objects

### DIFF
--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/plan_a/15_update.yaml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/plan_a/15_update.yaml
@@ -58,4 +58,30 @@
 
   - match: { _source.foo:        yyy }
   - match: { _source.count:      1   }
-  
+
+---
+"Update Script with script error":
+  - do:
+      index:
+          index:  test_1
+          type:   test
+          id:     2
+          body:
+              foo:    bar
+              count:  1
+
+  - do:
+      catch: request
+      update:
+          index:  test_1
+          type:   test
+          id:     2
+          body:
+            script:
+              lang:   painless
+              inline: "for (def key : params.keySet()) { ctx._source[key] = params[key]}"
+              params: { bar: 'xxx' }
+
+  - match: { error.root_cause.0.type: "remote_transport_exception" }
+  - match: { error.type: "illegal_argument_exception" }
+  - match: { error.reason: "Object has already been built and is self-referencing itself" }

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/plan_a/20_scriptfield.yaml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/plan_a/20_scriptfield.yaml
@@ -20,7 +20,6 @@ setup:
         indices.refresh: {}
 
 ---
-
 "Scripted Field":
     - do:
         search:
@@ -34,3 +33,22 @@ setup:
                                 x: "bbb"
 
     - match: { hits.hits.0.fields.bar.0: "aaabbb"}
+
+---
+"Scripted Field with script error":
+    - do:
+        catch: request
+        search:
+          body:
+            script_fields:
+              bar:
+                script:
+                  lang: painless
+                  inline: "while (true) {}"
+
+    - match: { error.root_cause.0.type: "script_exception" }
+    - match: { error.root_cause.0.reason: "compile error" }
+    - match: { error.caused_by.type: "script_exception" }
+    - match: { error.caused_by.reason: "compile error" }
+    - match: { error.caused_by.caused_by.type: "illegal_argument_exception" }
+    - match: { error.caused_by.caused_by.reason: "While loop has no escape." }


### PR DESCRIPTION
Some objects like maps, iterables or arrays of objects can self-reference themselves. This is mostly due to a bug in code but the XContentBuilder should be able to detect such situations and throws an IllegalArgumentException instead of building objects over and over until a stackoverflow occurs.

closes #20540
closes #19475
