### PR TITLE
Allow position_gap_increment for fields in indices created prior to 5.0

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/mapper/LegacyStringMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/LegacyStringMappingTests.java
@@ -731,9 +731,8 @@ public class LegacyStringMappingTests extends ESSingleNodeTestCase {
                 .field("position_increment_gap", 10)
                 .endObject().endObject().endObject().endObject().string();
 
-            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> parser.parse("type", new CompressedXContent(mapping)));
-            assertEquals("Cannot set position_increment_gap on field [field] without positions enabled", e.getMessage());
+            // allowed in index created before 5.0
+            parser.parse("type", new CompressedXContent(mapping));
         }
     }
 
@@ -746,9 +745,8 @@ public class LegacyStringMappingTests extends ESSingleNodeTestCase {
                 .field("position_increment_gap", 10)
                 .endObject().endObject().endObject().endObject().string();
 
-            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> parser.parse("type", new CompressedXContent(mapping)));
-            assertEquals("Cannot set position_increment_gap on field [field] without positions enabled", e.getMessage());
+            // allowed in index created before 5.0
+            parser.parse("type", new CompressedXContent(mapping));
         }
     }
 


### PR DESCRIPTION
We added a changed to disallow this in #19510, however, existing indices
may still be using this, so we should only disallow the setting on
indices created after 5.0.

Resolves #20413
