### PR TITLE
Remove unhelpful log message from TransportNodesAction

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -106,11 +106,12 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
         final List<NodeResponse> responses = new ArrayList<>();
         final List<FailedNodeException> failures = new ArrayList<>();
 
+        final boolean accumulateExceptions = accumulateExceptions();
         for (int i = 0; i < nodesResponses.length(); ++i) {
             Object response = nodesResponses.get(i);
 
             if (response instanceof FailedNodeException) {
-                if (accumulateExceptions()) {
+                if (accumulateExceptions) {
                     failures.add((FailedNodeException)response);
                 } else {
                     logger.warn("not accumulating exceptions, excluding exception from response", (FailedNodeException)response);


### PR DESCRIPTION
Today when handling responses from nodes in TransportNodesAction, if a
node timeouts or some other failure occurs and the action is not
accumulating exceptions, we log a confusing message:

```
org.elasticsearch.action.admin.cluster.stats.TransportClusterStatsAction] ignoring unexpected response [null] of type [null], expected [ClusterStatsNodeResponse] or [FailedNodeException]
```

Moreover, the original exception is completely lost. Since this log
message is confusing and unhelpful, we can drop it. Instead, we hold
onto the exception and log it at the warn level before dropping it from
the response.