### PR TITLE
Add information about in-flight requests when checking IndexShard operation counter

### DIFF
--- a/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
@@ -174,7 +174,7 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
     }
 
     @Override
-    protected void beforeIndexDeletion() {
+    protected void beforeIndexDeletion() throws IOException {
         if (disableBeforeIndexDeletion == false) {
             super.beforeIndexDeletion();
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -575,7 +575,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
         return Collections.emptySet();
     }
 
-    protected void beforeIndexDeletion() {
+    protected void beforeIndexDeletion() throws IOException {
         cluster().beforeIndexDeletion();
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
@@ -82,7 +82,7 @@ public abstract class TestCluster implements Closeable {
     /**
      * Assertions that should run before the cluster is wiped should be called in this method
      */
-    public void beforeIndexDeletion() {
+    public void beforeIndexDeletion() throws IOException {
     }
 
     /**


### PR DESCRIPTION
Our test infrastructure checks after running each test that there are no more in-flight requests on the shard level. Whenever the check fails, we only know
that there were in-flight requests but don't know what requests were causing this issue.

Supersedes #21307