### PR TITLE
Updates plugin documentation for 5.0

### DIFF
--- a/docs/plugins/alerting.asciidoc
+++ b/docs/plugins/alerting.asciidoc
@@ -8,11 +8,10 @@ Alerting plugins allow Elasticsearch to monitor indices and to trigger alerts wh
 
 The core alerting plugins are:
 
-link:/products/watcher[Watcher]::
+link:/products/x-pack/alerting[X-Pack]::
 
-Watcher is the alerting and notification product for Elasticsearch that lets
-you take action based on changes in your data. It is designed around the
+X-Pack contains the alerting and notification product for Elasticsearch that
+lets you take action based on changes in your data. It is designed around the
 principle that if you can query something in Elasticsearch, you can alert on
 it. Simply define a query, condition, schedule, and the actions to take, and
-Watcher will do the rest.
-
+X-Pack will do the rest.

--- a/docs/plugins/analysis.asciidoc
+++ b/docs/plugins/analysis.asciidoc
@@ -45,11 +45,9 @@ Provides stemming for Ukrainian.
 
 A number of analysis plugins have been contributed by our community:
 
-* https://github.com/yakaz/elasticsearch-analysis-combo/[Combo Analysis Plugin] (by Olivier Favre, Yakaz)
 * https://github.com/synhershko/elasticsearch-analysis-hebrew[Hebrew Analysis Plugin] (by Itamar Syn-Hershko)
 * https://github.com/medcl/elasticsearch-analysis-ik[IK Analysis Plugin] (by Medcl)
 * https://github.com/medcl/elasticsearch-analysis-mmseg[Mmseg Analysis Plugin] (by Medcl)
-* https://github.com/chytreg/elasticsearch-analysis-morfologik[Morfologik (Polish) Analysis plugin] (by chytreg)
 * https://github.com/imotov/elasticsearch-analysis-morphology[Russian and English Morphological Analysis Plugin] (by Igor Motov)
 * https://github.com/medcl/elasticsearch-analysis-pinyin[Pinyin Analysis Plugin] (by Medcl)
 * https://github.com/duydo/elasticsearch-analysis-vietnamese[Vietnamese Analysis Plugin] (by Duy Do)
@@ -67,5 +65,3 @@ include::analysis-smartcn.asciidoc[]
 include::analysis-stempel.asciidoc[]
 
 include::analysis-ukrainian.asciidoc[]
-
-

--- a/docs/plugins/api.asciidoc
+++ b/docs/plugins/api.asciidoc
@@ -14,10 +14,6 @@ A number of plugins have been contributed by our community:
 * https://github.com/wikimedia/search-extra[Elasticsearch Trigram Accelerated Regular Expression Filter]:
   (by Wikimedia Foundation/Nik Everett)
 
-* https://github.com/kzwang/elasticsearch-image[Elasticsearch Image Plugin]:
-  Uses https://code.google.com/p/lire/[Lire (Lucene Image Retrieval)] to allow users
-  to index images and search for similar images (by Kevin Wang)
-
 * https://github.com/wikimedia/search-highlighter[Elasticsearch Experimental Highlighter]:
   (by Wikimedia Foundation/Nik Everett)
 
@@ -30,7 +26,4 @@ A number of plugins have been contributed by our community:
 * https://github.com/codelibs/elasticsearch-taste[Elasticsearch Taste Plugin]:
   Mahout Taste-based Collaborative Filtering implementation (by CodeLibs Project)
 
-* https://github.com/hadashiA/elasticsearch-flavor[Elasticsearch Flavor Plugin] using
-  http://mahout.apache.org/[Mahout] Collaboration filtering (by hadashiA)
 * https://github.com/jurgc11/es-change-feed-plugin[WebSocket Change Feed Plugin] (by ForgeRock/Chris Clifton)
-

--- a/docs/plugins/discovery.asciidoc
+++ b/docs/plugins/discovery.asciidoc
@@ -30,9 +30,7 @@ The File-based discovery plugin allows providing the unicast hosts list through 
 
 A number of discovery plugins have been contributed by our community:
 
-* https://github.com/grantr/elasticsearch-srv-discovery[DNS SRV Discovery Plugin] (by Grant Rodgers)
 * https://github.com/shikhar/eskka[eskka Discovery Plugin] (by Shikhar Bhushan)
-* https://github.com/grmblfrz/elasticsearch-zookeeper[ZooKeeper Discovery Plugin] (by Sonian Inc.)
 * https://github.com/fabric8io/elasticsearch-cloud-kubernetes[Kubernetes Discovery Plugin] (by Jimmi Dyson, http://fabric8.io[fabric8])
 
 include::discovery-ec2.asciidoc[]
@@ -42,4 +40,3 @@ include::discovery-azure-classic.asciidoc[]
 include::discovery-gce.asciidoc[]
 
 include::discovery-file.asciidoc[]
-

--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -201,4 +201,3 @@ These projects appear to have been abandoned:
   D3.
 * https://github.com/OlegKunitsyn/eslogd[eslogd]:
   Linux daemon that replicates events to a central Elasticsearch server in realtime
->>>>>>> 02602a3... Update integrations.asciidoc (#18915)

--- a/docs/plugins/management.asciidoc
+++ b/docs/plugins/management.asciidoc
@@ -1,19 +1,16 @@
 [[management]]
-== Management and Site Plugins
+== Management Plugins
 
-Management and site plugins offer UIs for managing and interacting with
-Elasticsearch.
+Management plugins offer UIs for managing and interacting with Elasticsearch.
 
 [float]
 === Core management plugins
 
 The core management plugins are:
 
-link:/products/marvel[Marvel]::
+link:/products/x-pack/monitoring[X-Pack]::
 
-Marvel is a management and monitoring product for Elasticsearch. Marvel
+X-Pack contains the management and monitoring features for Elasticsearch. It
 aggregates cluster wide statistics and events and offers a single interface to
-view and analyze them. Marvel is free for development use but requires a
-license to run in production.
-
-
+view and analyze them. You can get a link:/subscriptions[free license] for basic
+monitoring or a higher level license for more advanced needs.

--- a/docs/plugins/security.asciidoc
+++ b/docs/plugins/security.asciidoc
@@ -8,12 +8,12 @@ Security plugins add a security layer to  Elasticsearch.
 
 The core security plugins are:
 
-link:/products/shield[Shield]::
+link:/products/x-pack/security[X-Pack]::
 
-Shield is the Elastic product that makes it easy for anyone to add
-enterprise-grade security to their ELK stack. Designed to address the growing security
-needs of thousands of enterprises using ELK today, Shield provides peace of
-mind when it comes to protecting your data.
+X-Pack is the Elastic product that makes it easy for anyone to add
+enterprise-grade security to their Elastic Stack. Designed to address the
+growing security needs of thousands of enterprises using the Elastic Stack
+today, X-Pack provides peace of mind when it comes to protecting your data.
 
 [float]
 === Community contributed security plugins
@@ -25,4 +25,3 @@ The following plugins have been contributed by our community:
 
 * https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin[Readonly REST]:
   High performance access control for Elasticsearch native REST API (by Simone Scarduzio)
-


### PR DESCRIPTION
PR does 2 things:
- Updates some of the verbiage for 5.x, e.g. changing Marvel plugin to X-Pack and updating the license information there
- Drops any plugins that obviously haven't been updated since before Elasticsearch 2.0.  I didn't dig in too much and left plugins that looked to be updated at least by 2.3/2.4, since they may be updating to 5.0 soon