### PR TITLE
Remove the `default` store type.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -295,9 +295,7 @@ public final class IndexModule {
         NIOFS,
         MMAPFS,
         SIMPLEFS,
-        FS,
-        @Deprecated
-        DEFAULT;
+        FS;
 
         public String getSettingsKey() {
             return this.name().toLowerCase(Locale.ROOT);

--- a/core/src/main/java/org/elasticsearch/index/store/FsDirectoryService.java
+++ b/core/src/main/java/org/elasticsearch/index/store/FsDirectoryService.java
@@ -84,7 +84,7 @@ public class FsDirectoryService extends DirectoryService {
     protected Directory newFSDirectory(Path location, LockFactory lockFactory) throws IOException {
         final String storeType = indexSettings.getSettings().get(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(),
             IndexModule.Type.FS.getSettingsKey());
-        if (IndexModule.Type.FS.match(storeType) || IndexModule.Type.DEFAULT.match(storeType)) {
+        if (IndexModule.Type.FS.match(storeType)) {
             return FSDirectory.open(location, lockFactory); // use lucene defaults
         } else if (IndexModule.Type.SIMPLEFS.match(storeType)) {
             return new SimpleFSDirectory(location, lockFactory);

--- a/core/src/test/java/org/elasticsearch/index/store/IndexStoreTests.java
+++ b/core/src/test/java/org/elasticsearch/index/store/IndexStoreTests.java
@@ -73,7 +73,6 @@ public class IndexStoreTests extends ESTestCase {
                     assertTrue(type + " " + directory.toString(), directory instanceof SimpleFSDirectory);
                     break;
                 case FS:
-                case DEFAULT:
                     if (Constants.JRE_IS_64BIT && MMapDirectory.UNMAP_SUPPORTED) {
                         assertTrue(directory.toString(), directory instanceof MMapDirectory);
                     } else if (Constants.WINDOWS) {

--- a/docs/reference/migration/migrate_6_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_6_0/settings.asciidoc
@@ -14,3 +14,9 @@ Store throttling has been removed. As a consequence, the
 cluster settings and the `index.store.throttle.type` and
 `index.store.throttle.max_bytes_per_sec` index settings are not
 recognized anymore.
+
+==== Store settings
+
+The `default` `index.store.type` has been removed. If you were using it, we
+advise that you simply remove it from your index settings and Elasticsearch
+will use the best `store` implementation for your operating system.


### PR DESCRIPTION
It used to be a hybrid store between `niofs` and `mmapfs`, which we removed when
we switched to `fs` by default (which is `mmapfs` on 64-bits systems).