### PR TITLE
Add support for booleans in scripts

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -291,4 +291,38 @@ public interface ScriptDocValues<T> extends List<T> {
             return geohashDistance(geohash);
         }
     }
+
+    class Booleans extends AbstractList<Boolean> implements ScriptDocValues<Boolean> {
+
+        private final SortedNumericDocValues values;
+
+        public Booleans(SortedNumericDocValues values) {
+            this.values = values;
+        }
+
+        @Override
+        public void setNextDocId(int docId) {
+            values.setDocument(docId);
+        }
+
+        @Override
+        public List<Boolean> getValues() {
+            return Collections.unmodifiableList(this);
+        }
+
+        public boolean getValue() {
+            return values.count() != 0 && values.valueAt(0) == 1;
+        }
+
+        @Override
+        public Boolean get(int index) {
+            return values.valueAt(index) == 1;
+        }
+
+        @Override
+        public int size() {
+            return values.count();
+        }
+
+    }
 }

--- a/core/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -292,7 +292,7 @@ public interface ScriptDocValues<T> extends List<T> {
         }
     }
 
-    class Booleans extends AbstractList<Boolean> implements ScriptDocValues<Boolean> {
+    final class Booleans extends AbstractList<Boolean> implements ScriptDocValues<Boolean> {
 
         private final SortedNumericDocValues values;
 
@@ -307,7 +307,7 @@ public interface ScriptDocValues<T> extends List<T> {
 
         @Override
         public List<Boolean> getValues() {
-            return Collections.unmodifiableList(this);
+            return this;
         }
 
         public boolean getValue() {

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericDVIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericDVIndexFieldData.java
@@ -96,7 +96,7 @@ public class SortedNumericDVIndexFieldData extends DocValuesIndexFieldData imple
             case DOUBLE:
                 return new SortedNumericDoubleFieldData(reader, field);
             default:
-                return new SortedNumericLongFieldData(reader, field);
+                return new SortedNumericLongFieldData(reader, field, numericType == NumericType.BOOLEAN);
         }
     }
 
@@ -117,8 +117,8 @@ public class SortedNumericDVIndexFieldData extends DocValuesIndexFieldData imple
         final LeafReader reader;
         final String field;
 
-        SortedNumericLongFieldData(LeafReader reader, String field) {
-            super(0L);
+        SortedNumericLongFieldData(LeafReader reader, String field, boolean isBoolean) {
+            super(0L, isBoolean);
             this.reader = reader;
             this.field = field;
         }

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.txt
@@ -101,6 +101,12 @@ class org.elasticsearch.index.fielddata.ScriptDocValues.GeoPoints -> org.elastic
   double geohashDistanceWithDefault(String,double)
 }
 
+class org.elasticsearch.index.fielddata.ScriptDocValues.Booleans -> org.elasticsearch.index.fielddata.ScriptDocValues$Booleans extends List,Collection,Iterable,Object {
+  Boolean get(int)
+  boolean getValue()
+  List getValues()
+}
+
 # for testing.
 # currently FeatureTest exposes overloaded constructor, field load store, and overloaded static methods
 class org.elasticsearch.painless.FeatureTest -> org.elasticsearch.painless.FeatureTest extends Object {

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/plan_a/30_search.yaml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/plan_a/30_search.yaml
@@ -6,19 +6,19 @@
             index: test
             type: test
             id: 1
-            body: { "test": "value beck", "num1": 1.0 }
+            body: { "test": "value beck", "num1": 1.0, "bool": true }
     - do:
         index:
             index: test
             type: test
             id: 2
-            body: { "test": "value beck", "num1": 2.0 }
+            body: { "test": "value beck", "num1": 2.0, "bool": false }
     - do:
         index:
             index: test
             type: test
             id: 3
-            body: { "test": "value beck", "num1": 3.0 }
+            body: { "test": "value beck", "num1": 3.0, "bool": true }
     - do:
         indices.refresh: {}
 
@@ -94,6 +94,19 @@
     - match: { hits.hits.0.fields.sNum1.0: 1.0 }
     - match: { hits.hits.1.fields.sNum1.0: 2.0 }
     - match: { hits.hits.2.fields.sNum1.0: 3.0 }
+
+    - do:
+        index: test
+        search:
+            body:
+                query:
+                    script:
+                        script:
+                            inline: "doc['bool'].value == false"
+                            lang: painless
+
+    - match: { hits.total: 1 }
+    - match: { hits.hits.0._id: "2" }
 
 ---
 


### PR DESCRIPTION
Since 2.0, booleans have been represented as numeric fields (longs).
However, in scripts, this is odd, since you expect doing a comparison
against a boolean to work. While languages like groovy will auto convert
between booleans and longs, painless does not.

This changes the doc values accessor for boolean fields in scripts to
return Boolean objects instead of Long objects.

closes #20949
