### PR TITLE
Add support for merging custom meta data in tribe node

### DIFF
--- a/core/src/test/java/org/elasticsearch/cluster/ClusterChangedEventTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterChangedEventTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cluster;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexGraveyard;
@@ -33,6 +34,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TestCustomMetaData;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -222,6 +224,128 @@ public class ClusterChangedEventTests extends ESTestCase {
         assertTrue("index routing table should not be the same object", event.indexRoutingTableChanged(initialIndices.get(0).getName()));
     }
 
+    /**
+     * Test custom metadata change checks
+     */
+    public void testChangedCustomMetaDataSet() {
+        final int numNodesInCluster = 3;
+
+        final ClusterState originalState = createState(numNodesInCluster, randomBoolean(), initialIndices);
+        CustomMetaData1 customMetaData1 = new CustomMetaData1("data");
+        final ClusterState stateWithCustomMetaData = nextState(originalState, Collections.singletonList(customMetaData1));
+
+        // no custom metadata present in any state
+        ClusterState nextState = ClusterState.builder(originalState).build();
+        ClusterChangedEvent event = new ClusterChangedEvent("_na_", originalState, nextState);
+        assertTrue(event.changedCustomMetaDataSet().isEmpty());
+
+        // next state has new custom metadata
+        nextState = nextState(originalState, Collections.singletonList(customMetaData1));
+        event = new ClusterChangedEvent("_na_", originalState, nextState);
+        Set<String> changedCustomMetaDataTypeSet = event.changedCustomMetaDataSet();
+        assertTrue(changedCustomMetaDataTypeSet.size() == 1);
+        assertTrue(changedCustomMetaDataTypeSet.contains(customMetaData1.type()));
+
+        // next state has same custom metadata
+        nextState = nextState(originalState, Collections.singletonList(customMetaData1));
+        event = new ClusterChangedEvent("_na_", stateWithCustomMetaData, nextState);
+        changedCustomMetaDataTypeSet = event.changedCustomMetaDataSet();
+        assertTrue(changedCustomMetaDataTypeSet.isEmpty());
+
+        // next state has equivalent custom metadata
+        nextState = nextState(originalState, Collections.singletonList(new CustomMetaData1("data")));
+        event = new ClusterChangedEvent("_na_", stateWithCustomMetaData, nextState);
+        changedCustomMetaDataTypeSet = event.changedCustomMetaDataSet();
+        assertTrue(changedCustomMetaDataTypeSet.isEmpty());
+
+        // next state removes custom metadata
+        nextState = originalState;
+        event = new ClusterChangedEvent("_na_", stateWithCustomMetaData, nextState);
+        changedCustomMetaDataTypeSet = event.changedCustomMetaDataSet();
+        assertTrue(changedCustomMetaDataTypeSet.size() == 1);
+        assertTrue(changedCustomMetaDataTypeSet.contains(customMetaData1.type()));
+
+        // next state updates custom metadata
+        nextState = nextState(stateWithCustomMetaData, Collections.singletonList(new CustomMetaData1("data1")));
+        event = new ClusterChangedEvent("_na_", stateWithCustomMetaData, nextState);
+        changedCustomMetaDataTypeSet = event.changedCustomMetaDataSet();
+        assertTrue(changedCustomMetaDataTypeSet.size() == 1);
+        assertTrue(changedCustomMetaDataTypeSet.contains(customMetaData1.type()));
+
+        // next state adds new custom metadata type
+        CustomMetaData2 customMetaData2 = new CustomMetaData2("data2");
+        nextState = nextState(stateWithCustomMetaData, Arrays.asList(customMetaData1, customMetaData2));
+        event = new ClusterChangedEvent("_na_", stateWithCustomMetaData, nextState);
+        changedCustomMetaDataTypeSet = event.changedCustomMetaDataSet();
+        assertTrue(changedCustomMetaDataTypeSet.size() == 1);
+        assertTrue(changedCustomMetaDataTypeSet.contains(customMetaData2.type()));
+
+        // next state adds two custom metadata type
+        nextState = nextState(originalState, Arrays.asList(customMetaData1, customMetaData2));
+        event = new ClusterChangedEvent("_na_", originalState, nextState);
+        changedCustomMetaDataTypeSet = event.changedCustomMetaDataSet();
+        assertTrue(changedCustomMetaDataTypeSet.size() == 2);
+        assertTrue(changedCustomMetaDataTypeSet.contains(customMetaData2.type()));
+        assertTrue(changedCustomMetaDataTypeSet.contains(customMetaData1.type()));
+
+        // next state removes two custom metadata type
+        nextState = originalState;
+        event = new ClusterChangedEvent("_na_",
+                nextState(originalState, Arrays.asList(customMetaData1, customMetaData2)), nextState);
+        changedCustomMetaDataTypeSet = event.changedCustomMetaDataSet();
+        assertTrue(changedCustomMetaDataTypeSet.size() == 2);
+        assertTrue(changedCustomMetaDataTypeSet.contains(customMetaData2.type()));
+        assertTrue(changedCustomMetaDataTypeSet.contains(customMetaData1.type()));
+    }
+
+    private static class CustomMetaData2 extends TestCustomMetaData {
+        static {
+            MetaData.registerPrototype("2", new CustomMetaData2(""));
+        }
+        protected CustomMetaData2(String data) {
+            super(data);
+        }
+
+        @Override
+        protected TestCustomMetaData newTestCustomMetaData(String data) {
+            return new CustomMetaData2(data);
+        }
+
+        @Override
+        public String type() {
+            return "2";
+        }
+
+        @Override
+        public EnumSet<MetaData.XContentContext> context() {
+            return EnumSet.of(MetaData.XContentContext.GATEWAY);
+        }
+    }
+
+    private static class CustomMetaData1 extends TestCustomMetaData {
+        static {
+            MetaData.registerPrototype("1", new CustomMetaData1(""));
+        }
+        protected CustomMetaData1(String data) {
+            super(data);
+        }
+
+        @Override
+        protected TestCustomMetaData newTestCustomMetaData(String data) {
+            return new CustomMetaData1(data);
+        }
+
+        @Override
+        public String type() {
+            return "1";
+        }
+
+        @Override
+        public EnumSet<MetaData.XContentContext> context() {
+            return EnumSet.of(MetaData.XContentContext.GATEWAY);
+        }
+    }
+
     private static ClusterState createSimpleClusterState() {
         return ClusterState.builder(TEST_CLUSTER_NAME).build();
     }
@@ -242,6 +366,22 @@ public class ClusterChangedEventTests extends ESTestCase {
         return ClusterState.builder(withoutBlock)
                            .blocks(ClusterBlocks.builder().addGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK).build())
                            .build();
+    }
+
+    private static ClusterState nextState(final ClusterState previousState, List<TestCustomMetaData> customMetaDataList) {
+        final ClusterState.Builder builder = ClusterState.builder(previousState);
+        builder.stateUUID(UUIDs.randomBase64UUID());
+        MetaData.Builder metaDataBuilder = new MetaData.Builder(previousState.metaData());
+        for (ObjectObjectCursor<String, MetaData.Custom> customMetaData : previousState.metaData().customs()) {
+            if (customMetaData.value instanceof TestCustomMetaData) {
+                metaDataBuilder.removeCustom(customMetaData.key);
+            }
+        }
+        for (TestCustomMetaData testCustomMetaData : customMetaDataList) {
+            metaDataBuilder.putCustom(testCustomMetaData.type(), testCustomMetaData);
+        }
+        builder.metaData(metaDataBuilder);
+        return builder.build();
     }
 
     // Create a modified cluster state from another one, but with some number of indices added and deleted.

--- a/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
+++ b/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
@@ -519,6 +519,14 @@ public class TribeIT extends ESIntegTestCase {
             putCustomMetaData(cluster2, secondCustomMetaDataType2);
             assertCustomMetaDataUpdated(internalCluster(), mergedCustomMetaDataType1.get(0));
             assertCustomMetaDataUpdated(internalCluster(), mergedCustomMetaDataType2.get(0));
+
+            // test removing custom md is propagates to tribe
+            removeCustomMetaData(cluster2, secondCustomMetaDataType1.type());
+            assertCustomMetaDataUpdated(internalCluster(), firstCustomMetaDataType1);
+            assertCustomMetaDataUpdated(internalCluster(), mergedCustomMetaDataType2.get(0));
+            removeCustomMetaData(cluster2, secondCustomMetaDataType2.type());
+            assertCustomMetaDataUpdated(internalCluster(), firstCustomMetaDataType1);
+            assertCustomMetaDataUpdated(internalCluster(), firstCustomMetaDataType2);
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
+++ b/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
@@ -44,8 +44,10 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.NodeConfigurationSource;
+import org.elasticsearch.test.TestCustomMetaData;
 import org.elasticsearch.transport.MockTcpTransportPlugin;
 import org.elasticsearch.tribe.TribeServiceTests.MergableCustomMetaData1;
+import org.elasticsearch.tribe.TribeServiceTests.MergableCustomMetaData2;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -61,6 +63,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -454,42 +457,93 @@ public class TribeIT extends ESIntegTestCase {
 
     public void testMergingRemovedCustomMetaData() throws Exception {
         MetaData.registerPrototype(MergableCustomMetaData1.TYPE, new MergableCustomMetaData1(""));
+        removeCustomMetaData(cluster1, MergableCustomMetaData1.TYPE);
+        removeCustomMetaData(cluster2, MergableCustomMetaData1.TYPE);
         MergableCustomMetaData1 customMetaData1 = new MergableCustomMetaData1("a");
         MergableCustomMetaData1 customMetaData2 = new MergableCustomMetaData1("b");
         try (Releasable tribeNode = startTribeNode()) {
-            updateCustomMetaData(cluster1, customMetaData1);
-            updateCustomMetaData(cluster2, customMetaData2);
+            assertNodes(ALL);
+            putCustomMetaData(cluster1, customMetaData1);
+            putCustomMetaData(cluster2, customMetaData2);
             assertCustomMetaDataUpdated(internalCluster(), customMetaData2);
-            updateCustomMetaData(cluster2, null);
+            removeCustomMetaData(cluster2, customMetaData2.type());
             assertCustomMetaDataUpdated(internalCluster(), customMetaData1);
         }
     }
 
     public void testMergingCustomMetaData() throws Exception {
         MetaData.registerPrototype(MergableCustomMetaData1.TYPE, new MergableCustomMetaData1(""));
+        removeCustomMetaData(cluster1, MergableCustomMetaData1.TYPE);
+        removeCustomMetaData(cluster2, MergableCustomMetaData1.TYPE);
         MergableCustomMetaData1 customMetaData1 = new MergableCustomMetaData1(randomAsciiOfLength(10));
         MergableCustomMetaData1 customMetaData2 = new MergableCustomMetaData1(randomAsciiOfLength(10));
         List<MergableCustomMetaData1> customMetaDatas = Arrays.asList(customMetaData1, customMetaData2);
         Collections.sort(customMetaDatas, (cm1, cm2) -> cm2.getData().compareTo(cm1.getData()));
         final MergableCustomMetaData1 tribeNodeCustomMetaData = customMetaDatas.get(0);
         try (Releasable tribeNode = startTribeNode()) {
-            updateCustomMetaData(cluster1, customMetaData1);
-            updateCustomMetaData(cluster2, customMetaData2);
+            assertNodes(ALL);
+            putCustomMetaData(cluster1, customMetaData1);
+            assertCustomMetaDataUpdated(internalCluster(), customMetaData1);
+            putCustomMetaData(cluster2, customMetaData2);
             assertCustomMetaDataUpdated(internalCluster(), tribeNodeCustomMetaData);
         }
     }
 
+    public void testMergingMultipleCustomMetaData() throws Exception {
+        MetaData.registerPrototype(MergableCustomMetaData1.TYPE, new MergableCustomMetaData1(""));
+        MetaData.registerPrototype(MergableCustomMetaData2.TYPE, new MergableCustomMetaData2(""));
+        removeCustomMetaData(cluster1, MergableCustomMetaData1.TYPE);
+        removeCustomMetaData(cluster2, MergableCustomMetaData1.TYPE);
+        MergableCustomMetaData1 firstCustomMetaDataType1 = new MergableCustomMetaData1(randomAsciiOfLength(10));
+        MergableCustomMetaData1 secondCustomMetaDataType1 = new MergableCustomMetaData1(randomAsciiOfLength(10));
+        MergableCustomMetaData2 firstCustomMetaDataType2 = new MergableCustomMetaData2(randomAsciiOfLength(10));
+        MergableCustomMetaData2 secondCustomMetaDataType2 = new MergableCustomMetaData2(randomAsciiOfLength(10));
+        List<MergableCustomMetaData1> mergedCustomMetaDataType1 = Arrays.asList(firstCustomMetaDataType1, secondCustomMetaDataType1);
+        List<MergableCustomMetaData2> mergedCustomMetaDataType2 = Arrays.asList(firstCustomMetaDataType2, secondCustomMetaDataType2);
+        Collections.sort(mergedCustomMetaDataType1, (cm1, cm2) -> cm2.getData().compareTo(cm1.getData()));
+        Collections.sort(mergedCustomMetaDataType2, (cm1, cm2) -> cm2.getData().compareTo(cm1.getData()));
+        try (Releasable tribeNode = startTribeNode()) {
+            assertNodes(ALL);
+            // test putting multiple custom md types propagates to tribe
+            putCustomMetaData(cluster1, firstCustomMetaDataType1);
+            putCustomMetaData(cluster1, firstCustomMetaDataType2);
+            assertCustomMetaDataUpdated(internalCluster(), firstCustomMetaDataType1);
+            assertCustomMetaDataUpdated(internalCluster(), firstCustomMetaDataType2);
+
+            // test multiple same type custom md is merged and propagates to tribe
+            putCustomMetaData(cluster2, secondCustomMetaDataType1);
+            assertCustomMetaDataUpdated(internalCluster(), firstCustomMetaDataType2);
+            assertCustomMetaDataUpdated(internalCluster(), mergedCustomMetaDataType1.get(0));
+
+            // test multiple same type custom md is merged and propagates to tribe
+            putCustomMetaData(cluster2, secondCustomMetaDataType2);
+            assertCustomMetaDataUpdated(internalCluster(), mergedCustomMetaDataType1.get(0));
+            assertCustomMetaDataUpdated(internalCluster(), mergedCustomMetaDataType2.get(0));
+        }
+    }
+
     private static void assertCustomMetaDataUpdated(InternalTestCluster cluster,
-                                                    MergableCustomMetaData1 expectedCustomMetaData) throws Exception {
+                                                    TestCustomMetaData expectedCustomMetaData) throws Exception {
         assertBusy(() -> {
             ClusterState tribeState = cluster.getInstance(ClusterService.class, cluster.getNodeNames()[0]).state();
-            MetaData.Custom custom = tribeState.metaData().custom(MergableCustomMetaData1.TYPE);
+            MetaData.Custom custom = tribeState.metaData().custom(expectedCustomMetaData.type());
             assertNotNull(custom);
             assertThat(custom, equalTo(expectedCustomMetaData));
         });
     }
 
-    private static void updateCustomMetaData(InternalTestCluster cluster, final MergableCustomMetaData1 customMetaData) {
+    private void removeCustomMetaData(InternalTestCluster cluster, final String customMetaDataType) {
+        logger.info("removing custom_md type [{}] from [{}]", customMetaDataType, cluster.getClusterName());
+        updateMetaData(cluster, builder -> builder.removeCustom(customMetaDataType));
+    }
+
+    private void putCustomMetaData(InternalTestCluster cluster, final TestCustomMetaData customMetaData) {
+        logger.info("putting custom_md type [{}] with data[{}] from [{}]", customMetaData.type(),
+                customMetaData.getData(), cluster.getClusterName());
+        updateMetaData(cluster, builder -> builder.putCustom(customMetaData.type(), customMetaData));
+    }
+
+    private static void updateMetaData(InternalTestCluster cluster, UnaryOperator<MetaData.Builder> addCustoms) {
         ClusterService clusterService = cluster.getInstance(ClusterService.class, cluster.getMasterName());
         final CountDownLatch latch = new CountDownLatch(1);
         clusterService.submitStateUpdateTask("update customMetaData", new ClusterStateUpdateTask(Priority.IMMEDIATE) {
@@ -501,11 +555,7 @@ public class TribeIT extends ESIntegTestCase {
             @Override
             public ClusterState execute(ClusterState currentState) throws Exception {
                 MetaData.Builder builder = MetaData.builder(currentState.metaData());
-                if (customMetaData == null) {
-                    builder.removeCustom(MergableCustomMetaData1.TYPE);
-                } else {
-                    builder.putCustom(MergableCustomMetaData1.TYPE, customMetaData);
-                }
+                builder = addCustoms.apply(builder);
                 return new ClusterState.Builder(currentState).metaData(builder).build();
             }
 
@@ -520,6 +570,7 @@ public class TribeIT extends ESIntegTestCase {
             fail("latch waiting on publishing custom md interrupted [" + e.getMessage() + "]");
         }
         assertThat("timed out trying to add custom metadata to " + cluster.getClusterName(), latch.getCount(), equalTo(0L));
+
     }
 
     private void assertIndicesExist(Client client, String... indices) throws Exception {

--- a/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
+++ b/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
@@ -22,12 +22,15 @@ package org.elasticsearch.tribe;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.lease.Releasable;
@@ -42,6 +45,7 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.NodeConfigurationSource;
 import org.elasticsearch.transport.MockTcpTransportPlugin;
+import org.elasticsearch.tribe.TribeServiceTests.MergableCustomMetaData1;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -52,6 +56,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -444,6 +450,76 @@ public class TribeIT extends ESIntegTestCase {
                 assertNodes(predicate);
             }
         }
+    }
+
+    public void testMergingRemovedCustomMetaData() throws Exception {
+        MetaData.registerPrototype(MergableCustomMetaData1.TYPE, new MergableCustomMetaData1(""));
+        MergableCustomMetaData1 customMetaData1 = new MergableCustomMetaData1("a");
+        MergableCustomMetaData1 customMetaData2 = new MergableCustomMetaData1("b");
+        try (Releasable tribeNode = startTribeNode()) {
+            updateCustomMetaData(cluster1, customMetaData1);
+            updateCustomMetaData(cluster2, customMetaData2);
+            assertCustomMetaDataUpdated(internalCluster(), customMetaData2);
+            updateCustomMetaData(cluster2, null);
+            assertCustomMetaDataUpdated(internalCluster(), customMetaData1);
+        }
+    }
+
+    public void testMergingCustomMetaData() throws Exception {
+        MetaData.registerPrototype(MergableCustomMetaData1.TYPE, new MergableCustomMetaData1(""));
+        MergableCustomMetaData1 customMetaData1 = new MergableCustomMetaData1(randomAsciiOfLength(10));
+        MergableCustomMetaData1 customMetaData2 = new MergableCustomMetaData1(randomAsciiOfLength(10));
+        List<MergableCustomMetaData1> customMetaDatas = Arrays.asList(customMetaData1, customMetaData2);
+        Collections.sort(customMetaDatas, (cm1, cm2) -> cm2.getData().compareTo(cm1.getData()));
+        final MergableCustomMetaData1 tribeNodeCustomMetaData = customMetaDatas.get(0);
+        try (Releasable tribeNode = startTribeNode()) {
+            updateCustomMetaData(cluster1, customMetaData1);
+            updateCustomMetaData(cluster2, customMetaData2);
+            assertCustomMetaDataUpdated(internalCluster(), tribeNodeCustomMetaData);
+        }
+    }
+
+    private static void assertCustomMetaDataUpdated(InternalTestCluster cluster,
+                                                    MergableCustomMetaData1 expectedCustomMetaData) throws Exception {
+        assertBusy(() -> {
+            ClusterState tribeState = cluster.getInstance(ClusterService.class, cluster.getNodeNames()[0]).state();
+            MetaData.Custom custom = tribeState.metaData().custom(MergableCustomMetaData1.TYPE);
+            assertNotNull(custom);
+            assertThat(custom, equalTo(expectedCustomMetaData));
+        });
+    }
+
+    private static void updateCustomMetaData(InternalTestCluster cluster, final MergableCustomMetaData1 customMetaData) {
+        ClusterService clusterService = cluster.getInstance(ClusterService.class, cluster.getMasterName());
+        final CountDownLatch latch = new CountDownLatch(1);
+        clusterService.submitStateUpdateTask("update customMetaData", new ClusterStateUpdateTask(Priority.IMMEDIATE) {
+            @Override
+            public void clusterStatePublished(ClusterChangedEvent clusterChangedEvent) {
+                latch.countDown();
+            }
+
+            @Override
+            public ClusterState execute(ClusterState currentState) throws Exception {
+                MetaData.Builder builder = MetaData.builder(currentState.metaData());
+                if (customMetaData == null) {
+                    builder.removeCustom(MergableCustomMetaData1.TYPE);
+                } else {
+                    builder.putCustom(MergableCustomMetaData1.TYPE, customMetaData);
+                }
+                return new ClusterState.Builder(currentState).metaData(builder).build();
+            }
+
+            @Override
+            public void onFailure(String source, Exception e) {
+                fail("failed to apply cluster state from [" + source + "] with " + e.getMessage());
+            }
+        });
+        try {
+            latch.await(1, TimeUnit.MINUTES);
+        } catch (InterruptedException e) {
+            fail("latch waiting on publishing custom md interrupted [" + e.getMessage() + "]");
+        }
+        assertThat("timed out trying to add custom metadata to " + cluster.getClusterName(), latch.getCount(), equalTo(0L));
     }
 
     private void assertIndicesExist(Client client, String... indices) throws Exception {

--- a/core/src/test/java/org/elasticsearch/tribe/TribeServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/tribe/TribeServiceTests.java
@@ -131,7 +131,7 @@ public class TribeServiceTests extends ESTestCase {
     }
 
     public void testMergeMultipleCustomMetaData() {
-        Map<String, List<MetaData.Custom>> inputMap = new HashMap<>();
+        Map<String, List<TribeService.MergableCustomMetaData>> inputMap = new HashMap<>();
         inputMap.put(MergableCustomMetaData1.TYPE,
                 Arrays.asList(new MergableCustomMetaData1("data10"), new MergableCustomMetaData1("data11")));
         inputMap.put(MergableCustomMetaData2.TYPE,
@@ -149,15 +149,15 @@ public class TribeServiceTests extends ESTestCase {
     }
 
     public void testMergeCustomMetaDataFromMany() {
-        Map<String, List<MetaData.Custom>> inputMap = new HashMap<>();
+        Map<String, List<TribeService.MergableCustomMetaData>> inputMap = new HashMap<>();
         int n = randomIntBetween(3, 5);
-        List<MetaData.Custom> customList1 = new ArrayList<>();
+        List<TribeService.MergableCustomMetaData> customList1 = new ArrayList<>();
         for (int i = 0; i <= n; i++) {
             customList1.add(new MergableCustomMetaData1("data1"+String.valueOf(i)));
         }
         Collections.shuffle(customList1, random());
         inputMap.put(MergableCustomMetaData1.TYPE, customList1);
-        List<MetaData.Custom> customList2 = new ArrayList<>();
+        List<TribeService.MergableCustomMetaData> customList2 = new ArrayList<>();
         for (int i = 0; i <= n; i++) {
             customList2.add(new MergableCustomMetaData2("data2"+String.valueOf(i)));
         }

--- a/core/src/test/java/org/elasticsearch/tribe/TribeServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/tribe/TribeServiceTests.java
@@ -19,9 +19,22 @@
 
 package org.elasticsearch.tribe;
 
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TestCustomMetaData;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.instanceOf;
 
 public class TribeServiceTests extends ESTestCase {
     public void testMinimalSettings() {
@@ -95,5 +108,129 @@ public class TribeServiceTests extends ESTestCase {
         assertEquals("6.6.6.6", clientSettings.get("transport.host"));
         assertEquals("7.7.7.7", clientSettings.get("transport.bind_host"));
         assertEquals("8.8.8.8", clientSettings.get("transport.publish_host"));
+    }
+
+    public void testMergeCustomMetaDataSimple() {
+        Map<String, MetaData.Custom> mergedCustoms =
+                TribeService.mergeChangedCustomMetaData(Collections.singleton(MergableCustomMetaData1.TYPE),
+                        s -> Collections.singletonList(new MergableCustomMetaData1("data1")));
+        TestCustomMetaData mergedCustom = (TestCustomMetaData) mergedCustoms.get(MergableCustomMetaData1.TYPE);
+        assertThat(mergedCustom, instanceOf(MergableCustomMetaData1.class));
+        assertNotNull(mergedCustom);
+        assertEquals(mergedCustom.getData(), "data1");
+    }
+
+    public void testMergeCustomMetaData() {
+        Map<String, MetaData.Custom> mergedCustoms =
+                TribeService.mergeChangedCustomMetaData(Collections.singleton(MergableCustomMetaData1.TYPE),
+                        s -> Arrays.asList(new MergableCustomMetaData1("data1"), new MergableCustomMetaData1("data2")));
+        TestCustomMetaData mergedCustom = (TestCustomMetaData) mergedCustoms.get(MergableCustomMetaData1.TYPE);
+        assertThat(mergedCustom, instanceOf(MergableCustomMetaData1.class));
+        assertNotNull(mergedCustom);
+        assertEquals(mergedCustom.getData(), "data2");
+    }
+
+    public void testMergeMultipleCustomMetaData() {
+        Map<String, List<MetaData.Custom>> inputMap = new HashMap<>();
+        inputMap.put(MergableCustomMetaData1.TYPE,
+                Arrays.asList(new MergableCustomMetaData1("data10"), new MergableCustomMetaData1("data11")));
+        inputMap.put(MergableCustomMetaData2.TYPE,
+                Arrays.asList(new MergableCustomMetaData2("data21"), new MergableCustomMetaData2("data20")));
+        Map<String, MetaData.Custom> mergedCustoms = TribeService.mergeChangedCustomMetaData(
+                        Sets.newHashSet(MergableCustomMetaData1.TYPE, MergableCustomMetaData2.TYPE), inputMap::get);
+        TestCustomMetaData mergedCustom = (TestCustomMetaData) mergedCustoms.get(MergableCustomMetaData1.TYPE);
+        assertNotNull(mergedCustom);
+        assertThat(mergedCustom, instanceOf(MergableCustomMetaData1.class));
+        assertEquals(mergedCustom.getData(), "data11");
+        mergedCustom = (TestCustomMetaData) mergedCustoms.get(MergableCustomMetaData2.TYPE);
+        assertNotNull(mergedCustom);
+        assertThat(mergedCustom, instanceOf(MergableCustomMetaData2.class));
+        assertEquals(mergedCustom.getData(), "data21");
+    }
+
+    public void testMergeCustomMetaDataFromMany() {
+        Map<String, List<MetaData.Custom>> inputMap = new HashMap<>();
+        int n = randomIntBetween(3, 5);
+        List<MetaData.Custom> customList1 = new ArrayList<>();
+        for (int i = 0; i <= n; i++) {
+            customList1.add(new MergableCustomMetaData1("data1"+String.valueOf(i)));
+        }
+        Collections.shuffle(customList1, random());
+        inputMap.put(MergableCustomMetaData1.TYPE, customList1);
+        List<MetaData.Custom> customList2 = new ArrayList<>();
+        for (int i = 0; i <= n; i++) {
+            customList2.add(new MergableCustomMetaData2("data2"+String.valueOf(i)));
+        }
+        Collections.shuffle(customList2, random());
+        inputMap.put(MergableCustomMetaData2.TYPE, customList2);
+
+        Map<String, MetaData.Custom> mergedCustoms = TribeService.mergeChangedCustomMetaData(
+                        Sets.newHashSet(MergableCustomMetaData1.TYPE, MergableCustomMetaData2.TYPE), inputMap::get);
+        TestCustomMetaData mergedCustom = (TestCustomMetaData) mergedCustoms.get(MergableCustomMetaData1.TYPE);
+        assertNotNull(mergedCustom);
+        assertThat(mergedCustom, instanceOf(MergableCustomMetaData1.class));
+        assertEquals(mergedCustom.getData(), "data1"+String.valueOf(n));
+        mergedCustom = (TestCustomMetaData) mergedCustoms.get(MergableCustomMetaData2.TYPE);
+        assertNotNull(mergedCustom);
+        assertThat(mergedCustom, instanceOf(MergableCustomMetaData2.class));
+        assertEquals(mergedCustom.getData(), "data2"+String.valueOf(n));
+    }
+
+    static class MergableCustomMetaData1 extends TestCustomMetaData
+            implements TribeService.MergableCustomMetaData<MergableCustomMetaData1> {
+        public static final String TYPE = "custom_md_1";
+
+        protected MergableCustomMetaData1(String data) {
+            super(data);
+        }
+
+        @Override
+        protected TestCustomMetaData newTestCustomMetaData(String data) {
+            return new MergableCustomMetaData1(data);
+        }
+
+        @Override
+        public String type() {
+            return TYPE;
+        }
+
+        @Override
+        public EnumSet<MetaData.XContentContext> context() {
+            return EnumSet.of(MetaData.XContentContext.GATEWAY);
+        }
+
+        @Override
+        public MergableCustomMetaData1 merge(MergableCustomMetaData1 other) {
+            return (getData().compareTo(other.getData()) >= 0) ? this : other;
+        }
+    }
+
+    static class MergableCustomMetaData2 extends TestCustomMetaData
+            implements TribeService.MergableCustomMetaData<MergableCustomMetaData2> {
+        public static final String TYPE = "custom_md_2";
+
+        protected MergableCustomMetaData2(String data) {
+            super(data);
+        }
+
+        @Override
+        protected TestCustomMetaData newTestCustomMetaData(String data) {
+            return new MergableCustomMetaData2(data);
+        }
+
+        @Override
+        public String type() {
+            return TYPE;
+        }
+
+        @Override
+        public EnumSet<MetaData.XContentContext> context() {
+            return EnumSet.of(MetaData.XContentContext.GATEWAY);
+        }
+
+        @Override
+        public MergableCustomMetaData2 merge(MergableCustomMetaData2 other) {
+            return (getData().compareTo(other.getData()) >= 0) ? this : other;
+        }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/TestCustomMetaData.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestCustomMetaData.java
@@ -99,4 +99,9 @@ public abstract class TestCustomMetaData extends AbstractDiffable<MetaData.Custo
         builder.field("data", getData());
         return builder;
     }
+
+    @Override
+    public String toString() {
+        return "[" + type() + "][" + data +"]";
+    }
 }


### PR DESCRIPTION
Currently, when any underlying cluster has custom metadata
(via plugin), tribe node does not store custom meta data in its
cluster state. This is because the tribe node has no idea how to
select the appropriate custom metadata from one or many custom
metadata (corresponding to the number of underlying clusters).

This change adds an interface that custom metadata implementations
can extend to add support for merging mulitple custom metadata of
the same type for storing in the tribe state.

Relates to #20544
Supersedes #20791
Closes #9372