### PR TITLE
Fix NPE when parsing InnerHits with highlight query

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/IndexQueryParserService.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IndexQueryParserService.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import com.google.common.collect.ImmutableMap;
+
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.CloseableThreadLocal;
 import org.elasticsearch.Version;
@@ -232,6 +233,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
     @Nullable
     public ParsedQuery parseInnerFilter(XContentParser parser) throws IOException {
         QueryParseContext context = cache.get();
+        XContentParser originalParser = context.parser();
         context.reset(parser);
         try {
             Query filter = context.parseInnerFilter();
@@ -240,18 +242,19 @@ public class IndexQueryParserService extends AbstractIndexComponent {
             }
             return new ParsedQuery(filter, context.copyNamedQueries());
         } finally {
-            context.reset(null);
+            context.reset(originalParser);
         }
     }
 
     @Nullable
     public Query parseInnerQuery(XContentParser parser) throws IOException {
         QueryParseContext context = cache.get();
+        XContentParser originalParser = context.parser();
         context.reset(parser);
         try {
             return context.parseInnerQuery();
         } finally {
-            context.reset(null);
+            context.reset(originalParser);
         }
     }
 
@@ -314,6 +317,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
     }
 
     private ParsedQuery innerParse(QueryParseContext parseContext, XContentParser parser) throws IOException, QueryParsingException {
+        XContentParser originalParser = parseContext.parser();
         parseContext.reset(parser);
         try {
             parseContext.parseFieldMatcher(parseFieldMatcher);
@@ -323,7 +327,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
             }
             return new ParsedQuery(query, parseContext.copyNamedQueries());
         } finally {
-            parseContext.reset(null);
+            parseContext.reset(originalParser);
         }
     }
 


### PR DESCRIPTION
When parsing nested queries or filters in IndexQueryParserService, the parser on the cached (or provided) QueryParseContext gets reset while parsing the inner element and never gets reset to the original parser that was present before the reset. In #21061 this cause strange NPEs while parsing InnerHits with highlighting where the highlighter itself containes an inner query. On 5.0 we already fixed this problem by cleaning up QueryParseContext internals. This PR captures the original parser present before the reset and restores it after the inner parsing is done.

Closes #21061
