### PR TITLE
RankEval: Add `hits` section to response for each query

### DIFF
--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/DiscountedCumulativeGainAt.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/DiscountedCumulativeGainAt.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.index.rankeval.RankedListQualityMetric.filterUnknownDocuments;
 import static org.elasticsearch.index.rankeval.RankedListQualityMetric.joinHitsWithRatings;
 
 public class DiscountedCumulativeGainAt implements RankedListQualityMetric {
@@ -159,7 +158,6 @@ public class DiscountedCumulativeGainAt implements RankedListQualityMetric {
         }
         EvalQueryQuality evalQueryQuality = new EvalQueryQuality(taskId, dcg);
         evalQueryQuality.addHitsAndRatings(ratedHits);
-        evalQueryQuality.setUnknownDocs(filterUnknownDocuments(ratedHits));
         return evalQueryQuality;
     }
 

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/DocumentKey.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/DocumentKey.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Objects;
 
-public class RatedDocumentKey extends ToXContentToBytes implements Writeable {
+public class DocumentKey extends ToXContentToBytes implements Writeable {
 
     private String docId;
     private String type;
@@ -46,13 +46,13 @@ public class RatedDocumentKey extends ToXContentToBytes implements Writeable {
         this.docId = docId;
     }
 
-    public RatedDocumentKey(String index, String type, String docId) {
+    public DocumentKey(String index, String type, String docId) {
         this.index = index;
         this.type = type;
         this.docId = docId;
     }
 
-    public RatedDocumentKey(StreamInput in) throws IOException {
+    public DocumentKey(StreamInput in) throws IOException {
         this.index = in.readString();
         this.type = in.readString();
         this.docId = in.readString();
@@ -85,7 +85,7 @@ public class RatedDocumentKey extends ToXContentToBytes implements Writeable {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        RatedDocumentKey other = (RatedDocumentKey) obj;
+        DocumentKey other = (DocumentKey) obj;
         return Objects.equals(index, other.index) &&
                 Objects.equals(type, other.type) &&
                 Objects.equals(docId, other.docId);

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/EvalQueryQuality.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/EvalQueryQuality.java
@@ -39,20 +39,20 @@ import java.util.Objects;;
 public class EvalQueryQuality implements ToXContent, Writeable {
 
     /** documents seen as result for one request that were not annotated.*/
-    private List<RatedDocumentKey> unknownDocs;
+    private List<DocumentKey> unknownDocs = new ArrayList<>();
     private String id;
     private double qualityLevel;
     private MetricDetails optionalMetricDetails;
     private List<RatedSearchHit> hits = new ArrayList<>();
 
-    public EvalQueryQuality(String id, double qualityLevel, List<RatedDocumentKey> unknownDocs) {
+    public EvalQueryQuality(String id, double qualityLevel) {
         this.id = id;
-        this.unknownDocs = unknownDocs;
         this.qualityLevel = qualityLevel;
     }
 
     public EvalQueryQuality(StreamInput in) throws IOException {
-        this(in.readString(), in.readDouble(), in.readList(RatedDocumentKey::new));
+        this(in.readString(), in.readDouble());
+        this.unknownDocs = in.readList(DocumentKey::new);
         this.hits = in.readList(RatedSearchHit::new);
         this.optionalMetricDetails = in.readOptionalNamedWriteable(MetricDetails.class);
     }
@@ -74,7 +74,11 @@ public class EvalQueryQuality implements ToXContent, Writeable {
         return qualityLevel;
     }
 
-    public List<RatedDocumentKey> getUnknownDocs() {
+    public void setUnknownDocs(List<DocumentKey> unknownDocs) {
+        this.unknownDocs = unknownDocs;
+    }
+
+    public List<DocumentKey> getUnknownDocs() {
         return Collections.unmodifiableList(this.unknownDocs);
     }
 
@@ -99,7 +103,7 @@ public class EvalQueryQuality implements ToXContent, Writeable {
         builder.startObject(id);
         builder.field("quality_level", this.qualityLevel);
         builder.startArray("unknown_docs");
-        for (RatedDocumentKey key : unknownDocs) {
+        for (DocumentKey key : unknownDocs) {
             key.toXContent(builder, params);
         }
         builder.endArray();

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/PrecisionAtN.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/PrecisionAtN.java
@@ -35,7 +35,6 @@ import java.util.Optional;
 
 import javax.naming.directory.SearchResult;
 
-import static org.elasticsearch.index.rankeval.RankedListQualityMetric.filterUnknownDocuments;
 import static org.elasticsearch.index.rankeval.RankedListQualityMetric.joinHitsWithRatings;
 
 /**
@@ -140,7 +139,6 @@ public class PrecisionAtN implements RankedListQualityMetric {
         EvalQueryQuality evalQueryQuality = new EvalQueryQuality(taskId, precision);
         evalQueryQuality.addMetricDetails(new PrecisionAtN.Breakdown(good, good + bad));
         evalQueryQuality.addHitsAndRatings(ratedSearchHits);
-        evalQueryQuality.setUnknownDocs(filterUnknownDocuments(ratedSearchHits));
         return evalQueryQuality;
     }
 

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankedListQualityMetric.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankedListQualityMetric.java
@@ -19,18 +19,21 @@
 
 package org.elasticsearch.index.rankeval;
 
-import org.elasticsearch.action.support.ToXContentToBytes;
 import org.elasticsearch.common.ParseFieldMatcherSupplier;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.NamedWriteable;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.search.SearchHit;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Classes implementing this interface provide a means to compute the quality of a result list
@@ -38,20 +41,20 @@ import java.util.List;
  *
  * RelevancyLevel specifies the type of object determining the relevancy level of some known docid.
  * */
-public abstract class RankedListQualityMetric extends ToXContentToBytes implements NamedWriteable {
+public interface RankedListQualityMetric extends ToXContent, NamedWriteable {
 
     /**
      * Returns a single metric representing the ranking quality of a set of returned documents
      * wrt. to a set of document Ids labeled as relevant for this search.
      *
      * @param taskId the id of the query for which the ranking is currently evaluated
-     * @param hits the result hits as returned by some search
+     * @param hits the result hits as returned by a search request
      * @param ratedDocs the documents that were ranked by human annotators for this query case
      * @return some metric representing the quality of the result hit list wrt. to relevant doc ids.
      * */
-    public abstract EvalQueryQuality evaluate(String taskId, SearchHit[] hits, List<RatedDocument> ratedDocs);
+    EvalQueryQuality evaluate(String taskId, SearchHit[] hits, List<RatedDocument> ratedDocs);
 
-    public static RankedListQualityMetric fromXContent(XContentParser parser, ParseFieldMatcherSupplier context) throws IOException {
+    static RankedListQualityMetric fromXContent(XContentParser parser, ParseFieldMatcherSupplier context) throws IOException {
         RankedListQualityMetric rc;
         Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
@@ -80,10 +83,33 @@ public abstract class RankedListQualityMetric extends ToXContentToBytes implemen
         return rc;
     }
 
-    double combine(Collection<EvalQueryQuality> partialResults) {
-        return partialResults.stream().mapToDouble(EvalQueryQuality::getQualityLevel).sum() / partialResults.size();
+    static List<RatedSearchHit> joinHitsWithRatings(SearchHit[] hits, List<RatedDocument> ratedDocs) {
+     // join hits with rated documents
+        Map<DocumentKey, RatedDocument> ratedDocumentMap = ratedDocs.stream()
+                .collect(Collectors.toMap(RatedDocument::getKey, item -> item));
+        List<RatedSearchHit> ratedSearchHits = new ArrayList<>(hits.length);
+        for (SearchHit hit : hits) {
+            DocumentKey key = new DocumentKey(hit.getIndex(), hit.getType(), hit.getId());
+            RatedDocument ratedDoc = ratedDocumentMap.get(key);
+            if (ratedDoc != null) {
+                ratedSearchHits.add(new RatedSearchHit(hit, Optional.of(ratedDoc.getRating())));
+            } else {
+                ratedSearchHits.add(new RatedSearchHit(hit, Optional.empty()));
+            }
+        }
+        return ratedSearchHits;
     }
 
-    @Override
-    public abstract XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException;
+    static List<DocumentKey> filterUnknownDocuments(List<RatedSearchHit> ratedHits) {
+        // join hits with rated documents
+        List<DocumentKey> unknownDocs = ratedHits.stream()
+                .filter(hit -> hit.getRating().isPresent() == false)
+                .map(hit -> new DocumentKey(hit.getSearchHit().getIndex(), hit.getSearchHit().getType(), hit.getSearchHit().getId()))
+                .collect(Collectors.toList());
+           return unknownDocs;
+       }
+
+    default double combine(Collection<EvalQueryQuality> partialResults) {
+        return partialResults.stream().mapToDouble(EvalQueryQuality::getQualityLevel).sum() / partialResults.size();
+    }
 }

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedDocument.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedDocument.java
@@ -54,23 +54,23 @@ public class RatedDocument extends ToXContentToBytes implements Writeable {
     }
 
     private int rating;
-    private RatedDocumentKey key;
+    private DocumentKey key;
 
     public RatedDocument(String index, String type, String docId, int rating) {
-        this(new RatedDocumentKey(index, type, docId), rating);
+        this(new DocumentKey(index, type, docId), rating);
     }
 
     public RatedDocument(StreamInput in) throws IOException {
-        this.key = new RatedDocumentKey(in);
+        this.key = new DocumentKey(in);
         this.rating = in.readVInt();
     }
 
-    public RatedDocument(RatedDocumentKey ratedDocumentKey, int rating) {
+    public RatedDocument(DocumentKey ratedDocumentKey, int rating) {
         this.key = ratedDocumentKey;
         this.rating = rating;
     }
 
-    public RatedDocumentKey getKey() {
+    public DocumentKey getKey() {
         return this.key;
     }
 

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedSearchHit.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedSearchHit.java
@@ -100,7 +100,7 @@ public class RatedSearchHit implements Writeable, ToXContent {
 
     @Override
     public final int hashCode() {
-        //NORELEASE for this to work requires InternalSearchHit to properly implement equals()/hashCode()
+        // NORELEASE for this to work requires InternalSearchHit to properly implement equals()/hashCode()
         XContentBuilder builder;
         String hitAsXContent;
         try {

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedSearchHit.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedSearchHit.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.rankeval;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.internal.InternalSearchHit;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+
+public class RatedSearchHit implements Writeable, ToXContent {
+
+    private final SearchHit searchHit;
+    private final Optional<Integer> rating;
+
+    public RatedSearchHit(SearchHit searchHit, Optional<Integer> rating) {
+        this.searchHit = searchHit;
+        this.rating = rating;
+    }
+
+    public RatedSearchHit(StreamInput in) throws IOException {
+        this(InternalSearchHit.readSearchHit(in), in.readBoolean() == true ? Optional.of(in.readVInt()) : Optional.empty());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        searchHit.writeTo(out);
+        out.writeBoolean(rating.isPresent());
+        if (rating.isPresent()) {
+            out.writeVInt(rating.get());
+        }
+    }
+
+    public SearchHit getSearchHit() {
+        return this.searchHit;
+    }
+
+    public Optional<Integer> getRating() {
+        return this.rating;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        builder.field("hit", (ToXContent) searchHit);
+        builder.field("rating", rating.orElse(null));
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        RatedSearchHit other = (RatedSearchHit) obj;
+        // NORELEASE this is a workaround because InternalSearchHit does not properly implement equals()/hashCode(), so we compare their
+        // xcontent
+        XContentBuilder builder;
+        String hitAsXContent;
+        String otherHitAsXContent;
+        try {
+            builder = XContentFactory.jsonBuilder();
+            hitAsXContent = searchHit.toXContent(builder, ToXContent.EMPTY_PARAMS).string();
+            builder = XContentFactory.jsonBuilder();
+            otherHitAsXContent = other.searchHit.toXContent(builder, ToXContent.EMPTY_PARAMS).string();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return Objects.equals(rating, other.rating) &&
+                Objects.equals(hitAsXContent, otherHitAsXContent);
+    }
+
+    @Override
+    public final int hashCode() {
+        //NORELEASE for this to work requires InternalSearchHit to properly implement equals()/hashCode()
+        XContentBuilder builder;
+        String hitAsXContent;
+        try {
+            builder = XContentFactory.jsonBuilder();
+            hitAsXContent = searchHit.toXContent(builder, ToXContent.EMPTY_PARAMS).string();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return Objects.hash(rating, hitAsXContent);
+    }
+}

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/ReciprocalRank.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/ReciprocalRank.java
@@ -35,7 +35,6 @@ import java.util.Optional;
 
 import javax.naming.directory.SearchResult;
 
-import static org.elasticsearch.index.rankeval.RankedListQualityMetric.filterUnknownDocuments;
 import static org.elasticsearch.index.rankeval.RankedListQualityMetric.joinHitsWithRatings;
 
 /**
@@ -133,7 +132,6 @@ public class ReciprocalRank implements RankedListQualityMetric {
         EvalQueryQuality evalQueryQuality = new EvalQueryQuality(taskId, reciprocalRank);
         evalQueryQuality.addMetricDetails(new Breakdown(firstRelevant));
         evalQueryQuality.addHitsAndRatings(ratedHits);
-        evalQueryQuality.setUnknownDocs(filterUnknownDocuments(ratedHits));
         return evalQueryQuality;
     }
 

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/ReciprocalRank.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/ReciprocalRank.java
@@ -29,23 +29,21 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchHit;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 import javax.naming.directory.SearchResult;
+
+import static org.elasticsearch.index.rankeval.RankedListQualityMetric.filterUnknownDocuments;
+import static org.elasticsearch.index.rankeval.RankedListQualityMetric.joinHitsWithRatings;
 
 /**
  * Evaluate reciprocal rank.
  * By default documents with a rating equal or bigger than 1 are considered to be "relevant" for the reciprocal rank
  * calculation. This value can be changes using the "relevant_rating_threshold" parameter.
  * */
-public class ReciprocalRank extends RankedListQualityMetric {
+public class ReciprocalRank implements RankedListQualityMetric {
 
     public static final String NAME = "reciprocal_rank";
     public static final int DEFAULT_MAX_ACCEPTABLE_RANK = 10;
@@ -117,47 +115,25 @@ public class ReciprocalRank extends RankedListQualityMetric {
      **/
     @Override
     public EvalQueryQuality evaluate(String taskId, SearchHit[] hits, List<RatedDocument> ratedDocs) {
-        Map<RatedDocumentKey, RatedDocument> ratedDocsByKey = new HashMap<>();
-        for (RatedDocument doc : ratedDocs) {
-            ratedDocsByKey.put(doc.getKey(), doc);
-        }
-
-        Set<RatedDocumentKey> relevantDocIds = new HashSet<>();
-        Set<RatedDocumentKey> irrelevantDocIds = new HashSet<>();
-        for (RatedDocument doc : ratedDocs) {
-            if (doc.getRating() >= this.relevantRatingThreshhold) {
-                relevantDocIds.add(doc.getKey());
-            } else {
-                irrelevantDocIds.add(doc.getKey());
-            }
-        }
-
-        List<RatedDocumentKey> unknownDocIds = new ArrayList<>();
-        List<RatedSearchHit> hitsAndRatings = new ArrayList<>();
+        List<RatedSearchHit> ratedHits = joinHitsWithRatings(hits, ratedDocs);
         int firstRelevant = -1;
-        boolean found = false;
-        for (int i = 0; i < hits.length; i++) {
-            RatedDocumentKey key = new RatedDocumentKey(hits[i].getIndex(), hits[i].getType(), hits[i].getId());
-            RatedDocument ratedDocument = ratedDocsByKey.get(key);
-            if (ratedDocument != null) {
-                if (ratedDocument.getRating() >= this.relevantRatingThreshhold) {
-                    if (found == false && i < maxAcceptableRank) {
-                        firstRelevant = i + 1; // add one because rank is not
-                                               // 0-based
-                        found = true;
-                    }
-                    hitsAndRatings.add(new RatedSearchHit(hits[i], Optional.of(ratedDocument.getRating())));
+        int rank = 1;
+        for (RatedSearchHit hit : ratedHits.subList(0, Math.min(maxAcceptableRank, ratedHits.size()))) {
+            Optional<Integer> rating = hit.getRating();
+            if (rating.isPresent()) {
+                if (rating.get() >= this.relevantRatingThreshhold) {
+                    firstRelevant = rank;
+                    break;
                 }
-            } else {
-                unknownDocIds.add(key);
-                hitsAndRatings.add(new RatedSearchHit(hits[i], Optional.empty()));
             }
+            rank++;
         }
 
         double reciprocalRank = (firstRelevant == -1) ? 0 : 1.0d / firstRelevant;
-        EvalQueryQuality evalQueryQuality = new EvalQueryQuality(taskId, reciprocalRank, unknownDocIds);
+        EvalQueryQuality evalQueryQuality = new EvalQueryQuality(taskId, reciprocalRank);
         evalQueryQuality.addMetricDetails(new Breakdown(firstRelevant));
-        evalQueryQuality.addHitsAndRatings(hitsAndRatings);
+        evalQueryQuality.addHitsAndRatings(ratedHits);
+        evalQueryQuality.setUnknownDocs(filterUnknownDocuments(ratedHits));
         return evalQueryQuality;
     }
 

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -64,7 +64,7 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
     protected void doExecute(RankEvalRequest request, ActionListener<RankEvalResponse> listener) {
         RankEvalSpec qualityTask = request.getRankEvalSpec();
 
-        Map<String, Collection<RatedDocumentKey>> unknownDocs = new ConcurrentHashMap<>();
+        Map<String, Collection<DocumentKey>> unknownDocs = new ConcurrentHashMap<>();
         Collection<RatedRequest> specifications = qualityTask.getSpecifications();
         AtomicInteger responseCounter = new AtomicInteger(specifications.size());
         Map<String, EvalQueryQuality> partialResults = new ConcurrentHashMap<>(specifications.size());
@@ -94,31 +94,31 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
 
         private ActionListener<RankEvalResponse> listener;
         private RatedRequest specification;
-        private Map<String, EvalQueryQuality> partialResults;
+        private Map<String, EvalQueryQuality> requestDetails;
         private RankEvalSpec task;
         private AtomicInteger responseCounter;
 
         public RankEvalActionListener(ActionListener<RankEvalResponse> listener, RankEvalSpec task, RatedRequest specification,
-                Map<String, EvalQueryQuality> partialResults, Map<String, Collection<RatedDocumentKey>> unknownDocs,
+                Map<String, EvalQueryQuality> details, Map<String, Collection<DocumentKey>> unknownDocs,
                 AtomicInteger responseCounter) {
             this.listener = listener;
             this.task = task;
             this.specification = specification;
-            this.partialResults = partialResults;
+            this.requestDetails = details;
             this.responseCounter = responseCounter;
         }
 
         @Override
         public void onResponse(SearchResponse searchResponse) {
-            SearchHits hits = searchResponse.getHits();
-            EvalQueryQuality queryQuality = task.getEvaluator().evaluate(specification.getSpecId(), hits.getHits(),
+            SearchHit[] hits = searchResponse.getHits().getHits();
+            EvalQueryQuality queryQuality = task.getEvaluator().evaluate(specification.getSpecId(), hits,
                     specification.getRatedDocs());
-            partialResults.put(specification.getSpecId(), queryQuality);
+            requestDetails.put(specification.getSpecId(), queryQuality);
 
             if (responseCounter.decrementAndGet() < 1) {
                 // TODO add other statistics like micro/macro avg?
                 listener.onResponse(
-                        new RankEvalResponse(task.getEvaluator().combine(partialResults.values()), partialResults));
+                        new RankEvalResponse(task.getEvaluator().combine(requestDetails.values()), requestDetails));
             }
         }
 

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
@@ -34,6 +34,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -72,6 +73,13 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
             final RankEvalActionListener searchListener = new RankEvalActionListener(listener, qualityTask, querySpecification,
                     partialResults, unknownDocs, responseCounter);
             SearchSourceBuilder specRequest = querySpecification.getTestRequest();
+            List<String> summaryFields = querySpecification.getSummaryFields();
+            if (summaryFields.isEmpty()) {
+                specRequest.fetchSource(false);
+            } else {
+                specRequest.fetchSource(summaryFields.toArray(new String[summaryFields.size()]), new String[0]);
+            }
+
             String[] indices = new String[querySpecification.getIndices().size()];
             querySpecification.getIndices().toArray(indices);
             SearchRequest templatedRequest = new SearchRequest(indices, specRequest);

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/DiscountedCumulativeGainAtTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/DiscountedCumulativeGainAtTests.java
@@ -50,7 +50,7 @@ public class DiscountedCumulativeGainAtTests extends ESTestCase {
      *
      * dcg = 13.84826362927298 (sum of last column)
      */
-    public void testDCGAtSix() throws IOException, InterruptedException, ExecutionException {
+    public void testDCGAt() throws IOException, InterruptedException, ExecutionException {
         List<RatedDocument> rated = new ArrayList<>();
         int[] relevanceRatings = new int[] { 3, 2, 3, 0, 1, 2 };
         InternalSearchHit[] hits = new InternalSearchHit[6];
@@ -128,6 +128,59 @@ public class DiscountedCumulativeGainAtTests extends ESTestCase {
          */
         dcg.setNormalize(true);
         assertEquals(12.779642067948913 / 13.347184833073591, dcg.evaluate("id", hits, rated).getQualityLevel(), 0.00001);
+    }
+
+    /**
+     * This tests that normalization works as expected when there are more rated documents than search hits
+     * because we restrict DCG to be calculated at the fourth position
+     *
+     * rank | rel_rank | 2^(rel_rank) - 1 | log_2(rank + 1)    | (2^(rel_rank) - 1) / log_2(rank + 1)
+     * -------------------------------------------------------------------------------------------
+     * 1    | 3        | 7.0              | 1.0                | 7.0
+     * 2    | 2        | 3.0              | 1.5849625007211563 | 1.8927892607143721
+     * 3    | 3        | 7.0              | 2.0                | 3.5
+     * 4    | n/a      | n/a              | n/a                | n/a
+     * -----------------------------------------------------------------
+     * 5    | 1        | 1.0              | 2.584962500721156  | 0.38685280723454163
+     * 6    | n/a      | n/a              | n/a                | n/a
+     *
+     * dcg = 12.392789260714371 (sum of last column until position 4)
+     */
+    public void testDCGAtFourMoreRatings() throws IOException, InterruptedException, ExecutionException {
+        List<RatedDocument> rated = new ArrayList<>();
+        Integer[] relevanceRatings = new Integer[] { 3, 2, 3, null, 1};
+        InternalSearchHit[] hits = new InternalSearchHit[6];
+        for (int i = 0; i < 6; i++) {
+            if (i < relevanceRatings.length) {
+                if (relevanceRatings[i] != null) {
+                    rated.add(new RatedDocument("index", "type", Integer.toString(i), relevanceRatings[i]));
+                }
+            }
+            hits[i] = new InternalSearchHit(i, Integer.toString(i), new Text("type"), Collections.emptyMap());
+            hits[i].shard(new SearchShardTarget("testnode", new ShardId("index", "uuid", 0)));
+        }
+        DiscountedCumulativeGainAt dcg = new DiscountedCumulativeGainAt(4);
+        EvalQueryQuality result = dcg.evaluate("id", hits, rated);
+        assertEquals(12.392789260714371 , result.getQualityLevel(), 0.00001);
+        assertEquals(1, result.getUnknownDocs().size());
+
+        /**
+         * Check with normalization: to get the maximal possible dcg, sort documents by relevance in descending order
+         *
+         * rank | rel_rank | 2^(rel_rank) - 1 | log_2(rank + 1)    | (2^(rel_rank) - 1) / log_2(rank + 1)
+         * -------------------------------------------------------------------------------------------
+         * 1    | 3        | 7.0              | 1.0                | 7.0
+         * 2    | 3        | 7.0              | 1.5849625007211563 | 4.416508275000202
+         * 3    | 2        | 3.0              | 2.0                | 1.5
+         * 4    | 1        | 1.0              | 2.321928094887362   | 0.43067655807339
+         * -------------------------------------------------------------------------------------------
+         * 5    | n.a        | n.a              | n.a.  | n.a.
+         * 6    | n.a        | n.a              | n.a  | n.a
+         *
+         * idcg = 13.347184833073591 (sum of last column)
+         */
+        dcg.setNormalize(true);
+        assertEquals(12.392789260714371  / 13.347184833073591, dcg.evaluate("id", hits, rated).getQualityLevel(), 0.00001);
     }
 
     public void testParseFromXContent() throws IOException {

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/DocumentKeyTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/DocumentKeyTests.java
@@ -24,20 +24,20 @@ import org.elasticsearch.test.ESTestCase;
 import java.io.IOException;
 
 
-public class RatedDocumentKeyTests extends ESTestCase {
+public class DocumentKeyTests extends ESTestCase {
 
-    static RatedDocumentKey createRandomRatedDocumentKey() {
+    static DocumentKey createRandomRatedDocumentKey() {
         String index = randomAsciiOfLengthBetween(0, 10);
         String type = randomAsciiOfLengthBetween(0, 10);
         String docId = randomAsciiOfLengthBetween(0, 10);
-        return  new RatedDocumentKey(index, type, docId);
+        return  new DocumentKey(index, type, docId);
     }
 
-    public RatedDocumentKey createRandomTestItem() {
+    public DocumentKey createRandomTestItem() {
         return createRandomRatedDocumentKey();
     }
 
-    public RatedDocumentKey mutateTestItem(RatedDocumentKey original) {
+    public DocumentKey mutateTestItem(DocumentKey original) {
         String index = original.getIndex();
         String type = original.getType();
         String docId = original.getDocID();
@@ -54,12 +54,12 @@ public class RatedDocumentKeyTests extends ESTestCase {
         default:
             throw new IllegalStateException("The test should only allow three parameters mutated");
         }
-        return new RatedDocumentKey(index, type, docId);
+        return new DocumentKey(index, type, docId);
     }
 
     public void testEqualsAndHash() throws IOException {
-        RatedDocumentKey testItem = createRandomRatedDocumentKey();
+        DocumentKey testItem = createRandomRatedDocumentKey();
         RankEvalTestHelper.testHashCodeAndEquals(testItem, mutateTestItem(testItem),
-                new RatedDocumentKey(testItem.getIndex(), testItem.getType(), testItem.getDocID()));
+                new DocumentKey(testItem.getIndex(), testItem.getType(), testItem.getDocID()));
     }
 }

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/EvalQueryQualityTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/EvalQueryQualityTests.java
@@ -31,21 +31,22 @@ public class EvalQueryQualityTests extends ESTestCase {
     private static NamedWriteableRegistry namedWritableRegistry = new NamedWriteableRegistry(new RankEvalPlugin().getNamedWriteables());
 
     public static EvalQueryQuality randomEvalQueryQuality() {
-        List<RatedDocumentKey> unknownDocs = new ArrayList<>();
+        List<DocumentKey> unknownDocs = new ArrayList<>();
         int numberOfUnknownDocs = randomInt(5);
         for (int i = 0; i < numberOfUnknownDocs; i++) {
-            unknownDocs.add(RatedDocumentKeyTests.createRandomRatedDocumentKey());
+            unknownDocs.add(DocumentKeyTests.createRandomRatedDocumentKey());
         }
         int numberOfSearchHits = randomInt(5);
         List<RatedSearchHit> ratedHits = new ArrayList<>();
         for (int i = 0; i < numberOfSearchHits; i++) {
             ratedHits.add(RatedSearchHitTests.randomRatedSearchHit());
         }
-        EvalQueryQuality evalQueryQuality = new EvalQueryQuality(randomAsciiOfLength(10), randomDoubleBetween(0.0, 1.0, true), unknownDocs);
+        EvalQueryQuality evalQueryQuality = new EvalQueryQuality(randomAsciiOfLength(10), randomDoubleBetween(0.0, 1.0, true));
         if (randomBoolean()) {
             // TODO randomize this
             evalQueryQuality.addMetricDetails(new PrecisionAtN.Breakdown(1, 5));
         }
+        evalQueryQuality.setUnknownDocs(unknownDocs);
         evalQueryQuality.addHitsAndRatings(ratedHits);
         return evalQueryQuality;
     }
@@ -67,7 +68,7 @@ public class EvalQueryQualityTests extends ESTestCase {
     private static EvalQueryQuality mutateTestItem(EvalQueryQuality original) {
         String id = original.getId();
         double qualityLevel = original.getQualityLevel();
-        List<RatedDocumentKey> unknownDocs = new ArrayList<>(original.getUnknownDocs());
+        List<DocumentKey> unknownDocs = new ArrayList<>(original.getUnknownDocs());
         List<RatedSearchHit> ratedHits = new ArrayList<>(original.getHitsAndRatings());
         MetricDetails breakdown = original.getMetricDetails();
         switch (randomIntBetween(0, 3)) {
@@ -78,7 +79,7 @@ public class EvalQueryQualityTests extends ESTestCase {
             qualityLevel = qualityLevel + 0.1;
             break;
         case 2:
-            unknownDocs.add(RatedDocumentKeyTests.createRandomRatedDocumentKey());
+            unknownDocs.add(DocumentKeyTests.createRandomRatedDocumentKey());
             break;
         case 3:
             if (breakdown == null) {
@@ -93,7 +94,8 @@ public class EvalQueryQualityTests extends ESTestCase {
         default:
             throw new IllegalStateException("The test should only allow five parameters mutated");
         }
-        EvalQueryQuality evalQueryQuality = new EvalQueryQuality(id, qualityLevel, unknownDocs);
+        EvalQueryQuality evalQueryQuality = new EvalQueryQuality(id, qualityLevel);
+        evalQueryQuality.setUnknownDocs(unknownDocs);
         evalQueryQuality.addMetricDetails(breakdown);
         evalQueryQuality.addHitsAndRatings(ratedHits);
         return evalQueryQuality;

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/EvalQueryQualityTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/EvalQueryQualityTests.java
@@ -46,7 +46,6 @@ public class EvalQueryQualityTests extends ESTestCase {
             // TODO randomize this
             evalQueryQuality.addMetricDetails(new PrecisionAtN.Breakdown(1, 5));
         }
-        evalQueryQuality.setUnknownDocs(unknownDocs);
         evalQueryQuality.addHitsAndRatings(ratedHits);
         return evalQueryQuality;
     }
@@ -68,9 +67,8 @@ public class EvalQueryQualityTests extends ESTestCase {
     private static EvalQueryQuality mutateTestItem(EvalQueryQuality original) {
         String id = original.getId();
         double qualityLevel = original.getQualityLevel();
-        List<DocumentKey> unknownDocs = new ArrayList<>(original.getUnknownDocs());
         List<RatedSearchHit> ratedHits = new ArrayList<>(original.getHitsAndRatings());
-        MetricDetails breakdown = original.getMetricDetails();
+        MetricDetails metricDetails = original.getMetricDetails();
         switch (randomIntBetween(0, 3)) {
         case 0:
             id = id + "_";
@@ -79,24 +77,20 @@ public class EvalQueryQualityTests extends ESTestCase {
             qualityLevel = qualityLevel + 0.1;
             break;
         case 2:
-            unknownDocs.add(DocumentKeyTests.createRandomRatedDocumentKey());
-            break;
-        case 3:
-            if (breakdown == null) {
-                breakdown = new PrecisionAtN.Breakdown(1, 5);
+            if (metricDetails == null) {
+                metricDetails = new PrecisionAtN.Breakdown(1, 5);
             } else {
-                breakdown = null;
+                metricDetails = null;
             }
             break;
-        case 4:
+        case 3:
             ratedHits.add(RatedSearchHitTests.randomRatedSearchHit());
             break;
         default:
-            throw new IllegalStateException("The test should only allow five parameters mutated");
+            throw new IllegalStateException("The test should only allow four parameters mutated");
         }
         EvalQueryQuality evalQueryQuality = new EvalQueryQuality(id, qualityLevel);
-        evalQueryQuality.setUnknownDocs(unknownDocs);
-        evalQueryQuality.addMetricDetails(breakdown);
+        evalQueryQuality.addMetricDetails(metricDetails);
         evalQueryQuality.addHitsAndRatings(ratedHits);
         return evalQueryQuality;
     }

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/EvalQueryQualityTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/EvalQueryQualityTests.java
@@ -19,10 +19,7 @@
 
 package org.elasticsearch.index.rankeval;
 
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -39,26 +36,23 @@ public class EvalQueryQualityTests extends ESTestCase {
         for (int i = 0; i < numberOfUnknownDocs; i++) {
             unknownDocs.add(RatedDocumentKeyTests.createRandomRatedDocumentKey());
         }
+        int numberOfSearchHits = randomInt(5);
+        List<RatedSearchHit> ratedHits = new ArrayList<>();
+        for (int i = 0; i < numberOfSearchHits; i++) {
+            ratedHits.add(RatedSearchHitTests.randomRatedSearchHit());
+        }
         EvalQueryQuality evalQueryQuality = new EvalQueryQuality(randomAsciiOfLength(10), randomDoubleBetween(0.0, 1.0, true), unknownDocs);
         if (randomBoolean()) {
             // TODO randomize this
             evalQueryQuality.addMetricDetails(new PrecisionAtN.Breakdown(1, 5));
         }
+        evalQueryQuality.addHitsAndRatings(ratedHits);
         return evalQueryQuality;
-    }
-
-    private static EvalQueryQuality copy(EvalQueryQuality original) throws IOException {
-        try (BytesStreamOutput output = new BytesStreamOutput()) {
-            original.writeTo(output);
-            try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), namedWritableRegistry)) {
-                return new EvalQueryQuality(in);
-            }
-        }
     }
 
     public void testSerialization() throws IOException {
         EvalQueryQuality original = randomEvalQueryQuality();
-        EvalQueryQuality deserialized = copy(original);
+        EvalQueryQuality deserialized = RankEvalTestHelper.copy(original, EvalQueryQuality::new, namedWritableRegistry);
         assertEquals(deserialized, original);
         assertEquals(deserialized.hashCode(), original.hashCode());
         assertNotSame(deserialized, original);
@@ -67,13 +61,14 @@ public class EvalQueryQualityTests extends ESTestCase {
     public void testEqualsAndHash() throws IOException {
         EvalQueryQuality testItem = randomEvalQueryQuality();
         RankEvalTestHelper.testHashCodeAndEquals(testItem, mutateTestItem(testItem),
-                copy(testItem));
+                RankEvalTestHelper.copy(testItem, EvalQueryQuality::new, namedWritableRegistry));
     }
 
     private static EvalQueryQuality mutateTestItem(EvalQueryQuality original) {
         String id = original.getId();
         double qualityLevel = original.getQualityLevel();
-        List<RatedDocumentKey> unknownDocs = original.getUnknownDocs();
+        List<RatedDocumentKey> unknownDocs = new ArrayList<>(original.getUnknownDocs());
+        List<RatedSearchHit> ratedHits = new ArrayList<>(original.getHitsAndRatings());
         MetricDetails breakdown = original.getMetricDetails();
         switch (randomIntBetween(0, 3)) {
         case 0:
@@ -83,7 +78,6 @@ public class EvalQueryQualityTests extends ESTestCase {
             qualityLevel = qualityLevel + 0.1;
             break;
         case 2:
-            unknownDocs = new ArrayList<>(unknownDocs);
             unknownDocs.add(RatedDocumentKeyTests.createRandomRatedDocumentKey());
             break;
         case 3:
@@ -93,13 +87,15 @@ public class EvalQueryQualityTests extends ESTestCase {
                 breakdown = null;
             }
             break;
+        case 4:
+            ratedHits.add(RatedSearchHitTests.randomRatedSearchHit());
+            break;
         default:
-            throw new IllegalStateException("The test should only allow three parameters mutated");
+            throw new IllegalStateException("The test should only allow five parameters mutated");
         }
         EvalQueryQuality evalQueryQuality = new EvalQueryQuality(id, qualityLevel, unknownDocs);
         evalQueryQuality.addMetricDetails(breakdown);
+        evalQueryQuality.addHitsAndRatings(ratedHits);
         return evalQueryQuality;
     }
-
-
 }

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalRequestTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalRequestTests.java
@@ -36,6 +36,9 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import static org.elasticsearch.index.rankeval.RankedListQualityMetric.filterUnknownDocuments;
+
+
 public class RankEvalRequestTests  extends ESIntegTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> transportClientPlugins() {
@@ -93,7 +96,7 @@ public class RankEvalRequestTests  extends ESIntegTestCase {
         for (Entry<String, EvalQueryQuality> entry : entrySet) {
             EvalQueryQuality quality = entry.getValue();
             if (entry.getKey() == "amsterdam_query") {
-                assertEquals(2, quality.getUnknownDocs().size());
+                assertEquals(2, filterUnknownDocuments(quality.getHitsAndRatings()).size());
                 List<RatedSearchHit> hitsAndRatings = quality.getHitsAndRatings();
                 assertEquals(6, hitsAndRatings.size());
                 for (RatedSearchHit hit : hitsAndRatings) {
@@ -106,7 +109,7 @@ public class RankEvalRequestTests  extends ESIntegTestCase {
                 }
             }
             if (entry.getKey() == "berlin_query") {
-                assertEquals(5, quality.getUnknownDocs().size());
+                assertEquals(5, filterUnknownDocuments(quality.getHitsAndRatings()).size());
                 List<RatedSearchHit> hitsAndRatings = quality.getHitsAndRatings();
                 assertEquals(6, hitsAndRatings.size());
                 for (RatedSearchHit hit : hitsAndRatings) {

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalResponseTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalResponseTests.java
@@ -41,11 +41,13 @@ public class RankEvalResponseTests extends ESTestCase {
         for (int i = 0; i < numberOfRequests; i++) {
             String id = randomAsciiOfLengthBetween(3, 10);
             int numberOfUnknownDocs = randomIntBetween(0, 5);
-            List<RatedDocumentKey> unknownDocs = new ArrayList<>(numberOfUnknownDocs);
+            List<DocumentKey> unknownDocs = new ArrayList<>(numberOfUnknownDocs);
             for (int d = 0; d < numberOfUnknownDocs; d++) {
-                unknownDocs.add(RatedDocumentKeyTests.createRandomRatedDocumentKey());
+                unknownDocs.add(DocumentKeyTests.createRandomRatedDocumentKey());
             }
-            partials.put(id, new EvalQueryQuality(id, randomDoubleBetween(0.0, 1.0, true), unknownDocs));
+            EvalQueryQuality evalQuality = new EvalQueryQuality(id, randomDoubleBetween(0.0, 1.0, true));
+            evalQuality.setUnknownDocs(unknownDocs);
+            partials.put(id, evalQuality);
         }
         return new RankEvalResponse(randomDouble(), partials);
     }

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalResponseTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalResponseTests.java
@@ -46,7 +46,6 @@ public class RankEvalResponseTests extends ESTestCase {
                 unknownDocs.add(DocumentKeyTests.createRandomRatedDocumentKey());
             }
             EvalQueryQuality evalQuality = new EvalQueryQuality(id, randomDoubleBetween(0.0, 1.0, true));
-            evalQuality.setUnknownDocs(unknownDocs);
             partials.put(id, evalQuality);
         }
         return new RankEvalResponse(randomDouble(), partials);

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalTestHelper.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalTestHelper.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.rankeval;
 
-import org.elasticsearch.action.support.ToXContentToBytes;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
@@ -46,7 +45,7 @@ import static org.junit.Assert.assertTrue;
 
 public class RankEvalTestHelper {
 
-    public static XContentParser roundtrip(ToXContentToBytes testItem) throws IOException {
+    public static XContentParser roundtrip(ToXContent testItem) throws IOException {
         XContentBuilder builder = XContentFactory.contentBuilder(ESTestCase.randomFrom(XContentType.values()));
         if (ESTestCase.randomBoolean()) {
             builder.prettyPrint();

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
@@ -79,7 +79,15 @@ public class RatedRequestsTests extends ESTestCase {
             ratedDocs.add(RatedDocumentTests.createRatedDocument());
         }
 
-        return new RatedRequest(specId, testRequest, indices, types, ratedDocs);
+        RatedRequest ratedRequest = new RatedRequest(specId, testRequest, indices, types, ratedDocs);
+
+        List<String> summaryFields = new ArrayList<>();
+        int numSummaryFields = randomIntBetween(0, 5);
+        for (int i = 0; i < numSummaryFields; i++) {
+            summaryFields.add(randomAsciiOfLength(5));
+        }
+        ratedRequest.setSummaryFields(summaryFields);
+        return ratedRequest;
     }
 
     public void testXContentRoundtrip() throws IOException {
@@ -126,6 +134,7 @@ public class RatedRequestsTests extends ESTestCase {
          + "           },\n"
          + "           \"size\": 10\n"
          + "   },\n"
+         + "   \"summary_fields\" : [\"title\"],\n"
          + "   \"ratings\": [ "
          + "        {\"_index\": \"test\", \"_type\": \"testtype\", \"_id\": \"1\", \"rating\" : 1 }, "
          + "        {\"_type\": \"testtype\", \"_index\": \"test\", \"_id\": \"2\", \"rating\" : 0 }, "

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedSearchHitTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedSearchHitTests.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.rankeval;
+
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.internal.InternalSearchHit;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+
+public class RatedSearchHitTests extends ESTestCase {
+
+    public static RatedSearchHit randomRatedSearchHit() {
+        Optional<Integer> rating = randomBoolean() ? Optional.empty() : Optional.of(randomIntBetween(0, 5));
+        SearchHit searchHit = new InternalSearchHit(randomIntBetween(0, 10), randomAsciiOfLength(10), new Text(randomAsciiOfLength(10)),
+                Collections.emptyMap());
+        RatedSearchHit ratedSearchHit = new RatedSearchHit(searchHit, rating);
+        return ratedSearchHit;
+    }
+
+    private static RatedSearchHit mutateTestItem(RatedSearchHit original) {
+        Optional<Integer> rating = original.getRating();
+        InternalSearchHit hit = (InternalSearchHit) original.getSearchHit();
+        switch (randomIntBetween(0, 1)) {
+        case 0:
+            rating = rating.isPresent() ? Optional.of(rating.get() + 1) : Optional.of(randomInt(5));
+            break;
+        case 1:
+            hit = new InternalSearchHit(hit.docId(), hit.getId() + randomAsciiOfLength(10), new Text(hit.getType()),
+                    Collections.emptyMap());
+            break;
+        default:
+            throw new IllegalStateException("The test should only allow two parameters mutated");
+        }
+        return new RatedSearchHit(hit, rating);
+    }
+
+    public void testSerialization() throws IOException {
+        RatedSearchHit original = randomRatedSearchHit();
+        RatedSearchHit deserialized = RankEvalTestHelper.copy(original, RatedSearchHit::new);
+        assertEquals(deserialized, original);
+        assertEquals(deserialized.hashCode(), original.hashCode());
+        assertNotSame(deserialized, original);
+    }
+
+    public void testEqualsAndHash() throws IOException {
+        RatedSearchHit testItem = randomRatedSearchHit();
+        RankEvalTestHelper.testHashCodeAndEquals(testItem, mutateTestItem(testItem),
+                RankEvalTestHelper.copy(testItem, RatedSearchHit::new));
+    }
+}

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/ReciprocalRankTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/ReciprocalRankTests.java
@@ -46,7 +46,7 @@ public class ReciprocalRankTests extends ESTestCase {
         reciprocalRank.setMaxAcceptableRank(maxRank);
         assertEquals(maxRank, reciprocalRank.getMaxAcceptableRank());
 
-        SearchHit[] hits = toSearchHits(0, 9, "test", "type");
+        SearchHit[] hits = createSearchHits(0, 9, "test", "type");
         List<RatedDocument> ratedDocs = new ArrayList<>();
         int relevantAt = 5;
         for (int i = 0; i < 10; i++) {
@@ -76,7 +76,7 @@ public class ReciprocalRankTests extends ESTestCase {
 
     public void testEvaluationOneRelevantInResults() {
         ReciprocalRank reciprocalRank = new ReciprocalRank();
-        SearchHit[] hits = toSearchHits(0, 9, "test", "type");
+        SearchHit[] hits = createSearchHits(0, 9, "test", "type");
         List<RatedDocument> ratedDocs = new ArrayList<>();
         // mark one of the ten docs relevant
         int relevantAt = randomIntBetween(0, 9);
@@ -105,7 +105,7 @@ public class ReciprocalRankTests extends ESTestCase {
         rated.add(new RatedDocument("test", "testtype", "2", 2));
         rated.add(new RatedDocument("test", "testtype", "3", 3));
         rated.add(new RatedDocument("test", "testtype", "4", 4));
-        SearchHit[] hits = toSearchHits(0, 5, "test", "testtype");
+        SearchHit[] hits = createSearchHits(0, 5, "test", "testtype");
 
         ReciprocalRank reciprocalRank = new ReciprocalRank();
         reciprocalRank.setRelevantRatingThreshhold(2);
@@ -125,7 +125,7 @@ public class ReciprocalRankTests extends ESTestCase {
 
     public void testEvaluationNoRelevantInResults() {
         ReciprocalRank reciprocalRank = new ReciprocalRank();
-        SearchHit[] hits = toSearchHits(0, 9, "test", "type");
+        SearchHit[] hits = createSearchHits(0, 9, "test", "type");
         List<RatedDocument> ratedDocs = new ArrayList<>();
         EvalQueryQuality evaluation = reciprocalRank.evaluate("id", hits, ratedDocs);
         assertEquals(0.0, evaluation.getQualityLevel(), Double.MIN_VALUE);
@@ -144,9 +144,13 @@ public class ReciprocalRankTests extends ESTestCase {
         assertEquals(testItem.hashCode(), parsedItem.hashCode());
     }
 
-    private static SearchHit[] toSearchHits(int from, int to, String index, String type) {
-        InternalSearchHit[] hits = new InternalSearchHit[to - from];
-        for (int i = from; i < to; i++) {
+    /**
+     * Create InternalSearchHits for testing, starting from dociId 'from' up to docId 'to'.
+     * The search hits index and type also need to be provided
+     */
+    private static SearchHit[] createSearchHits(int from, int to, String index, String type) {
+        InternalSearchHit[] hits = new InternalSearchHit[to + 1 - from];
+        for (int i = from; i <= to; i++) {
             hits[i] = new InternalSearchHit(i, i+"", new Text(type), Collections.emptyMap());
             hits[i].shard(new SearchShardTarget("testnode", new Index(index, "uuid"), 0));
         }

--- a/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/10_basic.yaml
+++ b/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/10_basic.yaml
@@ -59,13 +59,27 @@
           "metric" : { "precisionatn": { "size": 10}}
         }
 
-  - match: {rank_eval.quality_level: 1}
-  - match: {rank_eval.details.amsterdam_query.quality_level: 1.0}
-  - match: {rank_eval.details.amsterdam_query.unknown_docs:  [ {"_index": "foo", "_type": "bar", "_id": "doc4"}]}
-  - match: {rank_eval.details.amsterdam_query.metric_details: {"relevant_docs_retrieved": 2, "docs_retrieved": 2}}
-  - match: {rank_eval.details.berlin_query.quality_level: 1.0}
-  - match: {rank_eval.details.berlin_query.unknown_docs:  [ {"_index": "foo", "_type": "bar", "_id": "doc4"}]}
-  - match: {rank_eval.details.berlin_query.metric_details: {"relevant_docs_retrieved": 1, "docs_retrieved": 1}}
+  - match: { rank_eval.quality_level: 1}
+  - match: { rank_eval.details.amsterdam_query.quality_level: 1.0}
+  - match: { rank_eval.details.amsterdam_query.unknown_docs:  [ {"_index": "foo", "_type": "bar", "_id": "doc4"}]}
+  - match: { rank_eval.details.amsterdam_query.metric_details: {"relevant_docs_retrieved": 2, "docs_retrieved": 2}}
+  
+  - length: { rank_eval.details.amsterdam_query.hits: 3}
+  - match: { rank_eval.details.amsterdam_query.hits.0.hit:  {"_index" : "foo", "_type" : "bar", "_id" : "doc2", "_score" : 0.44839138}}
+  - match: { rank_eval.details.amsterdam_query.hits.0.rating: 1}
+  - match: { rank_eval.details.amsterdam_query.hits.1.hit:  {"_index" : "foo", "_type" : "bar", "_id" : "doc3", "_score" : 0.44839138}}
+  - match: { rank_eval.details.amsterdam_query.hits.1.rating: 1}
+  - match: { rank_eval.details.amsterdam_query.hits.2.hit:  {"_index" : "foo", "_type" : "bar", "_id" : "doc4", "_score" : 0.21492207}}
+  - is_false: rank_eval.details.amsterdam_query.hits.2.rating
+  
+  - match: { rank_eval.details.berlin_query.quality_level: 1.0}
+  - match: { rank_eval.details.berlin_query.unknown_docs:  [ {"_index": "foo", "_type": "bar", "_id": "doc4"}]}
+  - match: { rank_eval.details.berlin_query.metric_details: {"relevant_docs_retrieved": 1, "docs_retrieved": 1}}
+  - length: { rank_eval.details.berlin_query.hits: 2}
+  - match: { rank_eval.details.berlin_query.hits.0.hit:  { "_index" : "foo", "_type" : "bar", "_id" : "doc1", "_score" : 0.87138504}}
+  - match: { rank_eval.details.berlin_query.hits.0.rating: 1}
+  - match: { rank_eval.details.berlin_query.hits.1.hit:  { "_index" : "foo", "_type" : "bar", "_id" : "doc4", "_score" : 0.41767058}}
+  - is_false: rank_eval.details.berlin_query.hits.1.rating 
 
 ---
 "Reciprocal Rank":
@@ -133,7 +147,7 @@
   - match: {rank_eval.details.amsterdam_query.quality_level: 0.3333333333333333}
   - match: {rank_eval.details.amsterdam_query.metric_details: {"first_relevant": 3}}
   - match: {rank_eval.details.amsterdam_query.unknown_docs:  [ {"_index": "foo", "_type": "bar", "_id": "doc2"},
-                                                                       {"_index": "foo", "_type": "bar", "_id": "doc3"} ]}
+                                                               {"_index": "foo", "_type": "bar", "_id": "doc3"} ]}
   - match: {rank_eval.details.berlin_query.quality_level: 0.5}
   - match: {rank_eval.details.berlin_query.metric_details: {"first_relevant": 2}}
   - match: {rank_eval.details.berlin_query.unknown_docs:  [ {"_index": "foo", "_type": "bar", "_id": "doc1"}]}
@@ -168,7 +182,7 @@
   - match: {rank_eval.details.amsterdam_query.quality_level: 0}
   - match: {rank_eval.details.amsterdam_query.metric_details: {"first_relevant": -1}}  
   - match: {rank_eval.details.amsterdam_query.unknown_docs:  [ {"_index": "foo", "_type": "bar", "_id": "doc2"},
-                                                                       {"_index": "foo", "_type": "bar", "_id": "doc3"} ]}
+                                                               {"_index": "foo", "_type": "bar", "_id": "doc3"} ]}
   - match: {rank_eval.details.berlin_query.quality_level: 0.5}
   - match: {rank_eval.details.berlin_query.metric_details: {"first_relevant": 2}}
   - match: {rank_eval.details.berlin_query.unknown_docs:  [ {"_index": "foo", "_type": "bar", "_id": "doc1"}]}


### PR DESCRIPTION
This change adds a `hits` section to the response part for each ranking evaluation query, containing a list of documents (index/type/id) and ratings (if the document was rated in the request). This section can be used to better understand the calculation of the ranking quality of this particular query, but it can also be used to identify the "unknown" (that is unrated) documents that were part of the seach hits, for example because a UI later wants to present those documents to the user to get a rating for them. If the user specifies a set of field names using a parameter called `summary_fields` in the request, those fields are also included as part of the response in addition to "_index", "_type", "_id".

There are two other changes to the internal structuring of the code that I'd like to discuss with this PR as well:
-  Pull common operations into RankedListQualityMetric interface
  
  Currently each implementation of RankedListQualityMetric does some initial joining operation that links the input search hits with a rated document rating, if available. Also all metrics collect unknown docs and now also need to add the list of rated search hits to the partial query evaluation. This change centralizes this work in some new helper methods in RankedListQualityMetric.
-  Remove unknown docs from EvalQueryQuality
  
  The unknown document section in the response for each query can be rendered using the rated hits that are now also part of the response by just filtering the documents without a rating. By removing the unknown docs section from the EvalQueryQuality we save work serializing this object over the wire. Should we choose to make the `hits` section optional later (via a verbose mode) we'd need to decide if we still always want to include the unknown docs for each request in the response. In that case we'd probably still need this structure.

Relatest to #20364 
