### PR TITLE
Fix distribution build ordering issue

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -196,6 +196,13 @@ subprojects {
  *                         Zip and tgz configuration                         *
  *****************************************************************************/
 configure(subprojects.findAll { ['zip', 'tar', 'integ-test-zip'].contains(it.name) }) {
+  // CopySpec does not make it easy to create an empty director so we create the directory that we want, and then point CopySpec to its
+  // parent to copy to the root of the distribution
+  File plugins = new File(buildDir, 'plugins-hack/plugins')
+  task createPluginsDir(type: EmptyDirTask) {
+    dir "${plugins}"
+    dirMode 0755
+  }
   project.ext.archivesFiles = copySpec {
     into("elasticsearch-${version}") {
       with libFiles
@@ -215,12 +222,6 @@ configure(subprojects.findAll { ['zip', 'tar', 'integ-test-zip'].contains(it.nam
         }
       }
       into('') {
-        // CopySpec does not make it easy to create an empty directory
-        // so we create the directory that we want, and then point
-        // CopySpec to its parent to copy to the root of the
-        // distribution
-        File plugins = new File(buildDir, 'plugins-hack/plugins')
-        plugins.mkdirs()
         from {
           plugins.getParent()
         }

--- a/distribution/integ-test-zip/build.gradle
+++ b/distribution/integ-test-zip/build.gradle
@@ -20,6 +20,7 @@
 import org.elasticsearch.gradle.plugin.PluginBuildPlugin
 
 task buildZip(type: Zip) {
+  dependsOn createPluginsDir
   baseName = 'elasticsearch'
   with archivesFiles
 }

--- a/distribution/tar/build.gradle
+++ b/distribution/tar/build.gradle
@@ -18,6 +18,7 @@
  */
 
 task buildTar(type: Tar) {
+  dependsOn createPluginsDir
   baseName = 'elasticsearch'
   extension = 'tar.gz'
   with archivesFiles

--- a/distribution/zip/build.gradle
+++ b/distribution/zip/build.gradle
@@ -20,6 +20,7 @@
 import org.elasticsearch.gradle.plugin.PluginBuildPlugin
 
 task buildZip(type: Zip) {
+  dependsOn createPluginsDir
   baseName = 'elasticsearch'
   with archivesFiles
 }


### PR DESCRIPTION
Today when running gradle clean
:distribution:(integ-test-zip|tar|zip):assemble, the created archive
distribution will be missing the empty plugins directory. This is
because the empty plugins folder created in the build folder for the
copy spec task is created during configuration and then is later wiped
away by the clean task. This commit addresses this issue, by pushing
creation of the directory out of the configuration phase.