### PR TITLE
MetaData: Add method to retrieve concrete index meta data

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -74,6 +74,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.unmodifiableSet;
 import static org.elasticsearch.common.settings.Settings.readSettingsFromStream;
@@ -305,6 +306,39 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
             }
         }
         return aliases.length == 0;
+    }
+
+    /**
+     * Allows to return the concrete index meta data of the index specified or of the
+     * index that is hidden behind the alias specified
+     *
+     * @param aliasOrIndexName An alias or an index name
+     * @return The index metadata of the concrete index
+     * @throws IllegalArgumentException if the parameter points to an alias with more than one index
+     * @throws IndexNotFoundException if the parameter points neither to an index nor to an alias
+     */
+    public IndexMetaData findConcreteIndexMetaData(String aliasOrIndexName) {
+        assert aliasOrIndexName != null;
+        AliasOrIndex aliasOrIndex = getAliasAndIndexLookup().get(aliasOrIndexName);
+        if (aliasOrIndex == null) {
+            throw new IndexNotFoundException(aliasOrIndexName);
+        }
+
+        // regular index
+        if (indices.containsKey(aliasOrIndexName)) {
+            return indices.get(aliasOrIndexName);
+        }
+
+        // alias
+        if (aliasOrIndex.getIndices().size() == 1) {
+            String concreteIndex = aliasOrIndex.getIndices().get(0).getIndex().getName();
+            return indices.get(concreteIndex);
+        } else {
+            List<String> indices = aliasOrIndex.getIndices().stream()
+                    .map(IndexMetaData::getIndex).map(Index::getName).sorted().collect(Collectors.toList());
+            throw new IllegalArgumentException("alias [" + aliasOrIndexName + "] points to indices " + indices
+                    + ", cannot get concrete index");
+        }
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -185,5 +186,61 @@ public class MetaDataTests extends ESTestCase {
         originalMeta.writeTo(out);
         final MetaData fromStreamMeta = MetaData.PROTO.readFrom(out.bytes().streamInput());
         assertThat(fromStreamMeta.indexGraveyard(), equalTo(fromStreamMeta.indexGraveyard()));
+    }
+
+    public void testGetConcreteIndexWorksOnIndex() throws Exception {
+        IndexMetaData.Builder builder = IndexMetaData.builder("my-index")
+                .settings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT))
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .putAlias(AliasMetaData.builder("my-alias").build());
+
+        MetaData metaData = MetaData.builder().put(builder).build();
+
+        IndexMetaData indexMetaData = metaData.findConcreteIndexMetaData("my-index");
+        assertThat(indexMetaData.getIndex().getName(), is("my-index"));
+    }
+
+    public void testGetConcreteIndexWorksOnAlias() throws Exception {
+        IndexMetaData.Builder builder = IndexMetaData.builder("my-index")
+                .settings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT))
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .putAlias(AliasMetaData.builder("my-alias").build());
+
+        MetaData metaData = MetaData.builder().put(builder).build();
+
+        IndexMetaData indexMetaData = metaData.findConcreteIndexMetaData("my-alias");
+        assertThat(indexMetaData.getIndex().getName(), is("my-index"));
+    }
+
+    public void testGetConcreteIndexFailsForNoIndex() throws Exception {
+        IndexMetaData.Builder builder = IndexMetaData.builder("my-index")
+                .settings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT))
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .putAlias(AliasMetaData.builder("my-alias").build());
+
+        MetaData metaData = MetaData.builder().put(builder).build();
+        IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> metaData.findConcreteIndexMetaData("does-not-exist"));
+        assertThat(e.getIndex().getName(), is("does-not-exist"));
+    }
+
+    public void testGetConcreteIndexFailsWithTwoAliases() throws Exception {
+        IndexMetaData.Builder myIndexBuilder = IndexMetaData.builder("my-index")
+                .settings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT))
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .putAlias(AliasMetaData.builder("my-alias").build());
+
+        IndexMetaData.Builder myOtherIndexBuilder = IndexMetaData.builder("my-other-index")
+                .settings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT))
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .putAlias(AliasMetaData.builder("my-alias").build());
+
+        MetaData metaData = MetaData.builder().put(myIndexBuilder).put(myOtherIndexBuilder).build();
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> metaData.findConcreteIndexMetaData("my-alias"));
+        assertThat(e.getMessage(), is("alias [my-alias] points to indices [my-index, my-other-index], cannot get concrete index"));
     }
 }


### PR DESCRIPTION
... regardless if you specify an index or an alias.

If an alias not equal than one index is specified, an IllegalArgumentException
is thrown. An IndexNotFoundException is thrown if the specified alias or index
name does not exist.

This is intended as a helper method in cases, the user usually knows that there
should be only one index hidden behind an alias (i.e. plugins).
