### PR TITLE
Write -1 on unbounded queue in cat thread pool

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
@@ -228,7 +228,7 @@ public class RestThreadPoolAction extends AbstractCatAction {
                 table.addCell(poolStats == null ? null : poolStats.getActive());
                 table.addCell(poolStats == null ? null : poolStats.getThreads());
                 table.addCell(poolStats == null ? null : poolStats.getQueue());
-                table.addCell(maxQueueSize);
+                table.addCell(maxQueueSize == null ? -1 : maxQueueSize);
                 table.addCell(poolStats == null ? null : poolStats.getRejected());
                 table.addCell(poolStats == null ? null : poolStats.getLargest());
                 table.addCell(poolStats == null ? null : poolStats.getCompleted());

--- a/docs/reference/migration/migrate_5_1.asciidoc
+++ b/docs/reference/migration/migrate_5_1.asciidoc
@@ -9,3 +9,14 @@
 
 The Log4j dependency has been upgraded from version 2.6.2 to version 2.7. If you're using the transport client in your
 application, you should update your Log4j dependencies accordingly.
+
+[[breaking_51_cat_api]]
+[float]
+=== Cat API changes
+
+==== Unbounded queue size in cat thread pool
+
+Previously if a queue size backing a thread pool was unbounded, the cat thread pool API would output an empty string in
+the queue_size column. This has been changed to now output -1 so that the output is always present and always numeric.
+Note that if you're running in a mixed version cluster with 5.0.x and 5.1.y nodes, you will see different responses
+from the cat thread pool API depending on the version of the node that your request hits.

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.thread_pool/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.thread_pool/10_basic.yaml
@@ -52,7 +52,7 @@
   - match:
       $body: |
                /^  id  \s+ name \s+ type  \s+ active \s+ size \s+ queue \s+ queue_size \s+ rejected \s+ largest \s+ completed \s+ min \s+ max \s+ keep_alive \n
-                  (\S+ \s+ bulk \s+ fixed \s+ \d+    \s+ \d+  \s+ \d+   \s+ \d*        \s+ \d+      \s+ \d+     \s+ \d+       \s+ \d* \s+ \d* \s+ \S*        \n)+  $/
+                  (\S+ \s+ bulk \s+ fixed \s+ \d+    \s+ \d+  \s+ \d+   \s+ (-1|\d+)   \s+ \d+      \s+ \d+     \s+ \d+       \s+ \d* \s+ \d* \s+ \S*        \n)+  $/
 
   - do:
       cat.thread_pool:
@@ -63,8 +63,8 @@
   - match:
       $body: |
                /^  id  \s+ name                \s+ type    \s+ active \s+ size \s+ queue \s+ queue_size \s+ rejected \s+ largest \s+ completed \s+ min \s+ max \s+ keep_alive \n
-                  (\S+ \s+ fetch_shard_started \s+ scaling \s+ \d+    \s+ \d+  \s+ \d+   \s+ \d*        \s+ \d+      \s+ \d+     \s+ \d+       \s+ \d* \s+ \d* \s+ \S*        \n
-                   \S+ \s+ fetch_shard_store   \s+ scaling \s+ \d+    \s+ \d+  \s+ \d+   \s+ \d*        \s+ \d+      \s+ \d+     \s+ \d+       \s+ \d* \s+ \d* \s+ \S*        \n)+  $/
+                  (\S+ \s+ fetch_shard_started \s+ scaling \s+ \d+    \s+ \d+  \s+ \d+   \s+ (-1|\d+)   \s+ \d+      \s+ \d+     \s+ \d+       \s+ \d* \s+ \d* \s+ \S*        \n
+                   \S+ \s+ fetch_shard_store   \s+ scaling \s+ \d+    \s+ \d+  \s+ \d+   \s+ (-1|\d+)   \s+ \d+      \s+ \d+     \s+ \d+       \s+ \d* \s+ \d* \s+ \S*        \n)+  $/
 
   - do:
       cat.thread_pool:
@@ -77,4 +77,3 @@
                ^  (\S+       \s+ bulk   \s+ \d+    \s+ \d+   \s+ \d+      \n
                    \S+       \s+ index  \s+ \d+    \s+ \d+   \s+ \d+      \n
                    \S+       \s+ search \s+ \d+    \s+ \d+   \s+ \d+      \n)+  $/
-


### PR DESCRIPTION
Today when writing an unbounded queue_size in the cat thread pool API,
we write null. This commit modifies this so that the output is -1 so
that the output is always present, and always a numeric value.

Closes #21187