### PR TITLE
RankEval: Normalize rated document key parameter

### DIFF
--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedDocument.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedDocument.java
@@ -38,9 +38,9 @@ import java.util.Objects;
 public class RatedDocument extends ToXContentToBytes implements Writeable {
 
     public static final ParseField RATING_FIELD = new ParseField("rating");
-    public static final ParseField DOC_ID_FIELD = new ParseField("doc_id");
-    public static final ParseField TYPE_FIELD = new ParseField("type");
-    public static final ParseField INDEX_FIELD = new ParseField("index");
+    public static final ParseField DOC_ID_FIELD = new ParseField("_id");
+    public static final ParseField TYPE_FIELD = new ParseField("_type");
+    public static final ParseField INDEX_FIELD = new ParseField("_index");
 
     private static final ConstructingObjectParser<RatedDocument, ParseFieldMatcherSupplier> PARSER =
             new ConstructingObjectParser<>("rated_document",

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
@@ -127,9 +127,9 @@ public class RatedRequestsTests extends ESTestCase {
          + "           \"size\": 10\n"
          + "   },\n"
          + "   \"ratings\": [ "
-         + "        {\"index\": \"test\", \"type\": \"testtype\", \"doc_id\": \"1\", \"rating\" : 1 }, "
-         + "        {\"type\": \"testtype\", \"index\": \"test\", \"doc_id\": \"2\", \"rating\" : 0 }, "
-         + "        {\"doc_id\": \"3\", \"index\": \"test\", \"type\": \"testtype\", \"rating\" : 1 }]\n"
+         + "        {\"_index\": \"test\", \"_type\": \"testtype\", \"_id\": \"1\", \"rating\" : 1 }, "
+         + "        {\"_type\": \"testtype\", \"_index\": \"test\", \"_id\": \"2\", \"rating\" : 0 }, "
+         + "        {\"_id\": \"3\", \"_index\": \"test\", \"_type\": \"testtype\", \"rating\" : 1 }]\n"
          + "}";
         XContentParser parser = XContentFactory.xContent(querySpecString).createParser(querySpecString);
         QueryParseContext queryContext = new QueryParseContext(searchRequestParsers.queryParsers, parser, ParseFieldMatcher.STRICT);

--- a/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/10_basic.yaml
+++ b/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/10_basic.yaml
@@ -46,22 +46,22 @@
                 "id": "amsterdam_query",
                 "request": { "query": { "match" : {"text" : "amsterdam" }}},
                 "ratings": [
-                    {"index": "foo", "type": "bar", "doc_id": "doc1", "rating": 0},
-                    {"index": "foo", "type": "bar", "doc_id": "doc2", "rating": 1},
-                    {"index": "foo", "type": "bar", "doc_id": "doc3", "rating": 1}]
+                    {"_index": "foo", "_type": "bar", "_id": "doc1", "rating": 0},
+                    {"_index": "foo", "_type": "bar", "_id": "doc2", "rating": 1},
+                    {"_index": "foo", "_type": "bar", "_id": "doc3", "rating": 1}]
             },
             {
                 "id" : "berlin_query",
                 "request": { "query": { "match" : { "text" : "berlin" } }, "size" : 10 },
-                "ratings": [{"index": "foo", "type": "bar", "doc_id": "doc1", "rating": 1}]
+                "ratings": [{"_index": "foo", "_type": "bar", "_id": "doc1", "rating": 1}]
             }
           ],
           "metric" : { "precisionatn": { "size": 10}}
         }
 
   - match: {rank_eval.quality_level: 1}
-  - match: {rank_eval.unknown_docs.amsterdam_query:  [ {"index": "foo", "type": "bar", "doc_id": "doc4"}]}
-  - match: {rank_eval.unknown_docs.berlin_query:  [ {"index": "foo", "type": "bar", "doc_id": "doc4"}]}
+  - match: {rank_eval.unknown_docs.amsterdam_query:  [ {"_index": "foo", "_type": "bar", "_id": "doc4"}]}
+  - match: {rank_eval.unknown_docs.berlin_query:  [ {"_index": "foo", "_type": "bar", "_id": "doc4"}]}
 ---
 "Reciprocal Rank":
 
@@ -111,13 +111,13 @@
                 "id": "amsterdam_query",
                 "request": { "query": { "match" : {"text" : "amsterdam" }}},
                 # doc4 should be returned in third position, so reciprocal rank is 1/3
-                "ratings": [{"index": "foo", "type": "bar", "doc_id": "doc4", "rating": 1}]
+                "ratings": [{"_index": "foo", "_type": "bar", "_id": "doc4", "rating": 1}]
             },
             {
                 "id" : "berlin_query",
                 "request": { "query": { "match" : { "text" : "berlin" } }, "size" : 10 },
                 # doc1 should be returned in first position, doc3 in second, so reciprocal rank is 1/2 
-                "ratings": [{"index": "foo", "type": "bar", "doc_id": "doc4", "rating": 1}]
+                "ratings": [{"_index": "foo", "_type": "bar", "_id": "doc4", "rating": 1}]
             }
           ],
           "metric" : { "reciprocal_rank": {} }
@@ -134,13 +134,13 @@
               "id": "amsterdam_query",
               "request": { "query": { "match" : {"text" : "amsterdam" }}},
               # doc4 should be returned in third position, so reciprocal rank is 1/3
-              "ratings": [{"index": "foo", "type": "bar", "doc_id": "doc4", "rating": 1}]
+              "ratings": [{"_index": "foo", "_type": "bar", "_id": "doc4", "rating": 1}]
           },
           {
               "id" : "berlin_query",
               "request": { "query": { "match" : { "text" : "berlin" } }, "size" : 10 },
               # doc1 should be returned in first position, doc3 in second, so reciprocal rank is 1/2 
-              "ratings": [{"index": "foo", "type": "bar", "doc_id": "doc4", "rating": 1}]
+              "ratings": [{"_index": "foo", "_type": "bar", "_id": "doc4", "rating": 1}]
           }
         ],
         "metric" : { 

--- a/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/20_dcg.yaml
+++ b/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/20_dcg.yaml
@@ -52,12 +52,12 @@
                 "id": "dcg_query",
                 "request": { "query": { "match_all" : {}}, "sort" : [ "bar" ] },
                 "ratings": [
-                    {"index": "foo", "type": "bar", "doc_id": "doc1", "rating": 3},
-                    {"index": "foo", "type": "bar", "doc_id": "doc2", "rating": 2},
-                    {"index": "foo", "type": "bar", "doc_id": "doc3", "rating": 3},
-                    {"index": "foo", "type": "bar", "doc_id": "doc4", "rating": 0},
-                    {"index": "foo", "type": "bar", "doc_id": "doc5", "rating": 1},
-                    {"index": "foo", "type": "bar", "doc_id": "doc6", "rating": 2}]
+                    {"_index" : "foo", "_type" : "bar", "_id" : "doc1", "rating": 3},
+                    {"_index" : "foo", "_type" : "bar", "_id" : "doc2", "rating": 2},
+                    {"_index" : "foo", "_type" : "bar", "_id" : "doc3", "rating": 3},
+                    {"_index" : "foo", "_type" : "bar", "_id" : "doc4", "rating": 0},
+                    {"_index" : "foo", "_type" : "bar", "_id" : "doc5", "rating": 1},
+                    {"_index" : "foo", "_type" : "bar", "_id" : "doc6", "rating": 2}]
             }
           ],
           "metric" : { "dcg_at_n": { "size": 6}}
@@ -75,12 +75,12 @@
                 "id": "dcg_query_reverse",
                 "request": { "query": { "match_all" : {}}, "sort" : [ {"bar" : "desc" }] },
                 "ratings": [
-                    {"index": "foo", "type": "bar", "doc_id": "doc1", "rating": 3},
-                    {"index": "foo", "type": "bar", "doc_id": "doc2", "rating": 2},
-                    {"index": "foo", "type": "bar", "doc_id": "doc3", "rating": 3},
-                    {"index": "foo", "type": "bar", "doc_id": "doc4", "rating": 0},
-                    {"index": "foo", "type": "bar", "doc_id": "doc5", "rating": 1},
-                    {"index": "foo", "type": "bar", "doc_id": "doc6", "rating": 2}]
+                    {"_index" : "foo", "_type" : "bar", "_id" : "doc1", "rating": 3},
+                    {"_index" : "foo", "_type" : "bar", "_id" : "doc2", "rating": 2},
+                    {"_index" : "foo", "_type" : "bar", "_id" : "doc3", "rating": 3},
+                    {"_index" : "foo", "_type" : "bar", "_id" : "doc4", "rating": 0},
+                    {"_index" : "foo", "_type" : "bar", "_id" : "doc5", "rating": 1},
+                    {"_index" : "foo", "_type" : "bar", "_id" : "doc6", "rating": 2}]
             }, 
           ],
           "metric" : { "dcg_at_n": { "size": 6}}
@@ -98,23 +98,23 @@
               "id": "dcg_query",
               "request": { "query": { "match_all" : {}}, "sort" : [ "bar" ] },
               "ratings": [
-                {"index": "foo", "type": "bar", "doc_id": "doc1", "rating": 3},
-                {"index": "foo", "type": "bar", "doc_id": "doc2", "rating": 2},
-                {"index": "foo", "type": "bar", "doc_id": "doc3", "rating": 3},
-                {"index": "foo", "type": "bar", "doc_id": "doc4", "rating": 0},
-                {"index": "foo", "type": "bar", "doc_id": "doc5", "rating": 1},
-                {"index": "foo", "type": "bar", "doc_id": "doc6", "rating": 2}]
+                {"_index" : "foo", "_type" : "bar", "_id" : "doc1", "rating": 3},
+                {"_index" : "foo", "_type" : "bar", "_id" : "doc2", "rating": 2},
+                {"_index" : "foo", "_type" : "bar", "_id" : "doc3", "rating": 3},
+                {"_index" : "foo", "_type" : "bar", "_id" : "doc4", "rating": 0},
+                {"_index" : "foo", "_type" : "bar", "_id" : "doc5", "rating": 1},
+                {"_index" : "foo", "_type" : "bar", "_id" : "doc6", "rating": 2}]
           },
           {
               "id": "dcg_query_reverse",
               "request": { "query": { "match_all" : {}}, "sort" : [ {"bar" : "desc" }] },
               "ratings": [
-                {"index": "foo", "type": "bar", "doc_id": "doc1", "rating": 3},
-                {"index": "foo", "type": "bar", "doc_id": "doc2", "rating": 2},
-                {"index": "foo", "type": "bar", "doc_id": "doc3", "rating": 3},
-                {"index": "foo", "type": "bar", "doc_id": "doc4", "rating": 0},
-                {"index": "foo", "type": "bar", "doc_id": "doc5", "rating": 1},
-                {"index": "foo", "type": "bar", "doc_id": "doc6", "rating": 2}]
+                {"_index" : "foo", "_type" : "bar", "_id" : "doc1", "rating": 3},
+                {"_index" : "foo", "_type" : "bar", "_id" : "doc2", "rating": 2},
+                {"_index" : "foo", "_type" : "bar", "_id" : "doc3", "rating": 3},
+                {"_index" : "foo", "_type" : "bar", "_id" : "doc4", "rating": 0},
+                {"_index" : "foo", "_type" : "bar", "_id" : "doc5", "rating": 1},
+                {"_index" : "foo", "_type" : "bar", "_id" : "doc6", "rating": 2}]
           }, 
         ],
         "metric" : { "dcg_at_n": { "size": 6}}


### PR DESCRIPTION
To be consitent with the output of the search API, we should use the same field names for specifying the document ("_index", "_type", "_id") when providing the rated documents in the `rank_eval` request.
