### PR TITLE
Null checked for source when calling sourceRef

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/internal/InternalSearchHit.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/InternalSearchHit.java
@@ -200,6 +200,9 @@ public class InternalSearchHit implements SearchHit {
      */
     @Override
     public BytesReference sourceRef() {
+        if (this.source == null)
+            return null;
+        
         try {
             this.source = CompressorFactory.uncompressIfNeeded(this.source);
             return this.source;

--- a/core/src/main/java/org/elasticsearch/search/internal/InternalSearchHit.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/InternalSearchHit.java
@@ -200,9 +200,10 @@ public class InternalSearchHit implements SearchHit {
      */
     @Override
     public BytesReference sourceRef() {
-        if (this.source == null)
+        if (this.source == null) {
             return null;
-        
+        }
+
         try {
             this.source = CompressorFactory.uncompressIfNeeded(this.source);
             return this.source;

--- a/core/src/test/java/org/elasticsearch/search/internal/InternalSearchHitTests.java
+++ b/core/src/test/java/org/elasticsearch/search/internal/InternalSearchHitTests.java
@@ -76,4 +76,15 @@ public class InternalSearchHitTests extends ESTestCase {
         assertThat(results.getAt(1).shard(), equalTo(target));
     }
 
+    public void testNullSource() throws Exception {
+        InternalSearchHit searchHit = new InternalSearchHit(0, "_id", new Text("_type"), null);
+
+        assertThat(searchHit.source(), nullValue());
+        assertThat(searchHit.sourceRef(), nullValue());
+        assertThat(searchHit.sourceAsMap(), nullValue());
+        assertThat(searchHit.sourceAsString(), nullValue());
+        assertThat(searchHit.getSource(), nullValue());
+        assertThat(searchHit.getSourceRef(), nullValue());
+        assertThat(searchHit.getSourceAsString(), nullValue());
+    }
 }


### PR DESCRIPTION
`sourceRef` always throw `NullPointerException` when `source` is `null`

Closes #19279