### PR TITLE
update date-math-index-names first doc example to work in Console

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -88,7 +88,7 @@ You must enclose date math index name expressions within angle brackets. For exa
 
 [source,js]
 ----------------------------------------------------------------------
-GET /<logstash-{now/d}>/_search
+GET /<logstash-{now%2Fd}>/_search
 {
   "query" : {
     "match": {


### PR DESCRIPTION
The first example of date-math-index-names did not work in Console,
updated to work like the second one.
