### PR TITLE
Docs: Cluster Allocation Filtering

### DIFF
--- a/docs/reference/modules/cluster/allocation_filtering.asciidoc
+++ b/docs/reference/modules/cluster/allocation_filtering.asciidoc
@@ -6,6 +6,31 @@ allocation of shards to nodes, cluster-level shard allocation filtering allows
 you to allow or disallow the allocation of shards from *any* index to
 particular nodes.
 
+The available _dynamic_ cluster settings are as follows, where `{attribute}`
+refers to an arbitrary node attribute.:
+
+`cluster.routing.allocation.include.{attribute}`::
+
+    Allocate shards to a node whose `{attribute}` has at least one of the
+    comma-separated values.
+
+`cluster.routing.allocation.require.{attribute}`::
+
+    Only allocate shards to a node whose `{attribute}` has _all_ of the
+    comma-separated values.
+
+`cluster.routing.allocation.exclude.{attribute}`::
+
+    Do not allocate shards to a node whose `{attribute}` has _none_ of the
+    comma-separated values.
+
+These special attributes are also supported:
+
+[horizontal]
+`_name`::   Match nodes by node names
+`_ip`::     Match nodes by IP addresses (the IP address associated with the hostname)
+`_host`::   Match nodes by hostnames
+
 The typical use case for cluster-wide shard allocation filtering is when you
 want to decommission a node, and you would like to move the shards from that
 node to other nodes in the cluster before shutting it down.
@@ -27,35 +52,8 @@ NOTE: Shards will only be relocated if it is possible to do so without
 breaking another routing constraint, such as never allocating a primary and
 replica shard to the same node.
 
-Cluster-wide shard allocation filtering works in the same way as index-level
-shard allocation filtering (see <<index-modules-allocation>> for details).
-
-The available _dynamic_ cluster settings are as follows, where `{attribute}`
-refers to an arbitrary node attribute.:
-
-`cluster.routing.allocation.include.{attribute}`::
-
-    Assign the index to a node whose `{attribute}` has at least one of the
-    comma-separated values.
-
-`cluster.routing.allocation.require.{attribute}`::
-
-    Assign the index to a node whose `{attribute}` has _all_ of the
-    comma-separated values.
-
-`cluster.routing.allocation.exclude.{attribute}`::
-
-    Assign the index to a node whose `{attribute}` has _none_ of the
-    comma-separated values.
-
-These special attributes are also supported:
-
-[horizontal]
-`_name`::   Match nodes by node name
-`_ip`::     Match nodes by IP address (the IP address associated with the hostname)
-`_host`::   Match nodes by hostname
-
-All attribute values can be specified with wildcards, eg:
+In addition to listing multiple values as a comma-separated list, all
+attribute values can be specified with wildcards, eg:
 
 [source,js]
 ------------------------


### PR DESCRIPTION
Put more emphasis on the fact that multiple values can be specified
and move examples after explanation of settings.

Supercedes #17498.  Suggestion for #16997.
