### PR TITLE
Add deprecation logging for users that explicitly opt in for the `default` fs type.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/store/FsDirectoryService.java
+++ b/core/src/main/java/org/elasticsearch/index/store/FsDirectoryService.java
@@ -105,7 +105,10 @@ public class FsDirectoryService extends DirectoryService implements StoreRateLim
     protected Directory newFSDirectory(Path location, LockFactory lockFactory) throws IOException {
         final String storeType = indexSettings.getSettings().get(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(),
             IndexModule.Type.FS.getSettingsKey());
-        if (IndexModule.Type.FS.match(storeType) || IndexModule.Type.DEFAULT.match(storeType)) {
+        if (IndexModule.Type.FS.match(storeType)) {
+            return FSDirectory.open(location, lockFactory); // use lucene defaults
+        } else if (IndexModule.Type.DEFAULT.match(storeType)) {
+            deprecationLogger.deprecated("[default] store type is deprecated, use [fs] instead");
             return FSDirectory.open(location, lockFactory); // use lucene defaults
         } else if (IndexModule.Type.SIMPLEFS.match(storeType)) {
             return new SimpleFSDirectory(location, lockFactory);


### PR DESCRIPTION
It will be remoned in 6.0.