### PR TITLE
Add a StreamInput#readArraySize method that ensures sane array sizes

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
+++ b/core/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
@@ -23,6 +23,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
 import org.elasticsearch.common.io.stream.StreamInput;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -252,6 +253,11 @@ public abstract class BytesReference implements Accountable, Comparable<BytesRef
         @Override
         public int available() throws IOException {
             return input.available();
+        }
+
+        @Override
+        public void ensureCanReadBytes(int length) throws EOFException {
+            input.ensureCanReadBytes(length);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
+++ b/core/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
@@ -216,6 +216,7 @@ public abstract class BytesReference implements Accountable, Comparable<BytesRef
      * that way.
      */
     private static final class MarkSupportingStreamInputWrapper extends StreamInput {
+        // can't use FilterStreamInput it needs to reset the delegate
         private final BytesReference reference;
         private BytesReferenceStreamInput input;
         private int mark = 0;
@@ -256,7 +257,7 @@ public abstract class BytesReference implements Accountable, Comparable<BytesRef
         }
 
         @Override
-        public void ensureCanReadBytes(int length) throws EOFException {
+        protected void ensureCanReadBytes(int length) throws EOFException {
             input.ensureCanReadBytes(length);
         }
 

--- a/core/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
@@ -115,6 +115,14 @@ final class BytesReferenceStreamInput extends StreamInput {
     }
 
     @Override
+    public void ensureCanReadBytes(int bytesToRead) throws EOFException {
+        int bytesAvailable = length - offset;
+        if (bytesAvailable < bytesToRead) {
+            throw new EOFException("tried to read: " + bytesToRead + " bytes but only " + bytesAvailable + " remaining");
+        }
+    }
+
+    @Override
     public long skip(long n) throws IOException {
         final int skip = (int) Math.min(Integer.MAX_VALUE, n);
         final int numBytesSkipped =  Math.min(skip, length - offset);

--- a/core/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
@@ -115,7 +115,7 @@ final class BytesReferenceStreamInput extends StreamInput {
     }
 
     @Override
-    public void ensureCanReadBytes(int bytesToRead) throws EOFException {
+    protected void ensureCanReadBytes(int bytesToRead) throws EOFException {
         int bytesAvailable = length - offset;
         if (bytesAvailable < bytesToRead) {
             throw new EOFException("tried to read: " + bytesToRead + " bytes but only " + bytesAvailable + " remaining");

--- a/core/src/main/java/org/elasticsearch/common/io/stream/ByteBufferStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/ByteBufferStreamInput.java
@@ -87,6 +87,13 @@ public class ByteBufferStreamInput extends StreamInput {
     }
 
     @Override
+    public void ensureCanReadBytes(int length) throws EOFException {
+        if (buffer.remaining() < length) {
+            throw new EOFException("tried to read: " + length + " bytes but only " + buffer.remaining() + " remaining");
+        }
+    }
+
+    @Override
     public void mark(int readlimit) {
         buffer.mark();
     }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/ByteBufferStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/ByteBufferStreamInput.java
@@ -87,7 +87,7 @@ public class ByteBufferStreamInput extends StreamInput {
     }
 
     @Override
-    public void ensureCanReadBytes(int length) throws EOFException {
+    protected void ensureCanReadBytes(int length) throws EOFException {
         if (buffer.remaining() < length) {
             throw new EOFException("tried to read: " + length + " bytes but only " + buffer.remaining() + " remaining");
         }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.io.stream;
 
 import org.elasticsearch.Version;
 
+import java.io.EOFException;
 import java.io.IOException;
 
 /**
@@ -72,5 +73,10 @@ public abstract class FilterStreamInput extends StreamInput {
     @Override
     public void setVersion(Version version) {
         delegate.setVersion(version);
+    }
+
+    @Override
+    public void ensureCanReadBytes(int length) throws EOFException {
+        delegate.ensureCanReadBytes(length);
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
@@ -76,7 +76,7 @@ public abstract class FilterStreamInput extends StreamInput {
     }
 
     @Override
-    public void ensureCanReadBytes(int length) throws EOFException {
+    protected void ensureCanReadBytes(int length) throws EOFException {
         delegate.ensureCanReadBytes(length);
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  */
 public abstract class FilterStreamInput extends StreamInput {
 
-    private final StreamInput delegate;
+    protected final StreamInput delegate;
 
     protected FilterStreamInput(StreamInput delegate) {
         this.delegate = delegate;

--- a/core/src/main/java/org/elasticsearch/common/io/stream/InputStreamStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/InputStreamStreamInput.java
@@ -97,7 +97,7 @@ public class InputStreamStreamInput extends StreamInput {
     }
 
     @Override
-    public void ensureCanReadBytes(int length) throws EOFException {
+    protected void ensureCanReadBytes(int length) throws EOFException {
         // TODO what can we do here?
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/InputStreamStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/InputStreamStreamInput.java
@@ -95,4 +95,9 @@ public class InputStreamStreamInput extends StreamInput {
     public long skip(long n) throws IOException {
         return is.skip(n);
     }
+
+    @Override
+    public void ensureCanReadBytes(int length) throws EOFException {
+        // TODO what can we do here?
+    }
 }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -28,7 +28,6 @@ import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CharsRef;
-import org.apache.lucene.util.CharsRefBuilder;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
@@ -113,7 +112,7 @@ public abstract class StreamInput extends InputStream {
      * bytes of the stream.
      */
     public BytesReference readBytesReference() throws IOException {
-        int length = readVInt();
+        int length = readArraySize();
         return readBytesReference(length);
     }
 
@@ -145,7 +144,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     public BytesRef readBytesRef() throws IOException {
-        int length = readVInt();
+        int length = readArraySize();
         return readBytesRef(length);
     }
 
@@ -332,7 +331,7 @@ public abstract class StreamInput extends InputStream {
     public String readString() throws IOException {
         // TODO it would be nice to not call readByte() for every character but we don't know how much to read up-front
         // we can make the loop much more complicated but that won't buy us much compared to the bounds checks in readByte()
-        final int charCount = readVInt();
+        final int charCount = readArraySize();
         if (spare.chars.length < charCount) {
             // we don't use ArrayUtils.grow since there is no need to copy the array
             spare.chars = new char[ArrayUtil.oversize(charCount, Character.BYTES)];
@@ -412,7 +411,7 @@ public abstract class StreamInput extends InputStream {
     public abstract int available() throws IOException;
 
     public String[] readStringArray() throws IOException {
-        int size = readVInt();
+        int size = readArraySize();
         if (size == 0) {
             return Strings.EMPTY_ARRAY;
         }
@@ -432,7 +431,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     public <K, V> Map<K, V> readMap(Writeable.Reader<K> keyReader, Writeable.Reader<V> valueReader) throws IOException {
-        int size = readVInt();
+        int size = readArraySize();
         Map<K, V> map = new HashMap<>(size);
         for (int i = 0; i < size; i++) {
             K key = keyReader.read(this);
@@ -454,7 +453,7 @@ public abstract class StreamInput extends InputStream {
      */
     public <K, V> Map<K, List<V>> readMapOfLists(final Writeable.Reader<K> keyReader, final Writeable.Reader<V> valueReader)
             throws IOException {
-        final int size = readVInt();
+        final int size = readArraySize();
         if (size == 0) {
             return Collections.emptyMap();
         }
@@ -531,7 +530,7 @@ public abstract class StreamInput extends InputStream {
 
     @SuppressWarnings("unchecked")
     private List readArrayList() throws IOException {
-        int size = readVInt();
+        int size = readArraySize();
         List list = new ArrayList(size);
         for (int i = 0; i < size; i++) {
             list.add(readGenericValue());
@@ -545,7 +544,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     private Object[] readArray() throws IOException {
-        int size8 = readVInt();
+        int size8 = readArraySize();
         Object[] list8 = new Object[size8];
         for (int i = 0; i < size8; i++) {
             list8[i] = readGenericValue();
@@ -554,7 +553,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     private Map readLinkedHashMap() throws IOException {
-        int size9 = readVInt();
+        int size9 = readArraySize();
         Map map9 = new LinkedHashMap(size9);
         for (int i = 0; i < size9; i++) {
             map9.put(readString(), readGenericValue());
@@ -563,7 +562,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     private Map readHashMap() throws IOException {
-        int size10 = readVInt();
+        int size10 = readArraySize();
         Map map10 = new HashMap(size10);
         for (int i = 0; i < size10; i++) {
             map10.put(readString(), readGenericValue());
@@ -600,7 +599,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     public int[] readIntArray() throws IOException {
-        int length = readVInt();
+        int length = readArraySize();
         int[] values = new int[length];
         for (int i = 0; i < length; i++) {
             values[i] = readInt();
@@ -609,7 +608,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     public int[] readVIntArray() throws IOException {
-        int length = readVInt();
+        int length = readArraySize();
         int[] values = new int[length];
         for (int i = 0; i < length; i++) {
             values[i] = readVInt();
@@ -618,7 +617,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     public long[] readLongArray() throws IOException {
-        int length = readVInt();
+        int length = readArraySize();
         long[] values = new long[length];
         for (int i = 0; i < length; i++) {
             values[i] = readLong();
@@ -627,7 +626,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     public long[] readVLongArray() throws IOException {
-        int length = readVInt();
+        int length = readArraySize();
         long[] values = new long[length];
         for (int i = 0; i < length; i++) {
             values[i] = readVLong();
@@ -636,7 +635,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     public float[] readFloatArray() throws IOException {
-        int length = readVInt();
+        int length = readArraySize();
         float[] values = new float[length];
         for (int i = 0; i < length; i++) {
             values[i] = readFloat();
@@ -645,7 +644,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     public double[] readDoubleArray() throws IOException {
-        int length = readVInt();
+        int length = readArraySize();
         double[] values = new double[length];
         for (int i = 0; i < length; i++) {
             values[i] = readDouble();
@@ -654,14 +653,14 @@ public abstract class StreamInput extends InputStream {
     }
 
     public byte[] readByteArray() throws IOException {
-        final int length = readVInt();
+        final int length = readArraySize();
         final byte[] bytes = new byte[length];
         readBytes(bytes, 0, bytes.length);
         return bytes;
     }
 
     public <T> T[] readArray(Writeable.Reader<T> reader, IntFunction<T[]> arraySupplier) throws IOException {
-        int length = readVInt();
+        int length = readArraySize();
         T[] values = arraySupplier.apply(length);
         for (int i = 0; i < length; i++) {
             values[i] = reader.read(this);
@@ -833,7 +832,7 @@ public abstract class StreamInput extends InputStream {
      * @throws IOException if any step fails
      */
     public <T extends Streamable> List<T> readStreamableList(Supplier<T> constructor) throws IOException {
-        int count = readVInt();
+        int count = readArraySize();
         List<T> builder = new ArrayList<>(count);
         for (int i=0; i<count; i++) {
             T instance = constructor.get();
@@ -847,7 +846,7 @@ public abstract class StreamInput extends InputStream {
      * Reads a list of objects
      */
     public <T> List<T> readList(Writeable.Reader<T> reader) throws IOException {
-        int count = readVInt();
+        int count = readArraySize();
         List<T> builder = new ArrayList<>(count);
         for (int i=0; i<count; i++) {
             builder.add(reader.read(this));
@@ -859,7 +858,7 @@ public abstract class StreamInput extends InputStream {
      * Reads a list of {@link NamedWriteable}s.
      */
     public <T extends NamedWriteable> List<T> readNamedWriteableList(Class<T> categoryClass) throws IOException {
-        int count = readVInt();
+        int count = readArraySize();
         List<T> builder = new ArrayList<>(count);
         for (int i=0; i<count; i++) {
             builder.add(readNamedWriteable(categoryClass));
@@ -874,5 +873,30 @@ public abstract class StreamInput extends InputStream {
     public static StreamInput wrap(byte[] bytes, int offset, int length) {
         return new InputStreamStreamInput(new ByteArrayInputStream(bytes, offset, length));
     }
+
+    /**
+     * Reads a vint via {@link #readVInt()} and applies basic checks to ensure the read array size is sane.
+     * This method uses {@link #ensureCanReadBytes(int)} to ensure this stream has enough bytes to read for the read array size.
+     */
+    private int readArraySize() throws IOException {
+        final int arraySize = readVInt();
+        if (arraySize > ArrayUtil.MAX_ARRAY_LENGTH) {
+            throw new IllegalStateException("array length must be <= to " + ArrayUtil.MAX_ARRAY_LENGTH  + " but was: " + arraySize);
+        }
+        if (arraySize < 0) {
+            throw new NegativeArraySizeException("array size must be positive but was: " + arraySize);
+        }
+        // lets do a sanity check that if we are reading an array size that is bigger that the remaining bytes we can safely
+        // throw an exception instead of allocating the array based on the size. A simple corrutpted byte can make a node go OOM
+        // if the size is large and for perf reasons we allocate arrays ahead of time
+        ensureCanReadBytes(arraySize);
+        return arraySize;
+    }
+
+    /**
+     * This method throws an {@link EOFException} iff the given number of bytes can not be read from the this stream. This method might
+     * be a no-op depending on the underlying implementation if the information of the remaining bytes is not present.
+     */
+    public abstract void ensureCanReadBytes(int length) throws EOFException;
 
 }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -897,6 +897,6 @@ public abstract class StreamInput extends InputStream {
      * This method throws an {@link EOFException} if the given number of bytes can not be read from the this stream. This method might
      * be a no-op depending on the underlying implementation if the information of the remaining bytes is not present.
      */
-    public abstract void ensureCanReadBytes(int length) throws EOFException;
+    protected abstract void ensureCanReadBytes(int length) throws EOFException;
 
 }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -894,7 +894,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
-     * This method throws an {@link EOFException} iff the given number of bytes can not be read from the this stream. This method might
+     * This method throws an {@link EOFException} if the given number of bytes can not be read from the this stream. This method might
      * be a no-op depending on the underlying implementation if the information of the remaining bytes is not present.
      */
     public abstract void ensureCanReadBytes(int length) throws EOFException;

--- a/core/src/main/java/org/elasticsearch/index/translog/BufferedChecksumStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/BufferedChecksumStreamInput.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.translog;
 import org.apache.lucene.store.BufferedChecksum;
 import org.elasticsearch.common.io.stream.StreamInput;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
@@ -121,5 +122,10 @@ public final class BufferedChecksumStreamInput extends StreamInput {
 
     public void resetDigest() {
         digest.reset();
+    }
+
+    @Override
+    public void ensureCanReadBytes(int length) throws EOFException {
+        in.ensureCanReadBytes(length);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/translog/BufferedChecksumStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/BufferedChecksumStreamInput.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.translog;
 
 import org.apache.lucene.store.BufferedChecksum;
+import org.elasticsearch.common.io.stream.FilterStreamInput;
 import org.elasticsearch.common.io.stream.StreamInput;
 
 import java.io.EOFException;
@@ -31,19 +32,18 @@ import java.util.zip.Checksum;
  * Similar to Lucene's BufferedChecksumIndexInput, however this wraps a
  * {@link StreamInput} so anything read will update the checksum
  */
-public final class BufferedChecksumStreamInput extends StreamInput {
+public final class BufferedChecksumStreamInput extends FilterStreamInput {
     private static final int SKIP_BUFFER_SIZE = 1024;
     private byte[] skipBuffer;
-    private final StreamInput in;
     private final Checksum digest;
 
     public BufferedChecksumStreamInput(StreamInput in) {
-        this.in = in;
+        super(in);
         this.digest = new BufferedChecksum(new CRC32());
     }
 
     public BufferedChecksumStreamInput(StreamInput in, BufferedChecksumStreamInput reuse) {
-        this.in = in;
+        super(in);
         if (reuse == null ) {
             this.digest = new BufferedChecksum(new CRC32());
         } else {
@@ -59,20 +59,20 @@ public final class BufferedChecksumStreamInput extends StreamInput {
 
     @Override
     public byte readByte() throws IOException {
-        final byte b = in.readByte();
+        final byte b = delegate.readByte();
         digest.update(b);
         return b;
     }
 
     @Override
     public void readBytes(byte[] b, int offset, int len) throws IOException {
-        in.readBytes(b, offset, len);
+        delegate.readBytes(b, offset, len);
         digest.update(b, offset, len);
     }
 
     @Override
     public void reset() throws IOException {
-        in.reset();
+        delegate.reset();
         digest.reset();
     }
 
@@ -82,13 +82,8 @@ public final class BufferedChecksumStreamInput extends StreamInput {
     }
 
     @Override
-    public void close() throws IOException {
-        in.close();
-    }
-
-    @Override
     public boolean markSupported() {
-        return in.markSupported();
+        return delegate.markSupported();
     }
 
 
@@ -110,22 +105,14 @@ public final class BufferedChecksumStreamInput extends StreamInput {
         return skipped;
     }
 
-    @Override
-    public int available() throws IOException {
-        return in.available();
-    }
 
     @Override
     public synchronized void mark(int readlimit) {
-        in.mark(readlimit);
+        delegate.mark(readlimit);
     }
 
     public void resetDigest() {
         digest.reset();
     }
 
-    @Override
-    public void ensureCanReadBytes(int length) throws EOFException {
-        in.ensureCanReadBytes(length);
-    }
 }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/ByteBufStreamInput.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/ByteBufStreamInput.java
@@ -24,6 +24,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 
+import java.io.EOFException;
 import java.io.IOException;
 
 /**
@@ -65,6 +66,14 @@ class ByteBufStreamInput extends StreamInput {
     @Override
     public int available() throws IOException {
         return endIndex - buffer.readerIndex();
+    }
+
+    @Override
+    public void ensureCanReadBytes(int length) throws EOFException {
+        int bytesAvailable = endIndex - buffer.readerIndex();
+        if (bytesAvailable < length) {
+            throw new EOFException("tried to read: " + length + " bytes but only " + bytesAvailable + " remaining");
+        }
     }
 
     @Override

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/ByteBufStreamInput.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/ByteBufStreamInput.java
@@ -69,7 +69,7 @@ class ByteBufStreamInput extends StreamInput {
     }
 
     @Override
-    public void ensureCanReadBytes(int length) throws EOFException {
+    protected void ensureCanReadBytes(int length) throws EOFException {
         int bytesAvailable = endIndex - buffer.readerIndex();
         if (bytesAvailable < length) {
             throw new EOFException("tried to read: " + length + " bytes but only " + bytesAvailable + " remaining");


### PR DESCRIPTION
Today we read a vint from the stream to allocate the size of an array up-front
before we start reading the values. This can be dangerous if for instance we read
from a corrupted stream or if some manipulated bytes are send for instance from
an attacker or a fuzzer. In most of the cases we can apply some best effort and
validate the array size to be _sane_ by ensuring we can at read at least N bytes
where N is the expected size of the array.