### PR TITLE
Remove reference to version 3.0.0

### DIFF
--- a/docs/plugins/discovery-multicast.asciidoc
+++ b/docs/plugins/discovery-multicast.asciidoc
@@ -1,7 +1,7 @@
 [[discovery-multicast]]
 === Multicast Discovery Plugin
 
-deprecated[2.2.0,This plugin is deprecated and has been removed in 3.0.0]
+deprecated[2.2.0,This plugin is deprecated and has been removed in 5.0.0]
 
 The Multicast Discovery plugin provides the ability to form a cluster using
 TCP/IP multicast messages.

--- a/docs/plugins/plugin-script.asciidoc
+++ b/docs/plugins/plugin-script.asciidoc
@@ -74,13 +74,11 @@ sudo bin/plugin install lmenezes/elasticsearch-kopf/2.x <2>
 <2> Installs the 2.x version from GitHub.
 
 When installing from Maven Central/Sonatype, `[org]` should be replaced by
-the artifact `groupId`, and `[user|component]` by the `artifactId`.  For
-instance, to install the {plugins}/mapper-attachments.html[`mapper-attachments`]
-plugin from Sonatype, run:
+the artifact `groupId`, and `[user|component]` by the `artifactId`:
 
 [source,shell]
 -----------------------------------
-sudo bin/plugin install org.elasticsearch.plugin/mapper-attachments/3.0.0 <1>
+sudo bin/plugin install groupId/artifactId/version <1>
 -----------------------------------
 <1> When installing from `download.elastic.co` or from Maven Central/Sonatype, the
     version is required.

--- a/docs/python/index.asciidoc
+++ b/docs/python/index.asciidoc
@@ -50,7 +50,7 @@ The recommended way to set your requirements in your `setup.py` or
 
 ------------------------------------
     # Elasticsearch 2.x
-    elasticsearch>=2.0.0,<3.0.0
+    elasticsearch>=2.0.0,<5.0.0
 
     # Elasticsearch 1.x
     elasticsearch>=1.0.0,<2.0.0

--- a/qa/backwards/current/pom.xml
+++ b/qa/backwards/current/pom.xml
@@ -22,7 +22,7 @@
         2. To keep the backwards compatibility tests alive when there isn't a
         released version that much be backwards compatible. When 2.0.0 was under
         development the backwards compatibility tests atrophied because there
-        wasn't a version to run them against. That should not happen with 3.0.0!
+        wasn't a version to run them against. That should not happen with 5.0.0!
     -->
 
     <properties>


### PR DESCRIPTION
This commit removes/replaces some references to version 3.0.0.
