### PR TITLE
[test] Required parameters are checked client-side

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/create/15_without_id.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/create/15_without_id.yaml
@@ -1,7 +1,7 @@
 ---
 "Create without ID":
  - do:
-      catch:            /Validation|Invalid/
+      catch: param
       create:
           index:  test_1
           type:   test


### PR DESCRIPTION
Based on the changes introduced in #20924 the `id` parameter is now required for `create` API. Required parameters are supposed to be checked client-side.
