### PR TITLE
Add elasticsearcher for PHP

### DIFF
--- a/docs/community-clients/index.asciidoc
+++ b/docs/community-clients/index.asciidoc
@@ -147,6 +147,8 @@ Also see the {client}/php-api/current/index.html[official Elasticsearch PHP clie
 
 * http://github.com/nervetattoo/elasticsearch[elasticsearch] PHP client.
 
+* https://github.com/madewithlove/elasticsearcher[elasticsearcher] Agnostic lightweight package on top of the Elasticsearch PHP client. Its main goal is to allow for easier structuring of queries and indices in your application.  It does not want to hide or replace functionality of the Elasticsearch PHP client.
+
 [[python]]
 == Python
 


### PR DESCRIPTION
Added a link to [Elasticsearcher](https://github.com/madewithlove/elasticsearcher), a library written by one of the engineers in [my company](https://madewithlove.be).

This agnostic package is a lightweight wrapper on top of the [Elasticsearch PHP client](http://www.elastic.co/guide/en/elasticsearch/client/php-api/current/index.html).
Its main goal is to allow for easier structuring of queries and indices in your application. It does not want to hide or replace functionality of the Elasticsearch PHP client.
