### PR TITLE
Remove stale install plugins assertion

### DIFF
--- a/qa/vagrant/src/test/resources/packaging/scripts/module_and_plugin_test_cases.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/module_and_plugin_test_cases.bash
@@ -436,38 +436,21 @@ fi
     sudo -E -u $ESPLUGIN_COMMAND_USER "$ESHOME/bin/elasticsearch-plugin" install "file://$relativePath" > /tmp/plugin-cli-output
     # exclude progress line
     local loglines=$(cat /tmp/plugin-cli-output | grep -v "^[[:cntrl:]]" | wc -l)
-    if [ "$GROUP" == "TAR PLUGINS" ]; then
-    # tar extraction does not create the plugins directory so the plugin tool will print an additional line that the directory will be created
-        [ "$loglines" -eq "3" ] || {
-            echo "Expected 3 lines excluding progress bar but the output had $loglines lines and was:"
-            cat /tmp/plugin-cli-output
-            false
-        }
-    else
-        [ "$loglines" -eq "2" ] || {
-            echo "Expected 2 lines excluding progress bar but the output had $loglines lines and was:"
-            cat /tmp/plugin-cli-output
-            false
-        }
-    fi
+    [ "$loglines" -eq "2" ] || {
+        echo "Expected 2 lines excluding progress bar but the output had $loglines lines and was:"
+        cat /tmp/plugin-cli-output
+        false
+    }
     remove_jvm_example
 
     local relativePath=${1:-$(readlink -m jvm-example-*.zip)}
     sudo -E -u $ESPLUGIN_COMMAND_USER ES_JAVA_OPTS="-Des.logger.level=DEBUG" "$ESHOME/bin/elasticsearch-plugin" install "file://$relativePath" > /tmp/plugin-cli-output
     local loglines=$(cat /tmp/plugin-cli-output | grep -v "^[[:cntrl:]]" | wc -l)
-    if [ "$GROUP" == "TAR PLUGINS" ]; then
-        [ "$loglines" -gt "3" ] || {
-            echo "Expected more than 3 lines excluding progress bar but the output had $loglines lines and was:"
-            cat /tmp/plugin-cli-output
-            false
-        }
-    else
-        [ "$loglines" -gt "2" ] || {
-            echo "Expected more than 2 lines excluding progress bar but the output had $loglines lines and was:"
-            cat /tmp/plugin-cli-output
-            false
-        }
-    fi
+    [ "$loglines" -gt "2" ] || {
+        echo "Expected more than 2 lines excluding progress bar but the output had $loglines lines and was:"
+        cat /tmp/plugin-cli-output
+        false
+    }
     remove_jvm_example
 }
 


### PR DESCRIPTION
When installing a plugin when the plugins directory does not exist, the
install plugin command outputs a line saying that it is creating this
directory. The packaging tests for the archive distributions accounted
for this including an assertion that this line was output. The packages
have since been updated to include an empty plugins folder, so this line
will no longer be output. This commit removes this stale assertion from
the packaging tests.

Relates #21204