### PR TITLE
add section header to systemd unit extension

### DIFF
--- a/docs/reference/setup/sysconfig/configuring.asciidoc
+++ b/docs/reference/setup/sysconfig/configuring.asciidoc
@@ -98,6 +98,7 @@ any changes in that file, such as:
 
 [source,sh]
 ---------------------------------
+[Service]
 LimitMEMLOCK=infinity
 ---------------------------------
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?

Without [Service] in the /etc/systemd/system/elasticsearch.service.d/elasticsearch.conf file the following error is shown and the setting is not used:
````
Nov 21 14:14:03 es50-eb-5bj1g-1 systemd[1]: [/etc/systemd/system/elasticsearch.service.d/elasticsearch.conf:1] Assignment outside of section. Ignoring.
````