### PR TITLE
Fix cross_fields type on multi_match query with synonyms

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -31,6 +31,7 @@ import org.apache.lucene.search.MultiPhraseQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.SynonymQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.QueryBuilder;
 import org.elasticsearch.ElasticsearchException;
@@ -302,6 +303,11 @@ public class MatchQuery {
             return blendTermQuery(term, mapper);
         }
 
+        @Override
+        protected Query newSynonymQuery(Term[] terms) {
+            return blendTermsQuery(terms, mapper);
+        }
+
         public Query createPhrasePrefixQuery(String field, String queryText, int phraseSlop, int maxExpansions) {
             final Query query = createFieldQuery(getAnalyzer(), Occur.MUST, field, queryText, true, phraseSlop);
             float boost = 1;
@@ -356,6 +362,10 @@ public class MatchQuery {
             return booleanQuery;
 
         }
+    }
+
+    protected Query blendTermsQuery(Term[] terms, MappedFieldType fieldType) {
+        return new SynonymQuery(terms);
     }
 
     protected Query blendTermQuery(Term term, MappedFieldType fieldType) {

--- a/core/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
@@ -158,6 +158,10 @@ public class MultiMatchQuery extends MatchQuery {
             return MultiMatchQuery.super.blendTermQuery(term, fieldType);
         }
 
+        public Query blendTerms(Term[] terms, MappedFieldType fieldType) {
+            return MultiMatchQuery.super.blendTermsQuery(terms, fieldType);
+        }
+
         public Query termQuery(MappedFieldType fieldType, Object value) {
             return MultiMatchQuery.this.termQuery(fieldType, value, lenient);
         }
@@ -224,6 +228,18 @@ public class MultiMatchQuery extends MatchQuery {
         }
 
         @Override
+        public Query blendTerms(Term[] terms, MappedFieldType fieldType) {
+            if (blendedFields == null) {
+                return super.blendTerms(terms, fieldType);
+            }
+            BytesRef[] values = new BytesRef[terms.length];
+            for (int i = 0; i < terms.length; i++) {
+                values[i] = terms[i].bytes();
+            }
+            return MultiMatchQuery.blendTerms(context, values, commonTermsCutoff, tieBreaker, blendedFields);
+        }
+
+        @Override
         public Query blendTerm(Term term, MappedFieldType fieldType) {
             if (blendedFields == null) {
                 return super.blendTerm(term, fieldType);
@@ -243,44 +259,51 @@ public class MultiMatchQuery extends MatchQuery {
     }
 
     static Query blendTerm(QueryShardContext context, BytesRef value, Float commonTermsCutoff, float tieBreaker,
+                           FieldAndFieldType... blendedFields) {
+        return blendTerms(context, new BytesRef[] {value}, commonTermsCutoff, tieBreaker, blendedFields);
+    }
+
+    static Query blendTerms(QueryShardContext context, BytesRef[] values, Float commonTermsCutoff, float tieBreaker,
             FieldAndFieldType... blendedFields) {
         List<Query> queries = new ArrayList<>();
-        Term[] terms = new Term[blendedFields.length];
-        float[] blendedBoost = new float[blendedFields.length];
+        Term[] terms = new Term[blendedFields.length * values.length];
+        float[] blendedBoost = new float[blendedFields.length * values.length];
         int i = 0;
         for (FieldAndFieldType ft : blendedFields) {
-            Query query;
-            try {
-                query = ft.fieldType.termQuery(value, context);
-            } catch (IllegalArgumentException e) {
-                // the query expects a certain class of values such as numbers
-                // of ip addresses and the value can't be parsed, so ignore this
-                // field
-                continue;
-            } catch (ElasticsearchParseException parseException) {
-                // date fields throw an ElasticsearchParseException with the
-                // underlying IAE as the cause, ignore this field if that is
-                // the case
-                if (parseException.getCause() instanceof IllegalArgumentException) {
+            for (BytesRef term : values) {
+                Query query;
+                try {
+                    query = ft.fieldType.termQuery(term, context);
+                } catch (IllegalArgumentException e) {
+                    // the query expects a certain class of values such as numbers
+                    // of ip addresses and the value can't be parsed, so ignore this
+                    // field
                     continue;
+                } catch (ElasticsearchParseException parseException) {
+                    // date fields throw an ElasticsearchParseException with the
+                    // underlying IAE as the cause, ignore this field if that is
+                    // the case
+                    if (parseException.getCause() instanceof IllegalArgumentException) {
+                        continue;
+                    }
+                    throw parseException;
                 }
-                throw parseException;
-            }
-            float boost = ft.boost;
-            while (query instanceof BoostQuery) {
-                BoostQuery bq = (BoostQuery) query;
-                query = bq.getQuery();
-                boost *= bq.getBoost();
-            }
-            if (query.getClass() == TermQuery.class) {
-                terms[i] = ((TermQuery) query).getTerm();
-                blendedBoost[i] = boost;
-                i++;
-            } else {
-                if (boost != 1f) {
-                    query = new BoostQuery(query, boost);
+                float boost = ft.boost;
+                while (query instanceof BoostQuery) {
+                    BoostQuery bq = (BoostQuery) query;
+                    query = bq.getQuery();
+                    boost *= bq.getBoost();
                 }
-                queries.add(query);
+                if (query.getClass() == TermQuery.class) {
+                    terms[i] = ((TermQuery) query).getTerm();
+                    blendedBoost[i] = boost;
+                    i++;
+                } else {
+                    if (boost != 1f) {
+                        query = new BoostQuery(query, boost);
+                    }
+                    queries.add(query);
+                }
             }
         }
         if (i > 0) {
@@ -315,6 +338,14 @@ public class MultiMatchQuery extends MatchQuery {
             return super.blendTermQuery(term, fieldType);
         }
         return queryBuilder.blendTerm(term, fieldType);
+    }
+
+    @Override
+    protected Query blendTermsQuery(Term[] terms, MappedFieldType fieldType) {
+        if (queryBuilder == null) {
+            return super.blendTermsQuery(terms, fieldType);
+        }
+        return queryBuilder.blendTerms(terms, fieldType);
     }
 
     static final class FieldAndFieldType {

--- a/core/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
@@ -229,7 +229,7 @@ public class MultiMatchQuery extends MatchQuery {
 
         @Override
         public Query blendTerms(Term[] terms, MappedFieldType fieldType) {
-            if (blendedFields == null) {
+            if (blendedFields == null || blendedFields.length == 1) {
                 return super.blendTerms(terms, fieldType);
             }
             BytesRef[] values = new BytesRef[terms.length];


### PR DESCRIPTION
This change fixes the cross_fields type of the multi_match query when synonyms are involved.
Since 2.x the Lucene query parser creates SynonymQuery for words that appear at the same position.
For simple term query the CrossFieldsQueryBuilder expands the term to all requested fields and creates a BlendedTermQuery.
This change adds the same mechanism for SynonymQuery which otherwise are not expanded to all requested fields.
As a side note I wonder if we should not replace the BlendedTermQuery with the SynonymQuery. They have the same purpose and behave similarly.

Fixes #21633