### PR TITLE
Node attributes and REST API spec README

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
@@ -49,7 +49,7 @@ import org.elasticsearch.common.settings.Settings;
  * To enable allocation awareness in this example nodes should contain a value
  * for the <tt>rack_id</tt> key like:
  * <pre>
- * node.rack_id:1
+ * node.attr.rack_id:1
  * </pre>
  * <p>
  * Awareness can also be used to prevent over-allocation in the case of node or

--- a/distribution/src/main/resources/config/elasticsearch.yml
+++ b/distribution/src/main/resources/config/elasticsearch.yml
@@ -24,7 +24,7 @@
 #
 # Add custom attributes to the node:
 #
-#node.rack: r1
+#node.attr.rack: r1
 #
 # ----------------------------------- Paths ------------------------------------
 #

--- a/docs/reference/cluster.asciidoc
+++ b/docs/reference/cluster.asciidoc
@@ -22,7 +22,7 @@ curl localhost:9200/_nodes/10.0.0.*
 # Names
 curl localhost:9200/_nodes/node_name_goes_here
 curl localhost:9200/_nodes/node_name_goes_*
-# Attributes (set something like node.rack: 2 in the config)
+# Attributes (set something like node.attr.rack: 2 in the config)
 curl localhost:9200/_nodes/rack:2
 curl localhost:9200/_nodes/ra*:2
 curl localhost:9200/_nodes/ra*:2*

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
@@ -10,7 +10,7 @@ Elasticsearch as follows:
 
 [source,sh]
 ---------------------
-bin/elasticsearch --script.inline true --node.testattr test --path.repo /tmp --repositories.url.allowed_urls 'http://snapshot.*'
+bin/elasticsearch --script.inline true --node.attr.testattr test --path.repo /tmp --repositories.url.allowed_urls 'http://snapshot.*'
 ---------------------
 
 =======================================

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
@@ -10,7 +10,7 @@ Elasticsearch as follows:
 
 [source,sh]
 ---------------------
-bin/elasticsearch --script.inline true --node.attr.testattr test --path.repo /tmp --repositories.url.allowed_urls 'http://snapshot.*'
+bin/elasticsearch -E script.inline true -E node.attr.testattr test -E path.repo /tmp -E repositories.url.allowed_urls 'http://snapshot.*'
 ---------------------
 
 =======================================


### PR DESCRIPTION
Previously node attributes could be set via node.\* but this now requires
using node.attr.*. This commit fixes some leftover usages of the old
way.

The command-line arguments for Elasticsearch must now be specified using
-E. This commit fixes the usage of command-line arguments in the REST
API spec README.

Relates #17402, relates #18198,  closes #20542
