### PR TITLE
ClusterAdminClient.prepareDeletePipeline method should accept pipeline id to delete

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ingest/DeletePipelineRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/DeletePipelineRequestBuilder.java
@@ -32,4 +32,12 @@ public class DeletePipelineRequestBuilder extends ActionRequestBuilder<DeletePip
         super(client, action, new DeletePipelineRequest(id));
     }
 
+    /**
+     * Sets the id of the pipeline to delete.
+     */
+    public DeletePipelineRequestBuilder setId(String id) {
+        request.setId(id);
+        return this;
+    }
+
 }

--- a/core/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
+++ b/core/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
@@ -564,6 +564,11 @@ public interface ClusterAdminClient extends ElasticsearchClient {
     DeletePipelineRequestBuilder prepareDeletePipeline();
 
     /**
+     * Deletes a stored ingest pipeline
+     */
+    DeletePipelineRequestBuilder prepareDeletePipeline(String id);
+
+    /**
      * Returns a stored ingest pipeline
      */
     void getPipeline(GetPipelineRequest request, ActionListener<GetPipelineResponse> listener);

--- a/core/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/core/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -1097,6 +1097,11 @@ public abstract class AbstractClient extends AbstractComponent implements Client
         }
 
         @Override
+        public DeletePipelineRequestBuilder prepareDeletePipeline(String id) {
+            return new DeletePipelineRequestBuilder(this, DeletePipelineAction.INSTANCE, id);
+        }
+
+        @Override
         public void getPipeline(GetPipelineRequest request, ActionListener<GetPipelineResponse> listener) {
             execute(GetPipelineAction.INSTANCE, request, listener);
         }


### PR DESCRIPTION
Currently there is no way to specify the pipeline id when using client().prepareDeletePipeline() method