### PR TITLE
Updated dynamic mapper section

### DIFF
--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -65,8 +65,7 @@ section for more information on mapping definitions.
 Automatic index creation can be disabled by setting
 `action.auto_create_index` to `false` in the config file of all nodes.
 Automatic mapping creation can be disabled by setting
-`index.mapper.dynamic` to `false` in the config files of all nodes (or
-on the specific index settings).
+`index.mapper.dynamic` to `false` per-index as an index setting.
 
 Automatic index creation can include a pattern based white/black list,
 for example, set `action.auto_create_index` to `+aaa*,-bbb*,+ccc*,-*` (+


### PR DESCRIPTION
Similar to https://github.com/elastic/elasticsearch/pull/21551, removing reference to setting dynamic mapper at the node level.