### PR TITLE
Remove output_uuid parameter from cluster stats

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
@@ -37,19 +37,18 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
 
     ClusterStatsNodes nodesStats;
     ClusterStatsIndices indicesStats;
-    String clusterUUID;
     ClusterHealthStatus status;
     long timestamp;
-
 
     ClusterStatsResponse() {
     }
 
-    public ClusterStatsResponse(long timestamp, ClusterName clusterName, String clusterUUID,
-                                List<ClusterStatsNodeResponse> nodes, List<FailedNodeException> failures) {
+    public ClusterStatsResponse(long timestamp,
+                                ClusterName clusterName,
+                                List<ClusterStatsNodeResponse> nodes,
+                                List<FailedNodeException> failures) {
         super(clusterName, nodes, failures);
         this.timestamp = timestamp;
-        this.clusterUUID = clusterUUID;
         nodesStats = new ClusterStatsNodes(nodes);
         indicesStats = new ClusterStatsIndices(nodes);
         for (ClusterStatsNodeResponse response : nodes) {
@@ -81,7 +80,6 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         timestamp = in.readVLong();
-        clusterUUID = in.readString();
         // it may be that the master switched on us while doing the operation. In this case the status may be null.
         status = in.readOptionalWriteable(ClusterHealthStatus::readFrom);
     }
@@ -90,7 +88,6 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeVLong(timestamp);
-        out.writeString(clusterUUID);
         out.writeOptionalWriteable(status);
     }
 
@@ -114,9 +111,6 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.field("timestamp", getTimestamp());
-        if (params.paramAsBoolean("output_uuid", false)) {
-            builder.field("uuid", clusterUUID);
-        }
         if (status != null) {
             builder.field("status", status.name().toLowerCase(Locale.ROOT));
         }
@@ -141,4 +135,5 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
             return "{ \"error\" : \"" + e.getMessage() + "\"}";
         }
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -72,8 +72,11 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
     @Override
     protected ClusterStatsResponse newResponse(ClusterStatsRequest request,
                                                List<ClusterStatsNodeResponse> responses, List<FailedNodeException> failures) {
-        return new ClusterStatsResponse(System.currentTimeMillis(), clusterService.getClusterName(),
-            clusterService.state().metaData().clusterUUID(), responses, failures);
+        return new ClusterStatsResponse(
+            System.currentTimeMillis(),
+            clusterService.getClusterName(),
+            responses,
+            failures);
     }
 
     @Override


### PR DESCRIPTION
This commit removes an undocumented output parameter output_uuid from
the cluster stats API. Currently the parameter does not even work as it
is not whitelisted as an output parameter. Since the cluster UUID is
available from the main action, and this parameter is not documented, we
opt to just remove it.

Relates #20722
