### PR TITLE
Add empty plugins dir for archive distributions

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -214,6 +214,17 @@ configure(subprojects.findAll { ['zip', 'tar', 'integ-test-zip'].contains(it.nam
           MavenFilteringHack.filter(it, expansions)
         }
       }
+      into('') {
+        // CopySpec does not make it easy to create an empty directory
+        // so we create the directory that we want, and then point
+        // CopySpec to its parent to copy to the root of the
+        // distribution
+        File plugins = new File(buildDir, 'plugins-hack/plugins')
+        plugins.mkdirs()
+        from {
+          plugins.getParent()
+        }
+      }
       with commonFiles
       from('../src/main/resources') {
         include 'bin/*.exe'

--- a/qa/vagrant/src/test/resources/packaging/scripts/20_tar_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/20_tar_package.bats
@@ -73,7 +73,7 @@ setup() {
     verify_archive_installation
 }
 
-@test "[TAR] verify elasticsearch-plugin list runs" {
+@test "[TAR] verify elasticsearch-plugin list runs without any plugins installed" {
     # previously this would fail because the archive installations did
     # not create an empty plugins directory
     local plugins_list=`$ESHOME/bin/elasticsearch-plugin list`

--- a/qa/vagrant/src/test/resources/packaging/scripts/20_tar_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/20_tar_package.bats
@@ -73,6 +73,13 @@ setup() {
     verify_archive_installation
 }
 
+@test "[TAR] verify elasticsearch-plugin list runs" {
+    # previously this would fail because the archive installations did
+    # not create an empty plugins directory
+    local plugins_list=`$ESHOME/bin/elasticsearch-plugin list`
+    [[ -z $plugins_list ]]
+}
+
 @test "[TAR] elasticsearch fails if java executable is not found" {
   local JAVA=$(which java)
 

--- a/qa/vagrant/src/test/resources/packaging/scripts/30_deb_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/30_deb_package.bats
@@ -74,7 +74,7 @@ setup() {
     verify_package_installation
 }
 
-@test "[DEB] verify elasticsearch-plugin list runs" {
+@test "[DEB] verify elasticsearch-plugin list runs without any plugins installed" {
     local plugins_list=`$ESHOME/bin/elasticsearch-plugin list`
     [[ -z $plugins_list ]]
 }

--- a/qa/vagrant/src/test/resources/packaging/scripts/30_deb_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/30_deb_package.bats
@@ -74,6 +74,11 @@ setup() {
     verify_package_installation
 }
 
+@test "[DEB] verify elasticsearch-plugin list runs" {
+    local plugins_list=`$ESHOME/bin/elasticsearch-plugin list`
+    [[ -z $plugins_list ]]
+}
+
 @test "[DEB] elasticsearch isn't started by package install" {
     # Wait a second to give Elasticsearch a change to start if it is going to.
     # This isn't perfect by any means but its something.

--- a/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
@@ -73,6 +73,11 @@ setup() {
     verify_package_installation
 }
 
+@test "[RPM] verify elasticsearch-plugin list runs" {
+    local plugins_list=`$ESHOME/bin/elasticsearch-plugin list`
+    [[ -z $plugins_list ]]
+}
+
 @test "[RPM] elasticsearch isn't started by package install" {
     # Wait a second to give Elasticsearch a change to start if it is going to.
     # This isn't perfect by any means but its something.

--- a/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
@@ -73,7 +73,7 @@ setup() {
     verify_package_installation
 }
 
-@test "[RPM] verify elasticsearch-plugin list runs" {
+@test "[RPM] verify elasticsearch-plugin list runs without any plugins installed" {
     local plugins_list=`$ESHOME/bin/elasticsearch-plugin list`
     [[ -z $plugins_list ]]
 }

--- a/qa/vagrant/src/test/resources/packaging/scripts/tar.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/tar.bash
@@ -89,6 +89,7 @@ verify_archive_installation() {
     assert_file "$ESCONFIG/elasticsearch.yml" f elasticsearch elasticsearch 660
     assert_file "$ESCONFIG/jvm.options" f elasticsearch elasticsearch 660
     assert_file "$ESCONFIG/log4j2.properties" f elasticsearch elasticsearch 660
+    assert_file "$ESPLUGINS" d elasticsearch elasticsearch 755
     assert_file "$ESHOME/lib" d elasticsearch elasticsearch 755
     assert_file "$ESHOME/NOTICE.txt" f elasticsearch elasticsearch 644
     assert_file "$ESHOME/LICENSE.txt" f elasticsearch elasticsearch 644


### PR DESCRIPTION
Today when installing Elasticsearch from an archive distribution (tar.gz
or zip), an empty plugins folder is not included. This means that if you
install Elasticsearch and immediately run elasticsearch-plugin list, you
will receive an error message about the plugins directory missing. While
the plugins directory would be created when starting Elasticsearch for
the first time, it would be better to just include an empty plugins
directory in the archive distributions. This commit makes this the
case. Note that the package distributions already include an empty
plugins folder.

Closes #20342