### PR TITLE
Whitelist Class in painless and document it

### DIFF
--- a/docs/reference/modules/scripting.asciidoc
+++ b/docs/reference/modules/scripting.asciidoc
@@ -93,9 +93,10 @@ include::scripting/painless.asciidoc[]
 
 include::scripting/painless-syntax.asciidoc[]
 
+include::scripting/painless-debugging.asciidoc[]
+
 include::scripting/expression.asciidoc[]
 
 include::scripting/native.asciidoc[]
 
 include::scripting/advanced-scripting.asciidoc[]
-

--- a/docs/reference/modules/scripting/painless-debugging.asciidoc
+++ b/docs/reference/modules/scripting/painless-debugging.asciidoc
@@ -1,0 +1,113 @@
+[[modules-scripting-painless-debugging]]
+=== Painless Debugging
+
+experimental[The Painless scripting language is new and is still marked as experimental. The syntax or API may be changed in the future in non-backwards compatible ways if required.]
+
+==== Throwing Exceptions
+
+Painless doesn't have a
+https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop[REPL]
+and while it'd be nice for it to have one one day, it wouldn't tell you the
+whole story around debugging painless scripts embedded in Elasticsearch because
+the data that the scripts have access to or "context" is so important. For now
+the best way to debug embedded scripts is by throwing exceptions at choice
+places. For example, you can use the <<search-explain>> to explore the context
+available to a <<query-dsl-script-query>>.
+
+[source,js]
+---------------------------------------------------------
+PUT /hockey/player/1?refresh
+{"first":"johnny","last":"gaudreau","goals":[9,27,1],"assists":[17,46,0],"gp":[26,82,1]}
+
+POST /hockey/player/1/_explain
+{
+  "query": {
+    "script": {
+      "script": "throw new RuntimeException('doc.goals is a ' + doc.goals.class.name)"
+    }
+  }
+}
+---------------------------------------------------------
+// CONSOLE
+// TEST[catch:/runtime_exception/]
+
+Which shows that the class of `doc.first` is
+`org.elasticsearch.index.fielddata.ScriptDocValues.Longs` by responding with:
+
+[source,js]
+---------------------------------------------------------
+{
+   "error": {
+      "root_cause": ...,
+      "type": "script_exception",
+      "reason": "runtime error",
+      "caused_by": {
+         "type": "runtime_exception",
+         "reason": "doc.goals is a org.elasticsearch.index.fielddata.ScriptDocValues$Longs" <1>
+      },
+      ...
+   },
+   "status": 500
+}
+---------------------------------------------------------
+// TESTRESPONSE[s/"root_cause": \.\.\./"root_cause": $body.error.root_cause/]
+// TESTRESPONSE[s/\.\.\./"script_stack": $body.error.script_stack, "script": $body.error.script, "lang": $body.error.lang/]
+
+<1> This is the message in the exception.
+
+You can use the same trick to see that `_source` is a `Map` in the `_update`
+API:
+
+[source,js]
+---------------------------------------------------------
+POST /hockey/player/1/_update
+{
+  "script": "throw new RuntimeException('_source is a ' + ctx._source.class.name)"
+}
+---------------------------------------------------------
+// CONSOLE
+// TEST[continued catch:request]
+
+The response looks like:
+
+[source,js]
+---------------------------------------------------------
+{
+  "error" : {
+    "root_cause": ...,
+    "type": "illegal_argument_exception",
+    "reason": "failed to execute script",
+    "caused_by": {
+      "type": "script_exception",
+      "reason": "runtime error",
+      "caused_by": {
+        "type": "runtime_exception",
+        "reason": "_source is a java.util.LinkedHashMap" <1>
+      },
+      ...
+    }
+  },
+  "status": 400
+}
+---------------------------------------------------------
+// TESTRESPONSE[s/"root_cause": \.\.\./"root_cause": $body.error.root_cause/]
+// TESTRESPONSE[s/\.\.\./"script_stack": $body.error.caused_by.script_stack, "script": $body.error.caused_by.script, "lang": $body.error.caused_by.lang/]
+
+<1> This is the message in the exception.
+
+// TODO we should build some javadoc like mashup so people don't have to jump through these hoops.
+
+Once you have the class of an object you can go
+https://github.com/elastic/elasticsearch/tree/{branch}/modules/lang-painless/src/main/resources/org/elasticsearch/painless[here]
+and check the available methods. Painless uses a strict whitelist to prevent
+scripts that don't work well with Elasticsearch and all whitelisted methods
+are listed in a file named after the package of the object (everything before
+the last `.`). So `java.util.Map` is listed in a file named `java.util.txt`
+starting on the line that looks like `class Map -> java.util.Map {`.
+
+With the list of whitelisted methods in hand you can turn to either
+https://docs.oracle.com/javase/8/docs/api/[Javadoc],
+https://github.com/elastic/elasticsearch/tree/{branch}[Elasticsearch's source tree]
+or, for whitelisted methods ending in `*`, the
+https://github.com/elastic/elasticsearch/blob/{branch}/modules/lang-painless/src/main/java/org/elasticsearch/painless/Augmentation.java[Augmentation]
+class.

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.lang.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.lang.txt
@@ -454,6 +454,12 @@ class Character.UnicodeBlock -> java.lang.Character$UnicodeBlock extends Charact
   Character.UnicodeBlock of(int)
 }
 
+class Class -> java.lang.Class extends Object {
+  # We only allow innocuous things like toString and equals. No reflection
+  String getName()
+  String getSimpleName()
+}
+
 # Class: skipped for obvious reasons
 # ClassLoader: ...
 # ClassValue: ...
@@ -661,6 +667,7 @@ class Number -> java.lang.Number extends Object {
 }
 
 class Object -> java.lang.Object {
+  Class getClass()
   boolean equals(Object)
   int hashCode()
   String toString()
@@ -1101,4 +1108,3 @@ class UnsupportedOperationException -> java.lang.UnsupportedOperationException e
   UnsupportedOperationException <init>()
   UnsupportedOperationException <init>(String)
 }
-

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
@@ -174,7 +174,7 @@ public class WhenThingsGoWrongTests extends ScriptTestCase {
 
     public void testIllegalDynamicMethod() {
         IllegalArgumentException expected = expectScriptThrows(IllegalArgumentException.class, () -> {
-            exec("def x = 'test'; return x.getClass().toString()");
+            exec("def x = 'test'; return x.getClass().getClassLoader()");
         });
         assertTrue(expected.getMessage().contains("Unable to find dynamic method"));
     }


### PR DESCRIPTION
This whitelists `java.lang.Class`, `Class#getName` and
`Class#getSimpleName` and documents using `getName` to find the
class you are working with.

Closes #20263