### PR TITLE
Be strict when parsing values searching for booleans

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -152,16 +152,15 @@ public class BooleanFieldMapper extends FieldMapper {
             } else {
                 sValue = value.toString();
             }
-            if (sValue.length() == 0) {
-                return Values.FALSE;
+            switch (sValue) {
+                case "true":
+                    return Values.TRUE;
+                case "false":
+                    return Values.FALSE;
+                default:
+                    throw new IllegalArgumentException("Can't parse boolean value [" +
+                                    sValue + "], expected [true] or [false]");
             }
-            if (sValue.length() == 1 && sValue.charAt(0) == 'F') {
-                return Values.FALSE;
-            }
-            if (Booleans.parseBoolean(sValue, false)) {
-                return Values.TRUE;
-            }
-            return Values.FALSE;
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/index/mapper/ExternalValuesMapperIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ExternalValuesMapperIntegrationIT.java
@@ -106,7 +106,7 @@ public class ExternalValuesMapperIntegrationIT extends ESIntegTestCase {
         SearchResponse response;
 
         response = client().prepareSearch("test-idx")
-                .setPostFilter(QueryBuilders.termQuery("field.bool", "T"))
+                .setPostFilter(QueryBuilders.termQuery("field.bool", "true"))
                 .execute().actionGet();
 
         assertThat(response.getHits().totalHits(), equalTo((long) 1));

--- a/core/src/test/java/org/elasticsearch/search/query/QueryStringIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/QueryStringIT.java
@@ -247,6 +247,14 @@ public class QueryStringIT extends ESIntegTestCase {
         assertHitCount(resp, 1L);
     }
 
+    public void testBooleanStrictQuery() throws Exception {
+        Exception e = expectThrows(Exception.class, () ->
+                client().prepareSearch("test").setQuery(
+                        queryStringQuery("foo").field("f_bool")).get());
+        assertThat(ExceptionsHelper.detailedMessage(e),
+                containsString("Can't parse boolean value [foo], expected [true] or [false]"));
+    }
+
     private void assertHits(SearchHits hits, String... ids) {
         assertThat(hits.totalHits(), equalTo((long) ids.length));
         Set<String> hitIds = new HashSet<>();

--- a/docs/reference/mapping/types/boolean.asciidoc
+++ b/docs/reference/mapping/types/boolean.asciidoc
@@ -32,21 +32,21 @@ PUT my_index
 
 POST my_index/my_type/1
 {
-  "is_published": true <1>
+  "is_published": 1 <1>
 }
 
 GET my_index/_search
 {
   "query": {
     "term": {
-      "is_published": 1 <2>
+      "is_published": true <2>
     }
   }
 }
 --------------------------------------------------
 // CONSOLE
-<1> Indexing a document with a JSON `true`.
-<2> Querying for the document with `1`, which is interpreted as `true`.
+<1> Indexing a document with `1`, which is interpreted as `true`.
+<1> Searching for documents with a JSON `true`.
 
 Aggregations like the <<search-aggregations-bucket-terms-aggregation,`terms`
 aggregation>>  use `1` and `0` for the `key`, and the strings `"true"` and

--- a/docs/reference/migration/migrate_6_0/search.asciidoc
+++ b/docs/reference/migration/migrate_6_0/search.asciidoc
@@ -5,3 +5,7 @@
 
 * The `collect_payloads` parameter of the `span_near` query has been removed. Payloads will be
   loaded when needed.
+
+* Queries on boolean fields now strictly parse boolean-like values. This means
+  only the strings `"true"` and `"false"` will be parsed into their boolean
+  counterparts. Other strings will cause an error to be thrown.


### PR DESCRIPTION
This changes only the query parsing behavior to be strict when searching on
boolean values. We continue to accept the variety of values during index time,
but searches will only be parsed using `"true"` or `"false"`.

Resolves #21545
