### PR TITLE
Add option to TransportReplicationAction to prevent failing the shard on exception

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportShardFlushAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportShardFlushAction.java
@@ -33,10 +33,7 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-/**
- *
- */
-public class TransportShardFlushAction extends TransportReplicationAction<ShardFlushRequest, ShardFlushRequest, ReplicationResponse> {
+public final class TransportShardFlushAction extends TransportReplicationAction<ShardFlushRequest, ShardFlushRequest, ReplicationResponse> {
 
     public static final String NAME = FlushAction.NAME + "[s]";
 
@@ -82,5 +79,10 @@ public class TransportShardFlushAction extends TransportReplicationAction<ShardF
     @Override
     protected boolean shouldExecuteReplication(Settings settings) {
         return true;
+    }
+
+    @Override
+    protected boolean failShardsOnFailure() {
+        return false; // we never fail the shard on failure since the engine will take care of this.
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
@@ -36,7 +36,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 
-public class TransportShardRefreshAction
+public final class TransportShardRefreshAction
         extends TransportReplicationAction<BasicReplicationRequest, BasicReplicationRequest, ReplicationResponse> {
 
     public static final String NAME = RefreshAction.NAME + "[s]";
@@ -84,5 +84,10 @@ public class TransportShardRefreshAction
     @Override
     protected boolean shouldExecuteReplication(Settings settings) {
         return true;
+    }
+
+    @Override
+    protected boolean failShardsOnFailure() {
+        return false; // we never fail the shard on failure since the engine will take care of this.
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -365,8 +365,7 @@ public abstract class TransportReplicationAction<
             Request request, ActionListener<PrimaryResult> listener,
             PrimaryShardReference primaryShardReference, boolean executeOnReplicas) {
             return new ReplicationOperation<>(request, primaryShardReference, listener,
-                executeOnReplicas, replicasProxy, clusterService::state, logger, actionName
-            );
+                executeOnReplicas, replicasProxy, clusterService::state, logger, actionName, failShardsOnFailure());
         }
     }
 
@@ -1037,5 +1036,17 @@ public abstract class TransportReplicationAction<
         if (task != null) {
             task.setPhase(phase);
         }
+    }
+
+    /**
+     * Returns <code>true</code> iff a primary or replica shard should be failed in the case of a potentially fatal exception.
+     * This method returns <code>true</code> by default and must return true for all operations that modify the shard by adding or deleting
+     * documents. Operations that use this class to fan out to all shard copies might opt out of this behavior.
+     * The default is <code>true</code>.
+     */
+    protected boolean failShardsOnFailure() {
+        // we added this mainly for refresh and flush since they should never fail a shards since the engine will take care of this
+        // already.
+        return true;
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
@@ -314,4 +314,9 @@ public abstract class TransportWriteAction<
             }
         }
     }
+
+    @Override
+    protected final boolean failShardsOnFailure() {
+        return true; // write ops always fail the replica shard on failure
+    }
 }

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
@@ -492,7 +492,7 @@ public class ReplicationOperationTests extends ESTestCase {
         public TestReplicationOperation(Request request, Primary<Request, Request, TestPrimary.Result> primary,
                 ActionListener<TestPrimary.Result> listener, boolean executeOnReplicas,
                 Replicas<Request> replicas, Supplier<ClusterState> clusterStateSupplier, Logger logger, String opType) {
-            super(request, primary, listener, executeOnReplicas, replicas, clusterStateSupplier, logger, opType);
+            super(request, primary, listener, executeOnReplicas, replicas, clusterStateSupplier, logger, opType, true);
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -1048,7 +1048,7 @@ public class TransportReplicationActionTests extends ESTestCase {
 
     class NoopReplicationOperation extends ReplicationOperation<Request, Request, Action.PrimaryResult> {
         public NoopReplicationOperation(Request request, ActionListener<Action.PrimaryResult> listener) {
-            super(request, null, listener, true, null, null, TransportReplicationActionTests.this.logger, "noop");
+            super(request, null, listener, true, null, null, TransportReplicationActionTests.this.logger, "noop", true);
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -236,7 +236,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
 
         public IndexingOp(IndexRequest request, ActionListener<IndexingResult> listener, ReplicationGroup replicationGroup) {
             super(request, new PrimaryRef(replicationGroup), listener, true, new ReplicasRef(replicationGroup),
-                () -> null, logger, "indexing");
+                () -> null, logger, "indexing", true);
             this.replicationGroup = replicationGroup;
             request.process(null, true, request.index());
         }


### PR DESCRIPTION
Today we use TransportReplicationAction to refresh / flush a shard. Yet, this is problematic
since a shard might throw an exception that is just fine to catch and continue and should never
result in failing a shard. If a fatal exception happens that should fail the shard this happen on
the engine level. In contrast to write actions we should never fail a shards in such a situation.
