### PR TITLE
Fix `_shrink` test to work under a mixed version cluster

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
@@ -41,7 +41,7 @@
         "wait_for_events": {
           "type" : "enum",
           "options" : ["immediate", "urgent", "high", "normal", "low", "languid"],
-          "description" : "Wait until all currently queued events with the given priorty are processed"
+          "description" : "Wait until all currently queued events with the given priority are processed"
         },
         "wait_for_no_relocating_shards": {
           "type" : "boolean",

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yaml
@@ -1,6 +1,6 @@
 ---
 "Shrink index via API":
-  # creates an index with one document soely allocated on the master node
+  # creates an index with one document solely allocated on the master node
   # and shrinks it into a new index with a single shard
   # we don't do the relocation to a single node after the index is created
   # here since in a mixed version cluster we can't identify

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yaml
@@ -51,8 +51,6 @@
       cluster.health:
         wait_for_status: green
         index: source
-        wait_for_no_relocating_shards: true
-        wait_for_events: "languid"
 
   # now we do the actual shrink
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yaml
@@ -1,21 +1,26 @@
 ---
 "Shrink index via API":
-  - skip:
-    version: " - 5.0.0"
-    reason:  this doesn't work yet with BWC tests since the master is from the old verion
-    # TODO we need to fix this for BWC tests to make sure we get a node that all shards can allocate on
-    # today if we run BWC tests and we select the master as a _shrink node but since primaries are allocated
-    # on the newer version nodes this fails...
-  # creates an index with one document.
-  # relocates all it's shards to one node
-  # shrinks it into a new index with a single shard
+  # creates an index with one document soely allocated on the master node
+  # and shrinks it into a new index with a single shard
+  # we don't do the relocation to a single node after the index is created
+  # here since in a mixed version cluster we can't identify
+  # which node is the one with the highest version and that is the only one that can safely
+  # be used to shrink the index.
+  - do:
+      cluster.state: {}
+      # Get master node id
+      
+  - set: { master_node: master }
+
   - do:
       indices.create:
         index: source
         wait_for_active_shards: 1
         body:
           settings:
-            number_of_replicas: "0"
+            # ensure everything is allocated on a single node
+            index.routing.allocation.include._id: $master
+            number_of_replicas: 0
   - do:
       index:
         index: source
@@ -34,18 +39,11 @@
   - match: { _id:      "1"     }
   - match: { _source:  { foo: "hello world" } }
 
-  - do:
-      cluster.state: {}
-
-  # Get master node id
-  - set: { master_node: master }
-
-  # relocate everything to the master node and make it read-only
+  # make it read-only
   - do:
       indices.put_settings:
         index: source
         body:
-          index.routing.allocation.include._id: $master
           index.blocks.write: true
           index.number_of_replicas: 0
 


### PR DESCRIPTION
today the `_shrink` tests do relocate all shards to a single node in
the cluster. Yet, that is not always possible since the only node we can
safely identify in the cluster is the master and if the master is a BWC
node in such a cluster we won't be able to relocate shards that have a
primary on the newer version nodes since allocation deciders forbit this.

This change restricts allocation for that index when the index is created
to restrict allocation to the master that guarantees that all primaries
are on the same node which is sufficient for the `_shrink` API to run.