### PR TITLE
delete temp file if file exists

### DIFF
--- a/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -1003,8 +1003,12 @@ public final class NodeEnvironment  implements Closeable {
         if (Files.exists(path)) {
             Path resolve = path.resolve(".es_temp_file");
             try {
-                Files.createFile(resolve);
-                Files.deleteIfExists(resolve);
+                if (Files.exists(resolve)) {
+                    Files.deleteIfExists(resolve);
+                } else {
+                    Files.createFile(resolve);
+                    Files.deleteIfExists(resolve);
+                }
             } catch (IOException ex) {
                 throw new IOException("failed to write in data directory [" + path + "] write permission is required", ex);
             }

--- a/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -1004,14 +1004,21 @@ public final class NodeEnvironment  implements Closeable {
             Path resolve = path.resolve(".es_temp_file");
             try {
                 if (Files.exists(resolve)) {
+                    // if the temp file is left over after a crash, we should delete this file first
                     Files.deleteIfExists(resolve);
+
+                    createAndDeleteTempFile(resolve);
                 } else {
-                    Files.createFile(resolve);
-                    Files.deleteIfExists(resolve);
+                    createAndDeleteTempFile(resolve);
                 }
             } catch (IOException ex) {
                 throw new IOException("failed to write in data directory [" + path + "] write permission is required", ex);
             }
         }
+    }
+
+    private static void createAndDeleteTempFile(Path resolve) throws IOException {
+        Files.createFile(resolve);
+        Files.deleteIfExists(resolve);
     }
 }

--- a/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -1013,6 +1013,9 @@ public final class NodeEnvironment  implements Closeable {
                 }
             } catch (IOException ex) {
                 throw new IOException("failed to write in data directory [" + path + "] write permission is required", ex);
+            } finally {
+                // make our best effort to ensure the temp file will eventually be deleted
+                Files.deleteIfExists(resolve);
             }
         }
     }


### PR DESCRIPTION
Closes #20992 

If system crashes after creating the .es_temp_file but before deleting this file, next time the system will not be able to start because the Files.createFile(resolve) will throw an exception because of the left over temp file.
So We should first check if the temp file exists, if yes, delete it and create, delete it again; if not exist, then create and delete it.
