### PR TITLE
Specify fielddata formats in string docs

### DIFF
--- a/docs/reference/mapping/types/string.asciidoc
+++ b/docs/reference/mapping/types/string.asciidoc
@@ -90,7 +90,7 @@ The following parameters are accepted by `string` fields:
 <<fielddata,`fielddata`>>::
 
     Can the field use in-memory fielddata for sorting, aggregations,
-    or scripting? Accepts `disabled` or `paged_bytes` (default).
+    or scripting? Accepts `{ "format": "disabled" }` or `{ "format": "paged_bytes" }` (default).
     Not analyzed fields will use <<doc-values,doc values>> in preference
     to fielddata.
 


### PR DESCRIPTION
fielddata=disabled or fielddata=paged_bytes doesn't actually work. Specifying the `format` part here also makes the fielddata part consistent with the norms one (where the value is also an object).