### PR TITLE
Updates vagrant tests upgrade version number

### DIFF
--- a/qa/vagrant/versions
+++ b/qa/vagrant/versions
@@ -1,1 +1,1 @@
-6.0.0-alpha1-SNAPSHOT
+5.0.0


### PR DESCRIPTION
This PR updates the latest version the vagrant tests can upgrade from to 5.0.0.
