### PR TITLE
Remove special case in case no action filters are registered

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/TransportAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/TransportAction.java
@@ -138,17 +138,8 @@ public abstract class TransportAction<Request extends ActionRequest<Request>, Re
             listener = new TaskResultStoringActionListener<>(taskManager, task, listener);
         }
 
-        if (filters.length == 0) {
-            try {
-                doExecute(task, request, listener);
-            } catch(Exception e) {
-                logger.trace("Error during transport action execution.", e);
-                listener.onFailure(e);
-            }
-        } else {
-            RequestFilterChain<Request, Response> requestFilterChain = new RequestFilterChain<>(this, logger);
-            requestFilterChain.proceed(task, actionName, request, listener);
-        }
+        RequestFilterChain<Request, Response> requestFilterChain = new RequestFilterChain<>(this, logger);
+        requestFilterChain.proceed(task, actionName, request, listener);
     }
 
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {


### PR DESCRIPTION
Since we have the ingest node type, there is either `IngestActionFilter` or `IngestProxyActionFilter` registered, depending on whether the node is an ingest node or not. The special case that shortcuts the execution in case there are no filters is never exercised, hence we are probably better off removing it as it is not needed and never tested.