### PR TITLE
Generate POM files with non-wildcard excludes

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.Task
 import org.gradle.api.XmlProvider
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.dsl.RepositoryHandler
@@ -294,7 +295,7 @@ class BuildPlugin implements Plugin<Project> {
      * Returns a closure which can be used with a MavenPom for fixing problems with gradle generated poms.
      *
      * <ul>
-     *     <li>Remove transitive dependencies (using wildcard exclusions, fixed in gradle 2.14)</li>
+     *     <li>Remove transitive dependencies (using explicit exclusions to be compatible with Ivy)</li>
      *     <li>Set compile time deps back to compile from runtime (known issue with maven-publish plugin)
      * </ul>
      */
@@ -334,10 +335,19 @@ class BuildPlugin implements Plugin<Project> {
                     continue
                 }
 
-                // we now know we have something to exclude, so add a wildcard exclusion element
-                Node exclusion = depNode.appendNode('exclusions').appendNode('exclusion')
-                exclusion.appendNode('groupId', '*')
-                exclusion.appendNode('artifactId', '*')
+                // we now know we have something to exclude, so add exclusions for all artifacts except the main one
+                Node exclusions = depNode.appendNode('exclusions')
+                for (ResolvedArtifact artifact : artifacts) {
+                    ModuleVersionIdentifier moduleVersionIdentifier = artifact.moduleVersion.id;
+                    String depGroupId = moduleVersionIdentifier.group
+                    String depArtifactId = moduleVersionIdentifier.name
+                    // add exclusions for all artifacts except the main one
+                    if (depGroupId != groupId || depArtifactId != artifactId) {
+                        Node exclusion = exclusions.appendNode('exclusion')
+                        exclusion.appendNode('groupId', depGroupId)
+                        exclusion.appendNode('artifactId', depArtifactId)
+                    }
+                }
             }
         }
     }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -295,12 +295,15 @@ class BuildPlugin implements Plugin<Project> {
      * Returns a closure which can be used with a MavenPom for fixing problems with gradle generated poms.
      *
      * <ul>
-     *     <li>Remove transitive dependencies (using explicit exclusions to be compatible with Ivy)</li>
-     *     <li>Set compile time deps back to compile from runtime (known issue with maven-publish plugin)
+     *     <li>Remove transitive dependencies. We currently exclude all artifacts explicitly instead of using wildcards
+     *         as Ivy incorrectly translates POMs with * excludes to Ivy XML with * excludes which results in the main artifact
+     *         being excluded as well (see https://issues.apache.org/jira/browse/IVY-1531). Note that Gradle 2.14+ automatically
+     *         translates non-transitive dependencies to * excludes. We should revisit this when upgrading Gradle.</li>
+     *     <li>Set compile time deps back to compile from runtime (known issue with maven-publish plugin)</li>
      * </ul>
      */
     private static Closure fixupDependencies(Project project) {
-        // TODO: remove this when enforcing gradle 2.14+, it now properly handles exclusions
+        // TODO: revisit this when upgrading to Gradle 2.14+, see Javadoc comment above
         return { XmlProvider xml ->
             // first find if we have dependencies at all, and grab the node
             NodeList depsNodes = xml.asNode().get('dependencies')


### PR DESCRIPTION
Dependencies are currently marked as non-transitive in generated POM files by adding a wildcard (*) exclusion. This breaks compatibility with the dependency manager Apache Ivy as it incorrectly translates POMs with * excludes to Ivy XML with * excludes which results in the main artifact being excluded as well (see https://issues.apache.org/jira/browse/IVY-1531). To stay compatible with the current release of Ivy this commit uses explicit excludes for each transitive artifact instead to ensure that the main artifact is not excluded. This should be revisited when we upgrade Gradle to a higher version as the current one (2.13) as Gradle automatically translates non-transitive dependencies to * excludes in 2.14+.

Relates to #21170

I've tested this patch as follows:

1) applied patch to 5.0 branch and published artifacts to local maven repository by running `gradle publishToMavenLocal`
2) checked various dependency management systems how they compare between the officially published 5.0.0 and the generated 5.0.1-SNAPSHOT version with the applied patch.

Dependency management systems:

**Gradle**

Build file:

```
apply plugin: 'java'

repositories {
	mavenLocal()
	mavenCentral()
}

dependencies {
	compile 'org.elasticsearch:elasticsearch:5.0.0'
}
```

Run `gradle dependencies --configuration compile` which yields

```
\--- org.elasticsearch:elasticsearch:5.0.0
     +--- org.apache.lucene:lucene-core:6.2.0
     +--- org.apache.lucene:lucene-analyzers-common:6.2.0
     +--- org.apache.lucene:lucene-backward-codecs:6.2.0
     +--- org.apache.lucene:lucene-grouping:6.2.0
     +--- org.apache.lucene:lucene-highlighter:6.2.0
     +--- org.apache.lucene:lucene-join:6.2.0
     +--- org.apache.lucene:lucene-memory:6.2.0
     +--- org.apache.lucene:lucene-misc:6.2.0
     +--- org.apache.lucene:lucene-queries:6.2.0
     +--- org.apache.lucene:lucene-queryparser:6.2.0
     +--- org.apache.lucene:lucene-sandbox:6.2.0
     +--- org.apache.lucene:lucene-spatial:6.2.0
     +--- org.apache.lucene:lucene-spatial-extras:6.2.0
     +--- org.apache.lucene:lucene-spatial3d:6.2.0
     +--- org.apache.lucene:lucene-suggest:6.2.0
     +--- org.elasticsearch:securesm:1.1
     +--- net.sf.jopt-simple:jopt-simple:5.0.2
     +--- com.carrotsearch:hppc:0.7.1
     +--- joda-time:joda-time:2.9.4
     +--- org.joda:joda-convert:1.2
     +--- org.yaml:snakeyaml:1.15
     +--- com.fasterxml.jackson.core:jackson-core:2.8.1
     +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.1
     +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.1
     +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.1
     +--- com.tdunning:t-digest:3.0
     +--- org.hdrhistogram:HdrHistogram:2.1.6
     \--- net.java.dev.jna:jna:4.2.2
```

Replace the 5.0.0 dependency by 5.0.1-SNAPSHOT in the build file and run same command again:

```
\--- org.elasticsearch:elasticsearch:5.0.1-SNAPSHOT
     +--- org.apache.lucene:lucene-core:6.2.1
     +--- org.apache.lucene:lucene-analyzers-common:6.2.1
     +--- org.apache.lucene:lucene-backward-codecs:6.2.1
     +--- org.apache.lucene:lucene-grouping:6.2.1
     +--- org.apache.lucene:lucene-highlighter:6.2.1
     +--- org.apache.lucene:lucene-join:6.2.1
     +--- org.apache.lucene:lucene-memory:6.2.1
     +--- org.apache.lucene:lucene-misc:6.2.1
     +--- org.apache.lucene:lucene-queries:6.2.1
     +--- org.apache.lucene:lucene-queryparser:6.2.1
     +--- org.apache.lucene:lucene-sandbox:6.2.1
     +--- org.apache.lucene:lucene-spatial:6.2.1
     +--- org.apache.lucene:lucene-spatial-extras:6.2.1
     +--- org.apache.lucene:lucene-spatial3d:6.2.1
     +--- org.apache.lucene:lucene-suggest:6.2.1
     +--- org.elasticsearch:securesm:1.1
     +--- net.sf.jopt-simple:jopt-simple:5.0.2
     +--- com.carrotsearch:hppc:0.7.1
     +--- joda-time:joda-time:2.9.4
     +--- org.joda:joda-convert:1.2
     +--- org.yaml:snakeyaml:1.15
     +--- com.fasterxml.jackson.core:jackson-core:2.8.1
     +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.1
     +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.1
     +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.1
     +--- com.tdunning:t-digest:3.0
     +--- org.hdrhistogram:HdrHistogram:2.1.6
     \--- net.java.dev.jna:jna:4.2.2
```

Conclusion:

Gradle was handling the * excludes fine before and is still working as expected afterwards.


**Ivy**

Create `ivysettings.xml` file with following contents:

```
<ivysettings>
    <settings defaultResolver="default"/>
    <resolvers>
        <chain name="default">
            <filesystem name="local-maven2" m2compatible="true" checkmodified="true" changingPattern=".*SNAPSHOT">      
              <ivy pattern="${user.home}/.m2/repository/[organisation]/[module]/[revision]/[module]-[revision].pom" />
              <artifact pattern="${user.home}/.m2/repository/[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]" />
            </filesystem>
            <ibiblio name="central" m2compatible="true"/>
        </chain>
    </resolvers>
</ivysettings>
```

Then run
`ivy -settings ivysettings.xml -confs default -dependency org.elasticsearch elasticsearch 5.0.0 -retrieve "jars/[module]-[artifact](-[revision]).[ext]"`

which yields

```
	---------------------------------------------------------------------
	|                  |            modules            ||   artifacts   |
	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
	---------------------------------------------------------------------
	|      default     |   29  |   29  |   29  |   0   ||   12  |   12  |
	---------------------------------------------------------------------
```

Only 12 artifacts instead of the 29 that we expect.

```
$ ls jars
HdrHistogram-HdrHistogram-2.1.6.jar   jackson-core-jackson-core-2.8.1.jar   joda-time-joda-time-2.9.4.jar         securesm-securesm-1.1.jar
elasticsearch-elasticsearch-5.0.0.jar jna-jna-4.2.2.jar                     jopt-simple-jopt-simple-5.0.2.jar     snakeyaml-snakeyaml-1.15.jar
hppc-hppc-0.7.1.jar                   joda-convert-joda-convert-1.2.jar     lucene-core-lucene-core-6.2.0.jar     t-digest-t-digest-3.0.jar
```

Let's repeat the same for 5.0.1-SNAPSHOT (but first `rm jars/*`):

`ivy -settings ivysettings.xml -confs default -dependency org.elasticsearch elasticsearch 5.0.1-SNAPSHOT -retrieve "jars/[module]-[artifact](-[revision]).[ext]"`

which yields:

```
	---------------------------------------------------------------------
	|                  |            modules            ||   artifacts   |
	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
	---------------------------------------------------------------------
	|      default     |   29  |   16  |   16  |   0   ||   29  |   19  |
	---------------------------------------------------------------------
```

All 29 artifacts are accounted for.

```
$ ls jars
HdrHistogram-HdrHistogram-2.1.6.jar                         lucene-highlighter-lucene-highlighter-6.2.1.jar
elasticsearch-elasticsearch-5.0.1-SNAPSHOT.jar              lucene-join-lucene-join-6.2.1.jar
hppc-hppc-0.7.1.jar                                         lucene-memory-lucene-memory-6.2.1.jar
jackson-core-jackson-core-2.8.1.jar                         lucene-misc-lucene-misc-6.2.1.jar
jackson-dataformat-cbor-jackson-dataformat-cbor-2.8.1.jar   lucene-queries-lucene-queries-6.2.1.jar
jackson-dataformat-smile-jackson-dataformat-smile-2.8.1.jar lucene-queryparser-lucene-queryparser-6.2.1.jar
jackson-dataformat-yaml-jackson-dataformat-yaml-2.8.1.jar   lucene-sandbox-lucene-sandbox-6.2.1.jar
jna-jna-4.2.2.jar                                           lucene-spatial-extras-lucene-spatial-extras-6.2.1.jar
joda-convert-joda-convert-1.2.jar                           lucene-spatial-lucene-spatial-6.2.1.jar
joda-time-joda-time-2.9.4.jar                               lucene-spatial3d-lucene-spatial3d-6.2.1.jar
jopt-simple-jopt-simple-5.0.2.jar                           lucene-suggest-lucene-suggest-6.2.1.jar
lucene-analyzers-common-lucene-analyzers-common-6.2.1.jar   securesm-securesm-1.1.jar
lucene-backward-codecs-lucene-backward-codecs-6.2.1.jar     snakeyaml-snakeyaml-1.15.jar
lucene-core-lucene-core-6.2.1.jar                           t-digest-t-digest-3.0.jar
lucene-grouping-lucene-grouping-6.2.1.jar
```

**SBT** (version 0.13.12)

Let's create a simple build file (`build.sbt`):

```
name := "test"

resolvers += Resolver.mavenLocal

libraryDependencies ++= Seq(
   "org.elasticsearch" % "elasticsearch" % "5.0.0"
)

```

and run `sbt 'show runtime:fullClasspath'`

```
List(Attributed(/Users/ywelsch/dev/sbt-example/target/scala-2.10/classes), Attributed(/Users/ywelsch/.sbt/boot/scala-2.10.6/lib/scala-library.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.elasticsearch/elasticsearch/jars/elasticsearch-5.0.0.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.apache.lucene/lucene-core/jars/lucene-core-6.2.0.jar), Attributed(/Users/ywelsch/.m2/repository/org/elasticsearch/securesm/1.1/securesm-1.1.jar), Attributed(/Users/ywelsch/.m2/repository/net/sf/jopt-simple/jopt-simple/5.0.2/jopt-simple-5.0.2.jar), Attributed(/Users/ywelsch/.m2/repository/com/carrotsearch/hppc/0.7.1/hppc-0.7.1.jar), Attributed(/Users/ywelsch/.m2/repository/joda-time/joda-time/2.9.4/joda-time-2.9.4.jar), Attributed(/Users/ywelsch/.m2/repository/org/joda/joda-convert/1.2/joda-convert-1.2.jar), Attributed(/Users/ywelsch/.m2/repository/org/yaml/snakeyaml/1.15/snakeyaml-1.15.jar), Attributed(/Users/ywelsch/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.8.1/jackson-core-2.8.1.jar), Attributed(/Users/ywelsch/.m2/repository/com/tdunning/t-digest/3.0/t-digest-3.0.jar), Attributed(/Users/ywelsch/.m2/repository/org/hdrhistogram/HdrHistogram/2.1.6/HdrHistogram-2.1.6.jar), Attributed(/Users/ywelsch/.m2/repository/net/java/dev/jna/jna/4.2.2/jna-4.2.2.jar))
```

Same as for Ivy, only 12 artifacts instead of the 29 that we expect.

Replace the 5.0.0 dependency by 5.0.1-SNAPSHOT in the build file and run same command again:

```
List(Attributed(/Users/ywelsch/dev/sbt-example/target/scala-2.10/classes), Attributed(/Users/ywelsch/.sbt/boot/scala-2.10.6/lib/scala-library.jar), Attributed(/Users/ywelsch/.m2/repository/org/elasticsearch/elasticsearch/5.0.1-SNAPSHOT/elasticsearch-5.0.1-SNAPSHOT.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.apache.lucene/lucene-core/jars/lucene-core-6.2.1.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.apache.lucene/lucene-analyzers-common/jars/lucene-analyzers-common-6.2.1.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.apache.lucene/lucene-backward-codecs/jars/lucene-backward-codecs-6.2.1.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.apache.lucene/lucene-grouping/jars/lucene-grouping-6.2.1.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.apache.lucene/lucene-highlighter/jars/lucene-highlighter-6.2.1.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.apache.lucene/lucene-join/jars/lucene-join-6.2.1.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.apache.lucene/lucene-memory/jars/lucene-memory-6.2.1.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.apache.lucene/lucene-misc/jars/lucene-misc-6.2.1.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.apache.lucene/lucene-queries/jars/lucene-queries-6.2.1.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.apache.lucene/lucene-queryparser/jars/lucene-queryparser-6.2.1.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.apache.lucene/lucene-sandbox/jars/lucene-sandbox-6.2.1.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.apache.lucene/lucene-spatial/jars/lucene-spatial-6.2.1.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.apache.lucene/lucene-spatial-extras/jars/lucene-spatial-extras-6.2.1.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.apache.lucene/lucene-spatial3d/jars/lucene-spatial3d-6.2.1.jar), Attributed(/Users/ywelsch/.ivy2/cache/org.apache.lucene/lucene-suggest/jars/lucene-suggest-6.2.1.jar), Attributed(/Users/ywelsch/.m2/repository/org/elasticsearch/securesm/1.1/securesm-1.1.jar), Attributed(/Users/ywelsch/.m2/repository/net/sf/jopt-simple/jopt-simple/5.0.2/jopt-simple-5.0.2.jar), Attributed(/Users/ywelsch/.m2/repository/com/carrotsearch/hppc/0.7.1/hppc-0.7.1.jar), Attributed(/Users/ywelsch/.m2/repository/joda-time/joda-time/2.9.4/joda-time-2.9.4.jar), Attributed(/Users/ywelsch/.m2/repository/org/joda/joda-convert/1.2/joda-convert-1.2.jar), Attributed(/Users/ywelsch/.m2/repository/org/yaml/snakeyaml/1.15/snakeyaml-1.15.jar), Attributed(/Users/ywelsch/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.8.1/jackson-core-2.8.1.jar), Attributed(/Users/ywelsch/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-smile/2.8.1/jackson-dataformat-smile-2.8.1.jar), Attributed(/Users/ywelsch/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.8.1/jackson-dataformat-yaml-2.8.1.jar), Attributed(/Users/ywelsch/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.8.1/jackson-dataformat-cbor-2.8.1.jar), Attributed(/Users/ywelsch/.m2/repository/com/tdunning/t-digest/3.0/t-digest-3.0.jar), Attributed(/Users/ywelsch/.m2/repository/org/hdrhistogram/HdrHistogram/2.1.6/HdrHistogram-2.1.6.jar), Attributed(/Users/ywelsch/.m2/repository/net/java/dev/jna/jna/4.2.2/jna-4.2.2.jar))
```

All 29 artifacts are there.