### PR TITLE
Return target index name even if _rollover conditions are not met

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -149,7 +149,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                     } else {
                         // conditions not met
                         listener.onResponse(
-                            new RolloverResponse(sourceIndexName, sourceIndexName, conditionResults, false, false, false, false)
+                            new RolloverResponse(sourceIndexName, rolloverIndexName, conditionResults, false, false, false, false)
                         );
                     }
                 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yaml
@@ -71,3 +71,18 @@
   - match: { hits.total: 1 }
   - match: { hits.hits.0._index: "logs-000002"}
 
+  # run again and verify results without rolling over
+  - do:
+      indices.rollover:
+        alias: "logs_search"
+        wait_for_active_shards: 1
+        body:
+          conditions:
+            max_docs: 100
+
+  - match: { old_index: logs-000002 }
+  - match: { new_index: logs-000003 }
+  - match: { rolled_over: false }
+  - match: { dry_run: false }
+  - match: { conditions: { "[max_docs: 100]": false } }
+


### PR DESCRIPTION
Today we return the old index name as the target / new index name.
This change passes the correct rollover index name to the response.
