### PR TITLE
Do not actively promote setting index.mapper.dynamic at the node level

### DIFF
--- a/docs/reference/mapping/dynamic-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic-mapping.asciidoc
@@ -41,8 +41,7 @@ automatically or explicitly.
 === Disabling automatic type creation
 
 Automatic type creation can be disabled by setting the `index.mapper.dynamic`
-setting to `false`, either by setting the default value in the
-`config/elasticsearch.yml` file, or per-index as an index setting:
+setting to `false` per-index as an index setting:
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/mapping/dynamic-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic-mapping.asciidoc
@@ -41,7 +41,7 @@ automatically or explicitly.
 === Disabling automatic type creation
 
 Automatic type creation can be disabled by setting the `index.mapper.dynamic`
-setting to `false` per-index as an index setting:
+setting to `false` in the index settings:
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
Due to various issues (https://github.com/elastic/elasticsearch/issues/20618) reported by the field on setting index.mapper.dynamic at the node level in the yml, let's not actively promote users to set this in the yml and only mention setting it at the index level (which is what should be done starting in 5.0 anyway).