### PR TITLE
Binary fields indexed into an upgraded (from 1.x -> 2.x) index hit "Compressor detection can only be called on some xcontent bytes or compressed xcontent bytes" exception

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper.core;
 
 import com.carrotsearch.hppc.ObjectArrayList;
+
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.store.ByteArrayDataOutput;
@@ -32,6 +33,7 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressorFactory;
+import org.elasticsearch.common.compress.NotXContentException;;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -174,7 +176,12 @@ public class BinaryFieldMapper extends FieldMapper {
             }
             try {
                 if (tryUncompressing) { // backcompat behavior
-                    return CompressorFactory.uncompressIfNeeded(bytes);
+                    try {
+                        return CompressorFactory.uncompressIfNeeded(bytes);
+                    } catch (NotXContentException e) {
+                        // OK: we are an arbitrary binary field, not xcontent
+                        return bytes;
+                    }
                 } else {
                     return bytes;
                 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/binary/BinaryMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/binary/BinaryMappingTests.java
@@ -123,6 +123,15 @@ public class BinaryMappingTests extends ESSingleNodeTestCase {
         FieldMapper fieldMapper = mapper.mappers().smartNameFieldMapper("field");
         Object originalValue = fieldMapper.fieldType().valueForSearch(indexedValue);
         assertEquals(new BytesArray(original), originalValue);
+
+        // also test the use case where, after upgrading to beyond to this change and indexing a new binary field on a bwc (pre-2.0) index,
+        // that we can still pull its (uncompressed) search-time value:
+        doc = mapper.parse("test", "type", "id", XContentFactory.jsonBuilder().startObject().field("field", original).endObject().bytes());
+        indexedValue = doc.rootDoc().getBinaryValue("field");
+        assertEquals(new BytesRef(original), indexedValue);
+        fieldMapper = mapper.mappers().smartNameFieldMapper("field");
+        originalValue = fieldMapper.fieldType().valueForSearch(indexedValue);
+        assertEquals(new BytesArray(original), originalValue);
     }
 
 }


### PR DESCRIPTION
In #11280 we removed compress/compress_threshold options to binary
fields, but there is a bug in the bwc such that uncompressed field
values, either because compression was disabled in the original index,
or because you indexed new documents after upgrading, will hit the
above exception if you try to retrieve them at search time.

This only affects 2.x since in 5.0 we don't support 1.x indices.