### PR TITLE
Install a security manager on startup

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -33,6 +33,7 @@ import org.elasticsearch.node.NodeValidationException;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.security.Permission;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -69,6 +70,14 @@ class Elasticsearch extends SettingCommand {
      * Main entry point for starting elasticsearch
      */
     public static void main(final String[] args) throws Exception {
+        // we want the JVM to think there is a security manager installed so that if internal policy decisions that would be based on the
+        // presence of a security manager or lack thereof act as if there is a security manager present (e.g., DNS cache policy)
+        System.setSecurityManager(new SecurityManager() {
+            @Override
+            public void checkPermission(Permission perm) {
+                // grant all permissions so that we can later set the security manager to the one that we want
+            }
+        });
         final Elasticsearch elasticsearch = new Elasticsearch();
         int status = main(args, elasticsearch, Terminal.DEFAULT);
         if (status != ExitCodes.OK) {


### PR DESCRIPTION
When Elasticsearch starts, we go through some initialization before we
install a security manager. Yet, the JVM makes internal policy decisions
on the basis of whether or not a security manager is present. This
commit installs a security manager immediately on startup so that the
JVM always thinks a security manager is present when making such policy
decisions.