### PR TITLE
Fix NPE in SearchContext.toString()

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -397,7 +397,11 @@ public abstract class SearchContext extends AbstractRefCounted implements Releas
             result.append("searchType=[").append(searchType()).append("]");
         }
         if (scrollContext() != null) {
-            result.append("scroll=[").append(scrollContext().scroll.keepAlive()).append("]");
+            if (scrollContext().scroll != null) {
+                result.append("scroll=[").append(scrollContext().scroll.keepAlive()).append("]");
+            } else {
+                result.append("scroll=[null]");
+            }
         }
         result.append(" query=[").append(query()).append("]");
         return result.toString();


### PR DESCRIPTION
Fixes NPE in SearchContext.toString() for user requests that contain scroll id but not scroll timeout.

It doesn't seem to do any harm to production code, but it was kind of annoying to see all these NPE error messages while debugging.
