### PR TITLE
Never archive mandatory settings

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -165,7 +165,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
             throw new IllegalArgumentException("es.index.max_number_of_shards must be > 0");
         }
         return Setting.intSetting(SETTING_NUMBER_OF_SHARDS, Math.min(5, maxNumShards), 1, maxNumShards,
-            Property.IndexScope);
+            Property.IndexScope, Property.Mandatory);
     }
 
     public static final String INDEX_SETTING_PREFIX = "index.";
@@ -173,7 +173,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
     public static final Setting<Integer> INDEX_NUMBER_OF_SHARDS_SETTING = buildNumberOfShardsSetting();
     public static final String SETTING_NUMBER_OF_REPLICAS = "index.number_of_replicas";
     public static final Setting<Integer> INDEX_NUMBER_OF_REPLICAS_SETTING =
-        Setting.intSetting(SETTING_NUMBER_OF_REPLICAS, 1, 0, Property.Dynamic, Property.IndexScope);
+        Setting.intSetting(SETTING_NUMBER_OF_REPLICAS, 1, 0, Property.Dynamic, Property.IndexScope, Property.Mandatory);
     public static final String SETTING_SHADOW_REPLICAS = "index.shadow_replicas";
     public static final Setting<Boolean> INDEX_SHADOW_REPLICAS_SETTING =
         Setting.boolSetting(SETTING_SHADOW_REPLICAS, false, Property.IndexScope);

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
@@ -77,7 +77,12 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
         IndexMetaData newMetaData = indexMetaData;
         // we have to run this first otherwise in we try to create IndexSettings
         // with broken settings and fail in checkMappingsCompatibility
-        newMetaData = archiveBrokenIndexSettings(newMetaData);
+        try {
+            newMetaData = archiveBrokenIndexSettings(newMetaData);
+        } catch (Exception ex) {
+            logger.error("{} failed to process index settings: {}", newMetaData.getIndex(), ex.getMessage());
+            throw ex;
+        }
         // only run the check with the upgraded settings!!
         checkMappingsCompatibility(newMetaData);
         return markAsUpgraded(newMetaData);

--- a/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -507,6 +507,8 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
      *                        associated value)
      * @param invalidConsumer callback on invalid settings (consumer receives invalid key, its
      *                        associated value and an exception)
+     * @throws IllegalStateException if an {@link org.elasticsearch.common.settings.Setting.Property#Mandatory} setting must be archived
+     *
      * @return a {@link Settings} instance with the unknown or invalid settings archived
      */
     public Settings archiveUnknownOrInvalidSettings(

--- a/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -519,7 +519,14 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
             try {
                 Setting<?> setting = get(entry.getKey());
                 if (setting != null) {
-                    setting.get(settings);
+                    try {
+                        setting.get(settings);
+                    } catch (IllegalArgumentException ex) {
+                        if (setting.isMandatory()) {
+                            throw new IllegalStateException("can't archive mandatory setting [" + setting.getKey() + "]", ex);
+                        }
+                        throw ex;
+                    }
                     builder.put(entry.getKey(), entry.getValue());
                 } else {
                     if (entry.getKey().startsWith(ARCHIVED_SETTINGS_PREFIX) || isPrivateSetting(entry.getKey())) {

--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -104,7 +104,11 @@ public class Setting<T> extends ToXContentToBytes {
         /**
          * Index scope
          */
-        IndexScope
+        IndexScope,
+        /**
+         * Mandatory settings ie. index.number_of_shards
+         */
+        Mandatory
     }
 
     private final Key key;
@@ -255,6 +259,12 @@ public class Setting<T> extends ToXContentToBytes {
     public boolean isShared() {
         return properties.contains(Property.Shared);
     }
+
+    /**
+     * Returns <code>true</code> if this setting is a mandatory setting or in other words settings without this particular setting are
+     * invalid, otherwise <code>false</code>
+     */
+    public boolean isMandatory() { return properties.contains(Property.Mandatory);}
 
     /**
      * Returns <code>true</code> iff this setting is a group setting. Group settings represent a set of settings rather than a single value.

--- a/core/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -392,6 +392,18 @@ public class IndexSettingsTests extends ESTestCase {
         assertEquals("foo", settings.get("archived.index.unknown"));
         assertEquals(Integer.toString(Version.CURRENT.id), settings.get("index.version.created"));
         assertEquals("2s", settings.get("index.refresh_interval"));
+
+        IllegalStateException failure = expectThrows(IllegalStateException.class, () ->
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS.archiveUnknownOrInvalidSettings(
+                Settings.builder()
+                    .put("index.version.created", Version.CURRENT.id) // private setting
+                    .put("index.number_of_shards", Integer.MAX_VALUE)
+                    .put("index.refresh_interval", "2s").build(),
+                e -> { fail("no invalid setting expected but got: " + e);},
+                (e, ex) -> fail("should not have been invoked, no invalid settings")));
+        assertEquals("can't archive mandatory setting [index.number_of_shards]", failure.getMessage());
+        assertEquals("Failed to parse value [2147483647] for setting [index.number_of_shards] must be <= 1024",
+            failure.getCause().getMessage());
     }
 
 }


### PR DESCRIPTION
We have some settings like `index.number_of_shards` and `index.number_of_replicas`
that should never be archived if they are invalid. If such a setting is invalid
the node should not start-up instead. This change throws an IllegalStateException
if such a setting can't be parsed.

Closes #21114