### PR TITLE
[docs] clients need to add jackson-databind

### DIFF
--- a/docs/java-api/docs/index_.asciidoc
+++ b/docs/java-api/docs/index_.asciidoc
@@ -60,8 +60,9 @@ json.put("message","trying out Elasticsearch");
 [[java-docs-index-generate-beans]]
 ===== Serialize your beans
 
-Elasticsearch already uses http://wiki.fasterxml.com/JacksonHome[Jackson].
-So you can use it to serialize your beans to JSON:
+You can use http://wiki.fasterxml.com/JacksonHome[Jackson] to serialize
+your beans to JSON. Please add https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/[Jackson Databind]
+ to your project. Then you can use `ObjectMapper` to serialize your beans:
 
 [source,java]
 --------------------------------------------------

--- a/docs/java-api/docs/index_.asciidoc
+++ b/docs/java-api/docs/index_.asciidoc
@@ -61,7 +61,7 @@ json.put("message","trying out Elasticsearch");
 ===== Serialize your beans
 
 You can use http://wiki.fasterxml.com/JacksonHome[Jackson] to serialize
-your beans to JSON. Please add https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/[Jackson Databind]
+your beans to JSON. Please add http://search.maven.org/#search%7Cga%7C1%7Cjackson-databind[Jackson Databind]
  to your project. Then you can use `ObjectMapper` to serialize your beans:
 
 [source,java]


### PR DESCRIPTION
With ES 5.0 we do not include Jackson
Databind anymore with ES core. This commit
updates our docs to state that users need
to add this artifact now in their projects.