### PR TITLE
Fixed date math expression support in multi get requests.

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
+++ b/core/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
@@ -67,15 +67,15 @@ public class TransportMultiGetAction extends HandledTransportAction<MultiGetRequ
             String concreteSingleIndex;
             try {
                 concreteSingleIndex = indexNameExpressionResolver.concreteSingleIndex(clusterState, item).getName();
+
+                item.routing(clusterState.metaData().resolveIndexRouting(item.parent(), item.routing(), concreteSingleIndex));
+                if ((item.routing() == null) && (clusterState.getMetaData().routingRequired(concreteSingleIndex, item.type()))) {
+                    String message = "routing is required for [" + concreteSingleIndex + "]/[" + item.type() + "]/[" + item.id() + "]";
+                    responses.set(i, newItemFailure(concreteSingleIndex, item.type(), item.id(), new IllegalArgumentException(message)));
+                    continue;
+                }
             } catch (Exception e) {
                 responses.set(i, newItemFailure(item.index(), item.type(), item.id(), e));
-                continue;
-            }
-
-            item.routing(clusterState.metaData().resolveIndexRouting(item.parent(), item.routing(), concreteSingleIndex));
-            if ((item.routing() == null) && (clusterState.getMetaData().routingRequired(concreteSingleIndex, item.type()))) {
-                String message = "routing is required for [" + concreteSingleIndex + "]/[" + item.type() + "]/[" + item.id() + "]";
-                responses.set(i, newItemFailure(concreteSingleIndex, item.type(), item.id(), new IllegalArgumentException(message)));
                 continue;
             }
 

--- a/core/src/test/java/org/elasticsearch/indices/DateMathIndexExpressionsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/DateMathIndexExpressionsIntegrationIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.get.MultiGetResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -76,6 +77,17 @@ public class DateMathIndexExpressionsIntegrationIT extends ESIntegTestCase {
         getResponse = client().prepareGet(dateMathExp3, "type", "3").get();
         assertThat(getResponse.isExists(), is(true));
         assertThat(getResponse.getId(), equalTo("3"));
+
+        MultiGetResponse mgetResponse = client().prepareMultiGet()
+            .add(dateMathExp1, "type", "1")
+            .add(dateMathExp2, "type", "2")
+            .add(dateMathExp3, "type", "3").get();
+        assertThat(mgetResponse.getResponses()[0].getResponse().isExists(), is(true));
+        assertThat(mgetResponse.getResponses()[0].getResponse().getId(), equalTo("1"));
+        assertThat(mgetResponse.getResponses()[1].getResponse().isExists(), is(true));
+        assertThat(mgetResponse.getResponses()[1].getResponse().getId(), equalTo("2"));
+        assertThat(mgetResponse.getResponses()[2].getResponse().isExists(), is(true));
+        assertThat(mgetResponse.getResponses()[2].getResponse().getId(), equalTo("3"));
 
         IndicesStatsResponse indicesStatsResponse = client().admin().indices().prepareStats(dateMathExp1, dateMathExp2, dateMathExp3).get();
         assertThat(indicesStatsResponse.getIndex(index1), notNullValue());

--- a/core/src/test/java/org/elasticsearch/mget/SimpleMgetIT.java
+++ b/core/src/test/java/org/elasticsearch/mget/SimpleMgetIT.java
@@ -53,7 +53,7 @@ public class SimpleMgetIT extends ESIntegTestCase {
         MultiGetResponse mgetResponse = client().prepareMultiGet()
                 .add(new MultiGetRequest.Item("test", "test", "1"))
                 .add(new MultiGetRequest.Item("nonExistingIndex", "test", "1"))
-                .execute().actionGet();
+                .get();
         assertThat(mgetResponse.getResponses().length, is(2));
 
         assertThat(mgetResponse.getResponses()[0].getIndex(), is("test"));
@@ -65,10 +65,9 @@ public class SimpleMgetIT extends ESIntegTestCase {
         assertThat(((ElasticsearchException) mgetResponse.getResponses()[1].getFailure().getFailure()).getIndex().getName(),
             is("nonExistingIndex"));
 
-
         mgetResponse = client().prepareMultiGet()
                 .add(new MultiGetRequest.Item("nonExistingIndex", "test", "1"))
-                .execute().actionGet();
+                .get();
         assertThat(mgetResponse.getResponses().length, is(1));
         assertThat(mgetResponse.getResponses()[0].getIndex(), is("nonExistingIndex"));
         assertThat(mgetResponse.getResponses()[0].isFailed(), is(true));
@@ -87,7 +86,7 @@ public class SimpleMgetIT extends ESIntegTestCase {
         MultiGetResponse mgetResponse = client().prepareMultiGet()
             .add(new MultiGetRequest.Item("test", "test", "1"))
             .add(new MultiGetRequest.Item("multiIndexAlias", "test", "1"))
-            .execute().actionGet();
+            .get();
         assertThat(mgetResponse.getResponses().length, is(2));
 
         assertThat(mgetResponse.getResponses()[0].getIndex(), is("test"));
@@ -99,7 +98,7 @@ public class SimpleMgetIT extends ESIntegTestCase {
 
         mgetResponse = client().prepareMultiGet()
             .add(new MultiGetRequest.Item("multiIndexAlias", "test", "1"))
-            .execute().actionGet();
+            .get();
         assertThat(mgetResponse.getResponses().length, is(1));
         assertThat(mgetResponse.getResponses()[0].getIndex(), is("multiIndexAlias"));
         assertThat(mgetResponse.getResponses()[0].isFailed(), is(true));
@@ -124,7 +123,7 @@ public class SimpleMgetIT extends ESIntegTestCase {
         MultiGetResponse mgetResponse = client().prepareMultiGet()
                 .add(new MultiGetRequest.Item(indexOrAlias(), "test", "1").parent("4"))
                 .add(new MultiGetRequest.Item(indexOrAlias(), "test", "1"))
-                .execute().actionGet();
+                .get();
 
         assertThat(mgetResponse.getResponses().length, is(2));
         assertThat(mgetResponse.getResponses()[0].isFailed(), is(false));
@@ -192,7 +191,7 @@ public class SimpleMgetIT extends ESIntegTestCase {
         MultiGetResponse mgetResponse = client().prepareMultiGet()
                 .add(new MultiGetRequest.Item(indexOrAlias(), "test", id).routing(routingOtherShard))
                 .add(new MultiGetRequest.Item(indexOrAlias(), "test", id))
-                .execute().actionGet();
+                .get();
 
         assertThat(mgetResponse.getResponses().length, is(2));
         assertThat(mgetResponse.getResponses()[0].isFailed(), is(false));


### PR DESCRIPTION
Fixed date math expression support in multi get requests.
Date math index/alias expressions in `mget` will now be resolved to a concrete single index instead of failing the mget item with a `IndexNotFoundException`.
Note `mget` uses the same `IndicesOptions` as `get`; which prevents the expression from resolving to multiple indices (i.e. wilcards).
Added integration test to verify multi index aliases do not fail the entire mget request.

Closes #17957
