### PR TITLE
Handle SynonymQuery extraction for the FastVectorHighlighter

### DIFF
--- a/core/src/main/java/org/apache/lucene/search/vectorhighlight/CustomFieldQuery.java
+++ b/core/src/main/java/org/apache/lucene/search/vectorhighlight/CustomFieldQuery.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.MultiPhraseQuery;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.SynonymQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.join.ToParentBlockJoinQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
@@ -88,6 +89,13 @@ public class CustomFieldQuery extends FieldQuery {
             flatten(boostingQuery.getMatch(), reader, flatQueries, boost);
             //flatten negative query with negative boost
             flatten(boostingQuery.getContext(), reader, flatQueries, boostingQuery.getBoost());
+        } else if (sourceQuery instanceof SynonymQuery) {
+            // SynonymQuery should be handled by the parent class directly.
+            // This statement should be removed when https://issues.apache.org/jira/browse/LUCENE-7484 is merged.
+            SynonymQuery synQuery = (SynonymQuery) sourceQuery;
+            for (Term term : synQuery.getTerms()) {
+                flatten(new TermQuery(term), reader, flatQueries, boost);
+            }
         } else {
             super.flatten(sourceQuery, reader, flatQueries, boost);
         }


### PR DESCRIPTION
SynonymQuery was ignored by the FastVectorHighlighter.
This change adds the support for SynonymQuery in the FVH.
Although this change should be implemented in Lucene directly which is why https://issues.apache.org/jira/browse/LUCENE-7484 has been opened.
In the meantime this PR handles the issue on ES side and could be removed when LUCENE-7484 gets merged.

Fixes #20781
