### PR TITLE
Enables rolling upgrade testing on 5.0

### DIFF
--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -25,12 +25,8 @@ task oldClusterTest(type: RestIntegTestTask) {
     mustRunAfter(precommit)
     cluster {
         distribution = 'zip'
-        // TODO: Right now, this just forms a cluster with the current version of ES,
-        // because we don't support clusters with nodes on different alpha/beta releases of ES.
-        // When the GA is released, we should change the bwcVersion to 5.0.0 and uncomment
-        // numBwcNodes = 2
-        //bwcVersion = '5.0.0-alpha5' // TODO: either randomize, or make this settable with sysprop
-        //numBwcNodes = 2
+        bwcVersion = '5.0.0' // TODO: either randomize, or make this settable with sysprop
+        numBwcNodes = 1
         numNodes = 2
         clusterName = 'rolling-upgrade'
     }


### PR DESCRIPTION
Enables rolling upgrade testing on a 5.0 cluster now that we have 5.0.0 GA
