### PR TITLE
[DOCS] Remove documentation for `force` version-type

### DIFF
--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -155,12 +155,10 @@ than the version of the stored document. If there is no existing document
 the operation will succeed as well. The given version will be used as the new version
 and will be stored with the new document. The supplied version must be a non-negative long number.
 
-`force`:: the document will be indexed regardless of the version of the stored document or if there
-is no existing document. The given version will be used as the new version and will be stored
-with the new document. This version type is typically used for correcting errors.
-
-*NOTE*: The `external_gte` & `force` version types are meant for special use cases and should be used
-with care. If used incorrectly, they can result in loss of data.
+*NOTE*: The `external_gte` version type is meant for special use cases and
+should be used with care. If used incorrectly, it can result in loss of data.
+There is another option, `force`, which is deprecated because it can cause
+primary and replica shards to diverge.
 
 [float]
 [[operation-type]]


### PR DESCRIPTION
This option should not be recommended to anyone, and should never be
used, upon chance of primary/replica divergence.

Relates to #19769
