### PR TITLE
Allow overriding all-field leniency when `lenient` option is specified

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -964,8 +964,8 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
                         this.fieldsAndWeights.size() == 0)) {
             // Use the automatically determined expansion of all queryable fields
             resolvedFields = allQueryableDefaultFields(context);
-            // Automatically set leniency to "true" so mismatched fields don't cause exceptions
-            qpSettings.lenient(true);
+            // Automatically set leniency to "true" if unset so mismatched fields don't cause exceptions
+            qpSettings.lenient(lenient == null ? true : lenient);
         } else {
             qpSettings.defaultField(this.defaultField == null ? context.defaultField() : this.defaultField);
 

--- a/core/src/test/java/org/elasticsearch/search/query/QueryStringIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/QueryStringIT.java
@@ -255,6 +255,14 @@ public class QueryStringIT extends ESIntegTestCase {
                 containsString("Can't parse boolean value [foo], expected [true] or [false]"));
     }
 
+    public void testAllFieldsWithSpecifiedLeniency() throws IOException {
+        Exception e = expectThrows(Exception.class, () ->
+                client().prepareSearch("test").setQuery(
+                        queryStringQuery("f_date:[now-2D TO now]").lenient(false)).get());
+        assertThat(ExceptionsHelper.detailedMessage(e),
+                containsString("unit [D] not supported for date math [-2D]"));
+    }
+
     private void assertHits(SearchHits hits, String... ids) {
         assertThat(hits.totalHits(), equalTo((long) ids.length));
         Set<String> hitIds = new HashSet<>();
@@ -263,5 +271,4 @@ public class QueryStringIT extends ESIntegTestCase {
         }
         assertThat(hitIds, containsInAnyOrder(ids));
     }
-
 }

--- a/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
@@ -564,6 +564,18 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         assertHitCount(resp, 1L);
     }
 
+    public void testAllFieldsWithSpecifiedLeniency() throws IOException {
+        String indexBody = copyToStringFromClasspath("/org/elasticsearch/search/query/all-query-index.json");
+        prepareCreate("test").setSource(indexBody).get();
+        ensureGreen("test");
+
+        Exception e = expectThrows(Exception.class, () ->
+                client().prepareSearch("test").setQuery(
+                        simpleQueryStringQuery("foo123").lenient(false)).get());
+        assertThat(ExceptionsHelper.detailedMessage(e),
+                containsString("NumberFormatException[For input string: \"foo123\"]"));
+    }
+
     private void assertHits(SearchHits hits, String... ids) {
         assertThat(hits.totalHits(), equalTo((long) ids.length));
         Set<String> hitIds = new HashSet<>();

--- a/docs/reference/search/validate.asciidoc
+++ b/docs/reference/search/validate.asciidoc
@@ -87,7 +87,7 @@ due to dynamic mapping, and 'foo' does not correctly parse into a date:
 
 [source,js]
 --------------------------------------------------
-GET twitter/tweet/_validate/query?q=post_date:foo
+GET twitter/tweet/_validate/query?q=post_date:foo%5d
 --------------------------------------------------
 // CONSOLE
 
@@ -102,7 +102,7 @@ about why a query failed:
 
 [source,js]
 --------------------------------------------------
-GET twitter/tweet/_validate/query?q=post_date:foo&explain=true
+GET twitter/tweet/_validate/query?q=post_date:foo%5d&explain=true
 --------------------------------------------------
 // CONSOLE
 


### PR DESCRIPTION
As part of #20925 and #21341 we added an "all-fields" mode to the
`query_string` and `simple_query_string`. This would expand the query to
all fields and automatically set `lenient` to true.

However, we should still allow a user to override the `lenient` flag to
whichever value they desire, should they add it in the request. This
commit does that.