### PR TITLE
Fix bwc cluster formation in order to run BWC tests against a mixed version cluster

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -73,8 +73,8 @@ class ClusterFormationTasks {
         }
         // this is our current version distribution configuration we use for all kinds of REST tests etc.
         String distroConfigName = "${task.name}_elasticsearchDistro"
-        Configuration distro = project.configurations.create(distroConfigName)
-        configureDistributionDependency(project, config.distribution, distro, VersionProperties.elasticsearch)
+        Configuration currentDistro = project.configurations.create(distroConfigName)
+        configureDistributionDependency(project, config.distribution, currentDistro, VersionProperties.elasticsearch)
         if (config.bwcVersion != null && config.numBwcNodes > 0) {
             // if we have a cluster that has a BWC cluster we also need to configure a dependency on the BWC version
             // this version uses the same distribution etc. and only differs in the version we depend on.
@@ -85,11 +85,11 @@ class ClusterFormationTasks {
             }
             configureDistributionDependency(project, config.distribution, project.configurations.elasticsearchBwcDistro, config.bwcVersion)
         }
-
-        for (int i = 0; i < config.numNodes; ++i) {
+        for (int i = 0; i < config.numNodes; i++) {
             // we start N nodes and out of these N nodes there might be M bwc nodes.
             // for each of those nodes we might have a different configuratioon
             String elasticsearchVersion = VersionProperties.elasticsearch
+            Configuration distro = currentDistro
             if (i < config.numBwcNodes) {
                 elasticsearchVersion = config.bwcVersion
                 distro = project.configurations.elasticsearchBwcDistro
@@ -252,7 +252,7 @@ class ClusterFormationTasks {
                 'path.repo'                    : "${node.sharedDir}/repo",
                 'path.shared_data'             : "${node.sharedDir}/",
                 // Define a node attribute so we can test that it exists
-                'node.attr.testattr'                : 'test',
+                'node.attr.testattr'           : 'test',
                 'repositories.url.allowed_urls': 'http://snapshot.test*'
         ]
         esConfig['node.max_local_storage_nodes'] = node.config.numNodes

--- a/qa/backwards-5.0/build.gradle
+++ b/qa/backwards-5.0/build.gradle
@@ -18,6 +18,6 @@ integTest {
   cluster {
     numNodes = 2
     numBwcNodes = 1
-    bwcVersion = "5.0.1-SNAPSHOT"
+    bwcVersion = "5.0.0"
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/delete/27_force_version.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/delete/27_force_version.yaml
@@ -1,5 +1,9 @@
 ---
-"Force version":
+"Force Version":
+
+ - skip:
+    version: " - 5.0.0"
+    reason:  headers were introduced in 5.0.1
 
  - do:
       warnings:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get/90_versions.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get/90_versions.yaml
@@ -87,35 +87,3 @@
           version: 1
           version_type: external_gte
 
- - do:
-      warnings:
-          - version type FORCE is deprecated and will be removed in the next major version
-      get:
-          index:  test_1
-          type:   test
-          id:     1
-          version: 2
-          version_type: force
- - match:   { _id: "1" }
-
- - do:
-      warnings:
-          - version type FORCE is deprecated and will be removed in the next major version
-      get:
-          index:  test_1
-          type:   test
-          id:     1
-          version: 10
-          version_type: force
- - match:   { _id: "1" }
-
- - do:
-      warnings:
-          - version type FORCE is deprecated and will be removed in the next major version
-      get:
-          index:  test_1
-          type:   test
-          id:     1
-          version: 1
-          version_type: force
- - match:   { _id: "1" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get/95_force_versions.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get/95_force_versions.yaml
@@ -1,0 +1,53 @@
+---
+"Force Versions":
+ - skip:
+    version: " - 5.0.0"
+    reason:  headers were introduced in 5.0.1
+ - do:
+      index:
+          index:  test_1
+          type:   test
+          id:     1
+          body:   { foo: bar }
+ - match:   { _version: 1}
+
+ - do:
+      index:
+          index:  test_1
+          type:   test
+          id:     1
+          body:   { foo: bar }
+ - match:   { _version: 2}
+
+ - do:
+      warnings:
+          - version type FORCE is deprecated and will be removed in the next major version
+      get:
+          index:  test_1
+          type:   test
+          id:     1
+          version: 2
+          version_type: force
+ - match:   { _id: "1" }
+
+ - do:
+      warnings:
+          - version type FORCE is deprecated and will be removed in the next major version
+      get:
+          index:  test_1
+          type:   test
+          id:     1
+          version: 10
+          version_type: force
+ - match:   { _id: "1" }
+
+ - do:
+      warnings:
+          - version type FORCE is deprecated and will be removed in the next major version
+      get:
+          index:  test_1
+          type:   test
+          id:     1
+          version: 1
+          version_type: force
+ - match:   { _id: "1" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/37_force_version.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/37_force_version.yaml
@@ -1,5 +1,9 @@
 ---
-"Force version":
+"Force Version":
+
+ - skip:
+    version: " - 5.0.0"
+    reason:  headers were introduced in 5.0.1
 
  - do:
       warnings:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yaml
@@ -71,6 +71,22 @@
   - match: { hits.total: 1 }
   - match: { hits.hits.0._index: "logs-000002"}
 
+---
+"Rollover no condition matched":
+  - skip:
+        version: " - 5.0.0"
+        reason:  bug fixed in 5.0.1
+
+  # create index with alias
+  - do:
+      indices.create:
+        index: logs-1
+        wait_for_active_shards: 1
+        body:
+          aliases:
+            logs_index: {}
+            logs_search: {}
+
   # run again and verify results without rolling over
   - do:
       indices.rollover:
@@ -78,11 +94,11 @@
         wait_for_active_shards: 1
         body:
           conditions:
-            max_docs: 100
+            max_docs: 1
 
-  - match: { old_index: logs-000002 }
-  - match: { new_index: logs-000003 }
+  - match: { old_index: logs-1 }
+  - match: { new_index: logs-000002 }
   - match: { rolled_over: false }
   - match: { dry_run: false }
-  - match: { conditions: { "[max_docs: 100]": false } }
+  - match: { conditions: { "[max_docs: 1]": false } }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yaml
@@ -1,5 +1,11 @@
 ---
 "Shrink index via API":
+  - skip:
+    version: " - 5.0.0"
+    reason:  this doesn't work yet with BWC tests since the master is from the old verion
+    # TODO we need to fix this for BWC tests to make sure we get a node that all shards can allocate on
+    # today if we run BWC tests and we select the master as a _shrink node but since primaries are allocated
+    # on the newer version nodes this fails...
   # creates an index with one document.
   # relocates all it's shards to one node
   # shrinks it into a new index with a single shard

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/termvectors/40_versions.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/termvectors/40_versions.yaml
@@ -86,36 +86,3 @@
           id:     1
           version: 1
           version_type: external_gte
-
- - do:
-      warnings:
-          - version type FORCE is deprecated and will be removed in the next major version
-      get:
-          index:  test_1
-          type:   test
-          id:     1
-          version: 2
-          version_type: force
- - match:   { _id: "1" }
-
- - do:
-      warnings:
-          - version type FORCE is deprecated and will be removed in the next major version
-      get:
-          index:  test_1
-          type:   test
-          id:     1
-          version: 10
-          version_type: force
- - match:   { _id: "1" }
-
- - do:
-      warnings:
-          - version type FORCE is deprecated and will be removed in the next major version
-      get:
-          index:  test_1
-          type:   test
-          id:     1
-          version: 1
-          version_type: force
- - match:   { _id: "1" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/termvectors/45_force_versions.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/termvectors/45_force_versions.yaml
@@ -1,0 +1,54 @@
+---
+"Force Version":
+ - skip:
+    version: " - 5.0.0"
+    reason:  headers were introduced in 5.0.1
+
+ - do:
+      index:
+          index:  test_1
+          type:   test
+          id:     1
+          body:   { foo: bar }
+ - match:   { _version: 1}
+
+ - do:
+      index:
+          index:  test_1
+          type:   test
+          id:     1
+          body:   { foo: bar }
+ - match:   { _version: 2}
+
+ - do:
+      warnings:
+          - version type FORCE is deprecated and will be removed in the next major version
+      get:
+          index:  test_1
+          type:   test
+          id:     1
+          version: 2
+          version_type: force
+ - match:   { _id: "1" }
+
+ - do:
+      warnings:
+          - version type FORCE is deprecated and will be removed in the next major version
+      get:
+          index:  test_1
+          type:   test
+          id:     1
+          version: 10
+          version_type: force
+ - match:   { _id: "1" }
+
+ - do:
+      warnings:
+          - version type FORCE is deprecated and will be removed in the next major version
+      get:
+          index:  test_1
+          type:   test
+          id:     1
+          version: 1
+          version_type: force
+ - match:   { _id: "1" }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/parser/ClientYamlTestSectionParser.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/parser/ClientYamlTestSectionParser.java
@@ -36,16 +36,17 @@ public class ClientYamlTestSectionParser implements ClientYamlTestFragmentParser
         try {
             parser.nextToken();
             testSection.setSkipSection(parseContext.parseSkipSection());
-    
+
             while ( parser.currentToken() != XContentParser.Token.END_ARRAY) {
                 parseContext.advanceToFieldName();
                 testSection.addExecutableSection(parseContext.parseExecutableSection());
             }
-    
+
             parser.nextToken();
-            assert parser.currentToken() == XContentParser.Token.END_OBJECT;
+            assert parser.currentToken() == XContentParser.Token.END_OBJECT : "malformed section [" + testSection.getName() + "] expected "
+                + XContentParser.Token.END_OBJECT  + " but was " + parser.currentToken();
             parser.nextToken();
-    
+
             return testSection;
         } catch (Exception e) {
             throw new ClientYamlTestParseException("Error parsing test named [" + testSection.getName() + "]", e);


### PR DESCRIPTION
This fixes our cluster formation task to run REST tests against a mixed version cluster.
Yet, due to some limitations in our test framework `indices.rollover` tests are currently
disabled for the BWC case since they select the current master as the merge node which
happens to be a BWC node and we can't relocate all shards to it since the primaries are on
a higher version node. This will be fixed in a followup.

Closes #21142
