### PR TITLE
Makes allocator decision classes top-level classes

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/MoveDecision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/MoveDecision.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.common.Nullable;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a decision to move a started shard because it is no longer allowed to remain on its current node.
+ */
+public final class MoveDecision extends RelocationDecision {
+    /** a constant representing no decision taken */
+    public static final MoveDecision NOT_TAKEN = new MoveDecision(null, null, null, null, null);
+    /** cached decisions so we don't have to recreate objects for common decisions when not in explain mode. */
+    private static final MoveDecision CACHED_STAY_DECISION = new MoveDecision(Decision.YES, Decision.Type.NO, null, null, null);
+    private static final MoveDecision CACHED_CANNOT_MOVE_DECISION = new MoveDecision(Decision.NO, Decision.Type.NO, null, null, null);
+
+    @Nullable
+    private final Decision canRemainDecision;
+    @Nullable
+    private final Map<String, NodeAllocationResult> nodeDecisions;
+
+    private MoveDecision(Decision canRemainDecision, Decision.Type finalDecision, String finalExplanation,
+                         String assignedNodeId, Map<String, NodeAllocationResult> nodeDecisions) {
+        super(finalDecision, finalExplanation, assignedNodeId);
+        this.canRemainDecision = canRemainDecision;
+        this.nodeDecisions = nodeDecisions != null ? Collections.unmodifiableMap(nodeDecisions) : null;
+    }
+
+    /**
+     * Creates a move decision for the shard being able to remain on its current node, so not moving.
+     */
+    public static MoveDecision stay(Decision canRemainDecision, boolean explain) {
+        assert canRemainDecision.type() != Decision.Type.NO;
+        if (explain) {
+            final String explanation;
+            if (explain) {
+                explanation = "shard is allowed to remain on its current node, so no reason to move";
+            } else {
+                explanation = null;
+            }
+            return new MoveDecision(Objects.requireNonNull(canRemainDecision), Decision.Type.NO, explanation, null, null);
+        } else {
+            return CACHED_STAY_DECISION;
+        }
+    }
+
+    /**
+     * Creates a move decision for the shard not being able to remain on its current node.
+     *
+     * @param canRemainDecision the decision for whether the shard is allowed to remain on its current node
+     * @param finalDecision the decision of whether to move the shard to another node
+     * @param explain true if in explain mode
+     * @param currentNodeId the current node id where the shard is assigned
+     * @param assignedNodeId the node id for where the shard can move to
+     * @param nodeDecisions the node-level decisions that comprised the final decision, non-null iff explain is true
+     * @return the {@link MoveDecision} for moving the shard to another node
+     */
+    public static MoveDecision decision(Decision canRemainDecision, Decision.Type finalDecision, boolean explain, String currentNodeId,
+                                        String assignedNodeId, Map<String, NodeAllocationResult> nodeDecisions) {
+        assert canRemainDecision != null;
+        assert canRemainDecision.type() != Decision.Type.YES : "create decision with MoveDecision#stay instead";
+        String finalExplanation = null;
+        if (explain) {
+            assert currentNodeId != null;
+            if (finalDecision == Decision.Type.YES) {
+                assert assignedNodeId != null;
+                finalExplanation = "shard cannot remain on node [" + currentNodeId + "], moving to node [" + assignedNodeId + "]";
+            } else if (finalDecision == Decision.Type.THROTTLE) {
+                finalExplanation = "shard cannot remain on node [" + currentNodeId + "], throttled on moving to another node";
+            } else {
+                finalExplanation = "shard cannot remain on node [" + currentNodeId + "], but cannot be assigned to any other node";
+            }
+        }
+        if (finalExplanation == null && finalDecision == Decision.Type.NO) {
+            // the final decision is NO (no node to move the shard to) and we are not in explain mode, return a cached version
+            return CACHED_CANNOT_MOVE_DECISION;
+        } else {
+            assert ((assignedNodeId == null) == (finalDecision != Decision.Type.YES));
+            return new MoveDecision(canRemainDecision, finalDecision, finalExplanation, assignedNodeId, nodeDecisions);
+        }
+    }
+
+    /**
+     * Returns {@code true} if the shard cannot remain on its current node and can be moved, returns {@code false} otherwise.
+     */
+    public boolean move() {
+        return cannotRemain() && getFinalDecisionType() == Decision.Type.YES;
+    }
+
+    /**
+     * Returns {@code true} if the shard cannot remain on its current node.
+     */
+    public boolean cannotRemain() {
+        return isDecisionTaken() && canRemainDecision.type() == Decision.Type.NO;
+    }
+
+    /**
+     * Gets the individual node-level decisions that went into making the final decision as represented by
+     * {@link #getFinalDecisionType()}.  The map that is returned has the node id as the key and a {@link NodeAllocationResult}.
+     */
+    @Nullable
+    public Map<String, NodeAllocationResult> getNodeDecisions() {
+        return nodeDecisions;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+
+import java.util.Objects;
+
+/**
+ * This class represents the shard allocation decision for a single node,
+ * including the {@link Decision} whether to allocate to the node and other
+ * information related to obtaining the decision for the node.
+ */
+public final class NodeAllocationResult {
+
+    private final Decision decision;
+    private final float weight;
+
+    public NodeAllocationResult(Decision decision) {
+        this.decision = Objects.requireNonNull(decision);
+        this.weight = Float.POSITIVE_INFINITY;
+    }
+
+    public NodeAllocationResult(Decision decision, float weight) {
+        this.decision = Objects.requireNonNull(decision);
+        this.weight = Objects.requireNonNull(weight);
+    }
+
+    /**
+     * The decision for allocating to the node.
+     */
+    public Decision getDecision() {
+        return decision;
+    }
+
+    /**
+     * The calculated weight for allocating a shard to the node.  A value of {@link Float#POSITIVE_INFINITY}
+     * means the weight was not calculated or factored into the decision.
+     */
+    public float getWeight() {
+        return weight;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        NodeAllocationResult that = (NodeAllocationResult) other;
+        return decision.equals(that.decision) && Float.compare(weight, that.weight) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(decision, weight);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeRebalanceResult.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeRebalanceResult.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+
+import java.util.Objects;
+
+/**
+ * A node-level explanation for the decision to rebalance a shard.
+ */
+public final class NodeRebalanceResult {
+    private final Decision.Type nodeDecisionType;
+    private final Decision canAllocate;
+    private final boolean betterWeightThanCurrent;
+    private final boolean deltaAboveThreshold;
+    private final float currentWeight;
+    private final float weightWithShardAdded;
+
+    public NodeRebalanceResult(Decision.Type nodeDecisionType, Decision canAllocate, boolean betterWeightThanCurrent,
+                               boolean deltaAboveThreshold, float currentWeight, float weightWithShardAdded) {
+        this.nodeDecisionType = Objects.requireNonNull(nodeDecisionType);
+        this.canAllocate = Objects.requireNonNull(canAllocate);
+        this.betterWeightThanCurrent = betterWeightThanCurrent;
+        this.deltaAboveThreshold = deltaAboveThreshold;
+        this.currentWeight = currentWeight;
+        this.weightWithShardAdded = weightWithShardAdded;
+    }
+
+    /**
+     * Returns the decision to rebalance to the node.
+     */
+    public Decision.Type getNodeDecisionType() {
+        return nodeDecisionType;
+    }
+
+    /**
+     * Returns whether the shard is allowed to be allocated to the node.
+     */
+    public Decision getCanAllocateDecision() {
+        return canAllocate;
+    }
+
+    /**
+     * Returns whether the weight of the node is better than the weight of the node where the shard currently resides.
+     */
+    public boolean isBetterWeightThanCurrent() {
+        return betterWeightThanCurrent;
+    }
+
+    /**
+     * Returns if the weight delta by assigning to this node was above the threshold to warrant a rebalance.
+     */
+    public boolean isDeltaAboveThreshold() {
+        return deltaAboveThreshold;
+    }
+
+    /**
+     * Returns the current weight of the node if the shard is not added to the node.
+     */
+    public float getCurrentWeight() {
+        return currentWeight;
+    }
+
+    /**
+     * Returns the weight of the node if the shard is added to the node.
+     */
+    public float getWeightWithShardAdded() {
+        return weightWithShardAdded;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/RebalanceDecision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/RebalanceDecision.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
+import org.elasticsearch.common.Nullable;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Represents a decision to move a started shard to form a more optimally balanced cluster.
+ */
+public final class RebalanceDecision extends RelocationDecision {
+    /** a constant representing no decision taken */
+    public static final RebalanceDecision NOT_TAKEN = new RebalanceDecision(null, null, null, null, null, Float.POSITIVE_INFINITY);
+
+    @Nullable
+    private final Decision canRebalanceDecision;
+    @Nullable
+    private final Map<String, NodeRebalanceResult> nodeDecisions;
+    private float currentWeight;
+
+    public RebalanceDecision(Decision canRebalanceDecision, Type finalDecision, String finalExplanation) {
+        this(canRebalanceDecision, finalDecision, finalExplanation, null, null, Float.POSITIVE_INFINITY);
+    }
+
+    public RebalanceDecision(Decision canRebalanceDecision, Type finalDecision, String finalExplanation,
+                             String assignedNodeId, Map<String, NodeRebalanceResult> nodeDecisions, float currentWeight) {
+        super(finalDecision, finalExplanation, assignedNodeId);
+        this.canRebalanceDecision = canRebalanceDecision;
+        this.nodeDecisions = nodeDecisions != null ? Collections.unmodifiableMap(nodeDecisions) : null;
+        this.currentWeight = currentWeight;
+    }
+
+    /**
+     * Creates a new {@link RebalanceDecision}, computing the explanation based on the decision parameters.
+     */
+    public static RebalanceDecision decision(Decision canRebalanceDecision, Type finalDecision, String assignedNodeId,
+                                             Map<String, NodeRebalanceResult> nodeDecisions, float currentWeight, float threshold) {
+        final String explanation = produceFinalExplanation(finalDecision, assignedNodeId, threshold);
+        return new RebalanceDecision(canRebalanceDecision, finalDecision, explanation, assignedNodeId, nodeDecisions, currentWeight);
+    }
+
+    /**
+     * Returns the decision for being allowed to rebalance the shard.
+     */
+    @Nullable
+    public Decision getCanRebalanceDecision() {
+        return canRebalanceDecision;
+    }
+
+    /**
+     * Gets the individual node-level decisions that went into making the final decision as represented by
+     * {@link #getFinalDecisionType()}.  The map that is returned has the node id as the key and a {@link NodeRebalanceResult}.
+     */
+    @Nullable
+    public Map<String, NodeRebalanceResult> getNodeDecisions() {
+        return nodeDecisions;
+    }
+
+    private static String produceFinalExplanation(final Type finalDecisionType, final String assignedNodeId, final float threshold) {
+        final String finalExplanation;
+        if (assignedNodeId != null) {
+            if (finalDecisionType == Type.THROTTLE) {
+                finalExplanation = "throttle moving shard to node [" + assignedNodeId + "], as it is " +
+                                       "currently busy with other shard relocations";
+            } else {
+                finalExplanation = "moving shard to node [" + assignedNodeId + "] to form a more balanced cluster";
+            }
+        } else {
+            finalExplanation = "cannot rebalance shard, no other node exists that would form a more balanced " +
+                                   "cluster within the defined threshold [" + threshold + "]";
+        }
+        return finalExplanation;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/RelocationDecision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/RelocationDecision.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.common.Nullable;
+
+/**
+ * Represents a decision to relocate a started shard from its current node.
+ */
+public abstract class RelocationDecision {
+    @Nullable
+    private final Decision.Type finalDecision;
+    @Nullable
+    private final String finalExplanation;
+    @Nullable
+    private final String assignedNodeId;
+
+    protected RelocationDecision(Decision.Type finalDecision, String finalExplanation, String assignedNodeId) {
+        this.finalDecision = finalDecision;
+        this.finalExplanation = finalExplanation;
+        this.assignedNodeId = assignedNodeId;
+    }
+
+    /**
+     * Returns {@code true} if a decision was taken by the allocator, {@code false} otherwise.
+     * If no decision was taken, then the rest of the fields in this object are meaningless and return {@code null}.
+     */
+    public boolean isDecisionTaken() {
+        return finalDecision != null;
+    }
+
+    /**
+     * Returns the final decision made by the allocator on whether to assign the shard, and
+     * {@code null} if no decision was taken.
+     */
+    public Decision.Type getFinalDecisionType() {
+        return finalDecision;
+    }
+
+    /**
+     * Returns the free-text explanation for the reason behind the decision taken in {@link #getFinalDecisionType()}.
+     */
+    @Nullable
+    public String getFinalExplanation() {
+        return finalExplanation;
+    }
+
+    /**
+     * Get the node id that the allocator will assign the shard to, unless {@link #getFinalDecisionType()} returns
+     * a value other than {@link Decision.Type#YES}, in which case this returns {@code null}.
+     */
+    @Nullable
+    public String getAssignedNodeId() {
+        return assignedNodeId;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -31,8 +31,8 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.allocation.AllocateUnassignedDecision;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
-import org.elasticsearch.cluster.routing.allocation.ShardAllocationDecision;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.Tuple;
@@ -139,12 +139,12 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
     }
 
     @Override
-    public ShardAllocationDecision makeAllocationDecision(final ShardRouting unassignedShard,
-                                                          final RoutingAllocation allocation,
-                                                          final Logger logger) {
+    public AllocateUnassignedDecision makeAllocationDecision(final ShardRouting unassignedShard,
+                                                             final RoutingAllocation allocation,
+                                                             final Logger logger) {
         if (isResponsibleFor(unassignedShard) == false) {
             // this allocator is not responsible for deciding on this shard
-            return ShardAllocationDecision.DECISION_NOT_TAKEN;
+            return AllocateUnassignedDecision.NOT_TAKEN;
         }
 
         final RoutingNodes routingNodes = allocation.routingNodes();
@@ -153,7 +153,7 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
         Tuple<Decision, Map<String, Decision>> allocateDecision = canBeAllocatedToAtLeastOneNode(unassignedShard, allocation, explain);
         if (allocateDecision.v1().type() != Decision.Type.YES) {
             logger.trace("{}: ignoring allocation, can't be allocated on any node", unassignedShard);
-            return ShardAllocationDecision.no(UnassignedInfo.AllocationStatus.fromDecision(allocateDecision.v1().type()),
+            return AllocateUnassignedDecision.no(UnassignedInfo.AllocationStatus.fromDecision(allocateDecision.v1().type()),
                 explain ? "all nodes returned a " + allocateDecision.v1().type() + " decision for allocating the replica shard" : null,
                 allocateDecision.v2());
         }
@@ -162,7 +162,7 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
         if (shardStores.hasData() == false) {
             logger.trace("{}: ignoring allocation, still fetching shard stores", unassignedShard);
             allocation.setHasPendingAsyncFetch();
-            return ShardAllocationDecision.no(AllocationStatus.FETCHING_SHARD_DATA,
+            return AllocateUnassignedDecision.no(AllocationStatus.FETCHING_SHARD_DATA,
                 explain ? "still fetching shard state from the nodes in the cluster" : null);
         }
 
@@ -175,7 +175,7 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
             // will try and recover from
             // Note, this is the existing behavior, as exposed in running CorruptFileTest#testNoPrimaryData
             logger.trace("{}: no primary shard store found or allocated, letting actual allocation figure it out", unassignedShard);
-            return ShardAllocationDecision.DECISION_NOT_TAKEN;
+            return AllocateUnassignedDecision.NOT_TAKEN;
         }
 
         MatchingNodes matchingNodes = findMatchingNodes(unassignedShard, allocation, primaryStore, shardStores, explain);
@@ -189,14 +189,14 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
                 logger.debug("[{}][{}]: throttling allocation [{}] to [{}] in order to reuse its unallocated persistent store",
                     unassignedShard.index(), unassignedShard.id(), unassignedShard, nodeWithHighestMatch.node());
                 // we are throttling this, as we have enough other shards to allocate to this node, so ignore it for now
-                return ShardAllocationDecision.throttle(
+                return AllocateUnassignedDecision.throttle(
                     explain ? "returned a THROTTLE decision on each node that has an existing copy of the shard, so waiting to re-use one of those copies" : null,
                     matchingNodes.nodeDecisions);
             } else {
                 logger.debug("[{}][{}]: allocating [{}] to [{}] in order to reuse its unallocated persistent store",
                     unassignedShard.index(), unassignedShard.id(), unassignedShard, nodeWithHighestMatch.node());
                 // we found a match
-                return ShardAllocationDecision.yes(nodeWithHighestMatch.nodeId(),
+                return AllocateUnassignedDecision.yes(nodeWithHighestMatch.nodeId(),
                     "allocating to node [" + nodeWithHighestMatch.nodeId() + "] in order to re-use its unallocated persistent store",
                     null,
                     matchingNodes.nodeDecisions);
@@ -206,11 +206,11 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
             // unassigned due to a node leaving, so we delay allocation of this replica to see if the
             // node with the shard copy will rejoin so we can re-use the copy it has
             logger.debug("{}: allocation of [{}] is delayed", unassignedShard.shardId(), unassignedShard);
-            return ShardAllocationDecision.no(AllocationStatus.DELAYED_ALLOCATION,
+            return AllocateUnassignedDecision.no(AllocationStatus.DELAYED_ALLOCATION,
                 explain ? "not allocating this shard, no nodes contain data for the replica and allocation is delayed" : null);
         }
 
-        return ShardAllocationDecision.DECISION_NOT_TAKEN;
+        return AllocateUnassignedDecision.NOT_TAKEN;
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
@@ -31,8 +31,6 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.Balancer;
-import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.NodeRebalanceDecision;
-import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.RebalanceDecision;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
@@ -222,8 +220,8 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
         assertEquals(shardToRebalance.relocatingNodeId(), rebalanceDecision.getAssignedNodeId());
         // make sure all excluded nodes returned a NO decision
         for (String exludedNode : excludeNodes) {
-            NodeRebalanceDecision nodeRebalanceDecision = rebalanceDecision.getNodeDecisions().get(exludedNode);
-            assertEquals(Type.NO, nodeRebalanceDecision.getCanAllocateDecision().type());
+            NodeRebalanceResult nodeRebalanceResult = rebalanceDecision.getNodeDecisions().get(exludedNode);
+            assertEquals(Type.NO, nodeRebalanceResult.getCanAllocateDecision().type());
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/MoveDecisionTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/MoveDecisionTests.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
-import org.elasticsearch.cluster.routing.allocation.ShardAllocationDecision.WeightedDecision;
-import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.MoveDecision;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
 import org.elasticsearch.test.ESTestCase;
@@ -79,9 +77,9 @@ public class MoveDecisionTests extends ESTestCase {
     }
 
     public void testDecisionWithExplain() {
-        Map<String, WeightedDecision> nodeDecisions = new HashMap<>();
-        nodeDecisions.put("node1", new WeightedDecision(randomFrom(Decision.NO, Decision.THROTTLE, Decision.YES), randomFloat()));
-        nodeDecisions.put("node2", new WeightedDecision(randomFrom(Decision.NO, Decision.THROTTLE, Decision.YES), randomFloat()));
+        Map<String, NodeAllocationResult> nodeDecisions = new HashMap<>();
+        nodeDecisions.put("node1", new NodeAllocationResult(randomFrom(Decision.NO, Decision.THROTTLE, Decision.YES), randomFloat()));
+        nodeDecisions.put("node2", new NodeAllocationResult(randomFrom(Decision.NO, Decision.THROTTLE, Decision.YES), randomFloat()));
         MoveDecision decision = MoveDecision.decision(Decision.NO, Type.NO, true, "node1", null, nodeDecisions);
         assertNotNull(decision.getFinalDecisionType());
         assertNotNull(decision.getFinalExplanation());


### PR DESCRIPTION
This commit moves several allocation decider related inner classes
into their own top-level class, in order to use more easily in
the allocation explain API.  This commit also renames some of those
decision related classes to more suitable names.

This is simply a cosmetic change - no functionality changes with this
commit whatsoever.

To summarize the changes:
1. `ShardAllocationDecision` renamed to `AllocateUnassignedDecision`
2. `RelocationDecision` moved to a top-level class
3. `MoveDecision` moved to a top-level class
4. `RebalanceDecision` moved to a top-level class
5. `ShardAllocationDecisionTests` renamed to `AllocateUnassignedDecisionTests`
6. `NodeRebalanceResult` moved to a top-level class
7. `ShardAllocationDecision#WeightedDecision` moved to a top-level class and renamed to `NodeAllocationResult`.