### PR TITLE
Correction of the names of numirals

### DIFF
--- a/docs/reference/analysis/anatomy.asciidoc
+++ b/docs/reference/analysis/anatomy.asciidoc
@@ -15,8 +15,8 @@ combined to define new <<analysis-custom-analyzer,`custom`>> analyzers.
 
 A _character filter_ receives the original text as a stream of characters and
 can transform the stream by adding, removing, or changing characters.  For
-instance, a character filter could be used to convert Arabic numerals
-(٠‎١٢٣٤٥٦٧٨‎٩‎) into their Latin equivalents (0123456789), or to strip HTML
+instance, a character filter could be used to convert Hindu-Arabic numerals
+(٠‎١٢٣٤٥٦٧٨‎٩‎) into their Arabic-Latin equivalents (0123456789), or to strip HTML
 elements like `<b>` from the stream.
 
 An analyzer may have *zero or more* <<analysis-charfilters,character filters>>,


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?

What was called Arabic numirals is actually Hindu - Eastern Arabic notation. And the Latin numirals you refer to is the Arabic numbers. Please see wikipedia for more informations 
Regards.