### PR TITLE
add `ignore_missing` option to SplitProcessor

### DIFF
--- a/core/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/core/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -117,6 +117,28 @@ public final class IngestDocument {
     }
 
     /**
+     * Returns the value contained in the document for the provided path
+     *
+     * @param path The path within the document in dot-notation
+     * @param clazz The expected class of the field value
+     * @param ignoreMissing The flag to determine whether to throw an exception when `path` is not found in the document.
+     * @return the value for the provided path if existing, null otherwise.
+     * @throws IllegalArgumentException only if ignoreMissing is false and the path is null, empty, invalid, if the field doesn't exist
+     * or if the field that is found at the provided path is not of the expected type.
+     */
+    public <T> T getFieldValue(String path, Class<T> clazz, boolean ignoreMissing) {
+        try {
+            return getFieldValue(path, clazz);
+        } catch (IllegalArgumentException e) {
+            if (ignoreMissing && hasField(path) != true) {
+                return null;
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    /**
      * Returns the value contained in the document with the provided templated path
      * @param pathTemplate The path within the document in dot-notation
      * @param clazz The expected class fo the field value

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -1442,9 +1442,10 @@ Splits a field into an array using a separator character. Only works on string f
 .Split Options
 [options="header"]
 |======
-| Name        | Required  | Default  | Description
-| `field`     | yes       | -        | The field to split
-| `separator` | yes       | -        | A regex which matches the separator, eg `,` or `\s+`
+| Name              | Required  | Default  | Description
+| `field`           | yes       | -        | The field to split
+| `separator`       | yes       | -        | A regex which matches the separator, eg `,` or `\s+`
+| `ignore_missing`  | no        | `false`  | If `true` and `field` does not exist, the processor quietly exits without modifying the document
 |======
 
 [source,js]

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/AbstractStringProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/AbstractStringProcessor.java
@@ -34,7 +34,7 @@ abstract class AbstractStringProcessor extends AbstractProcessor {
     private final String field;
     private final boolean ignoreMissing;
 
-    protected AbstractStringProcessor(String tag, String field, boolean ignoreMissing) {
+    AbstractStringProcessor(String tag, String field, boolean ignoreMissing) {
         super(tag);
         this.field = field;
         this.ignoreMissing = ignoreMissing;
@@ -50,16 +50,8 @@ abstract class AbstractStringProcessor extends AbstractProcessor {
 
     @Override
     public final void execute(IngestDocument document) {
-        String val;
+        String val = document.getFieldValue(field, String.class, ignoreMissing);
 
-        try {
-            val = document.getFieldValue(field, String.class);
-        } catch (IllegalArgumentException e) {
-            if (ignoreMissing && document.hasField(field) != true) {
-                return;
-            }
-            throw e;
-        }
         if (val == null && ignoreMissing) {
             return;
         } else if (val == null) {
@@ -72,7 +64,7 @@ abstract class AbstractStringProcessor extends AbstractProcessor {
     protected abstract String process(String value);
 
     abstract static class Factory implements Processor.Factory {
-        protected final String processorType;
+        final String processorType;
 
         protected Factory(String processorType) {
             this.processorType = processorType;

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
@@ -142,17 +142,8 @@ public final class ConvertProcessor extends AbstractProcessor {
 
     @Override
     public void execute(IngestDocument document) {
-        Object oldValue = null;
+        Object oldValue = document.getFieldValue(field, Object.class, ignoreMissing);
         Object newValue;
-
-        try {
-            oldValue = document.getFieldValue(field, Object.class);
-        } catch (IllegalArgumentException e) {
-            if (ignoreMissing) {
-                return;
-            }
-            throw e;
-        }
 
         if (oldValue == null && ignoreMissing) {
             return;

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessor.java
@@ -52,16 +52,7 @@ public final class GrokProcessor extends AbstractProcessor {
 
     @Override
     public void execute(IngestDocument ingestDocument) throws Exception {
-        String fieldValue;
-
-        try {
-            fieldValue = ingestDocument.getFieldValue(matchField, String.class);
-        } catch (IllegalArgumentException e) {
-            if (ignoreMissing && ingestDocument.hasField(matchField) != true) {
-                return;
-            }
-            throw e;
-        }
+        String fieldValue = ingestDocument.getFieldValue(matchField, String.class, ignoreMissing);
 
         if (fieldValue == null && ignoreMissing) {
             return;

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SplitProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SplitProcessorFactoryTests.java
@@ -39,6 +39,7 @@ public class SplitProcessorFactoryTests extends ESTestCase {
         assertThat(splitProcessor.getTag(), equalTo(processorTag));
         assertThat(splitProcessor.getField(), equalTo("field1"));
         assertThat(splitProcessor.getSeparator(), equalTo("\\."));
+        assertFalse(splitProcessor.isIgnoreMissing());
     }
 
     public void testCreateNoFieldPresent() throws Exception {


### PR DESCRIPTION
Similar to the additional `ignore_missing` param that was added to many of the processors from: https://github.com/elastic/elasticsearch/issues/19995.

When option is `true`, `null`-valued and non-existent fields will not result in a thrown exception.

Closes #20840.
