### PR TITLE
Update description for requests_per_second

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_rethrottle.json
@@ -15,7 +15,7 @@
         "requests_per_second": {
           "type": "number",
           "required": true,
-          "description": "The throttle to set on this request in sub-requests per second. 0 means set no throttle. As does \"unlimited\". Otherwise it must be a float."
+          "description": "The throttle to set on this request in sub-requests per second. \"unlimited\" means set no throttle, otherwise it must be a float greater than 0."
         }
       }
     },


### PR DESCRIPTION
- Remove the mention of using 0 to represent no throttle
- Specify that the float must be greater than 0.

See #20625
