### PR TITLE
Remove more equivalents of the now method from the Painless whitelist.

### DIFF
--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.time.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.time.txt
@@ -29,14 +29,6 @@ class Clock -> java.time.Clock extends Object {
   ZoneId getZone()
   Instant instant()
   long millis()
-  Clock offset(Clock,Duration)
-  Clock system(ZoneId)
-  Clock systemDefaultZone()
-  Clock systemUTC()
-  Clock tick(Clock,Duration)
-  Clock tickMinutes(ZoneId)
-  Clock tickSeconds(ZoneId)
-  Clock withZone(ZoneId)
 }
 
 class Duration -> java.time.Duration extends Comparable,TemporalAmount,Object {

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.time.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.time.txt
@@ -29,6 +29,8 @@ class Clock -> java.time.Clock extends Object {
   ZoneId getZone()
   Instant instant()
   long millis()
+  Clock offset(Clock,Duration)
+  Clock tick(Clock,Duration)
 }
 
 class Duration -> java.time.Duration extends Comparable,TemporalAmount,Object {


### PR DESCRIPTION
As the title says.
