### PR TITLE
Add placeholder to the docs to distinguish released,unreleased,prerelease versions

### DIFF
--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -3,6 +3,8 @@
 
 :version:        5.0.0-beta1
 :major-version:  5.x
+// release-state can be: released | prerelease | unreleased
+:release-state:  prerelease
 :lucene_version: 6.2.0
 :branch:         master
 :jdk:            1.8.0_73

--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -22,6 +22,14 @@ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add
 [[deb-repo]]
 ==== Installing from the APT repository
 
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of Elasticsearch has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
 You may need to install the `apt-transport-https` package on Debian before proceeding:
 
 [source,sh]
@@ -31,10 +39,24 @@ sudo apt-get install apt-transport-https
 
 Save the repository definition to  +/etc/apt/sources.list.d/elastic-{major-version}.list+:
 
+ifeval::["{release-state}"=="released"]
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+echo "deb https://artifacts.elastic.co/packages/{major-version}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{major-version}.list
+--------------------------------------------------
+
+endif::[]
+
+ifeval::["{release-state}"=="prerelease"]
+
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------------
 echo "deb https://artifacts.elastic.co/packages/{major-version}-prerelease/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{major-version}.list
 --------------------------------------------------
+
+endif::[]
+
 
 [WARNING]
 ==================================================
@@ -82,6 +104,9 @@ sudo dpkg -i elasticsearch-{version}.deb
 --------------------------------------------
 <1> Compare the SHA produced by `sha1sum` or `shasum` with the
     https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.deb.sha1[published SHA].
+
+endif::[]
+// release-state!=unreleased
 
 include::init-systemd.asciidoc[]
 

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -26,9 +26,35 @@ rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch
 [[rpm-repo]]
 ==== Installing from the RPM repository
 
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of Elasticsearch has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
 Create a file called `elasticsearch.repo` in the `/etc/yum.repos.d/` directory
 for RedHat based distributions, or in the `/etc/zypp/repos.d/` directory for
 OpenSuSE based distributions, containing:
+
+ifeval::["{release-state}"=="released"]
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+[elasticsearch-{major-version}]
+name=Elasticsearch repository for {major-version} packages
+baseurl=https://artifacts.elastic.co/packages/{major-version}/yum
+gpgcheck=1
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+enabled=1
+autorefresh=1
+type=rpm-md
+--------------------------------------------------
+
+endif::[]
+
+ifeval::["{release-state}"=="prerelease"]
 
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------------
@@ -41,6 +67,8 @@ enabled=1
 autorefresh=1
 type=rpm-md
 --------------------------------------------------
+
+endif::[]
 
 And your repository is ready for use. You can now install Elasticsearch with one of the following commands:
 
@@ -67,6 +95,9 @@ sudo rpm --install elasticsearch-{version}.rpm
 --------------------------------------------
 <1> Compare the SHA produced by `sha1sum` or `shasum` with the
     https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.rpm.sha1[published SHA].
+
+endif::[]
+// release-state!=unreleased
 
 include::init-systemd.asciidoc[]
 

--- a/docs/reference/setup/install/windows.asciidoc
+++ b/docs/reference/setup/install/windows.asciidoc
@@ -13,6 +13,14 @@ link:/downloads/past-releases[Past Releases page].
 [[install-windows]]
 ==== Download and install the `.zip` package
 
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of Elasticsearch has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
 Download the `.zip` archive for Elasticsearch v{version} from: https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.zip
 
 Unzip it with your favourite unzip tool.  This will create a folder called
@@ -23,6 +31,8 @@ window, `CD` to the `%ES_HOME%` directory, for instance:
 ----------------------------
 CD c:\elasticsearch-{version}
 ----------------------------
+
+endif:[]
 
 [[windows-running]]
 ==== Running Elasticsearch from the command line

--- a/docs/reference/setup/install/zip-targz.asciidoc
+++ b/docs/reference/setup/install/zip-targz.asciidoc
@@ -13,7 +13,16 @@ link:/downloads/past-releases[Past Releases page].
 [[install-zip]]
 ==== Download and install the `.zip` package
 
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of Elasticsearch has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
 The `.zip` archive for Elastisearch v{version} can be downloaded and installed as follows:
+
 
 ["source","sh",subs="attributes"]
 --------------------------------------------
@@ -26,8 +35,19 @@ cd elasticsearch-{version}/ <2>
     https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.zip.sha1[published SHA].
 <2> This directory is known as `$ES_HOME`.
 
+endif::[]
+
+
 [[install-targz]]
 ==== Download and install the `.tar.gz` package
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of Elasticsearch has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 The `.tar.gz` archive for Elastisearch v{version} can be downloaded and installed as follows:
 
@@ -41,6 +61,8 @@ cd elasticsearch-{version}/ <2>
 <1> Compare the SHA produced by `sha1sum` or `shasum` with the
     https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.tar.gz.sha1[published SHA].
 <2> This directory is known as `$ES_HOME`.
+
+endif::[]
 
 [[zip-targz-running]]
 ==== Running Elasticsearch from the command line


### PR DESCRIPTION
I've added a placeholder to the Elasticsearch docs `release-state` which can be set to `released`, `unreleased`, or `prerelease` and the install instructions vary based on this setting.

/cc @rjernst @tsg @suyograo @epixa 
