### PR TITLE
Disallow `VersionType.FORCE` for GetRequest

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/get/GetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/GetRequest.java
@@ -101,6 +101,9 @@ public class GetRequest extends SingleShardRequest<GetRequest> implements Realti
             validationException = ValidateActions.addValidationError("illegal version value [" + version + "] for version type [" + versionType.name() + "]",
                     validationException);
         }
+        if (versionType == VersionType.FORCE) {
+            validationException = ValidateActions.addValidationError("version type [force] may no longer be used", validationException);
+        }
         return validationException;
     }
 


### PR DESCRIPTION
This doesn't make much sense to have at all, since a user can do a `GET`
request without a version of they want to get it unconditionally.

Relates to #20995
