### PR TITLE
Clean up confusing error message on unhandled endpoint

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
@@ -77,7 +77,7 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
                     return feature;
                 }
             }
-            throw new IllegalArgumentException("No feature for name [" + name + "]");
+            throw new IllegalArgumentException("No endpoint or operation is available at [" + name + "]");
         }
 
         public static Feature fromId(byte id) {


### PR DESCRIPTION
It currently returns something like:

```
"No feature for name [_siohgjoidfhjfihfg]"
```

Which is not the most understandable message, this changes it to be a
little more readable.

Resolves #10946
