### PR TITLE
Don't send exception responses twice

### DIFF
--- a/core/src/main/java/org/elasticsearch/transport/netty/NettyTransportChannel.java
+++ b/core/src/main/java/org/elasticsearch/transport/netty/NettyTransportChannel.java
@@ -141,7 +141,6 @@ public class NettyTransportChannel implements TransportChannel {
         BytesReference bytes = stream.bytes();
         ChannelBuffer buffer = bytes.toChannelBuffer();
         NettyHeader.writeHeader(buffer, requestId, status, version);
-        channel.write(buffer);
         ChannelFuture future = channel.write(buffer);
         ChannelFutureListener onResponseSentListener = new ChannelFutureListener() {
             @Override

--- a/core/src/test/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/core/src/test/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -579,6 +579,9 @@ public class MockTransportService extends TransportService {
 
         public void requestSent(DiscoveryNode node, long requestId, String action, TransportRequestOptions options) {
         }
+
+        public void unresolvedResponse(long requestId) {
+        }
     }
 
     public void addTracer(Tracer tracer) {
@@ -642,6 +645,14 @@ public class MockTransportService extends TransportService {
             super.traceRequestSent(node, requestId, action, options);
             for (Tracer tracer : activeTracers) {
                 tracer.requestSent(node, requestId, action, options);
+            }
+        }
+
+        @Override
+        protected void traceUnresolvedResponse(long requestId) {
+            super.traceUnresolvedResponse(requestId);
+            for (Tracer tracer : activeTracers) {
+                tracer.unresolvedResponse(requestId);
             }
         }
     }


### PR DESCRIPTION
Due to a typo, each exception is getting sent to recipients twice. This manifests itself by sporadic `Transport response handler not found of id [.....]` warnings in log files on nodes connected to 2.4.0+ nodes.

This bug only exists in 2.x branch.
