### PR TITLE
Make path syntax for lower and upper standard deviation bounds in the extended_stats aggregation more obvious

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStats.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStats.java
@@ -67,7 +67,7 @@ public interface ExtendedStats extends Stats {
     String getVarianceAsString();
 
 
-    public enum Bounds {
+    enum Bounds {
         UPPER, LOWER
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/InternalExtendedStats.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/InternalExtendedStats.java
@@ -91,6 +91,20 @@ public class InternalExtendedStats extends InternalStats implements ExtendedStat
     }
 
     @Override
+    public Object getProperty(List<String> path) {
+        if (path.size() == 2 && "std_deviation_bounds".equals(path.get(0))) {
+            String bound = path.get(1);
+            if ("lower".equals(bound)) {
+                return getStdDeviationBound(Bounds.LOWER);
+            }
+            if ("upper".equals(bound)) {
+                return getStdDeviationBound(Bounds.UPPER);
+            }
+        }
+        return super.getProperty(path);
+    }
+
+    @Override
     public double getSumOfSquares() {
         return sumOfSqrs;
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsTests.java
@@ -19,7 +19,13 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStatsAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.stats.extended.InternalExtendedStats;
+import org.junit.Test;
+
+import java.util.Collections;
 
 public class ExtendedStatsTests extends AbstractNumericMetricTestCase<ExtendedStatsAggregationBuilder> {
 
@@ -32,4 +38,15 @@ public class ExtendedStatsTests extends AbstractNumericMetricTestCase<ExtendedSt
         return factory;
     }
 
+    @Test
+    public void getStdDeviationBoundsByPath() throws Exception {
+        double min = 1.0;
+        double max = 4.0;
+
+        ExtendedStats stats = new InternalExtendedStats("test", 2, min + max, min, max, Math.pow(min, 2) + Math.pow(max, 2),
+            1.0, DocValueFormat.RAW, Collections.emptyList(), Collections.emptyMap());
+
+        assertEquals(stats.getStdDeviationBound(ExtendedStats.Bounds.LOWER), stats.getProperty("std_deviation_bounds.lower"));
+        assertEquals(stats.getStdDeviationBound(ExtendedStats.Bounds.UPPER), stats.getProperty("std_deviation_bounds.upper"));
+    }
 }


### PR DESCRIPTION
Closes #19040
