### PR TITLE
Add checkstyle rule to forbid empty javadoc comments

### DIFF
--- a/buildSrc/src/main/resources/checkstyle.xml
+++ b/buildSrc/src/main/resources/checkstyle.xml
@@ -10,6 +10,13 @@
     <property name="file" value="${suppressions}" />
   </module>
 
+  <!-- Checks Java files and forbids empty Javadoc comments -->
+  <module name="RegexpMultiline">
+    <property name="format" value="\/\*[\s\*]*\*\/"/>
+    <property name="fileExtensions" value="java"/>
+    <property name="message" value="Empty javadoc comments are forbidden"/>
+  </module>
+
   <module name="TreeWalker">
     <!-- Its our official line length! See checkstyle_suppressions.xml for the files that don't pass this. For now we
       suppress the check there but enforce it everywhere else. This prevents the list from getting longer even if it is

--- a/core/src/test/java/org/elasticsearch/search/nested/SimpleNestedIT.java
+++ b/core/src/test/java/org/elasticsearch/search/nested/SimpleNestedIT.java
@@ -1053,14 +1053,11 @@ public class SimpleNestedIT extends ESIntegTestCase {
         assertThat(clusterStatsResponse.getIndicesStats().getSegments().getBitsetMemoryInBytes(), equalTo(0L));
     }
 
-    /**
-     */
     private void assertDocumentCount(String index, long numdocs) {
         IndicesStatsResponse stats = admin().indices().prepareStats(index).clear().setDocs(true).get();
         assertNoFailures(stats);
         assertThat(stats.getIndex(index).getPrimaries().docs.getCount(), is(numdocs));
 
     }
-
 
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
@@ -68,7 +68,7 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
     public static final String REST_TESTS_SUITE = "tests.rest.suite";
     /**
      * Property that allows to blacklist some of the REST tests based on a comma separated list of globs
-     * e.g. -Dtests.rest.blacklist=get/10_basic/*
+     * e.g. "-Dtests.rest.blacklist=get/10_basic/*"
      */
     public static final String REST_TESTS_BLACKLIST = "tests.rest.blacklist";
     /**


### PR DESCRIPTION
As suggested by @nik9000 in https://github.com/elastic/elasticsearch/pull/20871#issuecomment-253010319, this PR adds a checkstyle check to ensure that Java files do not contain any empty Javadoc comment.

This also fix few remaining empty comments.
