### PR TITLE
Remove unused ClusterService dependency from SearchPhaseController

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -69,7 +69,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                                  ClusterService clusterService, ActionFilters actionFilters, IndexNameExpressionResolver
                                              indexNameExpressionResolver) {
         super(settings, SearchAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, SearchRequest::new);
-        this.searchPhaseController = new SearchPhaseController(settings, bigArrays, scriptService, clusterService);;
+        this.searchPhaseController = new SearchPhaseController(settings, bigArrays, scriptService);
         this.searchTransportService = new SearchTransportService(settings, transportService);
         SearchTransportService.registerRequestHandler(transportService, searchService);
         this.clusterService = clusterService;

--- a/core/src/main/java/org/elasticsearch/action/search/TransportSearchScrollAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/TransportSearchScrollAction.java
@@ -50,9 +50,8 @@ public class TransportSearchScrollAction extends HandledTransportAction<SearchSc
                 SearchScrollRequest::new);
         this.clusterService = clusterService;
         this.searchTransportService = new SearchTransportService(settings, transportService);
-        this.searchPhaseController = new SearchPhaseController(settings, bigArrays, scriptService, clusterService);
+        this.searchPhaseController = new SearchPhaseController(settings, bigArrays, scriptService);
     }
-
 
     @Override
     protected final void doExecute(SearchScrollRequest request, ActionListener<SearchResponse> listener) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations;
 
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -69,12 +68,10 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, Na
 
         private final BigArrays bigArrays;
         private final ScriptService scriptService;
-        private final ClusterState clusterState;
 
-        public ReduceContext(BigArrays bigArrays, ScriptService scriptService, ClusterState clusterState) {
+        public ReduceContext(BigArrays bigArrays, ScriptService scriptService) {
             this.bigArrays = bigArrays;
             this.scriptService = scriptService;
-            this.clusterState = clusterState;
         }
 
         public BigArrays bigArrays() {
@@ -83,10 +80,6 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, Na
 
         public ScriptService scriptService() {
             return scriptService;
-        }
-
-        public ClusterState clusterState() {
-            return clusterState;
         }
     }
 
@@ -125,7 +118,6 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, Na
     }
 
     protected abstract void doWriteTo(StreamOutput out) throws IOException;
-
 
     @Override
     public String getName() {
@@ -215,5 +207,4 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, Na
         public static final String TO = "to";
         public static final String TO_AS_STRING = "to_as_string";
     }
-
 }

--- a/core/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.search;
 
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.elasticsearch.action.search.SearchPhaseController;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.util.BigArrays;
@@ -57,7 +56,7 @@ public class SearchPhaseControllerTests extends ESTestCase {
 
     @Before
     public void setup() {
-        searchPhaseController = new SearchPhaseController(Settings.EMPTY, BigArrays.NON_RECYCLING_INSTANCE, null, null);
+        searchPhaseController = new SearchPhaseController(Settings.EMPTY, BigArrays.NON_RECYCLING_INSTANCE, null);
     }
 
     public void testSort() throws Exception {


### PR DESCRIPTION
The dependency was carried all the way to InternalAggregation but it was never used.