### PR TITLE
On windows, allow java_home to contain spaces

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -1,7 +1,7 @@
 @echo off
 
 IF DEFINED JAVA_HOME (
-  set JAVA=“%JAVA_HOME%\bin\java.exe”
+  set "JAVA=%JAVA_HOME%\bin\java.exe”
 ) ELSE (
   FOR %%I IN (java.exe) DO set JAVA=%%~$PATH:I
 )

--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -1,7 +1,7 @@
 @echo off
 
 IF DEFINED JAVA_HOME (
-  set JAVA=%JAVA_HOME%\bin\java.exe
+  set JAVA=“%JAVA_HOME%\bin\java.exe”
 ) ELSE (
   FOR %%I IN (java.exe) DO set JAVA=%%~$PATH:I
 )


### PR DESCRIPTION
It’s not operate when %java_home% contains space.
like ‘C:\Program Files (x86)\Java\jre1.8.0_101’

related #20809