### PR TITLE
Remove unused assignedReplicasIncludingRelocating from ShardsIterator interface

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/PlainShardsIterator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/PlainShardsIterator.java
@@ -74,32 +74,6 @@ public class PlainShardsIterator implements ShardsIterator {
     }
 
     @Override
-    public int assignedReplicasIncludingRelocating() {
-        int count = 0;
-        for (ShardRouting shard : shards) {
-            if (shard.unassigned()) {
-                continue;
-            }
-            // if the shard is primary and relocating, add one to the counter since we perform it on the replica as well
-            // (and we already did it on the primary)
-            if (shard.primary()) {
-                if (shard.relocating()) {
-                    count++;
-                }
-            } else {
-                count++;
-                // if we are relocating the replica, we want to perform the index operation on both the relocating
-                // shard and the target shard. This means that we won't loose index operations between end of recovery
-                // and reassignment of the shard by the master node
-                if (shard.relocating()) {
-                    count++;
-                }
-            }
-        }
-        return count;
-    }
-
-    @Override
     public Iterable<ShardRouting> asUnordered() {
         return shards;
     }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/ShardsIterator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/ShardsIterator.java
@@ -43,13 +43,6 @@ public interface ShardsIterator {
     int sizeActive();
 
     /**
-     * Returns the number of replicas in this iterator that are not in the
-     * {@link ShardRoutingState#UNASSIGNED}. The returned double-counts replicas
-     * that are in the state {@link ShardRoutingState#RELOCATING}
-     */
-    int assignedReplicasIncludingRelocating();
-
-    /**
      * Returns the next shard, or <tt>null</tt> if none available.
      */
     ShardRouting nextOrNull();


### PR DESCRIPTION
I noticed this method was not used anywhere. Not sure what it was used for in the past, but I guess we can remove it now that it's not used.