### PR TITLE
Optimize query with types filter in the URL (t/t/_search)

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/TypeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TypeFieldMapper.java
@@ -197,16 +197,13 @@ public class TypeFieldMapper extends MetadataFieldMapper {
                         // this _type is not present in the reader
                         continue;
                     }
-                    if (context.docFreq() == reader.maxDoc()) {
-                        // All docs have the same type.
-                        // Using a match_all query will help Lucene perform some optimizations
-                        // For instance, match_all queries as filter clauses are automatically removed
-                        return new MatchAllDocsQuery();
-                    }
                     totalDocFreq += context.docFreq();
                     // strict equality should be enough ?
                     if (totalDocFreq >= reader.maxDoc()) {
-                        // matches all docs since _type is a single value field
+                        assert totalDocFreq == reader.maxDoc();
+                        // Matches all docs since _type is a single value field
+                        // Using a match_all query will help Lucene perform some optimizations
+                        // For instance, match_all queries as filter clauses are automatically removed
                         return new MatchAllDocsQuery();
                     }
                     bq.add(new TermQuery(term, context), BooleanClause.Occur.SHOULD);

--- a/core/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search;
 
-import org.apache.lucene.queries.TermsQuery;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Collector;
@@ -290,21 +289,11 @@ final class DefaultSearchContext extends SearchContext {
     static Query createSearchFilter(String[] types, Query aliasFilter, boolean hasNestedFields) {
         Query typesFilter = null;
         if (types != null && types.length >= 1) {
-            final int threshold = Math.min(16, BooleanQuery.getMaxClauseCount());
-            if (types.length < threshold) {
-                BooleanQuery.Builder builder = new BooleanQuery.Builder();
-                for (String type : types) {
-                    BytesRef typeBytes = new BytesRef(type);
-                    builder.add(new TypeFieldMapper.TypeQuery(typeBytes), Occur.SHOULD);
-                }
-                typesFilter = builder.build();
-            } else {
-                BytesRef[] typesBytes = new BytesRef[types.length];
-                for (int i = 0; i < typesBytes.length; i++) {
-                    typesBytes[i] = new BytesRef(types[i]);
-                }
-                typesFilter = new TermsQuery(TypeFieldMapper.NAME, typesBytes);
+            BytesRef[] typesBytes = new BytesRef[types.length];
+            for (int i = 0; i < typesBytes.length; i++) {
+                typesBytes[i] = new BytesRef(types[i]);
             }
+            typesFilter = new TypeFieldMapper.TypesQuery(typesBytes);
         }
 
         if (typesFilter == null && aliasFilter == null && hasNestedFields == false) {

--- a/core/src/test/java/org/elasticsearch/index/mapper/TypeFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/TypeFieldTypeTests.java
@@ -34,10 +34,11 @@ import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.TypeFieldMapper;
 import org.junit.Before;
+
+import java.io.IOException;
 
 public class TypeFieldTypeTests extends FieldTypeTestCase {
     @Override
@@ -59,17 +60,11 @@ public class TypeFieldTypeTests extends FieldTypeTestCase {
     public void testTermQuery() throws Exception {
         Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
-        Document doc = new Document();
-        StringField type = new StringField(TypeFieldMapper.NAME, "my_type", Store.NO);
-        doc.add(type);
-        w.addDocument(doc);
-        w.addDocument(doc);
-        IndexReader reader = DirectoryReader.open(w);
+        IndexReader reader = openReaderWithNewType("my_type", w);
 
         TypeFieldMapper.TypeFieldType ft = new TypeFieldMapper.TypeFieldType();
         ft.setName(TypeFieldMapper.NAME);
         Query query = ft.termQuery("my_type", null);
-
         assertEquals(new MatchAllDocsQuery(), query.rewrite(reader));
 
         // Make sure that Lucene actually simplifies the query when there is a single type
@@ -78,13 +73,45 @@ public class TypeFieldTypeTests extends FieldTypeTestCase {
         Query rewritten = new IndexSearcher(reader).rewrite(filteredQuery);
         assertEquals(userQuery, rewritten);
 
-        type.setStringValue("my_type2");
-        w.addDocument(doc);
+        // ... and does not rewrite it if there is more than one type
         reader.close();
-        reader = DirectoryReader.open(w);
-
+        reader = openReaderWithNewType("my_type2", w);
         assertEquals(new ConstantScoreQuery(new TermQuery(new Term(TypeFieldMapper.NAME, "my_type"))), query.rewrite(reader));
 
         IOUtils.close(reader, w, dir);
+    }
+
+    public void testTermsQuery() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
+        IndexReader reader = openReaderWithNewType( "my_type", w);
+        BytesRef[] types =
+            new BytesRef[] {new BytesRef("my_type"), new BytesRef("my_type2"), new BytesRef("my_type3")};
+        Query query = new TypeFieldMapper.TypesQuery(types);
+        assertEquals(new MatchAllDocsQuery(), query.rewrite(reader));
+
+        reader.close();
+        reader = openReaderWithNewType("my_type2", w);
+        query = new TypeFieldMapper.TypesQuery(types);
+        Query expected =
+            new ConstantScoreQuery(
+                new BooleanQuery.Builder()
+                    .add(new TermQuery(new Term(TypeFieldMapper.CONTENT_TYPE, types[0])), Occur.SHOULD)
+                    .add(new TermQuery(new Term(TypeFieldMapper.CONTENT_TYPE, types[1])), Occur.SHOULD)
+                    .add(new TermQuery(new Term(TypeFieldMapper.CONTENT_TYPE, types[2])), Occur.SHOULD)
+                .build()
+            );
+        Query rewritten = query.rewrite(reader);
+        assertEquals(expected, rewritten);
+
+        IOUtils.close(reader, w, dir);
+    }
+
+    static DirectoryReader openReaderWithNewType(String type, IndexWriter writer) throws IOException {
+        Document doc = new Document();
+        StringField typeField = new StringField(TypeFieldMapper.NAME, type, Store.NO);
+        doc.add(typeField);
+        writer.addDocument(doc);
+        return DirectoryReader.open(writer);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/HasChildQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/HasChildQueryBuilderTests.java
@@ -280,7 +280,7 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
         assertThat(termQuery.getTerm().bytes(), equalTo(ids[0]));
         //check the type filter
         assertThat(booleanQuery.clauses().get(1).getOccur(), equalTo(BooleanClause.Occur.FILTER));
-        assertEquals(new TypeFieldMapper.TypeQuery(new BytesRef(type)), booleanQuery.clauses().get(1).getQuery());
+        assertEquals(new TypeFieldMapper.TypesQuery(new BytesRef(type)), booleanQuery.clauses().get(1).getQuery());
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/TypeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TypeQueryBuilderTests.java
@@ -40,7 +40,7 @@ public class TypeQueryBuilderTests extends AbstractQueryTestCase<TypeQueryBuilde
         if (createShardContext().getMapperService().documentMapper(queryBuilder.type()) == null) {
             assertEquals(new MatchNoDocsQuery(), query);
         } else {
-            assertEquals(new TypeFieldMapper.TypeQuery(new BytesRef(queryBuilder.type())), query);
+            assertEquals(new TypeFieldMapper.TypesQuery(new BytesRef(queryBuilder.type())), query);
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
+++ b/core/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
@@ -26,10 +26,10 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.mapper.TypeFieldMapper;
-import org.elasticsearch.search.DefaultSearchContext;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.apache.lucene.search.BooleanClause.Occur.FILTER;
+import static org.apache.lucene.search.BooleanClause.Occur.SHOULD;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -38,13 +38,21 @@ public class DefaultSearchContextTests extends ESTestCase {
     public void testCreateSearchFilter() {
         Query searchFilter = DefaultSearchContext.createSearchFilter(new String[]{"type1", "type2"}, null, randomBoolean());
         Query expectedQuery = new BooleanQuery.Builder()
-            .add(new TermsQuery(TypeFieldMapper.NAME, new BytesRef("type1"), new BytesRef("type2")), FILTER)
+            .add(new BooleanQuery.Builder()
+                .add(new TypeFieldMapper.TypeQuery(new BytesRef("type1")), SHOULD)
+                .add(new TypeFieldMapper.TypeQuery(new BytesRef("type2")), SHOULD)
+                .build(), FILTER
+            )
             .build();
         assertThat(searchFilter, equalTo(expectedQuery));
 
         searchFilter = DefaultSearchContext.createSearchFilter(new String[]{"type1", "type2"}, new MatchAllDocsQuery(), randomBoolean());
         expectedQuery = new BooleanQuery.Builder()
-            .add(new TermsQuery(TypeFieldMapper.NAME, new BytesRef("type1"), new BytesRef("type2")), FILTER)
+            .add(new BooleanQuery.Builder()
+                .add(new TypeFieldMapper.TypeQuery(new BytesRef("type1")), SHOULD)
+                .add(new TypeFieldMapper.TypeQuery(new BytesRef("type2")), SHOULD)
+                .build(), FILTER
+            )
             .add(new MatchAllDocsQuery(), FILTER)
             .build();
         assertThat(searchFilter, equalTo(expectedQuery));
@@ -66,6 +74,19 @@ public class DefaultSearchContextTests extends ESTestCase {
         searchFilter = DefaultSearchContext.createSearchFilter(null, new MatchAllDocsQuery(), false);
         expectedQuery = new BooleanQuery.Builder()
             .add(new MatchAllDocsQuery(), FILTER)
+            .build();
+        assertThat(searchFilter, equalTo(expectedQuery));
+
+        int size = randomInt(100);
+        String[] types = new String[size];
+        BytesRef[] typesBytes = new BytesRef[size];
+        for (int i = 0; i < size; i++) {
+            types[i] = "types" + i;
+            typesBytes[i] = new BytesRef(types[i]);
+        }
+        searchFilter = DefaultSearchContext.createSearchFilter(types, null, randomBoolean());
+        expectedQuery = new BooleanQuery.Builder()
+            .add(new TermsQuery(TypeFieldMapper.NAME, typesBytes), FILTER)
             .build();
         assertThat(searchFilter, equalTo(expectedQuery));
     }

--- a/core/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
+++ b/core/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
@@ -77,7 +77,7 @@ public class DefaultSearchContextTests extends ESTestCase {
             .build();
         assertThat(searchFilter, equalTo(expectedQuery));
 
-        int size = randomInt(100);
+        int size = randomIntBetween(17, 100);
         String[] types = new String[size];
         BytesRef[] typesBytes = new BytesRef[size];
         for (int i = 0; i < size; i++) {

--- a/docs/reference/search/explain.asciidoc
+++ b/docs/reference/search/explain.asciidoc
@@ -68,7 +68,7 @@ This will yield the following result:
         "details" : [ ]
       }, {
         "value" : 1.0,
-        "description" : "_type:tweet, product of:",
+        "description" : "*:*, product of:",
         "details" : [
           { "value" : 1.0, "description" : "boost", "details" : [ ] },
           { "value" : 1.0, "description" : "queryNorm", "details" : [ ] }


### PR DESCRIPTION
The TypeQuery has an optimization when only one type is present in an index.
This optimization is used when a type query is explicitly used in the query (_type:t) but it is not leveraged when the type is in the URL (GET t/t/_search).
This change uses the TypeQuery when the type filter is built from the URL (GET t/t/_search).
Since the number of types is unbounded in a query this change also preserves the current behavior which uses a TermsQuery when the number of types to query is greater than a threshold (16 by default).
