### PR TITLE
Validate the `_rollover` target index name early to also fail if dry_run=true

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -44,6 +44,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.DocsStats;
+import org.elasticsearch.indices.IndexAlreadyExistsException;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -109,16 +110,18 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
         final String sourceProvidedName = indexMetaData.getSettings().get(IndexMetaData.SETTING_INDEX_PROVIDED_NAME,
             indexMetaData.getIndex().getName());
         final String sourceIndexName = indexMetaData.getIndex().getName();
+        final String unresolvedName = (rolloverRequest.getNewIndexName() != null)
+            ? rolloverRequest.getNewIndexName()
+            : generateRolloverIndexName(sourceProvidedName, indexNameExpressionResolver);
+        final String rolloverIndexName = indexNameExpressionResolver.resolveDateMathExpression(unresolvedName);
+        MetaDataCreateIndexService.validateIndexName(rolloverIndexName, state); // will fail if the index already exists
         client.admin().indices().prepareStats(sourceIndexName).clear().setDocs(true).execute(
             new ActionListener<IndicesStatsResponse>() {
                 @Override
                 public void onResponse(IndicesStatsResponse statsResponse) {
                     final Set<Condition.Result> conditionResults = evaluateConditions(rolloverRequest.getConditions(),
                         statsResponse.getTotal().getDocs(), metaData.index(sourceIndexName));
-                    final String unresolvedName = (rolloverRequest.getNewIndexName() != null)
-                        ? rolloverRequest.getNewIndexName()
-                        : generateRolloverIndexName(sourceProvidedName, indexNameExpressionResolver);
-                    final String rolloverIndexName = indexNameExpressionResolver.resolveDateMathExpression(unresolvedName);
+
                     if (rolloverRequest.isDryRun()) {
                         listener.onResponse(
                             new RolloverResponse(sourceIndexName, rolloverIndexName, conditionResults, true, false, false, false));

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
@@ -22,6 +22,10 @@
           "type" : "time",
           "description" : "Explicit operation timeout"
         },
+        "dry_run": {
+          "type" : "boolean",
+          "description" : "If set to true the rollover action will only be validated but not actually performed even if a condition matches. The default is false"
+        },
         "master_timeout": {
           "type" : "time",
           "description" : "Specify timeout for connection to master"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yaml
@@ -143,3 +143,15 @@
         body:
           conditions:
             max_docs: 1
+
+  - do:
+      catch: /invalid_index_name_exception/
+      indices.rollover:
+        new_index: invalid|index|name
+        dry_run: true
+        alias: "logs_search"
+        wait_for_active_shards: 1
+        body:
+          conditions:
+            max_docs: 1
+

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yaml
@@ -102,3 +102,44 @@
   - match: { dry_run: false }
   - match: { conditions: { "[max_docs: 1]": false } }
 
+---
+"Rollover with dry-run but target index exists":
+
+  - skip:
+        version: " - 5.0.0"
+        reason:  bug fixed in 5.0.1 - dry run was returning just fine even if the index exists
+
+  # create index with alias
+  - do:
+      indices.create:
+        index: logs-1
+        wait_for_active_shards: 1
+        body:
+          aliases:
+            logs_index: {}
+            logs_search: {}
+
+  - do:
+      indices.create:
+        index: logs-000002
+
+  - do:
+      catch: /index_already_exists_exception/
+      indices.rollover:
+        dry_run: true
+        alias: "logs_search"
+        wait_for_active_shards: 1
+        body:
+          conditions:
+            max_docs: 1
+
+  # also do it without dry_run
+  - do:
+      catch: /index_already_exists_exception/
+      indices.rollover:
+        dry_run: false
+        alias: "logs_search"
+        wait_for_active_shards: 1
+        body:
+          conditions:
+            max_docs: 1


### PR DESCRIPTION
Today we validate the target index name late and therefore don't fail for instance
if the target index already exists and `dry_run=true` was specified. This change
validates the index name before we early terminate if dry_run is set.

Closes #21149