### PR TITLE
Make ensureGreen and ensureYellow wait for cluster size consistency

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -182,6 +182,7 @@ import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 
@@ -906,9 +907,8 @@ public abstract class ESIntegTestCase extends ESTestCase {
                 client().admin().cluster().preparePendingClusterTasks().get());
             fail("timed out waiting for " + color + " state");
         }
-        if (clusterHealthStatus == ClusterHealthStatus.GREEN) {
-            assertThat(actionGet.getStatus(), equalTo(ClusterHealthStatus.GREEN));
-        }
+        assertThat("Expected at least " + clusterHealthStatus + " but got " + actionGet.getStatus(),
+            actionGet.getStatus().value(), lessThanOrEqualTo(clusterHealthStatus.value()));
         logger.debug("indices {} are {}", indices.length == 0 ? "[_all]" : indices, color);
         return actionGet.getStatus();
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -152,6 +152,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -869,32 +870,33 @@ public abstract class ESIntegTestCase extends ESTestCase {
      * @param timeout time out value to set on {@link org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest}
      */
     public ClusterHealthStatus ensureGreen(TimeValue timeout, String... indices) {
-        return ensureGreenOrYellow(true, timeout, indices);
+        return ensureColor(ClusterHealthStatus.GREEN, timeout, indices);
     }
 
     /**
      * Ensures the cluster has a yellow state via the cluster health API.
      */
     public ClusterHealthStatus ensureYellow(String... indices) {
-        return ensureGreenOrYellow(false, TimeValue.timeValueSeconds(30), indices);
+        return ensureColor(ClusterHealthStatus.YELLOW, TimeValue.timeValueSeconds(30), indices);
     }
 
-    private ClusterHealthStatus ensureGreenOrYellow(boolean green, TimeValue timeout, String... indices) {
-        String color = green ? "green" : "yellow";
-        String method = green ? "ensureGreen" : "ensureYellow";
+    private ClusterHealthStatus ensureColor(ClusterHealthStatus clusterHealthStatus, TimeValue timeout, String... indices) {
+        String color = clusterHealthStatus.name().toLowerCase(Locale.ROOT);
+        String method = "ensure" + Strings.capitalize(color);
 
         ClusterHealthRequest healthRequest = Requests.clusterHealthRequest(indices)
             .timeout(timeout)
+            .waitForStatus(clusterHealthStatus)
             .waitForEvents(Priority.LANGUID)
-            .waitForNoRelocatingShards(true);
-        if (green) {
-            healthRequest.waitForGreenStatus();
-        } else {
-            healthRequest.waitForYellowStatus();
-        }
-        if (cluster() != null) {
-            healthRequest.waitForNodes(Integer.toString(cluster().size()));
-        }
+            .waitForNoRelocatingShards(true)
+            // We currently often use ensureGreen or ensureYellow to check whether the cluster is back in a good state after shutting down
+            // a node. If the node that is stopped is the master node, another node will become master and publish a cluster state where it
+            // is master but where the node that was stopped hasn't been removed yet from the cluster state. It will only subsequently
+            // publish a second state where the old master is removed. If the ensureGreen/ensureYellow is timed just right, it will get to
+            // execute before the second cluster state update removes the old master and the condition ensureGreen / ensureYellow will
+            // trivially hold if it held before the node was shut down. The following "waitForNodes" condition ensures that the node has
+            // been removed by the master so that the health check applies to the set of nodes we expect to be part of the cluster.
+            .waitForNodes(Integer.toString(cluster().size()));
 
         ClusterHealthResponse actionGet = client().admin().cluster().health(healthRequest).actionGet();
         if (actionGet.isTimedOut()) {
@@ -904,7 +906,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
                 client().admin().cluster().preparePendingClusterTasks().get());
             fail("timed out waiting for " + color + " state");
         }
-        if (green) {
+        if (clusterHealthStatus == ClusterHealthStatus.GREEN) {
             assertThat(actionGet.getStatus(), equalTo(ClusterHealthStatus.GREEN));
         }
         logger.debug("indices {} are {}", indices.length == 0 ? "[_all]" : indices, color);


### PR DESCRIPTION
We currently often use ensureGreen or ensureYellow to check whether the cluster is in a good state again after shutting down a node:
```
stopRandomNode(...);
ensureGreen() / ensureYellow();
```

With the change in #21092, however, it can happen that if the node that is stopped is the master node, another node will become master and publish a cluster state where it is master but where the node that was stopped hasn't been removed yet from the cluster state. It will only publish a second state thereafter where the old master is removed. If the ensureGreen/ensureYellow is timed just right, it will get to execute before the second cluster state update removing the old master and the condition ensureGreen / ensureYellow might not hold at that point anymore.