### PR TITLE
Use expectThrows() instead of try-catch blocks for testing expected exceptions

### DIFF
--- a/core/src/test/java/org/elasticsearch/VersionTests.java
+++ b/core/src/test/java/org/elasticsearch/VersionTests.java
@@ -97,40 +97,23 @@ public class VersionTests extends ESTestCase {
     }
 
     public void testTooLongVersionFromString() {
-        try {
-            Version.fromString("1.0.0.1.3");
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("needs to contain major, minor, and revision"));
-        }
+        Exception e = expectThrows(IllegalArgumentException.class, () -> Version.fromString("1.0.0.1.3"));
+        assertThat(e.getMessage(), containsString("needs to contain major, minor, and revision"));
     }
 
     public void testTooShortVersionFromString() {
-        try {
-            Version.fromString("1.0");
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("needs to contain major, minor, and revision"));
-        }
-
+        Exception e = expectThrows(IllegalArgumentException.class, () -> Version.fromString("1.0"));
+        assertThat(e.getMessage(), containsString("needs to contain major, minor, and revision"));
     }
 
     public void testWrongVersionFromString() {
-        try {
-            Version.fromString("WRONG.VERSION");
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("needs to contain major, minor, and revision"));
-        }
+        Exception e = expectThrows(IllegalArgumentException.class, () -> Version.fromString("WRONG.VERSION"));
+        assertThat(e.getMessage(), containsString("needs to contain major, minor, and revision"));
     }
 
     public void testVersionNoPresentInSettings() {
-        try {
-            Version.indexCreated(Settings.builder().build());
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage(), containsString("[index.version.created] is not present"));
-        }
+        Exception e = expectThrows(IllegalStateException.class, () -> Version.indexCreated(Settings.builder().build()));
+        assertThat(e.getMessage(), containsString("[index.version.created] is not present"));
     }
 
     public void testIndexCreatedVersion() {

--- a/core/src/test/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationActionTests.java
@@ -137,6 +137,7 @@ public class TransportInstanceSingleOperationActionTests extends ESTestCase {
         THREAD_POOL = new TestThreadPool(TransportInstanceSingleOperationActionTests.class.getSimpleName());
     }
 
+    @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
@@ -156,6 +157,7 @@ public class TransportInstanceSingleOperationActionTests extends ESTestCase {
         );
     }
 
+    @Override
     @After
     public void tearDown() throws Exception {
         super.tearDown();

--- a/core/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
@@ -226,12 +226,8 @@ public class UpdateRequestTests extends ESTestCase {
     // Related to issue #15822
     public void testInvalidBodyThrowsParseException() throws Exception {
         UpdateRequest request = new UpdateRequest("test", "type", "1");
-        try {
-            request.fromXContent(new byte[] { (byte) '"' });
-            fail("Should have thrown a ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), equalTo("Failed to derive xcontent"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> request.fromXContent(new byte[] { (byte) '"' }));
+        assertThat(e.getMessage(), equalTo("Failed to derive xcontent"));
     }
 
     // Related to issue 15338

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/DateMathExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/DateMathExpressionResolverTests.java
@@ -177,43 +177,31 @@ public class DateMathExpressionResolverTests extends ESTestCase {
     }
 
     public void testExpressionInvalidUnescaped() throws Exception {
-        try {
-            expressionResolver.resolve(context, Arrays.asList("<.mar}vel-{now/d}>"));
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), containsString("invalid dynamic name expression"));
-            assertThat(e.getMessage(), containsString("invalid character at position ["));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class,
+                () -> expressionResolver.resolve(context, Arrays.asList("<.mar}vel-{now/d}>")));
+        assertThat(e.getMessage(), containsString("invalid dynamic name expression"));
+        assertThat(e.getMessage(), containsString("invalid character at position ["));
     }
 
     public void testExpressionInvalidDateMathFormat() throws Exception {
-        try {
-            expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{}>"));
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), containsString("invalid dynamic name expression"));
-            assertThat(e.getMessage(), containsString("date math placeholder is open ended"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class,
+                () -> expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{}>")));
+        assertThat(e.getMessage(), containsString("invalid dynamic name expression"));
+        assertThat(e.getMessage(), containsString("date math placeholder is open ended"));
     }
 
     public void testExpressionInvalidEmptyDateMathFormat() throws Exception {
-        try {
-            expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{}}>"));
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), containsString("invalid dynamic name expression"));
-            assertThat(e.getMessage(), containsString("missing date format"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class,
+                () -> expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{}}>")));
+        assertThat(e.getMessage(), containsString("invalid dynamic name expression"));
+        assertThat(e.getMessage(), containsString("missing date format"));
     }
 
     public void testExpressionInvalidOpenEnded() throws Exception {
-        try {
-            expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d>"));
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), containsString("invalid dynamic name expression"));
-            assertThat(e.getMessage(), containsString("date math placeholder is open ended"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class,
+                () -> expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d>")));
+        assertThat(e.getMessage(), containsString("invalid dynamic name expression"));
+        assertThat(e.getMessage(), containsString("date math placeholder is open ended"));
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/common/TableTests.java
+++ b/core/src/test/java/org/elasticsearch/common/TableTests.java
@@ -28,71 +28,43 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 public class TableTests extends ESTestCase {
+
     public void testFailOnStartRowWithoutHeader() {
         Table table = new Table();
-        try {
-            table.startRow();
-            fail("Expected IllegalStateException");
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage(), is("no headers added..."));
-        }
+        Exception e = expectThrows(IllegalStateException.class, () -> table.startRow());
+        assertThat(e.getMessage(), is("no headers added..."));
     }
 
     public void testFailOnEndHeadersWithoutStart() {
         Table table = new Table();
-        try {
-            table.endHeaders();
-            fail("Expected IllegalStateException");
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage(), is("no headers added..."));
-        }
-
+        Exception e = expectThrows(IllegalStateException.class, () -> table.endHeaders());
+        assertThat(e.getMessage(), is("no headers added..."));
     }
 
     public void testFailOnAddCellWithoutHeader() {
         Table table = new Table();
-        try {
-            table.addCell("error");
-            fail("Expected IllegalStateException");
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage(), is("no block started..."));
-        }
-
+        Exception e = expectThrows(IllegalStateException.class, () -> table.addCell("error"));
+        assertThat(e.getMessage(), is("no block started..."));
     }
 
     public void testFailOnAddCellWithoutRow() {
         Table table = this.getTableWithHeaders();
-        try {
-            table.addCell("error");
-            fail("Expected IllegalStateException");
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage(), is("no block started..."));
-        }
-
+        Exception e = expectThrows(IllegalStateException.class, () -> table.addCell("error"));
+        assertThat(e.getMessage(), is("no block started..."));
     }
 
     public void testFailOnEndRowWithoutStart() {
         Table table = this.getTableWithHeaders();
-        try {
-            table.endRow();
-            fail("Expected IllegalStateException");
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage(), is("no row started..."));
-        }
-
+        Exception e = expectThrows(IllegalStateException.class, () -> table.endRow());
+        assertThat(e.getMessage(), is("no row started..."));
     }
 
     public void testFailOnLessCellsThanDeclared() {
         Table table = this.getTableWithHeaders();
         table.startRow();
         table.addCell("foo");
-        try {
-            table.endRow(true);
-            fail("Expected IllegalStateException");
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage(), is("mismatch on number of cells 1 in a row compared to header 2"));
-        }
-
+        Exception e = expectThrows(IllegalStateException.class, () -> table.endRow());
+        assertThat(e.getMessage(), is("mismatch on number of cells 1 in a row compared to header 2"));
     }
 
     public void testOnLessCellsThanDeclaredUnchecked() {
@@ -107,13 +79,8 @@ public class TableTests extends ESTestCase {
         table.startRow();
         table.addCell("foo");
         table.addCell("bar");
-        try {
-            table.addCell("foobar");
-            fail("Expected IllegalStateException");
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage(), is("can't add more cells to a row than the header"));
-        }
-
+        Exception e = expectThrows(IllegalStateException.class, () -> table.addCell("foobar"));
+        assertThat(e.getMessage(), is("can't add more cells to a row than the header"));
     }
 
     public void testSimple() {

--- a/core/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
@@ -19,12 +19,6 @@
 
 package org.elasticsearch.common.geo;
 
-import org.locationtech.spatial4j.exception.InvalidShapeException;
-import org.locationtech.spatial4j.shape.Circle;
-import org.locationtech.spatial4j.shape.Point;
-import org.locationtech.spatial4j.shape.Rectangle;
-import org.locationtech.spatial4j.shape.Shape;
-import org.locationtech.spatial4j.shape.impl.PointImpl;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.LineString;
 import com.vividsolutions.jts.geom.Polygon;
@@ -35,6 +29,12 @@ import org.elasticsearch.common.geo.builders.PolygonBuilder;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.geo.builders.ShapeBuilders;
 import org.elasticsearch.test.ESTestCase;
+import org.locationtech.spatial4j.exception.InvalidShapeException;
+import org.locationtech.spatial4j.shape.Circle;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.Rectangle;
+import org.locationtech.spatial4j.shape.Shape;
+import org.locationtech.spatial4j.shape.impl.PointImpl;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchGeoAssertions.assertMultiLineString;
 import static org.elasticsearch.test.hamcrest.ElasticsearchGeoAssertions.assertMultiPolygon;
@@ -183,17 +183,13 @@ public class ShapeBuilderTests extends ESTestCase {
     }
 
     public void testPolygonSelfIntersection() {
-        try {
-            ShapeBuilders.newPolygon(new CoordinatesBuilder()
+            PolygonBuilder newPolygon = ShapeBuilders.newPolygon(new CoordinatesBuilder()
                     .coordinate(-40.0, 50.0)
                     .coordinate(40.0, 50.0)
                     .coordinate(-40.0, -50.0)
-                    .coordinate(40.0, -50.0).close())
-                    .build();
-            fail("Expected InvalidShapeException");
-        } catch (InvalidShapeException e) {
-            assertThat(e.getMessage(), containsString("Self-intersection at or near point (0.0"));
-        }
+                    .coordinate(40.0, -50.0).close());
+        Exception e = expectThrows(InvalidShapeException.class, () -> newPolygon.build());
+        assertThat(e.getMessage(), containsString("Self-intersection at or near point (0.0"));
     }
 
     public void testGeoCircle() {
@@ -550,12 +546,8 @@ public class ShapeBuilderTests extends ESTestCase {
                 .coordinate(179, -10)
                 .coordinate(164, 0)
                 ));
-        try {
-            builder.close().build();
-            fail("Expected InvalidShapeException");
-        } catch (InvalidShapeException e) {
-            assertThat(e.getMessage(), containsString("interior cannot share more than one point with the exterior"));
-        }
+        Exception e = expectThrows(InvalidShapeException.class, () -> builder.close().build());
+        assertThat(e.getMessage(), containsString("interior cannot share more than one point with the exterior"));
     }
 
     public void testBoundaryShapeWithTangentialHole() {
@@ -602,12 +594,8 @@ public class ShapeBuilderTests extends ESTestCase {
                 .coordinate(176, -10)
                 .coordinate(-177, 10)
                 ));
-        try {
-            builder.close().build();
-            fail("Expected InvalidShapeException");
-        } catch (InvalidShapeException e) {
-            assertThat(e.getMessage(), containsString("interior cannot share more than one point with the exterior"));
-        }
+        Exception e = expectThrows(InvalidShapeException.class, () -> builder.close().build());
+        assertThat(e.getMessage(), containsString("interior cannot share more than one point with the exterior"));
     }
 
     /**
@@ -659,11 +647,7 @@ public class ShapeBuilderTests extends ESTestCase {
                 .coordinate(-176, 4)
                 .coordinate(180, 0)
                 );
-        try {
-            builder.close().build();
-            fail("Expected InvalidShapeException");
-        } catch (InvalidShapeException e) {
-            assertThat(e.getMessage(), containsString("duplicate consecutive coordinates at: ("));
-        }
+        Exception e = expectThrows(InvalidShapeException.class, () -> builder.close().build());
+        assertThat(e.getMessage(), containsString("duplicate consecutive coordinates at: ("));
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/core/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -123,48 +123,30 @@ public class ByteSizeValueTests extends ESTestCase {
     }
 
     public void testFailOnMissingUnits() {
-        try {
-            ByteSizeValue.parseBytesSizeValue("23", "test");
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), containsString("failed to parse setting [test]"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> ByteSizeValue.parseBytesSizeValue("23", "test"));
+        assertThat(e.getMessage(), containsString("failed to parse setting [test]"));
     }
 
     public void testFailOnUnknownUnits() {
-        try {
-            ByteSizeValue.parseBytesSizeValue("23jw", "test");
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), containsString("failed to parse setting [test]"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> ByteSizeValue.parseBytesSizeValue("23jw", "test"));
+        assertThat(e.getMessage(), containsString("failed to parse setting [test]"));
     }
 
     public void testFailOnEmptyParsing() {
-        try {
-            assertThat(ByteSizeValue.parseBytesSizeValue("", "emptyParsing").toString(), is("23kb"));
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), containsString("failed to parse setting [emptyParsing]"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class,
+                () -> assertThat(ByteSizeValue.parseBytesSizeValue("", "emptyParsing").toString(), is("23kb")));
+        assertThat(e.getMessage(), containsString("failed to parse setting [emptyParsing]"));
     }
 
     public void testFailOnEmptyNumberParsing() {
-        try {
-            assertThat(ByteSizeValue.parseBytesSizeValue("g", "emptyNumberParsing").toString(), is("23b"));
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), containsString("failed to parse [g]"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class,
+                () -> assertThat(ByteSizeValue.parseBytesSizeValue("g", "emptyNumberParsing").toString(), is("23b")));
+        assertThat(e.getMessage(), containsString("failed to parse [g]"));
     }
 
     public void testNoDotsAllowed() {
-        try {
-            ByteSizeValue.parseBytesSizeValue("42b.", null, "test");
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), containsString("failed to parse setting [test]"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> ByteSizeValue.parseBytesSizeValue("42b.", null, "test"));
+        assertThat(e.getMessage(), containsString("failed to parse setting [test]"));
     }
 
     public void testCompareEquality() {

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryUnitTests.java
@@ -87,7 +87,7 @@ public class ZenDiscoveryUnitTests extends ESTestCase {
 
         currentNodes = DiscoveryNodes.builder();
         currentNodes.masterNodeId("b").add(new DiscoveryNode("b", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT));
-        ;
+
         // version isn't taken into account, so randomize it to ensure this.
         if (randomBoolean()) {
             currentState.version(2);

--- a/core/src/test/java/org/elasticsearch/index/mapper/TimestampFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/TimestampFieldMapperTests.java
@@ -30,20 +30,11 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.joda.Joda;
-import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.DocumentMapperParser;
-import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.mapper.ParsedDocument;
-import org.elasticsearch.index.mapper.SourceToParse;
-import org.elasticsearch.index.mapper.TimestampFieldMapper;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -57,7 +48,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 
 import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
-import static org.elasticsearch.test.VersionUtils.randomVersion;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -212,12 +202,9 @@ public class TimestampFieldMapperTests extends ESSingleNodeTestCase {
                     .field("default", (String) null)
                 .endObject()
                 .endObject().endObject();
-        try {
-            createIndex("test", BW_SETTINGS).mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping.string()));
-            fail("we should reject the mapping with a TimestampParsingException: default timestamp can not be set to null");
-        } catch (TimestampParsingException e) {
-            assertThat(e.getDetailedMessage(), containsString("default timestamp can not be set to null"));
-        }
+        TimestampParsingException e = expectThrows(TimestampParsingException.class, () -> createIndex("test", BW_SETTINGS).mapperService()
+                .documentMapperParser().parse("type", new CompressedXContent(mapping.string())));
+        assertThat(e.getDetailedMessage(), containsString("default timestamp can not be set to null"));
     }
 
     // Issue 4718: was throwing a TimestampParsingException: failed to parse timestamp [null]
@@ -229,12 +216,9 @@ public class TimestampFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject()
                 .endObject().endObject();
 
-        try {
-            createIndex("test", BW_SETTINGS).mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping.string()));
-            fail("we should reject the mapping with a TimestampParsingException: default timestamp can not be set to null");
-        } catch (TimestampParsingException e) {
-            assertThat(e.getDetailedMessage(), containsString("default timestamp can not be set to null"));
-        }
+        TimestampParsingException e = expectThrows(TimestampParsingException.class, () -> createIndex("test", BW_SETTINGS).mapperService()
+                .documentMapperParser().parse("type", new CompressedXContent(mapping.string())));
+        assertThat(e.getDetailedMessage(), containsString("default timestamp can not be set to null"));
     }
 
     // Issue 4718: was throwing a TimestampParsingException: failed to parse timestamp [null]
@@ -247,12 +231,9 @@ public class TimestampFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject()
                 .endObject().endObject();
 
-        try {
-            createIndex("test", BW_SETTINGS).mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping.string()));
-            fail("we should reject the mapping with a TimestampParsingException: default timestamp can not be set with ignore_missing set to false");
-        } catch (TimestampParsingException e) {
-            assertThat(e.getDetailedMessage(), containsString("default timestamp can not be set with ignore_missing set to false"));
-        }
+        TimestampParsingException e = expectThrows(TimestampParsingException.class, () -> createIndex("test", BW_SETTINGS).mapperService()
+                .documentMapperParser().parse("type", new CompressedXContent(mapping.string())));
+        assertThat(e.getDetailedMessage(), containsString("default timestamp can not be set with ignore_missing set to false"));
     }
 
     // Issue 4718: was throwing a TimestampParsingException: failed to parse timestamp [null]

--- a/core/src/test/java/org/elasticsearch/index/search/geo/GeoPointParsingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/geo/GeoPointParsingTests.java
@@ -30,8 +30,8 @@ import org.elasticsearch.test.geo.RandomGeoGenerator;
 
 import java.io.IOException;
 
-import static org.hamcrest.Matchers.is;
 import static org.elasticsearch.common.geo.GeoHashUtils.stringEncode;
+import static org.hamcrest.Matchers.is;
 
 public class GeoPointParsingTests  extends ESTestCase {
     static double TOLERANCE = 1E-5;
@@ -112,13 +112,8 @@ public class GeoPointParsingTests  extends ESTestCase {
 
         XContentParser parser = JsonXContent.jsonXContent.createParser(content.bytes());
         parser.nextToken();
-
-        try {
-            GeoUtils.parseGeoPoint(parser);
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), is("field must be either [lat], [lon] or [geohash]"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+        assertThat(e.getMessage(), is("field must be either [lat], [lon] or [geohash]"));
     }
 
     public void testInvalidPointLatHashMix() throws IOException {
@@ -130,12 +125,8 @@ public class GeoPointParsingTests  extends ESTestCase {
         XContentParser parser = JsonXContent.jsonXContent.createParser(content.bytes());
         parser.nextToken();
 
-        try {
-            GeoUtils.parseGeoPoint(parser);
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), is("field must be either lat/lon or geohash"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+        assertThat(e.getMessage(), is("field must be either lat/lon or geohash"));
     }
 
     public void testInvalidPointLonHashMix() throws IOException {
@@ -147,12 +138,8 @@ public class GeoPointParsingTests  extends ESTestCase {
         XContentParser parser = JsonXContent.jsonXContent.createParser(content.bytes());
         parser.nextToken();
 
-        try {
-            GeoUtils.parseGeoPoint(parser);
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), is("field must be either lat/lon or geohash"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+        assertThat(e.getMessage(), is("field must be either lat/lon or geohash"));
     }
 
     public void testInvalidField() throws IOException {
@@ -164,12 +151,8 @@ public class GeoPointParsingTests  extends ESTestCase {
         XContentParser parser = JsonXContent.jsonXContent.createParser(content.bytes());
         parser.nextToken();
 
-        try {
-            GeoUtils.parseGeoPoint(parser);
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), is("field must be either [lat], [lon] or [geohash]"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+        assertThat(e.getMessage(), is("field must be either [lat], [lon] or [geohash]"));
     }
 
     private static XContentParser objectLatLon(double lat, double lon) throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/search/geo/GeoUtilsTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/geo/GeoUtilsTests.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.index.search.geo;
 
-import org.locationtech.spatial4j.context.SpatialContext;
-import org.locationtech.spatial4j.distance.DistanceUtils;
 import org.apache.lucene.spatial.prefix.tree.Cell;
 import org.apache.lucene.spatial.prefix.tree.GeohashPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
@@ -33,6 +31,8 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.test.ESTestCase;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.distance.DistanceUtils;
 
 import java.io.IOException;
 
@@ -439,12 +439,8 @@ public class GeoUtilsTests extends ESTestCase {
         BytesReference jsonBytes = jsonBuilder().startObject().field("geohash", 1.0).endObject().bytes();
         XContentParser parser = XContentHelper.createParser(jsonBytes);
         parser.nextToken();
-        try {
-            GeoUtils.parseGeoPoint(parser);
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), containsString("geohash must be a string"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+        assertThat(e.getMessage(), containsString("geohash must be a string"));
     }
 
     public void testParseGeoPointLatNoLon() throws IOException {
@@ -452,12 +448,8 @@ public class GeoUtilsTests extends ESTestCase {
         BytesReference jsonBytes = jsonBuilder().startObject().field("lat", lat).endObject().bytes();
         XContentParser parser = XContentHelper.createParser(jsonBytes);
         parser.nextToken();
-        try {
-            GeoUtils.parseGeoPoint(parser);
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), is("field [lon] missing"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+        assertThat(e.getMessage(), is("field [lon] missing"));
     }
 
     public void testParseGeoPointLonNoLat() throws IOException {
@@ -465,12 +457,8 @@ public class GeoUtilsTests extends ESTestCase {
         BytesReference jsonBytes = jsonBuilder().startObject().field("lon", lon).endObject().bytes();
         XContentParser parser = XContentHelper.createParser(jsonBytes);
         parser.nextToken();
-        try {
-            GeoUtils.parseGeoPoint(parser);
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), is("field [lat] missing"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+        assertThat(e.getMessage(), is("field [lat] missing"));
     }
 
     public void testParseGeoPointLonWrongType() throws IOException {
@@ -478,12 +466,8 @@ public class GeoUtilsTests extends ESTestCase {
         BytesReference jsonBytes = jsonBuilder().startObject().field("lat", lat).field("lon", false).endObject().bytes();
         XContentParser parser = XContentHelper.createParser(jsonBytes);
         parser.nextToken();
-        try {
-            GeoUtils.parseGeoPoint(parser);
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), is("longitude must be a number"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+        assertThat(e.getMessage(), is("longitude must be a number"));
     }
 
     public void testParseGeoPointLatWrongType() throws IOException {
@@ -491,12 +475,8 @@ public class GeoUtilsTests extends ESTestCase {
         BytesReference jsonBytes = jsonBuilder().startObject().field("lat", false).field("lon", lon).endObject().bytes();
         XContentParser parser = XContentHelper.createParser(jsonBytes);
         parser.nextToken();
-        try {
-            GeoUtils.parseGeoPoint(parser);
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), is("latitude must be a number"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+        assertThat(e.getMessage(), is("latitude must be a number"));
     }
 
     public void testParseGeoPointExtraField() throws IOException {
@@ -505,12 +485,8 @@ public class GeoUtilsTests extends ESTestCase {
         BytesReference jsonBytes = jsonBuilder().startObject().field("lat", lat).field("lon", lon).field("foo", true).endObject().bytes();
         XContentParser parser = XContentHelper.createParser(jsonBytes);
         parser.nextToken();
-        try {
-            GeoUtils.parseGeoPoint(parser);
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), is("field must be either [lat], [lon] or [geohash]"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+        assertThat(e.getMessage(), is("field must be either [lat], [lon] or [geohash]"));
     }
 
     public void testParseGeoPointLonLatGeoHash() throws IOException {
@@ -521,12 +497,8 @@ public class GeoUtilsTests extends ESTestCase {
                 .bytes();
         XContentParser parser = XContentHelper.createParser(jsonBytes);
         parser.nextToken();
-        try {
-            GeoUtils.parseGeoPoint(parser);
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), containsString("field must be either lat/lon or geohash"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+        assertThat(e.getMessage(), containsString("field must be either lat/lon or geohash"));
     }
 
     public void testParseGeoPointArrayTooManyValues() throws IOException {
@@ -539,12 +511,8 @@ public class GeoUtilsTests extends ESTestCase {
         while (parser.currentToken() != Token.START_ARRAY) {
             parser.nextToken();
         }
-        try {
-            GeoUtils.parseGeoPoint(parser);
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), is("only two values allowed"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+        assertThat(e.getMessage(), is("only two values allowed"));
     }
 
     public void testParseGeoPointArrayWrongType() throws IOException {
@@ -555,12 +523,8 @@ public class GeoUtilsTests extends ESTestCase {
         while (parser.currentToken() != Token.START_ARRAY) {
             parser.nextToken();
         }
-        try {
-            GeoUtils.parseGeoPoint(parser);
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), is("numeric value expected"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+        assertThat(e.getMessage(), is("numeric value expected"));
     }
 
     public void testParseGeoPointInvalidType() throws IOException {
@@ -569,12 +533,8 @@ public class GeoUtilsTests extends ESTestCase {
         while (parser.currentToken() != Token.VALUE_NUMBER) {
             parser.nextToken();
         }
-        try {
-            GeoUtils.parseGeoPoint(parser);
-            fail("Expected ElasticsearchParseException");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), is("geo_point expected"));
-        }
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+        assertThat(e.getMessage(), is("geo_point expected"));
     }
 
     public void testPrefixTreeCellSizes() {

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -470,8 +470,6 @@ public class IndexShardTests extends IndexShardTestCase {
                         throw new RuntimeException(ex);
                     }
                 }
-
-                ;
             };
             thread[i].start();
         }
@@ -1172,6 +1170,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 throw new RuntimeException("boom");
             }
 
+            @Override
             public IndexSearcher wrap(IndexSearcher searcher) throws EngineException {
                 return searcher;
             }

--- a/core/src/test/java/org/elasticsearch/index/shard/ShardPathTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/ShardPathTests.java
@@ -64,9 +64,8 @@ public class ShardPathTests extends ESTestCase {
             assumeTrue("This test tests multi data.path but we only got one", paths.length > 1);
             int id = randomIntBetween(1, 10);
             ShardStateMetaData.FORMAT.write(new ShardStateMetaData(id, true, indexUUID, AllocationId.newInitializing()), paths);
-            ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings));
-            fail("Expected IllegalStateException");
-        } catch (IllegalStateException e) {
+            Exception e = expectThrows(IllegalStateException.class, () ->
+                ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings)));
             assertThat(e.getMessage(), containsString("more than one shard state found"));
         }
     }
@@ -81,9 +80,8 @@ public class ShardPathTests extends ESTestCase {
             Path path = randomFrom(paths);
             int id = randomIntBetween(1, 10);
             ShardStateMetaData.FORMAT.write(new ShardStateMetaData(id, true, "0xDEADBEEF", AllocationId.newInitializing()), path);
-            ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings));
-            fail("Expected IllegalStateException");
-        } catch (IllegalStateException e) {
+            Exception e = expectThrows(IllegalStateException.class, () ->
+                ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings)));
             assertThat(e.getMessage(), containsString("expected: foobar on shard path"));
         }
     }
@@ -91,12 +89,8 @@ public class ShardPathTests extends ESTestCase {
     public void testIllegalCustomDataPath() {
         Index index = new Index("foo", "foo");
         final Path path = createTempDir().resolve(index.getUUID()).resolve("0");
-        try {
-            new ShardPath(true, path, path, new ShardId(index, 0));
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is("shard state path must be different to the data path when using custom data paths"));
-        }
+        Exception e = expectThrows(IllegalArgumentException.class, () -> new ShardPath(true, path, path, new ShardId(index, 0)));
+        assertThat(e.getMessage(), is("shard state path must be different to the data path when using custom data paths"));
     }
 
     public void testValidCtor() {

--- a/core/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
@@ -45,7 +45,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -444,21 +443,15 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
 
     public void testAllMissingStrict() throws Exception {
         createIndex("test1");
-        try {
+        expectThrows(IndexNotFoundException.class, () ->
             client().prepareSearch("test2")
                     .setQuery(matchAllQuery())
-                    .execute().actionGet();
-            fail("Exception should have been thrown.");
-        } catch (IndexNotFoundException e) {
-        }
+                    .execute().actionGet());
 
-        try {
+        expectThrows(IndexNotFoundException.class, () ->
             client().prepareSearch("test2","test3")
                     .setQuery(matchAllQuery())
-                    .execute().actionGet();
-            fail("Exception should have been thrown.");
-        } catch (IndexNotFoundException e) {
-        }
+                    .execute().actionGet());
 
         //you should still be able to run empty searches without things blowing up
         client().prepareSearch().setQuery(matchAllQuery()).execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
@@ -70,22 +70,16 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
 
     public void testSimpleCloseMissingIndex() {
         Client client = client();
-        try {
-            client.admin().indices().prepareClose("test1").execute().actionGet();
-            fail("Expected IndexNotFoundException");
-        } catch (IndexNotFoundException e) {
-            assertThat(e.getMessage(), is("no such index"));
-        }
+        Exception e = expectThrows(IndexNotFoundException.class, () ->
+            client.admin().indices().prepareClose("test1").execute().actionGet());
+        assertThat(e.getMessage(), is("no such index"));
     }
 
     public void testSimpleOpenMissingIndex() {
         Client client = client();
-        try {
-            client.admin().indices().prepareOpen("test1").execute().actionGet();
-            fail("Expected IndexNotFoundException");
-        } catch (IndexNotFoundException e) {
-            assertThat(e.getMessage(), is("no such index"));
-        }
+        Exception e = expectThrows(IndexNotFoundException.class, () ->
+            client.admin().indices().prepareOpen("test1").execute().actionGet());
+        assertThat(e.getMessage(), is("no such index"));
     }
 
     public void testCloseOneMissingIndex() {
@@ -93,12 +87,9 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
         createIndex("test1");
         ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
-        try {
-            client.admin().indices().prepareClose("test1", "test2").execute().actionGet();
-            fail("Expected IndexNotFoundException");
-        } catch (IndexNotFoundException e) {
-            assertThat(e.getMessage(), is("no such index"));
-        }
+        Exception e = expectThrows(IndexNotFoundException.class, () ->
+            client.admin().indices().prepareClose("test1", "test2").execute().actionGet());
+        assertThat(e.getMessage(), is("no such index"));
     }
 
     public void testCloseOneMissingIndexIgnoreMissing() {
@@ -117,12 +108,9 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
         createIndex("test1");
         ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
-        try {
-            client.admin().indices().prepareOpen("test1", "test2").execute().actionGet();
-            fail("Expected IndexNotFoundException");
-        } catch (IndexNotFoundException e) {
-            assertThat(e.getMessage(), is("no such index"));
-        }
+        Exception e = expectThrows(IndexNotFoundException.class, () ->
+            client.admin().indices().prepareOpen("test1", "test2").execute().actionGet());
+        assertThat(e.getMessage(), is("no such index"));
     }
 
     public void testOpenOneMissingIndexIgnoreMissing() {
@@ -204,42 +192,30 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
 
     public void testCloseNoIndex() {
         Client client = client();
-        try {
-            client.admin().indices().prepareClose().execute().actionGet();
-            fail("Expected ActionRequestValidationException");
-        } catch (ActionRequestValidationException e) {
-            assertThat(e.getMessage(), containsString("index is missing"));
-        }
+        Exception e = expectThrows(ActionRequestValidationException.class, () ->
+            client.admin().indices().prepareClose().execute().actionGet());
+        assertThat(e.getMessage(), containsString("index is missing"));
     }
 
     public void testCloseNullIndex() {
         Client client = client();
-        try {
-            client.admin().indices().prepareClose((String[])null).execute().actionGet();
-            fail("Expected ActionRequestValidationException");
-        } catch (ActionRequestValidationException e) {
-            assertThat(e.getMessage(), containsString("index is missing"));
-        }
+        Exception e = expectThrows(ActionRequestValidationException.class, () ->
+            client.admin().indices().prepareClose((String[])null).execute().actionGet());
+        assertThat(e.getMessage(), containsString("index is missing"));
     }
 
     public void testOpenNoIndex() {
         Client client = client();
-        try {
-            client.admin().indices().prepareOpen().execute().actionGet();
-            fail("Expected ActionRequestValidationException");
-        } catch (ActionRequestValidationException e) {
-            assertThat(e.getMessage(), containsString("index is missing"));
-        }
+        Exception e = expectThrows(ActionRequestValidationException.class, () ->
+            client.admin().indices().prepareOpen().execute().actionGet());
+        assertThat(e.getMessage(), containsString("index is missing"));
     }
 
     public void testOpenNullIndex() {
         Client client = client();
-        try {
-            client.admin().indices().prepareOpen((String[])null).execute().actionGet();
-            fail("Expected ActionRequestValidationException");
-        } catch (ActionRequestValidationException e) {
-            assertThat(e.getMessage(), containsString("index is missing"));
-        }
+        Exception e = expectThrows(ActionRequestValidationException.class, () ->
+            client.admin().indices().prepareOpen((String[])null).execute().actionGet());
+        assertThat(e.getMessage(), containsString("index is missing"));
     }
 
     public void testOpenAlreadyOpenedIndex() {


### PR DESCRIPTION
Many tests currently use try-catch constructs to test for expected exceptions and usually do some assertions on the exception message. This can be achieved by using LuceneTestCase#expectThrows() in a more concise way. Also adding some try-with-resources around some streams that were not closed in tests before to remove those compile warnings. There are still more occurences of this pattern in the tests but this is a first step at replacing those.
