### PR TITLE
Refactor handling for bad default permissions

### DIFF
--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/ESPolicyUnitTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/ESPolicyUnitTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.bootstrap;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.FilePermission;
+import java.net.SocketPermission;
 import java.security.AllPermission;
 import java.security.CodeSource;
 import java.security.Permission;
@@ -36,7 +37,7 @@ import java.util.Collections;
  * we don't allow messing with the policy
  */
 public class ESPolicyUnitTests extends ESTestCase {
-    /** 
+    /**
      * Test policy with null codesource.
      * <p>
      * This can happen when restricting privileges with doPrivileged,
@@ -55,7 +56,7 @@ public class ESPolicyUnitTests extends ESTestCase {
         assertFalse(policy.implies(new ProtectionDomain(null, noPermissions), new FilePermission("foo", "read")));
     }
 
-    /** 
+    /**
      * test with null location
      * <p>
      * its unclear when/if this happens, see https://bugs.openjdk.java.net/browse/JDK-8129972
@@ -67,4 +68,15 @@ public class ESPolicyUnitTests extends ESTestCase {
         assertFalse(policy.implies(new ProtectionDomain(new CodeSource(null, (Certificate[]) null), noPermissions),
                 new FilePermission("foo", "read")));
     }
+
+    public void testListen() {
+        assumeTrue("test cannot run with security manager", System.getSecurityManager() == null);
+        final PermissionCollection noPermissions = new Permissions();
+        final ESPolicy policy = new ESPolicy(noPermissions, Collections.emptyMap(), true);
+        assertFalse(
+            policy.implies(
+                new ProtectionDomain(ESPolicyUnitTests.class.getProtectionDomain().getCodeSource(), noPermissions),
+                new SocketPermission("localhost:" + randomFrom(0, randomIntBetween(49152, 65535)), "listen")));
+    }
+
 }


### PR DESCRIPTION
This commit refactors the handling of bad default permissions that come
from the system security policy.

Relates #14704