### PR TITLE
Reject DELETE requests with a body

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestDeleteAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestDeleteAction.java
@@ -49,7 +49,7 @@ public class RestDeleteAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         if (RestActions.hasBodyContent(request)) {
-            throw new IllegalArgumentException("can't specify a request body");
+            throw new IllegalArgumentException("DELETE requests may not contain a request body");
         }
 
         DeleteRequest deleteRequest = new DeleteRequest(request.param("index"), request.param("type"), request.param("id"));

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestDeleteAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestDeleteAction.java
@@ -48,6 +48,10 @@ public class RestDeleteAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        if (RestActions.hasBodyContent(request)) {
+            throw new IllegalArgumentException("can't specify a request body");
+        }
+
         DeleteRequest deleteRequest = new DeleteRequest(request.param("index"), request.param("type"), request.param("id"));
         deleteRequest.routing(request.param("routing"));
         deleteRequest.parent(request.param("parent")); // order is important, set it after routing, so it will set the routing


### PR DESCRIPTION
According to issues #8217 and #5960, DELETE requests that contains a body should be rejected.
