### PR TITLE
Change `gradle run` to use zip distribution

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RunTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RunTask.groovy
@@ -16,6 +16,7 @@ public class RunTask extends DefaultTask {
         clusterConfig.httpPort = 9200
         clusterConfig.transportPort = 9300
         clusterConfig.daemonize = false
+        clusterConfig.distribution = 'zip'
         project.afterEvaluate {
             ClusterFormationTasks.setup(project, this, clusterConfig)
         }

--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -25,6 +25,11 @@ subprojects {
     // for local ES plugins, the name of the plugin is the same as the directory
     name project.name
   }
+  
+  run {
+    // these cannot be run with the normal distribution, since they are included in it!
+    distribution = 'integ-test-zip'
+  }
 
   if (project.file('src/main/packaging').exists()) {
     throw new InvalidModelException("Modules cannot contain packaging files") 


### PR DESCRIPTION
When running `gradle run`, a developer usually intends to get a running
instance as if they had run elasticsearch from the command line. This is
different than the isolated environment we use for integration testing
plugins. This change switches the run task to use the zip distribution,
so that all modules included in the normal distribution are included.
