### PR TITLE
Fixing indentation in geospatial querying example.

### DIFF
--- a/docs/reference/query-dsl/geo-polygon-query.asciidoc
+++ b/docs/reference/query-dsl/geo-polygon-query.asciidoc
@@ -69,7 +69,7 @@ GET /_search
                     "person.location" : {
                         "points" : [
                             [-70, 40],
-                        [-80, 30],
+                            [-80, 30],
                             [-90, 20]
                         ]
                     }


### PR DESCRIPTION
Specifically the example which shows providing an array of an array of values.