### PR TITLE
Remove max_local_storage_nodes from elasticsearch.yml

### DIFF
--- a/distribution/src/main/resources/config/elasticsearch.yml
+++ b/distribution/src/main/resources/config/elasticsearch.yml
@@ -86,10 +86,6 @@
 #
 # ---------------------------------- Various -----------------------------------
 #
-# Disable starting multiple nodes on a single system:
-#
-#node.max_local_storage_nodes: 1
-#
 # Require explicit names when deleting indices:
 #
 #action.destructive_requires_name: true


### PR DESCRIPTION

Given that the default is now 1, the comment in the config file was outdated. Also considering that the default value is production ready, we shouldn't list it among the values that need attention when going to production.

Relates to #19964