### PR TITLE
Don't start reindex unless destination index exists

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -3,11 +3,19 @@
 
 experimental[The reindex API is new and should still be considered experimental.  The API may change in ways that are not backwards compatible]
 
-The most basic form of `_reindex` just copies documents from one index to another.
-This will copy documents from the `twitter` index into the `new_twitter` index:
+`_reindex` copies documents from one index to another. It never creates new
+indexes. Instead, you should create the destination index before starting the
+reindex process. This will copy documents from the `twitter` index into the
+`new_twitter` index:
 
 [source,js]
 --------------------------------------------------
+PUT new_twitter
+{
+  "settings": {
+    "index.number_of_shards": 1
+  }
+}
 POST _reindex
 {
   "source": {
@@ -70,6 +78,7 @@ POST _reindex
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:twitter]
+// TEST[s/^/PUT new_twitter\n/]
 
 Setting `version_type` to `external` will cause Elasticsearch to preserve the
 `version` from the source, create any documents that are missing, and update
@@ -91,6 +100,7 @@ POST _reindex
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:twitter]
+// TEST[s/^/PUT new_twitter\n/]
 
 Settings `op_type` to `create` will cause `_reindex` to only create missing
 documents in the target index. All existing documents will cause a version
@@ -111,6 +121,7 @@ POST _reindex
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:twitter]
+// TEST[s/^/PUT new_twitter\n/]
 
 By default version conflicts abort the `_reindex` process but you can just
 count them by settings `"conflicts": "proceed"` in the request body:
@@ -131,6 +142,7 @@ POST _reindex
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:twitter]
+// TEST[s/^/PUT new_twitter\n/]
 
 You can limit the documents by adding a type to the `source` or by adding a
 query. This will only copy ++tweet++&apos;s made by `kimchy` into `new_twitter`:
@@ -155,6 +167,7 @@ POST _reindex
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:twitter]
+// TEST[s/^/PUT new_twitter\n/]
 
 `index` and `type` in `source` can both be lists, allowing you to copy from
 lots of sources in one request. This will copy documents from the `tweet` and
@@ -179,6 +192,7 @@ POST _reindex
 --------------------------------------------------
 // CONSOLE
 // TEST[s/^/PUT twitter\nPUT blog\n/]
+// TEST[s/^/PUT all_together\n/]
 
 It's also possible to limit the number of processed documents by setting
 `size`. This will only copy a single document from `twitter` to
@@ -199,6 +213,7 @@ POST _reindex
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:twitter]
+// TEST[s/^/PUT new_twitter\n/]
 
 If you want a particular set of documents from the twitter index you'll
 need to sort. Sorting makes the scroll less efficient but in some contexts
@@ -221,6 +236,7 @@ POST _reindex
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:twitter]
+// TEST[s/^/PUT new_twitter\n/]
 
 Like `_update_by_query`, `_reindex` supports a script that modifies the
 document. Unlike `_update_by_query`, the script is allowed to modify the
@@ -245,6 +261,7 @@ POST _reindex
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:twitter]
+// TEST[s/^/PUT new_twitter\n/]
 
 Just as in `_update_by_query`, you can set `ctx.op` to change the
 operation that is executed on the destination index:
@@ -321,6 +338,7 @@ POST _reindex
 --------------------------------------------------
 // CONSOLE
 // TEST[s/^/PUT source\n/]
+// TEST[s/^/PUT dest\n/]
 
 By default `_reindex` uses scroll batches of 1000. You can change the
 batch size with the `size` field in the `source` element:
@@ -341,6 +359,7 @@ POST _reindex
 --------------------------------------------------
 // CONSOLE
 // TEST[s/^/PUT source\n/]
+// TEST[s/^/PUT dest\n/]
 
 Reindex can also use the <<ingest>> feature by specifying a
 `pipeline` like this:
@@ -360,6 +379,7 @@ POST _reindex
 --------------------------------------------------
 // CONSOLE
 // TEST[s/^/PUT source\n/]
+// TEST[s/^/PUT dest\n/]
 
 [float]
 === Reindex from Remote
@@ -394,6 +414,7 @@ POST _reindex
 // TEST[s/otherhost:9200",/\${host}"/]
 // TEST[s/"username": "user",//]
 // TEST[s/"password": "pass"//]
+// TEST[s/^/PUT dest\n/]
 
 The `host` parameter must contain a scheme, host, and port (e.g.
 `https://otherhost:9200`). The `username` and `password` parameters are
@@ -664,6 +685,7 @@ POST _reindex
 --------------------------------------------------
 // CONSOLE
 // TEST[continued]
+// TEST[s/^/PUT test2\n/]
 
 Now you can get the new document:
 
@@ -716,23 +738,25 @@ The new template for the `metricbeat-*` indices is already loaded into elasticse
 but it applies only to the newly created indices. Painless can be used to reindex
 the existing documents and apply the new template.
 
-The script below extracts the date from the index name and creates a new index
-with `-1` appended. All data from `metricbeat-2016.05.31` will be reindex
-into `metricbeat-2016.05.31-1`.
+The script below extracts the date from the index name and appends `-1` to the
+non-date part. All data from `metricbeat-2016.05.31` will be reindex into
+`metricbeat-1-2016.05.31`, etc.
 
 [source,js]
 ----------------------------------------------------------------
+PUT metricbeat-1-2016.05.30
+PUT metricbeat-1-2016.05.31
 POST _reindex
 {
   "source": {
-    "index": "metricbeat-*"
+    "index": "metricbeat-2016.*"
   },
   "dest": {
-    "index": "metricbeat"
+    "index": "metricbeat-1-2016.05.30"
   },
   "script": {
     "lang": "painless",
-    "inline": "ctx._index = 'metricbeat-' + (ctx._index.substring('metricbeat-'.length(), ctx._index.length())) + '-1'"
+    "inline": "ctx._index = 'metricbeat-1-' + ctx._index.substring('metricbeat-'.length())"
   }
 }
 ----------------------------------------------------------------
@@ -743,8 +767,8 @@ All documents from the previous metricbeat indices now can be found in the `*-1`
 
 [source,js]
 ----------------------------------------------------------------
-GET metricbeat-2016.05.30-1/beat/1
-GET metricbeat-2016.05.31-1/beat/1
+GET metricbeat-1-2016.05.30/beat/1
+GET metricbeat-1-2016.05.31/beat/1
 ----------------------------------------------------------------
 // CONSOLE
 // TEST[continued]

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/CancelTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/CancelTests.java
@@ -149,6 +149,7 @@ public class CancelTests extends ReindexTestCase {
     }
 
     public void testReindexCancel() throws Exception {
+        assertAcked(client().admin().indices().prepareCreate("dest").get());
         testCancel(ReindexAction.NAME, reindex().source(INDEX).destination("dest", TYPE), (response, total, modified) -> {
             assertThat(response, matcher().created(modified).reasonCancelled(equalTo("by user request")));
 

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexParentChildTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexParentChildTests.java
@@ -29,7 +29,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSear
 import static org.hamcrest.Matchers.equalTo;
 
 /**
- * Index-by-search tests for parent/child.
+ * Reindex tests for parent/child.
  */
 public class ReindexParentChildTests extends ReindexTestCase {
     QueryBuilder findsCountry;
@@ -73,14 +73,11 @@ public class ReindexParentChildTests extends ReindexTestCase {
     public void testErrorMessageWhenBadParentChild() throws Exception {
         createParentChildIndex("source");
         createParentChildDocs("source");
+        assertAcked(client().admin().indices().prepareCreate("dest").get());
 
-        ReindexRequestBuilder copy = reindex().source("source").destination("dest").filter(findsCity);
-        try {
-            copy.get();
-            fail("Expected exception");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("Can't specify parent if no parent field has been configured"));
-        }
+        Exception e = expectThrows(IllegalArgumentException.class, () ->
+            reindex().source("source").destination("dest").filter(findsCity).get());
+        assertThat(e.getMessage(), equalTo("Can't specify parent if no parent field has been configured"));
     }
 
     /**

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RethrottleTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RethrottleTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.reindex;
 import org.elasticsearch.action.ListenableActionFuture;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.hasSize;
 
 /**
@@ -32,6 +33,7 @@ import static org.hamcrest.Matchers.hasSize;
 public class RethrottleTests extends ReindexTestCase {
 
     public void testReindex() throws Exception {
+        assertAcked(client().admin().indices().prepareCreate("dest").get());
         testCase(reindex().source("test").destination("dest"), ReindexAction.NAME);
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RetryTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RetryTests.java
@@ -47,6 +47,7 @@ import java.util.concurrent.CyclicBarrier;
 
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.index.reindex.ReindexTestCase.matcher;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
@@ -118,6 +119,7 @@ public class RetryTests extends ESSingleNodeTestCase {
     }
 
     public void testReindex() throws Exception {
+        assertAcked(client().admin().indices().prepareCreate("dest").get());
         testCase(ReindexAction.NAME, ReindexAction.INSTANCE.newRequestBuilder(client()).source("source").destination("dest"),
                 matcher().created(DOC_COUNT));
     }

--- a/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/70_throttle.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/70_throttle.yaml
@@ -188,3 +188,5 @@
       tasks.get:
         wait_for_completion: true
         task_id: $task
+  - match: {response.batches: 3}
+  - match: {response.deleted: 3}

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/10_basic.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/10_basic.yaml
@@ -8,6 +8,9 @@
         body:    { "text": "test" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: dest
 
   - do:
       reindex:
@@ -70,6 +73,9 @@
         body:    { "text": "test" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: dest
 
   - do:
       reindex:
@@ -195,6 +201,9 @@
         body:    { "user": "kimchy" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: new_twitter
 
   - do:
       reindex:
@@ -226,6 +235,9 @@
         body:    { "user": "kimchy" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: new_twitter
 
   - do:
       reindex:
@@ -258,6 +270,9 @@
         body:    { "user": "junk" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: new_twitter
 
   - do:
       reindex:
@@ -292,6 +307,9 @@
         body:    { "user": "kimchy" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: new_twitter
 
   - do:
       reindex:
@@ -326,6 +344,9 @@
         body:   { "user": "kimchy" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: all_together
 
   - do:
       reindex:
@@ -373,6 +394,9 @@
         body:   { "user": "kimchy" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: new_twitter
 
   - do:
       reindex:
@@ -400,6 +424,9 @@
         body:    {}
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: dest
 
   - do:
       reindex:

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/20_validation.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/20_validation.yaml
@@ -48,6 +48,9 @@
         id:      1
         body:    { "text": "test" }
   - do:
+      indices.create:
+        index: dest
+  - do:
       reindex:
         body:
           source:
@@ -215,6 +218,9 @@
         body:   { age: 23 }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: dest
 
   - do:
       catch: /\[test\]\[test\]\[1\] didn't store _source/

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/30_search.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/30_search.yaml
@@ -14,6 +14,9 @@
         body:   { "text": "junk" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: target
 
   - do:
       reindex:
@@ -48,6 +51,9 @@
         body:   { "order": 2 }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: target
 
   - do:
       reindex:

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/50_routing.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/50_routing.yaml
@@ -8,6 +8,9 @@
         body:         { "company": "cat" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: dest
 
   - do:
       reindex:
@@ -38,6 +41,9 @@
         routing:      null
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: dest
 
   - do:
       reindex:

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/70_throttle.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/70_throttle.yaml
@@ -29,6 +29,9 @@
         body:    { "text": "test" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: dest
 
   - do:
       reindex:
@@ -78,6 +81,9 @@
         body:    { "text": "test" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: dest
 
   - do:
       reindex:
@@ -127,6 +133,9 @@
         body:    { "text": "test" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: dest
 
   - do:
       reindex:
@@ -150,6 +159,8 @@
       tasks.get:
         wait_for_completion: true
         task_id: $task
+  - match: {response.total: 3}
+  - match: {response.created: 3}
 
 ---
 "Rethrottle but not unlimited":
@@ -182,6 +193,9 @@
         body:    { "text": "test" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: dest
 
   - do:
       reindex:
@@ -205,3 +219,5 @@
       tasks.get:
         wait_for_completion: true
         task_id: $task
+  - match: {response.total: 3}
+  - match: {response.created: 3}

--- a/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/60_throttle.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/60_throttle.yaml
@@ -116,6 +116,8 @@
       tasks.get:
         wait_for_completion: true
         task_id: $task
+  - match: {response.batches: 3}
+  - match: {response.updated: 3}
 
 ---
 "Rethrottle but not unlimited":
@@ -163,3 +165,5 @@
       tasks.get:
         wait_for_completion: true
         task_id: $task
+  - match: {response.batches: 3}
+  - match: {response.updated: 3}

--- a/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/reindex/10_script.yaml
+++ b/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/reindex/10_script.yaml
@@ -8,6 +8,9 @@
         body:   { "user": "kimchy" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: new_twitter
 
   - do:
       reindex:
@@ -48,6 +51,9 @@
         body:   { "user": "blort" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: new_twitter
 
   - do:
       reindex:
@@ -149,6 +155,9 @@
         body:   { "user": "foo" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: new_twitter
 
   - do:
       reindex:
@@ -251,6 +260,9 @@
         body:   { "user": "foo" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: new_twitter
 
   - do:
       reindex:
@@ -305,6 +317,9 @@
         body:   { "user": "foo" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: new_twitter
 
   - do:
       reindex:
@@ -318,11 +333,6 @@
             inline: ctx.op = "noop"
   - match: {updated: 0}
   - match: {noops: 2}
-
-  - do:
-      indices.exists:
-        index: new_twitter
-  - is_false: ''
 
 ---
 "Set version to null to force an update":
@@ -425,6 +435,9 @@
         body:         { "user": "another" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: new_twitter
 
   - do:
       reindex:

--- a/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/reindex/20_broken.yaml
+++ b/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/reindex/20_broken.yaml
@@ -8,6 +8,9 @@
         body:   { "user": "kimchy" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: new_twitter
 
   - do:
       catch: request

--- a/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/reindex/40_search_failures.yaml
+++ b/qa/smoke-test-reindex-with-painless/src/test/resources/rest-api-spec/test/reindex/40_search_failures.yaml
@@ -8,6 +8,9 @@
         body:    { "text": "test" }
   - do:
       indices.refresh: {}
+  - do:
+      indices.create:
+        index: dest
 
   - do:
       catch: request


### PR DESCRIPTION
This isn't the same thing "don't reindex create indexes". We don't
have an easy way to prevent index operations from creating indexes
yet and I'm not sure this is important enough to add one. We _can_
do so if we think it is important to prevent reindex from _ever_
creating indexes.

As it stands reindex can create indexes if the index is deleted
after the reindex starts. In can also create indexes if you use
a script to change the destination index.
