### PR TITLE
Optimize null safe deref into elvis

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/IMaybeNullSafe.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/IMaybeNullSafe.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.painless.node;
+
+public interface IMaybeNullSafe {
+    public static boolean applyIfPossible(ANode node, EElvis defaultForNull) {
+        if (node instanceof IMaybeNullSafe) {
+            IMaybeNullSafe maybeNullSafe = (IMaybeNullSafe) node;
+            if (maybeNullSafe.isNullSafe()) {
+                maybeNullSafe.setDefaultForNull(defaultForNull);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    boolean isNullSafe();
+    void setDefaultForNull(EElvis defaultForNull);
+}

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/IMaybeNullSafe.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/IMaybeNullSafe.java
@@ -19,8 +19,18 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.antlr.Walker;
+
+/**
+ * Implemented by {@link ANode}s that might be "null safe" like {@link PField} and {@link PCallInvoke}. Only implemented by
+ * {@linkplain ANodes}s that are returned by the {@link Walker} so nodes like {@link PSubNullSafeCallInvoke} don't implement it
+ */
 public interface IMaybeNullSafe {
-    public static boolean applyIfPossible(ANode node, EElvis defaultForNull) {
+    /**
+     * If the {@code node} implements {@linkplain IMaybeNullSafe} and is null safe then set {@code defaultForNull} so it can jump to the
+     * {@linkplain EElvis}'s right hand side rather than emit {@code null}.
+     */
+    static boolean applyIfPossible(ANode node, EElvis defaultForNull) {
         if (node instanceof IMaybeNullSafe) {
             IMaybeNullSafe maybeNullSafe = (IMaybeNullSafe) node;
             if (maybeNullSafe.isNullSafe()) {
@@ -31,6 +41,14 @@ public interface IMaybeNullSafe {
         return false;
     }
 
+    /**
+     * Has this node been configured to be null safe? Nodes like {@link PField} aren't null safe if specified like {@code params.a} but are
+     * if specified like {@code params?.a}.
+     */
     boolean isNullSafe();
+
+    /**
+     * Set {@code defaultForNull} so this node can jump to the {@linkplain EElvis}'s right hand side rather than emit {@code null}.
+     */
     void setDefaultForNull(EElvis defaultForNull);
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubNullSafeField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubNullSafeField.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition.Type;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -32,11 +33,20 @@ import java.util.Set;
  * Implements a field who's value is null if the prefix is null rather than throwing an NPE.
  */
 public class PSubNullSafeField extends AStoreable {
-    private AStoreable guarded;
+    /**
+     * The expression guarded by the null check.
+     */
+    private final AStoreable guarded;
+    /**
+     * The {@link EElvis} operator containing this node to which we can emit a jump to put the replacement value for null on the stack.
+     * Null if there isn't such an operator.
+     */
+    private final EElvis defaultForNull;
 
-    public PSubNullSafeField(Location location, AStoreable guarded) {
+    public PSubNullSafeField(Location location, AStoreable guarded,  @Nullable EElvis defaultForNull) {
         super(location);
         this.guarded = guarded;
+        this.defaultForNull = defaultForNull;
     }
 
     @Override
@@ -52,8 +62,8 @@ public class PSubNullSafeField extends AStoreable {
         guarded.read = read;
         guarded.analyze(locals);
         actual = guarded.actual;
-        if (actual.sort.primitive) {
-            throw new IllegalArgumentException("Result of null safe operator must be nullable");
+        if (actual.sort.primitive && defaultForNull == null) {
+            throw new IllegalArgumentException("Result of null safe dereference must be nullable unless followed by ?:");
         }
     }
 
@@ -75,11 +85,15 @@ public class PSubNullSafeField extends AStoreable {
 
     @Override
     void write(MethodWriter writer, Globals globals) {
-        Label end = new Label();
+        writer.writeDebugInfo(location);
+
+        Label nullLabel = defaultForNull == null ? new Label() : defaultForNull.nullLabel();
         writer.dup();
-        writer.ifNull(end);
+        writer.ifNull(nullLabel);
         guarded.write(writer, globals);
-        writer.mark(end);
+        if (defaultForNull == null) {
+            writer.mark(nullLabel);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/package-info.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/package-info.java
@@ -142,7 +142,7 @@
  * loads from a postfix node works in the same fashion.  Stores work somewhat differently as
  * described by later documentation.
  * <p>
- * Storebable nodes have three methods for writing -- setup, load, and store.  These methods
+ * Storeable nodes have three methods for writing -- setup, load, and store.  These methods
  * are used in conjuction with a parent node aware of the storeable node (lhs) that has a node
  * representing a value to store (rhs). The setup method is always once called before a store
  * to give storeable nodes a chance to write any prefixes they may have and any values such as

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicExpressionTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicExpressionTests.java
@@ -156,12 +156,15 @@ public class BasicExpressionTests extends ScriptTestCase {
         //   Call with primitive result
         assertMustBeNullable(    "String a = null; return a?.length()");
         assertMustBeNullable(    "String a = 'foo'; return a?.length()");
+        assertEquals(0,     exec("String a = null;  return a?.length() ?: 0"));
+        assertEquals(3,     exec("String a = 'foo'; return a?.length() ?: 0"));
         assertNull(         exec("def    a = null;  return a?.length()"));
         assertEquals(3,     exec("def    a = 'foo'; return a?.length()"));
         //   Read shortcut
-        assertMustBeNullable(    "org.elasticsearch.painless.FeatureTest a = null; return a?.x");
-        assertMustBeNullable(
-                "org.elasticsearch.painless.FeatureTest a = new org.elasticsearch.painless.FeatureTest(); return a?.x");
+        assertMustBeNullable("org.elasticsearch.painless.FeatureTest a = null; return a?.x");
+        assertMustBeNullable("org.elasticsearch.painless.FeatureTest a = new org.elasticsearch.painless.FeatureTest(); return a?.x");
+        assertEquals(1, exec("org.elasticsearch.painless.FeatureTest a = null; return a?.x ?: 1"));
+        assertEquals(0, exec("org.elasticsearch.painless.FeatureTest a = new org.elasticsearch.painless.FeatureTest(); return a?.x ?: 1"));
         assertNull(         exec("def    a = null;  return a?.x"));
         assertEquals(0,     exec("def    a = new org.elasticsearch.painless.FeatureTest(); return a?.x"));
 
@@ -172,8 +175,10 @@ public class BasicExpressionTests extends ScriptTestCase {
         assertNull(        exec("def a = null;        return a?.toString()"));
         assertEquals("{}", exec("def a = [:];         return a?.toString()"));
         //   Call with primitive result
-        assertMustBeNullable(   "Map a = [:];  return a?.size()");
-        assertMustBeNullable(   "Map a = null; return a?.size()");
+        assertMustBeNullable(   "Map a = null;        return a?.size()");
+        assertMustBeNullable(   "Map a = [:];         return a?.size()");
+        assertEquals(1,    exec("Map a = null;        return a?.size() ?: 1"));
+        assertEquals(0,    exec("Map a = [:];         return a?.size() ?: 1"));
         assertNull(        exec("def a = null;        return a?.size()"));
         assertEquals(0,    exec("def a = [:];         return a?.size()"));
         //   Read shortcut
@@ -186,6 +191,8 @@ public class BasicExpressionTests extends ScriptTestCase {
         // Since you can't invoke methods on arrays we skip the toString and hashCode tests
         assertMustBeNullable("int[] a = null;             return a?.length");
         assertMustBeNullable("int[] a = new int[] {2, 3}; return a?.length");
+        assertEquals(0, exec("int[] a = null;             return a?.length ?: 0"));
+        assertEquals(2, exec("int[] a = new int[] {2, 3}; return a?.length ?: 0"));
         assertNull(     exec("def a = null;               return a?.length"));
         assertEquals(2, exec("def a = new int[] {2, 3};   return a?.length"));
 
@@ -234,6 +241,6 @@ public class BasicExpressionTests extends ScriptTestCase {
 
     private void assertMustBeNullable(String script) {
         Exception e = expectScriptThrows(IllegalArgumentException.class , () -> exec(script));
-        assertEquals("Result of null safe operator must be nullable", e.getMessage());
+        assertEquals("Result of null safe dereference must be nullable unless followed by ?:", e.getMessage());
     }
 }


### PR DESCRIPTION
Removes the need to pass through `null` for sequences like
`a?.foo() ?: 0`. This both eliminates a null check and makes
it possible to support primitive return types for null safe
dereferences as long as they are followed by an elvis operator.

I don't imagine we'll see a large performance bump from this but
the emitted bytecode is shorter and supporting primitives is a
plus, however rare they are.