### PR TITLE
File descriptors limit doesn't apply to Windows

### DIFF
--- a/docs/reference/setup/sysconfig/file-descriptors.asciidoc
+++ b/docs/reference/setup/sysconfig/file-descriptors.asciidoc
@@ -1,6 +1,10 @@
 [[file-descriptors]]
 === File Descriptors
 
+[NOTE]
+This is only a problem for Linux and macOS and can be safely ignored if running
+Elasticsearch on Windows.
+
 Elasticsearch uses a lot of file descriptors or file handles.  Running out of
 file descriptors can be disastrous and will most probably lead to data loss.
 Make sure to increase the limit on the number of open files descriptors for


### PR DESCRIPTION
On Windows the JDK uses `CreateFileW` which has a stupidly high
limit for the number of `Handle`s it can make - `16 * 1024 * 1024`.
So this isn't really a problem on Windows at all.

Closes #20732
