### PR TITLE
Remove es_port in GCE

### DIFF
--- a/docs/plugins/discovery-ec2.asciidoc
+++ b/docs/plugins/discovery-ec2.asciidoc
@@ -134,7 +134,11 @@ with the right signer to use.
 ==== EC2 Discovery
 
 ec2 discovery allows to use the ec2 APIs to perform automatic discovery (similar to multicast in non hostile multicast
-environments). Here is a simple sample configuration:
+environments).
+
+Note that ec2 discovery plugin expects your node running on default 9300 port.
+
+Here is a simple sample configuration:
 
 [source,yaml]
 ----

--- a/docs/plugins/discovery-gce.asciidoc
+++ b/docs/plugins/discovery-gce.asciidoc
@@ -78,6 +78,7 @@ The following gce settings (prefixed with `cloud.gce`) are supported:
      How long the list of hosts is cached to prevent further requests to the GCE API. `0s` disables caching.
      A negative value will cause infinite caching. Defaults to `0s`.
 
+Note that GCE discovery plugin expects your node running on default 9300 port.
 
 [IMPORTANT]
 .Binding the network host
@@ -408,41 +409,6 @@ discovery:
       gce:
             tags: elasticsearch, dev
 --------------------------------------------------
-
-[[discovery-gce-usage-port]]
-==== Changing default transport port
-
-By default, elasticsearch GCE plugin assumes that you run elasticsearch on 9300 default port.
-But you can specify the port value elasticsearch is meant to use using google compute engine metadata `es_port`:
-
-[[discovery-gce-usage-port-create]]
-===== When creating instance
-
-Add `--metadata es_port=9301` option:
-
-[source,sh]
---------------------------------------------------
-# when creating first instance
-gcloud compute instances create myesnode1 \
-       --scopes=compute-rw,storage-full \
-       --metadata es_port=9301
-
-# when creating an instance from an image
-gcloud compute instances create myesnode2 --image=elasticsearch-1-0-0-RC1 \
-       --zone europe-west1-a --machine-type f1-micro --scopes=compute-rw \
-       --metadata es_port=9301
---------------------------------------------------
-
-[[discovery-gce-usage-port-run]]
-===== On a running instance
-
-[source,sh]
---------------------------------------------------
-gcloud compute instances add-metadata myesnode1 \
-       --zone europe-west1-a \
-       --metadata es_port=9301
---------------------------------------------------
-
 
 [[discovery-gce-usage-tips]]
 ==== GCE Tips

--- a/docs/reference/migration/migrate_6_0/plugins.asciidoc
+++ b/docs/reference/migration/migrate_6_0/plugins.asciidoc
@@ -5,3 +5,8 @@
 
 * The mapper attachments plugin has been depecated in elasticsearch 5.0 and is now removed.
 You can use {plugins}/ingest-attachment.html[ingest attachment plugin] instead.
+
+==== GCE discovery plugin
+
+* The GCE discovery plugin does not take anymore into account `es_port` GCE instance metadata. It only tries to
+find nodes running on the GCE instance on port 9300.

--- a/plugins/discovery-gce/src/main/java/org/elasticsearch/discovery/gce/GceUnicastHostsProvider.java
+++ b/plugins/discovery-gce/src/main/java/org/elasticsearch/discovery/gce/GceUnicastHostsProvider.java
@@ -222,20 +222,8 @@ public class GceUnicastHostsProvider extends AbstractComponent implements Unicas
                         logger.trace("current node found. Ignoring {} - {}", name, ip_private);
                     } else {
                         String address = ip_private;
-                        // Test if we have es_port metadata defined here
-                        if (instance.getMetadata() != null && instance.getMetadata().containsKey("es_port")) {
-                            Object es_port = instance.getMetadata().get("es_port");
-                            logger.trace("es_port is defined with {}", es_port);
-                            if (es_port instanceof String) {
-                                address = address.concat(":").concat((String) es_port);
-                            } else {
-                                // Ignoring other values
-                                logger.trace("es_port is instance of {}. Ignoring...", es_port.getClass().getName());
-                            }
-                        }
 
                         // ip_private is a single IP Address. We need to build a TransportAddress from it
-                        // If user has set `es_port` metadata, we don't need to ping all ports
                         // we only limit to 1 addresses, makes no sense to ping 100 ports
                         TransportAddress[] addresses = transportService.addressesFromString(address, 1);
 


### PR DESCRIPTION
Follow up for #18790.

We need to be consistent with other discovery plugins and remove the support of GCE metadata `es_port`.
It means that we only discover elasticsearch instances running on port 9300.
