### PR TITLE
Use Lucenes expectThrows() when testing exceptions

### DIFF
--- a/buildSrc/src/main/resources/forbidden/es-test-signatures.txt
+++ b/buildSrc/src/main/resources/forbidden/es-test-signatures.txt
@@ -25,3 +25,4 @@ org.apache.lucene.util.LuceneTestCase$Nightly @ We don't run nightly tests at th
 com.carrotsearch.randomizedtesting.annotations.Nightly @ We don't run nightly tests at this point!
 
 org.junit.Test @defaultMessage Just name your test method testFooBar
+org.junit.rules.ExpectedException @ Use LuceneTestCase#expectThrows(Class<T>, LuceneTestCase.ThrowingRunnable) instead

--- a/core/src/test/java/org/elasticsearch/search/sort/ScoreSortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/ScoreSortBuilderTests.java
@@ -26,8 +26,6 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.search.DocValueFormat;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 
@@ -49,16 +47,12 @@ public class ScoreSortBuilderTests extends AbstractSortTestCase<ScoreSortBuilder
         return result;
     }
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     /**
      * test passing null to {@link ScoreSortBuilder#order(SortOrder)} is illegal
      */
     public void testIllegalOrder() {
-            exceptionRule.expect(NullPointerException.class);
-            exceptionRule.expectMessage("sort order cannot be null.");
-            new ScoreSortBuilder().order(null);
+        Exception e = expectThrows(NullPointerException.class, () -> new ScoreSortBuilder().order(null));
+        assertEquals("sort order cannot be null.", e.getMessage());
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/search/sort/SortModeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/SortModeTests.java
@@ -20,15 +20,10 @@
 package org.elasticsearch.search.sort;
 
 import org.elasticsearch.test.ESTestCase;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 
 import java.util.Locale;
 
 public class SortModeTests extends ESTestCase {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     public void testSortMode() {
         // we rely on these ordinals in serialization, so changing them breaks bwc.
@@ -50,16 +45,11 @@ public class SortModeTests extends ESTestCase {
         }
     }
 
-    public void testParseNull() {
-        exceptionRule.expect(NullPointerException.class);
-        exceptionRule.expectMessage("input string is null");
-        SortMode.fromString(null);
-    }
+    public void testParsingFromStringExceptions() {
+        Exception e = expectThrows(NullPointerException.class, () -> SortMode.fromString(null));
+        assertEquals("input string is null", e.getMessage());
 
-    public void testIllegalArgument() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Unknown SortMode [xyz]");
-        SortMode.fromString("xyz");
+        e = expectThrows(IllegalArgumentException.class, () -> SortMode.fromString("xyz"));
+        assertEquals("Unknown SortMode [xyz]", e.getMessage());
     }
-
 }


### PR DESCRIPTION
Cleaning up a few remaining occurences of using junits ExpectedException rule in favor of using LuceneTestCase#expectThrows() which is more concise and versatile.
