### PR TITLE
Replaced 'likely' with 'is' to make bootstrap check fails clearer

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
@@ -261,7 +261,7 @@ final class BootstrapCheck {
         public final String errorMessage() {
             return String.format(
                 Locale.ROOT,
-                "max file descriptors [%d] for elasticsearch process likely too low, increase to at least [%d]",
+                "max file descriptors [%d] for elasticsearch process is too low, increase to at least [%d]",
                 getMaxFileDescriptorCount(),
                 limit
             );
@@ -313,7 +313,7 @@ final class BootstrapCheck {
         public String errorMessage() {
             return String.format(
                 Locale.ROOT,
-                "max number of threads [%d] for user [%s] likely too low, increase to at least [%d]",
+                "max number of threads [%d] for user [%s] is too low, increase to at least [%d]",
                 getMaxNumberOfThreads(),
                 BootstrapInfo.getSystemProperties().get("user.name"),
                 maxNumberOfThreadsThreshold);
@@ -337,7 +337,7 @@ final class BootstrapCheck {
         public String errorMessage() {
             return String.format(
                 Locale.ROOT,
-                "max size virtual memory [%d] for user [%s] likely too low, increase to [unlimited]",
+                "max size virtual memory [%d] for user [%s] is too low, increase to [unlimited]",
                 getMaxSizeVirtualMemory(),
                 BootstrapInfo.getSystemProperties().get("user.name"));
         }
@@ -367,7 +367,7 @@ final class BootstrapCheck {
         public String errorMessage() {
             return String.format(
                     Locale.ROOT,
-                    "max virtual memory areas vm.max_map_count [%d] likely too low, increase to at least [%d]",
+                    "max virtual memory areas vm.max_map_count [%d] is too low, increase to at least [%d]",
                     getMaxMapCount(),
                     limit);
         }


### PR DESCRIPTION
The word "likely" implies that it might be too low, but if we are enforcing this limit (Elasticsearch will not start in production), then we should be clear and use the word "is".

