### PR TITLE
Rank Eval: Remove size from metrics

### DIFF
--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalPlugin.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalPlugin.java
@@ -52,8 +52,8 @@ public class RankEvalPlugin extends Plugin implements ActionPlugin {
         List<NamedWriteableRegistry.Entry> namedWriteables = new ArrayList<>();
         namedWriteables.add(new NamedWriteableRegistry.Entry(RankedListQualityMetric.class, Precision.NAME, Precision::new));
         namedWriteables.add(new NamedWriteableRegistry.Entry(RankedListQualityMetric.class, ReciprocalRank.NAME, ReciprocalRank::new));
-        namedWriteables.add(new NamedWriteableRegistry.Entry(RankedListQualityMetric.class, DiscountedCumulativeGainAt.NAME,
-                DiscountedCumulativeGainAt::new));
+        namedWriteables.add(new NamedWriteableRegistry.Entry(RankedListQualityMetric.class, DiscountedCumulativeGain.NAME,
+                DiscountedCumulativeGain::new));
         namedWriteables.add(new NamedWriteableRegistry.Entry(MetricDetails.class, Precision.NAME,
                 Precision.Breakdown::new));
         namedWriteables.add(new NamedWriteableRegistry.Entry(MetricDetails.class, ReciprocalRank.NAME,

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalPlugin.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalPlugin.java
@@ -50,12 +50,12 @@ public class RankEvalPlugin extends Plugin implements ActionPlugin {
     @Override
     public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
         List<NamedWriteableRegistry.Entry> namedWriteables = new ArrayList<>();
-        namedWriteables.add(new NamedWriteableRegistry.Entry(RankedListQualityMetric.class, PrecisionAtN.NAME, PrecisionAtN::new));
+        namedWriteables.add(new NamedWriteableRegistry.Entry(RankedListQualityMetric.class, Precision.NAME, Precision::new));
         namedWriteables.add(new NamedWriteableRegistry.Entry(RankedListQualityMetric.class, ReciprocalRank.NAME, ReciprocalRank::new));
         namedWriteables.add(new NamedWriteableRegistry.Entry(RankedListQualityMetric.class, DiscountedCumulativeGainAt.NAME,
                 DiscountedCumulativeGainAt::new));
-        namedWriteables.add(new NamedWriteableRegistry.Entry(MetricDetails.class, PrecisionAtN.NAME,
-                PrecisionAtN.Breakdown::new));
+        namedWriteables.add(new NamedWriteableRegistry.Entry(MetricDetails.class, Precision.NAME,
+                Precision.Breakdown::new));
         namedWriteables.add(new NamedWriteableRegistry.Entry(MetricDetails.class, ReciprocalRank.NAME,
                 ReciprocalRank.Breakdown::new));
         return namedWriteables;

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankedListQualityMetric.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankedListQualityMetric.java
@@ -70,8 +70,8 @@ public interface RankedListQualityMetric extends ToXContent, NamedWriteable {
         case ReciprocalRank.NAME:
             rc = ReciprocalRank.fromXContent(parser, context);
             break;
-        case DiscountedCumulativeGainAt.NAME:
-            rc = DiscountedCumulativeGainAt.fromXContent(parser, context);
+        case DiscountedCumulativeGain.NAME:
+            rc = DiscountedCumulativeGain.fromXContent(parser, context);
             break;
         default:
             throw new ParsingException(parser.getTokenLocation(), "[_na] unknown query metric name [{}]", metricName);

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankedListQualityMetric.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankedListQualityMetric.java
@@ -64,8 +64,8 @@ public interface RankedListQualityMetric extends ToXContent, NamedWriteable {
 
         // TODO maybe switch to using a plugable registry later?
         switch (metricName) {
-        case PrecisionAtN.NAME:
-            rc = PrecisionAtN.fromXContent(parser, context);
+        case Precision.NAME:
+            rc = Precision.fromXContent(parser, context);
             break;
         case ReciprocalRank.NAME:
             rc = ReciprocalRank.fromXContent(parser, context);

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/ReciprocalRank.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/ReciprocalRank.java
@@ -45,7 +45,7 @@ import static org.elasticsearch.index.rankeval.RankedListQualityMetric.joinHitsW
 public class ReciprocalRank implements RankedListQualityMetric {
 
     public static final String NAME = "reciprocal_rank";
-    public static final int DEFAULT_MAX_ACCEPTABLE_RANK = 10;
+    public static final int DEFAULT_MAX_ACCEPTABLE_RANK = Integer.MAX_VALUE;
     private int maxAcceptableRank = DEFAULT_MAX_ACCEPTABLE_RANK;
 
     /** ratings equal or above this value will be considered relevant. */

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/EvalQueryQualityTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/EvalQueryQualityTests.java
@@ -44,7 +44,7 @@ public class EvalQueryQualityTests extends ESTestCase {
         EvalQueryQuality evalQueryQuality = new EvalQueryQuality(randomAsciiOfLength(10), randomDoubleBetween(0.0, 1.0, true));
         if (randomBoolean()) {
             // TODO randomize this
-            evalQueryQuality.addMetricDetails(new PrecisionAtN.Breakdown(1, 5));
+            evalQueryQuality.addMetricDetails(new Precision.Breakdown(1, 5));
         }
         evalQueryQuality.addHitsAndRatings(ratedHits);
         return evalQueryQuality;
@@ -78,7 +78,7 @@ public class EvalQueryQualityTests extends ESTestCase {
             break;
         case 2:
             if (metricDetails == null) {
-                metricDetails = new PrecisionAtN.Breakdown(1, 5);
+                metricDetails = new Precision.Breakdown(1, 5);
             } else {
                 metricDetails = null;
             }

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalRequestTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalRequestTests.java
@@ -22,7 +22,7 @@ package org.elasticsearch.index.rankeval;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
-import org.elasticsearch.index.rankeval.PrecisionAtN.Rating;
+import org.elasticsearch.index.rankeval.Precision.Rating;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -84,7 +84,7 @@ public class RankEvalRequestTests  extends ESIntegTestCase {
         berlinRequest.setSummaryFields(Arrays.asList(new String[]{ "text", "title" }));
         specifications.add(berlinRequest);
 
-        RankEvalSpec task = new RankEvalSpec(specifications, new PrecisionAtN(10));
+        RankEvalSpec task = new RankEvalSpec(specifications, new Precision());
 
         RankEvalRequestBuilder builder = new RankEvalRequestBuilder(client(), RankEvalAction.INSTANCE, new RankEvalRequest());
         builder.setRankEvalSpec(task);
@@ -140,7 +140,7 @@ public class RankEvalRequestTests  extends ESIntegTestCase {
         brokenQuery.query(brokenRangeQuery);
         specifications.add(new RatedRequest("broken_query", brokenQuery, indices, types, createRelevant("1")));
 
-        RankEvalSpec task = new RankEvalSpec(specifications, new PrecisionAtN(10));
+        RankEvalSpec task = new RankEvalSpec(specifications, new Precision());
 
         RankEvalRequestBuilder builder = new RankEvalRequestBuilder(client(), RankEvalAction.INSTANCE, new RankEvalRequest());
         builder.setRankEvalSpec(task);

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalSpecTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalSpecTests.java
@@ -93,7 +93,7 @@ public class RankEvalSpecTests extends ESTestCase {
         if (randomBoolean()) {
             metric = PrecisionTests.createTestItem();
         } else {
-            metric = DiscountedCumulativeGainAtTests.createTestItem();
+            metric = DiscountedCumulativeGainTests.createTestItem();
         }
 
         RankEvalSpec testItem = new RankEvalSpec(specs, metric);

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/ReciprocalRankTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/ReciprocalRankTests.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
-import java.util.concurrent.ExecutionException;
 
 public class ReciprocalRankTests extends ESTestCase {
 
@@ -98,7 +97,7 @@ public class ReciprocalRankTests extends ESTestCase {
      * e.g. we set it to 2 here and expect dics 0-2 to be not relevant, so first relevant doc has
      * third ranking position, so RR should be 1/3
      */
-    public void testPrecisionAtFiveRelevanceThreshold() throws IOException, InterruptedException, ExecutionException {
+    public void testPrecisionAtFiveRelevanceThreshold() {
         List<RatedDocument> rated = new ArrayList<>();
         rated.add(new RatedDocument("test", "testtype", "0", 0));
         rated.add(new RatedDocument("test", "testtype", "1", 1));

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/ReciprocalRankTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/ReciprocalRankTests.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.rankeval.PrecisionAtN.Rating;
+import org.elasticsearch.index.rankeval.Precision.Rating;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.InternalSearchHit;

--- a/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/10_basic.yaml
+++ b/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/10_basic.yaml
@@ -56,7 +56,7 @@
                 "ratings": [{"_index": "foo", "_type": "bar", "_id": "doc1", "rating": 1}]
             }
           ],
-          "metric" : { "precision_atn": { "size": 10}}
+          "metric" : { "precision": { }}
         }
 
   - match: { rank_eval.quality_level: 1}

--- a/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/20_dcg.yaml
+++ b/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/20_dcg.yaml
@@ -60,7 +60,7 @@
                     {"_index" : "foo", "_type" : "bar", "_id" : "doc6", "rating": 2}]
             }
           ],
-          "metric" : { "dcg_at_n": { "size": 6}}
+          "metric" : { "dcg": {}}
         }
 
   - match: {rank_eval.quality_level: 13.84826362927298}
@@ -85,7 +85,7 @@
                     {"_index" : "foo", "_type" : "bar", "_id" : "doc6", "rating": 2}]
             }, 
           ],
-          "metric" : { "dcg_at_n": { "size": 6}}
+          "metric" : { "dcg": { }}
         }
 
   - match: {rank_eval.quality_level: 10.29967439154499}
@@ -121,7 +121,7 @@
                 {"_index" : "foo", "_type" : "bar", "_id" : "doc6", "rating": 2}]
           }, 
         ],
-        "metric" : { "dcg_at_n": { "size": 6}}
+        "metric" : { "dcg": { }}
       }
 
   - match: {rank_eval.quality_level: 12.073969010408984}


### PR DESCRIPTION
While test driving the current state of the api we realized that specifying a cut-off "size" in e.g. the Precision@N metric and issuing a search request with a different size leads to rather counter-intuitive results. This change removes the "size" parameters from precison and dcg metric, leaving a "max_acceptable_rank" for the reciprocal rank metric. The actual window size of the results that are evaluated should be controlled by setting the "size" parameter in each search request itself or in the template. We might also consider an option to set the maximum number of document to be retrieved on the top-level request and then set it on each individual sub-query.