### PR TITLE
Reenable shard management on IndicesClusterStateService

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -126,17 +126,12 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
 
     @Override
     protected void doStart() {
-        // Doesn't make sense to manage shards on non-master and non-data nodes
-        if (DiscoveryNode.dataNode(settings) || DiscoveryNode.masterNode(settings)) {
-            clusterService.addFirst(this);
-        }
+        clusterService.addFirst(this);
     }
 
     @Override
     protected void doStop() {
-        if (DiscoveryNode.dataNode(settings) || DiscoveryNode.masterNode(settings)) {
-            clusterService.remove(this);
-        }
+        clusterService.remove(this);
     }
 
     @Override


### PR DESCRIPTION
The previous commit d8b73e9 changed IndicesClusterStateService and IndicesStore to only run on master and data nodes. IndicesClusterStateService triggers acknowledgments of index deletes to the master. The current code that is waiting for the acknowledgments on the master is however expecting acknowledgements from tribe/client nodes as well. This commit reenables IndicesClusterStateService to run on tribe/client nodes to provide simple backward compatibility (but keeps IndicesStore disabled on tribe/client nodes). This is not an issue in the original patch on v5.x where acknowledgement of index deletes is done through the cluster state acking mechanism.
