### PR TITLE
Cache successful shard deletion checks

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -703,7 +703,7 @@ public class IndicesService extends AbstractLifecycleComponent
         final IndexMetaData metaData = clusterState.getMetaData().indices().get(shardId.getIndexName());
 
         final IndexSettings indexSettings = buildIndexSettings(metaData);
-        if (canDeleteShardContent(shardId, indexSettings) == false) {
+        if (canDeleteShardContent(shardId, indexSettings) != ShardDeletionCheckResult.CAN_DELETE) {
             throw new IllegalStateException("Can't delete shard " + shardId);
         }
         nodeEnv.deleteShardDirectorySafe(shardId, indexSettings);
@@ -785,39 +785,50 @@ public class IndicesService extends AbstractLifecycleComponent
     }
 
     /**
-     * Returns <code>true</code> iff the shards content for the given shard can be deleted.
-     * This method will return <code>false</code> if:
-     * <ul>
-     *     <li>if the shard is still allocated / active on this node</li>
-     *     <li>if for instance if the shard is located on shared and should not be deleted</li>
-     *     <li>if the shards data locations do not exists</li>
-     * </ul>
+     * result type returned by {@link #canDeleteShardContent signaling different reasons why a shard can / cannot be deleted}
+     */
+    public enum ShardDeletionCheckResult {
+        CAN_DELETE, // shard data exists and can be deleted
+        STILL_ALLOCATED, // the shard is still allocated / active on this node
+        NO_FOLDER_FOUND, // the shards data locations do not exist
+        SHARED_FILE_SYSTEM, // the shard is located on shared and should not be deleted
+        NO_NODE_LOCK // node does not have filesystem lock to perform lookup
+    }
+
+    /**
+     * Returns <code>ShardDeletionCheckResult</code> signaling whether the shards content for the given shard can be deleted.
      *
      * @param shardId the shard to delete.
      * @param indexSettings the shards's relevant {@link IndexSettings}. This is required to access the indexes settings etc.
      */
-    public boolean canDeleteShardContent(ShardId shardId, IndexSettings indexSettings) {
+    public ShardDeletionCheckResult canDeleteShardContent(ShardId shardId, IndexSettings indexSettings) {
         assert shardId.getIndex().equals(indexSettings.getIndex());
         final IndexService indexService = indexService(shardId.getIndex());
         if (indexSettings.isOnSharedFilesystem() == false) {
            if (nodeEnv.hasNodeFile()) {
                 final boolean isAllocated = indexService != null && indexService.hasShard(shardId.id());
                 if (isAllocated) {
-                    return false; // we are allocated - can't delete the shard
+                    return ShardDeletionCheckResult.STILL_ALLOCATED; // we are allocated - can't delete the shard
                 } else if (indexSettings.hasCustomDataPath()) {
                     // lets see if it's on a custom path (return false if the shared doesn't exist)
                     // we don't need to delete anything that is not there
-                    return Files.exists(nodeEnv.resolveCustomLocation(indexSettings, shardId));
+                    return Files.exists(nodeEnv.resolveCustomLocation(indexSettings, shardId)) ?
+                        ShardDeletionCheckResult.CAN_DELETE :
+                        ShardDeletionCheckResult.NO_FOLDER_FOUND;
                 } else {
                     // lets see if it's path is available (return false if the shared doesn't exist)
                     // we don't need to delete anything that is not there
-                    return FileSystemUtils.exists(nodeEnv.availableShardPaths(shardId));
+                    return FileSystemUtils.exists(nodeEnv.availableShardPaths(shardId)) ?
+                        ShardDeletionCheckResult.CAN_DELETE :
+                        ShardDeletionCheckResult.NO_FOLDER_FOUND;
                 }
-            }
+            } else {
+               return ShardDeletionCheckResult.NO_NODE_LOCK;
+           }
         } else {
             logger.trace("{} skipping shard directory deletion due to shadow replicas", shardId);
         }
-        return false;
+        return ShardDeletionCheckResult.SHARED_FILE_SYSTEM;
     }
 
     private IndexSettings buildIndexSettings(IndexMetaData metaData) {
@@ -1126,7 +1137,7 @@ public class IndicesService extends AbstractLifecycleComponent
     public void loadIntoContext(ShardSearchRequest request, SearchContext context, QueryPhase queryPhase) throws Exception {
         assert canCache(request, context);
         final DirectoryReader directoryReader = context.searcher().getDirectoryReader();
-        
+
         boolean[] loadedFromCache = new boolean[] { true };
         BytesReference bytesReference = cacheShardLevelResult(context.indexShard(), directoryReader, request.cacheKey(), out -> {
             queryPhase.execute(context);

--- a/core/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/core/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -206,13 +206,9 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
         String indexUUID = indexShardRoutingTable.shardId().getIndex().getUUID();
         ClusterName clusterName = state.getClusterName();
         for (ShardRouting shardRouting : indexShardRoutingTable) {
+            assert shardRouting.started() : "expected started shard but was " + shardRouting;
             DiscoveryNode currentNode = state.nodes().get(shardRouting.currentNodeId());
             requests.add(new Tuple<>(currentNode, new ShardActiveRequest(clusterName, indexUUID, shardRouting.shardId(), deleteShardTimeout)));
-            if (shardRouting.relocatingNodeId() != null) {
-                DiscoveryNode relocatingNode = state.nodes().get(shardRouting.relocatingNodeId());
-                assert relocatingNode != null;
-                requests.add(new Tuple<>(relocatingNode, new ShardActiveRequest(clusterName, indexUUID, shardRouting.shardId(), deleteShardTimeout)));
-            }
         }
 
         ShardActiveResponseHandler responseHandler = new ShardActiveResponseHandler(indexShardRoutingTable.shardId(), state, requests.size());

--- a/core/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/core/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -166,7 +166,11 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
                             break;
                         case NO_LOCAL_STORAGE:
                             assert false : "shard deletion only runs on data nodes which always have local storage";
+                            // nothing to do
+                            break;
                         case STILL_ALLOCATED:
+                            // nothing to do
+                            break;
                         case SHARED_FILE_SYSTEM:
                             // nothing to do
                             break;

--- a/core/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/core/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -31,6 +31,8 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.ClusterServiceState;
@@ -63,7 +65,10 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -79,6 +84,9 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
     private final ClusterService clusterService;
     private final TransportService transportService;
     private final ThreadPool threadPool;
+
+    // Cache successful shard deletion checks to prevent unnecessary file system lookups
+    private final Set<ShardId> deletionSkipCache = new HashSet<>();
 
     private TimeValue deleteShardTimeout;
 
@@ -115,11 +123,29 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
             return;
         }
 
-        for (IndexRoutingTable indexRoutingTable : event.state().routingTable()) {
+        RoutingTable routingTable = event.state().routingTable();
+
+        // remove entries from cache that don't exist in the routing table anymore
+        for (Iterator<ShardId> it = deletionSkipCache.iterator(); it.hasNext(); ) {
+            ShardId shardId = it.next();
+            if (routingTable.hasIndex(shardId.getIndex()) == false) {
+                it.remove();
+            }
+        }
+        // remove entries from cache which are allocated to this node
+        final String localNodeId = event.state().nodes().getLocalNodeId();
+        RoutingNode localRoutingNode = event.state().getRoutingNodes().node(localNodeId);
+        if (localRoutingNode != null) {
+            for (ShardRouting routing : localRoutingNode) {
+                deletionSkipCache.remove(routing.shardId());
+            }
+        }
+
+        for (IndexRoutingTable indexRoutingTable : routingTable) {
             // Note, closed indices will not have any routing information, so won't be deleted
             for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
-                if (shardCanBeDeleted(event.state(), indexShardRoutingTable)) {
-                    ShardId shardId = indexShardRoutingTable.shardId();
+                ShardId shardId = indexShardRoutingTable.shardId();
+                if (deletionSkipCache.contains(shardId) == false && shardCanBeDeleted(localNodeId, indexShardRoutingTable)) {
                     IndexService indexService = indicesService.indexService(indexRoutingTable.getIndex());
                     final IndexSettings indexSettings;
                     if (indexService == null) {
@@ -128,15 +154,24 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
                     } else {
                         indexSettings = indexService.getIndexSettings();
                     }
-                    if (indicesService.canDeleteShardContent(shardId, indexSettings)) {
-                        deleteShardIfExistElseWhere(event.state(), indexShardRoutingTable);
+                    IndicesService.ShardDeletionCheckResult shardDeletionCheckResult = indicesService.canDeleteShardContent(shardId, indexSettings);
+                    switch (shardDeletionCheckResult) {
+                        case CAN_DELETE:
+                            deleteShardIfExistElseWhere(event.state(), indexShardRoutingTable);
+                            break;
+                        case NO_FOLDER_FOUND:
+                        case SHARED_FILE_SYSTEM:
+                            deletionSkipCache.add(shardId);
+                            break;
+                        default:
+                            // do nothing;
                     }
                 }
             }
         }
     }
 
-    boolean shardCanBeDeleted(ClusterState state, IndexShardRoutingTable indexShardRoutingTable) {
+    boolean shardCanBeDeleted(String localNodeId, IndexShardRoutingTable indexShardRoutingTable) {
         // a shard can be deleted if all its copies are active, and its not allocated on this node
         if (indexShardRoutingTable.size() == 0) {
             // should not really happen, there should always be at least 1 (primary) shard in a
@@ -146,27 +181,12 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
 
         for (ShardRouting shardRouting : indexShardRoutingTable) {
             // be conservative here, check on started, not even active
-            if (!shardRouting.started()) {
+            if (shardRouting.started() == false) {
                 return false;
             }
 
-            // if the allocated or relocation node id doesn't exists in the cluster state  it may be a stale node,
-            // make sure we don't do anything with this until the routing table has properly been rerouted to reflect
-            // the fact that the node does not exists
-            DiscoveryNode node = state.nodes().get(shardRouting.currentNodeId());
-            if (node == null) {
-                return false;
-            }
-            if (shardRouting.relocatingNodeId() != null) {
-                node = state.nodes().get(shardRouting.relocatingNodeId());
-                if (node == null) {
-                    return false;
-                }
-            }
-
-            // check if shard is active on the current node or is getting relocated to the our node
-            String localNodeId = state.getNodes().getLocalNode().getId();
-            if (localNodeId.equals(shardRouting.currentNodeId()) || localNodeId.equals(shardRouting.relocatingNodeId())) {
+            // check if shard is active on the current node
+            if (localNodeId.equals(shardRouting.currentNodeId())) {
                 return false;
             }
         }

--- a/core/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/core/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -163,15 +163,19 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
                         case SHARED_FILE_SYSTEM:
                             deletionSkipCache.add(shardId);
                             break;
+                        case NO_NODE_LOCK:
+                        case STILL_ALLOCATED:
+                            // nothing to do
+                            break;
                         default:
-                            // do nothing;
+                            assert false : "unknown shard deletion check result: " + shardDeletionCheckResult;
                     }
                 }
             }
         }
     }
 
-    boolean shardCanBeDeleted(String localNodeId, IndexShardRoutingTable indexShardRoutingTable) {
+    static boolean shardCanBeDeleted(String localNodeId, IndexShardRoutingTable indexShardRoutingTable) {
         // a shard can be deleted if all its copies are active, and its not allocated on this node
         if (indexShardRoutingTable.size() == 0) {
             // should not really happen, there should always be at least 1 (primary) shard in a

--- a/core/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardPath;
+import org.elasticsearch.indices.IndicesService.ShardDeletionCheckResult;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
 
@@ -92,16 +93,19 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
                 1).build();
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", meta.getSettings());
         ShardId shardId = new ShardId(meta.getIndex(), 0);
-        assertFalse("no shard location", indicesService.canDeleteShardContent(shardId, indexSettings));
+        assertEquals("no shard location", indicesService.canDeleteShardContent(shardId, indexSettings),
+            ShardDeletionCheckResult.NO_FOLDER_FOUND);
         IndexService test = createIndex("test");
         shardId = new ShardId(test.index(), 0);
         assertTrue(test.hasShard(0));
-        assertFalse("shard is allocated", indicesService.canDeleteShardContent(shardId, test.getIndexSettings()));
+        assertEquals("shard is allocated", indicesService.canDeleteShardContent(shardId, test.getIndexSettings()),
+            ShardDeletionCheckResult.STILL_ALLOCATED);
         test.removeShard(0, "boom");
-        assertTrue("shard is removed", indicesService.canDeleteShardContent(shardId, test.getIndexSettings()));
+        assertEquals("shard is removed", indicesService.canDeleteShardContent(shardId, test.getIndexSettings()),
+            ShardDeletionCheckResult.CAN_DELETE);
         ShardId notAllocated = new ShardId(test.index(), 100);
-        assertFalse("shard that was never on this node should NOT be deletable",
-            indicesService.canDeleteShardContent(notAllocated, test.getIndexSettings()));
+        assertEquals("shard that was never on this node should NOT be deletable",
+            indicesService.canDeleteShardContent(notAllocated, test.getIndexSettings()), ShardDeletionCheckResult.NO_FOLDER_FOUND);
     }
 
     public void testDeleteIndexStore() throws Exception {

--- a/core/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -102,7 +102,7 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
             ShardDeletionCheckResult.STILL_ALLOCATED);
         test.removeShard(0, "boom");
         assertEquals("shard is removed", indicesService.canDeleteShardContent(shardId, test.getIndexSettings()),
-            ShardDeletionCheckResult.CAN_DELETE);
+            ShardDeletionCheckResult.FOLDER_FOUND_CAN_DELETE);
         ShardId notAllocated = new ShardId(test.index(), 100);
         assertEquals("shard that was never on this node should NOT be deletable",
             indicesService.canDeleteShardContent(notAllocated, test.getIndexSettings()), ShardDeletionCheckResult.NO_FOLDER_FOUND);

--- a/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
@@ -102,9 +102,10 @@ public class IndicesStoreTests extends ESTestCase {
                 if (state == ShardRoutingState.UNASSIGNED) {
                     unassignedInfo = new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null);
                 }
-                routingTable.addShard(TestShardRouting.newShardRouting("test", i, "xyz", null, j == 0, state, unassignedInfo));
+                routingTable.addShard(TestShardRouting.newShardRouting("test", i, randomBoolean() ? localNode.getId() : randomAsciiOfLength(10), null, j == 0, state, unassignedInfo));
             }
         }
+
         assertFalse(IndicesStore.shardCanBeDeleted(localNode.getId(), routingTable.build()));
     }
 

--- a/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
@@ -104,7 +104,7 @@ public class IndicesStoreTests extends ESTestCase {
         clusterState.metaData(MetaData.builder().put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(numShards).numberOfReplicas(numReplicas)));
         IndexShardRoutingTable.Builder routingTable = new IndexShardRoutingTable.Builder(new ShardId("test", "_na_", 1));
 
-        assertFalse(indicesStore.shardCanBeDeleted(clusterState.build(), routingTable.build()));
+        assertFalse(indicesStore.shardCanBeDeleted(localNode.getId(), routingTable.build()));
     }
 
     public void testShardCanBeDeletedNoShardStarted() throws Exception {
@@ -131,7 +131,7 @@ public class IndicesStoreTests extends ESTestCase {
                 routingTable.addShard(TestShardRouting.newShardRouting("test", i, "xyz", null, j == 0, state, unassignedInfo));
             }
         }
-        assertFalse(indicesStore.shardCanBeDeleted(clusterState.build(), routingTable.build()));
+        assertFalse(indicesStore.shardCanBeDeleted(localNode.getId(), routingTable.build()));
     }
 
     public void testShardCanBeDeletedShardExistsLocally() throws Exception {
@@ -154,27 +154,7 @@ public class IndicesStoreTests extends ESTestCase {
         }
 
         // Shard exists locally, can't delete shard
-        assertFalse(indicesStore.shardCanBeDeleted(clusterState.build(), routingTable.build()));
-    }
-
-    public void testShardCanBeDeletedNodeNotInList() throws Exception {
-        int numShards = randomIntBetween(1, 7);
-        int numReplicas = randomInt(2);
-
-        ClusterState.Builder clusterState = ClusterState.builder(new ClusterName("test"));
-        clusterState.metaData(MetaData.builder().put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(numShards).numberOfReplicas(numReplicas)));
-        clusterState.nodes(DiscoveryNodes.builder().localNodeId(localNode.getId()).add(localNode));
-        IndexShardRoutingTable.Builder routingTable = new IndexShardRoutingTable.Builder(new ShardId("test", "_na_", 1));
-        for (int i = 0; i < numShards; i++) {
-            String relocatingNodeId = randomBoolean() ? null : "def";
-            routingTable.addShard(TestShardRouting.newShardRouting("test", i, "xyz", relocatingNodeId, true, ShardRoutingState.STARTED));
-            for (int j = 0; j < numReplicas; j++) {
-                routingTable.addShard(TestShardRouting.newShardRouting("test", i, "xyz", relocatingNodeId, false, ShardRoutingState.STARTED));
-            }
-        }
-
-        // null node -> false
-        assertFalse(indicesStore.shardCanBeDeleted(clusterState.build(), routingTable.build()));
+        assertFalse(indicesStore.shardCanBeDeleted(localNode.getId(), routingTable.build()));
     }
 
     public void testShardCanBeDeletedNodeVersion() throws Exception {
@@ -196,7 +176,7 @@ public class IndicesStoreTests extends ESTestCase {
         }
 
         // shard exist on other node (abc)
-        assertTrue(indicesStore.shardCanBeDeleted(clusterState.build(), routingTable.build()));
+        assertTrue(indicesStore.shardCanBeDeleted(localNode.getId(), routingTable.build()));
     }
 
     public void testShardCanBeDeletedRelocatingNode() throws Exception {
@@ -221,6 +201,6 @@ public class IndicesStoreTests extends ESTestCase {
         }
 
         // shard exist on other node (abc and def)
-        assertTrue(indicesStore.shardCanBeDeleted(clusterState.build(), routingTable.build()));
+        assertTrue(indicesStore.shardCanBeDeleted(localNode.getId(), routingTable.build()));
     }
 }


### PR DESCRIPTION
Each node checks on every cluster state update if there are shards that it can possibly delete from its disk. It decides this by doing a file-system lookup for each shard id that is fully allocated in the cluster. With lots of shards, this amounts to lots of `Files.exists()` checks, considerably slowing down cluster state updates. This commit adds a caching layer so that the `Files.exists()` checks can be skipped if not needed.


I've done some simple benchmarking to validate the approach using the following test method:

```
public void testSimple() {
    String node1 = internalCluster().startNode();
    String node2 = internalCluster().startNode();
    ensureStableCluster(2);

    ClusterState state = internalCluster().getInstance(ClusterService.class, node1).state();
    ClusterStateChanges cluster = new ClusterStateChanges();
    for (int i = 0; i < 1000; i++) {
        String name = "index_" + i;
        Settings.Builder settingsBuilder = Settings.builder()
            .put(SETTING_NUMBER_OF_SHARDS, 1)
            .put(SETTING_NUMBER_OF_REPLICAS, 0)
            .put("index.routing.allocation.exclude._name", node1);
        CreateIndexRequest request = new CreateIndexRequest(name, settingsBuilder.build()).waitForActiveShards(ActiveShardCount.NONE);

        state = cluster.createIndex(state, request);
    }

    state = cluster.applyStartedShards(state, state.routingTable().shardsWithState(ShardRoutingState.INITIALIZING));

    ClusterState state1 = cluster.closeIndices(state, new CloseIndexRequest("index_0"));
    ClusterState state2 = cluster.openIndices(state, new OpenIndexRequest("index_0"));

    ClusterChangedEvent changedEvent = new ClusterChangedEvent("simulated change 1", state1, state2);

    IndicesStore indicesStore = internalCluster().getInstance(IndicesStore.class, node1);

    logger.info("first iteration");
    indicesStore.clusterChanged(changedEvent);
    logger.info("second iteration");
    indicesStore.clusterChanged(changedEvent);
    logger.info("finished");
}
```

Output on my Laptop (with SSD):


WITHOUT PATCH
```
[2016-11-10T02:30:15,456][INFO ][o.e.i.s.IndicesStoreIntegrationIT] first iteration
[2016-11-10T02:30:15,834][INFO ][o.e.i.s.IndicesStoreIntegrationIT] second iteration
[2016-11-10T02:30:16,015][INFO ][o.e.i.s.IndicesStoreIntegrationIT] finished
```

WITH PATCH APPLIED
```
[2016-11-10T13:29:07,053][INFO ][o.e.i.s.IndicesStoreIntegrationIT] first iteration
[2016-11-10T13:29:07,337][INFO ][o.e.i.s.IndicesStoreIntegrationIT] second iteration
[2016-11-10T13:29:07,340][INFO ][o.e.i.s.IndicesStoreIntegrationIT] finished
```