### PR TITLE
Fix slowlog docs

### DIFF
--- a/docs/reference/index-modules/slowlog.asciidoc
+++ b/docs/reference/index-modules/slowlog.asciidoc
@@ -24,7 +24,7 @@ index.search.slowlog.threshold.fetch.debug: 500ms
 index.search.slowlog.threshold.fetch.trace: 200ms
 --------------------------------------------------
 
-All of the above settings are _dynamic_ and can be set per-index.
+All of the above settings are _dynamic_ and are set per-index.
 
 By default, none are enabled (set to `-1`). Levels (`warn`, `info`,
 `debug`, `trace`) allow to control under which logging level the log
@@ -42,7 +42,7 @@ level.
 The logging file is configured by default using the following
 configuration (found in `log4j2.properties`):
 
-[source,yaml]
+[source,properties]
 --------------------------------------------------
 appender.index_search_slowlog_rolling.type = RollingFile
 appender.index_search_slowlog_rolling.name = index_search_slowlog_rolling
@@ -67,8 +67,8 @@ logger.index_search_slowlog_rolling.additivity = false
 
 The indexing slow log, similar in functionality to the search slow
 log. The log file name ends with `_index_indexing_slowlog.log`. Log and
-the thresholds are configured in the elasticsearch.yml file in the same
-way as the search slowlog. Index slowlog sample:
+the thresholds are configured in the same way as the search slowlog.
+Index slowlog sample:
 
 [source,yaml]
 --------------------------------------------------
@@ -80,23 +80,31 @@ index.indexing.slowlog.level: info
 index.indexing.slowlog.source: 1000
 --------------------------------------------------
 
-All of the above settings are _dynamic_ and can be set per-index.
+All of the above settings are _dynamic_ and are set per-index.
 
 By default Elasticsearch will log the first 1000 characters of the _source in
 the slowlog. You can change that with `index.indexing.slowlog.source`. Setting
 it to `false` or `0` will skip logging the source entirely an setting it to
 `true` will log the entire source regardless of size.
 
-The index slow log file is configured by default in the `logging.yml`
+The index slow log file is configured by default in the `log4j2.properties`
 file:
 
-[source,yaml]
+[source,properties]
 --------------------------------------------------
-index_indexing_slow_log_file:
-    type: dailyRollingFile
-    file: ${path.logs}/${cluster.name}_index_indexing_slowlog.log
-    datePattern: "'.'yyyy-MM-dd"
-    layout:
-      type: pattern
-      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+appender.index_indexing_slowlog_rolling.type = RollingFile
+appender.index_indexing_slowlog_rolling.name = index_indexing_slowlog_rolling
+appender.index_indexing_slowlog_rolling.fileName = ${sys:es.logs}_index_indexing_slowlog.log
+appender.index_indexing_slowlog_rolling.layout.type = PatternLayout
+appender.index_indexing_slowlog_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %marker%.10000m%n
+appender.index_indexing_slowlog_rolling.filePattern = ${sys:es.logs}_index_indexing_slowlog-%d{yyyy-MM-dd}.log
+appender.index_indexing_slowlog_rolling.policies.type = Policies
+appender.index_indexing_slowlog_rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.index_indexing_slowlog_rolling.policies.time.interval = 1
+appender.index_indexing_slowlog_rolling.policies.time.modulate = true
+
+logger.index_indexing_slowlog.name = index.indexing.slowlog.index
+logger.index_indexing_slowlog.level = trace
+logger.index_indexing_slowlog.appenderRef.index_indexing_slowlog_rolling.ref = index_indexing_slowlog_rolling
+logger.index_indexing_slowlog.additivity = false
 --------------------------------------------------


### PR DESCRIPTION
This commit fixes two issues with the slow log docs:
- clarifies that these settings are per index
- updates index slow log configuration for Log4j 2

Closes #20927
