### PR TITLE
[DOCS] warn of using 5.0.0 reindex-remote for 1.7 parent-child docs

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -418,6 +418,17 @@ you are likely to find. This should allow you to upgrade from any version of
 Elasticsearch to the current version by reindexing from a cluster of the old
 version.
 
+[WARNING]
+=============================================
+
+Reindex-from-remote in Elasticsearch 5.0.0 will not preserve `_parent`,
+`_routing`, or `_ttl` fields from a 1.x cluster. Re-indexing documents
+whose mappings require any of these fields, such as child documents, will
+fail. To re-index documents requiring these fields, use Elasticsearch 5.0.1
+or later.
+
+=============================================
+
 To enable queries sent to older versions of Elasticsearch the `query` parameter
 is sent directly to the remote host without validation or modification.
 

--- a/docs/reference/setup/reindex_upgrade.asciidoc
+++ b/docs/reference/setup/reindex_upgrade.asciidoc
@@ -81,6 +81,12 @@ the previous major version to be upgraded to the current major version.  By
 moving directly from Elasticsearch 1.x to 5.x, you will have to solve any
 backwards compatibility issues yourself.
 
+Reindex-from-remote in Elasticsearch 5.0.0 will not preserve `_parent`,
+`_routing`, or `_ttl` fields from a 1.x cluster. Re-indexing documents
+whose mappings require any of these fields, such as child documents, will
+fail. To re-index documents requiring these fields, use Elasticsearch 5.0.1
+or later.
+
 =============================================
 
 You will need to set up a 5.x cluster alongside your existing 1.x cluster.


### PR DESCRIPTION
Reindex-from-remote in 5.0.0 will fail to reindex parent-child docs
from a 1.7 cluster. This adds a warning to the 5.0.0 docs. See #21070 and #21044.
