### PR TITLE
Clarify wording for the strict REST params message

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/core/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -30,6 +30,7 @@ import org.elasticsearch.plugins.ActionPlugin;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -63,7 +64,12 @@ public abstract class BaseRestHandler extends AbstractComponent implements RestH
 
         // validate the non-response params
         if (!unconsumedParams.isEmpty()) {
-            throw new IllegalArgumentException("request [" + request.path() + "] contains unused params: " + unconsumedParams.toString());
+            final String message = String.format(
+                Locale.ROOT,
+                "request [%s] contains unrecognized parameters: %s",
+                request.path(),
+                unconsumedParams.toString());
+            throw new IllegalArgumentException(message);
         }
 
         // execute the action


### PR DESCRIPTION
This commit changes the strict REST parameters message to say that
unconsumed parameters are unrecognized rather than unused. Additionally,
the test is beefed up to include two unused parameters.

Relates #20722
