### PR TITLE
Disconnect from newly added nodes if cluster state publishing fails

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/NodeConnectionsService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/NodeConnectionsService.java
@@ -36,6 +36,7 @@ import org.elasticsearch.discovery.zen.NodesFaultDetection;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
 
@@ -75,10 +76,10 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
         this.reconnectInterval = NodeConnectionsService.CLUSTER_NODE_RECONNECT_INTERVAL_SETTING.get(settings);
     }
 
-    public void connectToAddedNodes(ClusterChangedEvent event) {
+    public void connectToNodes(List<DiscoveryNode> addedNodes) {
 
         // TODO: do this in parallel (and wait)
-        for (final DiscoveryNode node : event.nodesDelta().addedNodes()) {
+        for (final DiscoveryNode node : addedNodes) {
             try (Releasable ignored = nodeLocks.acquire(node)) {
                 Integer current = nodes.put(node, 0);
                 assert current == null : "node " + node + " was added in event but already in internal nodes";
@@ -87,8 +88,8 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
         }
     }
 
-    public void disconnectFromRemovedNodes(ClusterChangedEvent event) {
-        for (final DiscoveryNode node : event.nodesDelta().removedNodes()) {
+    public void disconnectFromNodes(List<DiscoveryNode> removedNodes) {
+        for (final DiscoveryNode node : removedNodes) {
             try (Releasable ignored = nodeLocks.acquire(node)) {
                 Integer current = nodes.remove(node);
                 assert current != null : "node " + node + " was removed in event but not in internal nodes";

--- a/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -671,7 +671,7 @@ public class ClusterService extends AbstractLifecycleComponent {
                 }
             }
 
-            nodeConnectionsService.connectToAddedNodes(clusterChangedEvent);
+            nodeConnectionsService.connectToNodes(clusterChangedEvent.nodesDelta().addedNodes());
 
             // if we are the master, publish the new state to all nodes
             // we publish here before we send a notification to all the listeners, since if it fails
@@ -686,6 +686,8 @@ public class ClusterService extends AbstractLifecycleComponent {
                         (Supplier<?>) () -> new ParameterizedMessage(
                             "failing [{}]: failed to commit cluster state version [{}]", tasksSummary, version),
                         t);
+                    // ensure that list of connected nodes in NodeConnectionsService is in-sync with the nodes of the current cluster state
+                    nodeConnectionsService.disconnectFromNodes(clusterChangedEvent.nodesDelta().addedNodes());
                     proccessedListeners.forEach(task -> task.listener.onFailure(task.source, t));
                     return;
                 }
@@ -711,7 +713,7 @@ public class ClusterService extends AbstractLifecycleComponent {
                 }
             }
 
-            nodeConnectionsService.disconnectFromRemovedNodes(clusterChangedEvent);
+            nodeConnectionsService.disconnectFromNodes(clusterChangedEvent.nodesDelta().removedNodes());
 
             newClusterState.status(ClusterState.ClusterStateStatus.APPLIED);
 

--- a/core/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
@@ -84,19 +84,19 @@ public class NodeConnectionsServiceTests extends ESTestCase {
         ClusterState current = clusterStateFromNodes(Collections.emptyList());
         ClusterChangedEvent event = new ClusterChangedEvent("test", clusterStateFromNodes(randomSubsetOf(nodes)), current);
 
-        service.connectToAddedNodes(event);
+        service.connectToNodes(event.nodesDelta().addedNodes());
         assertConnected(event.nodesDelta().addedNodes());
 
-        service.disconnectFromRemovedNodes(event);
+        service.disconnectFromNodes(event.nodesDelta().removedNodes());
         assertConnectedExactlyToNodes(event.state());
 
         current = event.state();
         event = new ClusterChangedEvent("test", clusterStateFromNodes(randomSubsetOf(nodes)), current);
 
-        service.connectToAddedNodes(event);
+        service.connectToNodes(event.nodesDelta().addedNodes());
         assertConnected(event.nodesDelta().addedNodes());
 
-        service.disconnectFromRemovedNodes(event);
+        service.disconnectFromNodes(event.nodesDelta().removedNodes());
         assertConnectedExactlyToNodes(event.state());
     }
 
@@ -110,7 +110,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
 
         transport.randomConnectionExceptions = true;
 
-        service.connectToAddedNodes(event);
+        service.connectToNodes(event.nodesDelta().addedNodes());
 
         for (int i = 0; i < 3; i++) {
             // simulate disconnects

--- a/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
@@ -34,6 +34,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import static junit.framework.TestCase.fail;
@@ -53,12 +54,12 @@ public class ClusterServiceUtils {
         clusterService.setLocalNode(localNode);
         clusterService.setNodeConnectionsService(new NodeConnectionsService(Settings.EMPTY, null, null) {
             @Override
-            public void connectToAddedNodes(ClusterChangedEvent event) {
+            public void connectToNodes(List<DiscoveryNode> addedNodes) {
                 // skip
             }
 
             @Override
-            public void disconnectFromRemovedNodes(ClusterChangedEvent event) {
+            public void disconnectFromNodes(List<DiscoveryNode> removedNodes) {
                 // skip
             }
         });


### PR DESCRIPTION
Before publishing a cluster state the master connects to the nodes that are added in the cluster state. When publishing fails, it does not disconnect from these nodes, however, leaving NodeConnectionsService out of sync with the currently applied cluster state.

Build failure:

https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+g1gc/473/consoleFull

Relevant log lines:

```
1> [2016-10-30T14:01:21,434][DEBUG][o.e.d.z.ZenDiscovery     ] [node_t0] failed to publish cluster state version [9] (not enough nodes acknowledged, min master nodes [2])
 1> [2016-10-30T14:01:21,434][WARN ][o.e.c.s.ClusterService   ] [node_t0] failing [zen-disco-node-join[{node_t1}{n9SEnXUhQhizsfKmupS59g}{QOn4dJWMQ--uztoIl5j37w}{127.0.0.1}{127.0.0.1:30301}]]: failed to commit cluster state version [9]
```

and

```
java.lang.AssertionError: node {node_t1}{n9SEnXUhQhizsfKmupS59g}{QOn4dJWMQ--uztoIl5j37w}{127.0.0.1}{127.0.0.1:30301} was added in event but already in internal nodes
 2> 	at __randomizedtesting.SeedInfo.seed([B06683F6A37CB70F]:0)
 2> 	at org.elasticsearch.cluster.NodeConnectionsService.connectToAddedNodes(NodeConnectionsService.java:84)
 2> 	at org.elasticsearch.cluster.service.ClusterService.runTasksForExecutor(ClusterService.java:674)
 2> 	at org.elasticsearch.cluster.service.ClusterService$UpdateTask.run(ClusterService.java:897)
```
