### PR TITLE
Add rudimentary logstash and beats template BWC tests

### DIFF
--- a/core/src/test/java/org/elasticsearch/action/admin/indices/template/BWCTemplateTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/template/BWCTemplateTests.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.template;
+
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
+
+/**
+ * Rudimentary tests that the templates used by Logstash and Beats
+ * prior to their 5.x releases work for newly created indices
+ */
+public class BWCTemplateTests extends ESSingleNodeTestCase {
+    public void testBeatsTemplatesBWC() throws Exception {
+        String metricBeat = copyToStringFromClasspath("/org/elasticsearch/action/admin/indices/template/metricbeat-5.0.template.json");
+        String packetBeat = copyToStringFromClasspath("/org/elasticsearch/action/admin/indices/template/packetbeat-5.0.template.json");
+        String fileBeat = copyToStringFromClasspath("/org/elasticsearch/action/admin/indices/template/filebeat-5.0.template.json");
+        String winLogBeat = copyToStringFromClasspath("/org/elasticsearch/action/admin/indices/template/winlogbeat-5.0.template.json");
+        client().admin().indices().preparePutTemplate("metricbeat").setSource(metricBeat).get();
+        client().admin().indices().preparePutTemplate("packetbeat").setSource(packetBeat).get();
+        client().admin().indices().preparePutTemplate("filebeat").setSource(fileBeat).get();
+        client().admin().indices().preparePutTemplate("winlogbeat").setSource(winLogBeat).get();
+
+        client().prepareIndex("metricbeat-foo", "doc", "1").setSource("message", "foo").get();
+        client().prepareIndex("packetbeat-foo", "doc", "1").setSource("message", "foo").get();
+        client().prepareIndex("filebeat-foo", "doc", "1").setSource("message", "foo").get();
+        client().prepareIndex("winlogbeat-foo", "doc", "1").setSource("message", "foo").get();
+    }
+
+    public void testLogstashTemplatesBWC() throws Exception {
+        String ls5x = copyToStringFromClasspath("/org/elasticsearch/action/admin/indices/template/logstash-5.0.template.json");
+        client().admin().indices().preparePutTemplate("logstash-5x").setSource(ls5x).get();
+        client().prepareIndex("logstash-foo", "doc", "1").setSource("message", "foo").get();
+    }
+
+}

--- a/core/src/test/resources/org/elasticsearch/action/admin/indices/template/filebeat-5.0.template.json
+++ b/core/src/test/resources/org/elasticsearch/action/admin/indices/template/filebeat-5.0.template.json
@@ -1,0 +1,69 @@
+{
+  "mappings": {
+    "_default_": {
+      "_all": {
+        "norms": false
+      },
+      "_meta": {
+        "version": "5.0.0-beta1"
+      },
+      "dynamic_templates": [
+        {
+          "fields": {
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "fields.*"
+          }
+        }
+      ],
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "beat": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "input_type": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "message": {
+          "norms": false,
+          "type": "text"
+        },
+        "offset": {
+          "type": "long"
+        },
+        "source": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "tags": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "type": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "order": 0,
+  "settings": {
+    "index.refresh_interval": "5s"
+  },
+  "template": "filebeat-*"
+}

--- a/core/src/test/resources/org/elasticsearch/action/admin/indices/template/logstash-5.0.template.json
+++ b/core/src/test/resources/org/elasticsearch/action/admin/indices/template/logstash-5.0.template.json
@@ -1,0 +1,45 @@
+{
+  "template" : "logstash-*",
+  "settings" : {
+    "index.refresh_interval" : "5s"
+  },
+  "mappings" : {
+    "_default_" : {
+      "_all" : {"enabled" : true, "norms" : false},
+      "dynamic_templates" : [ {
+        "message_field" : {
+          "match" : "message",
+          "match_mapping_type" : "string",
+          "mapping" : {
+            "type" : "string", "index" : "analyzed", "norms" : false,
+            "fielddata" : { "format" : "disabled" }
+          }
+        }
+      }, {
+        "string_fields" : {
+          "match" : "*",
+          "match_mapping_type" : "string",
+          "mapping" : {
+            "type" : "text", "norms" : false,
+            "fields" : {
+              "keyword" : { "type": "keyword" }
+            }
+          }
+        }
+      } ],
+      "properties" : {
+        "@timestamp": { "type": "date", "include_in_all": false },
+        "@version": { "type": "keyword", "include_in_all": false },
+        "geoip"  : {
+          "dynamic": true,
+          "properties" : {
+            "ip": { "type": "ip" },
+            "location" : { "type" : "geo_point" },
+            "latitude" : { "type" : "half_float" },
+            "longitude" : { "type" : "half_float" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/org/elasticsearch/action/admin/indices/template/metricbeat-5.0.template.json
+++ b/core/src/test/resources/org/elasticsearch/action/admin/indices/template/metricbeat-5.0.template.json
@@ -1,0 +1,2658 @@
+{
+  "mappings": {
+    "_default_": {
+      "_all": {
+        "norms": false
+      },
+      "_meta": {
+        "version": "5.0.0-beta1"
+      },
+      "dynamic_templates": [
+        {
+          "fields": {
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "fields.*"
+          }
+        }
+      ],
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "apache": {
+          "properties": {
+            "status": {
+              "properties": {
+                "bytes_per_request": {
+                  "scaling_factor": 1000,
+                  "type": "scaled_float"
+                },
+                "bytes_per_sec": {
+                  "scaling_factor": 1000,
+                  "type": "scaled_float"
+                },
+                "connections": {
+                  "properties": {
+                    "async": {
+                      "properties": {
+                        "closing": {
+                          "type": "long"
+                        },
+                        "keep_alive": {
+                          "type": "long"
+                        },
+                        "writing": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "total": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "cpu": {
+                  "properties": {
+                    "children_system": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "children_user": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "load": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "system": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "user": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    }
+                  }
+                },
+                "hostname": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "load": {
+                  "properties": {
+                    "1": {
+                      "scaling_factor": 100,
+                      "type": "scaled_float"
+                    },
+                    "15": {
+                      "scaling_factor": 100,
+                      "type": "scaled_float"
+                    },
+                    "5": {
+                      "scaling_factor": 100,
+                      "type": "scaled_float"
+                    }
+                  }
+                },
+                "requests_per_sec": {
+                  "scaling_factor": 1000,
+                  "type": "scaled_float"
+                },
+                "scoreboard": {
+                  "properties": {
+                    "closing_connection": {
+                      "type": "long"
+                    },
+                    "dns_lookup": {
+                      "type": "long"
+                    },
+                    "gracefully_finishing": {
+                      "type": "long"
+                    },
+                    "idle_cleanup": {
+                      "type": "long"
+                    },
+                    "keepalive": {
+                      "type": "long"
+                    },
+                    "logging": {
+                      "type": "long"
+                    },
+                    "open_slot": {
+                      "type": "long"
+                    },
+                    "reading_request": {
+                      "type": "long"
+                    },
+                    "sending_reply": {
+                      "type": "long"
+                    },
+                    "starting_up": {
+                      "type": "long"
+                    },
+                    "total": {
+                      "type": "long"
+                    },
+                    "waiting_for_connection": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "total_accesses": {
+                  "type": "long"
+                },
+                "total_kbytes": {
+                  "type": "long"
+                },
+                "uptime": {
+                  "properties": {
+                    "server_uptime": {
+                      "type": "long"
+                    },
+                    "uptime": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "workers": {
+                  "properties": {
+                    "busy": {
+                      "type": "long"
+                    },
+                    "idle": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "beat": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "haproxy": {
+          "properties": {
+            "info": {
+              "properties": {
+                "compress": {
+                  "properties": {
+                    "bps": {
+                      "properties": {
+                        "in": {
+                          "type": "long"
+                        },
+                        "out": {
+                          "type": "long"
+                        },
+                        "rate_limit": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "conn": {
+                  "properties": {
+                    "rate": {
+                      "properties": {
+                        "limit": {
+                          "type": "long"
+                        },
+                        "value": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "cum": {
+                  "properties": {
+                    "conns": {
+                      "type": "long"
+                    },
+                    "req": {
+                      "type": "long"
+                    },
+                    "ssl_conns": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "curr": {
+                  "properties": {
+                    "conns": {
+                      "type": "long"
+                    },
+                    "ssl_conns": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "idle_pct": {
+                  "scaling_factor": 1000,
+                  "type": "scaled_float"
+                },
+                "max": {
+                  "properties": {
+                    "conn": {
+                      "properties": {
+                        "rate": {
+                          "type": "long"
+                        },
+                        "value": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "hard_conn": {
+                      "type": "long"
+                    },
+                    "pipes": {
+                      "type": "long"
+                    },
+                    "sess_rate": {
+                      "type": "long"
+                    },
+                    "sock": {
+                      "type": "long"
+                    },
+                    "ssl": {
+                      "properties": {
+                        "conns": {
+                          "type": "long"
+                        },
+                        "rate": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "zlib_mem_usage": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "mem_max_bytes": {
+                  "type": "long"
+                },
+                "nb_proc": {
+                  "type": "long"
+                },
+                "pid": {
+                  "type": "long"
+                },
+                "pipes": {
+                  "properties": {
+                    "free": {
+                      "type": "long"
+                    },
+                    "used": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "process_num": {
+                  "type": "long"
+                },
+                "run_queue": {
+                  "type": "long"
+                },
+                "sess": {
+                  "properties": {
+                    "rate": {
+                      "properties": {
+                        "limit": {
+                          "type": "long"
+                        },
+                        "value": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "ssl": {
+                  "properties": {
+                    "backend": {
+                      "properties": {
+                        "key_rate": {
+                          "type": "long"
+                        },
+                        "max_key_rate": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "cache_misses": {
+                      "type": "long"
+                    },
+                    "cached_lookups": {
+                      "type": "long"
+                    },
+                    "frontend": {
+                      "properties": {
+                        "key_rate": {
+                          "type": "long"
+                        },
+                        "max_key_rate": {
+                          "type": "long"
+                        },
+                        "session_reuse_pct": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "rate": {
+                      "properties": {
+                        "limit": {
+                          "type": "long"
+                        },
+                        "value": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "tasks": {
+                  "type": "long"
+                },
+                "ulimit_n": {
+                  "type": "long"
+                },
+                "uptime_sec": {
+                  "type": "long"
+                },
+                "zlib_mem_usage": {
+                  "type": "long"
+                }
+              }
+            },
+            "stat": {
+              "properties": {
+                "act": {
+                  "type": "long"
+                },
+                "bck": {
+                  "type": "long"
+                },
+                "bin": {
+                  "type": "long"
+                },
+                "bout": {
+                  "type": "long"
+                },
+                "check": {
+                  "properties": {
+                    "code": {
+                      "type": "long"
+                    },
+                    "duration": {
+                      "type": "long"
+                    },
+                    "status": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "chkdown": {
+                  "type": "long"
+                },
+                "chkfail": {
+                  "type": "long"
+                },
+                "cli_abrt": {
+                  "type": "long"
+                },
+                "comp": {
+                  "properties": {
+                    "byp": {
+                      "type": "long"
+                    },
+                    "in": {
+                      "type": "long"
+                    },
+                    "out": {
+                      "type": "long"
+                    },
+                    "rsp": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "component_type": {
+                  "type": "long"
+                },
+                "ctime": {
+                  "type": "long"
+                },
+                "downtime": {
+                  "type": "long"
+                },
+                "dreq": {
+                  "type": "long"
+                },
+                "dresp": {
+                  "type": "long"
+                },
+                "econ": {
+                  "type": "long"
+                },
+                "ereq": {
+                  "type": "long"
+                },
+                "eresp": {
+                  "type": "long"
+                },
+                "hanafail": {
+                  "type": "long"
+                },
+                "hrsp": {
+                  "properties": {
+                    "1xx": {
+                      "type": "long"
+                    },
+                    "2xx": {
+                      "type": "long"
+                    },
+                    "3xx": {
+                      "type": "long"
+                    },
+                    "4xx": {
+                      "type": "long"
+                    },
+                    "5xx": {
+                      "type": "long"
+                    },
+                    "other": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "iid": {
+                  "type": "long"
+                },
+                "last": {
+                  "properties": {
+                    "agt": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "chk": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sess": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "lastchg": {
+                  "type": "long"
+                },
+                "lbtot": {
+                  "type": "long"
+                },
+                "pid": {
+                  "type": "long"
+                },
+                "pxname": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "qcur": {
+                  "type": "long"
+                },
+                "qlimit": {
+                  "type": "long"
+                },
+                "qmax": {
+                  "type": "long"
+                },
+                "qtime": {
+                  "type": "long"
+                },
+                "rate": {
+                  "properties": {
+                    "lim": {
+                      "type": "long"
+                    },
+                    "max": {
+                      "type": "long"
+                    },
+                    "value": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "req": {
+                  "properties": {
+                    "rate": {
+                      "properties": {
+                        "max": {
+                          "type": "long"
+                        },
+                        "value": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "tot": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "rtime": {
+                  "type": "long"
+                },
+                "scur": {
+                  "type": "long"
+                },
+                "sid": {
+                  "type": "long"
+                },
+                "slim": {
+                  "type": "long"
+                },
+                "smax": {
+                  "type": "long"
+                },
+                "srv_abrt": {
+                  "type": "long"
+                },
+                "status": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "stot": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "svname": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "throttle": {
+                  "type": "long"
+                },
+                "tracked": {
+                  "type": "long"
+                },
+                "ttime": {
+                  "type": "long"
+                },
+                "weight": {
+                  "type": "long"
+                },
+                "wredis": {
+                  "type": "long"
+                },
+                "wretr": {
+                  "type": "long"
+                }
+              }
+            }
+          }
+        },
+        "metricset": {
+          "properties": {
+            "host": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "module": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "rtt": {
+              "type": "long"
+            }
+          }
+        },
+        "mongodb": {
+          "properties": {
+            "status": {
+              "properties": {
+                "asserts": {
+                  "properties": {
+                    "msg": {
+                      "type": "long"
+                    },
+                    "regular": {
+                      "type": "long"
+                    },
+                    "rollovers": {
+                      "type": "long"
+                    },
+                    "user": {
+                      "type": "long"
+                    },
+                    "warning": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "background_flushing": {
+                  "properties": {
+                    "average": {
+                      "properties": {
+                        "ms": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "flushes": {
+                      "type": "long"
+                    },
+                    "last": {
+                      "properties": {
+                        "ms": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "last_finished": {
+                      "type": "date"
+                    },
+                    "total": {
+                      "properties": {
+                        "ms": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "connections": {
+                  "properties": {
+                    "available": {
+                      "type": "long"
+                    },
+                    "current": {
+                      "type": "long"
+                    },
+                    "total_created": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "extra_info": {
+                  "properties": {
+                    "heap_usage": {
+                      "properties": {
+                        "bytes": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "page_faults": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "journaling": {
+                  "properties": {
+                    "commits": {
+                      "type": "long"
+                    },
+                    "commits_in_write_lock": {
+                      "type": "long"
+                    },
+                    "compression": {
+                      "type": "long"
+                    },
+                    "early_commits": {
+                      "type": "long"
+                    },
+                    "journaled": {
+                      "properties": {
+                        "mb": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "times": {
+                      "properties": {
+                        "commits": {
+                          "properties": {
+                            "ms": {
+                              "type": "long"
+                            }
+                          }
+                        },
+                        "commits_in_write_lock": {
+                          "properties": {
+                            "ms": {
+                              "type": "long"
+                            }
+                          }
+                        },
+                        "dt": {
+                          "properties": {
+                            "ms": {
+                              "type": "long"
+                            }
+                          }
+                        },
+                        "prep_log_buffer": {
+                          "properties": {
+                            "ms": {
+                              "type": "long"
+                            }
+                          }
+                        },
+                        "remap_private_view": {
+                          "properties": {
+                            "ms": {
+                              "type": "long"
+                            }
+                          }
+                        },
+                        "write_to_data_files": {
+                          "properties": {
+                            "ms": {
+                              "type": "long"
+                            }
+                          }
+                        },
+                        "write_to_journal": {
+                          "properties": {
+                            "ms": {
+                              "type": "long"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "write_to_data_files": {
+                      "properties": {
+                        "mb": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "local_time": {
+                  "type": "date"
+                },
+                "memory": {
+                  "properties": {
+                    "bits": {
+                      "type": "long"
+                    },
+                    "mapped": {
+                      "properties": {
+                        "mb": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "mapped_with_journal": {
+                      "properties": {
+                        "mb": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "resident": {
+                      "properties": {
+                        "mb": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "virtual": {
+                      "properties": {
+                        "mb": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "network": {
+                  "properties": {
+                    "in": {
+                      "properties": {
+                        "bytes": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "out": {
+                      "properties": {
+                        "bytes": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "requests": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "opcounters": {
+                  "properties": {
+                    "command": {
+                      "type": "long"
+                    },
+                    "delete": {
+                      "type": "long"
+                    },
+                    "getmore": {
+                      "type": "long"
+                    },
+                    "insert": {
+                      "type": "long"
+                    },
+                    "query": {
+                      "type": "long"
+                    },
+                    "update": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "opcounters_replicated": {
+                  "properties": {
+                    "command": {
+                      "type": "long"
+                    },
+                    "delete": {
+                      "type": "long"
+                    },
+                    "getmore": {
+                      "type": "long"
+                    },
+                    "insert": {
+                      "type": "long"
+                    },
+                    "query": {
+                      "type": "long"
+                    },
+                    "update": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "storage_engine": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "uptime": {
+                  "properties": {
+                    "ms": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "write_backs_queued": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "mysql": {
+          "properties": {
+            "status": {
+              "properties": {
+                "aborted": {
+                  "properties": {
+                    "clients": {
+                      "type": "long"
+                    },
+                    "connects": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "binlog": {
+                  "properties": {
+                    "cache": {
+                      "properties": {
+                        "disk_use": {
+                          "type": "long"
+                        },
+                        "use": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "bytes": {
+                  "properties": {
+                    "received": {
+                      "type": "long"
+                    },
+                    "sent": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "connections": {
+                  "type": "long"
+                },
+                "created": {
+                  "properties": {
+                    "tmp": {
+                      "properties": {
+                        "disk_tables": {
+                          "type": "long"
+                        },
+                        "files": {
+                          "type": "long"
+                        },
+                        "tables": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "delayed": {
+                  "properties": {
+                    "errors": {
+                      "type": "long"
+                    },
+                    "insert_threads": {
+                      "type": "long"
+                    },
+                    "writes": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "flush_commands": {
+                  "type": "long"
+                },
+                "max_used_connections": {
+                  "type": "long"
+                },
+                "open": {
+                  "properties": {
+                    "files": {
+                      "type": "long"
+                    },
+                    "streams": {
+                      "type": "long"
+                    },
+                    "tables": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "opened_tables": {
+                  "type": "long"
+                },
+                "threads": {
+                  "properties": {
+                    "cached": {
+                      "type": "long"
+                    },
+                    "connected": {
+                      "type": "long"
+                    },
+                    "created": {
+                      "type": "long"
+                    },
+                    "running": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "nginx": {
+          "properties": {
+            "stubstatus": {
+              "properties": {
+                "accepts": {
+                  "type": "long"
+                },
+                "active": {
+                  "type": "long"
+                },
+                "current": {
+                  "type": "long"
+                },
+                "dropped": {
+                  "type": "long"
+                },
+                "handled": {
+                  "type": "long"
+                },
+                "hostname": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reading": {
+                  "type": "long"
+                },
+                "requests": {
+                  "type": "long"
+                },
+                "waiting": {
+                  "type": "long"
+                },
+                "writing": {
+                  "type": "long"
+                }
+              }
+            }
+          }
+        },
+        "postgresql": {
+          "properties": {
+            "activity": {
+              "properties": {
+                "application_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "backend_start": {
+                  "type": "date"
+                },
+                "client": {
+                  "properties": {
+                    "address": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "hostname": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "port": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "database": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "oid": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "pid": {
+                  "type": "long"
+                },
+                "query": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "query_start": {
+                  "type": "date"
+                },
+                "state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "state_change": {
+                  "type": "date"
+                },
+                "transaction_start": {
+                  "type": "date"
+                },
+                "user": {
+                  "properties": {
+                    "id": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "waiting": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "bgwriter": {
+              "properties": {
+                "buffers": {
+                  "properties": {
+                    "allocated": {
+                      "type": "long"
+                    },
+                    "backend": {
+                      "type": "long"
+                    },
+                    "backend_fsync": {
+                      "type": "long"
+                    },
+                    "checkpoints": {
+                      "type": "long"
+                    },
+                    "clean": {
+                      "type": "long"
+                    },
+                    "clean_full": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "checkpoints": {
+                  "properties": {
+                    "requested": {
+                      "type": "long"
+                    },
+                    "scheduled": {
+                      "type": "long"
+                    },
+                    "times": {
+                      "properties": {
+                        "sync": {
+                          "properties": {
+                            "ms": {
+                              "type": "float"
+                            }
+                          }
+                        },
+                        "write": {
+                          "properties": {
+                            "ms": {
+                              "type": "float"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "stats_reset": {
+                  "type": "date"
+                }
+              }
+            },
+            "database": {
+              "properties": {
+                "blocks": {
+                  "properties": {
+                    "hit": {
+                      "type": "long"
+                    },
+                    "read": {
+                      "type": "long"
+                    },
+                    "time": {
+                      "properties": {
+                        "read": {
+                          "properties": {
+                            "ms": {
+                              "type": "long"
+                            }
+                          }
+                        },
+                        "write": {
+                          "properties": {
+                            "ms": {
+                              "type": "long"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "conflicts": {
+                  "type": "long"
+                },
+                "deadlocks": {
+                  "type": "long"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "number_of_backends": {
+                  "type": "long"
+                },
+                "oid": {
+                  "type": "long"
+                },
+                "rows": {
+                  "properties": {
+                    "deleted": {
+                      "type": "long"
+                    },
+                    "fetched": {
+                      "type": "long"
+                    },
+                    "inserted": {
+                      "type": "long"
+                    },
+                    "returned": {
+                      "type": "long"
+                    },
+                    "updated": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "stats_reset": {
+                  "type": "date"
+                },
+                "temporary": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "files": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "transactions": {
+                  "properties": {
+                    "commit": {
+                      "type": "long"
+                    },
+                    "rollback": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "redis": {
+          "properties": {
+            "info": {
+              "properties": {
+                "clients": {
+                  "properties": {
+                    "biggest_input_buf": {
+                      "type": "long"
+                    },
+                    "blocked": {
+                      "type": "long"
+                    },
+                    "connected": {
+                      "type": "long"
+                    },
+                    "longest_output_list": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "cluster": {
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "cpu": {
+                  "properties": {
+                    "used": {
+                      "properties": {
+                        "sys": {
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
+                        },
+                        "sys_children": {
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
+                        },
+                        "user": {
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
+                        },
+                        "user_children": {
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
+                        }
+                      }
+                    }
+                  }
+                },
+                "memory": {
+                  "properties": {
+                    "allocator": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "used": {
+                      "properties": {
+                        "lua": {
+                          "type": "long"
+                        },
+                        "peak": {
+                          "type": "long"
+                        },
+                        "rss": {
+                          "type": "long"
+                        },
+                        "value": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "persistence": {
+                  "properties": {
+                    "aof": {
+                      "properties": {
+                        "bgrewrite": {
+                          "properties": {
+                            "last_status": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "rewrite": {
+                          "properties": {
+                            "current_time": {
+                              "properties": {
+                                "sec": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "in_progress": {
+                              "type": "boolean"
+                            },
+                            "last_time": {
+                              "properties": {
+                                "sec": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "scheduled": {
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "write": {
+                          "properties": {
+                            "last_status": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "loading": {
+                      "type": "boolean"
+                    },
+                    "rdb": {
+                      "properties": {
+                        "bgsave": {
+                          "properties": {
+                            "current_time": {
+                              "properties": {
+                                "sec": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "in_progress": {
+                              "type": "boolean"
+                            },
+                            "last_status": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "last_time": {
+                              "properties": {
+                                "sec": {
+                                  "type": "long"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "last_save": {
+                          "properties": {
+                            "changes_since": {
+                              "type": "long"
+                            },
+                            "time": {
+                              "type": "long"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "replication": {
+                  "properties": {
+                    "backlog": {
+                      "properties": {
+                        "active": {
+                          "type": "long"
+                        },
+                        "first_byte_offset": {
+                          "type": "long"
+                        },
+                        "histlen": {
+                          "type": "long"
+                        },
+                        "size": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "connected_slaves": {
+                      "type": "long"
+                    },
+                    "master_offset": {
+                      "type": "long"
+                    },
+                    "role": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "server": {
+                  "properties": {
+                    "arch_bits": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "build_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "config_file": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "gcc_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "git_dirty": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "git_sha1": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "hz": {
+                      "type": "long"
+                    },
+                    "lru_clock": {
+                      "type": "long"
+                    },
+                    "mode": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "multiplexing_api": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "os": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "process_id": {
+                      "type": "long"
+                    },
+                    "run_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "tcp_port": {
+                      "type": "long"
+                    },
+                    "uptime": {
+                      "type": "long"
+                    },
+                    "version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "stats": {
+                  "properties": {
+                    "commands_processed": {
+                      "type": "long"
+                    },
+                    "connections": {
+                      "properties": {
+                        "received": {
+                          "type": "long"
+                        },
+                        "rejected": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "instantaneous": {
+                      "properties": {
+                        "input_kbps": {
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
+                        },
+                        "ops_per_sec": {
+                          "type": "long"
+                        },
+                        "output_kbps": {
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
+                        }
+                      }
+                    },
+                    "keys": {
+                      "properties": {
+                        "evicted": {
+                          "type": "long"
+                        },
+                        "expired": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "keyspace": {
+                      "properties": {
+                        "hits": {
+                          "type": "long"
+                        },
+                        "misses": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "latest_fork_usec": {
+                      "type": "long"
+                    },
+                    "migrate_cached_sockets": {
+                      "type": "long"
+                    },
+                    "net": {
+                      "properties": {
+                        "input": {
+                          "properties": {
+                            "bytes": {
+                              "type": "long"
+                            }
+                          }
+                        },
+                        "output": {
+                          "properties": {
+                            "bytes": {
+                              "type": "long"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "pubsub": {
+                      "properties": {
+                        "channels": {
+                          "type": "long"
+                        },
+                        "patterns": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "sync": {
+                      "properties": {
+                        "full": {
+                          "type": "long"
+                        },
+                        "partial": {
+                          "properties": {
+                            "err": {
+                              "type": "long"
+                            },
+                            "ok": {
+                              "type": "long"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "keyspace": {
+              "properties": {
+                "avg_ttl": {
+                  "type": "long"
+                },
+                "expires": {
+                  "type": "long"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "keys": {
+                  "type": "long"
+                }
+              }
+            }
+          }
+        },
+        "system": {
+          "properties": {
+            "core": {
+              "properties": {
+                "id": {
+                  "type": "long"
+                },
+                "idle": {
+                  "properties": {
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "ticks": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "iowait": {
+                  "properties": {
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "ticks": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "irq": {
+                  "properties": {
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "ticks": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "nice": {
+                  "properties": {
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "ticks": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "softirq": {
+                  "properties": {
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "ticks": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "steal": {
+                  "properties": {
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "ticks": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "system": {
+                  "properties": {
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "ticks": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "user": {
+                  "properties": {
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "ticks": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "cpu": {
+              "properties": {
+                "idle": {
+                  "properties": {
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "ticks": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "iowait": {
+                  "properties": {
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "ticks": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "irq": {
+                  "properties": {
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "ticks": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "nice": {
+                  "properties": {
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "ticks": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "softirq": {
+                  "properties": {
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "ticks": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "steal": {
+                  "properties": {
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "ticks": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "system": {
+                  "properties": {
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "ticks": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "user": {
+                  "properties": {
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    },
+                    "ticks": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "diskio": {
+              "properties": {
+                "io": {
+                  "properties": {
+                    "time": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "read": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "count": {
+                      "type": "long"
+                    },
+                    "time": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "serial_number": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "write": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "count": {
+                      "type": "long"
+                    },
+                    "time": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "filesystem": {
+              "properties": {
+                "available": {
+                  "type": "long"
+                },
+                "device_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "files": {
+                  "type": "long"
+                },
+                "free": {
+                  "type": "long"
+                },
+                "free_files": {
+                  "type": "long"
+                },
+                "mount_point": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "total": {
+                  "type": "long"
+                },
+                "used": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    }
+                  }
+                }
+              }
+            },
+            "fsstat": {
+              "properties": {
+                "count": {
+                  "type": "long"
+                },
+                "total_files": {
+                  "type": "long"
+                },
+                "total_size": {
+                  "properties": {
+                    "free": {
+                      "type": "long"
+                    },
+                    "total": {
+                      "type": "long"
+                    },
+                    "used": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "load": {
+              "properties": {
+                "1": {
+                  "scaling_factor": 100,
+                  "type": "scaled_float"
+                },
+                "15": {
+                  "scaling_factor": 100,
+                  "type": "scaled_float"
+                },
+                "5": {
+                  "scaling_factor": 100,
+                  "type": "scaled_float"
+                },
+                "norm": {
+                  "properties": {
+                    "1": {
+                      "scaling_factor": 100,
+                      "type": "scaled_float"
+                    },
+                    "15": {
+                      "scaling_factor": 100,
+                      "type": "scaled_float"
+                    },
+                    "5": {
+                      "scaling_factor": 100,
+                      "type": "scaled_float"
+                    }
+                  }
+                }
+              }
+            },
+            "memory": {
+              "properties": {
+                "actual": {
+                  "properties": {
+                    "free": {
+                      "type": "long"
+                    },
+                    "used": {
+                      "properties": {
+                        "bytes": {
+                          "type": "long"
+                        },
+                        "pct": {
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
+                        }
+                      }
+                    }
+                  }
+                },
+                "free": {
+                  "type": "long"
+                },
+                "swap": {
+                  "properties": {
+                    "free": {
+                      "type": "long"
+                    },
+                    "total": {
+                      "type": "long"
+                    },
+                    "used": {
+                      "properties": {
+                        "bytes": {
+                          "type": "long"
+                        },
+                        "pct": {
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
+                        }
+                      }
+                    }
+                  }
+                },
+                "total": {
+                  "type": "long"
+                },
+                "used": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "pct": {
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
+                    }
+                  }
+                }
+              }
+            },
+            "network": {
+              "properties": {
+                "in": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "dropped": {
+                      "type": "long"
+                    },
+                    "errors": {
+                      "type": "long"
+                    },
+                    "packets": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "out": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "dropped": {
+                      "type": "long"
+                    },
+                    "errors": {
+                      "type": "long"
+                    },
+                    "packets": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "process": {
+              "properties": {
+                "cgroup": {
+                  "properties": {
+                    "blkio": {
+                      "properties": {
+                        "id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "path": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "total": {
+                          "properties": {
+                            "bytes": {
+                              "type": "long"
+                            },
+                            "ios": {
+                              "type": "long"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "cpu": {
+                      "properties": {
+                        "cfs": {
+                          "properties": {
+                            "period": {
+                              "properties": {
+                                "us": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "quota": {
+                              "properties": {
+                                "us": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "shares": {
+                              "type": "long"
+                            }
+                          }
+                        },
+                        "id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "path": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "rt": {
+                          "properties": {
+                            "period": {
+                              "properties": {
+                                "us": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "runtime": {
+                              "properties": {
+                                "us": {
+                                  "type": "long"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "stats": {
+                          "properties": {
+                            "periods": {
+                              "type": "long"
+                            },
+                            "throttled": {
+                              "properties": {
+                                "ns": {
+                                  "type": "long"
+                                },
+                                "periods": {
+                                  "type": "long"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "cpuacct": {
+                      "properties": {
+                        "id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "path": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "stats": {
+                          "properties": {
+                            "system": {
+                              "properties": {
+                                "ns": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "user": {
+                              "properties": {
+                                "ns": {
+                                  "type": "long"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "total": {
+                          "properties": {
+                            "ns": {
+                              "type": "long"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "memory": {
+                      "properties": {
+                        "id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "kmem": {
+                          "properties": {
+                            "failures": {
+                              "type": "long"
+                            },
+                            "limit": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "usage": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                },
+                                "max": {
+                                  "properties": {
+                                    "bytes": {
+                                      "type": "long"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "kmem_tcp": {
+                          "properties": {
+                            "failures": {
+                              "type": "long"
+                            },
+                            "limit": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "usage": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                },
+                                "max": {
+                                  "properties": {
+                                    "bytes": {
+                                      "type": "long"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "mem": {
+                          "properties": {
+                            "failures": {
+                              "type": "long"
+                            },
+                            "limit": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "usage": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                },
+                                "max": {
+                                  "properties": {
+                                    "bytes": {
+                                      "type": "long"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "memsw": {
+                          "properties": {
+                            "failures": {
+                              "type": "long"
+                            },
+                            "limit": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "usage": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                },
+                                "max": {
+                                  "properties": {
+                                    "bytes": {
+                                      "type": "long"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "path": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "stats": {
+                          "properties": {
+                            "active_anon": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "active_file": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "cache": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "hierarchical_memory_limit": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "hierarchical_memsw_limit": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "inactive_anon": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "inactive_file": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "major_page_faults": {
+                              "type": "long"
+                            },
+                            "mapped_file": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "page_faults": {
+                              "type": "long"
+                            },
+                            "pages_in": {
+                              "type": "long"
+                            },
+                            "pages_out": {
+                              "type": "long"
+                            },
+                            "rss": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "rss_huge": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "swap": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "unevictable": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "path": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "cmdline": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "cpu": {
+                  "properties": {
+                    "start_time": {
+                      "type": "date"
+                    },
+                    "system": {
+                      "type": "long"
+                    },
+                    "total": {
+                      "properties": {
+                        "pct": {
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
+                        },
+                        "ticks": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "user": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "fd": {
+                  "properties": {
+                    "limit": {
+                      "properties": {
+                        "hard": {
+                          "type": "long"
+                        },
+                        "soft": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "open": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "memory": {
+                  "properties": {
+                    "rss": {
+                      "properties": {
+                        "bytes": {
+                          "type": "long"
+                        },
+                        "pct": {
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
+                        }
+                      }
+                    },
+                    "share": {
+                      "type": "long"
+                    },
+                    "size": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "pgid": {
+                  "type": "long"
+                },
+                "pid": {
+                  "type": "long"
+                },
+                "ppid": {
+                  "type": "long"
+                },
+                "state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "username": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "tags": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "type": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "zookeeper": {
+          "properties": {
+            "mntr": {
+              "properties": {
+                "approximate_data_size": {
+                  "type": "long"
+                },
+                "ephemerals_count": {
+                  "type": "long"
+                },
+                "followers": {
+                  "type": "long"
+                },
+                "hostname": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "latency": {
+                  "properties": {
+                    "avg": {
+                      "type": "long"
+                    },
+                    "max": {
+                      "type": "long"
+                    },
+                    "min": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "max_file_descriptor_count": {
+                  "type": "long"
+                },
+                "num_alive_connections": {
+                  "type": "long"
+                },
+                "open_file_descriptor_count": {
+                  "type": "long"
+                },
+                "outstanding_requests": {
+                  "type": "long"
+                },
+                "packets": {
+                  "properties": {
+                    "received": {
+                      "type": "long"
+                    },
+                    "sent": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "pending_syncs": {
+                  "type": "long"
+                },
+                "server_state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "synced_followers": {
+                  "type": "long"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "watch_count": {
+                  "type": "long"
+                },
+                "znode_count": {
+                  "type": "long"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "order": 0,
+  "settings": {
+    "index.refresh_interval": "5s"
+  },
+  "template": "metricbeat-*"
+}

--- a/core/src/test/resources/org/elasticsearch/action/admin/indices/template/packetbeat-5.0.template.json
+++ b/core/src/test/resources/org/elasticsearch/action/admin/indices/template/packetbeat-5.0.template.json
@@ -1,0 +1,1360 @@
+{
+  "mappings": {
+    "_default_": {
+      "_all": {
+        "norms": false
+      },
+      "_meta": {
+        "version": "5.0.0-beta1"
+      },
+      "dynamic_templates": [
+        {
+          "fields": {
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "fields.*"
+          }
+        },
+        {
+          "amqp.headers": {
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "amqp.headers.*"
+          }
+        },
+        {
+          "cassandra.response.supported": {
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "cassandra.response.supported.*"
+          }
+        },
+        {
+          "http.request.headers": {
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "http.request.headers.*"
+          }
+        },
+        {
+          "http.response.headers": {
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "http.response.headers.*"
+          }
+        }
+      ],
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "amqp": {
+          "properties": {
+            "app-id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "auto-delete": {
+              "type": "boolean"
+            },
+            "class-id": {
+              "type": "long"
+            },
+            "consumer-count": {
+              "type": "long"
+            },
+            "consumer-tag": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "content-encoding": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "content-type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "correlation-id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "delivery-mode": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "delivery-tag": {
+              "type": "long"
+            },
+            "durable": {
+              "type": "boolean"
+            },
+            "exchange": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "exchange-type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "exclusive": {
+              "type": "boolean"
+            },
+            "expiration": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "if-empty": {
+              "type": "boolean"
+            },
+            "if-unused": {
+              "type": "boolean"
+            },
+            "immediate": {
+              "type": "boolean"
+            },
+            "mandatory": {
+              "type": "boolean"
+            },
+            "message-count": {
+              "type": "long"
+            },
+            "message-id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "method-id": {
+              "type": "long"
+            },
+            "multiple": {
+              "type": "boolean"
+            },
+            "no-ack": {
+              "type": "boolean"
+            },
+            "no-local": {
+              "type": "boolean"
+            },
+            "no-wait": {
+              "type": "boolean"
+            },
+            "passive": {
+              "type": "boolean"
+            },
+            "priority": {
+              "type": "long"
+            },
+            "queue": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "redelivered": {
+              "type": "boolean"
+            },
+            "reply-code": {
+              "type": "long"
+            },
+            "reply-text": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "reply-to": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "routing-key": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "timestamp": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "user-id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "beat": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "bytes_in": {
+          "type": "long"
+        },
+        "bytes_out": {
+          "type": "long"
+        },
+        "cassandra": {
+          "properties": {
+            "request": {
+              "properties": {
+                "headers": {
+                  "properties": {
+                    "flags": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "length": {
+                      "type": "long"
+                    },
+                    "op": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "stream": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "version": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "query": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "response": {
+              "properties": {
+                "authentication": {
+                  "properties": {
+                    "class": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "error": {
+                  "properties": {
+                    "code": {
+                      "type": "long"
+                    },
+                    "details": {
+                      "properties": {
+                        "alive": {
+                          "type": "long"
+                        },
+                        "arg_types": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "blockfor": {
+                          "type": "long"
+                        },
+                        "data_present": {
+                          "type": "boolean"
+                        },
+                        "function": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "keyspace": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "num_failures": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "read_consistency": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "received": {
+                          "type": "long"
+                        },
+                        "required": {
+                          "type": "long"
+                        },
+                        "stmt_id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "table": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "write_type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "msg": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "event": {
+                  "properties": {
+                    "change": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "host": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "schema_change": {
+                      "properties": {
+                        "args": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "change": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "keyspace": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "object": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "table": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "target": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "headers": {
+                  "properties": {
+                    "flags": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "length": {
+                      "type": "long"
+                    },
+                    "op": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "stream": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "version": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "result": {
+                  "properties": {
+                    "keyspace": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "prepared": {
+                      "properties": {
+                        "prepared_id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "req_meta": {
+                          "properties": {
+                            "col_count": {
+                              "type": "long"
+                            },
+                            "flags": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "keyspace": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "paging_state": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "pkey_columns": {
+                              "type": "long"
+                            },
+                            "table": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "resp_meta": {
+                          "properties": {
+                            "col_count": {
+                              "type": "long"
+                            },
+                            "flags": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "keyspace": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "paging_state": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "pkey_columns": {
+                              "type": "long"
+                            },
+                            "table": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "rows": {
+                      "properties": {
+                        "meta": {
+                          "properties": {
+                            "col_count": {
+                              "type": "long"
+                            },
+                            "flags": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "keyspace": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "paging_state": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "pkey_columns": {
+                              "type": "long"
+                            },
+                            "table": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "num_rows": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "schema_change": {
+                      "properties": {
+                        "args": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "change": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "keyspace": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "object": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "table": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "target": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "warnings": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "client_ip": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "client_location": {
+          "type": "geo_point"
+        },
+        "client_port": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "client_proc": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "client_server": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "client_service": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "connection_id": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "connecttime": {
+          "type": "long"
+        },
+        "cpu_time": {
+          "type": "long"
+        },
+        "dest": {
+          "properties": {
+            "ip": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ip_location": {
+              "type": "geo_point"
+            },
+            "ipv6": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ipv6_location": {
+              "type": "geo_point"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "outer_ip": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "outer_ip_location": {
+              "type": "geo_point"
+            },
+            "outer_ipv6": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "outer_ipv6_location": {
+              "type": "geo_point"
+            },
+            "port": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "stats": {
+              "properties": {
+                "net_bytes_total": {
+                  "type": "long"
+                },
+                "net_packets_total": {
+                  "type": "long"
+                }
+              }
+            }
+          }
+        },
+        "direction": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "dns": {
+          "properties": {
+            "additionals": {
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "data": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ttl": {
+                  "type": "long"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "additionals_count": {
+              "type": "long"
+            },
+            "answers": {
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "data": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ttl": {
+                  "type": "long"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "answers_count": {
+              "type": "long"
+            },
+            "authorities": {
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "authorities_count": {
+              "type": "long"
+            },
+            "flags": {
+              "properties": {
+                "authentic_data": {
+                  "type": "boolean"
+                },
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "checking_disabled": {
+                  "type": "boolean"
+                },
+                "recursion_available": {
+                  "type": "boolean"
+                },
+                "recursion_desired": {
+                  "type": "boolean"
+                },
+                "truncated_response": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "id": {
+              "type": "long"
+            },
+            "op_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "opt": {
+              "properties": {
+                "do": {
+                  "type": "boolean"
+                },
+                "ext_rcode": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "udp_size": {
+                  "type": "long"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "question": {
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "etld_plus_one": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "response_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "dnstime": {
+          "type": "long"
+        },
+        "domloadtime": {
+          "type": "long"
+        },
+        "final": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "flow_id": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "http": {
+          "properties": {
+            "request": {
+              "properties": {
+                "body": {
+                  "norms": false,
+                  "type": "text"
+                },
+                "params": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "response": {
+              "properties": {
+                "body": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "phrase": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "icmp": {
+          "properties": {
+            "request": {
+              "properties": {
+                "code": {
+                  "type": "long"
+                },
+                "message": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "type": "long"
+                }
+              }
+            },
+            "response": {
+              "properties": {
+                "code": {
+                  "type": "long"
+                },
+                "message": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "type": "long"
+                }
+              }
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "icmp_id": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "ip": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "last_time": {
+          "type": "date"
+        },
+        "loadtime": {
+          "type": "long"
+        },
+        "memcache": {
+          "properties": {
+            "protocol_type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "request": {
+              "properties": {
+                "automove": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "bytes": {
+                  "type": "long"
+                },
+                "cas_unique": {
+                  "type": "long"
+                },
+                "command": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "count_values": {
+                  "type": "long"
+                },
+                "delta": {
+                  "type": "long"
+                },
+                "dest_class": {
+                  "type": "long"
+                },
+                "exptime": {
+                  "type": "long"
+                },
+                "flags": {
+                  "type": "long"
+                },
+                "initial": {
+                  "type": "long"
+                },
+                "line": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "noreply": {
+                  "type": "boolean"
+                },
+                "opaque": {
+                  "type": "long"
+                },
+                "opcode": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "opcode_value": {
+                  "type": "long"
+                },
+                "quiet": {
+                  "type": "boolean"
+                },
+                "raw_args": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sleep_us": {
+                  "type": "long"
+                },
+                "source_class": {
+                  "type": "long"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "vbucket": {
+                  "type": "long"
+                },
+                "verbosity": {
+                  "type": "long"
+                }
+              }
+            },
+            "response": {
+              "properties": {
+                "bytes": {
+                  "type": "long"
+                },
+                "cas_unique": {
+                  "type": "long"
+                },
+                "command": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "count_values": {
+                  "type": "long"
+                },
+                "error_msg": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "flags": {
+                  "type": "long"
+                },
+                "opaque": {
+                  "type": "long"
+                },
+                "opcode": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "opcode_value": {
+                  "type": "long"
+                },
+                "status": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "status_code": {
+                  "type": "long"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "value": {
+                  "type": "long"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "method": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "mongodb": {
+          "properties": {
+            "cursorId": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "error": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "fullCollectionName": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "numberReturned": {
+              "type": "long"
+            },
+            "numberToReturn": {
+              "type": "long"
+            },
+            "numberToSkip": {
+              "type": "long"
+            },
+            "query": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "returnFieldsSelector": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "selector": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "startingFrom": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "update": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "mysql": {
+          "properties": {
+            "affected_rows": {
+              "type": "long"
+            },
+            "error_code": {
+              "type": "long"
+            },
+            "error_message": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "insert_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "iserror": {
+              "type": "boolean"
+            },
+            "num_fields": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "num_rows": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "query": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "nfs": {
+          "properties": {
+            "minor_version": {
+              "type": "long"
+            },
+            "opcode": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "status": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "tag": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "type": "long"
+            }
+          }
+        },
+        "notes": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "outer_vlan": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "params": {
+          "norms": false,
+          "type": "text"
+        },
+        "path": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "pgsql": {
+          "properties": {
+            "error_code": {
+              "type": "long"
+            },
+            "error_message": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "error_severity": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "iserror": {
+              "type": "boolean"
+            },
+            "num_fields": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "num_rows": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "query": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "port": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "proc": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "query": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "real_ip": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "redis": {
+          "properties": {
+            "error": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "return_value": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "release": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "request": {
+          "norms": false,
+          "type": "text"
+        },
+        "resource": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "response": {
+          "norms": false,
+          "type": "text"
+        },
+        "responsetime": {
+          "type": "long"
+        },
+        "rpc": {
+          "properties": {
+            "auth_flavor": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "call_size": {
+              "type": "long"
+            },
+            "cred": {
+              "properties": {
+                "gid": {
+                  "type": "long"
+                },
+                "gids": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "machinename": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "stamp": {
+                  "type": "long"
+                },
+                "uid": {
+                  "type": "long"
+                }
+              }
+            },
+            "reply_size": {
+              "type": "long"
+            },
+            "status": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "time": {
+              "type": "long"
+            },
+            "time_str": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "xid": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "server": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "service": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "source": {
+          "properties": {
+            "ip": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ip_location": {
+              "type": "geo_point"
+            },
+            "ipv6": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ipv6_location": {
+              "type": "geo_point"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "outer_ip": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "outer_ip_location": {
+              "type": "geo_point"
+            },
+            "outer_ipv6": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "outer_ipv6_location": {
+              "type": "geo_point"
+            },
+            "port": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "stats": {
+              "properties": {
+                "net_bytes_total": {
+                  "type": "long"
+                },
+                "net_packets_total": {
+                  "type": "long"
+                }
+              }
+            }
+          }
+        },
+        "start_time": {
+          "type": "date"
+        },
+        "status": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "tags": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "thrift": {
+          "properties": {
+            "exceptions": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "params": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "return_value": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "service": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "transport": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "type": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "vlan": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "order": 0,
+  "settings": {
+    "index.refresh_interval": "5s"
+  },
+  "template": "packetbeat-*"
+}

--- a/core/src/test/resources/org/elasticsearch/action/admin/indices/template/winlogbeat-5.0.template.json
+++ b/core/src/test/resources/org/elasticsearch/action/admin/indices/template/winlogbeat-5.0.template.json
@@ -1,0 +1,162 @@
+{
+  "mappings": {
+    "_default_": {
+      "_all": {
+        "norms": false
+      },
+      "_meta": {
+        "version": "5.0.0-beta1"
+      },
+      "dynamic_templates": [
+        {
+          "fields": {
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "fields.*"
+          }
+        },
+        {
+          "event_data": {
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "event_data.*"
+          }
+        },
+        {
+          "user_data": {
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "user_data.*"
+          }
+        }
+      ],
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "activity_id": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "beat": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "computer_name": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "event_id": {
+          "type": "long"
+        },
+        "keywords": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "level": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "log_name": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "message": {
+          "norms": false,
+          "type": "text"
+        },
+        "message_error": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "opcode": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "process_id": {
+          "type": "long"
+        },
+        "provider_guid": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "record_number": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "related_activity_id": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "source_name": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "tags": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "task": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "thread_id": {
+          "type": "long"
+        },
+        "type": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "user": {
+          "properties": {
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "identifier": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "version": {
+          "type": "long"
+        },
+        "xml": {
+          "norms": false,
+          "type": "text"
+        }
+      }
+    }
+  },
+  "order": 0,
+  "settings": {
+    "index.refresh_interval": "5s"
+  },
+  "template": "winlogbeat-*"
+}


### PR DESCRIPTION
This tests that the templates shipped with 5.0 versions of Logstash and
Beats still work on an Elasticsearch 6.0+ node, so that we ensure that
ES can be upgraded prior to upgrading tools dependent on it.

Related to #20491
Resolves #17275
