### PR TITLE
add reminder of cli --verbose for misinstall system modules

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -419,7 +419,7 @@ class InstallPluginCommand extends SettingCommand {
         // they might be unavoidably in maven central and are packaged up the same way)
         if (MODULES.contains(info.getName())) {
             throw new UserException(
-                    ExitCodes.USAGE, "plugin '" + info.getName() + "' cannot be installed like this, it is a system module");
+                    ExitCodes.USAGE, "plugin '" + info.getName() + "' cannot be installed like this, it is a system module. use --verbose to get detailed information");
         }
 
         // check for jar hell before any copying


### PR DESCRIPTION
if a system module was incorrect  installation, there provides detail information as a common plugin. but it is maintain as hidden println mode (VERBOSE). this commit add a reminder when user installs a system module and wants to view detail information. 
