### PR TITLE
Fix incorrect instructions for disabling deprecation logging

### DIFF
--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -179,4 +179,4 @@ logs to roll and compress after 1 GB, and to preserve a maximum of five log
 files (four rolled logs, and the active log).
 
 You can disable it in the `config/log4j2.properties` file by setting the deprecation
-log level to `info`.
+log level to `error`.


### PR DESCRIPTION
We log deprecation events at "WARN", so setting it to `info` means the events
are still logged. It must be set to `error` in order to disable the logging.