### PR TITLE
Separates decision making from decision application in BalancedShardsAllocator 

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
@@ -127,7 +127,7 @@ public class TransportClusterAllocationExplainAction
     }
 
     /**
-     * Construct a {@code NodeExplanation} object for the given shard given all the metadata. This also attempts to construct the human
+     * Construct a {@code WeightedDecision} object for the given shard given all the metadata. This also attempts to construct the human
      * readable FinalDecision and final explanation as part of the explanation.
      */
     public static NodeExplanation calculateNodeExplanation(ShardRouting shard,

--- a/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -185,15 +185,15 @@ public final class UnassignedInfo implements ToXContent, Writeable {
             }
         }
 
-        public static AllocationStatus fromDecision(Decision decision) {
+        public static AllocationStatus fromDecision(Decision.Type decision) {
             Objects.requireNonNull(decision);
-            switch (decision.type()) {
+            switch (decision) {
                 case NO:
                     return DECIDERS_NO;
                 case THROTTLE:
                     return DECIDERS_THROTTLED;
                 default:
-                    throw new IllegalArgumentException("no allocation attempt from decision[" + decision.type() + "]");
+                    throw new IllegalArgumentException("no allocation attempt from decision[" + decision + "]");
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardAllocationDecision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardAllocationDecision.java
@@ -67,7 +67,7 @@ public class ShardAllocationDecision {
     @Nullable
     private final String allocationId;
     @Nullable
-    private final Map<String, WeightedDecision> nodeExplanations;
+    private final Map<String, WeightedDecision> nodeDecisions;
     @Nullable
     private final Decision shardDecision;
 
@@ -76,7 +76,7 @@ public class ShardAllocationDecision {
                                     String finalExplanation,
                                     String assignedNodeId,
                                     String allocationId,
-                                    Map<String, WeightedDecision> nodeExplanations,
+                                    Map<String, WeightedDecision> nodeDecisions,
                                     Decision shardDecision) {
         assert assignedNodeId != null || finalDecision == null || finalDecision != Type.YES :
             "a yes decision must have a node to assign the shard to";
@@ -89,7 +89,7 @@ public class ShardAllocationDecision {
         this.finalExplanation = finalExplanation;
         this.assignedNodeId = assignedNodeId;
         this.allocationId = allocationId;
-        this.nodeExplanations = nodeExplanations != null ? Collections.unmodifiableMap(nodeExplanations) : null;
+        this.nodeDecisions = nodeDecisions != null ? Collections.unmodifiableMap(nodeDecisions) : null;
         this.shardDecision = shardDecision;
     }
 
@@ -153,7 +153,7 @@ public class ShardAllocationDecision {
      * Creates a {@link ShardAllocationDecision} from the given {@link Decision} and the assigned node, if any.
      */
     public static ShardAllocationDecision fromDecision(Decision decision, @Nullable String assignedNodeId, boolean explain,
-                                                       @Nullable Map<String, WeightedDecision> nodeExplanations) {
+                                                       @Nullable Map<String, WeightedDecision> nodeDecisions) {
         final Type decisionType = decision.type();
         AllocationStatus allocationStatus = decisionType != Type.YES ? AllocationStatus.fromDecision(decisionType) : null;
         String explanation = null;
@@ -168,7 +168,7 @@ public class ShardAllocationDecision {
                 explanation = "shard cannot be assigned to any node in the cluster";
             }
         }
-        return new ShardAllocationDecision(decisionType, allocationStatus, explanation, assignedNodeId, null, nodeExplanations, null);
+        return new ShardAllocationDecision(decisionType, allocationStatus, explanation, assignedNodeId, null, nodeDecisions, null);
     }
 
     private static ShardAllocationDecision getCachedDecision(AllocationStatus allocationStatus) {
@@ -254,13 +254,13 @@ public class ShardAllocationDecision {
     }
 
     /**
-     * Gets the individual node-level explanations that went into making the final decision as represented by
+     * Gets the individual node-level decisions that went into making the final decision as represented by
      * {@link #getFinalDecisionType()}.  The map that is returned has the node id as the key and a {@link Decision}
      * as the decision for the given node.
      */
     @Nullable
     public Map<String, WeightedDecision> getNodeDecisions() {
-        return nodeExplanations;
+        return nodeDecisions;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardAllocationDecision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardAllocationDecision.java
@@ -155,10 +155,7 @@ public class ShardAllocationDecision {
     public static ShardAllocationDecision fromDecision(Decision decision, @Nullable String assignedNodeId, @Nullable String explanation,
                                                        @Nullable Map<String, NodeExplanation> nodeExplanations) {
         final Type decisionType = decision.type();
-        AllocationStatus allocationStatus = null;
-        if (decisionType != Type.YES) {
-            allocationStatus = AllocationStatus.fromDecision(decisionType);
-        }
+        AllocationStatus allocationStatus = decisionType != Type.YES ? AllocationStatus.fromDecision(decisionType) : null;
         return new ShardAllocationDecision(decisionType, allocationStatus, explanation, assignedNodeId, null, nodeExplanations, null);
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -767,9 +767,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
              * iteration order is different for each run and makes testing hard */
             Map<String, WeightedDecision> nodeExplanationMap = explain ? new HashMap<>() : null;
             for (ModelNode node : nodes.values()) {
-                if ((throttledNodes.contains(node) // node is throttled OR
-                        || node.containsShard(shard)) // node already contains a copy of the shard
-                       && explain == false) { // not in explain mode
+                if ((throttledNodes.contains(node) || node.containsShard(shard)) && explain == false) {
                     // decision is NO without needing to check anything further, so short circuit
                     continue;
                 }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -1234,7 +1234,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
                 // the final decision is NO (no node to move the shard to) and we are not in explain mode, return a cached version
                 return CACHED_CANNOT_MOVE_DECISION;
             } else {
-                assert ((assignedNodeId == null) == (finalDecision == Type.NO));
+                assert ((assignedNodeId == null) == (finalDecision != Type.YES));
                 return new MoveDecision(canRemainDecision, finalDecision, finalExplanation, assignedNodeId, nodeDecisions);
             }
         }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
@@ -138,6 +138,20 @@ public abstract class Decision implements ToXContent {
                     throw new IllegalArgumentException("Invalid Type [" + type + "]");
             }
         }
+
+        public boolean higherThan(Type other) {
+            if (other == null) {
+                return true;
+            } else if (this == NO) {
+                return false;
+            } else if (other == NO) {
+                return true;
+            } else if (other == THROTTLE && this == YES) {
+                return true;
+            }
+            return false;
+        }
+
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
@@ -140,9 +140,7 @@ public abstract class Decision implements ToXContent {
         }
 
         public boolean higherThan(Type other) {
-            if (other == null) {
-                return true;
-            } else if (this == NO) {
+            if (this == NO) {
                 return false;
             } else if (other == NO) {
                 return true;

--- a/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -153,7 +153,7 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
         Tuple<Decision, Map<String, Decision>> allocateDecision = canBeAllocatedToAtLeastOneNode(unassignedShard, allocation, explain);
         if (allocateDecision.v1().type() != Decision.Type.YES) {
             logger.trace("{}: ignoring allocation, can't be allocated on any node", unassignedShard);
-            return ShardAllocationDecision.no(UnassignedInfo.AllocationStatus.fromDecision(allocateDecision.v1()),
+            return ShardAllocationDecision.no(UnassignedInfo.AllocationStatus.fromDecision(allocateDecision.v1().type()),
                 explain ? "all nodes returned a " + allocateDecision.v1().type() + " decision for allocating the replica shard" : null,
                 allocateDecision.v2());
         }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/MoveDecisionTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/MoveDecisionTests.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.cluster.routing.allocation.ShardAllocationDecision.WeightedDecision;
+import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.MoveDecision;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Unit tests for the {@link MoveDecision} class.
+ */
+public class MoveDecisionTests extends ESTestCase {
+
+    public void testCachedDecisions() {
+        // cached stay decision
+        MoveDecision stay1 = MoveDecision.stay(Decision.YES, false);
+        MoveDecision stay2 = MoveDecision.stay(Decision.YES, false);
+        assertSame(stay1, stay2); // not in explain mode, so should use cached decision
+        stay1 = MoveDecision.stay(Decision.YES, true);
+        stay2 = MoveDecision.stay(Decision.YES, true);
+        assertNotSame(stay1, stay2);
+
+        // cached cannot move decision
+        stay1 = MoveDecision.decision(Decision.NO, Type.NO, false, null, null, null);
+        stay2 = MoveDecision.decision(Decision.NO, Type.NO, false, null, null, null);
+        assertSame(stay1, stay2);
+        // final decision is YES, so shouldn't use cached decision
+        stay1 = MoveDecision.decision(Decision.NO, Type.YES, false, null, "node1", null);
+        stay2 = MoveDecision.decision(Decision.NO, Type.YES, false, null, "node1", null);
+        assertNotSame(stay1, stay2);
+        assertEquals(stay1.getAssignedNodeId(), stay2.getAssignedNodeId());
+        // final decision is NO, but in explain mode, so shouldn't use cached decision
+        stay1 = MoveDecision.decision(Decision.NO, Type.NO, true, "node1", null, null);
+        stay2 = MoveDecision.decision(Decision.NO, Type.NO, true, "node1", null, null);
+        assertNotSame(stay1, stay2);
+        assertSame(stay1.getFinalDecisionType(), stay2.getFinalDecisionType());
+        assertNotNull(stay1.getFinalExplanation());
+        assertEquals(stay1.getFinalExplanation(), stay2.getFinalExplanation());
+    }
+
+    public void testStayDecision() {
+        MoveDecision stay = MoveDecision.stay(Decision.YES, true);
+        assertFalse(stay.cannotRemain());
+        assertFalse(stay.move());
+        assertTrue(stay.isDecisionTaken());
+        assertNull(stay.getNodeDecisions());
+        assertNotNull(stay.getFinalExplanation());
+        assertEquals(Type.NO, stay.getFinalDecisionType());
+
+        stay = MoveDecision.stay(Decision.YES, false);
+        assertFalse(stay.cannotRemain());
+        assertFalse(stay.move());
+        assertTrue(stay.isDecisionTaken());
+        assertNull(stay.getNodeDecisions());
+        assertNull(stay.getFinalExplanation());
+        assertEquals(Type.NO, stay.getFinalDecisionType());
+    }
+
+    public void testDecisionWithExplain() {
+        Map<String, WeightedDecision> nodeDecisions = new HashMap<>();
+        nodeDecisions.put("node1", new WeightedDecision(randomFrom(Decision.NO, Decision.THROTTLE, Decision.YES), randomFloat()));
+        nodeDecisions.put("node2", new WeightedDecision(randomFrom(Decision.NO, Decision.THROTTLE, Decision.YES), randomFloat()));
+        MoveDecision decision = MoveDecision.decision(Decision.NO, Type.NO, true, "node1", null, nodeDecisions);
+        assertNotNull(decision.getFinalDecisionType());
+        assertNotNull(decision.getFinalExplanation());
+        assertNotNull(decision.getNodeDecisions());
+        assertEquals(2, decision.getNodeDecisions().size());
+
+        decision = MoveDecision.decision(Decision.NO, Type.YES, true, "node1", "node2", null);
+        assertEquals("node2", decision.getAssignedNodeId());
+    }
+}

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DecisionTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DecisionTests.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation.decider;
+
+import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.elasticsearch.cluster.routing.allocation.decider.Decision.Type.NO;
+import static org.elasticsearch.cluster.routing.allocation.decider.Decision.Type.THROTTLE;
+import static org.elasticsearch.cluster.routing.allocation.decider.Decision.Type.YES;
+
+/**
+ * A class for unit testing the {@link Decision} class.
+ */
+public class DecisionTests extends ESTestCase {
+
+    /**
+     * Tests {@link Type#higherThan(Type)}
+     */
+    public void testHigherThan() {
+        // test YES type
+        assertTrue(YES.higherThan(null));
+        assertTrue(YES.higherThan(NO));
+        assertTrue(YES.higherThan(THROTTLE));
+        assertFalse(YES.higherThan(YES));
+
+        // test THROTTLE type
+        assertTrue(THROTTLE.higherThan(null));
+        assertTrue(THROTTLE.higherThan(NO));
+        assertFalse(THROTTLE.higherThan(THROTTLE));
+        assertFalse(THROTTLE.higherThan(YES));
+
+        // test NO type
+        assertTrue(NO.higherThan(null));
+        assertFalse(NO.higherThan(NO));
+        assertFalse(NO.higherThan(THROTTLE));
+        assertFalse(NO.higherThan(YES));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DecisionTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DecisionTests.java
@@ -36,19 +36,16 @@ public class DecisionTests extends ESTestCase {
      */
     public void testHigherThan() {
         // test YES type
-        assertTrue(YES.higherThan(null));
         assertTrue(YES.higherThan(NO));
         assertTrue(YES.higherThan(THROTTLE));
         assertFalse(YES.higherThan(YES));
 
         // test THROTTLE type
-        assertTrue(THROTTLE.higherThan(null));
         assertTrue(THROTTLE.higherThan(NO));
         assertFalse(THROTTLE.higherThan(THROTTLE));
         assertFalse(THROTTLE.higherThan(YES));
 
         // test NO type
-        assertTrue(NO.higherThan(null));
         assertFalse(NO.higherThan(NO));
         assertFalse(NO.higherThan(THROTTLE));
         assertFalse(NO.higherThan(YES));


### PR DESCRIPTION
Refactors the BalancedShardsAllocator to create a method that
provides an allocation decision for allocating a single
unassigned shard or a single started shard that can no longer
remain on its current node.  Having a separate method that
provides a detailed decision on the allocation of a single shard
will enable the cluster allocation explain API to directly
invoke these methods to provide allocation explanations.
