### PR TITLE
IndicesAliasesRequest should not implement CompositeIndicesRequest

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/CompositeIndicesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/CompositeIndicesRequest.java
@@ -22,11 +22,13 @@ package org.elasticsearch.action;
 import java.util.List;
 
 /**
- * Needs to be implemented by all {@link org.elasticsearch.action.ActionRequest} subclasses that are composed of
- * multiple subrequests which relate to one or more indices. Allows to retrieve those subrequests.
+ * Needs to be implemented by all {@link org.elasticsearch.action.ActionRequest} subclasses that are composed of multiple subrequests
+ * which relate to one or more indices. Allows to retrieve those subrequests and reason about them separately. A composite request is
+ * executed by its own transport action class (e.g. {@link org.elasticsearch.action.search.TransportMultiSearchAction}), which goes
+ * through all the subrequests and delegates their exection to the appropriate transport action (e.g.
+ * {@link org.elasticsearch.action.search.TransportSearchAction}) for each single item.
  */
 public interface CompositeIndicesRequest {
-
     /**
      * Returns the subrequests that a composite request is composed of
      */

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -20,12 +20,9 @@
 package org.elasticsearch.action.admin.indices.alias;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.AliasesRequest;
-import org.elasticsearch.action.CompositeIndicesRequest;
-import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.cluster.metadata.AliasAction;
@@ -63,7 +60,7 @@ import static org.elasticsearch.common.xcontent.ObjectParser.fromList;
 /**
  * A request to add/remove aliases for one or more indices.
  */
-public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesRequest> implements CompositeIndicesRequest {
+public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesRequest> {
     private List<AliasActions> allAliasActions = new ArrayList<>();
 
     //indices options that require every specified index to exist, expand wildcards only to open indices and
@@ -501,10 +498,5 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
 
     public IndicesOptions indicesOptions() {
         return INDICES_OPTIONS;
-    }
-
-    @Override
-    public List<? extends IndicesRequest> subRequests() {
-        return allAliasActions;
     }
 }


### PR DESCRIPTION
`CompositeIndicesRequest` should be implemented by all requests that are composed of multiple subrequests which relate to one or more indices. A composite request is
executed by its own transport action class (e.g. `TransportMultiSearchAction` for `_msearch`), which goes through all the subrequests and delegates their execution to the appropriate transport action (e.g. `TransportSearchAction` for `_msearch`) for each single item. `IndicesAliasesRequest` is a particular request as it holds multiple items that implement `AliasesRequest`, but it shouldn't be considered a composite request, as it has no specific transport action for each of its items. Also, either all of its subitems fail or succeed.

Also clarified javadocs for `CompositeIndicesRequest`.
