### PR TITLE
.es_temp_file remains after system crash, causing it not to start again

### DIFF
--- a/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -1004,9 +1004,10 @@ public final class NodeEnvironment  implements Closeable {
             Path resolve = path.resolve(".es_temp_file");
             try {
                 Files.createFile(resolve);
-                Files.deleteIfExists(resolve);
             } catch (IOException ex) {
                 throw new IOException("failed to write in data directory [" + path + "] write permission is required", ex);
+            } finally {
+                Files.deleteIfExists(resolve);
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -1002,12 +1002,16 @@ public final class NodeEnvironment  implements Closeable {
     private static void tryWriteTempFile(Path path) throws IOException {
         if (Files.exists(path)) {
             Path resolve = path.resolve(".es_temp_file");
+            boolean tempFileCreated = false;
             try {
                 Files.createFile(resolve);
+                tempFileCreated = true;
             } catch (IOException ex) {
                 throw new IOException("failed to write in data directory [" + path + "] write permission is required", ex);
             } finally {
-                Files.deleteIfExists(resolve);
+                if (tempFileCreated) {
+                    Files.deleteIfExists(resolve);
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #20992 

Move the delete to `finally` block to ensure the file will be deleted when there is a left over temp file from a crash. 
