### PR TITLE
Add VirtualBox version check

### DIFF
--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -219,8 +219,15 @@ task checkVirtualBoxVersion(type: Exec) {
   standardOutput = new ByteArrayOutputStream()
   doLast {
     String version = standardOutput.toString().trim()
-    if ((version ==~ /5\.[1-9]\..+/) == false) {
-      throw new InvalidUserDataException("Illegal version of virtualbox [${version}]. Need [5.1+]")
+    try {
+      String[] versions = version.split('\\.')
+      int major = Integer.parseInt(versions[0])
+      int minor = Integer.parseInt(versions[1])
+      if ((major < 5) || (major == 5 && minor < 1)) {
+        throw new InvalidUserDataException("Illegal version of virtualbox [${version}]. Need [5.1+]")
+      }
+    } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
+      throw new InvalidUserDataException("Unable to parse version of virtualbox [${version}]. Required [5.1+]", e)
     }
   }
 }

--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -208,9 +208,19 @@ task checkVagrantVersion(type: Exec) {
   standardOutput = new ByteArrayOutputStream()
   doLast {
     String version = standardOutput.toString().trim()
-    if ((version ==~ /Vagrant 1\.[789]\..+/) == false) {
-      throw new InvalidUserDataException(
-        "Illegal version of vagrant [${version}]. Need [Vagrant 1.7+]")
+    if ((version ==~ /Vagrant 1\.(8\.[6-9]|9\.[0-9])+/) == false) {
+      throw new InvalidUserDataException("Illegal version of vagrant [${version}]. Need [Vagrant 1.8.6+]")
+    }
+  }
+}
+
+task checkVirtualBoxVersion(type: Exec) {
+  commandLine 'vboxmanage', '--version'
+  standardOutput = new ByteArrayOutputStream()
+  doLast {
+    String version = standardOutput.toString().trim()
+    if ((version ==~ /5\.[1-9]\..+/) == false) {
+      throw new InvalidUserDataException("Illegal version of virtualbox [${version}]. Need [5.1+]")
     }
   }
 }
@@ -247,7 +257,7 @@ for (String box : availableBoxes) {
   Task update = tasks.create("vagrant${boxTask}#update", VagrantCommandTask) {
     boxName box
     args 'box', 'update', box
-    dependsOn checkVagrantVersion
+    dependsOn checkVagrantVersion, checkVirtualBoxVersion
   }
 
   Task up = tasks.create("vagrant${boxTask}#up", VagrantCommandTask) {


### PR DESCRIPTION
This commit ensure that that VirtualBox is available in version 5.1+ in the system before running packaging tests. It also check for Vagrant version is now greater than 1.8.6.
