### PR TITLE
Fix Windows GC options

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -51,15 +51,16 @@ set JAVA_OPTS=%JAVA_OPTS% -Djava.net.preferIPv4Stack=true
 )
 
 REM Add gc options. ES_GC_OPTS is unsupported, for internal testing
+SETLOCAL EnableDelayedExpansion
 if "%ES_GC_OPTS%" == "" (
-set ES_GC_OPTS=%ES_GC_OPTS% -XX:+UseParNewGC
-set ES_GC_OPTS=%ES_GC_OPTS% -XX:+UseConcMarkSweepGC
-set ES_GC_OPTS=%ES_GC_OPTS% -XX:CMSInitiatingOccupancyFraction=75
-set ES_GC_OPTS=%ES_GC_OPTS% -XX:+UseCMSInitiatingOccupancyOnly
+set ES_GC_OPTS=!ES_GC_OPTS! -XX:+UseParNewGC
+set ES_GC_OPTS=!ES_GC_OPTS! -XX:+UseConcMarkSweepGC
+set ES_GC_OPTS=!ES_GC_OPTS! -XX:CMSInitiatingOccupancyFraction=75
+set ES_GC_OPTS=!ES_GC_OPTS! -XX:+UseCMSInitiatingOccupancyOnly
 REM When running under Java 7
-REM JAVA_OPTS=%JAVA_OPTS% -XX:+UseCondCardMark
+REM JAVA_OPTS=!JAVA_OPTS! -XX:+UseCondCardMark
 )
-set JAVA_OPTS=%JAVA_OPTS%%ES_GC_OPTS%
+ENDLOCAL & set JAVA_OPTS=%JAVA_OPTS%%ES_GC_OPTS%
 
 if "%ES_GC_LOG_FILE%" == "" goto nogclog
 


### PR DESCRIPTION
Today on Windows we attempt to set the GC options inside an if-block if
the environment variable ES_GC_OPTS is not set, as is the
default. Unfortunately, Windows command prompt expands variables when
commands are parsed, not when they are run. For an if-block, the entire
command is parsed before it is run. In this case, it means that
ES_GC_OPTS is "" for the life of the if-block, and so we are repeatedly
setting ES_GC_OPTS to "" and then some option that we intended to be
appending. Thus, when the if-block exists, ES_GC_OPTS is only set to
-XX:+UseCMSInitiatingOccupancyOnly. In particular, it means that the CMS
collector is never enabled and Windows users are sent to serial GC
purgatory. This commit fixes this bug by enabling delayed expansion
around the bad if-block.

Relates #20558
