### PR TITLE
Fixes cachability problems with fetching TTL values when searching

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/TTLFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TTLFieldMapper.java
@@ -28,8 +28,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.AlreadyExpiredException;
-import org.elasticsearch.search.internal.SearchContext;
-
 import java.io.IOException;
 import java.util.Date;
 import java.util.Iterator;
@@ -140,13 +138,7 @@ public class TTLFieldMapper extends MetadataFieldMapper {
         // Overrides valueForSearch to display live value of remaining ttl
         @Override
         public Object valueForSearch(Object value) {
-            long now;
-            SearchContext searchContext = SearchContext.current();
-            if (searchContext != null) {
-                now = searchContext.getQueryShardContext().nowInMillis();
-            } else {
-                now = System.currentTimeMillis();
-            }
+            long now = System.currentTimeMillis();
             Long val = (Long) super.valueForSearch(value);
             return val - now;
         }


### PR DESCRIPTION
This applies the same stance as 5.1 and 6.0 branches that we can  just use System.currentTimeMillis() when returning the value for expiration in the fetch phase instead of getting he value of now from the frozen context which is now not possible.

Closes #21457