### PR TITLE
Add basic cgroup CPU metrics

### DIFF
--- a/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -185,7 +185,7 @@ public class OsProbe {
         return Probes.getLoadAndScaleToPercent(getSystemCpuLoad, osMxBean);
     }
 
-    private Map<String, String> getCpuAccountingCGroup() {
+    private Map<String, String> getControlGroups() {
         try {
             final List<String> lines = readProcSelfCgroup();
             if (!lines.isEmpty()) {
@@ -332,7 +332,7 @@ public class OsProbe {
         final OsStats.Swap swap = new OsStats.Swap(getTotalSwapSpaceSize(), getFreeSwapSpaceSize());
         final OsStats.Cgroup cgroup;
         if (shouldReadCgroups()) {
-            final Map<String, String> controllerMap = getCpuAccountingCGroup();
+            final Map<String, String> controllerMap = getControlGroups();
             if (controllerMap.containsKey("cpu") && controllerMap.containsKey("cpuacct")) {
                 final String cpuAcctControlGroup = controllerMap.get("cpuacct");
                 final String cpuControlGroup = controllerMap.get("cpu");

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -271,9 +271,8 @@ public class OsProbe {
                 // note that Matcher#matches must be invoked as
                 // matching is lazy; this can not happen in an assert
                 // as assertions might not be enabled
-                if (!matcher.matches()) {
-                    assert false : line;
-                }
+                final boolean matches = matcher.matches();
+                assert matches : line;
                 // at this point we have captured the subsystems and the
                 // control group
                 final String[] controllers = matcher.group(1).split(",");

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -210,6 +210,7 @@ public class OsProbe {
     }
 
     // visible for testing
+    @SuppressForbidden(reason = "access /proc/self/cgroup")
     List<String> readProcSelfCgroup() throws IOException {
         return Files.readAllLines(PathUtils.get("/proc/self/cgroup"));
     }
@@ -228,6 +229,7 @@ public class OsProbe {
     }
 
     // visible for testing
+    @SuppressForbidden(reason = "access /sys/fs/cgroup/cpuacct")
     List<String> readSysFsCgroupCpuAcctCpuAcctUsage(final String path) throws IOException {
         return Files.readAllLines(PathUtils.get("/sys/fs/cgroup/cpuacct", path, "cpuacct.usage"));
     }
@@ -246,6 +248,7 @@ public class OsProbe {
     }
 
     // visible for testing
+    @SuppressForbidden(reason = "access /sys/fs/cgroup/cpu")
     List<String> readSysFsCgroupCpuAcctCpuCfsPeriod(final String path) throws IOException {
         return Files.readAllLines(PathUtils.get("/sys/fs/cgroup/cpu", path, "cpu.cfs_period_us"));
     }
@@ -264,6 +267,7 @@ public class OsProbe {
     }
 
     // visible for testing
+    @SuppressForbidden(reason = "access /sys/fs/cgroup/cpu")
     List<String> readSysFsCgroupCpuAcctCpuAcctCfsQuota(final String path) throws IOException {
         return Files.readAllLines(PathUtils.get("/sys/fs/cgroup/cpu", path, "cpu.cfs_quota_us"));
     }
@@ -299,6 +303,7 @@ public class OsProbe {
     }
 
     // visible for testing
+    @SuppressForbidden(reason = "access /sys/fs/cgroup/cpu")
     List<String> readSysFsCgroupCpuAcctCpuStat(final String path) throws IOException {
         return Files.readAllLines(PathUtils.get("/sys/fs/cgroup/cpu", path, "cpu.stat"));
     }

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -32,12 +32,10 @@ import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -189,65 +187,16 @@ public class OsProbe {
     }
 
     /**
-     * Reads all lines of a file and logs any {@link IOException}.
+     * Reads a file containing a single line.
      *
      * @param path path to the file to read
-     * @return all the line or an empty list if an {@link IOException}
-     * occurred
+     * @return the single line
+     * @throws IOException if an I/O exception occurs reading the file
      */
-    private List<String> readAllLines(final Path path) {
-        try {
-            return Files.readAllLines(path);
-        } catch (final IOException e) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("error reading " + path, e);
-            }
-            return Collections.emptyList();
-        }
-    }
-
-    /**
-     * Reads a file containing a single line and logs any
-     * {@link IOException}.
-     *
-     * @param path path to the file to read
-     * @return the single line or {@code null} if an
-     * {@link IOException} occurred
-     */
-    private String readSingleLine(final Path path) {
-        try {
-            final List<String> lines = Files.readAllLines(path);
-            assert lines != null && lines.size() == 1;
-            return lines.get(0);
-        } catch (final IOException e) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("error reading " + path, e);
-            }
-            return null;
-        }
-    }
-
-    /**
-     * Parses the input to a long and logs any
-     * {@link NumberFormatException} that occurs during parsing.
-     *
-     * @param line the line to parse
-     * @param message a debug message to log if parsing fails
-     * @return the parsed value
-     */
-    private long parseSingleLineAsLong(final String line, final Supplier<String> message) {
-        if (line != null) {
-            try {
-                return Long.parseLong(line);
-            } catch (final NumberFormatException e) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug(message.get(), e);
-                }
-                // fallback
-            }
-        }
-
-        return -1;
+    private String readSingleLine(final Path path) throws IOException {
+        final List<String> lines = Files.readAllLines(path);
+        assert lines != null && lines.size() == 1;
+        return lines.get(0);
     }
 
     // pattern for lines in /proc/self/cgroup
@@ -261,29 +210,27 @@ public class OsProbe {
      *
      * @return a map from subsystems to the control group for the
      * Elasticsearch process.
+     * @throws IOException if an I/O exception occurs reading
+     * {@code /proc/self/cgroup}
      */
-    private Map<String, String> getControlGroups() {
+    private Map<String, String> getControlGroups() throws IOException {
         final List<String> lines = readProcSelfCgroup();
-        if (!lines.isEmpty()) {
-            final Map<String, String> controllerMap = new HashMap<>();
-            for (final String line : lines) {
-                final Matcher matcher = CONTROL_GROUP_PATTERN.matcher(line);
-                // note that Matcher#matches must be invoked as
-                // matching is lazy; this can not happen in an assert
-                // as assertions might not be enabled
-                final boolean matches = matcher.matches();
-                assert matches : line;
-                // at this point we have captured the subsystems and the
-                // control group
-                final String[] controllers = matcher.group(1).split(",");
-                for (final String controller : controllers) {
-                    controllerMap.put(controller, matcher.group(2));
-                }
+        final Map<String, String> controllerMap = new HashMap<>();
+        for (final String line : lines) {
+            final Matcher matcher = CONTROL_GROUP_PATTERN.matcher(line);
+            // note that Matcher#matches must be invoked as
+            // matching is lazy; this can not happen in an assert
+            // as assertions might not be enabled
+            final boolean matches = matcher.matches();
+            assert matches : line;
+            // at this point we have captured the subsystems and the
+            // control group
+            final String[] controllers = matcher.group(1).split(",");
+            for (final String controller : controllers) {
+                controllerMap.put(controller, matcher.group(2));
             }
-            return controllerMap;
         }
-
-        return Collections.emptyMap();
+        return controllerMap;
     }
 
     /**
@@ -299,12 +246,15 @@ public class OsProbe {
      * bound to the hierarchy, and the last field representing the
      * control group.
      *
-     * @return the lines from {@code /proc/self/cgroup} or an empty
-     * list.
+     * @return the lines from {@code /proc/self/cgroup}
+     * @throws IOException if an I/O exception occurs reading
+     * {@code /proc/self/cgroup}
      */
     @SuppressForbidden(reason = "access /proc/self/cgroup")
-    List<String> readProcSelfCgroup() {
-        return readAllLines(PathUtils.get("/proc/self/cgroup"));
+    List<String> readProcSelfCgroup() throws IOException {
+        final List<String> lines = Files.readAllLines(PathUtils.get("/proc/self/cgroup"));
+        assert lines != null && !lines.isEmpty();
+        return lines;
     }
 
     /**
@@ -314,13 +264,12 @@ public class OsProbe {
      *
      * @param controlGroup the control group for the Elasticsearch
      *                     process for the {@code cpuacct} subsystem
-     * @return the total CPU time in nanoseconds, or -1
+     * @return the total CPU time in nanoseconds
+     * @throws IOException if an I/O exception occurs reading
+     * {@code cpuacct.usage} for the control group
      */
-    private long getCgroupCpuAcctUsageNanos(final String controlGroup) {
-        final String line = readSysFsCgroupCpuAcctCpuAcctUsage(controlGroup);
-        return parseSingleLineAsLong(
-            line,
-            () -> String.format(Locale.ROOT, "error parsing cpuacct.usage [%s] for control group [%s]", line, controlGroup));
+    private long getCgroupCpuAcctUsageNanos(final String controlGroup) throws IOException {
+        return Long.parseLong(readSysFsCgroupCpuAcctCpuAcctUsage(controlGroup));
     }
 
     /**
@@ -333,10 +282,12 @@ public class OsProbe {
      * @param controlGroup the control group to which the Elasticsearch
      *                     process belongs for the {@code cpuacct}
      *                     subsystem
-     * @return the line from {@code cpuacct.usage} or {@code null}
+     * @return the line from {@code cpuacct.usage}
+     * @throws IOException if an I/O exception occurs reading
+     * {@code cpuacct.usage} for the control group
      */
     @SuppressForbidden(reason = "access /sys/fs/cgroup/cpuacct")
-    String readSysFsCgroupCpuAcctCpuAcctUsage(final String controlGroup) {
+    String readSysFsCgroupCpuAcctCpuAcctUsage(final String controlGroup) throws IOException {
         return readSingleLine(PathUtils.get("/sys/fs/cgroup/cpuacct", controlGroup, "cpuacct.usage"));
     }
 
@@ -347,13 +298,12 @@ public class OsProbe {
      *
      * @param controlGroup the control group for the Elasticsearch
      *                     process for the {@code cpuacct} subsystem
-     * @return the CFS quota period in microseconds, or -1
+     * @return the CFS quota period in microseconds
+     * @throws IOException if an I/O exception occurs reading
+     * {@code cpu.cfs_period_us} for the control group
      */
-    private long getCgroupCpuAcctCpuCfsPeriodMicros(final String controlGroup) {
-        final String line = readSysFsCgroupCpuAcctCpuCfsPeriod(controlGroup);
-        return parseSingleLineAsLong(
-            line,
-            () -> String.format(Locale.ROOT, "error parsing cpu.cfs_period_us [%s] for control group [%s]", line, controlGroup));
+    private long getCgroupCpuAcctCpuCfsPeriodMicros(final String controlGroup) throws IOException {
+        return Long.parseLong(readSysFsCgroupCpuAcctCpuCfsPeriod(controlGroup));
     }
 
     /**
@@ -366,10 +316,12 @@ public class OsProbe {
      * @param controlGroup the control group to which the Elasticsearch
      *                     process belongs for the {@code cpu}
      *                     subsystem
-     * @return the line from {@code cpu.cfs_period_us} or {@code null}
+     * @return the line from {@code cpu.cfs_period_us}
+     * @throws IOException if an I/O exception occurs reading
+     * {@code cpu.cfs_period_us} for the control group
      */
     @SuppressForbidden(reason = "access /sys/fs/cgroup/cpu")
-    String readSysFsCgroupCpuAcctCpuCfsPeriod(final String controlGroup) {
+    String readSysFsCgroupCpuAcctCpuCfsPeriod(final String controlGroup) throws IOException {
         return readSingleLine(PathUtils.get("/sys/fs/cgroup/cpu", controlGroup, "cpu.cfs_period_us"));
     }
 
@@ -380,13 +332,12 @@ public class OsProbe {
      *
      * @param controlGroup the control group for the Elasticsearch
      *                     process for the {@code cpuacct} subsystem
-     * @return the CFS quota in microseconds, or -1
+     * @return the CFS quota in microseconds
+     * @throws IOException if an I/O exception occurs reading
+     * {@code cpu.cfs_quota_us} for the control group
      */
-    private long getCGroupCpuAcctCpuCfsQuotaMicros(final String controlGroup) {
-        final String line = readSysFsCgroupCpuAcctCpuAcctCfsQuota(controlGroup);
-        return parseSingleLineAsLong(
-            line,
-            () -> String.format(Locale.ROOT, "error parsing cpu.cfs_quota_us [%s] for control group [%s]", line, controlGroup));
+    private long getCGroupCpuAcctCpuCfsQuotaMicros(final String controlGroup) throws IOException {
+        return Long.parseLong(readSysFsCgroupCpuAcctCpuAcctCfsQuota(controlGroup));
     }
 
     /**
@@ -399,10 +350,12 @@ public class OsProbe {
      * @param controlGroup the control group to which the Elasticsearch
      *                     process belongs for the {@code cpu}
      *                     subsystem
-     * @return the line from {@code cpu.cfs_quota_us} or {@code null}
+     * @return the line from {@code cpu.cfs_quota_us}
+     * @throws IOException if an I/O exception occurs reading
+     * {@code cpu.cfs_quota_us} for the control group
      */
     @SuppressForbidden(reason = "access /sys/fs/cgroup/cpu")
-    String readSysFsCgroupCpuAcctCpuAcctCfsQuota(final String controlGroup) {
+    String readSysFsCgroupCpuAcctCpuAcctCfsQuota(final String controlGroup) throws IOException {
         return readSingleLine(PathUtils.get("/sys/fs/cgroup/cpu", controlGroup, "cpu.cfs_quota_us"));
     }
 
@@ -412,39 +365,33 @@ public class OsProbe {
      *
      * @param controlGroup the control group for the Elasticsearch
      *                     process for the {@code cpuacct} subsystem
-     * @return the CPU time statistics or {@code null}
+     * @return the CPU time statistics
+     * @throws IOException if an I/O exception occurs reading
+     * {@code cpu.stat} for the control group
      */
-    private OsStats.Cgroup.CpuStat getCgroupCpuAcctCpuStat(final String controlGroup) {
+    private OsStats.Cgroup.CpuStat getCgroupCpuAcctCpuStat(final String controlGroup) throws IOException {
         final List<String> lines = readSysFsCgroupCpuAcctCpuStat(controlGroup);
-        if (!lines.isEmpty()) {
-            assert lines.size() == 3;
-            long numberOfPeriods = -1;
-            long numberOfTimesThrottled = -1;
-            long timeThrottledNanos = -1;
-            for (final String line : lines) {
-                final String[] fields = line.split("\\s+");
-                switch (fields[0]) {
-                    case "nr_periods":
-                        numberOfPeriods =
-                            parseSingleLineAsLong(fields[1], () -> String.format(Locale.ROOT, "error parsing nr_periods [%s]", line));
-                        break;
-                    case "nr_throttled":
-                        numberOfTimesThrottled =
-                            parseSingleLineAsLong(fields[1], () -> String.format(Locale.ROOT, "error parsing nr_throttled [%s]", line));
-                        break;
-                    case "throttled_time":
-                        timeThrottledNanos =
-                            parseSingleLineAsLong(fields[1], () -> String.format(Locale.ROOT, "error parsing throttled_time [%s]", line));
-                        break;
-                }
+        long numberOfPeriods = -1;
+        long numberOfTimesThrottled = -1;
+        long timeThrottledNanos = -1;
+        for (final String line : lines) {
+            final String[] fields = line.split("\\s+");
+            switch (fields[0]) {
+                case "nr_periods":
+                    numberOfPeriods = Long.parseLong(fields[1]);
+                    break;
+                case "nr_throttled":
+                    numberOfTimesThrottled = Long.parseLong(fields[1]);
+                    break;
+                case "throttled_time":
+                    timeThrottledNanos = Long.parseLong(fields[1]);
+                    break;
             }
-            assert numberOfPeriods != -1;
-            assert numberOfTimesThrottled != -1;
-            assert timeThrottledNanos != -1;
-            return new OsStats.Cgroup.CpuStat(numberOfPeriods, numberOfTimesThrottled, timeThrottledNanos);
         }
-
-        return null;
+        assert numberOfPeriods != -1;
+        assert numberOfTimesThrottled != -1;
+        assert timeThrottledNanos != -1;
+        return new OsStats.Cgroup.CpuStat(numberOfPeriods, numberOfTimesThrottled, timeThrottledNanos);
     }
 
     /**
@@ -468,11 +415,41 @@ public class OsProbe {
      *                     process belongs for the {@code cpu}
      *                     subsystem
      *
-     * @return the line from {@code cpu.cfs_quota_us} or {@code null}
+     * @return the lines from {@code cpu.stat}
+     * @throws IOException if an I/O exception occurs reading
+     * {@code cpu.stat} for the control group
      */
     @SuppressForbidden(reason = "access /sys/fs/cgroup/cpu")
-    List<String> readSysFsCgroupCpuAcctCpuStat(final String controlGroup) {
-        return readAllLines(PathUtils.get("/sys/fs/cgroup/cpu", controlGroup, "cpu.stat"));
+    List<String> readSysFsCgroupCpuAcctCpuStat(final String controlGroup) throws IOException {
+        final List<String> lines = Files.readAllLines(PathUtils.get("/sys/fs/cgroup/cpu", controlGroup, "cpu.stat"));
+        assert lines != null && lines.size() == 3;
+        return lines;
+    }
+
+    /**
+     * Basic cgroup stats.
+     *
+     * @return basic cgroup stats, or {@code null} if an I/O exception
+     * occurred reading the cgroup stats
+     */
+    private OsStats.Cgroup getCgroup() {
+        try {
+            final Map<String, String> controllerMap = getControlGroups();
+            final String cpuControlGroup = controllerMap.get("cpu");
+            final String cpuAcctControlGroup = controllerMap.get("cpuacct");
+            return new OsStats.Cgroup(
+                cpuAcctControlGroup,
+                getCgroupCpuAcctUsageNanos(cpuAcctControlGroup),
+                cpuControlGroup,
+                getCgroupCpuAcctCpuCfsPeriodMicros(cpuControlGroup),
+                getCGroupCpuAcctCpuCfsQuotaMicros(cpuControlGroup),
+                getCgroupCpuAcctCpuStat(cpuControlGroup));
+        } catch (final IOException e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("error reading control group stats", e);
+            }
+            return null;
+        }
     }
 
     private static class OsProbeHolder {
@@ -484,6 +461,7 @@ public class OsProbe {
     }
 
     OsProbe() {
+
     }
 
     private final Logger logger = ESLoggerFactory.getLogger(getClass());
@@ -497,26 +475,7 @@ public class OsProbe {
         final OsStats.Cpu cpu = new OsStats.Cpu(getSystemCpuPercent(), getSystemLoadAverage());
         final OsStats.Mem mem = new OsStats.Mem(getTotalPhysicalMemorySize(), getFreePhysicalMemorySize());
         final OsStats.Swap swap = new OsStats.Swap(getTotalSwapSpaceSize(), getFreeSwapSpaceSize());
-        final OsStats.Cgroup cgroup;
-        if (Constants.LINUX) {
-            final Map<String, String> controllerMap = getControlGroups();
-            if (controllerMap.containsKey("cpuacct") && controllerMap.containsKey("cpu")) {
-                final String cpuControlGroup = controllerMap.get("cpu");
-                final String cpuAcctControlGroup = controllerMap.get("cpuacct");
-                cgroup =
-                    new OsStats.Cgroup(
-                        cpuAcctControlGroup,
-                        getCgroupCpuAcctUsageNanos(cpuAcctControlGroup),
-                        cpuControlGroup,
-                        getCgroupCpuAcctCpuCfsPeriodMicros(cpuControlGroup),
-                        getCGroupCpuAcctCpuCfsQuotaMicros(cpuControlGroup),
-                        getCgroupCpuAcctCpuStat(cpuControlGroup));
-            } else {
-                cgroup = null;
-            }
-        } else {
-            cgroup = null;
-        }
+        final OsStats.Cgroup cgroup = Constants.LINUX ? getCgroup() : null;
         return new OsStats(System.currentTimeMillis(), cpu, mem, swap, cgroup);
     }
 

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -20,8 +20,6 @@
 package org.elasticsearch.monitor.os;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.apache.logging.log4j.util.Supplier;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.io.PathUtils;
@@ -33,10 +31,13 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -141,7 +142,9 @@ public class OsProbe {
                 try {
                     return new double[]{Double.parseDouble(fields[0]), Double.parseDouble(fields[1]), Double.parseDouble(fields[2])};
                 } catch (final NumberFormatException e) {
-                    logger.debug((Supplier<?>) () -> new ParameterizedMessage("error parsing /proc/loadavg [{}]", procLoadAvg), e);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug(String.format(Locale.ROOT, "error parsing /proc/loadavg [%s]", procLoadAvg), e);
+                    }
                 }
             }
             // fallback
@@ -185,127 +188,292 @@ public class OsProbe {
         return Probes.getLoadAndScaleToPercent(getSystemCpuLoad, osMxBean);
     }
 
-    private Map<String, String> getControlGroups() {
+    /**
+     * Reads all lines of a file and logs any {@link IOException}.
+     *
+     * @param path path to the file to read
+     * @return all the line or an empty list if an {@link IOException}
+     * occurred
+     */
+    private List<String> readAllLines(final Path path) {
         try {
-            final List<String> lines = readProcSelfCgroup();
-            if (!lines.isEmpty()) {
-                final Map<String, String> controllerMap = new HashMap<>();
-                final Pattern pattern = Pattern.compile("\\d+:(\\w+(?:,\\w+)?):(/.*)");
-                for (final String line : lines) {
-                    final Matcher matcher = pattern.matcher(line);
-                    if (matcher.matches()) {
-                        final String[] controllers = matcher.group(1).split(",");
-                        for (final String controller : controllers) {
-                            controllerMap.put(controller, matcher.group(2));
-                        }
-                    }
-                }
-                return controllerMap;
-            }
+            return Files.readAllLines(path);
         } catch (final IOException e) {
-            // do not fail Elasticsearch if something unexpected happens here
+            if (logger.isDebugEnabled()) {
+                logger.debug("error reading " + path, e);
+            }
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Reads a file containing a single line and logs any
+     * {@link IOException}.
+     *
+     * @param path path to the file to read
+     * @return the single line or {@code null} if an
+     * {@link IOException} occurred
+     */
+    private String readSingleLine(final Path path) {
+        try {
+            final List<String> lines = Files.readAllLines(path);
+            assert lines != null && lines.size() == 1;
+            return lines.get(0);
+        } catch (final IOException e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("error reading " + path, e);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Parses the input to a long and logs any
+     * {@link NumberFormatException} that occurs during parsing.
+     *
+     * @param line the line to parse
+     * @param message a debug message to log if parsing fails
+     * @return the parsed value
+     */
+    private long parseSingleLineAsLong(final String line, final Supplier<String> message) {
+        if (line != null) {
+            try {
+                return Long.parseLong(line);
+            } catch (final NumberFormatException e) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug(message.get(), e);
+                }
+                // fallback
+            }
+        }
+
+        return -1;
+    }
+
+    // pattern for lines in /proc/self/cgroup
+    private static final Pattern CONTROL_GROUP_PATTERN = Pattern.compile("\\d+:([^:,]+(?:,[^:,]+)?):(/.*)");
+
+    /**
+     * A map of the control groups to which the Elasticsearch process
+     * belongs. Note that this is a map because the control groups can
+     * vary from subsystem to subsystem. Additionally, this map can not
+     * be cached because a running process can be reclassified.
+     *
+     * @return a map from subsystems to the control group for the
+     * Elasticsearch process.
+     */
+    private Map<String, String> getControlGroups() {
+        final List<String> lines = readProcSelfCgroup();
+        if (!lines.isEmpty()) {
+            final Map<String, String> controllerMap = new HashMap<>();
+            for (final String line : lines) {
+                final Matcher matcher = CONTROL_GROUP_PATTERN.matcher(line);
+                // note that Matcher#matches must be invoked as
+                // matching is lazy; this can not happen in an assert
+                // as assertions might not be enabled
+                if (!matcher.matches()) {
+                    assert false : line;
+                }
+                // at this point we have captured the subsystems and the
+                // control group
+                final String[] controllers = matcher.group(1).split(",");
+                for (final String controller : controllers) {
+                    controllerMap.put(controller, matcher.group(2));
+                }
+            }
+            return controllerMap;
         }
 
         return Collections.emptyMap();
     }
 
-    // visible for testing
+    /**
+     * The lines from {@code /proc/self/cgroup}. This file represents
+     * the control groups to which the Elasticsearch process belongs.
+     * Each line in this file represents a control group hierarchy of
+     * the form
+     * <p>
+     * {@code \d+:([^:,]+(?:,[^:,]+)?):(/.*)}
+     * <p>
+     * with the first field representing the hierarchy ID, the second
+     * field representing a comma-separated list of the subsystems
+     * bound to the hierarchy, and the last field representing the
+     * control group.
+     *
+     * @return the lines from {@code /proc/self/cgroup} or an empty
+     * list.
+     */
     @SuppressForbidden(reason = "access /proc/self/cgroup")
-    List<String> readProcSelfCgroup() throws IOException {
-        return Files.readAllLines(PathUtils.get("/proc/self/cgroup"));
+    List<String> readProcSelfCgroup() {
+        return readAllLines(PathUtils.get("/proc/self/cgroup"));
     }
 
-    private long getCgroupCpuAcctUsageNanos(final String path) {
-        try {
-            final List<String> lines = readSysFsCgroupCpuAcctCpuAcctUsage(path);
-            if (!lines.isEmpty()) {
-                return Long.parseLong(lines.get(0));
-            }
-        } catch (IOException e) {
-            // do not fail Elasticsearch is something unexpected happens here
-        }
-
-        return -1;
+    /**
+     * The total CPU time in nanoseconds consumed by all tasks in the
+     * cgroup to which the Elasticsearch process belongs for the
+     * {@code cpuacct} subsystem.
+     *
+     * @param controlGroup the control group for the Elasticsearch
+     *                     process for the {@code cpuacct} subsystem
+     * @return the total CPU time in nanoseconds, or -1
+     */
+    private long getCgroupCpuAcctUsageNanos(final String controlGroup) {
+        final String line = readSysFsCgroupCpuAcctCpuAcctUsage(controlGroup);
+        return parseSingleLineAsLong(
+            line,
+            () -> String.format(Locale.ROOT, "error parsing cpuacct.usage [%s] for control group [%s]", line, controlGroup));
     }
 
-    // visible for testing
+    /**
+     * Returns the line from {@code cpuacct.usage} for the control
+     * group to which the Elasticsearch process belongs for the
+     * {@code cpuacct} subsystem. This line represents the total CPU
+     * time in nanoseconds consumed by all tasks in the same control
+     * group.
+     *
+     * @param controlGroup the control group to which the Elasticsearch
+     *                     process belongs for the {@code cpuacct}
+     *                     subsystem
+     * @return the line from {@code cpuacct.usage} or {@code null}
+     */
     @SuppressForbidden(reason = "access /sys/fs/cgroup/cpuacct")
-    List<String> readSysFsCgroupCpuAcctCpuAcctUsage(final String path) throws IOException {
-        return Files.readAllLines(PathUtils.get("/sys/fs/cgroup/cpuacct", path, "cpuacct.usage"));
+    String readSysFsCgroupCpuAcctCpuAcctUsage(final String controlGroup) {
+        return readSingleLine(PathUtils.get("/sys/fs/cgroup/cpuacct", controlGroup, "cpuacct.usage"));
     }
 
-    private long getCgroupCpuAcctCpuCfsPeriodMicros(final String path) {
-        try {
-            final List<String> lines = readSysFsCgroupCpuAcctCpuCfsPeriod(path);
-            if (!lines.isEmpty()) {
-                return Long.parseLong(lines.get(0));
-            }
-        } catch (IOException e) {
-            // do not fail Elasticsearch is something unexpected happens here
-        }
-
-        return -1;
+    /**
+     * The total period of time in microseconds for how frequently the
+     * Elasticsearch control group's access to CPU resources will be
+     * reallocated.
+     *
+     * @param controlGroup the control group for the Elasticsearch
+     *                     process for the {@code cpuacct} subsystem
+     * @return the CFS quota period in microseconds, or -1
+     */
+    private long getCgroupCpuAcctCpuCfsPeriodMicros(final String controlGroup) {
+        final String line = readSysFsCgroupCpuAcctCpuCfsPeriod(controlGroup);
+        return parseSingleLineAsLong(
+            line,
+            () -> String.format(Locale.ROOT, "error parsing cpu.cfs_period_us [%s] for control group [%s]", line, controlGroup));
     }
 
-    // visible for testing
+    /**
+     * Returns the line from {@code cpu.cfs_period_us} for the control
+     * group to which the Elasticsearch process belongs for the
+     * {@code cpu} subsystem. This line represents the period of time
+     * in microseconds for how frequently the control group's access to
+     * CPU resources will be reallocated.
+     *
+     * @param controlGroup the control group to which the Elasticsearch
+     *                     process belongs for the {@code cpu}
+     *                     subsystem
+     * @return the line from {@code cpu.cfs_period_us} or {@code null}
+     */
     @SuppressForbidden(reason = "access /sys/fs/cgroup/cpu")
-    List<String> readSysFsCgroupCpuAcctCpuCfsPeriod(final String path) throws IOException {
-        return Files.readAllLines(PathUtils.get("/sys/fs/cgroup/cpu", path, "cpu.cfs_period_us"));
+    String readSysFsCgroupCpuAcctCpuCfsPeriod(final String controlGroup) {
+        return readSingleLine(PathUtils.get("/sys/fs/cgroup/cpu", controlGroup, "cpu.cfs_period_us"));
     }
 
-    private long getCGroupCpuAcctCpuCfsQuotaMicros(final String path) {
-        try {
-            final List<String> lines = readSysFsCgroupCpuAcctCpuAcctCfsQuota(path);
-            if (!lines.isEmpty()) {
-                return Long.parseLong(lines.get(0));
-            }
-        } catch (IOException e) {
-            // do not fail Elasticsearch is something unexpected happens here
-        }
-
-        return -1;
+    /**
+     * The total time in microseconds that all tasks in the
+     * Elasticsearch control group can run during one period as
+     * specified by {@code cpu.cfs_period_us}.
+     *
+     * @param controlGroup the control group for the Elasticsearch
+     *                     process for the {@code cpuacct} subsystem
+     * @return the CFS quota in microseconds, or -1
+     */
+    private long getCGroupCpuAcctCpuCfsQuotaMicros(final String controlGroup) {
+        final String line = readSysFsCgroupCpuAcctCpuAcctCfsQuota(controlGroup);
+        return parseSingleLineAsLong(
+            line,
+            () -> String.format(Locale.ROOT, "error parsing cpu.cfs_quota_us [%s] for control group [%s]", line, controlGroup));
     }
 
-    // visible for testing
+    /**
+     * Returns the line from {@code cpu.cfs_quota_us} for the control
+     * group to which the Elasticsearch process belongs for the
+     * {@code cpu} subsystem. This line represents the total time in
+     * microseconds that all tasks in the control group can run during
+     * one period as specified by {@code cpu.cfs_period_us}.
+     *
+     * @param controlGroup the control group to which the Elasticsearch
+     *                     process belongs for the {@code cpu}
+     *                     subsystem
+     * @return the line from {@code cpu.cfs_quota_us} or {@code null}
+     */
     @SuppressForbidden(reason = "access /sys/fs/cgroup/cpu")
-    List<String> readSysFsCgroupCpuAcctCpuAcctCfsQuota(final String path) throws IOException {
-        return Files.readAllLines(PathUtils.get("/sys/fs/cgroup/cpu", path, "cpu.cfs_quota_us"));
+    String readSysFsCgroupCpuAcctCpuAcctCfsQuota(final String controlGroup) {
+        return readSingleLine(PathUtils.get("/sys/fs/cgroup/cpu", controlGroup, "cpu.cfs_quota_us"));
     }
 
-    private OsStats.Cgroup.CpuStat getCgroupCpuAcctCpuStat(final String path) {
-        try {
-            final List<String> lines = readSysFsCgroupCpuAcctCpuStat(path);
+    /**
+     * The CPU time statistics for all tasks in the Elasticsearch
+     * control group.
+     *
+     * @param controlGroup the control group for the Elasticsearch
+     *                     process for the {@code cpuacct} subsystem
+     * @return the CPU time statistics or {@code null}
+     */
+    private OsStats.Cgroup.CpuStat getCgroupCpuAcctCpuStat(final String controlGroup) {
+        final List<String> lines = readSysFsCgroupCpuAcctCpuStat(controlGroup);
+        if (!lines.isEmpty()) {
+            assert lines.size() == 3;
             long numberOfPeriods = -1;
             long numberOfTimesThrottled = -1;
             long timeThrottledNanos = -1;
-            if (!lines.isEmpty()) {
-                for (final String line : lines) {
-                    final String[] fields = line.split("\\s+");
-                    switch(fields[0]) {
-                        case "nr_periods":
-                            numberOfPeriods = Long.parseLong(fields[1]);
-                            break;
-                        case "nr_throttled":
-                            numberOfTimesThrottled = Long.parseLong(fields[1]);
-                            break;
-                        case "throttled_time":
-                            timeThrottledNanos = Long.parseLong(fields[1]);
-                            break;
-                    }
+            for (final String line : lines) {
+                final String[] fields = line.split("\\s+");
+                switch (fields[0]) {
+                    case "nr_periods":
+                        numberOfPeriods =
+                            parseSingleLineAsLong(fields[1], () -> String.format(Locale.ROOT, "error parsing nr_periods [%s]", line));
+                        break;
+                    case "nr_throttled":
+                        numberOfTimesThrottled =
+                            parseSingleLineAsLong(fields[1], () -> String.format(Locale.ROOT, "error parsing nr_throttled [%s]", line));
+                        break;
+                    case "throttled_time":
+                        timeThrottledNanos =
+                            parseSingleLineAsLong(fields[1], () -> String.format(Locale.ROOT, "error parsing throttled_time [%s]", line));
+                        break;
                 }
             }
+            assert numberOfPeriods != -1;
+            assert numberOfTimesThrottled != -1;
+            assert timeThrottledNanos != -1;
             return new OsStats.Cgroup.CpuStat(numberOfPeriods, numberOfTimesThrottled, timeThrottledNanos);
-        } catch (IOException e) {
-            // do not fail Elasticsearch is something unexpected happens here
         }
 
         return null;
     }
 
-    // visible for testing
+    /**
+     * Returns the lines from {@code cpu.stat} for the control
+     * group to which the Elasticsearch process belongs for the
+     * {@code cpu} subsystem. These lines represent the CPU time
+     * statistics and have the form
+     *
+     * nr_periods \d+
+     * nr_throttled \d+
+     * throttled_time \d+
+     *
+     * where {@code nr_periods} is the number of period intervals
+     * as specified by {@code cpu.cfs_period_us} that have elapsed,
+     * {@code nr_throttled} is the number of times tasks in the given
+     * control group have been throttled, and {@code throttled_time} is
+     * the total time in nanoseconds for which tasks in the given
+     * control group have been throttled.
+     *
+     * @param controlGroup the control group to which the Elasticsearch
+     *                     process belongs for the {@code cpu}
+     *                     subsystem
+     *
+     * @return the line from {@code cpu.cfs_quota_us} or {@code null}
+     */
     @SuppressForbidden(reason = "access /sys/fs/cgroup/cpu")
-    List<String> readSysFsCgroupCpuAcctCpuStat(final String path) throws IOException {
-        return Files.readAllLines(PathUtils.get("/sys/fs/cgroup/cpu", path, "cpu.stat"));
+    List<String> readSysFsCgroupCpuAcctCpuStat(final String controlGroup) {
+        return readAllLines(PathUtils.get("/sys/fs/cgroup/cpu", controlGroup, "cpu.stat"));
     }
 
     private static class OsProbeHolder {
@@ -331,11 +499,11 @@ public class OsProbe {
         final OsStats.Mem mem = new OsStats.Mem(getTotalPhysicalMemorySize(), getFreePhysicalMemorySize());
         final OsStats.Swap swap = new OsStats.Swap(getTotalSwapSpaceSize(), getFreeSwapSpaceSize());
         final OsStats.Cgroup cgroup;
-        if (shouldReadCgroups()) {
+        if (Constants.LINUX) {
             final Map<String, String> controllerMap = getControlGroups();
-            if (controllerMap.containsKey("cpu") && controllerMap.containsKey("cpuacct")) {
-                final String cpuAcctControlGroup = controllerMap.get("cpuacct");
+            if (controllerMap.containsKey("cpuacct") && controllerMap.containsKey("cpu")) {
                 final String cpuControlGroup = controllerMap.get("cpu");
+                final String cpuAcctControlGroup = controllerMap.get("cpuacct");
                 cgroup =
                     new OsStats.Cgroup(
                         cpuAcctControlGroup,
@@ -351,11 +519,6 @@ public class OsProbe {
             cgroup = null;
         }
         return new OsStats(System.currentTimeMillis(), cpu, mem, swap, cgroup);
-    }
-
-    // visible for testing
-    boolean shouldReadCgroups() {
-        return Constants.LINUX;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -274,35 +274,74 @@ public class OsStats implements Writeable, ToXContent {
         }
     }
 
+    /**
+     * Encapsulates basic cgroup statistics.
+     */
     public static class Cgroup implements Writeable, ToXContent {
 
         private final String cpuAcctControlGroup;
         private final long cpuAcctUsageNanos;
         private final String cpuControlGroup;
-        private final long cpuCfsPeriodMicros; // completely fair scheduler enforcement period
-        private final long cpuCfsQuotaMicros; // completely fair scheduler quota
+        private final long cpuCfsPeriodMicros;
+        private final long cpuCfsQuotaMicros;
         private final CpuStat cpuStat;
 
+        /**
+         * The control group for the {@code cpuacct} subsystem.
+         *
+         * @return the control group
+         */
         public String getCpuAcctControlGroup() {
             return cpuAcctControlGroup;
         }
 
+        /**
+         * The total CPU time consumed by all tasks in the
+         * {@code cpuacct} control group from
+         * {@link Cgroup#cpuAcctControlGroup}.
+         *
+         * @return the total CPU time in nanoseconds
+         */
         public long getCpuAcctUsageNanos() {
             return cpuAcctUsageNanos;
         }
 
+        /**
+         * The control group for the {@code cpu} subsystem.
+         *
+         * @return the control group
+         */
         public String getCpuControlGroup() {
             return cpuControlGroup;
         }
 
+        /**
+         * The period of time for how frequently the control group from
+         * {@link Cgroup#cpuControlGroup} has its access to CPU
+         * resources reallocated.
+         *
+         * @return the period of time in microseconds
+         */
         public long getCpuCfsPeriodMicros() {
             return cpuCfsPeriodMicros;
         }
 
+        /**
+         * The total amount of time for which all tasks in the control
+         * group from {@link Cgroup#cpuControlGroup} can run in one
+         * period as represented by {@link Cgroup#cpuCfsPeriodMicros}.
+         *
+         * @return the total amount of time in microseconds
+         */
         public long getCpuCfsQuotaMicros() {
             return cpuCfsQuotaMicros;
         }
 
+        /**
+         * The CPU time statistics. See {@link CpuStat}.
+         *
+         * @return the CPU time statistics.
+         */
         public CpuStat getCpuStat() {
             return cpuStat;
         }
@@ -336,7 +375,7 @@ public class OsStats implements Writeable, ToXContent {
         }
 
         @Override
-        public void writeTo(StreamOutput out) throws IOException {
+        public void writeTo(final StreamOutput out) throws IOException {
             out.writeString(cpuAcctControlGroup);
             out.writeLong(cpuAcctUsageNanos);
             out.writeString(cpuControlGroup);
@@ -351,7 +390,7 @@ public class OsStats implements Writeable, ToXContent {
         }
 
         @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
             builder.startObject("cgroup");
             {
                 builder.startObject("cpuacct");
@@ -373,20 +412,41 @@ public class OsStats implements Writeable, ToXContent {
             return builder;
         }
 
+        /**
+         * Encapsulates CPU time statistics.
+         */
         public static class CpuStat implements Writeable, ToXContent {
 
             private final long numberOfElapsedPeriods;
             private final long numberOfTimesThrottled;
             private final long timeThrottledNanos;
 
+            /**
+             * The number of elapsed periods.
+             *
+             * @return the number of elapsed periods as measured by
+             * {@code cpu.cfs_period_us}
+             */
             public long getNumberOfElapsedPeriods() {
                 return numberOfElapsedPeriods;
             }
 
+            /**
+             * The number of times tasks in the control group have been
+             * throttled.
+             *
+             * @return the number of times
+             */
             public long getNumberOfTimesThrottled() {
                 return numberOfTimesThrottled;
             }
 
+            /**
+             * The total time duration for which tasks in the control
+             * group have been throttled.
+             *
+             * @return the total time in nanoseconds
+             */
             public long getTimeThrottledNanos() {
                 return timeThrottledNanos;
             }

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -358,7 +358,7 @@ public class OsStats implements Writeable, ToXContent {
             this.cpuControlGroup = cpuControlGroup;
             this.cpuCfsPeriodMicros = cpuCfsPeriodMicros;
             this.cpuCfsQuotaMicros = cpuCfsQuotaMicros;
-            this.cpuStat = cpuStat;
+            this.cpuStat = Objects.requireNonNull(cpuStat);
         }
 
         Cgroup(final StreamInput in) throws IOException {
@@ -367,11 +367,7 @@ public class OsStats implements Writeable, ToXContent {
             cpuControlGroup = in.readString();
             cpuCfsPeriodMicros = in.readLong();
             cpuCfsQuotaMicros = in.readLong();
-            if (!in.readBoolean()) {
-                cpuStat = null;
-            } else {
-                cpuStat = new CpuStat(in);
-            }
+            cpuStat = new CpuStat(in);
         }
 
         @Override
@@ -381,12 +377,7 @@ public class OsStats implements Writeable, ToXContent {
             out.writeString(cpuControlGroup);
             out.writeLong(cpuCfsPeriodMicros);
             out.writeLong(cpuCfsQuotaMicros);
-            if (cpuStat == null) {
-                out.writeBoolean(false);
-            } else {
-                out.writeBoolean(true);
-                cpuStat.writeTo(out);
-            }
+            cpuStat.writeTo(out);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -51,7 +51,7 @@ public class OsStats implements Writeable, ToXContent {
         this.cpu = new Cpu(in);
         this.mem = new Mem(in);
         this.swap = new Swap(in);
-        this.cgroup = new Cgroup(in);
+        this.cgroup = in.readOptionalWriteable(Cgroup::new);
     }
 
     @Override
@@ -60,7 +60,7 @@ public class OsStats implements Writeable, ToXContent {
         cpu.writeTo(out);
         mem.writeTo(out);
         swap.writeTo(out);
-        cgroup.writeTo(out);
+        out.writeOptionalWriteable(cgroup);
     }
 
     public long getTimestamp() {
@@ -111,7 +111,9 @@ public class OsStats implements Writeable, ToXContent {
         cpu.toXContent(builder, params);
         mem.toXContent(builder, params);
         swap.toXContent(builder, params);
-        cgroup.toXContent(builder, params);
+        if (cgroup != null) {
+            cgroup.toXContent(builder, params);
+        }
         builder.endObject();
         return builder;
     }

--- a/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -121,4 +121,8 @@ grant {
 
   // io stats on Linux
   permission java.io.FilePermission "/proc/diskstats", "read";
+
+  // control group stats on Linux
+  permission java.io.FilePermission "/proc/self/cgroup", "read";
+  permission java.io.FilePermission "/sys/fs/cgroup/cpuacct/-", "read";
 };

--- a/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -124,5 +124,6 @@ grant {
 
   // control group stats on Linux
   permission java.io.FilePermission "/proc/self/cgroup", "read";
+  permission java.io.FilePermission "/sys/fs/cgroup/cpu/-", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/cpuacct/-", "read";
 };

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -72,6 +72,24 @@ public class NodeStatsTests extends ESTestCase {
                     assertEquals(nodeStats.getOs().getMem().getFreePercent(), deserializedNodeStats.getOs().getMem().getFreePercent());
                     assertEquals(nodeStats.getOs().getMem().getUsedPercent(), deserializedNodeStats.getOs().getMem().getUsedPercent());
                     assertEquals(nodeStats.getOs().getCpu().getPercent(), deserializedNodeStats.getOs().getCpu().getPercent());
+                    assertEquals(
+                        nodeStats.getOs().getCgroup().getCpuAcctControlGroup(),
+                        deserializedNodeStats.getOs().getCgroup().getCpuAcctControlGroup());
+                    assertEquals(
+                        nodeStats.getOs().getCgroup().getCpuAcctUsageNanos(),
+                        deserializedNodeStats.getOs().getCgroup().getCpuAcctUsageNanos());
+                    assertEquals(
+                        nodeStats.getOs().getCgroup().getCpuCfsPeriodMicros(),
+                        deserializedNodeStats.getOs().getCgroup().getCpuCfsPeriodMicros());
+                    assertEquals(
+                        nodeStats.getOs().getCgroup().getCpuStat().getNumberOfElapsedPeriods(),
+                        deserializedNodeStats.getOs().getCgroup().getCpuStat().getNumberOfElapsedPeriods());
+                    assertEquals(
+                        nodeStats.getOs().getCgroup().getCpuStat().getNumberOfTimesThrottled(),
+                        deserializedNodeStats.getOs().getCgroup().getCpuStat().getNumberOfTimesThrottled());
+                    assertEquals(
+                        nodeStats.getOs().getCgroup().getCpuStat().getTimeThrottledNanos(),
+                        deserializedNodeStats.getOs().getCgroup().getCpuStat().getTimeThrottledNanos());
                     assertArrayEquals(nodeStats.getOs().getCpu().getLoadAverage(),
                             deserializedNodeStats.getOs().getCpu().getLoadAverage(), 0);
                 }
@@ -264,7 +282,14 @@ public class NodeStatsTests extends ESTestCase {
             }
             osStats = new OsStats(System.currentTimeMillis(), new OsStats.Cpu(randomShort(), loadAverages),
                     new OsStats.Mem(randomLong(), randomLong()),
-                    new OsStats.Swap(randomLong(), randomLong()));
+                    new OsStats.Swap(randomLong(), randomLong()),
+                    new OsStats.Cgroup(
+                        randomAsciiOfLength(8),
+                        randomPositiveLong(),
+                        randomAsciiOfLength(8),
+                        randomPositiveLong(),
+                        randomPositiveLong(),
+                        new OsStats.Cgroup.CpuStat(randomPositiveLong(), randomPositiveLong(), randomPositiveLong())));
         }
         ProcessStats processStats = frequently() ? new ProcessStats(randomPositiveLong(), randomPositiveLong(), randomPositiveLong(),
                 new ProcessStats.Cpu(randomShort(), randomPositiveLong()),

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -79,8 +79,14 @@ public class NodeStatsTests extends ESTestCase {
                         nodeStats.getOs().getCgroup().getCpuAcctUsageNanos(),
                         deserializedNodeStats.getOs().getCgroup().getCpuAcctUsageNanos());
                     assertEquals(
+                        nodeStats.getOs().getCgroup().getCpuControlGroup(),
+                        deserializedNodeStats.getOs().getCgroup().getCpuControlGroup());
+                    assertEquals(
                         nodeStats.getOs().getCgroup().getCpuCfsPeriodMicros(),
                         deserializedNodeStats.getOs().getCgroup().getCpuCfsPeriodMicros());
+                    assertEquals(
+                        nodeStats.getOs().getCgroup().getCpuCfsQuotaMicros(),
+                        deserializedNodeStats.getOs().getCgroup().getCpuCfsQuotaMicros());
                     assertEquals(
                         nodeStats.getOs().getCgroup().getCpuStat().getNumberOfElapsedPeriods(),
                         deserializedNodeStats.getOs().getCgroup().getCpuStat().getNumberOfElapsedPeriods());

--- a/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -22,9 +22,7 @@ package org.elasticsearch.monitor.os;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.test.ESTestCase;
 
-import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.Matchers.allOf;
@@ -146,14 +144,13 @@ public class OsProbeTests extends ESTestCase {
         assertThat(systemLoadAverage[2], equalTo(Double.parseDouble("1.99")));
     }
 
-    public void testCGroupProbe() {
-
+    public void testCgroupProbe() {
         final String hierarchy = randomAsciiOfLength(16);
 
         final OsProbe probe = new OsProbe() {
 
             @Override
-            List<String> readProcSelfCgroup() throws IOException {
+            List<String> readProcSelfCgroup() {
                 return Arrays.asList(
                     "11:freezer:/",
                     "10:net_cls,net_prio:/",
@@ -169,34 +166,29 @@ public class OsProbeTests extends ESTestCase {
             }
 
             @Override
-            List<String> readSysFsCgroupCpuAcctCpuAcctUsage(String path) throws IOException {
-                assertThat(path, equalTo("/" + hierarchy));
-                return Collections.singletonList("364869866063112");
+            String readSysFsCgroupCpuAcctCpuAcctUsage(String controlGroup) {
+                assertThat(controlGroup, equalTo("/" + hierarchy));
+                return "364869866063112";
             }
 
             @Override
-            List<String> readSysFsCgroupCpuAcctCpuCfsPeriod(String path) throws IOException {
-                assertThat(path, equalTo("/" + hierarchy));
-                return Collections.singletonList("100000");
+            String readSysFsCgroupCpuAcctCpuCfsPeriod(String controlGroup) {
+                assertThat(controlGroup, equalTo("/" + hierarchy));
+                return "100000";
             }
 
             @Override
-            List<String> readSysFsCgroupCpuAcctCpuAcctCfsQuota(String path) throws IOException {
-                assertThat(path, equalTo("/" + hierarchy));
-                return Collections.singletonList("50000");
+            String readSysFsCgroupCpuAcctCpuAcctCfsQuota(String controlGroup) {
+                assertThat(controlGroup, equalTo("/" + hierarchy));
+                return "50000";
             }
 
             @Override
-            List<String> readSysFsCgroupCpuAcctCpuStat(String path) throws IOException {
+            List<String> readSysFsCgroupCpuAcctCpuStat(String controlGroup) {
                 return Arrays.asList(
                     "nr_periods 17992",
                     "nr_throttled 1311",
                     "throttled_time 139298645489");
-            }
-
-            @Override
-            boolean shouldReadCgroups() {
-                return true;
             }
 
         };

--- a/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -145,6 +145,8 @@ public class OsProbeTests extends ESTestCase {
     }
 
     public void testCgroupProbe() {
+        assumeTrue("test runs on Linux only", Constants.LINUX);
+
         final String hierarchy = randomAsciiOfLength(16);
 
         final OsProbe probe = new OsProbe() {

--- a/core/src/test/java/org/elasticsearch/monitor/os/OsStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/os/OsStatsTests.java
@@ -36,7 +36,14 @@ public class OsStatsTests extends ESTestCase {
         OsStats.Cpu cpu = new OsStats.Cpu(randomShort(), loadAverages);
         OsStats.Mem mem = new OsStats.Mem(randomLong(), randomLong());
         OsStats.Swap swap = new OsStats.Swap(randomLong(), randomLong());
-        OsStats osStats = new OsStats(System.currentTimeMillis(), cpu, mem, swap);
+        OsStats.Cgroup cgroup = new OsStats.Cgroup(
+            randomAsciiOfLength(8),
+            randomPositiveLong(),
+            randomAsciiOfLength(8),
+            randomPositiveLong(),
+            randomPositiveLong(),
+            new OsStats.Cgroup.CpuStat(randomPositiveLong(), randomPositiveLong(), randomPositiveLong()));
+        OsStats osStats = new OsStats(System.currentTimeMillis(), cpu, mem, swap, cgroup);
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             osStats.writeTo(out);
@@ -49,7 +56,22 @@ public class OsStatsTests extends ESTestCase {
                 assertEquals(osStats.getMem().getTotal(), deserializedOsStats.getMem().getTotal());
                 assertEquals(osStats.getSwap().getFree(), deserializedOsStats.getSwap().getFree());
                 assertEquals(osStats.getSwap().getTotal(), deserializedOsStats.getSwap().getTotal());
+                assertEquals(osStats.getCgroup().getCpuAcctControlGroup(), deserializedOsStats.getCgroup().getCpuAcctControlGroup());
+                assertEquals(osStats.getCgroup().getCpuAcctUsageNanos(), deserializedOsStats.getCgroup().getCpuAcctUsageNanos());
+                assertEquals(osStats.getCgroup().getCpuControlGroup(), deserializedOsStats.getCgroup().getCpuControlGroup());
+                assertEquals(osStats.getCgroup().getCpuCfsPeriodMicros(), deserializedOsStats.getCgroup().getCpuCfsPeriodMicros());
+                assertEquals(osStats.getCgroup().getCpuCfsQuotaMicros(), deserializedOsStats.getCgroup().getCpuCfsQuotaMicros());
+                assertEquals(
+                    osStats.getCgroup().getCpuStat().getNumberOfElapsedPeriods(),
+                    deserializedOsStats.getCgroup().getCpuStat().getNumberOfElapsedPeriods());
+                assertEquals(
+                    osStats.getCgroup().getCpuStat().getNumberOfTimesThrottled(),
+                    deserializedOsStats.getCgroup().getCpuStat().getNumberOfTimesThrottled());
+                assertEquals(
+                    osStats.getCgroup().getCpuStat().getTimeThrottledNanos(),
+                    deserializedOsStats.getCgroup().getCpuStat().getTimeThrottledNanos());
             }
         }
     }
+
 }

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -217,6 +217,38 @@ the operating system:
 `os.swap.used_in_bytes`::
 	Amount of used swap space in bytes
 
+`os.cgroup.cpuacct.control_group` (Linux only)::
+    The `cpuacct` control group to which the Elasticsearch process
+    belongs
+
+`os.cgroup.cpuacct.usage` (Linux only)::
+    The total CPU time (in nanoseconds) consumed by all tasks in the
+    same cgroup as the Elasticsearch process
+
+`os.cgroup.cpu.control_group` (Linux only)::
+    The `cpu` control group to which the Elasticsearch process belongs
+
+`os.cgroup.cpu.cfs_period_micros` (Linux only)::
+    The period of time (in microseconds) for how regularly all tasks in
+    the same cgroup as the Elasticsearch process should have their
+    access to CPU resources reallocated.
+
+`os.cgroup.cpu.cfs_quota_micros` (Linux only)::
+    The total amount of time (in microseconds) for which all tasks in
+    the same cgroup as the Elasticsearch process can run during one
+    period `os.cgroup.cpu.cfs_period_micros`
+
+`os.cgroup.cpu.stat.number_of_elapsed_periods` (Linux only)::
+    The number of reporting periods (as specified by
+    `os.cgroup.cpu.cfs_period_micros`) that have elapsed
+
+`os.cgroup.cpu.stat.number_of_times_throttled` (Linux only)::
+    The number of times all tasks in the same cgroup as the
+    Elasticsearch process have been throttled.
+
+`os.cgroup.cpu.stat.time_throttled_nanos` (Linux only)::
+    The total amount of time (in nanoseconds) for which all tasks in
+    the same cgroup as the Elasticsearch process have been throttled.
 
 [float]
 [[process-stats]]


### PR DESCRIPTION
This commit adds basic cgroup CPU metrics to the node stats API.
