### PR TITLE
RankEval: Add optional parameter to ignore unlabeled documents in Precision metric

### DIFF
--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalRequestTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalRequestTests.java
@@ -22,13 +22,12 @@ package org.elasticsearch.index.rankeval;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
-import org.elasticsearch.index.rankeval.Precision.Rating;
+import org.elasticsearch.index.rankeval.PrecisionTests.Rating;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Before;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -70,7 +69,7 @@ public class RankEvalRequestTests  extends ESIntegTestCase {
         refresh();
     }
 
-    public void testPrecisionAtRequest() throws IOException {
+    public void testPrecisionAtRequest() {
         List<String> indices = Arrays.asList(new String[] { "test" });
         List<String> types = Arrays.asList(new String[] { "testtype" });
 
@@ -84,7 +83,9 @@ public class RankEvalRequestTests  extends ESIntegTestCase {
         berlinRequest.setSummaryFields(Arrays.asList(new String[]{ "text", "title" }));
         specifications.add(berlinRequest);
 
-        RankEvalSpec task = new RankEvalSpec(specifications, new Precision());
+        Precision metric = new Precision();
+        metric.setIgnoreUnlabeled(true);
+        RankEvalSpec task = new RankEvalSpec(specifications, metric);
 
         RankEvalRequestBuilder builder = new RankEvalRequestBuilder(client(), RankEvalAction.INSTANCE, new RankEvalRequest());
         builder.setRankEvalSpec(task);

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/ReciprocalRankTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/ReciprocalRankTests.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.rankeval.Precision.Rating;
+import org.elasticsearch.index.rankeval.PrecisionTests.Rating;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.InternalSearchHit;

--- a/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/10_basic.yaml
+++ b/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/10_basic.yaml
@@ -56,7 +56,7 @@
                 "ratings": [{"_index": "foo", "_type": "bar", "_id": "doc1", "rating": 1}]
             }
           ],
-          "metric" : { "precision": { }}
+          "metric" : { "precision": { "ignore_unlabeled" : true }}
         }
 
   - match: { rank_eval.quality_level: 1}


### PR DESCRIPTION
Our current default behaviour to ignore unrated documents when calculating the precision seems a bit counter intuitive. Instead we should treat those documents
as "irrelevant" by default and provide an optional parameter to ignore those documents if that is the behaviour the user wants.

Closes #21304 