### PR TITLE
Add did you mean to strict REST params

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/core/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -19,8 +19,11 @@
 
 package org.elasticsearch.rest;
 
+import org.apache.lucene.search.spell.LevensteinDistance;
+import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.ParseFieldMatcher;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -28,10 +31,12 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.ActionPlugin;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -59,16 +64,40 @@ public abstract class BaseRestHandler extends AbstractComponent implements RestH
         final RestChannelConsumer action = prepareRequest(request, client);
 
         // validate unconsumed params, but we must exclude params used to format the response
-        final List<String> unconsumedParams =
-            request.unconsumedParams().stream().filter(p -> !responseParams().contains(p)).collect(Collectors.toList());
+        // use a sorted set so the unconsumed parameters appear in a reliable sorted order
+        final SortedSet<String> unconsumedParams =
+            request.unconsumedParams().stream().filter(p -> !responseParams().contains(p)).collect(Collectors.toCollection(TreeSet::new));
 
         // validate the non-response params
         if (!unconsumedParams.isEmpty()) {
-            final String message = String.format(
-                Locale.ROOT,
-                "request [%s] contains unrecognized parameters: %s",
-                request.path(),
-                unconsumedParams.toString());
+            String message = "request [" + request.path() + "] contains unrecognized parameters: ";
+            boolean first = true;
+            for (final String unconsumedParam : unconsumedParams) {
+                final LevensteinDistance ld = new LevensteinDistance();
+                final List<Tuple<Float, String>> scoredParams = new ArrayList<>();
+                for (String consumedParam : request.consumedParams()) {
+                    final float distance = ld.getDistance(unconsumedParam, consumedParam);
+                    if (distance > 0.5f) {
+                        scoredParams.add(new Tuple<>(distance, consumedParam));
+                    }
+                }
+                CollectionUtil.timSort(scoredParams, (a, b) -> {
+                    // sort by distance in reverse order, then parameter name for equal distances
+                    int compare = a.v1().compareTo(b.v1());
+                    if (compare != 0) return -compare;
+                    else return a.v2().compareTo(b.v2());
+                });
+                if (first == false) {
+                    message += ", ";
+                }
+                message += "[" + unconsumedParam + "]";
+                final List<String> keys = scoredParams.stream().map(Tuple::v2).collect(Collectors.toList());
+                if (keys.isEmpty() == false) {
+                    message += " -> did you mean " + (keys.size() == 1 ? "[" + keys.get(0) + "]": "any of " + keys.toString()) + "?";
+                }
+                first = false;
+            }
+
             throw new IllegalArgumentException(message);
         }
 

--- a/core/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/core/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -70,7 +71,11 @@ public abstract class BaseRestHandler extends AbstractComponent implements RestH
 
         // validate the non-response params
         if (!unconsumedParams.isEmpty()) {
-            String message = "request [" + request.path() + "] contains unrecognized parameters: ";
+            String message = String.format(
+                Locale.ROOT,
+                "request [%s] contains unrecognized parameter%s: ",
+                request.path(),
+                unconsumedParams.size() > 1 ? "s" : "");
             boolean first = true;
             for (final String unconsumedParam : unconsumedParams) {
                 final LevensteinDistance ld = new LevensteinDistance();

--- a/core/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 
 import java.net.SocketAddress;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -127,6 +126,16 @@ public abstract class RestRequest implements ToXContent.Params {
 
     public Map<String, String> params() {
         return params;
+    }
+
+    /**
+     * Returns a list of parameters that have been consumed. This method returns a copy, callers
+     * are free to modify the returned list.
+     *
+     * @return the list of currently consumed parameters.
+     */
+    List<String> consumedParams() {
+        return consumedParams.stream().collect(Collectors.toList());
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeAction.java
@@ -73,8 +73,9 @@ public class RestAnalyzeAction extends BaseRestHandler {
         analyzeRequest.text(texts);
         analyzeRequest.analyzer(request.param("analyzer"));
         analyzeRequest.field(request.param("field"));
-        if (request.hasParam("tokenizer")) {
-            analyzeRequest.tokenizer(request.param("tokenizer"));
+        final String tokenizer = request.param("tokenizer");
+        if (tokenizer != null) {
+            analyzeRequest.tokenizer(tokenizer);
         }
         for (String filter : request.paramAsStringArray("filter", Strings.EMPTY_ARRAY)) {
             analyzeRequest.addTokenFilter(filter);

--- a/core/src/test/java/org/elasticsearch/rest/BaseRestHandlerTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/BaseRestHandlerTests.java
@@ -101,6 +101,7 @@ public class BaseRestHandlerTests extends ESTestCase {
         params.put("flied", randomAsciiOfLength(8));
         params.put("tokenzier", randomAsciiOfLength(8));
         params.put("very_close_to_parametre", randomAsciiOfLength(8));
+        params.put("very_far_from_every_consumed_parameter", randomAsciiOfLength(8));
         RestRequest request = new FakeRestRequest.Builder().withParams(params).build();
         RestChannel channel = new FakeRestChannel(request, randomBoolean(), 1);
         final IllegalArgumentException e =
@@ -110,8 +111,9 @@ public class BaseRestHandlerTests extends ESTestCase {
             hasToString(containsString(
                 "request [/] contains unrecognized parameters: " +
                     "[flied] -> did you mean [field]?, " +
-                    "[tokenzier] -> did you mean [tokenizer]?, " + "" +
-                    "[very_close_to_parametre] -> did you mean any of [very_close_to_parameter_1, very_close_to_parameter_2]?")));
+                    "[tokenzier] -> did you mean [tokenizer]?, " +
+                    "[very_close_to_parametre] -> did you mean any of [very_close_to_parameter_1, very_close_to_parameter_2]?, " +
+                    "[very_far_from_every_consumed_parameter]")));
         assertFalse(executed.get());
     }
 


### PR DESCRIPTION
This commit adds a did you mean feature to the strict REST params error
message. This works by comparing any unconsumed parameters to all of the
consumer parameters, comparing the Levenstein distance between those
parameters, and taking any consumed parameters that are close to an
unconsumed parameter as candiates for the did you mean.

Relates #20722
