### PR TITLE
Repo changes are breaking

### DIFF
--- a/docs/reference/migration/migrate_5_0/packaging.asciidoc
+++ b/docs/reference/migration/migrate_5_0/packaging.asciidoc
@@ -6,7 +6,7 @@
 The repository for apt and yum packages has changed from 
 `https://packages.elastic.co` to `https://artifacts.elastic.co/`.
 
-Full details can be found in the installation chapter of the 
+Full details can be found in the <<installing-elasticsearch,installation>> chapter of the 
 documentation.
 
 ==== Default logging using systemd (since Elasticsearch 2.2.0)

--- a/docs/reference/migration/migrate_5_0/packaging.asciidoc
+++ b/docs/reference/migration/migrate_5_0/packaging.asciidoc
@@ -1,6 +1,14 @@
 [[breaking_50_packaging]]
 === Packaging
 
+==== APT/YUM repository URL changes
+
+The repository for apt and yum packages has changed from 
+`https://packages.elastic.co` to `https://artifacts.elastic.co/`.
+
+Full details can be found in the installation chapter of the 
+documentation.
+
 ==== Default logging using systemd (since Elasticsearch 2.2.0)
 
 In previous versions of Elasticsearch, the default logging


### PR DESCRIPTION
We're changing the URLs for the repos, and while the new URLs are in the install docs, we should be explicit and put it in the breaking changes so users don't assume they can just change the version number in the URL.
