### PR TITLE
elasticsearch/issues/4880 some improvements in term suggester

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -467,11 +467,15 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
                 return result;
             }
 
-            @Override
-            public void readFrom(StreamInput in) throws IOException {
+            protected void readFieldsFrom(StreamInput in) throws IOException {
                 text = in.readText();
                 offset = in.readVInt();
                 length = in.readVInt();
+            }
+
+            @Override
+            public void readFrom(StreamInput in) throws IOException {
+                readFieldsFrom(in);
                 int suggestedWords = in.readVInt();
                 options = new ArrayList<>(suggestedWords);
                 for (int j = 0; j < suggestedWords; j++) {
@@ -485,23 +489,31 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
                 return (O) new Option();
             }
 
-            @Override
-            public void writeTo(StreamOutput out) throws IOException {
+            protected void writeFieldsTo(StreamOutput out) throws IOException {
                 out.writeText(text);
                 out.writeVInt(offset);
                 out.writeVInt(length);
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                writeFieldsTo(out);
                 out.writeVInt(options.size());
                 for (Option option : options) {
                     option.writeTo(out);
                 }
             }
 
-            @Override
-            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                builder.startObject();
+            protected void writeFields(XContentBuilder builder) throws IOException {
                 builder.field(Fields.TEXT, text);
                 builder.field(Fields.OFFSET, offset);
                 builder.field(Fields.LENGTH, length);
+            }
+
+            @Override
+            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                builder.startObject();
+                writeFields(builder);
                 builder.startArray(Fields.OPTIONS);
                 for (Option option : options) {
                     option.toXContent(builder, params);

--- a/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggester.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggester.java
@@ -53,7 +53,9 @@ public final class TermSuggester extends Suggester<TermSuggestionContext> {
                     token.term, suggestion.getShardSize(), indexReader, suggestion.getDirectSpellCheckerSettings().suggestMode()
             );
             Text key = new Text(new BytesArray(token.term.bytes()));
-            TermSuggestion.Entry resultEntry = new TermSuggestion.Entry(key, token.startOffset, token.endOffset - token.startOffset);
+            int tokenLength = token.endOffset - token.startOffset;
+            boolean inIndex = indexReader.docFreq(token.term) > 0;
+            TermSuggestion.Entry resultEntry = new TermSuggestion.Entry(key, token.startOffset, tokenLength, inIndex);
             for (SuggestWord suggestWord : suggestedWords) {
                 Text word = new Text(suggestWord.string);
                 resultEntry.addOption(new TermSuggestion.Entry.Option(word, suggestWord.freq, suggestWord.score));
@@ -76,7 +78,7 @@ public final class TermSuggester extends Suggester<TermSuggestionContext> {
             @Override
             public void nextToken() {
                 Term term = new Term(field, BytesRef.deepCopyOf(fillBytesRef(new BytesRefBuilder())));
-                result.add(new Token(term, offsetAttr.startOffset(), offsetAttr.endOffset())); 
+                result.add(new Token(term, offsetAttr.startOffset(), offsetAttr.endOffset()));
             }
         }, spare);
        return result;

--- a/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestion.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestion.java
@@ -140,6 +140,10 @@ public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
         Entry() {
         }
 
+        public boolean isInIndex() {
+            return inIndex;
+        }
+
         @Override
         protected void readFieldsFrom(StreamInput in) throws IOException {
             super.readFieldsFrom(in);

--- a/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestion.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestion.java
@@ -130,11 +130,32 @@ public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
     public static class Entry extends
             org.elasticsearch.search.suggest.Suggest.Suggestion.Entry<TermSuggestion.Entry.Option> {
 
-        Entry(Text text, int offset, int length) {
+        private boolean inIndex;
+
+        Entry(Text text, int offset, int length, boolean inIndex) {
             super(text, offset, length);
+            this.inIndex = inIndex;
         }
 
         Entry() {
+        }
+
+        @Override
+        protected void readFieldsFrom(StreamInput in) throws IOException {
+            super.readFieldsFrom(in);
+            inIndex = in.readBoolean();
+        }
+
+        @Override
+        protected void writeFieldsTo(StreamOutput out) throws IOException {
+            super.writeFieldsTo(out);
+            out.writeBoolean(inIndex);
+        }
+
+        @Override
+        protected void writeFields(XContentBuilder builder) throws IOException {
+            super.writeFields(builder);
+            builder.field("inIndex", inIndex);
         }
 
         @Override


### PR DESCRIPTION
Those commit adds functionality for making decision to show "Did you mean ...?" or not. For example, user forget to switch keyboard layout and entered 'фззду' (QWERTY -> ЙЦУКЕН). So we need to invert input, and check index, is there such words (and we need to fix query), or it's just random abracadabra.
``` JSON
      {
         "text": "apple",
         "offset": 0,
         "length": 5,
         "inIndex": true,
         "options": [
```
Old issue about that: https://github.com/elastic/elasticsearch/issues/4880