### PR TITLE
The routing query string param is supported by mget but was missing from the rest spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json
@@ -32,6 +32,10 @@
           "type" : "boolean",
           "description" : "Refresh the shard containing the document before performing the operation"
         },
+        "routing": {
+          "type" : "string",
+          "description" : "Specific routing value"
+        },
         "_source": {
           "type" : "list",
           "description" : "True or false to return the _source field or not, or a list of fields to return"


### PR DESCRIPTION
This PR adds the `routing` query string param to the `mget` rest spec.