### PR TITLE
Non-master node cannot commit changes to the cluster state

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -143,7 +143,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
         assert waitFor >= 0;
         final ClusterStateObserver observer = new ClusterStateObserver(clusterService, logger, threadPool.getThreadContext());
         final ClusterServiceState observedState = observer.observedState();
-        final ClusterState state = observedState.getClusterState();
+        final ClusterState state = observedState.getLocalClusterState();
         if (request.timeout().millis() == 0) {
             listener.onResponse(getResponse(request, state, waitFor, request.timeout().millis() == 0));
             return;
@@ -152,7 +152,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
         final ClusterStateObserver.ChangePredicate validationPredicate = new ClusterStateObserver.ValidationPredicate() {
             @Override
             protected boolean validate(ClusterServiceState newState) {
-                return newState.getClusterStateStatus() == ClusterStateStatus.APPLIED && validateRequest(request, newState.getClusterState(), concreteWaitFor);
+                return newState.getClusterStateStatus() == ClusterStateStatus.APPLIED && validateRequest(request, newState.getLocalClusterState(), concreteWaitFor);
             }
         };
 

--- a/core/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -134,7 +134,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
         }
 
         protected void doStart() {
-            final ClusterState clusterState = observer.observedState().getClusterState();
+            final ClusterState clusterState = observer.observedState().getLocalClusterState();
             final DiscoveryNodes nodes = clusterState.nodes();
             if (nodes.isLocalNodeElectedMaster() || localExecute(request)) {
                 // check for block, if blocked, retry, else, execute locally

--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -622,7 +622,7 @@ public abstract class TransportReplicationAction<
         @Override
         protected void doRun() {
             setPhase(task, "routing");
-            final ClusterState state = observer.observedState().getClusterState();
+            final ClusterState state = observer.observedState().getLocalClusterState();
             if (handleBlockExceptions(state)) {
                 return;
             }

--- a/core/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
@@ -124,7 +124,7 @@ public abstract class TransportInstanceSingleOperationAction<Request extends Ins
         }
 
         protected void doStart() {
-            final ClusterState clusterState = observer.observedState().getClusterState();
+            final ClusterState clusterState = observer.observedState().getLocalClusterState();
             nodes = clusterState.nodes();
             try {
                 ClusterBlockException blockException = checkGlobalBlock(clusterState);

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterServiceTask.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterServiceTask.java
@@ -23,44 +23,20 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.unit.TimeValue;
 
-import java.util.List;
-
 /**
- * A task that can update the cluster state.
+ * A task to execute for the cluster service.
  */
-public abstract class ClusterStateUpdateTask implements ClusterTaskConfig, ClusterStateTaskExecutor<ClusterStateUpdateTask>, ClusterStateTaskListener {
+public abstract class ClusterServiceTask implements ClusterServiceTaskExecutor, ClusterTaskConfig, ClusterTaskListener {
 
     private final Priority priority;
 
-    public ClusterStateUpdateTask() {
+    public ClusterServiceTask() {
         this(Priority.NORMAL);
     }
 
-    public ClusterStateUpdateTask(Priority priority) {
+    public ClusterServiceTask(Priority priority) {
         this.priority = priority;
     }
-
-    @Override
-    public final BatchResult<ClusterStateUpdateTask> execute(ClusterState currentState, List<ClusterStateUpdateTask> tasks) throws Exception {
-        ClusterState result = execute(currentState);
-        return BatchResult.<ClusterStateUpdateTask>builder().successes(tasks).build(result);
-    }
-
-    @Override
-    public String describeTasks(List<ClusterStateUpdateTask> tasks) {
-        return ""; // one of task, source is enough
-    }
-
-    /**
-     * Update the cluster state based on the current state. Return the *same instance* if no state
-     * should be changed.
-     */
-    public abstract ClusterState execute(ClusterState currentState) throws Exception;
-
-    /**
-     * A callback called when execute fails.
-     */
-    public abstract void onFailure(String source, Exception e);
 
     /**
      * If the cluster state update task wasn't processed by the provided timeout, call

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterServiceTaskExecutor.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterServiceTaskExecutor.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster;
+
+/**
+ * An interface for specifying tasks to be executed by the cluster service.
+ */
+public interface ClusterServiceTaskExecutor {
+
+    /** A cached cluster task result that indicates the cluster has no master and a block should be added. */
+    ClusterServiceTaskResult NO_MASTER_RESULT = new ClusterServiceTaskResult(true);
+    /** A cached cluster task result that indicates the cluster does have a master, nothing to change with the blocks. */
+    ClusterServiceTaskResult HAS_MASTER_RESULT = new ClusterServiceTaskResult(false);
+
+    /**
+     * The method to be executed by the cluster service, operating on the current cluster state passed in.
+     */
+    ClusterServiceTaskResult execute(ClusterState currentState) throws Exception;
+
+    /**
+     * Indicates whether this task should only run if current node is master.  Defaults to {@code false}.
+     */
+    default boolean runOnlyOnMaster() {
+        return false;
+    }
+
+    /**
+     * A class that represents the result of running a task on the cluster service.
+     */
+    final class ClusterServiceTaskResult {
+        private final boolean hasNoMaster;
+
+        private ClusterServiceTaskResult(boolean hasNoMaster) {
+            this.hasNoMaster = hasNoMaster;
+        }
+
+        /**
+         * Returns {@code true} if the cluster service task should set the no master block on the local state,
+         * {@code false} otherwise.
+         */
+        public boolean hasNoMaster() {
+            return hasNoMaster;
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterStateObserver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterStateObserver.java
@@ -182,8 +182,7 @@ public class ClusterStateObserver {
             if (context.changePredicate.apply(previousState, currentState)) {
                 if (observingContext.compareAndSet(context, null)) {
                     clusterService.remove(this);
-                    ClusterServiceState state = new ClusterServiceState(currentState.getClusterState(), ClusterStateStatus.APPLIED,
-                                                                           currentState.getLocalClusterState());
+                    ClusterServiceState state = new ClusterServiceState(currentState.getClusterState(), ClusterStateStatus.APPLIED, null);
                     logger.trace("observer: accepting cluster state change ({})", state);
                     lastObservedState.set(state);
                     context.listener.onNewClusterState(state.getClusterState());

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
@@ -72,16 +72,14 @@ public interface ClusterStateTaskExecutor<T> {
     class BatchResult<T> {
         public final ClusterState resultingState;
         public final Map<T, TaskResult> executionResults;
-        public final boolean hasNoMaster;
 
         /**
          * Construct an execution result instance with a correspondence between the tasks and their execution result
          * @param resultingState the resulting cluster state
          * @param executionResults the correspondence between tasks and their outcome
          */
-        private BatchResult(ClusterState resultingState, boolean hasNoMaster, Map<T, TaskResult> executionResults) {
+        private BatchResult(ClusterState resultingState, Map<T, TaskResult> executionResults) {
             this.resultingState = resultingState;
-            this.hasNoMaster = hasNoMaster;
             this.executionResults = executionResults;
         }
 
@@ -121,11 +119,7 @@ public interface ClusterStateTaskExecutor<T> {
             }
 
             public BatchResult<T> build(ClusterState resultingState) {
-                return new BatchResult<>(resultingState, false, executionResults);
-            }
-
-            public BatchResult<T> build(ClusterState resultingState, boolean hasNoMaster) {
-                return new BatchResult<>(resultingState, hasNoMaster, executionResults);
+                return new BatchResult<>(resultingState, executionResults);
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
@@ -72,14 +72,16 @@ public interface ClusterStateTaskExecutor<T> {
     class BatchResult<T> {
         public final ClusterState resultingState;
         public final Map<T, TaskResult> executionResults;
+        public final boolean hasNoMaster;
 
         /**
          * Construct an execution result instance with a correspondence between the tasks and their execution result
          * @param resultingState the resulting cluster state
          * @param executionResults the correspondence between tasks and their outcome
          */
-        BatchResult(ClusterState resultingState, Map<T, TaskResult> executionResults) {
+        private BatchResult(ClusterState resultingState, boolean hasNoMaster, Map<T, TaskResult> executionResults) {
             this.resultingState = resultingState;
+            this.hasNoMaster = hasNoMaster;
             this.executionResults = executionResults;
         }
 
@@ -119,7 +121,11 @@ public interface ClusterStateTaskExecutor<T> {
             }
 
             public BatchResult<T> build(ClusterState resultingState) {
-                return new BatchResult<>(resultingState, executionResults);
+                return new BatchResult<>(resultingState, false, executionResults);
+            }
+
+            public BatchResult<T> build(ClusterState resultingState, boolean hasNoMaster) {
+                return new BatchResult<>(resultingState, hasNoMaster, executionResults);
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
@@ -78,7 +78,7 @@ public interface ClusterStateTaskExecutor<T> {
          * @param resultingState the resulting cluster state
          * @param executionResults the correspondence between tasks and their outcome
          */
-        private BatchResult(ClusterState resultingState, Map<T, TaskResult> executionResults) {
+        BatchResult(ClusterState resultingState, Map<T, TaskResult> executionResults) {
             this.resultingState = resultingState;
             this.executionResults = executionResults;
         }

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * A task that can update the cluster state.
  */
-public abstract  class ClusterStateUpdateTask implements ClusterStateTaskConfig, ClusterStateTaskExecutor<ClusterStateUpdateTask>, ClusterStateTaskListener {
+public abstract class ClusterStateUpdateTask implements ClusterStateTaskConfig, ClusterStateTaskExecutor<ClusterStateUpdateTask>, ClusterStateTaskListener {
 
     private final Priority priority;
 
@@ -43,7 +43,7 @@ public abstract  class ClusterStateUpdateTask implements ClusterStateTaskConfig,
     @Override
     public final BatchResult<ClusterStateUpdateTask> execute(ClusterState currentState, List<ClusterStateUpdateTask> tasks) throws Exception {
         ClusterState result = execute(currentState);
-        return BatchResult.<ClusterStateUpdateTask>builder().successes(tasks).build(result);
+        return BatchResult.<ClusterStateUpdateTask>builder().successes(tasks).build(result, clusterHasNoMaster());
     }
 
     @Override
@@ -74,5 +74,13 @@ public abstract  class ClusterStateUpdateTask implements ClusterStateTaskConfig,
     @Override
     public Priority priority() {
         return priority;
+    }
+
+    /**
+     * Returns {@code true} if the update task should reflect that there is no master
+     * in the cluster from the point of view of the current node, {@code false} otherwise.
+     */
+    public boolean clusterHasNoMaster() {
+        return false;
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterTaskConfig.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterTaskConfig.java
@@ -23,14 +23,13 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.unit.TimeValue;
 
 /**
- * Cluster state update task configuration for timeout and priority
+ * Cluster task configuration for timeout and priority
  */
-public interface ClusterStateTaskConfig {
+public interface ClusterTaskConfig {
     /**
-     * The timeout for this cluster state update task configuration. If
-     * the cluster state update task isn't processed within this
-     * timeout, the associated {@link ClusterStateTaskListener#onFailure(String, Exception)}
-     * is invoked.
+     * The timeout for this cluster task configuration. If the cluster task
+     * isn't processed within this timeout, the associated
+     * {@link ClusterStateTaskListener#onFailure(String, Exception)} is invoked.
      *
      * @return the timeout, or null if one is not set
      */
@@ -38,39 +37,36 @@ public interface ClusterStateTaskConfig {
     TimeValue timeout();
 
     /**
-     * The {@link Priority} for this cluster state update task configuration.
+     * The {@link Priority} for this cluster task configuration.
      *
      * @return the priority
      */
     Priority priority();
 
     /**
-     * Build a cluster state update task configuration with the
+     * Build a cluster task configuration with the
      * specified {@link Priority} and no timeout.
      *
-     * @param priority the priority for the associated cluster state
-     *                 update task
-     * @return the resulting cluster state update task configuration
+     * @param priority the priority for the associated cluster task
+     * @return the resulting cluster task configuration
      */
-    static ClusterStateTaskConfig build(Priority priority) {
+    static ClusterTaskConfig build(Priority priority) {
         return new Basic(priority, null);
     }
 
     /**
-     * Build a cluster state update task configuration with the
+     * Build a cluster task configuration with the
      * specified {@link Priority} and timeout.
      *
-     * @param priority the priority for the associated cluster state
-     *                 update task
-     * @param timeout  the timeout for the associated cluster state
-     *                 update task
-     * @return the result cluster state update task configuration
+     * @param priority the priority for the associated cluster task
+     * @param timeout  the timeout for the associated cluster task
+     * @return the result cluster task configuration
      */
-    static ClusterStateTaskConfig build(Priority priority, TimeValue timeout) {
+    static ClusterTaskConfig build(Priority priority, TimeValue timeout) {
         return new Basic(priority, timeout);
     }
 
-    class Basic implements ClusterStateTaskConfig {
+    class Basic implements ClusterTaskConfig {
         final TimeValue timeout;
         final Priority priority;
 

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterTaskListener.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterTaskListener.java
@@ -16,15 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch.cluster;
 
-import java.util.List;
-
-public interface ClusterStateTaskListener extends ClusterTaskListener {
+/**
+ * An interface for responding to failures when executing cluster service tasks.
+ */
+public interface ClusterTaskListener {
     /**
-     * Called when the result of the {@link ClusterStateTaskExecutor#execute(ClusterState, List)} have been processed
-     * properly by all listeners.
+     * A callback called when execute fails.
      */
-    default void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+    void onFailure(String source, Exception e);
+
+    /**
+     * A callback for when the task was rejected because the local node is no longer master
+     */
+    default void onNoLongerMaster(String source) {
+        onFailure(source, new NotMasterException("no longer master. source: [" + source + "]"));
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/MasterNodeChangePredicate.java
+++ b/core/src/main/java/org/elasticsearch/cluster/MasterNodeChangePredicate.java
@@ -30,12 +30,7 @@ public enum MasterNodeChangePredicate implements ClusterStateObserver.ChangePred
         ClusterServiceState newState) {
         // checking if the masterNodeId changed is insufficient as the
         // same master node might get re-elected after a disruption
-        return newState.getClusterState().nodes().getMasterNodeId() != null &&
-            newState.getClusterState() != previousState.getClusterState();
-    }
-
-    @Override
-    public boolean apply(ClusterChangedEvent changedEvent) {
-        return changedEvent.nodesDelta().masterNodeChanged();
+        return newState.getLocalClusterState().nodes().getMasterNodeId() != null &&
+            newState.getLocalClusterState() != previousState.getLocalClusterState();
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -92,7 +92,7 @@ public class ShardStateAction extends AbstractComponent {
     }
 
     private void sendShardAction(final String actionName, final ClusterStateObserver observer, final ShardEntry shardEntry, final Listener listener) {
-        DiscoveryNode masterNode = observer.observedState().getClusterState().nodes().getMasterNode();
+        DiscoveryNode masterNode = observer.observedState().getLocalClusterState().nodes().getMasterNode();
         if (masterNode == null) {
             logger.warn("{} no master known for action [{}] for shard entry [{}]", shardEntry.shardId, actionName, shardEntry);
             waitForNewMasterAndRetry(actionName, observer, shardEntry, listener);

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
-import org.elasticsearch.cluster.ClusterStateTaskConfig;
+import org.elasticsearch.cluster.ClusterTaskConfig;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.MasterNodeChangePredicate;
@@ -200,7 +200,7 @@ public class ShardStateAction extends AbstractComponent {
             clusterService.submitStateUpdateTask(
                 "shard-failed",
                 request,
-                ClusterStateTaskConfig.build(Priority.HIGH),
+                ClusterTaskConfig.build(Priority.HIGH),
                 shardFailedClusterStateTaskExecutor,
                 new ClusterStateTaskListener() {
                     @Override
@@ -364,7 +364,7 @@ public class ShardStateAction extends AbstractComponent {
             clusterService.submitStateUpdateTask(
                 "shard-started",
                 request,
-                ClusterStateTaskConfig.build(Priority.URGENT),
+                ClusterTaskConfig.build(Priority.URGENT),
                 shardStartedClusterStateTaskExecutor,
                 shardStartedClusterStateTaskExecutor);
             channel.sendResponse(TransportResponse.Empty.INSTANCE);

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
@@ -27,7 +27,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingClusterStateUpdateRequest;
 import org.elasticsearch.cluster.AckedClusterStateTaskListener;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskConfig;
+import org.elasticsearch.cluster.ClusterTaskConfig;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -202,7 +202,7 @@ public class MetaDataMappingService extends AbstractComponent {
         final RefreshTask refreshTask = new RefreshTask(index, indexUUID);
         clusterService.submitStateUpdateTask("refresh-mapping",
             refreshTask,
-            ClusterStateTaskConfig.build(Priority.HIGH),
+            ClusterTaskConfig.build(Priority.HIGH),
             refreshExecutor,
                 (source, e) -> logger.warn((Supplier<?>) () -> new ParameterizedMessage("failure during [{}]", source), e)
         );
@@ -359,7 +359,7 @@ public class MetaDataMappingService extends AbstractComponent {
     public void putMapping(final PutMappingClusterStateUpdateRequest request, final ActionListener<ClusterStateUpdateResponse> listener) {
         clusterService.submitStateUpdateTask("put-mapping",
                 request,
-                ClusterStateTaskConfig.build(Priority.HIGH, request.masterNodeTimeout()),
+                ClusterTaskConfig.build(Priority.HIGH, request.masterNodeTimeout()),
                 putMappingExecutor,
                 new AckedClusterStateTaskListener() {
 

--- a/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -737,6 +737,13 @@ public class ClusterService extends AbstractLifecycleComponent {
             return;
         }
 
+        // remove the no master block, if it exists
+        if (newClusterState.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID)) {
+            ClusterBlocks.Builder clusterBlocks = ClusterBlocks.builder().blocks(newClusterState.blocks())
+                                                      .removeGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID);
+            newClusterState = ClusterState.builder(newClusterState).blocks(clusterBlocks).build();
+        }
+
         try {
             ArrayList<Discovery.AckListener> ackListeners = new ArrayList<>();
             if (newClusterState.nodes().isLocalNodeElectedMaster()) {

--- a/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -66,7 +66,6 @@ import org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor;
 import org.elasticsearch.common.util.concurrent.PrioritizedRunnable;
 import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.discovery.Discovery;
-import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -149,8 +148,6 @@ public class ClusterService extends AbstractLifecycleComponent {
 
     private NodeConnectionsService nodeConnectionsService;
 
-    private final DiscoverySettings discoverySettings;
-
     private boolean initialNoMaster = true;
 
     private volatile ClusterBlock noMasterBlock;
@@ -160,7 +157,6 @@ public class ClusterService extends AbstractLifecycleComponent {
         this.operationRouting = new OperationRouting(settings, clusterSettings);
         this.threadPool = threadPool;
         this.clusterSettings = clusterSettings;
-        this.discoverySettings = new DiscoverySettings(settings, clusterSettings);
         this.clusterName = ClusterName.CLUSTER_NAME_SETTING.get(settings);
         // will be replaced on doStart.
         this.state = new AtomicReference<>(new ClusterServiceState(ClusterState.builder(clusterName).build(),
@@ -343,13 +339,6 @@ public class ClusterService extends AbstractLifecycleComponent {
      */
     public ClusterServiceState clusterServiceState() {
         return this.state.get();
-    }
-
-    /**
-     * Gets the discovery settings for this cluster.
-     */
-    public DiscoverySettings getDiscoverySettings() {
-        return discoverySettings;
     }
 
     /**
@@ -922,7 +911,6 @@ public class ClusterService extends AbstractLifecycleComponent {
             ClusterState finalNewClusterState = newClusterState;
             updateState(css -> new ClusterServiceState(finalNewClusterState, ClusterStateStatus.BEING_APPLIED, null));
             logger.debug("set local cluster state to version {}", newClusterState.version());
-
             try {
                 // nothing to do until we actually recover from the gateway or any other block indicates we need to disable persistency
                 if (clusterChangedEvent.state().blocks().disableStatePersistence() == false && clusterChangedEvent.metaDataChanged()) {
@@ -932,7 +920,6 @@ public class ClusterService extends AbstractLifecycleComponent {
             } catch (Exception ex) {
                 logger.warn("failed to apply cluster settings", ex);
             }
-
             for (ClusterStateListener listener : preAppliedListeners) {
                 try {
                     listener.clusterChanged(clusterChangedEvent);

--- a/core/src/main/java/org/elasticsearch/cluster/service/ClusterServiceState.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/ClusterServiceState.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cluster.service;
 
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.discovery.DiscoverySettings;
@@ -33,16 +34,16 @@ public final class ClusterServiceState {
     private final ClusterStateStatus clusterStateStatus;
     private final ClusterState localClusterState;
 
-    public ClusterServiceState(ClusterState clusterState, ClusterStateStatus clusterStateStatus, boolean hasNoMaster,
-                               DiscoverySettings discoverySettings) {
+    public ClusterServiceState(ClusterState clusterState, ClusterStateStatus clusterStateStatus, ClusterBlock noMasterBlock) {
         this.clusterState = clusterState;
         this.clusterStateStatus = clusterStateStatus;
-        if (hasNoMaster) {
+        if (noMasterBlock != null) {
+            assert noMasterBlock.id() == DiscoverySettings.NO_MASTER_BLOCK_ID : "block must have NO_MASTER block id";
             // There is no master currently, so add the appropriate blocks to the returned
             // cluster state and set the masterNodeId to null.
             ClusterBlocks clusterBlocks =
                 ClusterBlocks.builder().blocks(clusterState.blocks())
-                    .addGlobalBlock(discoverySettings.getNoMasterBlock())
+                    .addGlobalBlock(noMasterBlock)
                     .build();
 
             DiscoveryNodes discoveryNodes =
@@ -57,12 +58,6 @@ public final class ClusterServiceState {
         } else {
             localClusterState = clusterState;
         }
-    }
-
-    public ClusterServiceState(ClusterState clusterState, ClusterStateStatus clusterStateStatus, ClusterState localClusterState) {
-        this.clusterState = clusterState;
-        this.clusterStateStatus = clusterStateStatus;
-        this.localClusterState = localClusterState;
     }
 
     public ClusterState getClusterState() {

--- a/core/src/main/java/org/elasticsearch/cluster/service/ClusterServiceState.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/ClusterServiceState.java
@@ -20,18 +20,49 @@
 package org.elasticsearch.cluster.service;
 
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.discovery.DiscoverySettings;
 
 /**
  * A simple immutable container class that comprises a cluster state and cluster state status. Used by {@link ClusterService}
  * to provide a snapshot view on which cluster state is currently being applied / already applied.
  */
-public class ClusterServiceState {
+public final class ClusterServiceState {
     private final ClusterState clusterState;
     private final ClusterStateStatus clusterStateStatus;
+    private final ClusterState localClusterState;
 
-    public ClusterServiceState(ClusterState clusterState, ClusterStateStatus clusterStateStatus) {
+    public ClusterServiceState(ClusterState clusterState, ClusterStateStatus clusterStateStatus, boolean hasNoMaster,
+                               DiscoverySettings discoverySettings) {
         this.clusterState = clusterState;
         this.clusterStateStatus = clusterStateStatus;
+        if (hasNoMaster) {
+            // There is no master currently, so add the appropriate blocks to the returned
+            // cluster state and set the masterNodeId to null.
+            ClusterBlocks clusterBlocks =
+                ClusterBlocks.builder().blocks(clusterState.blocks())
+                    .addGlobalBlock(discoverySettings.getNoMasterBlock())
+                    .build();
+
+            DiscoveryNodes discoveryNodes =
+                new DiscoveryNodes.Builder(clusterState.nodes())
+                    .masterNodeId(null)
+                    .build();
+
+            localClusterState = ClusterState.builder(clusterState)
+                                        .blocks(clusterBlocks)
+                                        .nodes(discoveryNodes)
+                                        .build();
+        } else {
+            localClusterState = clusterState;
+        }
+    }
+
+    public ClusterServiceState(ClusterState clusterState, ClusterStateStatus clusterStateStatus, ClusterState localClusterState) {
+        this.clusterState = clusterState;
+        this.clusterStateStatus = clusterStateStatus;
+        this.localClusterState = localClusterState;
     }
 
     public ClusterState getClusterState() {
@@ -40,6 +71,25 @@ public class ClusterServiceState {
 
     public ClusterStateStatus getClusterStateStatus() {
         return clusterStateStatus;
+    }
+
+    /**
+     * Returns the local view of the cluster state, which is based on the authoritative cluster state as
+     * obtained from {@link #getClusterState()} with added overlays on the cluster state based on the local
+     * state of the {@link ClusterService} at the time of this instance's creation.  In particular, the overlays
+     * that can be added are NO_MASTER blocks on the cluster state and setting the masterNodeId to null, in
+     * the case of the ClusterService having no master.
+     */
+    public ClusterState getLocalClusterState() {
+        return localClusterState;
+    }
+
+    /**
+     * Returns {@code true} if the cluster service's state as represented by this instance has no master node,
+     * returns {@code false} otherwise.
+     */
+    public boolean hasNoMaster() {
+        return localClusterState.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/cluster/service/ClusterServiceState.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/ClusterServiceState.java
@@ -23,7 +23,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.discovery.DiscoverySettings;
 
 /**
  * A simple immutable container class that comprises a cluster state and cluster state status. Used by {@link ClusterService}
@@ -38,11 +37,12 @@ public final class ClusterServiceState {
         this.clusterState = clusterState;
         this.clusterStateStatus = clusterStateStatus;
         if (noMasterBlock != null) {
-            assert noMasterBlock.id() == DiscoverySettings.NO_MASTER_BLOCK_ID : "block must have NO_MASTER block id";
+            assert noMasterBlock.id() == ClusterService.NO_MASTER_BLOCK_ID : "block must have NO_MASTER block id";
             // There is no master currently, so add the appropriate blocks to the returned
             // cluster state and set the masterNodeId to null.
             ClusterBlocks clusterBlocks =
                 ClusterBlocks.builder().blocks(clusterState.blocks())
+                    .removeGlobalBlock(ClusterService.NO_MASTER_BLOCK_ID) // remove block if it already exists before adding new one
                     .addGlobalBlock(noMasterBlock)
                     .build();
 
@@ -84,7 +84,7 @@ public final class ClusterServiceState {
      * returns {@code false} otherwise.
      */
     public boolean hasNoMaster() {
-        return localClusterState.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID);
+        return localClusterState.blocks().hasGlobalBlock(ClusterService.NO_MASTER_BLOCK_ID);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/cluster/service/ClusterServiceStateListener.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/ClusterServiceStateListener.java
@@ -17,21 +17,18 @@
  * under the License.
  */
 
-package org.elasticsearch.cluster;
-
-import org.elasticsearch.cluster.service.ClusterServiceStateListener;
-import org.elasticsearch.common.unit.TimeValue;
+package org.elasticsearch.cluster.service;
 
 /**
- * An exception to cluster service state listener that allows for timeouts and for post added notifications.
- *
- *
+ * A listener to listen for changes to the {@link ClusterServiceState} held by the {@link ClusterService}.
  */
-public interface TimeoutClusterStateListener extends ClusterServiceStateListener {
+public interface ClusterServiceStateListener {
 
-    void postAdded();
-
-    void onClose();
-
-    void onTimeout(TimeValue timeout);
+    /**
+     * Called when the local cluster state of the {@link ClusterService} changes.
+     *
+     * @param previousState the previous cluster service state
+     * @param currentState the current cluster service state
+     */
+    void clusterServiceStateChanged(ClusterServiceState previousState, ClusterServiceState currentState);
 }

--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -213,7 +213,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     DiscoverySettings.PUBLISH_TIMEOUT_SETTING,
                     DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING,
                     DiscoverySettings.COMMIT_TIMEOUT_SETTING,
-                    DiscoverySettings.NO_MASTER_BLOCK_SETTING,
+                    ClusterService.NO_MASTER_BLOCK_SETTING,
                     GatewayService.EXPECTED_DATA_NODES_SETTING,
                     GatewayService.EXPECTED_MASTER_NODES_SETTING,
                     GatewayService.EXPECTED_NODES_SETTING,

--- a/core/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
+++ b/core/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
@@ -19,26 +19,18 @@
 
 package org.elasticsearch.discovery;
 
-import org.elasticsearch.cluster.block.ClusterBlock;
-import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.rest.RestStatus;
-
-import java.util.EnumSet;
 
 /**
  * Exposes common discovery settings that may be supported by all the different discovery implementations
  */
 public class DiscoverySettings extends AbstractComponent {
 
-    public static final int NO_MASTER_BLOCK_ID = 2;
-    public static final ClusterBlock NO_MASTER_BLOCK_ALL = new ClusterBlock(NO_MASTER_BLOCK_ID, "no master", true, true, RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.ALL);
-    public static final ClusterBlock NO_MASTER_BLOCK_WRITES = new ClusterBlock(NO_MASTER_BLOCK_ID, "no master", true, false, RestStatus.SERVICE_UNAVAILABLE, EnumSet.of(ClusterBlockLevel.WRITE, ClusterBlockLevel.METADATA_WRITE));
     /**
      * sets the timeout for a complete publishing cycle, including both sending and committing. the master
      * will continue to process the next cluster state update after this time has elapsed
@@ -55,15 +47,11 @@ public class DiscoverySettings extends AbstractComponent {
         new Setting<>("discovery.zen.commit_timeout", (s) -> PUBLISH_TIMEOUT_SETTING.getRaw(s),
             (s) -> TimeValue.parseTimeValue(s, TimeValue.timeValueSeconds(30), "discovery.zen.commit_timeout"),
             Property.Dynamic, Property.NodeScope);
-    public static final Setting<ClusterBlock> NO_MASTER_BLOCK_SETTING =
-        new Setting<>("discovery.zen.no_master_block", "write", DiscoverySettings::parseNoMasterBlock,
-            Property.Dynamic, Property.NodeScope);
     public static final Setting<Boolean> PUBLISH_DIFF_ENABLE_SETTING =
         Setting.boolSetting("discovery.zen.publish_diff.enable", true, Property.Dynamic, Property.NodeScope);
     public static final Setting<TimeValue> INITIAL_STATE_TIMEOUT_SETTING =
         Setting.positiveTimeSetting("discovery.initial_state_timeout", TimeValue.timeValueSeconds(30), Property.NodeScope);
 
-    private volatile ClusterBlock noMasterBlock;
     private volatile TimeValue publishTimeout;
 
     private volatile TimeValue commitTimeout;
@@ -71,11 +59,9 @@ public class DiscoverySettings extends AbstractComponent {
 
     public DiscoverySettings(Settings settings, ClusterSettings clusterSettings) {
         super(settings);
-        clusterSettings.addSettingsUpdateConsumer(NO_MASTER_BLOCK_SETTING, this::setNoMasterBlock);
         clusterSettings.addSettingsUpdateConsumer(PUBLISH_DIFF_ENABLE_SETTING, this::setPublishDiff);
         clusterSettings.addSettingsUpdateConsumer(COMMIT_TIMEOUT_SETTING, this::setCommitTimeout);
         clusterSettings.addSettingsUpdateConsumer(PUBLISH_TIMEOUT_SETTING, this::setPublishTimeout);
-        this.noMasterBlock = NO_MASTER_BLOCK_SETTING.get(settings);
         this.publishTimeout = PUBLISH_TIMEOUT_SETTING.get(settings);
         this.commitTimeout = COMMIT_TIMEOUT_SETTING.get(settings);
         this.publishDiff = PUBLISH_DIFF_ENABLE_SETTING.get(settings);
@@ -92,14 +78,6 @@ public class DiscoverySettings extends AbstractComponent {
         return commitTimeout;
     }
 
-    public ClusterBlock getNoMasterBlock() {
-        return noMasterBlock;
-    }
-
-    private void setNoMasterBlock(ClusterBlock noMasterBlock) {
-        this.noMasterBlock = noMasterBlock;
-    }
-
     private void setPublishDiff(boolean publishDiff) {
         this.publishDiff = publishDiff;
     }
@@ -113,15 +91,4 @@ public class DiscoverySettings extends AbstractComponent {
     }
 
     public boolean getPublishDiff() { return publishDiff;}
-
-    private static ClusterBlock parseNoMasterBlock(String value) {
-        switch (value) {
-            case "all":
-                return NO_MASTER_BLOCK_ALL;
-            case "write":
-                return NO_MASTER_BLOCK_WRITES;
-            default:
-                throw new IllegalArgumentException("invalid master block [" + value + "]");
-        }
-    }
 }

--- a/core/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
@@ -25,11 +25,10 @@ import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskConfig;
+import org.elasticsearch.cluster.ClusterTaskConfig;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.NotMasterException;
-import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -180,7 +179,7 @@ public class NodeJoinController extends AbstractComponent {
             checkPendingJoinsAndElectIfNeeded();
         } else {
             clusterService.submitStateUpdateTask("zen-disco-node-join",
-                node, ClusterStateTaskConfig.build(Priority.URGENT),
+                node, ClusterTaskConfig.build(Priority.URGENT),
                 joinTaskExecutor, new JoinTaskListener(callback, logger));
         }
     }
@@ -282,7 +281,7 @@ public class NodeJoinController extends AbstractComponent {
 
             tasks.put(BECOME_MASTER_TASK, (source1, e) -> {}); // noop listener, the election finished listener determines result
             tasks.put(FINISH_ELECTION_TASK, electionFinishedListener);
-            clusterService.submitStateUpdateTasks(source, tasks, ClusterStateTaskConfig.build(Priority.URGENT), joinTaskExecutor);
+            clusterService.submitStateUpdateTasks(source, tasks, ClusterTaskConfig.build(Priority.URGENT), joinTaskExecutor);
         }
 
         public synchronized void closeAndProcessPending(String reason) {
@@ -290,7 +289,7 @@ public class NodeJoinController extends AbstractComponent {
             Map<DiscoveryNode, ClusterStateTaskListener> tasks = getPendingAsTasks();
             final String source = "zen-disco-election-stop [" + reason + "]";
             tasks.put(FINISH_ELECTION_TASK, electionFinishedListener);
-            clusterService.submitStateUpdateTasks(source, tasks, ClusterStateTaskConfig.build(Priority.URGENT), joinTaskExecutor);
+            clusterService.submitStateUpdateTasks(source, tasks, ClusterTaskConfig.build(Priority.URGENT), joinTaskExecutor);
         }
 
         private void innerClose() {

--- a/core/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
@@ -467,8 +467,6 @@ public class NodeJoinController extends AbstractComponent {
             assert currentState.nodes().getMasterNodeId() == null : currentState;
             DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(currentState.nodes());
             nodesBuilder.masterNodeId(currentState.nodes().getLocalNodeId());
-            ClusterBlocks clusterBlocks = ClusterBlocks.builder().blocks(currentState.blocks())
-                .removeGlobalBlock(discoverySettings.getNoMasterBlock()).build();
             for (final DiscoveryNode joiningNode : joiningNodes) {
                 final DiscoveryNode existingNode = nodesBuilder.get(joiningNode.getId());
                 if (existingNode != null && existingNode.equals(joiningNode) == false) {
@@ -479,7 +477,7 @@ public class NodeJoinController extends AbstractComponent {
 
             // now trim any left over dead nodes - either left there when the previous master stepped down
             // or removed by us above
-            ClusterState tmpState = ClusterState.builder(currentState).nodes(nodesBuilder).blocks(clusterBlocks).build();
+            ClusterState tmpState = ClusterState.builder(currentState).nodes(nodesBuilder).build();
             return ClusterState.builder(allocationService.deassociateDeadNodes(tmpState, false,
                 "removed dead nodes on election"));
         }

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -590,9 +590,7 @@ public class Node implements Closeable {
                 final CountDownLatch latch = new CountDownLatch(1);
                 observer.waitForNextChange(new ClusterStateObserver.Listener() {
                     @Override
-                    public void onNewClusterState(ClusterState state) {
-                        latch.countDown();
-                    }
+                    public void onNewClusterState(ClusterState state) { latch.countDown(); }
 
                     @Override
                     public void onClusterServiceClose() {

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -554,7 +554,6 @@ public class Node implements Closeable {
         injector.getInstance(ResourceWatcherService.class).start();
         injector.getInstance(GatewayService.class).start();
         Discovery discovery = injector.getInstance(Discovery.class);
-        clusterService.addInitialStateBlock(discovery.getDiscoverySettings().getNoMasterBlock());
         clusterService.setClusterStatePublisher(discovery::publish);
 
         // start before the cluster service since it adds/removes initial Cluster state blocks
@@ -587,11 +586,13 @@ public class Node implements Closeable {
         if (DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.get(settings).millis() > 0) {
             final ThreadPool thread = injector.getInstance(ThreadPool.class);
             ClusterStateObserver observer = new ClusterStateObserver(clusterService, null, logger, thread.getThreadContext());
-            if (observer.observedState().getClusterState().nodes().getMasterNodeId() == null) {
+            if (observer.observedState().getLocalClusterState().nodes().getMasterNodeId() == null) {
                 final CountDownLatch latch = new CountDownLatch(1);
                 observer.waitForNextChange(new ClusterStateObserver.Listener() {
                     @Override
-                    public void onNewClusterState(ClusterState state) { latch.countDown(); }
+                    public void onNewClusterState(ClusterState state) {
+                        latch.countDown();
+                    }
 
                     @Override
                     public void onClusterServiceClose() {

--- a/core/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -31,7 +31,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.ClusterStateTaskConfig;
+import org.elasticsearch.cluster.ClusterTaskConfig;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
@@ -682,7 +682,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
                     clusterService.submitStateUpdateTask(
                         "clean up snapshot restore state",
                         new CleanRestoreStateTaskExecutor.Task(entry.snapshot()),
-                        ClusterStateTaskConfig.build(Priority.URGENT),
+                        ClusterTaskConfig.build(Priority.URGENT),
                         cleanRestoreStateTaskExecutor,
                         cleanRestoreStateTaskExecutor);
                 }

--- a/core/src/main/java/org/elasticsearch/tribe/TribeService.java
+++ b/core/src/main/java/org/elasticsearch/tribe/TribeService.java
@@ -27,7 +27,7 @@ import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.ClusterStateTaskConfig;
+import org.elasticsearch.cluster.ClusterTaskConfig;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -58,12 +58,10 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.node.Node;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.transport.TransportSettings;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -323,7 +321,7 @@ public class TribeService extends AbstractLifecycleComponent {
             clusterService.submitStateUpdateTask(
                     "cluster event from " + tribeName,
                     event,
-                    ClusterStateTaskConfig.build(Priority.NORMAL),
+                    ClusterTaskConfig.build(Priority.NORMAL),
                     executor,
                     (source, e) -> logger.warn((Supplier<?>) () -> new ParameterizedMessage("failed to process [{}]", source), e));
         }

--- a/core/src/main/java/org/elasticsearch/tribe/TribeService.java
+++ b/core/src/main/java/org/elasticsearch/tribe/TribeService.java
@@ -262,7 +262,7 @@ public class TribeService extends AbstractLifecycleComponent {
         if (nodes.isEmpty() == false) {
             // remove the initial election / recovery blocks since we are not going to have a
             // master elected in this single tribe  node local "cluster"
-            clusterService.removeInitialStateBlock(DiscoverySettings.NO_MASTER_BLOCK_ID);
+            clusterService.setInitialNoMaster(false);
             clusterService.removeInitialStateBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK);
         }
     }

--- a/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.routing.IllegalShardRoutingStateException;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -48,7 +49,6 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentLocation;
-import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.index.AlreadyExpiredException;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.engine.RecoveryEngineException;
@@ -497,9 +497,9 @@ public class ExceptionSerializationTests extends ESTestCase {
     }
 
     public void testClusterBlockException() throws IOException {
-        ClusterBlockException ex = serialize(new ClusterBlockException(singleton(DiscoverySettings.NO_MASTER_BLOCK_WRITES)));
+        ClusterBlockException ex = serialize(new ClusterBlockException(singleton(ClusterService.NO_MASTER_BLOCK_WRITES)));
         assertEquals("blocked by: [SERVICE_UNAVAILABLE/2/no master];", ex.getMessage());
-        assertTrue(ex.blocks().contains(DiscoverySettings.NO_MASTER_BLOCK_WRITES));
+        assertTrue(ex.blocks().contains(ClusterService.NO_MASTER_BLOCK_WRITES));
         assertEquals(1, ex.blocks().size());
     }
 

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.RepositoriesMetaData;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.snapshots.SnapshotId;
@@ -47,7 +48,6 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -311,9 +311,9 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
     private ClusterBlock randomGlobalBlock() {
         switch (randomInt(2)) {
             case 0:
-                return DiscoverySettings.NO_MASTER_BLOCK_ALL;
+                return ClusterService.NO_MASTER_BLOCK_ALL;
             case 1:
-                return DiscoverySettings.NO_MASTER_BLOCK_WRITES;
+                return ClusterService.NO_MASTER_BLOCK_WRITES;
             default:
                 return GatewayService.STATE_NOT_RECOVERED_BLOCK;
         }

--- a/core/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
@@ -93,7 +93,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
 
         logger.info("--> should be blocked, no master...");
         ClusterState state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(true));
+        assertThat(state.blocks().hasGlobalBlock(ClusterService.NO_MASTER_BLOCK_ID), equalTo(true));
         assertThat(state.nodes().getSize(), equalTo(1)); // verify that we still see the local node in the cluster state
 
         logger.info("--> start second node, cluster should be formed");
@@ -103,9 +103,9 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlock(ClusterService.NO_MASTER_BLOCK_ID), equalTo(false));
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlock(ClusterService.NO_MASTER_BLOCK_ID), equalTo(false));
 
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         assertThat(state.nodes().getSize(), equalTo(2));
@@ -130,10 +130,10 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         internalCluster().stopCurrentMasterNode();
         awaitBusy(() -> {
             ClusterState clusterState = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-            return clusterState.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID);
+            return clusterState.blocks().hasGlobalBlock(ClusterService.NO_MASTER_BLOCK_ID);
         });
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(true));
+        assertThat(state.blocks().hasGlobalBlock(ClusterService.NO_MASTER_BLOCK_ID), equalTo(true));
         // verify that both nodes are still in the cluster state but there is no master
         assertThat(state.nodes().getSize(), equalTo(2));
         assertThat(state.nodes().getMasterNode(), equalTo(null));
@@ -145,9 +145,9 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlock(ClusterService.NO_MASTER_BLOCK_ID), equalTo(false));
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlock(ClusterService.NO_MASTER_BLOCK_ID), equalTo(false));
 
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         assertThat(state.nodes().getSize(), equalTo(2));
@@ -165,7 +165,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
             @Override
             public void run() {
                 ClusterState state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-                assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(true));
+                assertThat(state.blocks().hasGlobalBlock(ClusterService.NO_MASTER_BLOCK_ID), equalTo(true));
             }
         });
 
@@ -177,9 +177,9 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlock(ClusterService.NO_MASTER_BLOCK_ID), equalTo(false));
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlock(ClusterService.NO_MASTER_BLOCK_ID), equalTo(false));
 
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         assertThat(state.nodes().getSize(), equalTo(2));
@@ -211,7 +211,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
             public void run() {
                 for (Client client : clients()) {
                     ClusterState state = client.admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-                    assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(true));
+                    assertThat(state.blocks().hasGlobalBlock(ClusterService.NO_MASTER_BLOCK_ID), equalTo(true));
                 }
             }
         });
@@ -306,7 +306,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
     private void assertNoMasterBlockOnAllNodes() throws InterruptedException {
         Predicate<Client> hasNoMasterBlock = client -> {
             ClusterState state = client.admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-            return state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID);
+            return state.blocks().hasGlobalBlock(ClusterService.NO_MASTER_BLOCK_ID);
         };
         assertTrue(awaitBusy(
                         () -> {

--- a/core/src/test/java/org/elasticsearch/cluster/NoMasterNodeIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/NoMasterNodeIT.java
@@ -26,11 +26,11 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.discovery.DiscoveryModule;
-import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.discovery.zen.ZenDiscovery;
 import org.elasticsearch.rest.RestStatus;
@@ -69,7 +69,7 @@ public class NoMasterNodeIT extends ESIntegTestCase {
                 .put("discovery.zen.minimum_master_nodes", 2)
                 .put(ZenDiscovery.PING_TIMEOUT_SETTING.getKey(), "200ms")
                 .put("discovery.initial_state_timeout", "500ms")
-                .put(DiscoverySettings.NO_MASTER_BLOCK_SETTING.getKey(), "all")
+                .put(ClusterService.NO_MASTER_BLOCK_SETTING.getKey(), "all")
                 .build();
 
         TimeValue timeout = TimeValue.timeValueMillis(200);
@@ -84,7 +84,7 @@ public class NoMasterNodeIT extends ESIntegTestCase {
             @Override
             public void run() {
                 ClusterState state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-                assertTrue(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID));
+                assertTrue(state.blocks().hasGlobalBlock(ClusterService.NO_MASTER_BLOCK_ID));
             }
         });
 
@@ -207,7 +207,7 @@ public class NoMasterNodeIT extends ESIntegTestCase {
                 .put("discovery.zen.minimum_master_nodes", 2)
                 .put(ZenDiscovery.PING_TIMEOUT_SETTING.getKey(), "200ms")
                 .put("discovery.initial_state_timeout", "500ms")
-                .put(DiscoverySettings.NO_MASTER_BLOCK_SETTING.getKey(), "write")
+                .put(ClusterService.NO_MASTER_BLOCK_SETTING.getKey(), "write")
                 .build();
 
         internalCluster().startNode(settings);
@@ -228,7 +228,7 @@ public class NoMasterNodeIT extends ESIntegTestCase {
         internalCluster().stopRandomDataNode();
         assertTrue(awaitBusy(() -> {
                     ClusterState state = client().admin().cluster().prepareState().setLocal(true).get().getState();
-                    return state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID);
+                    return state.blocks().hasGlobalBlock(ClusterService.NO_MASTER_BLOCK_ID);
                 }
         ));
 

--- a/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
@@ -358,7 +358,7 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
         // continuously ping until network failures have been resolved. However
         // It may a take a bit before the node detects it has been cut off from the elected master
         logger.info("waiting for isolated node [{}] to have no master", isolatedNode);
-        assertNoMaster(isolatedNode, DiscoverySettings.NO_MASTER_BLOCK_WRITES, TimeValue.timeValueSeconds(10));
+        assertNoMaster(isolatedNode, ClusterService.NO_MASTER_BLOCK_WRITES, TimeValue.timeValueSeconds(10));
 
 
         logger.info("wait until elected master has been removed and a new 2 node cluster was from (via [{}])", isolatedNode);
@@ -385,9 +385,9 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
         // Wait until the master node sees al 3 nodes again.
         ensureStableCluster(3, new TimeValue(DISRUPTION_HEALING_OVERHEAD.millis() + networkDisruption.expectedTimeToHeal().millis()));
 
-        logger.info("Verify no master block with {} set to {}", DiscoverySettings.NO_MASTER_BLOCK_SETTING.getKey(), "all");
+        logger.info("Verify no master block with {} set to {}", ClusterService.NO_MASTER_BLOCK_SETTING.getKey(), "all");
         client().admin().cluster().prepareUpdateSettings()
-                .setTransientSettings(Settings.builder().put(DiscoverySettings.NO_MASTER_BLOCK_SETTING.getKey(), "all"))
+                .setTransientSettings(Settings.builder().put(ClusterService.NO_MASTER_BLOCK_SETTING.getKey(), "all"))
                 .get();
 
         networkDisruption.startDisrupting();
@@ -397,7 +397,7 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
         // continuously ping until network failures have been resolved. However
         // It may a take a bit before the node detects it has been cut off from the elected master
         logger.info("waiting for isolated node [{}] to have no master", isolatedNode);
-        assertNoMaster(isolatedNode, DiscoverySettings.NO_MASTER_BLOCK_ALL, TimeValue.timeValueSeconds(10));
+        assertNoMaster(isolatedNode, ClusterService.NO_MASTER_BLOCK_ALL, TimeValue.timeValueSeconds(10));
 
         // make sure we have stable cluster & cross partition recoveries are canceled by the removal of the missing node
         // the unresponsive partition causes recoveries to only time out after 15m (default) and these will cause

--- a/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
@@ -20,7 +20,6 @@ package org.elasticsearch.test;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.NodeConnectionsService;
@@ -65,6 +64,7 @@ public class ClusterServiceUtils {
         });
         clusterService.setClusterStatePublisher((event, ackListener) -> {
         });
+        clusterService.setInitialNoMaster(false);
         clusterService.start();
         final DiscoveryNodes.Builder nodes = DiscoveryNodes.builder(clusterService.state().nodes());
         nodes.masterNodeId(clusterService.localNode().getId());


### PR DESCRIPTION
There was only one remaining place where a non-master node would
alter the cluster state on its own local node - to update the
NO_MASTER cluster block.  In order to ensure that the authoritative
cluster state on each node is only updated by the master node, this
commit removes updating the NO_MASTER block in the cluster state via
a cluster state update task.  Instead, the ClusterService now uses
the newly created ClusterServiceState (see #21379) to maintain the
current cluster state and the local view of the cluster, including
whether there is currently a master from the point of view of the
ClusterService.  In order to minimize the impact of this change,
whenever the ClusterService#state() method is invoked to retrieve
the current state, if the no master flag is set, the returned
cluster state will contain a NO_MASTER block overlayed on the
authoritative state, without altering the authoritative cluster state.