### PR TITLE
Fix logger names for Netty

### DIFF
--- a/modules/transport-netty3/src/main/java/org/elasticsearch/transport/netty3/Netty3Utils.java
+++ b/modules/transport-netty3/src/main/java/org/elasticsearch/transport/netty3/Netty3Utils.java
@@ -99,7 +99,6 @@ public class Netty3Utils {
         InternalLoggerFactory.setDefaultFactory(new InternalLoggerFactory() {
             @Override
             public InternalLogger newInstance(String name) {
-                name = name.replace("org.jboss.netty.", "netty3.").replace("org.jboss.netty.", "netty3.");
                 return new Netty3InternalESLogger(Loggers.getLogger(name));
             }
         });

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
@@ -41,7 +41,7 @@ public class Netty4Utils {
 
             @Override
             public InternalLogger newInstance(final String name) {
-                return new Netty4InternalESLogger(name.replace("io.netty.", "netty."));
+                return new Netty4InternalESLogger(name);
             }
 
         });


### PR DESCRIPTION
Previously Elasticsearch would only use the package name for logging
levels, truncating the package prefix and the class name. This meant
that logger names for Netty were just prefixed by netty3 and netty. We
changed this for Elasticsearch so that it's the fully-qualified class
name now, but never corrected this for Netty. This commit fixes the
logger names for the Netty modules so that their levels are controlled
by the fully-qualified class name.

Relates #20457