### PR TITLE
Prevent thread suspension when inside SecurityManager

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/LongGCDisruption.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/LongGCDisruption.java
@@ -39,7 +39,9 @@ public class LongGCDisruption extends SingleNodeDisruption {
 
     private static final Pattern[] unsafeClasses = new Pattern[]{
         // logging has shared JVM locks - we may suspend a thread and block other nodes from doing their thing
-        Pattern.compile("logging\\.log4j")
+        Pattern.compile("logging\\.log4j"),
+        // security manager is shared across all nodes AND it uses synced hashmaps interanlly
+        Pattern.compile("java\\.lang\\.SecurityManager")
     };
 
     protected final String disruptedNode;


### PR DESCRIPTION
LongGCDisruption suspends and resumes node threads but respects several
`unsafe` class name patterns where it's unsafe to suspend. For instance
log4j uses a global lock so we can't suspend a thread that is currently
calling into log4j. The same is true for the security manager, it's similar
to log4j a shared resource between the test and the node that is _suspended_.
This change adds `java.lang.SecrityManager` to the unsafe patterns.
This prevents test framework deadlocking if a nodes thread is suspended
while it's calling into the security manager that uses synchronized maps etc.
