### PR TITLE
Split main ClusterService method into smaller chunks

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
@@ -21,7 +21,6 @@ package org.elasticsearch.cluster;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 public interface ClusterStateTaskExecutor<T> {
     /**
@@ -148,19 +147,6 @@ public interface ClusterStateTaskExecutor<T> {
         public Exception getFailure() {
             assert !isSuccess();
             return failure;
-        }
-
-        /**
-         * Handle the execution result with the provided consumers
-         * @param onSuccess handler to invoke on success
-         * @param onFailure handler to invoke on failure; the throwable passed through will not be null
-         */
-        public void handle(Runnable onSuccess, Consumer<Exception> onFailure) {
-            if (failure == null) {
-                onSuccess.run();
-            } else {
-                onFailure.accept(failure);
-            }
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -613,7 +613,7 @@ public class ClusterService extends AbstractLifecycleComponent {
         taskOutputs.notifyFailedTasks();
 
         if (taskOutputs.clusterStateUnchanged()) {
-            taskOutputs.notifySuccessfulTasks();
+            taskOutputs.notifySuccessfulTasksOnUnchangedClusterState();
             TimeValue executionTime = TimeValue.timeValueMillis(Math.max(0, TimeValue.nsecToMSec(currentTimeInNanos() - startTimeNS)));
             logger.debug("processing [{}]: took [{}] no change in cluster_state", taskInputs.summary, executionTime);
             warnAboutSlowTaskIfNeeded(executionTime, taskInputs.summary);
@@ -829,6 +829,9 @@ public class ClusterService extends AbstractLifecycleComponent {
         }
     }
 
+    /**
+     * Represents a set of tasks to be processed together with their executor
+     */
     class TaskInputs {
         public final String summary;
         public final ArrayList<UpdateTask> updateTasks;
@@ -853,6 +856,9 @@ public class ClusterService extends AbstractLifecycleComponent {
         }
     }
 
+    /**
+     * Output created by executing a set of tasks provided as TaskInputs
+     */
     class TaskOutputs {
         public final TaskInputs taskInputs;
         public final ClusterServiceState previousClusterServiceState;
@@ -922,7 +928,7 @@ public class ClusterService extends AbstractLifecycleComponent {
             }
         }
 
-        public void notifySuccessfulTasks() {
+        public void notifySuccessfulTasksOnUnchangedClusterState() {
             ClusterState clusterState = newClusterServiceState.getClusterState();
             nonFailedTasks.forEach(task -> {
                 if (task.listener instanceof AckedClusterStateTaskListener) {


### PR DESCRIPTION
This PR splits the main method in `ClusterService` into smaller chunks so that it's easier to understand and simpler to modify in subsequent PRs.