### PR TITLE
Explain how unreleased versions should be added to the codebase without adding it to Version.java

### DIFF
--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -95,6 +95,15 @@ public class Version {
     public static final Version V_6_0_0_alpha1 = new Version(V_6_0_0_alpha1_ID, org.apache.lucene.util.Version.LUCENE_6_2_0);
     public static final Version CURRENT = V_6_0_0_alpha1;
 
+    /* NOTE: don't add unreleased version to this list except of the version assigned to CURRENT.
+     * If you need a version that doesn't exist here for instance V_5_1_0 then go and create such a version
+     * as a constant where you need it:
+     * <pre>
+     *   public static final Version V_5_1_0_UNRELEASED = new Version(5010099, Version.CURRENT.luceneVersion);
+     * </pre>
+     * Then go to VersionsTest.java and add a test for this constant VersionTests#testUnknownVersions().
+     * This is particularly useful if you are building a feature that needs a BWC layer for this unreleased version etc.*/
+
     static {
         assert CURRENT.luceneVersion.equals(org.apache.lucene.util.Version.LATEST) : "Version must be upgraded to ["
                 + org.apache.lucene.util.Version.LATEST + "] is still set to [" + CURRENT.luceneVersion + "]";

--- a/core/src/test/java/org/elasticsearch/VersionTests.java
+++ b/core/src/test/java/org/elasticsearch/VersionTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 import org.hamcrest.Matchers;
+import org.junit.Assert;
 
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
@@ -278,5 +279,17 @@ public class VersionTests extends ESTestCase {
                 }
             }
         }
+    }
+    private  static final Version V_20_0_0_UNRELEASED = new Version(20000099, Version.CURRENT.luceneVersion);
+
+    // see comment in Version.java about this test
+    public void testUnknownVersions() {
+        assertUnknownVersion(V_20_0_0_UNRELEASED);
+        expectThrows(AssertionError.class, () -> assertUnknownVersion(Version.CURRENT));
+    }
+
+    public static void assertUnknownVersion(Version version) {
+        assertFalse("Version " + version + " has been releaed don't use a new instance of this version",
+            VersionUtils.allVersions().contains(version));
     }
 }


### PR DESCRIPTION
Sometimes it's useful / needed to use unreleased `Version` constants but we should not add those to the `Version.java` class for several reasons ie. BWC tests and assertions along those lines. Yet, it's not really obvious how to do that so I added some comments and a simple test for this.
