### PR TITLE
Don't fail replica if FlushNotAllowedEngineException is thrown

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportShardFlushAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportShardFlushAction.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.flush;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionWriteResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
@@ -31,6 +32,7 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.engine.FlushNotAllowedEngineException;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -90,5 +92,16 @@ public class TransportShardFlushAction extends TransportReplicationAction<ShardF
     @Override
     protected boolean shouldExecuteReplication(Settings settings) {
         return true;
+    }
+
+    @Override
+    protected boolean ignoreReplicaException(Throwable e) {
+        // if we are running flush ith wait_if_ongoing=false (default) we might get a FlushNotAllowedEngineException from the
+        // replica that is a signal that there is another flush ongoing and we stepped out. This behavior has changed in 5.x
+        // where we don't throw an exception anymore. In such a case we ignore the exception an do NOT fail the replica.
+        if (ExceptionsHelper.unwrapCause(e).getClass() == FlushNotAllowedEngineException.class) {
+            return true;
+        }
+        return super.ignoreReplicaException(e);
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportShardFlushAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportShardFlushAction.java
@@ -95,13 +95,13 @@ public class TransportShardFlushAction extends TransportReplicationAction<ShardF
     }
 
     @Override
-    protected boolean ignoreReplicaException(Throwable e) {
+    protected boolean mustFailReplica(Throwable e) {
         // if we are running flush ith wait_if_ongoing=false (default) we might get a FlushNotAllowedEngineException from the
         // replica that is a signal that there is another flush ongoing and we stepped out. This behavior has changed in 5.x
         // where we don't throw an exception anymore. In such a case we ignore the exception an do NOT fail the replica.
         if (ExceptionsHelper.unwrapCause(e).getClass() == FlushNotAllowedEngineException.class) {
-            return true;
+            return false;
         }
-        return super.ignoreReplicaException(e);
+        return super.mustFailReplica(e);
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -205,6 +205,14 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
         return false;
     }
 
+    /**
+     * Returns <code>true</code> iff the replica must be failed if it threw the given exception.
+     * This defaults to the inverse of {@link #ignoreReplicaException(Throwable)}
+     */
+    protected boolean mustFailReplica(Throwable e) {
+        return ignoreReplicaException(e) == false;
+    }
+
     protected boolean isConflictException(Throwable e) {
         Throwable cause = ExceptionsHelper.unwrapCause(e);
         // on version conflict or document missing, it means
@@ -360,7 +368,7 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
             String index = request.shardId().getIndex();
             int shardId = request.shardId().id();
             logger.trace("failure on replica [{}][{}], action [{}], request [{}]", t, index, shardId, actionName, request);
-            if (ignoreReplicaException(t) == false) {
+            if (mustFailReplica(t)) {
                 IndexService indexService = indicesService.indexService(index);
                 if (indexService == null) {
                     logger.debug("ignoring failed replica [{}][{}] because index was already removed.", index, shardId);

--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -935,7 +935,7 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
                     public void handleException(TransportException exp) {
                         onReplicaFailure(nodeId, exp);
                         logger.trace("[{}] transport failure during replica request [{}], action [{}]", exp, node, replicaRequest, transportReplicaAction);
-                        if (ignoreReplicaException(exp) == false) {
+                        if (mustFailReplica(exp)) {
                             logger.warn("{} failed to perform {} on node {}", exp, shardId, transportReplicaAction, node);
                             shardStateAction.shardFailed(shard, indexUUID, "failed to perform " + actionName + " on replica on node " + node, exp);
                         }

--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -369,6 +369,7 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
             int shardId = request.shardId().id();
             logger.trace("failure on replica [{}][{}], action [{}], request [{}]", t, index, shardId, actionName, request);
             if (mustFailReplica(t)) {
+                assert ignoreReplicaException(t) == false;
                 IndexService indexService = indicesService.indexService(index);
                 if (indexService == null) {
                     logger.debug("ignoring failed replica [{}][{}] because index was already removed.", index, shardId);
@@ -936,6 +937,7 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
                         onReplicaFailure(nodeId, exp);
                         logger.trace("[{}] transport failure during replica request [{}], action [{}]", exp, node, replicaRequest, transportReplicaAction);
                         if (mustFailReplica(exp)) {
+                            assert ignoreReplicaException(exp) == false;
                             logger.warn("{} failed to perform {} on node {}", exp, shardId, transportReplicaAction, node);
                             shardStateAction.shardFailed(shard, indexUUID, "failed to perform " + actionName + " on replica on node " + node, exp);
                         }


### PR DESCRIPTION
This is a issue in all 2.x releases that if we run into a FlushNotAllowedEngineException
on a replica (ie. a flush is already running) we fail the replica. We should just ignore this
exception and not fail the shard.

Note: this is against 2.x only. Master changed in #20597
Relates to #20569
