### PR TITLE
Fix logger when you can not create an azure storage client

### DIFF
--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
@@ -164,8 +164,8 @@ public class AzureStorageServiceImpl extends AbstractLifecycleComponent<AzureSto
             logger.trace("creating container [{}]", container);
             blobContainer.createIfNotExists();
         } catch (IllegalArgumentException e) {
-            logger.trace("fails creating container [{}]", container, e.getMessage());
-            throw new RepositoryException(container, e.getMessage());
+            logger.trace("fails creating container [{}]", e, container);
+            throw new RepositoryException(container, e.getMessage(), e);
         }
     }
 

--- a/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/AbstractAzureRepositoryServiceTestCase.java
+++ b/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/AbstractAzureRepositoryServiceTestCase.java
@@ -38,22 +38,7 @@ import java.util.Collection;
 
 public abstract class AbstractAzureRepositoryServiceTestCase extends AbstractAzureTestCase {
 
-    public static class TestPlugin extends Plugin {
-        @Override
-        public String name() {
-            return "mock-stoarge-service";
-        }
-        @Override
-        public String description() {
-            return "plugs in a mock storage service for testing";
-        }
-        public void onModule(AzureModule azureModule) {
-            azureModule.storageServiceImpl = AzureStorageServiceMock.class;
-        }
-    }
-
     protected String basePath;
-    private Class<? extends AzureStorageService> mock;
 
     public AbstractAzureRepositoryServiceTestCase(String basePath) {
         this.basePath = basePath;
@@ -79,7 +64,6 @@ public abstract class AbstractAzureRepositoryServiceTestCase extends AbstractAzu
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         Settings.Builder builder = Settings.settingsBuilder()
-                .put(Storage.API_IMPLEMENTATION, mock)
                 .put(Storage.CONTAINER, "snapshots");
 
         // We use sometime deprecated settings in tests
@@ -87,11 +71,6 @@ public abstract class AbstractAzureRepositoryServiceTestCase extends AbstractAzu
                 .put(Storage.KEY_DEPRECATED, "mock_azure_key");
 
         return builder.build();
-    }
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(CloudAzurePlugin.class, TestPlugin.class);
     }
 
     @Override

--- a/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/AbstractAzureRepositoryServiceTestCase.java
+++ b/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/AbstractAzureRepositoryServiceTestCase.java
@@ -38,7 +38,22 @@ import java.util.Collection;
 
 public abstract class AbstractAzureRepositoryServiceTestCase extends AbstractAzureTestCase {
 
+    public static class TestPlugin extends Plugin {
+        @Override
+        public String name() {
+            return "mock-stoarge-service";
+        }
+        @Override
+        public String description() {
+            return "plugs in a mock storage service for testing";
+        }
+        public void onModule(AzureModule azureModule) {
+            azureModule.storageServiceImpl = AzureStorageServiceMock.class;
+        }
+    }
+
     protected String basePath;
+    private Class<? extends AzureStorageService> mock;
 
     public AbstractAzureRepositoryServiceTestCase(String basePath) {
         this.basePath = basePath;
@@ -64,6 +79,7 @@ public abstract class AbstractAzureRepositoryServiceTestCase extends AbstractAzu
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         Settings.Builder builder = Settings.settingsBuilder()
+                .put(Storage.API_IMPLEMENTATION, mock)
                 .put(Storage.CONTAINER, "snapshots");
 
         // We use sometime deprecated settings in tests
@@ -71,6 +87,11 @@ public abstract class AbstractAzureRepositoryServiceTestCase extends AbstractAzu
                 .put(Storage.KEY_DEPRECATED, "mock_azure_key");
 
         return builder.build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return pluginList(CloudAzurePlugin.class, TestPlugin.class);
     }
 
     @Override


### PR DESCRIPTION
We were swallowing the original exception when creating a client with bad credentials.
So even in `TRACE` log level, nothing useful were coming out of it.
With this commit, it now prints:

```
[2016-09-27 15:54:13,118][ERROR][cloud.azure.storage      ] [node_s0] can not create azure storage client: Storage Key is not a valid base64 encoded string.
```

Closes #20633.

This PR applies to 2.4 branch. When accepted, I'll also apply it to master / 5.x branch (and 5.0? cc @clintongormley)
