### PR TITLE
Prevent double release in TcpTransport if send listener throws an exception

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/lease/Releasables.java
+++ b/core/src/main/java/org/elasticsearch/common/lease/Releasables.java
@@ -24,6 +24,7 @@ import org.apache.lucene.util.IOUtils;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /** Utility methods to work with {@link Releasable}s. */
 public enum Releasables {
@@ -92,5 +93,17 @@ public enum Releasables {
     /** @see #wrap(Iterable) */
     public static Releasable wrap(final Releasable... releasables) {
         return () -> close(releasables);
+    }
+
+    /**
+     * Equivalent to {@link #wrap(Releasable...)} but can be called multiple times without double releasing.
+     */
+    public static Releasable releaseOnce(final Releasable... releasables) {
+        final AtomicBoolean released = new AtomicBoolean(false);
+        return () -> {
+            if (released.compareAndSet(false, true)) {
+                close(releasables);
+            }
+        };
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/ReleasablesTests.java
+++ b/core/src/test/java/org/elasticsearch/common/ReleasablesTests.java
@@ -1,7 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.elasticsearch.common;
 
-/**
- * Created by simon on 10/12/16.
- */
-public class ReleasablesTests {
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ReleasablesTests extends ESTestCase {
+
+    public void testReleaseOnce() {
+        AtomicInteger count = new AtomicInteger(0);
+        Releasable releasable = Releasables.releaseOnce(count::incrementAndGet, count::incrementAndGet);
+        assertEquals(0, count.get());
+        releasable.close();
+        assertEquals(2, count.get());
+        releasable.close();
+        assertEquals(2, count.get());
+    }
 }

--- a/core/src/test/java/org/elasticsearch/common/ReleasablesTests.java
+++ b/core/src/test/java/org/elasticsearch/common/ReleasablesTests.java
@@ -1,0 +1,7 @@
+package org.elasticsearch.common;
+
+/**
+ * Created by simon on 10/12/16.
+ */
+public class ReleasablesTests {
+}


### PR DESCRIPTION
today we might release a bytes array more than once if the send listener
throws an exception but already has released the array. Yet, this is already fixed
in the BytesArray class we use in production to ensure 3rd party users don't release
twice but our mocks still enforce it.

see this build for reference https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+multijob-unix-compatibility/os=debian/95/consoleFull
