### PR TITLE
Remove duplicate timeout parameter in Delete/Update-By-Query REST Specs

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -122,10 +122,6 @@
           "type" : "list",
           "description" : "Specific 'tag' of the request for logging and statistical purposes"
         },
-        "timeout": {
-          "type" : "time",
-          "description" : "Explicit operation timeout"
-        },
         "version": {
           "type" : "boolean",
           "description" : "Specify whether to return document version as part of a hit"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -126,10 +126,6 @@
           "type" : "list",
           "description" : "Specific 'tag' of the request for logging and statistical purposes"
         },
-        "timeout": {
-          "type" : "time",
-          "description" : "Explicit operation timeout"
-        },
         "version": {
           "type" : "boolean",
           "description" : "Specify whether to return document version as part of a hit"


### PR DESCRIPTION
This commit removes the duplicated `timeout` parameter introduced in #20915
