### PR TITLE
cli -v may obscure user, better to show the plugin downloading url

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -265,7 +265,7 @@ class InstallPluginCommand extends SettingCommand {
 
     /** Downloads a zip from the url, into a temp file under the given temp dir. */
     private Path downloadZip(Terminal terminal, String urlString, Path tmpDir) throws IOException {
-        terminal.println(VERBOSE, "Retrieving zip from " + urlString);
+        terminal.println("Retrieving zip from " + urlString);
         URL url = new URL(urlString);
         Path zip = Files.createTempFile(tmpDir, null, ".zip");
         URLConnection urlConnection = url.openConnection();


### PR DESCRIPTION
In the version 2.x, users get used to seeing the plugin download url without adding cli "-v", and they get used to downloading the plugins themselves if http obstacle. Without showing the url directly, they may be confused.
