### PR TITLE
Docs: Update discovery plugins example configuration with discovery.zen.hosts_provider

### DIFF
--- a/docs/plugins/discovery-azure-classic.asciidoc
+++ b/docs/plugins/discovery-azure-classic.asciidoc
@@ -56,7 +56,7 @@ cloud:
                    type: pkcs12
 
 discovery:
-    type: azure
+    zen.hosts_provider: azure
 ----
 
 [IMPORTANT]

--- a/docs/plugins/discovery-ec2.asciidoc
+++ b/docs/plugins/discovery-ec2.asciidoc
@@ -139,7 +139,7 @@ environments). Here is a simple sample configuration:
 [source,yaml]
 ----
 discovery:
-    type: ec2
+    zen.hosts_provider: ec2
 ----
 
 You must also set `cloud.aws.region` if you are not using default AWS region. See <<discovery-ec2-usage-region>> for details.

--- a/docs/plugins/discovery-file.asciidoc
+++ b/docs/plugins/discovery-file.asciidoc
@@ -39,11 +39,15 @@ The node must be stopped before removing the plugin.
 
 The file-based discovery plugin provides the ability to specify the 
 unicast hosts list through a simple `unicast_hosts.txt` file that can
-be dynamically updated at any time.  The discovery type for this plugin
-is still the default `zen` plugin, so no changes are required to the 
-`elasticsearch.yml` config file.  This plugin simply provides a facility
-to supply the unicast hosts list for zen discovery through an external
-file that can be updated at any time by a side process.  
+be dynamically updated at any time. To enable, add the following in `elasticsearch.yml`:
+
+[source,yaml]
+----
+discovery.zen.hosts_provider: file
+----
+
+This plugin simply provides a facility to supply the unicast hosts list for
+zen discovery through an external file that can be updated at any time by a side process.  
 
 For example, this gives a convenient mechanism for an Elasticsearch instance 
 that is  run in docker containers to be dynamically supplied a list of IP 

--- a/docs/plugins/discovery-gce.asciidoc
+++ b/docs/plugins/discovery-gce.asciidoc
@@ -46,7 +46,7 @@ cloud:
       project_id: <your-google-project-id>
       zone: <your-zone>
 discovery:
-      type: gce
+      zen.hosts_provider: gce
 --------------------------------------------------
 
 The following gce settings (prefixed with `cloud.gce`) are supported:


### PR DESCRIPTION
This new setting was added with deguicing unicast hosts providers, but
the docs were not updated.