### PR TITLE
Add documentation for lenient in multimatch

### DIFF
--- a/docs/reference/query-dsl/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/multi-match-query.asciidoc
@@ -136,7 +136,7 @@ follows:
   * plus `tie_breaker * _score` for all other matching fields
 
 Also, accepts `analyzer`, `boost`, `operator`, `minimum_should_match`,
-`fuzziness`, `prefix_length`, `max_expansions`, `rewrite`, `zero_terms_query`
+`fuzziness`, `lenient`, `prefix_length`, `max_expansions`, `rewrite`, `zero_terms_query`
 and `cutoff_frequency`, as explained in <<query-dsl-match-query, match query>>.
 
 [IMPORTANT]
@@ -232,7 +232,7 @@ The score from each `match` clause is added together, then divided by the
 number of `match` clauses.
 
 Also, accepts `analyzer`, `boost`, `operator`, `minimum_should_match`,
-`fuzziness`, `prefix_length`, `max_expansions`, `rewrite`, `zero_terms_query`
+`fuzziness`, `lenient`, `prefix_length`, `max_expansions`, `rewrite`, `zero_terms_query`
 and `cutoff_frequency`, as explained in <<query-dsl-match-query,match query>>, but
 *see <<operator-min>>*.
 
@@ -277,7 +277,7 @@ GET /_search
 --------------------------------------------------
 // CONSOLE
 
-Also, accepts `analyzer`, `boost`, `slop` and `zero_terms_query`  as explained
+Also, accepts `analyzer`, `boost`, `lenient`, `slop` and `zero_terms_query`  as explained
 in <<query-dsl-match-query>>.  Type `phrase_prefix` additionally accepts
 `max_expansions`.
 
@@ -374,7 +374,7 @@ explanation:
     +blended("smith", fields: [first_name, last_name])
 
 Also, accepts `analyzer`, `boost`, `operator`, `minimum_should_match`,
-`zero_terms_query` and `cutoff_frequency`, as explained in
+`lenient`, `zero_terms_query` and `cutoff_frequency`, as explained in
 <<query-dsl-match-query, match query>>.
 
 ===== `cross_field` and analysis
@@ -506,10 +506,3 @@ per-term `blended` queries. It accepts:
 ===================================================
 The `fuzziness` parameter cannot be used with the `cross_fields` type.
 ===================================================
-
-[[multimatch-leniency]]
-==== Leniency
-
-The `lenient` parameter can be set to `true` to ignore exceptions caused by
-data-type mismatches,  such as trying to query a numeric field with a text
-query string. Defaults to `false`.

--- a/docs/reference/query-dsl/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/multi-match-query.asciidoc
@@ -506,3 +506,10 @@ per-term `blended` queries. It accepts:
 ===================================================
 The `fuzziness` parameter cannot be used with the `cross_fields` type.
 ===================================================
+
+[[multimatch-leniency]]
+==== Leniency
+
+The `lenient` parameter can be set to `true` to ignore exceptions caused by
+data-type mismatches,  such as trying to query a numeric field with a text
+query string. Defaults to `false`.


### PR DESCRIPTION
`lenient` option is documented for `match` query but not for `multi_match` query.