### PR TITLE
change health from string to enum in the cat indices rest test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
@@ -34,8 +34,10 @@
             "description" : "Comma-separated list of column names to display"
         },
         "health": {
-            "type" : "string",
-            "description" : "A health status (\"green\", \"yellow\", or \"red\" to filter only indices matching the specified health status"
+          "type" : "enum",
+          "options" : ["green","yellow","red"],
+          "default" : null,
+          "description" : "A health status (\"green\", \"yellow\", or \"red\" to filter only indices matching the specified health status"
         },
         "help": {
           "type": "boolean",


### PR DESCRIPTION
In most places we model this as an enum e.g `wait_for_status`
