### PR TITLE
Rename ClusterState#lookupPrototypeSafe to `lookupPrototype` and remove "unsafe" unused variant

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -108,13 +108,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
         registerPrototype(RestoreInProgress.TYPE, RestoreInProgress.PROTO);
     }
 
-    @Nullable
     public static <T extends Custom> T lookupPrototype(String type) {
-        //noinspection unchecked
-        return (T) customPrototypes.get(type);
-    }
-
-    public static <T extends Custom> T lookupPrototypeSafe(String type) {
         @SuppressWarnings("unchecked")
         T proto = (T) customPrototypes.get(type);
         if (proto == null) {
@@ -308,7 +302,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
 
         private final String value;
 
-        private Metric(String value) {
+        Metric(String value) {
             this.value = value;
         }
 
@@ -630,10 +624,6 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
             return this;
         }
 
-        public Custom getCustom(String type) {
-            return customs.get(type);
-        }
-
         public Builder putCustom(String type, Custom custom) {
             customs.put(type, custom);
             return this;
@@ -707,7 +697,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
         int customSize = in.readVInt();
         for (int i = 0; i < customSize; i++) {
             String type = in.readString();
-            Custom customIndexMetaData = lookupPrototypeSafe(type).readFrom(in);
+            Custom customIndexMetaData = lookupPrototype(type).readFrom(in);
             builder.putCustom(type, customIndexMetaData);
         }
         return builder.build();
@@ -779,12 +769,12 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
                 new DiffableUtils.DiffableValueSerializer<String, Custom>() {
                     @Override
                     public Custom read(StreamInput in, String key) throws IOException {
-                        return lookupPrototypeSafe(key).readFrom(in);
+                        return lookupPrototype(key).readFrom(in);
                     }
 
                     @Override
                     public Diff<Custom> readDiff(StreamInput in, String key) throws IOException {
-                        return lookupPrototypeSafe(key).readDiffFrom(in);
+                        return lookupPrototype(key).readDiffFrom(in);
                     }
                 });
         }


### PR DESCRIPTION
The `lookupPrototype` method is not used anywhere. Seems like we rather use its `lookupProrotypeSafe` variant (which also throws exception if the prototype is not found). This commit makes the safer variant the default one, by renaming it to  `lookupPrototype` and removes the previous "unsafe" variant.