### PR TITLE
add utest for Strings cleanPath

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/Strings.java
+++ b/core/src/main/java/org/elasticsearch/common/Strings.java
@@ -56,9 +56,9 @@ public class Strings {
 
     private static final String WINDOWS_FOLDER_SEPARATOR = "\\";
 
-    private static final String TOP_PATH = "src/test";
-
     private static final String CURRENT_PATH = ".";
+
+    private static final String PARENT_PATH = "..";
 
     public static void spaceify(int spaces, String from, StringBuilder to) throws Exception {
         try (BufferedReader reader = new BufferedReader(new FastStringReader(from))) {
@@ -458,32 +458,52 @@ public class Strings {
 
         String[] pathArray = delimitedListToStringArray(pathToUse, FOLDER_SEPARATOR);
         List<String> pathElements = new LinkedList<>();
-        int tops = 0;
 
-        for (int i = pathArray.length - 1; i >= 0; i--) {
-            String element = pathArray[i];
-            if (CURRENT_PATH.equals(element)) {
-                // Points to current directory - drop it.
-            } else if (TOP_PATH.equals(element)) {
-                // Registering top path found.
-                tops++;
-            } else {
-                if (tops > 0) {
-                    // Merging path element with element corresponding to top path.
-                    tops--;
-                } else {
-                    // Normal path element found.
-                    pathElements.add(0, element);
-                }
-            }
-        }
-
-        // Remaining top paths need to be retained.
-        for (int i = 0; i < tops; i++) {
-            pathElements.add(0, TOP_PATH);
-        }
+        mergeSubPath(pathArray, pathElements);
+        simplifyParentPath(pathToUse, pathArray, pathElements);
 
         return prefix + collectionToDelimitedString(pathElements, FOLDER_SEPARATOR);
+    }
+
+    private static void mergeSubPath(String[] pathArray, List<String> pathElements) {
+        for (int i = pathArray.length - 1; i >= 0; i--) {
+            String element = pathArray[i];
+            // Points to current directory - drop it.
+            if (!CURRENT_PATH.equals(element) && !"".equals(element)) {
+                pathElements.add(0, element);
+            }
+        }
+    }
+
+    private static void simplifyParentPath(String pathToUse, String[] pathArray, List<String> pathElements) {
+        if (pathToUse.contains(PARENT_PATH)) {
+            int lastParentPathIndex = 0;
+            int nonNullElementNumBeforeFirstParentPath = 0;
+
+            for (int index = pathArray.length - 1; index >= 0; index--) {
+                String subPath = pathArray[index];
+                if (PARENT_PATH.equals(subPath)) {
+                    break;
+                }
+                if (!"".equals(subPath) && !CURRENT_PATH.equals(subPath)) {
+                    lastParentPathIndex = index;
+                }
+            }
+
+            for (int i = 0; i < lastParentPathIndex; i++) {
+                String element = pathArray[i];
+                if (!CURRENT_PATH.equals(element) && !"".equals(element)) {
+                    if (!PARENT_PATH.equals(element)) {
+                        nonNullElementNumBeforeFirstParentPath += 1;
+                    }
+                }
+            }
+
+            //remove pairs of subPath and double dots to simplify path
+            for (int count2Remove = nonNullElementNumBeforeFirstParentPath * 2; count2Remove > 0; count2Remove--) {
+                pathElements.remove(0);
+            }
+        }
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/common/StringsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/StringsTests.java
@@ -102,4 +102,21 @@ public class StringsTests extends ESTestCase {
         assertEquals(Strings.splitStringToSet("aa   ", ' '), Sets.newHashSet("aa"));
         assertEquals(Strings.splitStringToSet("   ", ' '), Sets.newHashSet());
     }
+
+    public void testCleanPath() {
+        assertEquals("/root/home", Strings.cleanPath("/root//home"));
+        assertEquals("/root/home", Strings.cleanPath("\\root\\home"));
+
+        assertEquals("/home", Strings.cleanPath("/root/../home"));
+        assertEquals("home", Strings.cleanPath("./root/../home"));
+        assertEquals("home", Strings.cleanPath(".\\root\\..\\home"));
+
+        assertEquals("file:/home/elk", Strings.cleanPath("file:/root/../home/elk"));
+        assertEquals("file:home/elk", Strings.cleanPath("file:./root/../home/elk"));
+
+        assertEquals("file:../home/elk", Strings.cleanPath("file:./root/../../home/elk"));
+        assertEquals("file:/../home/elk", Strings.cleanPath("file:/root/../../home/elk"));
+
+        assertEquals("file:../../home/elk", Strings.cleanPath("file:./root/../../../home/elk"));
+    }
 }


### PR DESCRIPTION
When add a unit test for method "cleanPath" of Strings in elasticsearch/common package, the test results turn out to be far from its function description:
Normalize the path by suppressing sequences like ""path/.."and inner simple dots
--that means path like "/root/../home" would be suppressed as path "/home", but actually the test case failed.
--the below example original paths would be suppressed as the Expected normalized path, but actually not:
 **Original**                                **Expetced:**                  **Actual:**  
"/root//home"                             "/root/home"                 "/root//home"
"/root/../home"                           "/home"                         "/root/../home"
"/root/../home"                           "home"                          "/root/../home"
"file:./root/../home/elk"              "file:home/elk"               "file:./root/../home/elk"
Some common util classes and methods deserve more attention : )

Closes #20851 
