### PR TITLE
Remove `cluster.routing.allocation.snapshot.relocation_enabled` setting

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -114,7 +114,7 @@ public class ClusterModule extends AbstractModule {
         addAllocationDecider(deciders, new ConcurrentRebalanceAllocationDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new EnableAllocationDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new NodeVersionAllocationDecider(settings));
-        addAllocationDecider(deciders, new SnapshotInProgressAllocationDecider(settings, clusterSettings));
+        addAllocationDecider(deciders, new SnapshotInProgressAllocationDecider(settings));
         addAllocationDecider(deciders, new FilterAllocationDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new SameShardAllocationDecider(settings));
         addAllocationDecider(deciders, new DiskThresholdDecider(settings, clusterSettings));

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
@@ -23,9 +23,6 @@ import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
-import org.elasticsearch.common.settings.ClusterSettings;
-import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 
 /**
@@ -37,40 +34,13 @@ public class SnapshotInProgressAllocationDecider extends AllocationDecider {
     public static final String NAME = "snapshot_in_progress";
 
     /**
-     * Disables relocation of shards that are currently being snapshotted.
-     */
-    public static final Setting<Boolean> CLUSTER_ROUTING_ALLOCATION_SNAPSHOT_RELOCATION_ENABLED_SETTING =
-        Setting.boolSetting("cluster.routing.allocation.snapshot.relocation_enabled", false,
-            Property.Dynamic, Property.NodeScope);
-
-    private volatile boolean enableRelocation = false;
-
-    /**
-     * Creates a new {@link org.elasticsearch.cluster.routing.allocation.decider.SnapshotInProgressAllocationDecider} instance
-     */
-    public SnapshotInProgressAllocationDecider() {
-        this(Settings.Builder.EMPTY_SETTINGS);
-    }
-
-    /**
      * Creates a new {@link org.elasticsearch.cluster.routing.allocation.decider.SnapshotInProgressAllocationDecider} instance from
      * given settings
      *
      * @param settings {@link org.elasticsearch.common.settings.Settings} to use
      */
     public SnapshotInProgressAllocationDecider(Settings settings) {
-        this(settings, new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
-    }
-
-    public SnapshotInProgressAllocationDecider(Settings settings, ClusterSettings clusterSettings) {
         super(settings);
-        enableRelocation = CLUSTER_ROUTING_ALLOCATION_SNAPSHOT_RELOCATION_ENABLED_SETTING.get(settings);
-        clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_SNAPSHOT_RELOCATION_ENABLED_SETTING,
-                this::setEnableRelocation);
-    }
-
-    private void setEnableRelocation(boolean enableRelocation) {
-        this.enableRelocation = enableRelocation;
     }
 
     /**
@@ -93,7 +63,7 @@ public class SnapshotInProgressAllocationDecider extends AllocationDecider {
     }
 
     private Decision canMove(ShardRouting shardRouting, RoutingAllocation allocation) {
-        if (!enableRelocation && shardRouting.primary()) {
+        if (shardRouting.primary()) {
             // Only primary shards are snapshotted
 
             SnapshotsInProgress snapshotsInProgress = allocation.custom(SnapshotsInProgress.TYPE);

--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -209,7 +209,6 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     SameShardAllocationDecider.CLUSTER_ROUTING_ALLOCATION_SAME_HOST_SETTING,
                     InternalClusterInfoService.INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL_SETTING,
                     InternalClusterInfoService.INTERNAL_CLUSTER_INFO_TIMEOUT_SETTING,
-                    SnapshotInProgressAllocationDecider.CLUSTER_ROUTING_ALLOCATION_SNAPSHOT_RELOCATION_ENABLED_SETTING,
                     DestructiveOperations.REQUIRES_NAME_SETTING,
                     DiscoverySettings.PUBLISH_TIMEOUT_SETTING,
                     DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING,

--- a/docs/reference/migration/migrate_6_0.asciidoc
+++ b/docs/reference/migration/migrate_6_0.asciidoc
@@ -28,6 +28,7 @@ way to reindex old indices is to use the `reindex` API.
 * <<breaking_60_search_changes>>
 * <<breaking_60_docs_changes>>
 * <<breaking_60_cluster_changes>>
+* <<breaking_60_settings_changes>>
 * <<breaking_60_plugins_changes>>
 
 include::migrate_6_0/rest.asciidoc[]
@@ -37,5 +38,7 @@ include::migrate_6_0/search.asciidoc[]
 include::migrate_6_0/docs.asciidoc[]
 
 include::migrate_6_0/cluster.asciidoc[]
+
+include::migrate_6_0/settings.asciidoc[]
 
 include::migrate_6_0/plugins.asciidoc[]

--- a/docs/reference/migration/migrate_6_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_6_0/settings.asciidoc
@@ -1,0 +1,10 @@
+[[breaking_60_settings_changes]]
+=== Settings changes
+
+==== Snapshot settings
+
+The internal setting `cluster.routing.allocation.snapshot.relocation_enabled` that allowed shards with running snapshots to be reallocated to
+different nodes has been removed. Enabling this setting could cause allocation issues if a shard got allocated off a node and then
+reallocated back to this node while a snapshot was running.
+
+


### PR DESCRIPTION
This experimental setting enables relocation of shards that are being snapshotted, which can cause the shard allocation failures. This setting is undocumented and there is no good reason to ever set it in production.
