### PR TITLE
Remove shard ID from doc write response

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -243,8 +243,6 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
             builder.field("forced_refresh", forcedRefresh);
         }
         shardInfo.toXContent(builder, params);
-        // nocommit i'm not sure we want to expose it in the api but it will be handy for debugging while we work... remove this
-        builder.field("_shard_id", shardId.id());
         if (getSeqNo() >= 0) {
             builder.field("_seq_no", getSeqNo());
         }

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -99,8 +99,7 @@ The result of this bulk operation is:
             },
             "created": true,
             "status": 201,
-            "_seq_no" : 0,
-            "_shard_id" : 0
+            "_seq_no" : 0
          }
       },
       {
@@ -117,8 +116,7 @@ The result of this bulk operation is:
                "failed": 0
             },
             "status": 404,
-            "_seq_no" : 1,
-            "_shard_id" : 1
+            "_seq_no" : 1
          }
       },
       {
@@ -135,8 +133,7 @@ The result of this bulk operation is:
             },
             "created": true,
             "status": 201,
-            "_seq_no" : 2,
-            "_shard_id" : 2
+            "_seq_no" : 2
          }
       },
       {
@@ -152,14 +149,13 @@ The result of this bulk operation is:
                 "failed": 0
             },
             "status": 200,
-            "_seq_no" : 3,
-            "_shard_id" : 3
+            "_seq_no" : 3
          }
       }
    ]
 }
 --------------------------------------------------
-// TESTRESPONSE[s/"took": 30/"took": $body.took/ s/"index_uuid": .../"index_uuid": $body.items.3.update.error.index_uuid/ s/"_shard_id" : 0/"_shard_id" : $body.items.0.index._shard_id/ s/"_shard_id" : 1/"_shard_id" : $body.items.1.delete._shard_id/ s/"_shard_id" : 2/"_shard_id" : $body.items.2.create._shard_id/ s/"_shard_id" : 3/"_shard_id" : $body.items.3.update._shard_id/ s/"_seq_no" : 0/"_seq_no" : $body.items.0.index._seq_no/ s/"_seq_no" : 1/"_seq_no" : $body.items.1.delete._seq_no/ s/"_seq_no" : 2/"_seq_no" : $body.items.2.create._seq_no/ s/"_seq_no" : 3/"_seq_no" : $body.items.3.update._seq_no/]
+// TESTRESPONSE[s/"took": 30/"took": $body.took/ s/"index_uuid": .../"index_uuid": $body.items.3.update.error.index_uuid/ s/"_seq_no" : 0/"_seq_no" : $body.items.0.index._seq_no/ s/"_seq_no" : 1/"_seq_no" : $body.items.1.delete._seq_no/ s/"_seq_no" : 2/"_seq_no" : $body.items.2.create._seq_no/ s/"_seq_no" : 3/"_seq_no" : $body.items.3.update._seq_no/]
 
 The endpoints are `/_bulk`, `/{index}/_bulk`, and `{index}/{type}/_bulk`.
 When the index or the index/type are provided, they will be used by

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -32,11 +32,10 @@ The result of the above index operation is:
     "_version" : 1,
     "created" : true,
     "_seq_no" : 0,
-    "_shard_id" : 3,
     "result" : created
 }
 --------------------------------------------------
-// TESTRESPONSE[s/"successful" : 2/"successful" : 1/ s/"_shard_id" : 3/"_shard_id" : "$body._shard_id"/]
+// TESTRESPONSE[s/"successful" : 2/"successful" : 1/]
 
 The `_shards` header provides information about the replication process of the index operation.
 
@@ -232,11 +231,10 @@ The result of the above index operation is:
     "_version" : 1,
     "created" : true,
     "_seq_no" : 0,
-    "_shard_id" : 2,
     "result": "created"
 }
 --------------------------------------------------
-// TESTRESPONSE[s/6a8ca01c-7896-48e9-81cc-9f70661fcb32/$body._id/ s/"successful" : 2/"successful" : 1/ s/"_shard_id" : 2/"_shard_id" : "$body._shard_id"/]
+// TESTRESPONSE[s/6a8ca01c-7896-48e9-81cc-9f70661fcb32/$body._id/ s/"successful" : 2/"successful" : 1/]
 
 [float]
 [[index-routing]]

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -170,11 +170,10 @@ the request was ignored.
    "_type": "type1",
    "_id": "1",
    "_version": 6,
-   "result": noop,
-   "_shard_id" : 3
+   "result": noop
 }
 --------------------------------------------------
-// TESTRESPONSE[s/"_shard_id" : 3/"_shard_id" : "$body._shard_id"/]
+// TESTRESPONSE
 
 You can disable this behavior by setting "detect_noop": false like this:
 

--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -321,11 +321,10 @@ And the response:
     "failed" : 0
   },
   "created" : true,
-  "_seq_no" : 0,
-  "_shard_id" : 3
+  "_seq_no" : 0
 }
 --------------------------------------------------
-// TESTRESPONSE[s/"_seq_no" : 0/"_seq_no" : $body._seq_no/ s/"_shard_id" : 3/"_shard_id" : $body._shard_id/]
+// TESTRESPONSE[s/"_seq_no" : 0/"_seq_no" : $body._seq_no/]
 
 From the above, we can see that a new customer document was successfully created inside the customer index and the external type. The document also has an internal id of 1 which we specified at index time.
 

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -876,11 +876,10 @@ PUT /myindex/type/1?pipeline=monthlyindex
     "failed" : 0
   },
   "created" : true,
-  "_shard_id" : 3,
   "_seq_no" : 0
 }
 --------------------------------------------------
-// TESTRESPONSE[s/"_shard_id" : 3/"_shard_id" : "$body._shard_id"/]
+// TESTRESPONSE
 
 
 The above request will not index this document into the `myindex` index, but into the `myindex-2016-04-01` index because

--- a/docs/reference/query-dsl/percolate-query.asciidoc
+++ b/docs/reference/query-dsl/percolate-query.asciidoc
@@ -182,11 +182,10 @@ Index response:
   },
   "created": true,
   "result": "created",
-  "_shard_id" : 3,
   "_seq_no" : 1
 }
 --------------------------------------------------
-// TESTRESPONSE[s/"_shard_id" : 3/"_shard_id" : "$body._shard_id"/]
+// TESTRESPONSE
 
 Percolating an existing document, using the index response as basis to build to new search request:
 


### PR DESCRIPTION
This commit removes the shard ID from doc write response; this was
useful for debugging but its time has passed.

Relates #10708