### PR TITLE
Fix match_phrase_prefix on boosted fields

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.queries.ExtendedCommonTermsQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
@@ -29,11 +30,15 @@ import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.lucene.search.MultiPhrasePrefixQuery;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.search.MatchQuery;
 import org.elasticsearch.index.search.MatchQuery.Type;
 import org.elasticsearch.index.search.MatchQuery.ZeroTermsQuery;
@@ -457,5 +462,36 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
                 "  }\n" +
                 "}";
         expectThrows(IllegalStateException.class, () -> parseQuery(json2));
+    }
+
+    @Override
+    protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
+        mapperService.merge("t_boost", new CompressedXContent(PutMappingRequest.buildFromSimplifiedDef("t_boost",
+            "string_boost", "type=text,boost=4").string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+    }
+
+    public void testMatchPhrasePrefixWithBoost() throws Exception {
+        assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
+        QueryShardContext context = createShardContext();
+        assumeTrue("test runs only when the index version is on or after V_5_0_0_alpha1",
+            context.indexVersionCreated().onOrAfter(Version.V_5_0_0_alpha1));
+
+        {
+            // field boost is applied on a single term query
+            MatchPhrasePrefixQueryBuilder builder = new MatchPhrasePrefixQueryBuilder("string_boost", "foo");
+            Query query = builder.toQuery(context);
+            assertThat(query, instanceOf(BoostQuery.class));
+            assertThat(((BoostQuery) query).getBoost(), equalTo(4f));
+            Query innerQuery = ((BoostQuery) query).getQuery();
+            assertThat(innerQuery, instanceOf(MultiPhrasePrefixQuery.class));
+        }
+
+        {
+            // field boost is ignored on phrase query
+            MatchPhrasePrefixQueryBuilder builder = new MatchPhrasePrefixQueryBuilder("string_boost", "foo bar");
+            Query query = builder.toQuery(context);
+            assertThat(query, instanceOf(MultiPhrasePrefixQuery.class));
+        }
+
     }
 }


### PR DESCRIPTION
This change fixes the match_phrase_prefix on fields that define a boost in their mapping.

Fixes #21613