### PR TITLE
Remove unused bits from DiscoveryNodes

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -38,7 +38,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * This class holds all {@link DiscoveryNode} in the cluster and provides convenience methods to
@@ -338,16 +337,6 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
             }
             return resolvedNodesIds.toArray(String.class);
         }
-    }
-
-    public DiscoveryNodes removeDeadMembers(Set<String> newNodes, String masterNodeId) {
-        Builder builder = new Builder().masterNodeId(masterNodeId).localNodeId(localNodeId);
-        for (DiscoveryNode node : this) {
-            if (newNodes.contains(node.getId())) {
-                builder.add(node);
-            }
-        }
-        return builder.build();
     }
 
     public DiscoveryNodes newNode(DiscoveryNode node) {

--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -396,7 +396,7 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
         private final List<DiscoveryNode> removed;
         private final List<DiscoveryNode> added;
 
-        public Delta(@Nullable DiscoveryNode previousMasterNode, @Nullable DiscoveryNode newMasterNode, String localNodeId,
+        private Delta(@Nullable DiscoveryNode previousMasterNode, @Nullable DiscoveryNode newMasterNode, String localNodeId,
                      List<DiscoveryNode> removed, List<DiscoveryNode> added) {
             this.previousMasterNode = previousMasterNode;
             this.newMasterNode = newMasterNode;

--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -56,19 +56,17 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
 
     private final String masterNodeId;
     private final String localNodeId;
-    private final Version minNodeVersion;
     private final Version minNonClientNodeVersion;
 
     private DiscoveryNodes(ImmutableOpenMap<String, DiscoveryNode> nodes, ImmutableOpenMap<String, DiscoveryNode> dataNodes,
                            ImmutableOpenMap<String, DiscoveryNode> masterNodes, ImmutableOpenMap<String, DiscoveryNode> ingestNodes,
-                           String masterNodeId, String localNodeId, Version minNodeVersion, Version minNonClientNodeVersion) {
+                           String masterNodeId, String localNodeId, Version minNonClientNodeVersion) {
         this.nodes = nodes;
         this.dataNodes = dataNodes;
         this.masterNodes = masterNodes;
         this.ingestNodes = ingestNodes;
         this.masterNodeId = masterNodeId;
         this.localNodeId = localNodeId;
-        this.minNodeVersion = minNodeVersion;
         this.minNonClientNodeVersion = minNonClientNodeVersion;
     }
 
@@ -173,7 +171,6 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
         return existing != null && existing.equals(node);
     }
 
-
     /**
      * Get the id of the master node
      *
@@ -228,16 +225,6 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
 
     public boolean isAllNodes(String... nodesIds) {
         return nodesIds == null || nodesIds.length == 0 || (nodesIds.length == 1 && nodesIds[0].equals("_all"));
-    }
-
-
-    /**
-     * Returns the version of the node with the oldest version in the cluster
-     *
-     * @return the oldest version in the cluster
-     */
-    public Version getSmallestVersion() {
-        return minNodeVersion;
     }
 
     /**
@@ -677,7 +664,7 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
 
             return new DiscoveryNodes(
                 nodes.build(), dataNodesBuilder.build(), masterNodesBuilder.build(), ingestNodesBuilder.build(),
-                masterNodeId, localNodeId, minNodeVersion, minNonClientNodeVersion
+                masterNodeId, localNodeId, minNonClientNodeVersion
             );
         }
 

--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -396,10 +396,6 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
         private final List<DiscoveryNode> removed;
         private final List<DiscoveryNode> added;
 
-        public Delta(String localNodeId, List<DiscoveryNode> removed, List<DiscoveryNode> added) {
-            this(null, null, localNodeId, removed, added);
-        }
-
         public Delta(@Nullable DiscoveryNode previousMasterNode, @Nullable DiscoveryNode newMasterNode, String localNodeId,
                      List<DiscoveryNode> removed, List<DiscoveryNode> added) {
             this.previousMasterNode = previousMasterNode;


### PR DESCRIPTION
- Remove minNodeVersion and corresponding public `getSmallestVersion` getter method from DiscoveryNodes
- Remove unused DiscoveryNode#removeDeadMembers public method
- Remove unused DiscoveryNodes.Delta constructor
- Adjust visibility of DiscoveryNodes.Delta constructor: it can be private as it gets called by DiscoveryNodes#delta method, which is supposed to be the only way to create a Delta