### PR TITLE
Remove support for controversial `ignore_unavailable` and `allow_no_indices` from indices exists api

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsRequest.java
@@ -61,8 +61,15 @@ public class IndicesExistsRequest extends MasterNodeReadRequest<IndicesExistsReq
         return indicesOptions;
     }
 
-    public IndicesExistsRequest indicesOptions(IndicesOptions indicesOptions) {
-        this.indicesOptions = indicesOptions;
+    public IndicesExistsRequest expandWilcardsOpen(boolean expandWildcardsOpen) {
+        this.indicesOptions = IndicesOptions.fromOptions(indicesOptions.ignoreUnavailable(), indicesOptions.allowNoIndices(),
+                expandWildcardsOpen, indicesOptions.expandWildcardsClosed());
+        return this;
+    }
+
+    public IndicesExistsRequest expandWilcardsClosed(boolean expandWildcardsClosed) {
+        this.indicesOptions = IndicesOptions.fromOptions(indicesOptions.ignoreUnavailable(), indicesOptions.allowNoIndices(),
+                indicesOptions.expandWildcardsOpen(), expandWildcardsClosed);
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsRequestBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.exists.indices;
 
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
 
@@ -35,12 +34,18 @@ public class IndicesExistsRequestBuilder extends MasterNodeReadOperationRequestB
     }
 
     /**
-     * Specifies what type of requested indices to ignore and wildcard indices expressions.
-     * <p>
-     * For example indices that don't exist.
+     * Controls whether wildcard expressions will be expanded to existing open indices
      */
-    public IndicesExistsRequestBuilder setIndicesOptions(IndicesOptions options) {
-        request.indicesOptions(options);
+    public IndicesExistsRequestBuilder setExpandWildcardsOpen(boolean expandWildcardsOpen) {
+        request.expandWilcardsOpen(expandWildcardsOpen);
+        return this;
+    }
+
+    /**
+     * Controls whether wildcard expressions will be expanded to existing closed indices
+     */
+    public IndicesExistsRequestBuilder setExpandWildcardsClosed(boolean expandWildcardsClosed) {
+        request.expandWilcardsClosed(expandWildcardsClosed);
         return this;
     }
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesExistsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesExistsAction.java
@@ -51,7 +51,9 @@ public class RestIndicesExistsAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         IndicesExistsRequest indicesExistsRequest = new IndicesExistsRequest(Strings.splitStringByCommaToArray(request.param("index")));
-        indicesExistsRequest.indicesOptions(IndicesOptions.fromRequest(request, indicesExistsRequest.indicesOptions()));
+        IndicesOptions indicesOptions = IndicesOptions.fromRequest(request, indicesExistsRequest.indicesOptions());
+        indicesExistsRequest.expandWilcardsOpen(indicesOptions.expandWildcardsOpen());
+        indicesExistsRequest.expandWilcardsClosed(indicesOptions.expandWildcardsClosed());
         indicesExistsRequest.local(request.paramAsBoolean("local", indicesExistsRequest.local()));
         return channel -> client.admin().indices().exists(indicesExistsRequest, new RestResponseListener<IndicesExistsResponse>(channel) {
             @Override

--- a/core/src/test/java/org/elasticsearch/indices/exists/indices/IndicesExistsIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/exists/indices/IndicesExistsIT.java
@@ -19,7 +19,8 @@
 
 package org.elasticsearch.indices.exists.indices;
 
-import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
+import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequestBuilder;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -29,21 +30,33 @@ import java.util.Arrays;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_BLOCKS_READ;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_BLOCKS_WRITE;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_READ_ONLY;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
 public class IndicesExistsIT extends ESIntegTestCase {
     // Indices exists never throws IndexMissingException, the indices options control its behaviour (return true or false)
     public void testIndicesExists() throws Exception {
-        assertThat(client().admin().indices().prepareExists("foo").get().isExists(), equalTo(false));
-        assertThat(client().admin().indices().prepareExists("foo").setIndicesOptions(IndicesOptions.lenientExpandOpen()).get().isExists(), equalTo(true));
-        assertThat(client().admin().indices().prepareExists("foo*").get().isExists(), equalTo(false));
-        assertThat(client().admin().indices().prepareExists("foo*").setIndicesOptions(IndicesOptions.fromOptions(false, true, true, false)).get().isExists(), equalTo(true));
-        assertThat(client().admin().indices().prepareExists("_all").get().isExists(), equalTo(false));
+        assertFalse(client().admin().indices().prepareExists("foo").get().isExists());
+        assertFalse(client().admin().indices().prepareExists("foo*").get().isExists());
+        assertFalse(client().admin().indices().prepareExists("_all").get().isExists());
 
         createIndex("foo", "foobar", "bar", "barbaz");
 
+        IndicesExistsRequestBuilder indicesExistsRequestBuilder = client().admin().indices().prepareExists("foo*")
+                .setExpandWildcardsOpen(false);
+        IndicesExistsRequest request = indicesExistsRequestBuilder.request();
+        //check that ignore unavailable and allow no indices are set to false. That is their only valid value as it can't be overridden
+        assertFalse(request.indicesOptions().ignoreUnavailable());
+        assertFalse(request.indicesOptions().allowNoIndices());
+        assertThat(indicesExistsRequestBuilder.get().isExists(), equalTo(false));
+
+        assertAcked(client().admin().indices().prepareClose("foobar").get());
+
         assertThat(client().admin().indices().prepareExists("foo*").get().isExists(), equalTo(true));
+        assertThat(client().admin().indices().prepareExists("foo*").setExpandWildcardsOpen(false)
+                .setExpandWildcardsClosed(false).get().isExists(), equalTo(false));
         assertThat(client().admin().indices().prepareExists("foobar").get().isExists(), equalTo(true));
+        assertThat(client().admin().indices().prepareExists("foob*").setExpandWildcardsClosed(false).get().isExists(), equalTo(false));
         assertThat(client().admin().indices().prepareExists("bar*").get().isExists(), equalTo(true));
         assertThat(client().admin().indices().prepareExists("bar").get().isExists(), equalTo(true));
         assertThat(client().admin().indices().prepareExists("_all").get().isExists(), equalTo(true));

--- a/docs/reference/migration/migrate_6_0/rest.asciidoc
+++ b/docs/reference/migration/migrate_6_0/rest.asciidoc
@@ -11,3 +11,9 @@ has been removed in Elasticsearch 6.0.0.
 ==== Analyze API changes
 
 The deprecated request parameters and plain text in request body has been removed. Define parameters in request body.
+
+==== Indices exists API
+
+The `ignore_unavailable` and `allow_no_indices` options are no longer accepted
+as they could cause undesired results when their values differed from their
+defaults.

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
@@ -13,14 +13,6 @@
         }
       },
       "params": {
-        "ignore_unavailable": {
-            "type" : "boolean",
-            "description" : "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
-        },
-        "allow_no_indices": {
-            "type" : "boolean",
-            "description" : "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
-        },
         "expand_wildcards": {
             "type" : "enum",
             "options" : ["open","closed","none","all"],


### PR DESCRIPTION
Exist requests are supposed to never throw an exception, but rather return `true` or `false` depending on whether some resource exists or not. Indices exists does that for indices and accepts wildcard expressions. The way the api works internally is by resolving indices like any other api would do and catching `IndexNotFoundException`: if an exception is thrown `false` is returned, otherwise `true`. That works only if `ignore_unavailable` and `allow_no_indices` indices options are both set to `false`, meaning that they are strict and any missing index or wildcard expression that resolves to no indices leads to an exception that can be thrown and cause `false` to be returned.

Unfortunately the indices options have  been configurable up until now for the indices exists request, meaning that one can set `ignore_unavailable` or `allow_no_indices` to `true` and have the indices exist request return `true` for indices that really don't exist, which makes very little sense in the context of this api.

For instance `curl -iXHEAD localhost:9200/_all?allow_no_indices=true` returns `200 OK` against an empty cluster. `allow_no_indices` and `ignore_unavailable` affect badly what this api returns, hence I think they shouldn't be settable in this specific case.

This commit removes the `indicesOptions` setter from the `IndicesExistsRequest` and makes settable only `expandWildcardsOpen` and `expandWildcardsClosed`, hence a subset of the available indices options. This way we can guarantee more consistent behaviour of the indices exists api. `ignore_unavailable` will always be set to `false`, as well as `allow_no_indices`.
