### PR TITLE
Read indices options in indices upgrade API

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpgradeAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpgradeAction.java
@@ -20,9 +20,11 @@
 package org.elasticsearch.rest.action.admin.indices;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.indices.upgrade.get.UpgradeStatusRequest;
 import org.elasticsearch.action.admin.indices.upgrade.get.UpgradeStatusResponse;
 import org.elasticsearch.action.admin.indices.upgrade.post.UpgradeRequest;
 import org.elasticsearch.action.admin.indices.upgrade.post.UpgradeResponse;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
@@ -68,20 +70,22 @@ public class RestUpgradeAction extends BaseRestHandler {
     }
 
     private RestChannelConsumer handleGet(final RestRequest request, NodeClient client) {
-        return channel -> client.admin().indices().prepareUpgradeStatus(Strings.splitStringByCommaToArray(request.param("index")))
-            .execute(new RestBuilderListener<UpgradeStatusResponse>(channel) {
-                @Override
-                public RestResponse buildResponse(UpgradeStatusResponse response, XContentBuilder builder) throws Exception {
-                    builder.startObject();
-                    response.toXContent(builder, request);
-                    builder.endObject();
-                    return new BytesRestResponse(OK, builder);
-                }
-            });
+        UpgradeStatusRequest statusRequest = new UpgradeStatusRequest(Strings.splitStringByCommaToArray(request.param("index")));
+        statusRequest.indicesOptions(IndicesOptions.fromRequest(request, statusRequest.indicesOptions()));
+        return channel -> client.admin().indices().upgradeStatus(statusRequest, new RestBuilderListener<UpgradeStatusResponse>(channel) {
+            @Override
+            public RestResponse buildResponse(UpgradeStatusResponse response, XContentBuilder builder) throws Exception {
+                builder.startObject();
+                response.toXContent(builder, request);
+                builder.endObject();
+                return new BytesRestResponse(OK, builder);
+            }
+        });
     }
 
     private RestChannelConsumer handlePost(final RestRequest request, NodeClient client) {
         UpgradeRequest upgradeReq = new UpgradeRequest(Strings.splitStringByCommaToArray(request.param("index")));
+        upgradeReq.indicesOptions(IndicesOptions.fromRequest(request, upgradeReq.indicesOptions()));
         upgradeReq.upgradeOnlyAncientSegments(request.paramAsBoolean("only_ancient_segments", false));
         return channel -> client.admin().indices().upgrade(upgradeReq, new RestBuilderListener<UpgradeResponse>(channel) {
             @Override

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.upgrade.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.upgrade.json
@@ -12,6 +12,10 @@
         }
       },
       "params": {
+        "allow_no_indices": {
+          "type" : "boolean",
+          "description" : "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        },
         "expand_wildcards": {
             "type" : "enum",
             "options" : ["open","closed","none","all"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.upgrade/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.upgrade/10_basic.yaml
@@ -9,14 +9,64 @@
             index:
               number_of_replicas: 0
 
-
-  - do:
-      cluster.health:
-        wait_for_status: green
-
   - do:
       indices.upgrade:
         index: test_index
 
   - match: {upgraded_indices.test_index.oldest_lucene_segment_version: '/(\d\.)+\d/'}
   - is_true: upgraded_indices.test_index.upgrade_version
+
+---
+"Upgrade indices ignore unavailable":
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            index:
+              number_of_shards: 1
+              number_of_replicas: 0
+
+  - do:
+      indices.upgrade:
+        index: ["does_not_exist", "test_index"]
+        ignore_unavailable: true
+
+  - match: {_shards.total: 1}
+  - is_true: upgraded_indices.test_index.upgrade_version
+  - is_false: upgraded_indices.does_not_exist
+
+---
+"Upgrade indices allow no indices":
+
+  - do:
+      indices.upgrade:
+        index: test_index
+        ignore_unavailable: true
+        allow_no_indices: true
+
+  - match: {_shards.total: 0}
+
+---
+"Upgrade indices disallow no indices":
+
+  - do:
+      catch: missing
+      indices.upgrade:
+        index: test_index
+        ignore_unavailable: true
+        allow_no_indices: false
+
+---
+"Upgrade indices disallow unavailable":
+  - do:
+      indices.create:
+        index: test_index
+
+  - do:
+      catch: missing
+      indices.upgrade:
+        index: ["test_index", "does_not_exist"]
+        ignore_unavailable: false
+


### PR DESCRIPTION
With #21099 we removed support for the ignored allow_no_indices parameter in indices upgrade API. Truth is that ignore_unavailable and expand_wildcards were also ignored, in indices upgrade as well as upgrade status API. Those parameters are though supported internally and settable through java API, hence they should be all supported on the REST layer too.