### PR TITLE
Remove stale mention of minimum master nodes check

### DIFF
--- a/docs/reference/setup/important-settings.asciidoc
+++ b/docs/reference/setup/important-settings.asciidoc
@@ -158,15 +158,14 @@ discovery.zen.ping.unicast.hosts:
 === `discovery.zen.minimum_master_nodes`
 
 To prevent data loss, it is vital to configure the
-`discovery.zen.minimum_master_nodes setting` so that each master-eligible node
+`discovery.zen.minimum_master_nodes` setting so that each master-eligible node
 knows the _minimum number of master-eligible nodes_ that must be visible in
 order to form a cluster.
 
 Without this setting, a cluster that suffers a network failure is at risk of
 having the cluster split into two independent clusters -- a split brain --
-which will lead to data loss.  A more detailed explanation is provided
+which will lead to data loss. A more detailed explanation is provided
 in <<split-brain>>.
-
 
 To avoid a split brain, this setting should be set to a _quorum_ of master-
 eligible nodes:
@@ -181,6 +180,3 @@ nodes should be set to `(3 / 2) + 1` or `2`:
 discovery.zen.minimum_master_nodes: 2
 --------------------------------------------------
 
-IMPORTANT: If `discovery.zen.minimum_master_nodes` is not set when
-Elasticsearch is running in <<dev-vs-prod,production mode>>, an exception will
-be thrown which will prevent the node from starting.


### PR DESCRIPTION
This commit removes a stale mention of the minimum master nodes boostrap
check from the docs.

Relates #20082
