### PR TITLE
Pluggable rescorers

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/SearchPlugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/SearchPlugin.java
@@ -48,6 +48,9 @@ import org.elasticsearch.search.aggregations.pipeline.movavg.MovAvgPipelineAggre
 import org.elasticsearch.search.aggregations.pipeline.movavg.models.MovAvgModel;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.subphase.highlight.Highlighter;
+import org.elasticsearch.search.rescore.Rescorer;
+import org.elasticsearch.search.rescore.RescoreBuilder;
+import org.elasticsearch.search.rescore.RescoreParser;
 import org.elasticsearch.search.suggest.Suggester;
 import org.elasticsearch.search.suggest.SuggestionBuilder;
 
@@ -112,6 +115,12 @@ public interface SearchPlugin {
      * The new {@link Query}s defined by this plugin.
      */
     default List<QuerySpec<?>> getQueries() {
+        return emptyList();
+    }
+    /**
+     * The new {@link Rescorer}s defined by this plugin.
+     */
+    default List<RescoreSpec<?>> getRescorers() {
         return emptyList();
     }
     /**
@@ -212,6 +221,19 @@ public interface SearchPlugin {
             super(name, reader, parser);
         }
     }
+    /**
+     * Specification of custom {@link Rescorer}.
+     */
+    class RescoreSpec<T extends RescoreBuilder<T>> extends SearchExtensionSpec<T, RescoreParser<T>> {
+        public RescoreSpec(ParseField name, Writeable.Reader<T> reader, RescoreParser<T> parser) {
+            super(name, reader, parser);
+        }
+
+        public RescoreSpec(String name, Writeable.Reader<T> reader, RescoreParser<T> parser) {
+            super(name, reader, parser);
+        }
+    }
+
     /**
      * Specification for an {@link Aggregation}.
      */

--- a/core/src/main/java/org/elasticsearch/search/rescore/QueryRescorerBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/rescore/QueryRescorerBuilder.java
@@ -165,7 +165,7 @@ public class QueryRescorerBuilder extends RescoreBuilder<QueryRescorerBuilder> {
     }
 
     @Override
-    public QueryRescoreContext build(QueryShardContext context) throws IOException {
+    public RescoreSearchContext build(QueryShardContext context) throws IOException {
         org.elasticsearch.search.rescore.QueryRescorer rescorer = new org.elasticsearch.search.rescore.QueryRescorer();
         QueryRescoreContext queryRescoreContext = new QueryRescoreContext(rescorer);
         queryRescoreContext.setQuery(QueryBuilder.rewriteQuery(this.queryBuilder, context).toQuery(context));

--- a/core/src/main/java/org/elasticsearch/search/rescore/RescoreBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/rescore/RescoreBuilder.java
@@ -91,12 +91,7 @@ public abstract class RescoreBuilder<RB extends RescoreBuilder<RB>> extends ToXC
                     throw new ParsingException(parser.getTokenLocation(), "rescore doesn't support [" + fieldName + "]");
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
-                // we only have QueryRescorer at this point
-                if (QueryRescorerBuilder.NAME.equals(fieldName)) {
-                    rescorer = QueryRescorerBuilder.fromXContent(parseContext);
-                } else {
-                    throw new ParsingException(parser.getTokenLocation(), "rescore doesn't support rescorer with name [" + fieldName + "]");
-                }
+                rescorer = parser.namedObject(RescoreBuilder.class, fieldName, parseContext);
             } else {
                 throw new ParsingException(parser.getTokenLocation(), "unexpected token [" + token + "] after [" + fieldName + "]");
             }
@@ -123,7 +118,7 @@ public abstract class RescoreBuilder<RB extends RescoreBuilder<RB>> extends ToXC
 
     protected abstract void doXContent(XContentBuilder builder, Params params) throws IOException;
 
-    public abstract QueryRescoreContext build(QueryShardContext context) throws IOException;
+    public abstract RescoreSearchContext build(QueryShardContext context) throws IOException;
 
     public static QueryRescorerBuilder queryRescorer(QueryBuilder queryBuilder) {
         return new QueryRescorerBuilder(queryBuilder);

--- a/core/src/main/java/org/elasticsearch/search/rescore/RescoreParser.java
+++ b/core/src/main/java/org/elasticsearch/search/rescore/RescoreParser.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.rescore;
+
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.index.query.QueryParseContext;
+
+import java.io.IOException;
+
+/**
+ * Parses XContent into a {@link RescoreBuilder}.
+ */
+@FunctionalInterface
+public interface RescoreParser<RB extends RescoreBuilder<RB>> {
+    RB fromXContent(QueryParseContext parseContext) throws IOException, ParsingException;
+}

--- a/core/src/test/java/org/elasticsearch/search/rescore/QueryRescoreBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/rescore/QueryRescoreBuilderTests.java
@@ -148,7 +148,7 @@ public class QueryRescoreBuilderTests extends ESTestCase {
 
         for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
             QueryRescorerBuilder rescoreBuilder = randomRescoreBuilder();
-            QueryRescoreContext rescoreContext = rescoreBuilder.build(mockShardContext);
+            QueryRescoreContext rescoreContext = (QueryRescoreContext) rescoreBuilder.build(mockShardContext);
             int expectedWindowSize = rescoreBuilder.windowSize() == null ? QueryRescoreContext.DEFAULT_WINDOW_SIZE :
                 rescoreBuilder.windowSize().intValue();
             assertEquals(expectedWindowSize, rescoreContext.window());
@@ -179,7 +179,7 @@ public class QueryRescoreBuilderTests extends ESTestCase {
             RescoreBuilder.parseFromXContent(context);
             fail("expected a parsing exception");
         } catch (ParsingException e) {
-            assertEquals("rescore doesn't support rescorer with name [bad_rescorer_name]", e.getMessage());
+            assertEquals("Unknown RescoreBuilder [bad_rescorer_name]", e.getMessage());
         }
 
         rescoreElement = "{\n" +

--- a/core/src/test/java/org/elasticsearch/search/rescore/RescorePluginIT.java
+++ b/core/src/test/java/org/elasticsearch/search/rescore/RescorePluginIT.java
@@ -1,0 +1,342 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.rescore;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SearchPlugin;
+import org.elasticsearch.plugins.SearchPlugin.RescoreSpec;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
+import org.elasticsearch.test.ESIntegTestCase.Scope;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
+
+import static org.elasticsearch.client.Requests.indexRequest;
+import static org.elasticsearch.client.Requests.searchRequest;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import static java.util.Collections.singletonList;
+
+@ClusterScope(scope = Scope.SUITE, supportsDedicatedMasters = false, numDataNodes = 1)
+public class RescorePluginIT extends ESIntegTestCase {
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(CustomRescorePlugin.class);
+    }
+
+    public void testRescorePlugin() throws IOException {
+        client().admin()
+                .indices()
+                .prepareCreate("test")
+                .setSettings(SETTING_NUMBER_OF_SHARDS, 1)
+                .addMapping(
+                        "post",
+                        jsonBuilder()
+                        .startObject().startObject("post").startObject("properties")
+                        .startObject("title")
+                                .field("type", "text")
+                        .endObject()
+                        .endObject().endObject().endObject())
+                .execute()
+                .actionGet();
+        client().admin().cluster()
+                .prepareHealth()
+                .setWaitForEvents(Priority.LANGUID)
+                .setWaitForYellowStatus()
+                .execute()
+                .actionGet();
+
+        client().index(indexRequest("test").type("post").id("1").source(
+                        jsonBuilder()
+                        .startObject()
+                                .field("title", "The quick brown")
+                        .endObject()))
+                .actionGet();
+        client().index(indexRequest("test").type("post").id("2").source(
+                        jsonBuilder()
+                        .startObject()
+                                .field("title", "quick brown fox")
+                        .endObject()))
+                .actionGet();
+
+        client().admin().indices().prepareRefresh().execute().actionGet();
+
+        ActionFuture<SearchResponse> response;
+        SearchResponse resp;
+        SearchHits hits;
+
+        response = client().search(
+                searchRequest()
+                .searchType(SearchType.QUERY_THEN_FETCH)
+                .source(
+                        searchSource()
+                        .addRescorer(new DummyRescorerBuilder(4.0f))
+                        .explain(false)));
+
+        resp = response.actionGet();
+        ElasticsearchAssertions.assertNoFailures(resp);
+        hits = resp.getHits();
+
+        assertThat(hits.getHits().length, equalTo(2));
+        assertThat(hits.getMaxScore(), equalTo(4.0f));
+        assertThat(hits.getAt(0).getScore(), equalTo(4.0f));
+        assertThat(hits.getAt(1).getScore(), equalTo(4.0f));
+
+        response = client().search(
+                searchRequest()
+                .searchType(SearchType.QUERY_THEN_FETCH)
+                .source(
+                        searchSource()
+                        .addRescorer(new DummyRescorerBuilder(4.0f)
+                                .windowSize(1))
+                        .explain(true)));
+
+        resp = response.actionGet();
+        ElasticsearchAssertions.assertNoFailures(resp);
+        hits = resp.getHits();
+
+        assertThat(hits.getHits().length, equalTo(2));
+        assertThat(hits.getMaxScore(), equalTo(4.0f));
+        SearchHit hit = hits.getAt(0);
+        logger.info("Hit[0]: {}, Score: {},\nExplanation: {}",
+                    hit.getId(), hit.getScore(), hit.getExplanation());
+        assertThat(hit.getScore(), equalTo(4.0f));
+        assertThat(hit.getExplanation().getDetails()[1].toString(), equalTo("4.0 = weight\n"));
+        hit = hits.getAt(1);
+        logger.info("Hit[1]: {}, Score: {},\nExplanation: {}",
+                    hit.getId(), hit.getScore(), hit.getExplanation());
+        assertThat(hits.getAt(1).getScore(), equalTo(1.0f));
+        // rescore explanation considers top hits behind window size were rescored
+        assertThat(hit.getExplanation().getDetails()[1].toString(), equalTo("4.0 = weight\n"));
+    }
+
+    public static class CustomRescorePlugin extends Plugin implements SearchPlugin {
+        @Override
+        public List<RescoreSpec<?>> getRescorers() {
+            return singletonList(new RescoreSpec(
+                    DummyRescorerBuilder.NAME,
+                    DummyRescorerBuilder::new,
+                    DummyRescorerBuilder.PARSER));
+        }
+    }
+
+    public static class DummyRescorerBuilder extends RescoreBuilder<DummyRescorerBuilder> {
+        public static final String NAME = "dummy";
+        public static final RescoreParser<DummyRescorerBuilder> PARSER = new DummyRescorerParser(
+                DummyRescorerBuilder::new);
+
+        public static final float DEFAULT_WEIGHT = 1.0f;
+        private float weight = DEFAULT_WEIGHT;
+
+        public DummyRescorerBuilder(float weight) {
+            this.weight = weight;
+        }
+
+        public DummyRescorerBuilder(StreamInput in) throws IOException {
+            super(in);
+            weight = in.readFloat();
+        }
+
+        @Override
+        public void doWriteTo(StreamOutput out) throws IOException {
+            out.writeFloat(weight);
+        }
+
+        public DummyRescorerBuilder setWeight(float weight) {
+            this.weight = weight;
+            return this;
+        }
+
+        public float getWeight() {
+            return this.weight;
+        }
+
+        @Override
+        public void doXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject(NAME);
+            builder.field("weight", weight);
+            builder.endObject();
+        }
+
+        @Override
+        public RescoreSearchContext build(QueryShardContext context) throws IOException {
+            DummyRescoreContext dummyRescoreCtx = new DummyRescoreContext(DummyRescorer.INSTANCE);
+            dummyRescoreCtx.setWeight(weight);
+            if (windowSize != null) {
+                dummyRescoreCtx.setWindowSize(windowSize);
+            }
+            return dummyRescoreCtx;
+        }
+
+        @Override
+        public String getWriteableName() {
+            return NAME;
+        }
+    }
+
+    public static final class DummyRescorer implements Rescorer {
+        public static final String NAME = "dummy";
+        public static final DummyRescorer INSTANCE = new DummyRescorer();
+
+        @Override
+        public String name() {
+            return NAME;
+        }
+
+        @Override
+        public TopDocs rescore(TopDocs topDocs,
+                               SearchContext context,
+                               RescoreSearchContext rescoreContext)
+            throws IOException
+        {
+            assert rescoreContext != null;
+            if (topDocs == null || topDocs.totalHits == 0 || topDocs.scoreDocs.length == 0) {
+                return topDocs;
+            }
+
+            DummyRescoreContext rescoreCtx = (DummyRescoreContext) rescoreContext;
+            int windowSize = Math.min(rescoreCtx.window(), topDocs.scoreDocs.length);
+            for (int i = 0; i < windowSize; i++) {
+                // Just multiply score by weight
+                topDocs.scoreDocs[i].score *= rescoreCtx.weight;
+            }
+
+            topDocs.setMaxScore(topDocs.scoreDocs[0].score);
+            return topDocs;
+        }
+
+        @Override
+        public Explanation explain(int topLevelDocId,
+                                   SearchContext context,
+                                   RescoreSearchContext rescoreContext,
+                                   Explanation sourceExplanation)
+            throws IOException
+        {
+            DummyRescoreContext rescore = (DummyRescoreContext) rescoreContext;
+
+            if (sourceExplanation.isMatch()) {
+                return Explanation.match(
+                        sourceExplanation.getValue() * rescore.weight(),
+                        "product of:",
+                        sourceExplanation,
+                        Explanation.match(rescore.weight, "weight")
+                );
+            } else {
+                return sourceExplanation;
+            }
+        }
+
+        @Override
+        public void extractTerms(SearchContext context,
+                                 RescoreSearchContext rescoreContext,
+                                 Set<Term> termsSet) {
+        }
+    }
+
+    public static class DummyRescoreContext extends RescoreSearchContext {
+
+        static final int DEFAULT_WINDOW_SIZE = 10;
+
+        public DummyRescoreContext(DummyRescorer rescorer) {
+            super(DummyRescorerBuilder.NAME, DEFAULT_WINDOW_SIZE, rescorer);
+        }
+
+        private float weight = 1.0f;
+
+        public float weight() {
+            return weight;
+        }
+
+        public void setWeight(float weight) {
+            this.weight = weight;
+        }
+    }
+
+    public static class DummyRescorerParser implements RescoreParser<DummyRescorerBuilder> {
+        private static final ParseField WEIGHT_FIELD = new ParseField("weight");
+
+        private final Function<Float, DummyRescorerBuilder> builder;
+
+        public DummyRescorerParser(Function<Float, DummyRescorerBuilder> builder) {
+            this.builder = builder;
+        }
+
+        @Override
+        public DummyRescorerBuilder fromXContent(QueryParseContext parseContext)
+            throws IOException, ParsingException
+        {
+            Float weight = null;
+            String fieldName = null;
+            XContentParser parser = parseContext.parser();
+            XContentParser.Token token;
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    fieldName = parser.currentName();
+                } else if (token.isValue()) {
+                    if (WEIGHT_FIELD.match(fieldName)) {
+                        weight = parser.floatValue();
+                    } else {
+                        throw new ParsingException(
+                            parser.getTokenLocation(),
+                            "dummy rescorer doesn't support [" + fieldName + "]");
+                    }
+                }
+            }
+
+            if (weight == null) {
+                throw new ParsingException(
+                    parser.getTokenLocation(), "dummy rescorer requires [weight] field");
+            }
+
+            return builder.apply(weight);
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/rescore/RescorePluginIT.java
+++ b/core/src/test/java/org/elasticsearch/search/rescore/RescorePluginIT.java
@@ -28,7 +28,6 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -85,27 +84,20 @@ public class RescorePluginIT extends ESIntegTestCase {
                                 .field("type", "text")
                         .endObject()
                         .endObject().endObject().endObject())
-                .execute()
-                .actionGet();
-        client().admin().cluster()
-                .prepareHealth()
-                .setWaitForEvents(Priority.LANGUID)
-                .setWaitForYellowStatus()
-                .execute()
-                .actionGet();
+                .get();
 
-        client().index(indexRequest("test").type("post").id("1").source(
+        client().prepareIndex("test", "post", "1").setSource(
                         jsonBuilder()
                         .startObject()
                                 .field("title", "The quick brown")
-                        .endObject()))
-                .actionGet();
-        client().index(indexRequest("test").type("post").id("2").source(
+                        .endObject())
+                .get();
+        client().prepareIndex("test", "post", "2").setSource(
                         jsonBuilder()
                         .startObject()
                                 .field("title", "quick brown fox")
-                        .endObject()))
-                .actionGet();
+                        .endObject())
+                .get();
 
         client().admin().indices().prepareRefresh().execute().actionGet();
 


### PR DESCRIPTION
Prerequisites: In our company we need specific scoring. We have a lot of suppliers with huge amount of goods. Some suppliers are "better" than others. But if supplier rank affects score, goods from top ranked supplier supersede goods from other suppliers. What we really want to get is:
```
product1 (supplier1)
product2 (supplier2)
product3 (supplier3)
product4 (supplier1)
product5 (supplier2)
...
```

The most suitable and simple way to do that is to write specific rescorer (the only requirement that all products from specific supplier should be located on the same shard). Thus we decided to make rescorers pluggable. There were an [issue](#17331) and a [discussion](https://discuss.elastic.co/t/how-to-plug-in-alternative-rescorer/11555) for this feature.
