### PR TITLE
Remove lenient stats parsing 5.x

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesInfoAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesInfoAction.java
@@ -55,7 +55,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
     public RestNodesInfoAction(Settings settings, RestController controller, SettingsFilter settingsFilter) {
         super(settings);
         controller.registerHandler(GET, "/_nodes", this);
-        // this endpoint is used for metrics, not for nodeIds, like /_nodes/fs
+        // this endpoint is used for metrics, not for node IDs, like /_nodes/fs
         controller.registerHandler(GET, "/_nodes/{nodeId}", this);
         controller.registerHandler(GET, "/_nodes/{nodeId}/{metrics}", this);
         // added this endpoint to be aligned with stats

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
@@ -150,6 +150,12 @@ public class RestNodesStatsAction extends BaseRestHandler {
                         }
                     }
 
+                    if (invalidIndexMetrics.contains("percolate")) {
+                        deprecationLogger.deprecated(
+                            "percolate stats are no longer available and requests for percolate stats will fail starting in 6.0.0");
+                        invalidIndexMetrics.remove("percolate");
+                    }
+
                     if (!invalidIndexMetrics.isEmpty()) {
                         throw new IllegalArgumentException(unrecognized(request, invalidIndexMetrics, FLAGS.keySet(), "index metric"));
                     }

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsAction.java
@@ -113,6 +113,12 @@ public class RestIndicesStatsAction extends BaseRestHandler {
                 }
             }
 
+            if (invalidMetrics.contains("percolate")) {
+                deprecationLogger.deprecated(
+                    "percolate stats are no longer available and requests for percolate stats will fail starting in 6.0.0");
+                invalidMetrics.remove("percolate");
+            }
+
             if (!invalidMetrics.isEmpty()) {
                 throw new IllegalArgumentException(unrecognized(request, invalidMetrics, METRICS.keySet(), "metric"));
             }

--- a/core/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsActionTests.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.cluster;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.object.HasToString.hasToString;
+import static org.mockito.Mockito.mock;
+
+public class RestNodesStatsActionTests extends ESTestCase {
+
+    private RestNodesStatsAction action;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        action = new RestNodesStatsAction(Settings.EMPTY, new RestController(Settings.EMPTY, Collections.emptySet()));
+    }
+
+    public void testUnrecognizedMetric() throws IOException {
+        final HashMap<String, String> params = new HashMap<>();
+        final String metric = randomAsciiOfLength(64);
+        params.put("metric", metric);
+        final RestRequest request = new FakeRestRequest.Builder().withPath("/_nodes/stats").withParams(params).build();
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> action.prepareRequest(request, mock(NodeClient.class)));
+        assertThat(e, hasToString(containsString("request [/_nodes/stats] contains unrecognized metric: [" + metric + "]")));
+    }
+
+    public void testUnrecognizedMetricDidYouMean() throws IOException {
+        final HashMap<String, String> params = new HashMap<>();
+        params.put("metric", "os,transprot,unrecognized");
+        final RestRequest request = new FakeRestRequest.Builder().withPath("/_nodes/stats").withParams(params).build();
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> action.prepareRequest(request, mock(NodeClient.class)));
+        assertThat(
+            e,
+            hasToString(
+                containsString(
+                    "request [/_nodes/stats] contains unrecognized metrics: [transprot] -> did you mean [transport]?, [unrecognized]")));
+    }
+
+    public void testAllRequestWithOtherMetrics() throws IOException {
+        final HashMap<String, String> params = new HashMap<>();
+        final String metric = randomSubsetOf(1, RestNodesStatsAction.METRICS.keySet()).get(0);
+        params.put("metric", "_all," + metric);
+        final RestRequest request = new FakeRestRequest.Builder().withPath("/_nodes/stats").withParams(params).build();
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> action.prepareRequest(request, mock(NodeClient.class)));
+        assertThat(e, hasToString(containsString("request [/_nodes/stats] contains _all and individual metrics [_all," + metric + "]")));
+    }
+
+    public void testUnrecognizedIndexMetric() {
+        final HashMap<String, String> params = new HashMap<>();
+        params.put("metric", "indices");
+        final String indexMetric = randomAsciiOfLength(64);
+        params.put("index_metric", indexMetric);
+        final RestRequest request = new FakeRestRequest.Builder().withPath("/_nodes/stats").withParams(params).build();
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> action.prepareRequest(request, mock(NodeClient.class)));
+        assertThat(e, hasToString(containsString("request [/_nodes/stats] contains unrecognized index metric: [" + indexMetric + "]")));
+    }
+
+    public void testUnrecognizedIndexMetricDidYouMean() {
+        final HashMap<String, String> params = new HashMap<>();
+        params.put("metric", "indices");
+        params.put("index_metric", "indexing,stroe,unrecognized");
+        final RestRequest request = new FakeRestRequest.Builder().withPath("/_nodes/stats").withParams(params).build();
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> action.prepareRequest(request, mock(NodeClient.class)));
+        assertThat(
+            e,
+            hasToString(
+                containsString(
+                    "request [/_nodes/stats] contains unrecognized index metrics: [stroe] -> did you mean [store]?, [unrecognized]")));
+    }
+
+    public void testIndexMetricsRequestWithoutIndicesMetric() throws IOException {
+        final HashMap<String, String> params = new HashMap<>();
+        final Set<String> metrics = new HashSet<>(RestNodesStatsAction.METRICS.keySet());
+        metrics.remove("indices");
+        params.put("metric", randomSubsetOf(1, metrics).get(0));
+        final String indexMetric = randomSubsetOf(1, RestNodesStatsAction.FLAGS.keySet()).get(0);
+        params.put("index_metric", indexMetric);
+        final RestRequest request = new FakeRestRequest.Builder().withPath("/_nodes/stats").withParams(params).build();
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> action.prepareRequest(request, mock(NodeClient.class)));
+        assertThat(
+            e,
+            hasToString(
+                containsString("request [/_nodes/stats] contains index metrics [" + indexMetric + "] but indices stats not requested")));
+    }
+
+    public void testIndexMetricsRequestOnAllRequest() throws IOException {
+        final HashMap<String, String> params = new HashMap<>();
+        params.put("metric", "_all");
+        final String indexMetric = randomSubsetOf(1, RestNodesStatsAction.FLAGS.keySet()).get(0);
+        params.put("index_metric", indexMetric);
+        final RestRequest request = new FakeRestRequest.Builder().withPath("/_nodes/stats").withParams(params).build();
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> action.prepareRequest(request, mock(NodeClient.class)));
+        assertThat(
+            e,
+            hasToString(
+                containsString("request [/_nodes/stats] contains index metrics [" + indexMetric + "] but all stats requested")));
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsActionTests.java
@@ -109,6 +109,14 @@ public class RestNodesStatsActionTests extends ESTestCase {
                     "request [/_nodes/stats] contains unrecognized index metrics: [stroe] -> did you mean [store]?, [unrecognized]")));
     }
 
+    public void testIndexMetricsWithPercolate() throws IOException {
+        final HashMap<String, String> params = new HashMap<>();
+        params.put("metric", "indices");
+        params.put("index_metric", "percolate");
+        final RestRequest request = new FakeRestRequest.Builder().withPath("/_nodes/stats").withParams(params).build();
+        action.prepareRequest(request, mock(NodeClient.class));
+    }
+
     public void testIndexMetricsRequestWithoutIndicesMetric() throws IOException {
         final HashMap<String, String> params = new HashMap<>();
         final Set<String> metrics = new HashSet<>(RestNodesStatsAction.METRICS.keySet());

--- a/core/src/test/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsActionTests.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.indices;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.object.HasToString.hasToString;
+import static org.mockito.Mockito.mock;
+
+public class RestIndicesStatsActionTests extends ESTestCase {
+
+    private RestIndicesStatsAction action;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        action = new RestIndicesStatsAction(Settings.EMPTY, new RestController(Settings.EMPTY, Collections.emptySet()));
+    }
+
+    public void testUnrecognizedMetric() throws IOException {
+        final HashMap<String, String> params = new HashMap<>();
+        final String metric = randomAsciiOfLength(64);
+        params.put("metric", metric);
+        final RestRequest request = new FakeRestRequest.Builder().withPath("/_stats").withParams(params).build();
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> action.prepareRequest(request, mock(NodeClient.class)));
+        assertThat(e, hasToString(containsString("request [/_stats] contains unrecognized metric: [" + metric + "]")));
+    }
+
+    public void testUnrecognizedMetricDidYouMean() throws IOException {
+        final HashMap<String, String> params = new HashMap<>();
+        params.put("metric", "request_cache,fieldata,unrecognized");
+        final RestRequest request = new FakeRestRequest.Builder().withPath("/_stats").withParams(params).build();
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> action.prepareRequest(request, mock(NodeClient.class)));
+        assertThat(
+            e,
+            hasToString(
+                containsString(
+                    "request [/_stats] contains unrecognized metrics: [fieldata] -> did you mean [fielddata]?, [unrecognized]")));
+    }
+
+    public void testAllRequestWithOtherMetrics() throws IOException {
+        final HashMap<String, String> params = new HashMap<>();
+        final String metric = randomSubsetOf(1, RestIndicesStatsAction.METRICS.keySet()).get(0);
+        params.put("metric", "_all," + metric);
+        final RestRequest request = new FakeRestRequest.Builder().withPath("/_stats").withParams(params).build();
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> action.prepareRequest(request, mock(NodeClient.class)));
+        assertThat(e, hasToString(containsString("request [/_stats] contains _all and individual metrics [_all," + metric + "]")));
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsActionTests.java
@@ -80,4 +80,11 @@ public class RestIndicesStatsActionTests extends ESTestCase {
         assertThat(e, hasToString(containsString("request [/_stats] contains _all and individual metrics [_all," + metric + "]")));
     }
 
+    public void testIndexMetricsWithPercolate() throws IOException {
+        final HashMap<String, String> params = new HashMap<>();
+        params.put("metric", "percolate");
+        final RestRequest request = new FakeRestRequest.Builder().withPath("/_stats").withParams(params).build();
+        action.prepareRequest(request, mock(NodeClient.class));
+    }
+
 }

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -280,7 +280,7 @@ the current running process:
 	Size in bytes of virtual memory that is guaranteed to be available to the running process
 
 [float]
-[[indices-stats]]
+[[node-indices-stats]]
 === Indices statistics
 
 You can get information about indices stats on node level or on index level.

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -65,12 +65,11 @@ of `indices`, `os`, `process`, `jvm`, `transport`, `http`,
 
 [source,js]
 --------------------------------------------------
-# return indices and os
-curl -XGET 'http://localhost:9200/_nodes/stats/os'
+# return just indices
+curl -XGET 'http://localhost:9200/_nodes/stats/indices'
 # return just os and process
 curl -XGET 'http://localhost:9200/_nodes/stats/os,process'
-# specific type endpoint
-curl -XGET 'http://localhost:9200/_nodes/stats/process'
+# return just process for node with IP address 10.0.0.1
 curl -XGET 'http://localhost:9200/_nodes/10.0.0.1/stats/process'
 --------------------------------------------------
 
@@ -280,26 +279,44 @@ the current running process:
 `process.mem.total_virtual_in_bytes`::
 	Size in bytes of virtual memory that is guaranteed to be available to the running process
 
-
 [float]
-[[field-data]]
-=== Field data statistics
+[[indices-stats]]
+=== Indices statistics
 
-You can get information about field data memory usage on node
-level or on index level.
+You can get information about indices stats on node level or on index level.
 
 [source,js]
 --------------------------------------------------
-# Node Stats
-curl -XGET 'http://localhost:9200/_nodes/stats/indices/?fields=field1,field2&pretty'
+# Node level
+curl -XGET 'http://localhost:9200/_nodes/stats/indices/fielddata?fields=field1,field2&pretty'
 
-# Indices Stat
+# Index level
 curl -XGET 'http://localhost:9200/_stats/fielddata/?fields=field1,field2&pretty'
 
 # You can use wildcards for field names
+curl -XGET 'http://localhost:9200/_nodes/stats/indices/fielddata?fields=field*&pretty'
 curl -XGET 'http://localhost:9200/_stats/fielddata/?fields=field*&pretty'
-curl -XGET 'http://localhost:9200/_nodes/stats/indices/?fields=field*&pretty'
 --------------------------------------------------
+
+Supported metrics are:
+
+* `completion`
+* `docs`
+* `fielddata`
+* `flush`
+* `get`
+* `indexing`
+* `merge`
+* `query_cache`
+* `recovery`
+* `refresh`
+* `request_cache`
+* `search`
+* `segments`
+* `store`
+* `suggest`
+* `translog`
+* `warmer`
 
 [float]
 [[search-groups]]

--- a/docs/reference/indices/flush.asciidoc
+++ b/docs/reference/indices/flush.asciidoc
@@ -74,7 +74,7 @@ the <<indices-stats,indices stats>> API:
 
 [source,sh]
 --------------------------------------------------
-GET twitter/_stats/commit?level=shards
+GET twitter/_stats?level=shards
 --------------------------------------------------
 // CONSOLE
 // TEST[s/^/PUT twitter\n/]

--- a/docs/reference/migration/migrate_5_1.asciidoc
+++ b/docs/reference/migration/migrate_5_1.asciidoc
@@ -41,3 +41,15 @@ Plugging in a `UnicastHostsProvider` for zen discovery is now pull based. Implem
 ==== ZenPing and MasterElectService pluggability removed
 
 These classes are no longer pluggable. Either implement your own discovery, or extend from ZenDiscovery and customize as necessary.
+
+[[breaking_51_other_api_changes]]
+[float]
+=== Other API changes
+
+==== Indices stats and node stats API unrecognized metrics
+
+The indices stats and node stats APIs allow querying Elasticsearch for a variety of metrics. Previous versions of
+Elasticsearch would silently accept unrecognized metrics (e.g., typos like "transprot"). In 5.1.0, this is no longer
+the case; unrecognized metrics will cause the request to fail. There is one exception to this which is the percolate
+metric which was removed in 5.0.0 but requests for these will only produce a warning in the 5.x series starting with
+5.1.0 and will fail like any other unrecognized metric in 6.0.0.

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/10_index.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/10_index.yaml
@@ -110,3 +110,11 @@ setup:
   - match: { status: 400 }
   - match: { error.type: illegal_argument_exception }
   - match: { error.reason: "request [/_stats/fieldata] contains unrecognized metric: [fieldata] -> did you mean [fielddata]?" }
+
+---
+"Indices stats warns on percolate":
+  - do:
+      warnings:
+          - 'percolate stats are no longer available and requests for percolate stats will fail starting in 6.0.0'
+      indices.stats:
+        metric: [ percolate ]

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/10_index.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/10_index.yaml
@@ -100,3 +100,13 @@ setup:
   - is_false: indices.test1
   - is_true: indices.test2
 
+---
+"Indices stats unrecognized parameter":
+  - do:
+      indices.stats:
+        metric: [ fieldata ]
+        ignore: 400
+
+  - match: { status: 400 }
+  - match: { error.type: illegal_argument_exception }
+  - match: { error.reason: "request [/_stats/fieldata] contains unrecognized metric: [fieldata] -> did you mean [fielddata]?" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/10_basic.yaml
@@ -31,3 +31,12 @@
   - match: { status: 400 }
   - match: { error.type: illegal_argument_exception }
   - match: { error.reason: "request [/_nodes/stats/transprot] contains unrecognized metric: [transprot] -> did you mean [transport]?" }
+
+---
+"Node stats warns on percolate":
+  - do:
+      warnings:
+          - 'percolate stats are no longer available and requests for percolate stats will fail starting in 6.0.0'
+      nodes.stats:
+        metric: [ indices ]
+        index_metric: [ percolate ]

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/10_basic.yaml
@@ -20,3 +20,14 @@
         level: "indices"
 
   - is_true: nodes.$master.indices.indices
+
+---
+"Nodes stats unrecognized parameter":
+  - do:
+      nodes.stats:
+        metric: [ transprot ]
+        ignore: 400
+
+  - match: { status: 400 }
+  - match: { error.type: illegal_argument_exception }
+  - match: { error.reason: "request [/_nodes/stats/transprot] contains unrecognized metric: [transprot] -> did you mean [transport]?" }


### PR DESCRIPTION
Today when parsing a stats request, Elasticsearch silently ignores
incorrect metrics. This commit removes lenient parsing of stats requests
for the nodes stats and indices stats APIs.

This pull request is a backport of #21417 to 5.x; notable changes in the
backport include f497c7da502234125e5e77dc6b43542f24dd9d93 which adds a
note to the migration docs and 322009f57c5bffef5d7b24fa4f8d8bc1076afe48
which adds a backwards compatibility layer for percolate stats.

Relates #20722, relates #21410, relates #21417