### PR TITLE
[Tests] Do not pass all env vars to sudo

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -280,5 +280,15 @@ export BATS_UTILS=/project/build/bats/utils
 export BATS_TESTS=/project/build/bats/tests
 export BATS_ARCHIVES=/project/build/bats/archives
 VARS
+    cat \<\<SUDOERS_VARS > /etc/sudoers.d/elasticsearch_vars
+Defaults   env_keep += "ZIP"
+Defaults   env_keep += "TAR"
+Defaults   env_keep += "RPM"
+Defaults   env_keep += "DEB"
+Defaults   env_keep += "BATS"
+Defaults   env_keep += "BATS_UTILS"
+Defaults   env_keep += "BATS_TESTS"
+Defaults   env_keep += "BATS_ARCHIVES"
+SUDOERS_VARS
   SHELL
 end

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -40,7 +40,7 @@ class VagrantTestPlugin implements Plugin<Project> {
     static List<String> UPGRADE_FROM_ARCHIVES = ['rpm', 'deb']
 
     private static final BATS = 'bats'
-    private static final String BATS_TEST_COMMAND ="cd \$BATS_ARCHIVES && sudo -E bats --tap \$BATS_TESTS/*.$BATS"
+    private static final String BATS_TEST_COMMAND ="cd \$BATS_ARCHIVES && sudo bats --tap \$BATS_TESTS/*.$BATS"
 
     @Override
     void apply(Project project) {

--- a/qa/vagrant/src/test/resources/packaging/tests/20_tar_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/tests/20_tar_package.bats
@@ -88,7 +88,11 @@ setup() {
   sudo chmod +x $JAVA
 
   [ "$status" -eq 1 ]
-  [[ "$output" == *"Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"* ]]
+  local expected="Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+  [[ "$output" == *"$expected"* ]] || {
+    echo "Expected error message [$expected] but found: $output"
+    false
+  }
 }
 
 ##################################

--- a/qa/vagrant/src/test/resources/packaging/tests/module_and_plugin_test_cases.bash
+++ b/qa/vagrant/src/test/resources/packaging/tests/module_and_plugin_test_cases.bash
@@ -176,7 +176,11 @@ fi
   sudo chmod +x $JAVA
 
   [ "$status" -eq 1 ]
-  [[ "$output" == *"Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"* ]]
+  local expected="Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+  [[ "$output" == *"$expected"* ]] || {
+    echo "Expected error message [$expected] but found: $output"
+    false
+  }
 }
 
 # Note that all of the tests from here to the end of the file expect to be run


### PR DESCRIPTION
 In #21348 the command executed to run the packaging tests has been changed to "sudo -E bats ...", forcing all environment variables from the vagrant user to be passed to the `sudo` command. This breaks a test on opensuse-13 (the one where it checks that elasticsearch cannot be started when `java` is not found) because all the PATH from the user is passed to the sudo command.
    
This commit restores the previous behavior while allowing only necessary testing environment variables to be passed using a /etc/sudoers.d file.