### PR TITLE
Fix `InternalEngine#isThrottled` to not always return `false`.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -235,17 +235,13 @@ public abstract class Engine implements Closeable {
     /**
      * Returns the number of milliseconds this engine was under index throttling.
      */
-    public long getIndexThrottleTimeInMillis() {
-        return 0;
-    }
+    public abstract long getIndexThrottleTimeInMillis();
 
     /**
      * Returns the <code>true</code> iff this engine is currently under index throttling.
      * @see #getIndexThrottleTimeInMillis()
      */
-    public boolean isThrottled() {
-        return false;
-    }
+    public abstract boolean isThrottled();
 
     /** A Lock implementation that always allows the lock to be acquired */
     protected static final class NoOpLock implements Lock {

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1224,6 +1224,12 @@ public class InternalEngine extends Engine {
         }
     }
 
+    @Override
+    public boolean isThrottled() {
+        return throttle.isThrottled();
+    }
+
+    @Override
     public long getIndexThrottleTimeInMillis() {
         return throttle.getThrottleTimeInMillis();
     }

--- a/core/src/main/java/org/elasticsearch/index/engine/ShadowEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/ShadowEngine.java
@@ -257,6 +257,16 @@ public class ShadowEngine extends Engine {
     }
 
     @Override
+    public boolean isThrottled() {
+        return false;
+    }
+
+    @Override
+    public long getIndexThrottleTimeInMillis() {
+        return 0L;
+    }
+
+    @Override
     public Engine recoverFromTranslog() throws IOException {
         throw new UnsupportedOperationException("can't recover on a shadow engine");
     }


### PR DESCRIPTION
Currently it inherits from the default implementation which always returns
`false`, even if indexing is being throttled.