### PR TITLE
Added the `skip` configuration for `warnings` check in the "Indices Analyze" test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/10_analyze.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/10_analyze.yaml
@@ -6,6 +6,8 @@ setup:
 
 ---
 "Basic test":
+    - skip:
+        features: ["warnings"]
     - do:
         warnings:
           - text request parameter is deprecated and will be removed in the next major release. Please use the JSON in the request body instead request param
@@ -17,6 +19,8 @@ setup:
 
 ---
 "Tokenizer and filter":
+    - skip:
+        features: ["warnings"]
     - do:
         warnings:
           - filter request parameter is deprecated and will be removed in the next major release. Please use the JSON in the request body instead request param
@@ -31,6 +35,8 @@ setup:
 
 ---
 "Index and field":
+    - skip:
+        features: ["warnings"]
     - do:
         indices.create:
           index: test
@@ -62,6 +68,8 @@ setup:
     - match:     { tokens.0.token: foo bar }
 ---
 "Body params override query string":
+    - skip:
+        features: ["warnings"]
     - do:
         warnings:
           - text request parameter is deprecated and will be removed in the next major release. Please use the JSON in the request body instead request param


### PR DESCRIPTION
As part of b6537d719d840dc987a1fb2df4b48bf260e53371, a check for the `Warnings` headers has been added. Since the feature might be temporarily or permanently not supported by all clients (as is the case with eg. the `headers` feature), we should allow them to skip the tests.

Related: #20246, #20686
/cc @johtani
