### PR TITLE
[TEST] Check static test state after suite scoped cluster is shut down

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1972,6 +1972,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
             try {
                 INSTANCE.printTestMessage("cleaning up after");
                 INSTANCE.afterInternal(true);
+                checkStaticState();
             } finally {
                 INSTANCE = null;
             }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -237,6 +237,11 @@ public abstract class ESTestCase extends LuceneTestCase {
 
     @After
     public final void ensureCleanedUp() throws Exception {
+        checkStaticState();
+    }
+
+    // separate method so that this can be checked again after suite scoped cluster is shut down
+    protected static void checkStaticState() throws Exception {
         MockPageCacheRecycler.ensureAllPagesAreReleased();
         MockBigArrays.ensureAllArraysAreReleased();
         // field cache should NEVER get loaded.


### PR DESCRIPTION
Checks on static test state are run by an `@After` method in `ESTestCase`. Suite-scoped tests in `ESIntegTestCase` only shut down in an `@AfterClass` method, which executes after the `@After` method in ESTestCase. The suite-scoped cluster can thus still execute actions that will violate the checks in `@After` without those being caught. A subsequent test executing within the same JVM will fail these checks however when `@After` gets called for that test.

This commit adds an explicit call to check the static test state after the suite-scoped cluster has been shut down.