### PR TITLE
fix two errors in suggester docs

### DIFF
--- a/docs/reference/search/suggesters/phrase-suggest.asciidoc
+++ b/docs/reference/search/suggesters/phrase-suggest.asciidoc
@@ -106,12 +106,7 @@ POST _suggest
 --------------------------------------------------
 // CONSOLE
 
-The response contains suggestions scored by the most likely spell
-correction first. In this case we received the expected correction
-`xorr the god jewel` first while the second correction is less
-conservative where only one of the errors is corrected. Note, the
-request is executed with `max_errors` set to `0.5` so 50% of the terms
-can contain misspellings (See parameter descriptions below).
+The response contains suggestions scored by the most likely spell correction first. In this case we received the expected correction "nobel prize".
 
 [source,js]
 --------------------------------------------------
@@ -320,7 +315,7 @@ The direct generators support the following parameters:
     filtered out using `confidence`. Three possible values can be specified:
     ** `missing`: Only generate suggestions for terms that are not in the
                  shard. This is the default.
-    ** `popular`: Only suggest terms that occur in more docs on the shard then
+    ** `popular`: Only suggest terms that occur in more docs on the shard than
                  the original term.
     ** `always`: Suggest any matching suggestions based on terms in the
                  suggest text.


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?

The first changed referred to an example of the 2.4 documentation. I removed the no longer relevant parts. We should consider adding a little more here. 

The second change was just then->than in the suggest_mode popular section