### PR TITLE
Set vm.max_map_count on systemd package install

### DIFF
--- a/distribution/src/main/packaging/scripts/postinst
+++ b/distribution/src/main/packaging/scripts/postinst
@@ -51,6 +51,11 @@ case "$1" in
     ;;
 esac
 
+# to pick up /usr/lib/sysctl.d/elasticsearch.conf
+if command -v /usr/lib/systemd/systemd-sysctl > /dev/null; then
+    /usr/lib/systemd/systemd-sysctl
+fi
+
 if [ "x$IS_UPGRADE" != "xtrue" ]; then
     if command -v systemctl >/dev/null; then
         echo "### NOT starting on installation, please execute the following statements to configure elasticsearch service to start automatically using systemd"

--- a/qa/vagrant/src/test/resources/packaging/scripts/os_package.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/os_package.bash
@@ -123,6 +123,7 @@ verify_package_installation() {
         assert_file "/usr/lib/systemd/system/elasticsearch.service" f root root 644
         assert_file "/usr/lib/tmpfiles.d/elasticsearch.conf" f root root 644
         assert_file "/usr/lib/sysctl.d/elasticsearch.conf" f root root 644
+        [[ $(sysctl vm.max_map_count) =~ "vm.max_map_count = 262144" ]]
     fi
 
     if is_sysvinit; then


### PR DESCRIPTION
Our docs claim that we set vm.max_map_count automatically. This is not
quite the case. The story is that on SysV init we set vm.max_map_count
each time the service starts, which is good. On systemd, we create a
sysctl.d conf file that sets vm.map_max_count, but this is only
meaningful if the system is rebooted after package install. This commit
modifies the post-install script so that we run systemd-sysctl so that
the vm.max_map_count change occurs after package install without a
reboot.