### PR TITLE
Correct then phrase

### DIFF
--- a/docs/reference/mapping/types/array.asciidoc
+++ b/docs/reference/mapping/types/array.asciidoc
@@ -17,7 +17,7 @@ the same datatype. For instance:
 Arrays of objects do not work as you would expect: you cannot query each
 object independently of the other objects in the array.  If you need to be
 able to do this then you should use the <<nested,`nested`>> datatype instead
-of the <<object,`object`>> datatype.
+of the <<array,`array`>> datatype.
 
 This is explained in more detail in <<nested>>.
 ====================================================


### PR DESCRIPTION
On https://www.elastic.co/guide/en/elasticsearch/reference/current/array.html

There is a note:

```
Arrays of objects do not work as you would expect: you cannot query each object independently of the other objects in the array. If you need to be able to do this then you should use the nested datatype instead of the object datatype.
```

But it's on the page of the `array datatype`, so obviously it should say `array datatype` instead of `object datatype`