### PR TITLE
make painless the default scripting language for ScriptProcessor

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -1382,13 +1382,15 @@ caching see <<modules-scripting-using-caching, Script Caching>>.
 .Script Options
 [options="header"]
 |======
-| Name                   | Required  | Default | Description
-| `lang`                 | no        | -       | The scripting language
-| `file`                 | no        | -       | The script file to refer to
-| `id`                   | no        | -       | The stored script id to refer to
-| `inline`               | no        | -       | An inline script to be executed
-| `params`               | no        | -       | Script Parameters
+| Name                   | Required  | Default    | Description
+| `lang`                 | no        | "painless" | The scripting language
+| `file`                 | no        | -          | The script file to refer to
+| `id`                   | no        | -          | The stored script id to refer to
+| `inline`               | no        | -          | An inline script to be executed
+| `params`               | no        | -          | Script Parameters
 |======
+
+One of `file`, `id`, `inline` options must be provided in order to properly reference a script to execute.
 
 You can access the current ingest document from within the script context by using the `ctx` variable.
 

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
@@ -69,6 +69,10 @@ public final class ScriptProcessor extends AbstractProcessor {
         return TYPE;
     }
 
+    Script getScript() {
+        return script;
+    }
+
     public static final class Factory implements Processor.Factory {
 
         private final ScriptService scriptService;
@@ -80,7 +84,7 @@ public final class ScriptProcessor extends AbstractProcessor {
         @Override
         public ScriptProcessor create(Map<String, Processor.Factory> registry, String processorTag,
                                       Map<String, Object> config) throws Exception {
-            String lang = readStringProperty(TYPE, processorTag, config, "lang");
+            String lang = readOptionalStringProperty(TYPE, processorTag, config, "lang");
             String inline = readOptionalStringProperty(TYPE, processorTag, config, "inline");
             String file = readOptionalStringProperty(TYPE, processorTag, config, "file");
             String id = readOptionalStringProperty(TYPE, processorTag, config, "id");

--- a/qa/smoke-test-ingest-with-all-dependencies/src/test/resources/rest-api-spec/test/ingest/50_script_processor_using_painless.yaml
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/test/resources/rest-api-spec/test/ingest/50_script_processor_using_painless.yaml
@@ -9,7 +9,6 @@
             "processors": [
               {
                 "script" : {
-                  "lang" : "painless",
                   "inline": "ctx.bytes_total = (ctx.bytes_in + ctx.bytes_out) * params.factor",
                   "params": {
                      "factor": 10
@@ -48,7 +47,6 @@
             "processors": [
               {
                 "script" : {
-                  "lang" : "painless",
                   "file": "master"
                 }
               }
@@ -94,7 +92,6 @@
             "processors": [
               {
                 "script" : {
-                  "lang" : "painless",
                   "id" : "sum_bytes"
                 }
               }


### PR DESCRIPTION
- fixes a bug in the docs that mentions `lang` as optional
- now `lang` defaults to "painless"

Closes #20943.
