### PR TITLE
Implement IndicesRequest.Replaceable in RestoreSnapshotRequest

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.snapshots.restore;
 
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.common.Strings;
@@ -48,7 +49,7 @@ import static org.elasticsearch.common.xcontent.support.XContentMapValues.lenien
 /**
  * Restore snapshot request
  */
-public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotRequest> {
+public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotRequest> implements IndicesRequest.Replaceable {
 
     private String snapshot;
     private String repository;


### PR DESCRIPTION
The restore snapshot API does allow to select indices that should be restored the same way the create snapshot does. Unfortunately the `org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest` does not implement the `org.elasticsearch.action.IndicesRequest.Replaceable` interface like `org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest` does, although all needed methods are already present.

Closes #21491