### PR TITLE
Remove exception for sliced reindex on mixed version

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.reindex;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.search.SearchRequest;
@@ -422,11 +423,6 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
         out.writeFloat(requestsPerSecond);
         if (out.getVersion().onOrAfter(BulkByScrollTask.V_5_1_0_UNRELEASED)) {
             out.writeVInt(slices);
-        } else {
-            if (slices > 1) {
-                throw new UnsupportedOperationException("Attempting to send sliced reindex-style request to a node that doesn't support "
-                        + "it. Version is [" + out.getVersion() + "] but must be [" + BulkByScrollTask.V_5_1_0_UNRELEASED + "]");
-            }
         }
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RoundTripTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RoundTripTests.java
@@ -79,11 +79,11 @@ public class RoundTripTests extends ESTestCase {
         roundTrip(reindex, tripped);
         assertRequestEquals(reindex, tripped);
 
-        // Try slices with a version that doesn't support slices. That should fail.
+        // Try slices with a version that doesn't support slices. That should silently fall back to one slice.
         reindex.setSlices(between(2, 1000));
-        Exception e = expectThrows(UnsupportedOperationException.class, () -> roundTrip(Version.V_5_0_0_rc1, reindex, null));
-        assertEquals("Attempting to send sliced reindex-style request to a node that doesn't support it. "
-                + "Version is [5.0.0-rc1] but must be [5.1.0]", e.getMessage());
+        roundTrip(Version.V_5_0_0_rc1, reindex, tripped);
+        reindex.setSlices(1);
+        assertRequestEquals(reindex, tripped);
 
         // Try without slices with a version that doesn't support slices. That should work.
         tripped = new ReindexRequest();
@@ -103,11 +103,12 @@ public class RoundTripTests extends ESTestCase {
         assertRequestEquals(update, tripped);
         assertEquals(update.getPipeline(), tripped.getPipeline());
 
-        // Try slices with a version that doesn't support slices. That should fail.
+        // Try slices with a version that doesn't support slices. That should silently fall back to one slice.
         update.setSlices(between(2, 1000));
-        Exception e = expectThrows(UnsupportedOperationException.class, () -> roundTrip(Version.V_5_0_0_rc1, update, null));
-        assertEquals("Attempting to send sliced reindex-style request to a node that doesn't support it. "
-                + "Version is [5.0.0-rc1] but must be [5.1.0]", e.getMessage());
+        roundTrip(Version.V_5_0_0_rc1, update, tripped);
+        update.setSlices(1);
+        assertRequestEquals(update, tripped);
+        assertEquals(update.getPipeline(), tripped.getPipeline());
 
         // Try without slices with a version that doesn't support slices. That should work.
         tripped = new UpdateByQueryRequest();
@@ -124,11 +125,11 @@ public class RoundTripTests extends ESTestCase {
         roundTrip(delete, tripped);
         assertRequestEquals(delete, tripped);
 
-        // Try slices with a version that doesn't support slices. That should fail.
+        // Try slices with a version that doesn't support slices. That should silently fall back to one slice.
         delete.setSlices(between(2, 1000));
-        Exception e = expectThrows(UnsupportedOperationException.class, () -> roundTrip(Version.V_5_0_0_rc1, delete, null));
-        assertEquals("Attempting to send sliced reindex-style request to a node that doesn't support it. "
-                + "Version is [5.0.0-rc1] but must be [5.1.0]", e.getMessage());
+        roundTrip(Version.V_5_0_0_rc1, delete, tripped);
+        delete.setSlices(1);
+        assertRequestEquals(delete, tripped);
 
         // Try without slices with a version that doesn't support slices. That should work.
         tripped = new DeleteByQueryRequest();


### PR DESCRIPTION
This removes the exception thrown when serializing a reindex request
to a node < 5.1.0 and instead silently falls back to a single slice.
This is required to be compatible with `assertVersionSerializeable`.

Relates to #20767