### PR TITLE
Sequence numbers commit data for Lucene uses Iterable interface

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -74,6 +74,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -282,7 +283,7 @@ public class InternalEngine extends Engine {
             boolean success = false;
             try {
                 commitIndexWriter(writer, translog, openMode == EngineConfig.OpenMode.OPEN_INDEX_CREATE_TRANSLOG
-                    ? writer.getCommitData().get(SYNC_COMMIT_ID) : null);
+                    ? commitDataAsMap(writer).get(SYNC_COMMIT_ID) : null);
                 success = true;
             } finally {
                 if (success == false) {
@@ -307,7 +308,7 @@ public class InternalEngine extends Engine {
     private Translog.TranslogGeneration loadTranslogIdFromCommit(IndexWriter writer) throws IOException {
         // commit on a just opened writer will commit even if there are no changes done to it
         // we rely on that for the commit data translog id key
-        final Map<String, String> commitUserData = writer.getCommitData();
+        final Map<String, String> commitUserData = commitDataAsMap(writer);
         if (commitUserData.containsKey("translog_id")) {
             assert commitUserData.containsKey(Translog.TRANSLOG_UUID_KEY) == false : "legacy commit contains translog UUID";
             return new Translog.TranslogGeneration(null, Long.parseLong(commitUserData.get("translog_id")));
@@ -320,6 +321,11 @@ public class InternalEngine extends Engine {
             return new Translog.TranslogGeneration(translogUUID, translogGen);
         }
         return null;
+    }
+
+    // package private for testing
+    SeqNoStats loadSeqNoStatsFromCommit() throws IOException {
+        return loadSeqNoStatsFromCommit(indexWriter);
     }
 
     private SeqNoStats loadSeqNoStatsFromCommit(IndexWriter writer) throws IOException {
@@ -1308,40 +1314,52 @@ public class InternalEngine extends Engine {
         ensureCanFlush();
         try {
             Translog.TranslogGeneration translogGeneration = translog.getGeneration();
-            final Map<String, String> commitData = new HashMap<>(5);
 
-            commitData.put(Translog.TRANSLOG_GENERATION_KEY, Long.toString(translogGeneration.translogFileGeneration));
-            commitData.put(Translog.TRANSLOG_UUID_KEY, translogGeneration.translogUUID);
+            final String translogFileGen = Long.toString(translogGeneration.translogFileGeneration);
+            final String translogUUID = translogGeneration.translogUUID;
+            final String localCheckpoint = Long.toString(seqNoService().getLocalCheckpoint());
+            final String globalCheckpoint = Long.toString(seqNoService().getGlobalCheckpoint());
 
-            commitData.put(LOCAL_CHECKPOINT_KEY, Long.toString(seqNoService().getLocalCheckpoint()));
-            commitData.put(GLOBAL_CHECKPOINT_KEY, Long.toString(seqNoService().getGlobalCheckpoint()));
+            writer.setLiveCommitData(new Iterable<Map.Entry<String, String>>() {
+                // save the max seq no the first time its computed, so subsequent iterations don't recompute,
+                // potentially getting a different value
+                private String computedMaxSeqNoEntry = null;
 
-            if (syncId != null) {
-                commitData.put(Engine.SYNC_COMMIT_ID, syncId);
-            }
+                @Override
+                public Iterator<Map.Entry<String, String>> iterator() {
+                    /**
+                     * The user data captured above (e.g. local/global checkpoints) contains data that must be evaluated
+                     * *before* Lucene flushes segments, including the local and global checkpoints amongst other values.
+                     * The maximum sequence number is different - we never want the maximum sequence number to be
+                     * less than the last sequence number to go into a Lucene commit, otherwise we run the risk
+                     * of re-using a sequence number for two different documents when restoring from this commit
+                     * point and subsequently writing new documents to the index.  Since we only know which Lucene
+                     * documents made it into the final commit after the {@link IndexWriter#commit()} call flushes
+                     * all documents, we defer computation of the max_seq_no to the time of invocation of the commit
+                     * data iterator (which occurs after all documents have been flushed to Lucene).
+                     */
+                    final Map<String, String> commitData = new HashMap<>(6);
+                    commitData.put(Translog.TRANSLOG_GENERATION_KEY, translogFileGen);
+                    commitData.put(Translog.TRANSLOG_UUID_KEY, translogUUID);
+                    commitData.put(LOCAL_CHECKPOINT_KEY, localCheckpoint);
+                    commitData.put(GLOBAL_CHECKPOINT_KEY, globalCheckpoint);
+                    if (syncId != null) {
+                        commitData.put(Engine.SYNC_COMMIT_ID, syncId);
+                    }
+                    if (computedMaxSeqNoEntry == null) {
+                        // evaluated once at the time of the first invocation of this method
+                        computedMaxSeqNoEntry = Long.toString(seqNoService().getMaxSeqNo());
+                    }
+                    commitData.put(MAX_SEQ_NO, computedMaxSeqNoEntry);
+                    return commitData.entrySet().iterator();
+                }
+            });
+
+            writer.commit();
 
             if (logger.isTraceEnabled()) {
-                logger.trace("committing writer with commit data (max_seq_no excluded) [{}]", commitData);
+                logger.trace("committed writer with commit data [{}]", commitDataAsMap(writer));
             }
-
-            indexWriter.setLiveCommitData(() -> {
-                /**
-                 * The user data in the commitData map contains data that must be evaluated *before*
-                 * Lucene flushes segments, including the local and global checkpoints amongst other values.
-                 * The maximum sequence number is different - we never want the maximum sequence number to be
-                 * less than the last sequence number to go into a Lucene commit, otherwise we run the risk
-                 * of re-using a sequence number for two different documents when restoring from this commit
-                 * point and subsequently writing new documents to the index.  Since we only know which Lucene
-                 * documents made it into the final commit after the {@link IndexWriter#commit()} call flushes
-                 * all documents, we defer computation of the max_seq_no to the time of invocation of the commit
-                 * data iterator (which occurs after all documents have been flushed to Lucene).
-                 */
-                final Map<String, String> deferredCommitData = new HashMap<>(commitData.size() + 1);
-                deferredCommitData.putAll(commitData);
-                deferredCommitData.put(MAX_SEQ_NO, Long.toString(seqNoService().getMaxSeqNo()));
-                return deferredCommitData.entrySet().iterator();
-            });
-            writer.commit();
         } catch (Exception ex) {
             try {
                 failEngine("lucene commit failed", ex);
@@ -1442,5 +1460,16 @@ public class InternalEngine extends Engine {
     @Override
     public boolean isRecovering() {
         return pendingTranslogRecovery.get();
+    }
+
+    /**
+     * Gets the commit data from {@link IndexWriter} as a map.
+     */
+    private static Map<String, String> commitDataAsMap(final IndexWriter indexWriter) {
+        Map<String, String> commitData = new HashMap<>(6);
+        for (Map.Entry<String, String> entry : indexWriter.getLiveCommitData()) {
+            commitData.put(entry.getKey(), entry.getValue());
+        }
+        return commitData;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1341,7 +1341,7 @@ public class InternalEngine extends Engine {
                 }
                 commitData.put(MAX_SEQ_NO, Long.toString(seqNoService().getMaxSeqNo()));
                 if (logger.isTraceEnabled()) {
-                    logger.trace("committed writer with commit data [{}]", commitData);
+                    logger.trace("committing writer with commit data [{}]", commitData);
                 }
                 return commitData.entrySet().iterator();
             });

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -322,11 +322,6 @@ public class InternalEngine extends Engine {
         return null;
     }
 
-    // package private for testing
-    SeqNoStats loadSeqNoStatsFromCommit() throws IOException {
-        return loadSeqNoStatsFromCommit(indexWriter);
-    }
-
     private SeqNoStats loadSeqNoStatsFromCommit(IndexWriter writer) throws IOException {
         long maxSeqNo = SequenceNumbersService.NO_OPS_PERFORMED;
         long localCheckpoint = SequenceNumbersService.NO_OPS_PERFORMED;

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1341,7 +1341,7 @@ public class InternalEngine extends Engine {
                 }
                 commitData.put(MAX_SEQ_NO, Long.toString(seqNoService().getMaxSeqNo()));
                 if (logger.isTraceEnabled()) {
-                    logger.trace("committed writer with commit data [{}]", commitDataAsMap(writer));
+                    logger.trace("committed writer with commit data [{}]", commitData);
                 }
                 return commitData.entrySet().iterator();
             });

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -43,7 +43,6 @@ import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.InfoStream;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.fieldstats.FieldStats;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lease.Releasable;
@@ -59,7 +58,6 @@ import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.mapper.Uid;
-import org.elasticsearch.index.mapper.internal.SeqNoFieldMapper;
 import org.elasticsearch.index.merge.MergeStats;
 import org.elasticsearch.index.merge.OnGoingMerge;
 import org.elasticsearch.index.seqno.SeqNoStats;
@@ -85,8 +83,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
-
-import static org.elasticsearch.index.seqno.SequenceNumbersService.NO_OPS_PERFORMED;
 
 public class InternalEngine extends Engine {
 
@@ -121,6 +117,7 @@ public class InternalEngine extends Engine {
     private final SequenceNumbersService seqNoService;
     static final String LOCAL_CHECKPOINT_KEY = "local_checkpoint";
     static final String GLOBAL_CHECKPOINT_KEY = "global_checkpoint";
+    static final String MAX_SEQ_NO = "max_seq_no";
 
     // How many callers are currently requesting index throttling.  Currently there are only two situations where we do this: when merges
     // are falling behind and when writing indexing buffer to disk is too slow.  When this is 0, there is no throttling, else we throttling
@@ -326,30 +323,18 @@ public class InternalEngine extends Engine {
     }
 
     private SeqNoStats loadSeqNoStatsFromCommit(IndexWriter writer) throws IOException {
-        final long maxSeqNo;
-        try (IndexReader reader = DirectoryReader.open(writer)) {
-            final FieldStats stats = SeqNoFieldMapper.Defaults.FIELD_TYPE.stats(reader);
-            if (stats != null) {
-                maxSeqNo = (long) stats.getMaxValue();
-            } else {
-                maxSeqNo = NO_OPS_PERFORMED;
+        long maxSeqNo = SequenceNumbersService.NO_OPS_PERFORMED;
+        long localCheckpoint = SequenceNumbersService.NO_OPS_PERFORMED;
+        long globalCheckpoint = SequenceNumbersService.UNASSIGNED_SEQ_NO;
+        for (Map.Entry<String, String> entry : writer.getLiveCommitData()) {
+            final String key = entry.getKey();
+            if (key.equals(LOCAL_CHECKPOINT_KEY)) {
+                localCheckpoint = Long.parseLong(entry.getValue());
+            } else if (key.equals(GLOBAL_CHECKPOINT_KEY)) {
+                globalCheckpoint = Long.parseLong(entry.getValue());
+            } else if (key.equals(MAX_SEQ_NO)) {
+                maxSeqNo = Long.parseLong(entry.getValue());
             }
-        }
-
-        final Map<String, String> commitUserData = writer.getCommitData();
-
-        final long localCheckpoint;
-        if (commitUserData.containsKey(LOCAL_CHECKPOINT_KEY)) {
-            localCheckpoint = Long.parseLong(commitUserData.get(LOCAL_CHECKPOINT_KEY));
-        } else {
-            localCheckpoint = SequenceNumbersService.NO_OPS_PERFORMED;
-        }
-
-        final long globalCheckpoint;
-        if (commitUserData.containsKey(GLOBAL_CHECKPOINT_KEY)) {
-            globalCheckpoint = Long.parseLong(commitUserData.get(GLOBAL_CHECKPOINT_KEY));
-        } else {
-            globalCheckpoint = SequenceNumbersService.UNASSIGNED_SEQ_NO;
         }
 
         return new SeqNoStats(maxSeqNo, localCheckpoint, globalCheckpoint);
@@ -1336,10 +1321,26 @@ public class InternalEngine extends Engine {
             }
 
             if (logger.isTraceEnabled()) {
-                logger.trace("committing writer with commit data [{}]", commitData);
+                logger.trace("committing writer with commit data (max_seq_no excluded) [{}]", commitData);
             }
 
-            indexWriter.setCommitData(commitData);
+            indexWriter.setLiveCommitData(() -> {
+                /**
+                 * The user data in the commitData map contains data that must be evaluated *before*
+                 * Lucene flushes segments, including the local and global checkpoints amongst other values.
+                 * The maximum sequence number is different - we never want the maximum sequence number to be
+                 * less than the last sequence number to go into a Lucene commit, otherwise we run the risk
+                 * of re-using a sequence number for two different documents when restoring from this commit
+                 * point and subsequently writing new documents to the index.  Since we only know which Lucene
+                 * documents made it into the final commit after the {@link IndexWriter#commit()} call flushes
+                 * all documents, we defer computation of the max_seq_no to the time of invocation of the commit
+                 * data iterator (which occurs after all documents have been flushed to Lucene).
+                 */
+                final Map<String, String> deferredCommitData = new HashMap<>(commitData.size() + 1);
+                deferredCommitData.putAll(commitData);
+                deferredCommitData.put(MAX_SEQ_NO, Long.toString(seqNoService().getMaxSeqNo()));
+                return deferredCommitData.entrySet().iterator();
+            });
             writer.commit();
         } catch (Exception ex) {
             try {
@@ -1395,7 +1396,8 @@ public class InternalEngine extends Engine {
     public SequenceNumbersService seqNoService() {
         return seqNoService;
     }
-        @Override
+
+    @Override
     public DocsStats getDocStats() {
         final int numDocs = indexWriter.numDocs();
         final int maxDoc = indexWriter.maxDoc();

--- a/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
@@ -82,6 +82,13 @@ public class SequenceNumbersService extends AbstractIndexShardComponent {
     }
 
     /**
+     * Gets the maximum sequence number seen so far.  See {@link LocalCheckpointService#getMaxSeqNo()} for details.
+     */
+    public long getMaxSeqNo() {
+        return localCheckpointService.getMaxSeqNo();
+    }
+
+    /**
      * marks the given seqNo as completed. See {@link LocalCheckpointService#markSeqNoAsCompleted(long)}
      * more details
      */

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -1685,15 +1685,14 @@ public class InternalEngineTests extends ESTestCase {
                 // the first time the commit data iterable gets an iterator, the max seq no from that point in time should
                 // remain from any subsequent call to IndexWriter#getLiveCommitData unless the commit data is overwritten by a
                 // subsequent call to IndexWriter#setLiveCommitData.
-                if (initialEngine.seqNoService().getMaxSeqNo() != SequenceNumbersService.NO_OPS_PERFORMED) {
-                    assertThat(
-                        initialEngine.seqNoService().getMaxSeqNo(),
-                        // its possible that right after a commit, a version conflict exception happened so the max seq no was not updated,
-                        // so here we check greater than or equal to
-                        versionConflict ? greaterThanOrEqualTo(initialEngine.loadSeqNoStatsFromCommit().getMaxSeqNo()) :
-                                          greaterThan(initialEngine.loadSeqNoStatsFromCommit().getMaxSeqNo())
-                    );
-                }
+                assertThat(
+                    initialEngine.seqNoService().getMaxSeqNo(),
+                    // its possible we haven't indexed any documents yet, or its possible that right after a commit, a version conflict
+                    // exception happened so the max seq no was not updated, so here we check greater than or equal to
+                    initialEngine.seqNoService().getMaxSeqNo() != SequenceNumbersService.NO_OPS_PERFORMED || versionConflict ?
+                        greaterThanOrEqualTo(initialEngine.loadSeqNoStatsFromCommit().getMaxSeqNo()) :
+                        greaterThan(initialEngine.loadSeqNoStatsFromCommit().getMaxSeqNo())
+                );
 
                 if (rarely()) {
                     localCheckpoint = primarySeqNo;

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -1743,7 +1743,9 @@ public class InternalEngineTests extends ESTestCase {
                 equalTo(globalCheckpoint));
             assertThat(
                 Long.parseLong(recoveringEngine.commitStats().getUserData().get(InternalEngine.MAX_SEQ_NO)),
-                // after recovering from translog, all docs have been flushed to Lucene segments, so check against primarySeqNo
+                // after recovering from translog, all docs have been flushed to Lucene segments, so here we will assert
+                // that the committed max seq no is equivalent to what the current primary seq no is, as all data
+                // we have assigned sequence numbers to should be in the commit
                 equalTo(primarySeqNo));
             assertThat(recoveringEngine.seqNoService().stats().getLocalCheckpoint(), equalTo(primarySeqNo));
             assertThat(recoveringEngine.seqNoService().stats().getMaxSeqNo(), equalTo(primarySeqNo));

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -1789,8 +1789,8 @@ public class InternalEngineTests extends ESTestCase {
                     @Override
                     public void run() {
                         try {
-                            barrier.await(); // wait for both threads to start at the same time
-                            // index a random number of docs
+                            barrier.await(); // wait for all threads to start at the same time
+                            // index random number of docs
                             for (int i = 0; i < numDocsPerThread; i++) {
                                 final String id = "thread" + threadIdx + "#" + i;
                                 ParsedDocument doc = testParsedDocument(id, id, "test", null, -1, -1, testDocument(), B_1, null);


### PR DESCRIPTION
Sequence number related data (maximum sequence number, local checkpoint,
and global checkpoint) gets stored in Lucene on each commit. The logical
place to store this data is on each Lucene commit's user commit data
structure (see IndexWriter#setCommitData and the new version
IndexWriter#setLiveCommitData). However, previously we did not store the
maximum sequence number in the commit data because the commit data got
copied over before the Lucene IndexWriter flushed the documents to segments
in the commit.  This meant that between the time that the commit data was
set on the IndexWriter and the time that the IndexWriter completes the commit,
documents with higher sequence numbers could have entered the commit.
Hence, we would use FieldStats on the _seq_no field in the documents to get
the maximum sequence number value, but this suffers the drawback that if the
last sequence number in the commit corresponded to a delete document action,
that sequence number would not show up in FieldStats as there would be no
corresponding document in Lucene.

In Lucene 6.2, commit data was changed to take an Iterable interface, so
that the commit data can be calculated and retrieved _after_ all documents
have been flushed.  This commit changes max_seq_no so it is stored in the 
commit data instead of being calculated from FieldStats, taking advantage of 
the deferred calculation of the max_seq_no through passing an Iterable that 
dynamically sets the iterator data.

Relates #10708 
