### PR TITLE
Build: Fix plugin poms to have correct artifact id

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -231,6 +231,7 @@ public class PluginBuildPlugin extends BuildPlugin {
                  * ahold of the actual task. Furthermore, this entire hack only exists so we can make publishing to
                  * maven local work, since we publish to maven central externally. */
                 zipReal(MavenPublication) {
+                    artifactId = project.pluginProperties.extension.name
                     pom.withXml { XmlProvider xml ->
                         Node root = xml.asNode()
                         root.appendNode('name', project.pluginProperties.extension.name)


### PR DESCRIPTION
We already override the name in plugin pom files to be that configured
for the plugin but we also need to explicitly set the artifactId.
