### PR TITLE
Rank Eval: Handle exceptions on search requests and add them to response

### DIFF
--- a/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/30_failures.yaml
+++ b/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/30_failures.yaml
@@ -1,0 +1,38 @@
+---
+"Response format":
+
+  - do:
+      index:
+        index:   foo
+        type:    bar
+        id:      doc1
+        body:    { "bar": 1 }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      rank_eval:
+        body: {
+          "requests" : [
+            {
+                "id": "amsterdam_query",
+                "request": { "query": { "match_all" : { }}},
+                "ratings": [
+                    {"_index": "foo", "_type": "bar", "_id": "doc1", "rating": 1}]
+            },
+            {
+                "id" : "invalid_query",
+                "request": { "query": { "range" : { "bar" : { "time_zone": "+01:00" }}}},
+                "ratings": [{"_index": "foo", "_type": "bar", "_id": "doc1", "rating": 1}]
+            }
+          ],
+          "metric" : { "precision": { "ignore_unlabeled" : true }}
+        }
+
+  - match: { rank_eval.quality_level: 1}
+  - match: { rank_eval.details.amsterdam_query.quality_level: 1.0}
+  - match: { rank_eval.details.amsterdam_query.unknown_docs:  [ ]}
+  - match: { rank_eval.details.amsterdam_query.metric_details: {"relevant_docs_retrieved": 1, "docs_retrieved": 1}}
+
+  - is_true: rank_eval.failures.invalid_query


### PR DESCRIPTION
Currently we fail the whole ranking evaluation request when we receive an exception for any of the search requests. We should collect those errors and
report them back to the user in the rest response. This change adds collecting the errors and propagating them back via the RankEvalResponse.

Closes #19889