### PR TITLE
Add indices options tests to search api REST tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/80_date_math_index_names.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/80_date_math_index_names.yaml
@@ -1,7 +1,0 @@
----
-"Missing index with catch":
-
-  - do:
-      catch:   /logstash-\d{4}\.\d{2}\.\d{2}/
-      search:
-        index: <logstash-{now/M}>

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/80_indices_options.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/80_indices_options.yaml
@@ -1,0 +1,63 @@
+---
+"Missing index date math with catch":
+
+  - do:
+      catch:   /logstash-\d{4}\.\d{2}\.\d{2}/
+      search:
+        index: <logstash-{now/M}>
+
+---
+"Missing index":
+
+  - do:
+      catch:   missing
+      search:
+        index: missing_index
+
+  - do:
+      search:
+        index: missing_index
+        ignore_unavailable: true
+
+  - match: {hits.total: 0}
+
+---
+"Closed index":
+
+  - do:
+      indices.create:
+          index:  index_closed
+
+  - do:
+      indices.close:
+          index:  index_closed
+
+  - do:
+      catch:  /index_closed_exception/
+      search:
+        index: index_closed
+
+  - do:
+      search:
+        index: index_closed
+        ignore_unavailable: true
+
+  - match: {hits.total: 0}
+
+  - do:
+      search:
+        index: index*
+
+  - match: {hits.total: 0}
+
+  - do:
+      catch: missing
+      search:
+        index: index*
+        allow_no_indices: false
+
+  - do:
+      catch:  /index_closed_exception/
+      search:
+        index: index*
+        expand_wildcards: ["open","closed"]


### PR DESCRIPTION
This is a followup to #21689 where we removed a misplaced try catch for IndexMissingException and IndexClosedException which was related to #9047 (at least for the index closed case). The code block within the change was moved as part of #20890, which made the catch redundant. It was somehow used before (e.g. in 5.0) but it doesn't seem that this catch had any effect. Added tests to verify that. In fact a specific catch added to the search api only would defeat the purpose of having common indices options that work throughout all our APIs.

Relates to #21689