### PR TITLE
Export ES_JVM_OPTIONS for SysV init

### DIFF
--- a/distribution/deb/src/main/packaging/init.d/elasticsearch
+++ b/distribution/deb/src/main/packaging/init.d/elasticsearch
@@ -84,6 +84,7 @@ DAEMON_OPTS="-d -p $PID_FILE -Edefault.path.logs=$LOG_DIR -Edefault.path.data=$D
 export ES_JAVA_OPTS
 export JAVA_HOME
 export ES_INCLUDE
+export ES_JVM_OPTIONS
 
 if [ ! -x "$DAEMON" ]; then
 	echo "The elasticsearch startup script does not exists or it is not executable, tried: $DAEMON"

--- a/distribution/rpm/src/main/packaging/init.d/elasticsearch
+++ b/distribution/rpm/src/main/packaging/init.d/elasticsearch
@@ -60,9 +60,10 @@ prog="elasticsearch"
 pidfile="$PID_DIR/${prog}.pid"
 
 export ES_JAVA_OPTS
-export ES_STARTUP_SLEEP_TIME
 export JAVA_HOME
 export ES_INCLUDE
+export ES_JVM_OPTIONS
+export ES_STARTUP_SLEEP_TIME
 
 lockfile=/var/lock/subsys/$prog
 

--- a/qa/vagrant/src/test/resources/packaging/scripts/20_tar_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/20_tar_package.bats
@@ -110,12 +110,12 @@ setup() {
     local temp=`mktemp -d`
     touch "$temp/jvm.options"
     chown -R elasticsearch:elasticsearch "$temp"
-    echo "-Xms264m" >> "$temp/jvm.options"
-    echo "-Xmx264m" >> "$temp/jvm.options"
+    echo "-Xms512m" >> "$temp/jvm.options"
+    echo "-Xmx512m" >> "$temp/jvm.options"
     export ES_JVM_OPTIONS="$temp/jvm.options"
     export ES_JAVA_OPTS="-XX:-UseCompressedOops"
     start_elasticsearch_service
-    curl -s -XGET localhost:9200/_nodes | fgrep '"heap_init_in_bytes":276824064'
+    curl -s -XGET localhost:9200/_nodes | fgrep '"heap_init_in_bytes":536870912'
     curl -s -XGET localhost:9200/_nodes | fgrep '"using_compressed_ordinary_object_pointers":"false"'
     stop_elasticsearch_service
     export ES_JVM_OPTIONS=$es_jvm_options


### PR DESCRIPTION
The environment variable ES_JVM_OPTIONS allows end-users to specify a
custom location for the jvm.options file. Unfortunately, this
environment variable is not exported from the SysV init scripts. This
commit addresses this issue, and includes a test that ES_JVM_OPTIONS and
ES_JAVA_OPTS work for the SysV init packages.

Closes #21255