### PR TITLE
Do not cache term queries.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -137,6 +137,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexModule.INDEX_STORE_PRE_LOAD_SETTING,
         IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING,
         IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING,
+        IndexModule.INDEX_QUERY_CACHE_TERM_QUERIES_SETTING,
         PrimaryShardAllocator.INDEX_RECOVERY_INITIAL_SHARDS_SETTING,
         FsDirectoryService.INDEX_LOCK_FACTOR_SETTING,
         EngineConfig.INDEX_CODEC_SETTING,

--- a/core/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -104,7 +104,7 @@ public final class IndexModule {
     // This setting is an escape hatch in case not caching term queries would slow some users down
     // Do not document.
     public static final Setting<Boolean> INDEX_QUERY_CACHE_TERM_QUERIES_SETTING =
-        Setting.boolSetting("index.queries.cache.term_queries", true, Property.IndexScope);
+        Setting.boolSetting("index.queries.cache.term_queries", false, Property.IndexScope);
 
     private final IndexSettings indexSettings;
     private final IndexStoreConfig indexStoreConfig;

--- a/core/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -101,6 +101,11 @@ public final class IndexModule {
     public static final Setting<Boolean> INDEX_QUERY_CACHE_EVERYTHING_SETTING =
         Setting.boolSetting("index.queries.cache.everything", false, Property.IndexScope);
 
+    // This setting is an escape hatch in case not caching term queries would slow some users down
+    // Do not document.
+    public static final Setting<Boolean> INDEX_QUERY_CACHE_TERM_QUERIES_SETTING =
+        Setting.boolSetting("index.queries.cache.term_queries", true, Property.IndexScope);
+
     private final IndexSettings indexSettings;
     private final IndexStoreConfig indexStoreConfig;
     private final AnalysisRegistry analysisRegistry;

--- a/core/src/main/java/org/elasticsearch/index/shard/ElasticsearchQueryCachingPolicy.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ElasticsearchQueryCachingPolicy.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.shard;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryCachingPolicy;
+import org.apache.lucene.search.TermQuery;
+
+import java.io.IOException;
+
+/**
+ * A {@link QueryCachingPolicy} that does not cache {@link TermQuery}s.
+ */
+final class ElasticsearchQueryCachingPolicy implements QueryCachingPolicy {
+
+    private final QueryCachingPolicy in;
+
+    ElasticsearchQueryCachingPolicy(QueryCachingPolicy in) {
+        this.in = in;
+    }
+
+    @Override
+    public void onUse(Query query) {
+        if (query.getClass() != TermQuery.class) {
+            // Do not waste space in the history for term queries. The assumption
+            // is that these queries are very fast so not worth caching
+            in.onUse(query);
+        }
+    }
+
+    @Override
+    public boolean shouldCache(Query query) throws IOException {
+        if (query.getClass() == TermQuery.class) {
+            return false;
+        }
+        return in.shouldCache(query);
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -271,7 +271,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             cachingPolicy = QueryCachingPolicy.ALWAYS_CACHE;
         } else {
             QueryCachingPolicy cachingPolicy = new UsageTrackingQueryCachingPolicy();
-            if (IndexModule.INDEX_QUERY_CACHE_TERM_QUERIES_SETTING.get(settings)) {
+            if (IndexModule.INDEX_QUERY_CACHE_TERM_QUERIES_SETTING.get(settings) == false) {
                 cachingPolicy = new ElasticsearchQueryCachingPolicy(cachingPolicy);
             }
             this.cachingPolicy = cachingPolicy;

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -270,7 +270,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         if (IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.get(settings)) {
             cachingPolicy = QueryCachingPolicy.ALWAYS_CACHE;
         } else {
-            cachingPolicy = new UsageTrackingQueryCachingPolicy();
+            QueryCachingPolicy cachingPolicy = new UsageTrackingQueryCachingPolicy();
+            if (IndexModule.INDEX_QUERY_CACHE_TERM_QUERIES_SETTING.get(settings)) {
+                cachingPolicy = new ElasticsearchQueryCachingPolicy(cachingPolicy);
+            }
+            this.cachingPolicy = cachingPolicy;
         }
         indexShardOperationsLock = new IndexShardOperationsLock(shardId, logger, threadPool);
         searcherWrapper = indexSearcherWrapper;

--- a/core/src/test/java/org/elasticsearch/index/shard/ElasticsearchQueryCachingPolicyTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/ElasticsearchQueryCachingPolicyTests.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.shard;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryCachingPolicy;
+import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+public class ElasticsearchQueryCachingPolicyTests extends ESTestCase {
+
+    public void testDoesNotCacheTermQueries() throws IOException {
+        QueryCachingPolicy policy = QueryCachingPolicy.ALWAYS_CACHE;
+        assertTrue(policy.shouldCache(new TermQuery(new Term("foo", "bar"))));
+        assertTrue(policy.shouldCache(new PhraseQuery("foo", "bar", "baz")));
+        policy = new ElasticsearchQueryCachingPolicy(policy);
+        assertFalse(policy.shouldCache(new TermQuery(new Term("foo", "bar"))));
+        assertTrue(policy.shouldCache(new PhraseQuery("foo", "bar", "baz")));
+    }
+
+    public void testDoesNotPutTermQueriesIntoTheHistory() {
+        boolean[] used = new boolean[1];
+        QueryCachingPolicy policy = new QueryCachingPolicy() {
+            @Override
+            public boolean shouldCache(Query query) throws IOException {
+                throw new UnsupportedOperationException();
+            }
+            @Override
+            public void onUse(Query query) {
+                used[0] = true;
+            }
+        };
+        policy = new ElasticsearchQueryCachingPolicy(policy);
+        policy.onUse(new TermQuery(new Term("foo", "bar")));
+        assertFalse(used[0]);
+        policy.onUse(new PhraseQuery("foo", "bar", "baz"));
+        assertTrue(used[0]);
+    }
+
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -408,6 +408,9 @@ public abstract class ESIntegTestCase extends ESTestCase {
             if (randomBoolean()) {
                 randomSettingsBuilder.put(IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.getKey(), randomBoolean());
             }
+            if (randomBoolean()) {
+                randomSettingsBuilder.put(IndexModule.INDEX_QUERY_CACHE_TERM_QUERIES_SETTING.getKey(), randomBoolean());
+            }
             PutIndexTemplateRequestBuilder putTemplate = client().admin().indices()
                 .preparePutTemplate("random_index_template")
                 .setPatterns(Collections.singletonList("*"))


### PR DESCRIPTION
There have been reports that the query cache did not manage to speed up search
requests when the query includes a large number of different sub queries since
a single request may manage to exhaust the whole history (256 queries) while
the query cache only starts caching queries once they appear multiple times in
the history (#16031). On the other hand, increasing the size of the query cache
is a bit controversial (#20116) so this pull request proposes a different
approach that consists of never caching term queries, and not adding them to the
history of queries either. The reasoning is that these queries should be fast
anyway, regardless of caching, so taking them out of the equation should not
cause any slow down. On the other hand, the fact that they are not added to the
cache history anymore means that other queries have greater chances of being
cached.