### PR TITLE
Add deprecation logging for the case that store throttling is used.

### DIFF
--- a/core/src/main/java/org/apache/lucene/store/StoreRateLimiting.java
+++ b/core/src/main/java/org/apache/lucene/store/StoreRateLimiting.java
@@ -20,11 +20,16 @@ package org.apache.lucene.store;
 
 import org.apache.lucene.store.RateLimiter.SimpleRateLimiter;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.store.IndexStoreConfig;
 
 /**
  */
 public class StoreRateLimiting {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(IndexStoreConfig.class));
 
     public interface Provider {
 
@@ -85,9 +90,12 @@ public class StoreRateLimiting {
 
     public void setType(Type type) {
         this.type = type;
+        if (type != Type.NONE) {
+            DEPRECATION_LOGGER.deprecated("Store rate limiting is deprecated and will be removed in 6.0");
+        }
     }
 
     public void setType(String type) {
-        this.type = Type.fromString(type);
+        setType(Type.fromString(type));
     }
 }

--- a/core/src/main/java/org/apache/lucene/store/StoreRateLimiting.java
+++ b/core/src/main/java/org/apache/lucene/store/StoreRateLimiting.java
@@ -23,13 +23,12 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.index.store.IndexStoreConfig;
 
 /**
  */
 public class StoreRateLimiting {
 
-    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(IndexStoreConfig.class));
+    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(StoreRateLimiting.class));
 
     public interface Provider {
 


### PR DESCRIPTION
It will be removed in 6.0.
