### PR TITLE
Add POST /_search/clear_scroll endpoint and deprecate delete scroll endpoint

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/ClearScrollRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/ClearScrollRequest.java
@@ -37,6 +37,14 @@ public class ClearScrollRequest extends ActionRequest {
 
     private List<String> scrollIds;
 
+    public ClearScrollRequest() {
+
+    }
+
+    public ClearScrollRequest(List<String> scrollIds) {
+        this.scrollIds = scrollIds;
+    }
+
     public List<String> getScrollIds() {
         return scrollIds;
     }

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
@@ -62,7 +62,7 @@ public class RestClearScrollAction extends BaseRestHandler {
         }
         if (request.method() == POST && request.hasParam("scroll_id")) {
             deprecationLogger.deprecated("Deprecated [POST /_search/clear_scroll/{scroll_id}] endpoint used, " +
-                    "expected [POST /_search/clear_scroll] instead. The scroll_id should rather be provided as part of the request body");
+                    "expected [POST /_search/clear_scroll] instead. The scroll_id must be provided as part of the request body");
         }
         final ClearScrollRequest clearRequest;
         if (RestActions.hasBodyContent(request)) {

--- a/core/src/test/java/org/elasticsearch/search/scroll/SearchScrollIT.java
+++ b/core/src/test/java/org/elasticsearch/search/scroll/SearchScrollIT.java
@@ -545,16 +545,13 @@ public class SearchScrollIT extends ESIntegTestCase {
         BytesReference content = XContentFactory.jsonBuilder().startObject()
             .array("scroll_id", "value_1", "value_2")
             .endObject().bytes();
-        ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
-        RestClearScrollAction.buildFromContent(content, clearScrollRequest);
+        ClearScrollRequest clearScrollRequest = RestClearScrollAction.parseClearScrollRequest(content);
         assertThat(clearScrollRequest.scrollIds(), contains("value_1", "value_2"));
     }
 
     public void testParseClearScrollRequestWithInvalidJsonThrowsException() throws Exception {
-        ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
-
         try {
-            RestClearScrollAction.buildFromContent(new BytesArray("{invalid_json}"), clearScrollRequest);
+            RestClearScrollAction.parseClearScrollRequest(new BytesArray("{invalid_json}"));
             fail("expected parseContent failure");
         } catch (Exception e) {
             assertThat(e, instanceOf(IllegalArgumentException.class));
@@ -567,10 +564,8 @@ public class SearchScrollIT extends ESIntegTestCase {
             .array("scroll_id", "value_1", "value_2")
             .field("unknown", "keyword")
             .endObject().bytes();
-        ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
-
         try {
-            RestClearScrollAction.buildFromContent(invalidContent, clearScrollRequest);
+            RestClearScrollAction.parseClearScrollRequest(invalidContent);
             fail("expected parseContent failure");
         } catch (Exception e) {
             assertThat(e, instanceOf(IllegalArgumentException.class));

--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -134,15 +134,15 @@ GET /_nodes/stats/indices/search
 
 ==== Clear scroll API
 
-Search context are automatically removed when the `scroll` timeout has been
+Search contexts are automatically removed when the `scroll` timeout has been
 exceeded. However keeping scrolls open has a cost, as discussed in the
 <<scroll-search-context,previous section>> so scrolls should be explicitly
-cleared as soon as the scroll is not being used anymore using the
-`clear-scroll` API:
+cleared as soon as they are not being used anymore using the `clear-scroll`
+API:
 
 [source,js]
 ---------------------------------------
-DELETE /_search/scroll
+POST /_search/clear_scroll
 {
     "scroll_id" : ["DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ=="]
 }
@@ -154,7 +154,7 @@ Multiple scroll IDs can be passed as array:
 
 [source,js]
 ---------------------------------------
-DELETE /_search/scroll
+POST /_search/clear_scroll
 {
     "scroll_id" : [
       "DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==",
@@ -165,23 +165,24 @@ DELETE /_search/scroll
 // CONSOLE
 // TEST[catch:missing]
 
-All search contexts can be cleared with the `_all` parameter:
+The recommended way to provide the `scroll_id` is by placing it in the request
+body using the `POST` verb against the `clear_scroll` endpoint added[5.2.0].
+All of the other ways to provide the `scroll_id`, either as a url parameter or
+as part of the request body using the `DELETE /_search/scroll` endpoint, are
+ deprecated deprecated[5.2.0].
+
+All search contexts can be cleared with the special `_all` scroll id:
 
 [source,js]
 ---------------------------------------
-DELETE /_search/scroll/_all
+POST /_search/clear_scroll
+{
+    "scroll_id" : [
+      "_all"
+    ]
+}
 ---------------------------------------
 // CONSOLE
-
-The `scroll_id` can also be passed as a query string parameter or in the request body.
-Multiple scroll IDs can be passed as comma separated values:
-
-[source,js]
----------------------------------------
-DELETE /_search/scroll/DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==,DnF1ZXJ5VGhlbkZldGNoBQAAAAAAAAABFmtSWWRRWUJrU2o2ZExpSGJCVmQxYUEAAAAAAAAAAxZrUllkUVlCa1NqNmRMaUhiQlZkMWFBAAAAAAAAAAIWa1JZZFFZQmtTajZkTGlIYkJWZDFhQQAAAAAAAAAFFmtSWWRRWUJrU2o2ZExpSGJCVmQxYUEAAAAAAAAABBZrUllkUVlCa1NqNmRMaUhiQlZkMWFB
----------------------------------------
-// CONSOLE
-// TEST[catch:missing]
 
 [[sliced-scroll]]
 ==== Sliced Scroll

--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -138,19 +138,7 @@ Search contexts are automatically removed when the `scroll` timeout has been
 exceeded. However keeping scrolls open has a cost, as discussed in the
 <<scroll-search-context,previous section>> so scrolls should be explicitly
 cleared as soon as they are not being used anymore using the `clear-scroll`
-API:
-
-[source,js]
----------------------------------------
-POST /_search/clear_scroll
-{
-    "scroll_id" : ["DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ=="]
-}
----------------------------------------
-// CONSOLE
-// TEST[catch:missing]
-
-Multiple scroll IDs can be passed as array:
+API. Multiple scroll IDs can be passed as array:
 
 [source,js]
 ---------------------------------------
@@ -165,11 +153,7 @@ POST /_search/clear_scroll
 // CONSOLE
 // TEST[catch:missing]
 
-The recommended way to provide the `scroll_id` is by placing it in the request
-body using the `POST` verb against the `clear_scroll` endpoint added[5.2.0].
-All of the other ways to provide the `scroll_id`, either as a url parameter or
-as part of the request body using the `DELETE /_search/scroll` endpoint, are
- deprecated deprecated[5.2.0].
+deprecated[5.2.0,Providing the scroll ID as part of the URL or as a query string parameter has been deprecated in favour of specifying it in the request body.  The `DELETE _search/scroll` endpoints are deprecated in favour of `POST _search/clear_scroll`]
 
 All search contexts can be cleared with the special `_all` scroll id:
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
@@ -14,7 +14,7 @@
       "params": {}
     },
     "body": {
-      "description": "A comma-separated list of scroll IDs to clear"
+      "description": "A comma-separated list of scroll IDs to clear, has the precedence over the scroll_id parameter"
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
@@ -14,7 +14,7 @@
       "params": {}
     },
     "body": {
-      "description": "A comma-separated list of scroll IDs to clear, has the precedence over the scroll_id parameter"
+      "description": "A comma-separated list of scroll IDs to clear, has precedence over the scroll_id parameter"
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_scroll.json
@@ -14,7 +14,7 @@
       "params": {}
     },
     "body": {
-      "description": "A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter"
+      "description": "A comma-separated list of scroll IDs to clear, has the precedence over the scroll_id parameter"
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_scroll.json
@@ -14,7 +14,7 @@
       "params": {}
     },
     "body": {
-      "description": "A comma-separated list of scroll IDs to clear, has the precedence over the scroll_id parameter"
+      "description": "A comma-separated list of scroll IDs to clear, has precedence over the scroll_id parameter"
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_scroll.json
@@ -1,10 +1,10 @@
 {
-  "clear_scroll": {
+  "delete_scroll": {
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-request-scroll.html",
-    "methods": ["POST"],
+    "methods": ["DELETE"],
     "url": {
-      "path": "/_search/clear_scroll/{scroll_id}",
-      "paths": ["/_search/clear_scroll/{scroll_id}", "/_search/clear_scroll"],
+      "path": "/_search/scroll/{scroll_id}",
+      "paths": ["/_search/scroll/{scroll_id}", "/_search/scroll"],
       "parts": {
         "scroll_id": {
           "type" : "list",
@@ -14,7 +14,7 @@
       "params": {}
     },
     "body": {
-      "description": "A comma-separated list of scroll IDs to clear"
+      "description": "A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter"
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/10_basic.yaml
@@ -63,7 +63,7 @@
 
   - do:
       clear_scroll:
-        scroll_id: $scroll_id
+        body: { "scroll_id": [ "$scroll_id" ]}
 
 ---
 "Body params override query string":
@@ -123,5 +123,5 @@
 
   - do:
       clear_scroll:
-        scroll_id: $scroll_id
+        body: { "scroll_id": [ "$scroll_id" ]}
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/11_clear.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/11_clear.yaml
@@ -25,7 +25,7 @@
 
   - do:
       clear_scroll:
-        scroll_id: $scroll_id1
+        body: { "scroll_id": [ "$scroll_id1" ]}
 
   - do:
       catch: missing
@@ -33,46 +33,11 @@
         scroll_id: $scroll_id1
         
   - do:
-        catch: missing
-        clear_scroll:
-          scroll_id: $scroll_id1
-
----
-"Body params override query string":
-  - do:
-      indices.create:
-          index:  test_scroll
-  - do:
-      index:
-          index:  test_scroll
-          type:   test
-          id:     42
-          body:   { foo: bar }
-
-  - do:
-      indices.refresh: {}
-
-  - do:
-      search:
-        index: test_scroll
-        scroll: 1m
-        body:
-          query:
-            match_all: {}
-
-  - set: {_scroll_id: scroll_id1}
-
-  - do:
+      catch: missing
       clear_scroll:
-        scroll_id: "invalid_scroll_id"
         body: { "scroll_id": [ "$scroll_id1" ]}
 
   - do:
       catch: missing
-      scroll:
-        scroll_id: $scroll_id1
-
-  - do:
-        catch: missing
-        clear_scroll:
-          scroll_id: $scroll_id1
+      clear_scroll:
+        body: { "scroll_id": [ "$scroll_id1" ]}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/12_slices.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/12_slices.yaml
@@ -30,8 +30,8 @@
   - set: {_scroll_id: scroll_id}
 
   - do:
-        clear_scroll:
-          scroll_id: $scroll_id
+      clear_scroll:
+        body: { "scroll_id": [ "$scroll_id" ]}
 
   - do:
         catch:  /query_phase_execution_exception.*The number of slices.*index.max_slices_per_scroll/
@@ -67,6 +67,6 @@
   - set: {_scroll_id: scroll_id}
 
   - do:
-        clear_scroll:
-          scroll_id: $scroll_id
+      clear_scroll:
+        body: { "scroll_id": [ "$scroll_id" ]}
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/13_clear_scroll_deprecated_endpoints.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/13_clear_scroll_deprecated_endpoints.yaml
@@ -1,0 +1,171 @@
+---
+setup:
+  - do:
+      indices.create:
+          index:  test_scroll
+  - do:
+      index:
+          index:  test_scroll
+          type:   test
+          id:     42
+          body:   { foo: bar }
+
+  - do:
+      indices.refresh: {}
+
+---
+"Delete scroll with request body":
+
+  - skip:
+    features: "warnings"
+    version: " - 5.0.0"
+    reason:  response headers were introduced in 5.0.0
+
+  - do:
+      search:
+        index: test_scroll
+        scroll: 1m
+        body:
+          query:
+            match_all: {}
+
+  - set: {_scroll_id: scroll_id1}
+
+  - do:
+      warnings:
+        - Deprecated [DELETE /_search/scroll] endpoint used, expected [POST /_search/scroll] instead
+      delete_scroll:
+        body: { "scroll_id": [ "$scroll_id1" ]}
+
+  - do:
+      catch: missing
+      scroll:
+        scroll_id: $scroll_id1
+
+---
+"Delete scroll without request body":
+
+  - skip:
+    features: "warnings"
+    version: " - 5.0.0"
+    reason:  response headers were introduced in 5.0.0
+
+  - do:
+      search:
+        index: test_scroll
+        scroll: 1m
+        body:
+          query:
+            match_all: {}
+
+  - set: {_scroll_id: scroll_id1}
+
+  - do:
+      warnings:
+        - Deprecated [DELETE /_search/scroll] endpoint used, expected [POST /_search/scroll] instead
+      delete_scroll:
+        "scroll_id": "$scroll_id1"
+
+  - do:
+      catch: missing
+      scroll:
+        scroll_id: $scroll_id1
+
+---
+"Delete scroll body params override query string":
+
+  - skip:
+    features: "warnings"
+    version: " - 5.0.0"
+    reason:  response headers were introduced in 5.0.0
+
+  - do:
+      search:
+        index: test_scroll
+        scroll: 1m
+        body:
+          query:
+            match_all: {}
+
+  - set: {_scroll_id: scroll_id1}
+
+  - do:
+      warnings:
+        - Deprecated [DELETE /_search/scroll] endpoint used, expected [POST /_search/scroll] instead
+      delete_scroll:
+        scroll_id: "invalid_scroll_id"
+        body: { "scroll_id": [ "$scroll_id1" ]}
+
+  - do:
+      catch: missing
+      scroll:
+        scroll_id: $scroll_id1
+
+  - do:
+      catch: missing
+      clear_scroll:
+        body: { "scroll_id": [ "$scroll_id1" ]}
+
+---
+"Clear scroll without request body":
+
+  - skip:
+    features: "warnings"
+    version: " - 5.0.0"
+    reason:  response headers were introduced in 5.0.0
+
+  - do:
+      search:
+        index: test_scroll
+        scroll: 1m
+        body:
+          query:
+            match_all: {}
+
+  - set: {_scroll_id: scroll_id1}
+
+  - do:
+      warnings:
+        - Deprecated [POST /_search/clear_scroll/{scroll_id}] endpoint used, expected [POST /_search/clear_scroll] instead. The scroll_id should rather be provided as part of the request body
+      clear_scroll:
+        scroll_id: $scroll_id1
+
+  - do:
+      catch: missing
+      scroll:
+        scroll_id: $scroll_id1
+
+---
+"Clear scroll body params override query string":
+
+  - skip:
+    features: "warnings"
+    version: " - 5.0.0"
+    reason:  response headers were introduced in 5.0.0
+
+  - do:
+      search:
+        index: test_scroll
+        scroll: 1m
+        body:
+          query:
+            match_all: {}
+
+  - set: {_scroll_id: scroll_id1}
+
+  - do:
+      warnings:
+        - Deprecated [POST /_search/clear_scroll/{scroll_id}] endpoint used, expected [POST /_search/clear_scroll] instead. The scroll_id should rather be provided as part of the request body
+      clear_scroll:
+        scroll_id: "invalid_scroll_id"
+        body: { "scroll_id": [ "$scroll_id1" ]}
+
+  - do:
+      catch: missing
+      scroll:
+        scroll_id: $scroll_id1
+
+  - do:
+      catch: missing
+      clear_scroll:
+        body: { "scroll_id": [ "$scroll_id1" ]}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/13_clear_scroll_deprecated_endpoints.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/13_clear_scroll_deprecated_endpoints.yaml
@@ -126,7 +126,7 @@ setup:
 
   - do:
       warnings:
-        - Deprecated [POST /_search/clear_scroll/{scroll_id}] endpoint used, expected [POST /_search/clear_scroll] instead. The scroll_id should rather be provided as part of the request body
+        - Deprecated [POST /_search/clear_scroll/{scroll_id}] endpoint used, expected [POST /_search/clear_scroll] instead. The scroll_id must be provided as part of the request body
       clear_scroll:
         scroll_id: $scroll_id1
 
@@ -155,7 +155,7 @@ setup:
 
   - do:
       warnings:
-        - Deprecated [POST /_search/clear_scroll/{scroll_id}] endpoint used, expected [POST /_search/clear_scroll] instead. The scroll_id should rather be provided as part of the request body
+        - Deprecated [POST /_search/clear_scroll/{scroll_id}] endpoint used, expected [POST /_search/clear_scroll] instead. The scroll_id must be provided as part of the request body
       clear_scroll:
         scroll_id: "invalid_scroll_id"
         body: { "scroll_id": [ "$scroll_id1" ]}


### PR DESCRIPTION
The clear scroll api currently allows to provide a scroll by specifying it either as part of the url (it is effectively the resource that gets deleted) or within the request body. The current api uses the DELETE method though, and we have decided to remove support for providing the request body with any DELETE endpoint in the future. In order to get to this for the next major version, we introduce the  new endpoint `POST /_search/clear_scroll` which replaces the current clear_scroll api and uses POST instead of DELETE. It allows to provide the `scroll_id` as a url parameter, which is though deprecated (will output a deprecation warning when used) in favour of providing it as part of the request body.

 The `DELETE /_search/scroll/` is deprecated, hence it will output a deprecation warning whenever used. The DELETE endpoints will be removed in 6.0, as well as the support for providing the scroll_id as a url parameter against the POST endpoint.

Relates to #8217
Relates to #21453