### PR TITLE
Update BulkProcessor size in the example

### DIFF
--- a/docs/java-api/docs/bulk.asciidoc
+++ b/docs/java-api/docs/bulk.asciidoc
@@ -71,7 +71,7 @@ BulkProcessor bulkProcessor = BulkProcessor.builder(
                                   Throwable failure) { ... } <4>
         })
         .setBulkActions(10000) <5>
-        .setBulkSize(new ByteSizeValue(1, ByteSizeUnit.GB)) <6>
+        .setBulkSize(new ByteSizeValue(5, ByteSizeUnit.MB)) <6>
         .setFlushInterval(TimeValue.timeValueSeconds(5)) <7>
         .setConcurrentRequests(1) <8>
         .setBackoffPolicy(
@@ -85,7 +85,7 @@ BulkProcessor bulkProcessor = BulkProcessor.builder(
     with `response.hasFailures()`
 <4> This method is called when the bulk failed and raised a `Throwable`
 <5> We want to execute the bulk every 10 000 requests
-<6> We want to flush the bulk every 1gb
+<6> We want to flush the bulk every 5mb
 <7> We want to flush the bulk every 5 seconds whatever the number of requests
 <8> Set the number of concurrent requests. A value of 0 means that only a single request will  be allowed to be
     executed. A value of 1 means 1 concurrent request is allowed to be executed while accumulating new bulk requests.


### PR DESCRIPTION
By default, it is recommended to start bulk with a size of 10-15MB, and increase it gradually to get the right size for the environment. The example shows originally 1GB, which can lead to some users to just copy-paste the code snippet and start with excessively big sizes.