### PR TITLE
Skip shard management code when updating cluster state on client/tribe nodes

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -148,12 +148,17 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
 
     @Override
     protected void doStart() {
-        clusterService.addFirst(this);
+        // Doesn't make sense to manage shards on non-master and non-data nodes
+        if (DiscoveryNode.isDataNode(settings) || DiscoveryNode.isMasterNode(settings)) {
+            clusterService.addFirst(this);
+        }
     }
 
     @Override
     protected void doStop() {
-        clusterService.remove(this);
+        if (DiscoveryNode.isDataNode(settings) || DiscoveryNode.isMasterNode(settings)) {
+            clusterService.remove(this);
+        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/core/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -94,12 +94,17 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
         this.threadPool = threadPool;
         transportService.registerRequestHandler(ACTION_SHARD_EXISTS, ShardActiveRequest::new, ThreadPool.Names.SAME, new ShardActiveRequestHandler());
         this.deleteShardTimeout = INDICES_STORE_DELETE_SHARD_TIMEOUT.get(settings);
-        clusterService.addLast(this);
+        // Doesn't make sense to delete shards on non-data nodes
+        if (DiscoveryNode.isDataNode(settings)) {
+            clusterService.add(this);
+        }
     }
 
     @Override
     public void close() {
-        clusterService.remove(this);
+        if (DiscoveryNode.isDataNode(settings)) {
+            clusterService.remove(this);
+        }
     }
 
     @Override


### PR DESCRIPTION
`IndicesClusterStateService` and `IndicesStore` are responsible for synchronizing local shard state based on incoming cluster state updates. Actions that are taking are initializing shards, starting recoveries, or deleting shard and index data. On client or tribe nodes, which don't store any shard/index data, all of this is unnecessary, wasting unnecessary cycles to apply cluster state updates.
