### PR TITLE
Deprecate EOL'ed Ubuntu 15.04 from Vagrantfile

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -347,7 +347,6 @@ These are the linux flavors the Vagrantfile currently supports:
 
 * ubuntu-1204 aka precise
 * ubuntu-1404 aka trusty
-* ubuntu-1504 aka vivid
 * ubuntu-1604 aka xenial
 * debian-8 aka jessie, the current debian stable distribution
 * centos-6

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,13 +30,6 @@ Vagrant.configure(2) do |config|
     config.vm.box = "elastic/ubuntu-14.04-x86_64"
     ubuntu_common config
   end
-  config.vm.define "ubuntu-1504" do |config|
-    config.vm.box = "elastic/ubuntu-15.04-x86_64"
-    ubuntu_common config, extra: <<-SHELL
-      # Install Jayatana so we can work around it being present.
-      [ -f /usr/share/java/jayatanaag.jar ] || install jayatana
-    SHELL
-  end
   config.vm.define "ubuntu-1604" do |config|
     config.vm.box = "elastic/ubuntu-16.04-x86_64"
     ubuntu_common config, extra: <<-SHELL

--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -37,7 +37,6 @@ List<String> availableBoxes = [
     'sles-12',
     'ubuntu-1204',
     'ubuntu-1404',
-    'ubuntu-1504',
     'ubuntu-1604'
 ]
 


### PR DESCRIPTION
This PR references issue https://github.com/elastic/elasticsearch/issues/20920
