### PR TITLE
Balance step in BalancedShardsAllocator for a single shard

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -134,7 +134,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
      * shard.
      */
     public RebalanceDecision decideRebalance(final ShardRouting shard, final RoutingAllocation allocation) {
-        allocation.debugDecision();
+        allocation.debugDecision(true);
         return new Balancer(logger, allocation, weightFunction, threshold).decideRebalance(shard);
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -338,7 +338,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
                 String explanation = null;
                 Type explanationCause = null;
                 for (Decision subDecision : canRebalance.getDecisions()) {
-                    if ((subDecision.type() == Type.NO && (explanation != null || explanationCause == Type.THROTTLE))
+                    if ((subDecision.type() == Type.NO && (explanation == null || explanationCause == Type.THROTTLE))
                             || (subDecision.type() == Type.THROTTLE && explanation == null)) {
                         explanation = subDecision.getExplanation();
                         explanationCause = subDecision.type();

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -424,7 +424,8 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
 
 
             if (canRebalance.type() != Type.YES) {
-                return new RebalanceDecision(canRebalance, Type.NO, "rebalancing is not allowed", null, nodeDecisions, currentWeight);
+                return new RebalanceDecision(canRebalance, canRebalance.type(), "rebalancing is not allowed", null,
+                                                nodeDecisions, currentWeight);
             } else {
                 return RebalanceDecision.decision(canRebalance, rebalanceDecisionType, assignedNodeId,
                                                   nodeDecisions, currentWeight, threshold);

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -334,20 +334,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
 
             Decision canRebalance = allocation.deciders().canRebalance(shard, allocation);
             if (canRebalance.type() != Type.YES) {
-                // pick the first NO rebalance decision and use its explanation for the final explanation
-                String explanation = null;
-                Type explanationCause = null;
-                for (Decision subDecision : canRebalance.getDecisions()) {
-                    if ((subDecision.type() == Type.NO && (explanation == null || explanationCause == Type.THROTTLE))
-                            || (subDecision.type() == Type.THROTTLE && explanation == null)) {
-                        explanation = subDecision.getExplanation();
-                        explanationCause = subDecision.type();
-                        if (explanationCause == Type.NO) {
-                            break; // we already have an explanation from a NO decision, so no need to check decisions anymore
-                        }
-                    }
-                }
-                return new RebalanceDecision(canRebalance, Type.NO, explanation);
+                return new RebalanceDecision(canRebalance, Type.NO, "rebalancing is not allowed");
             }
 
             if (allocation.hasPendingAsyncFetch()) {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -134,6 +134,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
      * shard.
      */
     public RebalanceDecision decideRebalance(final ShardRouting shard, final RoutingAllocation allocation) {
+        allocation.debugDecision();
         return new Balancer(logger, allocation, weightFunction, threshold).decideRebalance(shard);
     }
 
@@ -339,7 +340,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
                 for (Decision subDecision : canRebalance.getDecisions()) {
                     if ((subDecision.type() == Type.NO && (explanation != null || explanationCause == Type.THROTTLE))
                             || (subDecision.type() == Type.THROTTLE && explanation == null)) {
-                        explanation = subDecision.label();
+                        explanation = subDecision.getExplanation();
                         explanationCause = subDecision.type();
                     }
                 }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
@@ -165,6 +165,12 @@ public abstract class Decision implements ToXContent {
     public abstract String label();
 
     /**
+     * Returns the explanation string, fully formatted.
+     */
+    @Nullable
+    public abstract String getExplanation();
+
+    /**
      * Return the list of all decisions that make up this decision
      */
     public abstract List<Decision> getDecisions();
@@ -221,12 +227,11 @@ public abstract class Decision implements ToXContent {
             return Collections.singletonList(this);
         }
 
-        /**
-         * Returns the explanation string, fully formatted. Only formats the string once
-         */
+        @Override
         @Nullable
         public String getExplanation() {
             if (explanationString == null && explanation != null) {
+                // Only formats the string once
                 explanationString = String.format(Locale.ROOT, explanation, explanationParams);
             }
             return this.explanationString;
@@ -312,6 +317,13 @@ public abstract class Decision implements ToXContent {
         @Nullable
         public String label() {
             // Multi decisions have no labels
+            return null;
+        }
+
+        @Override
+        @Nullable
+        public String getExplanation() {
+            // multi-decisions have no explanation
             return null;
         }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
@@ -165,12 +165,6 @@ public abstract class Decision implements ToXContent {
     public abstract String label();
 
     /**
-     * Returns the explanation string, fully formatted.
-     */
-    @Nullable
-    public abstract String getExplanation();
-
-    /**
      * Return the list of all decisions that make up this decision
      */
     public abstract List<Decision> getDecisions();
@@ -227,11 +221,12 @@ public abstract class Decision implements ToXContent {
             return Collections.singletonList(this);
         }
 
-        @Override
+        /**
+         * Returns the explanation string, fully formatted.  Only formats the string once.
+         */
         @Nullable
         public String getExplanation() {
             if (explanationString == null && explanation != null) {
-                // Only formats the string once
                 explanationString = String.format(Locale.ROOT, explanation, explanationParams);
             }
             return this.explanationString;
@@ -317,13 +312,6 @@ public abstract class Decision implements ToXContent {
         @Nullable
         public String label() {
             // Multi decisions have no labels
-            return null;
-        }
-
-        @Override
-        @Nullable
-        public String getExplanation() {
-            // multi-decisions have no explanation
             return null;
         }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
@@ -115,21 +115,21 @@ public class EnableAllocationDecider extends AllocationDecider {
             case ALL:
                 return allocation.decision(Decision.YES, NAME, "all allocations are allowed");
             case NONE:
-                return allocation.decision(Decision.NO, NAME, "no allocations are allowed due to " + setting(enable, usedIndexSetting));
+                return allocation.decision(Decision.NO, NAME, "no allocations are allowed due to {}", setting(enable, usedIndexSetting));
             case NEW_PRIMARIES:
                 if (shardRouting.primary() && shardRouting.active() == false &&
                     shardRouting.recoverySource().getType() != RecoverySource.Type.EXISTING_STORE) {
                     return allocation.decision(Decision.YES, NAME, "new primary allocations are allowed");
                 } else {
-                    return allocation.decision(Decision.NO, NAME, "non-new primary allocations are forbidden due to " +
-                                                                      setting(enable, usedIndexSetting));
+                    return allocation.decision(Decision.NO, NAME, "non-new primary allocations are forbidden due to {}",
+                                                setting(enable, usedIndexSetting));
                 }
             case PRIMARIES:
                 if (shardRouting.primary()) {
                     return allocation.decision(Decision.YES, NAME, "primary allocations are allowed");
                 } else {
-                    return allocation.decision(Decision.NO, NAME, "replica allocations are forbidden due to " +
-                                                                      setting(enable, usedIndexSetting));
+                    return allocation.decision(Decision.NO, NAME, "replica allocations are forbidden due to {}",
+                                                setting(enable, usedIndexSetting));
                 }
             default:
                 throw new IllegalStateException("Unknown allocation option");
@@ -156,20 +156,20 @@ public class EnableAllocationDecider extends AllocationDecider {
             case ALL:
                 return allocation.decision(Decision.YES, NAME, "all rebalancing is allowed");
             case NONE:
-                return allocation.decision(Decision.NO, NAME, "no rebalancing is allowed due to " + setting(enable, usedIndexSetting));
+                return allocation.decision(Decision.NO, NAME, "no rebalancing is allowed due to {}", setting(enable, usedIndexSetting));
             case PRIMARIES:
                 if (shardRouting.primary()) {
                     return allocation.decision(Decision.YES, NAME, "primary rebalancing is allowed");
                 } else {
-                    return allocation.decision(Decision.NO, NAME, "replica rebalancing is forbidden due to " +
-                                                                      setting(enable, usedIndexSetting));
+                    return allocation.decision(Decision.NO, NAME, "replica rebalancing is forbidden due to {}",
+                                                setting(enable, usedIndexSetting));
                 }
             case REPLICAS:
                 if (shardRouting.primary() == false) {
                     return allocation.decision(Decision.YES, NAME, "replica rebalancing is allowed");
                 } else {
-                    return allocation.decision(Decision.NO, NAME, "primary rebalancing is forbidden due to " +
-                                                                      setting(enable, usedIndexSetting));
+                    return allocation.decision(Decision.NO, NAME, "primary rebalancing is forbidden due to {}",
+                                                setting(enable, usedIndexSetting));
                 }
             default:
                 throw new IllegalStateException("Unknown rebalance option");

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
@@ -103,28 +103,33 @@ public class EnableAllocationDecider extends AllocationDecider {
 
         final IndexMetaData indexMetaData = allocation.metaData().getIndexSafe(shardRouting.index());
         final Allocation enable;
+        final boolean usedIndexSetting;
         if (INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.exists(indexMetaData.getSettings())) {
             enable = INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.get(indexMetaData.getSettings());
+            usedIndexSetting = true;
         } else {
             enable = this.enableAllocation;
+            usedIndexSetting = false;
         }
         switch (enable) {
             case ALL:
                 return allocation.decision(Decision.YES, NAME, "all allocations are allowed");
             case NONE:
-                return allocation.decision(Decision.NO, NAME, "no allocations are allowed");
+                return allocation.decision(Decision.NO, NAME, "no allocations are allowed due to " + setting(enable, usedIndexSetting));
             case NEW_PRIMARIES:
                 if (shardRouting.primary() && shardRouting.active() == false &&
                     shardRouting.recoverySource().getType() != RecoverySource.Type.EXISTING_STORE) {
                     return allocation.decision(Decision.YES, NAME, "new primary allocations are allowed");
                 } else {
-                    return allocation.decision(Decision.NO, NAME, "non-new primary allocations are forbidden");
+                    return allocation.decision(Decision.NO, NAME, "non-new primary allocations are forbidden due to " +
+                                                                      setting(enable, usedIndexSetting));
                 }
             case PRIMARIES:
                 if (shardRouting.primary()) {
                     return allocation.decision(Decision.YES, NAME, "primary allocations are allowed");
                 } else {
-                    return allocation.decision(Decision.NO, NAME, "replica allocations are forbidden");
+                    return allocation.decision(Decision.NO, NAME, "replica allocations are forbidden due to " +
+                                                                      setting(enable, usedIndexSetting));
                 }
             default:
                 throw new IllegalStateException("Unknown allocation option");
@@ -139,31 +144,58 @@ public class EnableAllocationDecider extends AllocationDecider {
 
         Settings indexSettings = allocation.metaData().getIndexSafe(shardRouting.index()).getSettings();
         final Rebalance enable;
+        final boolean usedIndexSetting;
         if (INDEX_ROUTING_REBALANCE_ENABLE_SETTING.exists(indexSettings)) {
             enable = INDEX_ROUTING_REBALANCE_ENABLE_SETTING.get(indexSettings);
+            usedIndexSetting = true;
         } else {
             enable = this.enableRebalance;
+            usedIndexSetting = false;
         }
         switch (enable) {
             case ALL:
                 return allocation.decision(Decision.YES, NAME, "all rebalancing is allowed");
             case NONE:
-                return allocation.decision(Decision.NO, NAME, "no rebalancing is allowed");
+                return allocation.decision(Decision.NO, NAME, "no rebalancing is allowed due to " + setting(enable, usedIndexSetting));
             case PRIMARIES:
                 if (shardRouting.primary()) {
                     return allocation.decision(Decision.YES, NAME, "primary rebalancing is allowed");
                 } else {
-                    return allocation.decision(Decision.NO, NAME, "replica rebalancing is forbidden");
+                    return allocation.decision(Decision.NO, NAME, "replica rebalancing is forbidden due to " +
+                                                                      setting(enable, usedIndexSetting));
                 }
             case REPLICAS:
                 if (shardRouting.primary() == false) {
                     return allocation.decision(Decision.YES, NAME, "replica rebalancing is allowed");
                 } else {
-                    return allocation.decision(Decision.NO, NAME, "primary rebalancing is forbidden");
+                    return allocation.decision(Decision.NO, NAME, "primary rebalancing is forbidden due to " +
+                                                                      setting(enable, usedIndexSetting));
                 }
             default:
                 throw new IllegalStateException("Unknown rebalance option");
         }
+    }
+
+    private static String setting(Allocation allocation, boolean usedIndexSetting) {
+        StringBuilder buf = new StringBuilder("[");
+        if (usedIndexSetting) {
+            buf.append(INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.getKey());
+        } else {
+            buf.append(CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey());
+        }
+        buf.append("=").append(allocation.toString().toLowerCase(Locale.ROOT)).append("]");
+        return buf.toString();
+    }
+
+    private static String setting(Rebalance rebalance, boolean usedIndexSetting) {
+        StringBuilder buf = new StringBuilder("[");
+        if (usedIndexSetting) {
+            buf.append(INDEX_ROUTING_REBALANCE_ENABLE_SETTING.getKey());
+        } else {
+            buf.append(CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey());
+        }
+        buf.append("=").append(rebalance.toString().toLowerCase(Locale.ROOT)).append("]");
+        return buf.toString();
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
@@ -157,7 +157,7 @@ public class ClusterStateCreationUtils {
             nodes.add(node.getId());
         }
         discoBuilder.localNodeId(newNode(0).getId());
-        discoBuilder.masterNodeId(newNode(0).getId());
+        discoBuilder.masterNodeId(randomFrom(nodes));
         IndexMetaData indexMetaData = IndexMetaData.builder(index).settings(Settings.builder()
             .put(SETTING_VERSION_CREATED, Version.CURRENT)
             .put(SETTING_NUMBER_OF_SHARDS, numberOfPrimaries).put(SETTING_NUMBER_OF_REPLICAS, 0)

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
@@ -151,13 +151,13 @@ public class ClusterStateCreationUtils {
     public static ClusterState state(String index, final int numberOfNodes, final int numberOfPrimaries) {
         DiscoveryNodes.Builder discoBuilder = DiscoveryNodes.builder();
         Set<String> nodes = new HashSet<>();
-        for (int i = 0; i < numberOfNodes + 1; i++) {
+        for (int i = 0; i < numberOfNodes; i++) {
             final DiscoveryNode node = newNode(i);
             discoBuilder = discoBuilder.add(node);
             nodes.add(node.getId());
         }
         discoBuilder.localNodeId(newNode(0).getId());
-        discoBuilder.masterNodeId(newNode(1).getId()); // we need a non-local master to test shard failures
+        discoBuilder.masterNodeId(newNode(0).getId());
         IndexMetaData indexMetaData = IndexMetaData.builder(index).settings(Settings.builder()
             .put(SETTING_VERSION_CREATED, Version.CURRENT)
             .put(SETTING_NUMBER_OF_SHARDS, numberOfPrimaries).put(SETTING_NUMBER_OF_REPLICAS, 0)
@@ -179,6 +179,53 @@ public class ClusterStateCreationUtils {
         state.nodes(discoBuilder);
         state.metaData(MetaData.builder().put(indexMetaData, false).generateClusterUuidIfNeeded());
         state.routingTable(RoutingTable.builder().add(indexRoutingTable).build());
+        return state.build();
+    }
+
+
+
+    /**
+     * Creates cluster state with the given indices, each index containing #(numberOfPrimaries)
+     * started primary shards and no replicas.  The cluster state contains #(numberOfNodes) nodes
+     * and assigns primaries to those nodes.
+     */
+    public static ClusterState state(final int numberOfNodes, final String[] indices, final int numberOfPrimaries) {
+        DiscoveryNodes.Builder discoBuilder = DiscoveryNodes.builder();
+        Set<String> nodes = new HashSet<>();
+        for (int i = 0; i < numberOfNodes; i++) {
+            final DiscoveryNode node = newNode(i);
+            discoBuilder = discoBuilder.add(node);
+            nodes.add(node.getId());
+        }
+        discoBuilder.localNodeId(newNode(0).getId());
+        discoBuilder.masterNodeId(newNode(0).getId());
+        MetaData.Builder metaData = MetaData.builder();
+        RoutingTable.Builder routingTable = RoutingTable.builder();
+        for (String index : indices) {
+            IndexMetaData indexMetaData = IndexMetaData.builder(index).settings(Settings.builder()
+                .put(SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(SETTING_NUMBER_OF_SHARDS, numberOfPrimaries).put(SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(SETTING_CREATION_DATE, System.currentTimeMillis())).build();
+
+            RoutingTable.Builder routing = new RoutingTable.Builder();
+            routing.addAsNew(indexMetaData);
+
+            IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(indexMetaData.getIndex());
+            for (int i = 0; i < 1; i++) {
+                ShardId shardId = new ShardId(indexMetaData.getIndex(), i);
+                IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(shardId);
+                indexShardRoutingBuilder.addShard(
+                    TestShardRouting.newShardRouting(shardId, randomFrom(nodes), true, ShardRoutingState.STARTED));
+                indexRoutingTable.addIndexShard(indexShardRoutingBuilder.build());
+            }
+
+            metaData.put(indexMetaData, false);
+            routingTable.add(indexRoutingTable);
+        }
+        ClusterState.Builder state = ClusterState.builder(new ClusterName("test"));
+        state.nodes(discoBuilder);
+        state.metaData(metaData.generateClusterUuidIfNeeded().build());
+        state.routingTable(routingTable.build());
         return state.build();
     }
 

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
@@ -145,7 +145,8 @@ public class ClusterStateCreationUtils {
     }
 
     /**
-     * Creates cluster state with and index that has #(shardStates) started primary shards and no replicas, using the given number of nodes.
+     * Creates cluster state with an index that has #(numberOfPrimaries) primary shards in the started state and no replicas.
+     * The cluster state contains #(numberOfNodes) nodes and assigns primaries to those nodes.
      */
     public static ClusterState state(String index, final int numberOfNodes, final int numberOfPrimaries) {
         DiscoveryNodes.Builder discoBuilder = DiscoveryNodes.builder();
@@ -157,11 +158,10 @@ public class ClusterStateCreationUtils {
         }
         discoBuilder.localNodeId(newNode(0).getId());
         discoBuilder.masterNodeId(newNode(1).getId()); // we need a non-local master to test shard failures
-        final int primaryTerm = 1 + randomInt(200);
         IndexMetaData indexMetaData = IndexMetaData.builder(index).settings(Settings.builder()
             .put(SETTING_VERSION_CREATED, Version.CURRENT)
             .put(SETTING_NUMBER_OF_SHARDS, numberOfPrimaries).put(SETTING_NUMBER_OF_REPLICAS, 0)
-            .put(SETTING_CREATION_DATE, System.currentTimeMillis())).primaryTerm(0, primaryTerm).build();
+            .put(SETTING_CREATION_DATE, System.currentTimeMillis())).build();
 
         RoutingTable.Builder routing = new RoutingTable.Builder();
         routing.addAsNew(indexMetaData);

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
@@ -211,7 +211,7 @@ public class ClusterStateCreationUtils {
             routing.addAsNew(indexMetaData);
 
             IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(indexMetaData.getIndex());
-            for (int i = 0; i < 1; i++) {
+            for (int i = 0; i < numberOfPrimaries; i++) {
                 ShardId shardId = new ShardId(indexMetaData.getIndex(), i);
                 IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(shardId);
                 indexShardRoutingBuilder.addShard(

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
@@ -91,7 +91,7 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
         assertNotEquals(Type.YES, rebalanceDecision.getCanRebalanceDecision().type());
         assertEquals(Type.NO, rebalanceDecision.getFinalDecisionType());
         assertEquals("rebalancing is not allowed", rebalanceDecision.getFinalExplanation());
-        assertNull(rebalanceDecision.getNodeDecisions());
+        assertNotNull(rebalanceDecision.getNodeDecisions());
         assertNull(rebalanceDecision.getAssignedNodeId());
         assertEquals(1, rebalanceDecision.getCanRebalanceDecision().getDecisions().size());
         for (Decision subDecision : rebalanceDecision.getCanRebalanceDecision().getDecisions()) {

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
@@ -77,7 +77,7 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
         AllocationDecider noRebalanceDecider = new AllocationDecider(Settings.EMPTY) {
             @Override
             public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
-                return randomFrom(Decision.NO, Decision.THROTTLE);
+                return allocation.decision(randomFrom(Decision.NO, Decision.THROTTLE), "TEST", "foobar");
             }
         };
         BalancedShardsAllocator allocator = new BalancedShardsAllocator(Settings.EMPTY);
@@ -87,7 +87,7 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
             new AllocationDeciders(Settings.EMPTY, Collections.singleton(noRebalanceDecider)), clusterState));
         assertNotEquals(Type.YES, rebalanceDecision.getCanRebalanceDecision().type());
         assertEquals(Type.NO, rebalanceDecision.getFinalDecisionType());
-        assertEquals("rebalancing is not allowed", rebalanceDecision.getFinalExplanation());
+        assertEquals("foobar", rebalanceDecision.getFinalExplanation());
         assertNull(rebalanceDecision.getNodeDecisions());
         assertNull(rebalanceDecision.getAssignedNodeId());
     }
@@ -166,10 +166,6 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
     }
 
     private RoutingAllocation newRoutingAllocation(AllocationDeciders deciders, ClusterState state) {
-        RoutingAllocation allocation = new RoutingAllocation(
-            deciders, new RoutingNodes(state, false), state, ClusterInfo.EMPTY, System.nanoTime(), false
-        );
-        allocation.debugDecision();
-        return allocation;
+        return new RoutingAllocation(deciders, new RoutingNodes(state, false), state, ClusterInfo.EMPTY, System.nanoTime(), false);
     }
 }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
+import org.hamcrest.Matchers;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -67,7 +68,7 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
         RebalanceDecision rebalanceDecision = allocator.decideRebalance(shard, routingAllocation);
         assertNotNull(rebalanceDecision.getCanRebalanceDecision());
         assertEquals(Type.NO, rebalanceDecision.getFinalDecisionType());
-        assertEquals("cannot rebalance due to in-flight shard store fetches", rebalanceDecision.getFinalExplanation());
+        assertThat(rebalanceDecision.getFinalExplanation(), Matchers.startsWith("cannot rebalance due to in-flight shard store fetches"));
         assertNull(rebalanceDecision.getNodeDecisions());
         assertNull(rebalanceDecision.getAssignedNodeId());
     }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
@@ -222,7 +222,11 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
     }
 
     private RoutingAllocation newRoutingAllocation(AllocationDeciders deciders, ClusterState state) {
-        return new RoutingAllocation(deciders, new RoutingNodes(state, false), state, ClusterInfo.EMPTY, System.nanoTime(), false);
+        RoutingAllocation allocation = new RoutingAllocation(
+            deciders, new RoutingNodes(state, false), state, ClusterInfo.EMPTY, System.nanoTime(), false
+        );
+        allocation.debugDecision(true);
+        return allocation;
     }
 
     private void assertAssignedNodeRemainsSame(BalancedShardsAllocator allocator, RoutingAllocation routingAllocation,

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
@@ -166,6 +166,10 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
     }
 
     private RoutingAllocation newRoutingAllocation(AllocationDeciders deciders, ClusterState state) {
-        return new RoutingAllocation(deciders, new RoutingNodes(state, false), state, ClusterInfo.EMPTY, System.nanoTime(), false);
+        RoutingAllocation allocation = new RoutingAllocation(
+            deciders, new RoutingNodes(state, false), state, ClusterInfo.EMPTY, System.nanoTime(), false
+        );
+        allocation.debugDecision();
+        return allocation;
     }
 }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
@@ -90,9 +90,13 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
         RebalanceDecision rebalanceDecision = allocator.decideRebalance(shard, routingAllocation);
         assertNotEquals(Type.YES, rebalanceDecision.getCanRebalanceDecision().type());
         assertEquals(Type.NO, rebalanceDecision.getFinalDecisionType());
-        assertEquals("foobar", rebalanceDecision.getFinalExplanation());
+        assertEquals("rebalancing is not allowed", rebalanceDecision.getFinalExplanation());
         assertNull(rebalanceDecision.getNodeDecisions());
         assertNull(rebalanceDecision.getAssignedNodeId());
+        assertEquals(1, rebalanceDecision.getCanRebalanceDecision().getDecisions().size());
+        for (Decision subDecision : rebalanceDecision.getCanRebalanceDecision().getDecisions()) {
+            assertEquals("foobar", ((Decision.Single) subDecision).getExplanation());
+        }
 
         assertAssignedNodeRemainsSame(allocator, routingAllocation, shard);
     }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
+import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.Balancer;
+import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.RebalanceDecision;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.Collections;
+
+/**
+ * Tests for balancing a single shard, see {@link Balancer#balanceShard(ShardRouting)}.
+ */
+public class BalancedSingleShardTests extends ESAllocationTestCase {
+
+    public void testRebalanceNonStartedShardNotAllowed() {
+        BalancedShardsAllocator allocator = new BalancedShardsAllocator(Settings.EMPTY);
+        ClusterState clusterState = ClusterStateCreationUtils.state("idx", randomBoolean(),
+            randomFrom(ShardRoutingState.INITIALIZING, ShardRoutingState.UNASSIGNED));
+        ShardRouting unassignedShard = clusterState.routingTable().index("idx").shard(0).primaryShard();
+        RebalanceDecision rebalanceDecision = allocator.rebalanceShard(unassignedShard, newRoutingAllocation(
+            new AllocationDeciders(Settings.EMPTY, Collections.emptyList()), clusterState));
+        assertSame(RebalanceDecision.NOT_TAKEN, rebalanceDecision);
+    }
+
+    public void testRebalanceNotAllowedDuringPendingAsyncFetch() {
+        BalancedShardsAllocator allocator = new BalancedShardsAllocator(Settings.EMPTY);
+        ClusterState clusterState = ClusterStateCreationUtils.state("idx", randomBoolean(), ShardRoutingState.STARTED);
+        ShardRouting unassignedShard = clusterState.routingTable().index("idx").shard(0).primaryShard();
+        RoutingAllocation routingAllocation = newRoutingAllocation(
+            new AllocationDeciders(Settings.EMPTY, Collections.emptyList()), clusterState);
+        routingAllocation.setHasPendingAsyncFetch();
+        RebalanceDecision rebalanceDecision = allocator.rebalanceShard(unassignedShard, routingAllocation);
+        assertNotNull(rebalanceDecision.getCanRebalanceDecision());
+        assertEquals(Type.NO, rebalanceDecision.getFinalDecisionType());
+        assertEquals("cannot rebalance due to in-flight shard store fetches", rebalanceDecision.getFinalExplanation());
+        assertNull(rebalanceDecision.getNodeDecisions());
+        assertNull(rebalanceDecision.getAssignedNodeId());
+    }
+
+    public void testRebalanceNotAllowed() {
+        AllocationDecider noRebalanceDecider = new AllocationDecider(Settings.EMPTY) {
+            @Override
+            public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
+                return Decision.NO;
+            }
+        };
+        BalancedShardsAllocator allocator = new BalancedShardsAllocator(Settings.EMPTY);
+        ClusterState clusterState = ClusterStateCreationUtils.state("idx", randomBoolean(), ShardRoutingState.STARTED);
+        ShardRouting unassignedShard = clusterState.routingTable().index("idx").shard(0).primaryShard();
+        RebalanceDecision rebalanceDecision = allocator.rebalanceShard(unassignedShard, newRoutingAllocation(
+            new AllocationDeciders(Settings.EMPTY, Collections.singleton(noRebalanceDecider)), clusterState));
+        assertNotEquals(Type.YES, rebalanceDecision.getCanRebalanceDecision().type());
+        assertEquals(Type.NO, rebalanceDecision.getFinalDecisionType());
+        assertEquals("rebalancing is not allowed", rebalanceDecision.getFinalExplanation());
+        assertNull(rebalanceDecision.getNodeDecisions());
+        assertNull(rebalanceDecision.getAssignedNodeId());
+    }
+
+    public void testBalanceShard() {
+        //TODO:
+    }
+
+    public void testDontBalanceShard() {
+        //TODO:
+    }
+
+    private RoutingAllocation newRoutingAllocation(AllocationDeciders deciders, ClusterState state) {
+        return new RoutingAllocation(deciders, new RoutingNodes(state, false), state, ClusterInfo.EMPTY, System.nanoTime(), false);
+    }
+}


### PR DESCRIPTION
This commit introduces a single-shard balance step for deciding on
rebalancing a single shard (without taking any other shards in the
cluster into account).  This method will be used by the cluster
allocation explain API to explain in detail the decision process for
finding a more optimal location for a started shard, if one exists.
