### PR TITLE
Add doc note regarding processors bound

### DIFF
--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -142,23 +142,37 @@ threadpool:
 [[processors]]
 === Processors setting
 The number of processors is automatically detected, and the thread pool
-settings are automatically set based on it. However, the number of
-processors is by default bounded to 32. This means that on systems that
-have more than 32 processors, Elasticsearch will size its thread pools
-as if there are only 32 processors present. This limitation was added to
-avoid creating too many threads on systems that have not properly
-adjusted the `ulimit` for max number of processes. In cases where you've
-adjusted the `ulimit` appropriately, you can override this bound by
-explicitly setting the `processors` setting.
+settings are automatically set based on it. In some cases it can be
+useful to override the number of detected processors. This can be done
+by explicitly setting the `processors` setting.
 
 [source,yaml]
 --------------------------------------------------
-processors: 36
+processors: 2
 --------------------------------------------------
 
-Additionally, sometimes the number of processors is wrongly detected and
-in such cases explicitly setting the `processors` setting will
-workaround such issues.
+There are a few use-cases for explicitly overriding the `processors`
+setting:
+
+. If you are running multiple instances of Elasticsearch on the same
+host but want Elasticsearch to size its thread pools as if it only has a
+fraction of the CPU, you should override the `processors` setting to the
+desired fraction (e.g., if you're running two instances of Elasticsearch
+on a 16-core machine, set `processors` to 8). Note that this is an
+expert-level use-case and there's a lot more involved than just setting
+the `processors` setting as there are other considerations like changing
+the number of garbage collector threads, pinning processes to cores,
+etc.
+. The number of processors is by default bounded to 32. This means that
+on systems that have more than 32 processors, Elasticsearch will size
+its thread pools as if there are only 32 processors present. This
+limitation was added to avoid creating too many threads on systems that
+have not properly adjusted the `ulimit` for max number of processes. In
+cases where you've adjusted the `ulimit` appropriately, you can override
+this bound by explicitly setting the `processors` setting.
+. Sometimes the number of processors is wrongly detected and in such
+cases explicitly setting the `processors` setting will workaround such
+issues.
 
 In order to check the number of processors detected, use the nodes info
 API with the `os` flag.

--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -142,14 +142,23 @@ threadpool:
 [[processors]]
 === Processors setting
 The number of processors is automatically detected, and the thread pool
-settings are automatically set based on it. Sometimes, the number of processors
-are wrongly detected, in such cases, the number of processors can be
-explicitly set using the `processors` setting.
+settings are automatically set based on it. However, the number of
+processors is by default bounded to 32. This means that on systems that
+have more than 32 processors, Elasticsearch will size its thread pools
+as if there are only 32 processors present. This limitation was added to
+avoid creating too many threads on systems that have not properly
+adjusted the `ulimit` for max number of processes. In cases where you've
+adjusted the `ulimit` appropriately, you can override this bound by
+explicitly setting the `processors` setting.
 
 [source,yaml]
 --------------------------------------------------
-processors: 2
+processors: 36
 --------------------------------------------------
+
+Additionally, sometimes the number of processors is wrongly detected and
+in such cases explicitly setting the `processors` setting will
+workaround such issues.
 
 In order to check the number of processors detected, use the nodes info
 API with the `os` flag.


### PR DESCRIPTION
This commit adds a note to the thread pool docs regarding the bound of
32 on the number of processors used when sizing the thread pools.

Relates #20828
