### PR TITLE
Fixes potential NullPointerException on shard closing

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexService.java
@@ -406,7 +406,11 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             }
         } finally {
             try {
-                store.close();
+                if (store != null) {
+                    store.close();
+                } else {
+                    logger.trace("[{}] store not initialized prior to closing shard, nothing to close", shardId);
+                }
             } catch (Exception e) {
                 logger.warn(
                     (Supplier<?>) () -> new ParameterizedMessage(


### PR DESCRIPTION
It was possible that in IndexService#closeShard(), an attempt
would be made to close the store where the store was not yet
initialized, throwing a NullPointerException.  This commit
ensures that we do not call close on a store that has not
yet been initialized.

This was already fixed as part of #21084 which went into 6.0
and 5.x (see https://github.com/elastic/elasticsearch/pull/21084/files#diff-00f21a995130f7df8879749075287053R414), so this is a backport of this 
particular NPE issue to 5.0.
