### PR TITLE
Introduce skip validation flag for index template API

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -564,7 +564,7 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
             aliases.add(Alias.read(in));
         }
         version = in.readOptionalVInt();
-        if (in.getVersion().onOrAfter(Version.V_5_1_0)) {
+        if (in.getVersion().onOrAfter(Version.V_5_4_0_UNRELEASED)) {
             validation = in.readBoolean();
         }
     }
@@ -593,7 +593,7 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
             alias.writeTo(out);
         }
         out.writeOptionalVInt(version);
-        if (out.getVersion().onOrAfter(Version.V_5_1_0)) {
+        if (out.getVersion().onOrAfter(Version.V_5_4_0_UNRELEASED)) {
             out.writeBoolean(validation);
         }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -372,6 +372,8 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
                     validation((Boolean)entry.getValue());
                 } else if (entry.getValue() instanceof String) {
                     validation(Booleans.parseBoolean((String)entry.getValue(), DEFAULT_VALIDATION));
+                } else {
+                    throw new IllegalArgumentException("Malformed [validate] value, should be a boolean or a string");
                 }
             } else {
                 // maybe custom?

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestBuilder.java
@@ -303,4 +303,12 @@ public class PutIndexTemplateRequestBuilder
         request.source(templateSource, offset, length, xContentType);
         return this;
     }
+
+    /**
+     * Set to <tt>true</tt> to validate
+     */
+    public PutIndexTemplateRequestBuilder setValidation(boolean validation) {
+        request.validation(validation);
+        return this;
+    }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
@@ -86,6 +86,7 @@ public class TransportPutIndexTemplateAction extends TransportMasterNodeAction<P
                 .aliases(request.aliases())
                 .customs(request.customs())
                 .create(request.create())
+                .validation(request.validation())
                 .masterTimeout(request.masterNodeTimeout())
                 .version(request.version()),
 

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
@@ -231,7 +231,9 @@ public class MetaDataIndexTemplateService extends AbstractComponent {
                 mappingsForValidation.put(entry.getKey(), MapperService.parseMapping(xContentRegistry, entry.getValue()));
             }
 
-            dummyIndexService.mapperService().merge(mappingsForValidation, MergeReason.MAPPING_UPDATE, false);
+            if (request.validation){
+                dummyIndexService.mapperService().merge(mappingsForValidation, MergeReason.MAPPING_UPDATE, false);
+            }
 
         } finally {
             if (createdIndex != null) {
@@ -316,6 +318,7 @@ public class MetaDataIndexTemplateService extends AbstractComponent {
         Map<String, String> mappings = new HashMap<>();
         List<Alias> aliases = new ArrayList<>();
         Map<String, IndexMetaData.Custom> customs = new HashMap<>();
+        boolean validation;
 
         TimeValue masterTimeout = MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT;
 
@@ -371,6 +374,11 @@ public class MetaDataIndexTemplateService extends AbstractComponent {
 
         public PutRequest version(Integer version) {
             this.version = version;
+            return this;
+        }
+
+        public PutRequest validation(boolean validation) {
+            this.validation = validation;
             return this;
         }
     }

--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -75,6 +75,10 @@ PUT _template/template_1
 <1> the `{index}` placeholder in the alias name will be replaced with the
 actual index name that the template gets applied to, during index creation.
 
+NOTE: After 2.4, Elasticsearch validates each template as a complete mapping and settings.
+If you have some incomplete template, e.g. analyzer settings in a template and mappings in another template,
+you can set `validate` to `false` and skip validation that is `true` by default.
+
 [float]
 [[delete]]
 === Deleting a Template


### PR DESCRIPTION
Introduce skip validation param for index template API.
Users can skip validation logic if they set `validate` to `false`.

Add flag and docs

Related #20479
