### PR TITLE
fixes issue:14469, support binary field type in script values

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVAtomicFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVAtomicFieldData.java
@@ -101,7 +101,7 @@ final class BytesBinaryDVAtomicFieldData implements AtomicFieldData {
 
     @Override
     public ScriptDocValues getScriptValues() {
-        throw new UnsupportedOperationException();
+        return new ScriptDocValues.Strings(getBytesValues());
     }
 
     @Override


### PR DESCRIPTION
Fixes: [14469](https://github.com/elastic/elasticsearch/issues/14469).

Followed the steps mentioned in the issue to re-create the issue:
1. Index binary fields: 
<script src="https://gist.github.com/umeshdangat/43b10532dc52c5d92c1a2d7aaf8c0d8c.js"></script>

2. Use painless script to query field as a doc value
<script src="https://gist.github.com/umeshdangat/d236b8f70ddfda739df8b01c672413b5.js"></script>

3. Result after fix:
<script src="https://gist.github.com/umeshdangat/c137c5d426bc23c5ff02b087d3a3684c.js"></script>

