### PR TITLE
Update ingest-attachment.asciidoc

### DIFF
--- a/docs/plugins/ingest-attachment.asciidoc
+++ b/docs/plugins/ingest-attachment.asciidoc
@@ -49,11 +49,12 @@ The node must be stopped before removing the plugin.
 [options="header"]
 |======
 | Name                   | Required  | Default          | Description
-| `field`                | yes       | -                | The field to get the base64 encoded field from
+| `field`*               | yes       | -                | The field to get the base64 encoded field from
 | `target_field`         | no        | attachment       | The field that will hold the attachment information
 | `indexed_chars`        | no        | 100000           | The number of chars being used for extraction to prevent huge fields. Use `-1` for no limit.
 | `properties`           | no        | all              | Properties to select to be stored. Can be `content`, `title`, `name`, `author`, `keywords`, `date`, `content_type`, `content_length`, `language`
 |======
+*The `field` must have been created in your index mapping.
 
 For example, this:
 


### PR DESCRIPTION
It would be easier for the new users to know that **field** must have been created in your index mapping, before you use the processors.

> I read many times the description... after a lot of lost time trying to use ingest attachment, I realized that the field must have been created with same name as of the mapping. So, I think this might help others. If you consider it would not, it's fine.