### PR TITLE
Avoid unnecessary creation of prefix loggers

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/lucene/LoggerInfoStream.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/LoggerInfoStream.java
@@ -23,11 +23,16 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.InfoStream;
 import org.elasticsearch.common.logging.Loggers;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 /** An InfoStream (for Lucene's IndexWriter) that redirects
  *  messages to "lucene.iw.ifd" and "lucene.iw" Logger.trace. */
 public final class LoggerInfoStream extends InfoStream {
 
     private final Logger parentLogger;
+
+    private final Map<String, Logger> loggers = new ConcurrentHashMap<>();
 
     public LoggerInfoStream(final Logger parentLogger) {
         this.parentLogger = parentLogger;
@@ -46,11 +51,12 @@ public final class LoggerInfoStream extends InfoStream {
     }
 
     private Logger getLogger(String component) {
-        return Loggers.getLogger(parentLogger, "." + component);
+        return loggers.computeIfAbsent(component, c -> Loggers.getLogger(parentLogger, "." + c));
     }
 
     @Override
     public void close() {
 
     }
+
 }


### PR DESCRIPTION
Today when acquiring a prefix logger for a logger info stream, we obtain
a new prefix logger per invocation. This can lead to contention on the
markers lock in the constructor of PrefixLogger. Usually this is not a
problem (because the vast majority of callers hold on to the logger they
obtain). Unfortunately, under heavy indexing with multiple threads, the
contention on the lock can be devastating. This commit modifies
LoggerInfoStream to hold on to the loggers it obtains to avoid
contending over the lock there.

Closes #20570
