### PR TITLE
Add information about in-flight requests when checking IndexShard operation counter

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -366,6 +366,11 @@ public abstract class TransportReplicationAction<
                 executeOnReplicas, replicasProxy, clusterService::state, logger, actionName
             );
         }
+
+        @Override
+        public String toString() {
+            return "AsyncPrimaryAction for " + request.getDescription();
+        }
     }
 
     protected class PrimaryResult implements ReplicationOperation.PrimaryResult<ReplicaRequest> {
@@ -582,6 +587,11 @@ public abstract class TransportReplicationAction<
             public void onFailure(Exception e) {
                 responseWithFailure(e);
             }
+        }
+
+        @Override
+        public String toString() {
+            return "AsyncReplicaAction for " + request.getDescription();
         }
     }
 
@@ -880,6 +890,10 @@ public abstract class TransportReplicationAction<
             @Override
             public void onFailure(Exception e) {
                 onReferenceAcquired.onFailure(e);
+            }
+
+            public String toString() {
+                return onReferenceAcquired.toString();
             }
         };
 

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -115,7 +115,6 @@ import java.util.function.BiConsumer;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.common.lucene.Lucene.cleanLuceneIndex;
-import static org.elasticsearch.common.lucene.Lucene.readScoreDoc;
 import static org.elasticsearch.common.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1054,7 +1054,12 @@ public final class InternalTestCluster extends TestCluster {
             IndicesService indexServices = getInstance(IndicesService.class, nodeAndClient.name);
             for (IndexService indexService : indexServices) {
                 for (IndexShard indexShard : indexService) {
-                    assertThat("index shard counter on shard " + indexShard.shardId() + " on node " + nodeAndClient.name + " not 0", indexShard.getActiveOperationsCount(), equalTo(0));
+                    try {
+                        indexShard.ensureNoActiveOperations();
+                    } catch (IllegalStateException ise) {
+                        throw new AssertionError("index shard counter on shard " + indexShard.shardId() + " on node " + nodeAndClient.name +
+                            " not 0 but " + indexShard.getActiveOperationsCount(), ise);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Our test infrastructure checks after running each test that there are no more in-flight requests on the shard level. Whenever the check fails, we only know that there were in-flight requests but don't know what requests were causing this issue.