### PR TITLE
Add docs with up to date instructions on updating default similarity

### DIFF
--- a/docs/reference/index-modules/similarity.asciidoc
+++ b/docs/reference/index-modules/similarity.asciidoc
@@ -174,9 +174,15 @@ implementation used for these two methods, while not changing the
 `default`, it is possible to configure a similarity with the name
 `base`. This similarity will then be used for the two methods.
 
-You can change the default similarity for all fields by putting the following setting into `elasticsearch.yml`:
+You can change the default similarity for all fields by sending the
+following <<indices-update-settings,update settings>> request, note you
+must <<indices-open-close,close>> your index before sending the request
+and <<indices-open-close,open>> it again afterwards:
 
 [source,js]
 --------------------------------------------------
-index.similarity.default.type: classic
+PUT /my_index/_settings
+{
+  "index.similarity.default.type" : "classic"
+}
 --------------------------------------------------

--- a/docs/reference/index-modules/similarity.asciidoc
+++ b/docs/reference/index-modules/similarity.asciidoc
@@ -174,15 +174,41 @@ implementation used for these two methods, while not changing the
 `default`, it is possible to configure a similarity with the name
 `base`. This similarity will then be used for the two methods.
 
-You can change the default similarity for all fields by sending the
-following <<indices-update-settings,update settings>> request, note you
-must <<indices-open-close,close>> your index before sending the request
-and <<indices-open-close,open>> it again afterwards:
+You can change the default similarity for all fields in an index when
+it is <<indices-create-index,created>>:
+
+[source,js]
+--------------------------------------------------
+PUT /my_index
+{
+  "settings": {
+    "index": {
+      "similarity": {
+        "default": {
+          "type": "classic"
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+
+If you want to change the default similarity after creating the index
+you must <<indices-open-close,close>> your index, send the follwing
+request and <<indices-open-close,open>> it again afterwards:
 
 [source,js]
 --------------------------------------------------
 PUT /my_index/_settings
 {
-  "index.similarity.default.type" : "classic"
+  "settings": {
+    "index": {
+      "similarity": {
+        "default": {
+          "type": "classic"
+        }
+      }
+    }
+  }
 }
 --------------------------------------------------


### PR DESCRIPTION
The default similarity can no longer be set in the configuration file
(you will get an error on startup). Update the docs with the method
that works.