### PR TITLE
Add docs for strict REST params parsing

### DIFF
--- a/docs/reference/migration/migrate_5_0/rest.asciidoc
+++ b/docs/reference/migration/migrate_5_0/rest.asciidoc
@@ -1,6 +1,15 @@
-
 [[breaking_50_rest_api_changes]]
 === REST API changes
+
+==== Strict REST query string parameter parsing
+
+Previous versions of Elasticsearch accepted unrecognized URL query
+string parameters. This means that extraneous parameters or parameters
+containing typographical errors would be silently accepted by
+Elasticsearch. This is dangerous from an end-user perspective because it
+means a submitted request will silently execute not as intended. This
+leniency has been removed and Elasticsearch will now fail any request
+that contains unrecognized query string parameters.
 
 ==== id values longer than 512 bytes are rejected
 

--- a/docs/reference/migration/migrate_5_0/rest.asciidoc
+++ b/docs/reference/migration/migrate_5_0/rest.asciidoc
@@ -3,7 +3,7 @@
 
 ==== Strict REST query string parameter parsing
 
-Previous versions of Elasticsearch accepted unrecognized URL query
+Previous versions of Elasticsearch ignored unrecognized URL query
 string parameters. This means that extraneous parameters or parameters
 containing typographical errors would be silently accepted by
 Elasticsearch. This is dangerous from an end-user perspective because it

--- a/docs/reference/migration/migrate_5_0/search.asciidoc
+++ b/docs/reference/migration/migrate_5_0/search.asciidoc
@@ -217,6 +217,15 @@ been superseded by `_prefer_nodes`. By specifying a single node,
 `_prefer_nodes` provides the same functionality as `_prefer_node` but
 also supports specifying multiple nodes.
 
+The <<search-request-preference,search preference>> `_shards` accepts a
+secondary preference, for example `_primary` to specify the primary copy
+of the specified shards. The separator previously used to separate the
+`_shards` portion of the parameter from the secondary preference was
+`;`. However, this is also an acceptable separator between query string
+parameters which means that unless the `;` was escaped, the secondary
+preference was never observed. The separator has been changed to `|` and
+does not need to be escaped.
+
 ==== Default similarity
 
 The default similarity has been changed to `BM25`.


### PR DESCRIPTION
This pull request adds notes to the breaking changes docs for #20722 and
#20786.
