### PR TITLE
Remove mention of params and lang on update action payload

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -183,8 +183,7 @@ the action itself (not in the extra payload line), to specify how many
 times an update should be retried in the case of a version conflict.
 
 The `update` action payload, supports the following options: `doc`
-(partial document), `upsert`, `doc_as_upsert`, `script`, `params` (for
-script), `lang` (for script) and `fields`. See update documentation for details on
+(partial document), `upsert`, `doc_as_upsert`, `script` and `fields`. See <<docs-update,update>> documentation for details on
 the options. Curl example with update actions:
 
 [source,js]


### PR DESCRIPTION
Both `params` and `lang` are properties on the object assigned to the `script` property on the payload, not top level properties themselves. Remove the mention of them for clarity.

Add link to update documentation.


