### PR TITLE
[DOCS] Mark combinatorial explosion in aggs as 'done'

### DIFF
--- a/docs/resiliency/index.asciidoc
+++ b/docs/resiliency/index.asciidoc
@@ -112,7 +112,7 @@ exceptions, but it is still possible to cause a node to run out of heap
 space.  The following issues have been identified:
 
 * Set a hard limit on `from`/`size` parameters {GIT}9311[#9311]. (STATUS: DONE, v2.1.0)
-* Prevent combinatorial explosion in aggregations from causing OOM {GIT}8081[#8081]. (STATUS: ONGOING)
+* Prevent combinatorial explosion in aggregations from causing OOM {GIT}8081[#8081]. (STATUS: DONE, v5.0.0)
 * Add the byte size of each hit to the request circuit breaker {GIT}9310[#9310]. (STATUS: ONGOING)
 * Limit the size of individual requests and also add a circuit breaker for the total memory used by in-flight request objects {GIT}16011[#16011]. (STATUS: DONE, v5.0.0)
 


### PR DESCRIPTION
This marks the "Prevent combinatorial explosion in aggregations from
causing OOM" task as done in 5.0.0.

Relates to #8081 and #19394
