### PR TITLE
StoreStatsCache should also ignore AccessDeniedException when checking file size

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/core/src/main/java/org/elasticsearch/index/store/Store.java
@@ -61,8 +61,8 @@ import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.store.ByteArrayIndexInput;
 import org.elasticsearch.common.lucene.store.InputStreamIndexInput;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.Callback;
@@ -84,6 +84,7 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -1373,8 +1374,9 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             for (String file : files) {
                 try {
                     estimatedSize += directory.fileLength(file);
-                } catch (NoSuchFileException | FileNotFoundException e) {
-                    // ignore, the file is not there no more
+                } catch (NoSuchFileException | FileNotFoundException | AccessDeniedException e) {
+                    // ignore, the file is not there no more; on Windows, if one thread concurrently deletes a file while
+                    // calling Files.size, you can also sometimes hit AccessDeniedException
                 }
             }
             return estimatedSize;


### PR DESCRIPTION
The `StoreStatsCache` periodically sums up file size of all files it lists in the store directory.

It is expected that these files are sometimes deleted (and new files created) while it runs, since we don't prevent active indexing, so we catch and ignore FNFE and NSFE today:

```
    for (String file : files) {
        try {
            estimatedSize += directory.fileLength(file);
        } catch (NoSuchFileException | FileNotFoundException e) {
            // ignore, the file is not there no more
        }
    }
```

However, for some reason, on Windows it is also possible to sometimes hit `AccessDeniedException`.  E.g. see https://discuss.elastic.co/t/access-denied-in-accessing-the-elastic-search-index-files/39761/7 and https://github.com/elastic/elasticsearch/issues/17580 

I dug a bit through the OpenJDK8 sources, and it eventually calls the `GetFileAttributesExW` Windows API, but I couldn't see in those docs (https://msdn.microsoft.com/en-us/library/windows/desktop/aa364946(v=vs.85).aspx) why access denied would occur.  So then I wrote a simple test:

```
import java.nio.file.*;
import java.io.*;

public class Test {
  public static void main(String[] args) throws IOException {

    Thread thread = new Thread() {
        @Override
        public void run() {
          while (true) {
            for(int i=0;i<10;i++) {
              try {
                Files.size(Paths.get("file" + i));
              } catch (NoSuchFileException | FileNotFoundException fnfe) {
                // ok
              } catch (IOException ioe) {
                throw new RuntimeException(ioe);
              }
            }
          }
        }
      };
    thread.start();

    while (true) {
      for(int i=0;i<10;i++) {
        OutputStream out = Files.newOutputStream(Paths.get("file"+ i));
        out.write(50);
        out.close();
      }
      for(int i=0;i<10;i++) {
        Files.delete(Paths.get("file" + i));
      }
    }
  }
}
```

Most of the time NSFE is hit, but sometimes `AccessDeniedException` does occur on a local NTFS file system.

I think we should just catch and ignore `AccessDeniedException` as well.
