### PR TITLE
fix thread_pool_patterns path variable definition

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
@@ -4,8 +4,12 @@
     "methods": ["GET"],
     "url": {
       "path": "/_cat/thread_pool",
-      "paths": ["/_cat/thread_pool","/_cat/thread_pool/{thread_pools}"],
+      "paths": ["/_cat/thread_pool","/_cat/thread_pool/{thread_pool_patterns}"],
       "parts": {
+        "thread_pool_patterns": {
+          "type": "list",
+          "description": "A comma-separated list of regular-expressions to filter the thread pools in the output"
+        }
       },
       "params": {
         "format": {
@@ -42,10 +46,6 @@
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
           "default": false
-        },
-        "thread_pool_patterns": {
-          "type": "list",
-          "description": "A comma-separated list of regular-expressions to filter the thread pools in the output"
         }
       }
     },


### PR DESCRIPTION
The api spec was not correct, the variable name didn't match and the variable definition was in the query parameters instead of the path parameters