### PR TITLE
Reject legacy `index` values for `text` and `keyword`.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -138,6 +138,23 @@ public final class KeywordFieldMapper extends FieldMapper {
                 return new StringFieldMapper.TypeParser().parse(name, node, parserContext);
             }
             KeywordFieldMapper.Builder builder = new KeywordFieldMapper.Builder(name);
+
+            // parse the index property explicitly, otherwise we fall back to the default impl that still accepts
+            // analyzed and not_analyzed, which does not make sense for keyword fields
+            Object index = node.remove("index");
+            if (index != null) {
+                switch (index.toString()) {
+                case "true":
+                    builder.index(true);
+                    break;
+                case "false":
+                    builder.index(false);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Can't parse [index] value [" + index + "] for field [" + name + "], expected [true] or [false]");
+                }
+            }
+
             parseField(builder, name, node, parserContext);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();

--- a/core/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -181,6 +181,23 @@ public class TextFieldMapper extends FieldMapper {
             builder.fieldType().setIndexAnalyzer(parserContext.getIndexAnalyzers().getDefaultIndexAnalyzer());
             builder.fieldType().setSearchAnalyzer(parserContext.getIndexAnalyzers().getDefaultSearchAnalyzer());
             builder.fieldType().setSearchQuoteAnalyzer(parserContext.getIndexAnalyzers().getDefaultSearchQuoteAnalyzer());
+
+            // parse the index property explicitly, otherwise we fall back to the default impl that still accepts
+            // analyzed and not_analyzed, which does not make sense for text fields
+            Object index = node.remove("index");
+            if (index != null) {
+                switch (index.toString()) {
+                case "true":
+                    builder.index(true);
+                    break;
+                case "false":
+                    builder.index(false);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Can't parse [index] value [" + index + "] for field [" + fieldName + "], expected [true] or [false]");
+                }
+            }
+
             parseTextField(builder, fieldName, node, parserContext);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();

--- a/core/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -354,4 +354,21 @@ public class KeywordFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
         assertEquals(downgradedMapping, defaultMapper.mappingSource().string());
     }
+
+    public void testRejectLegacyIndexValues() throws IOException {
+        for (String index : new String[] {"no", "not_analyzed", "analyzed"}) {
+            String mapping = XContentFactory.jsonBuilder().startObject()
+                    .startObject("type")
+                        .startObject("properties")
+                            .startObject("foo")
+                                .field("type", "keyword")
+                                .field("index", index)
+                            .endObject()
+                        .endObject()
+                    .endObject().endObject().string();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                    () -> parser.parse("type", new CompressedXContent(mapping)));
+            assertThat(e.getMessage(), containsString("Can't parse [index] value [" + index + "] for field [foo], expected [true] or [false]"));
+        }
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -592,4 +592,21 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
         assertEquals(downgradedMapping, defaultMapper.mappingSource().string());
     }
+
+    public void testRejectLegacyIndexValues() throws IOException {
+        for (String index : new String[] {"no", "not_analyzed", "analyzed"}) {
+            String mapping = XContentFactory.jsonBuilder().startObject()
+                    .startObject("type")
+                        .startObject("properties")
+                            .startObject("foo")
+                                .field("type", "text")
+                                .field("index", index)
+                            .endObject()
+                        .endObject()
+                    .endObject().endObject().string();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                    () -> parser.parse("type", new CompressedXContent(mapping)));
+            assertThat(e.getMessage(), containsString("Can't parse [index] value [" + index + "] for field [foo], expected [true] or [false]"));
+        }
+    }
 }


### PR DESCRIPTION
Closes #21134
