### PR TITLE
[DOC] Fix HttpHost constructor arguments

### DIFF
--- a/docs/java-rest/usage.asciidoc
+++ b/docs/java-rest/usage.asciidoc
@@ -51,8 +51,8 @@ https://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/org/apache/http/Ht
 [source,java]
 --------------------------------------------------
 RestClient restClient = RestClient.builder(
-        new HttpHost("http", "localhost", 9200),
-        new HttpHost("http", "localhost", 9201)).build();
+        new HttpHost("localhost", 9200, "http"),
+        new HttpHost("localhost", 9201, "http")).build();
 --------------------------------------------------
 
 The `RestClient` class is thread-safe and ideally has the same lifecycle as


### PR DESCRIPTION
Protocol is the last argument.
- Oficial API doc: https://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/org/apache/http/HttpHost.html
- Your own use here: https://github.com/elastic/elasticsearch/blob/7560101ec73331acb39a042bde6130e59e4bb630/client/rest/src/test/java/org/elasticsearch/client/RequestLoggerTests.java#L54
