### PR TITLE
Fix compilation in Eclipse

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -1018,7 +1018,7 @@ public abstract class TransportReplicationAction<
             }
             transportService.sendRequest(node, transportReplicaAction,
                 new ConcreteShardRequest<>(request, replica.allocationId().getId()), transportOptions,
-                new ActionListenerResponseHandler<>(listener, ReplicaResponse::new));
+                new ActionListenerResponseHandler<ReplicaResponse>(listener, ReplicaResponse::new));
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -1018,6 +1018,7 @@ public abstract class TransportReplicationAction<
             }
             transportService.sendRequest(node, transportReplicaAction,
                 new ConcreteShardRequest<>(request, replica.allocationId().getId()), transportOptions,
+                // Eclipse can't handle when this is <> so we specify the type here.
                 new ActionListenerResponseHandler<ReplicaResponse>(listener, ReplicaResponse::new));
         }
 


### PR DESCRIPTION
I'm not sure what the bug is, but ecj doesn't like this expression
unless the type is set explicitly.