### PR TITLE
Ignore IllegalArgumentException with assertVersionSerializable

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -424,7 +424,7 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
             out.writeVInt(slices);
         } else {
             if (slices > 1) {
-                throw new UnsupportedOperationException("Attempting to send sliced reindex-style request to a node that doesn't support "
+                throw new IllegalArgumentException("Attempting to send sliced reindex-style request to a node that doesn't support "
                         + "it. Version is [" + out.getVersion() + "] but must be [" + BulkByScrollTask.V_5_1_0_UNRELEASED + "]");
             }
         }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RoundTripTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RoundTripTests.java
@@ -81,7 +81,7 @@ public class RoundTripTests extends ESTestCase {
 
         // Try slices with a version that doesn't support slices. That should fail.
         reindex.setSlices(between(2, 1000));
-        Exception e = expectThrows(UnsupportedOperationException.class, () -> roundTrip(Version.V_5_0_0_rc1, reindex, null));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> roundTrip(Version.V_5_0_0_rc1, reindex, null));
         assertEquals("Attempting to send sliced reindex-style request to a node that doesn't support it. "
                 + "Version is [5.0.0-rc1] but must be [5.1.0]", e.getMessage());
 
@@ -105,7 +105,7 @@ public class RoundTripTests extends ESTestCase {
 
         // Try slices with a version that doesn't support slices. That should fail.
         update.setSlices(between(2, 1000));
-        Exception e = expectThrows(UnsupportedOperationException.class, () -> roundTrip(Version.V_5_0_0_rc1, update, null));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> roundTrip(Version.V_5_0_0_rc1, update, null));
         assertEquals("Attempting to send sliced reindex-style request to a node that doesn't support it. "
                 + "Version is [5.0.0-rc1] but must be [5.1.0]", e.getMessage());
 
@@ -126,7 +126,7 @@ public class RoundTripTests extends ESTestCase {
 
         // Try slices with a version that doesn't support slices. That should fail.
         delete.setSlices(between(2, 1000));
-        Exception e = expectThrows(UnsupportedOperationException.class, () -> roundTrip(Version.V_5_0_0_rc1, delete, null));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> roundTrip(Version.V_5_0_0_rc1, delete, null));
         assertEquals("Attempting to send sliced reindex-style request to a node that doesn't support it. "
                 + "Version is [5.0.0-rc1] but must be [5.1.0]", e.getMessage());
 

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -655,7 +655,13 @@ public class ElasticsearchAssertions {
             if (streamable instanceof ActionRequest) {
                 ((ActionRequest<?>) streamable).validate();
             }
-            BytesReference orig = serialize(version, streamable);
+            BytesReference orig;
+            try {
+                orig = serialize(version, streamable);
+            } catch (IllegalArgumentException e) {
+                // Can't serialize with this version so skip this test.
+                return;
+            }
             StreamInput input = orig.streamInput();
             if (namedWriteableRegistry != null) {
                 input = new NamedWriteableAwareStreamInput(input, namedWriteableRegistry);

--- a/test/framework/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertionsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertionsTests.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.hamcrest;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+import static java.util.Collections.emptyList;
+import static org.elasticsearch.test.VersionUtils.randomVersion;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertVersionSerializable;
+
+public class ElasticsearchAssertionsTests extends ESTestCase {
+    public void testAssertVersionSerializableIsOkWithIllegalArgumentException() {
+        Version version = randomVersion(random());
+        NamedWriteableRegistry registry = new NamedWriteableRegistry(emptyList());
+        Streamable testStreamable = new TestStreamable();
+
+        // Should catch the exception and do nothing.
+        assertVersionSerializable(version, testStreamable, registry);
+    }
+
+    public static class TestStreamable implements Streamable {
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            throw new IllegalArgumentException("Not supported.");
+        }
+    }
+}


### PR DESCRIPTION
This gives us a handy place to tell users that they can't make a certain request in a mixed version cluster. It fixes reindex to use that mechanism.

Replaces #21350
Relates to #20767