### PR TITLE
Cluster search shards improvements: expose ShardId, adjust visibility of some members

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsGroup.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsGroup.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
@@ -50,12 +49,8 @@ public class ClusterSearchShardsGroup implements Streamable, ToXContent {
         return response;
     }
 
-    public String getIndex() {
-        return shardId.getIndexName();
-    }
-
-    public int getShardId() {
-        return shardId.id();
+    public ShardId getShardId() {
+        return shardId;
     }
 
     public ShardRouting[] getShards() {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsGroup.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsGroup.java
@@ -32,18 +32,18 @@ import java.io.IOException;
 public class ClusterSearchShardsGroup implements Streamable, ToXContent {
 
     private ShardId shardId;
-    ShardRouting[] shards;
+    private ShardRouting[] shards;
 
-    ClusterSearchShardsGroup() {
+    private ClusterSearchShardsGroup() {
 
     }
 
-    public ClusterSearchShardsGroup(ShardId shardId, ShardRouting[] shards) {
+    ClusterSearchShardsGroup(ShardId shardId, ShardRouting[] shards) {
         this.shardId = shardId;
         this.shards = shards;
     }
 
-    public static ClusterSearchShardsGroup readSearchShardsGroupResponse(StreamInput in) throws IOException {
+    static ClusterSearchShardsGroup readSearchShardsGroupResponse(StreamInput in) throws IOException {
         ClusterSearchShardsGroup response = new ClusterSearchShardsGroup();
         response.readFrom(in);
         return response;

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponse.java
@@ -43,8 +43,7 @@ public class ClusterSearchShardsResponse extends ActionResponse implements ToXCo
 
     }
 
-    ClusterSearchShardsResponse(ClusterSearchShardsGroup[] groups, DiscoveryNode[] nodes,
-                                       Map<String, AliasFilter> indicesAndFilters) {
+    ClusterSearchShardsResponse(ClusterSearchShardsGroup[] groups, DiscoveryNode[] nodes, Map<String, AliasFilter> indicesAndFilters) {
         this.groups = groups;
         this.nodes = nodes;
         this.indicesAndFilters = indicesAndFilters;

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponse.java
@@ -39,7 +39,7 @@ public class ClusterSearchShardsResponse extends ActionResponse implements ToXCo
     private DiscoveryNode[] nodes;
     private Map<String, AliasFilter> indicesAndFilters;
 
-    ClusterSearchShardsResponse() {
+    public ClusterSearchShardsResponse() {
 
     }
 

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponseTests.java
@@ -91,7 +91,6 @@ public class ClusterSearchShardsResponseTests extends ESTestCase {
                     ClusterSearchShardsGroup clusterSearchShardsGroup = clusterSearchShardsResponse.getGroups()[i];
                     ClusterSearchShardsGroup deserializedGroup = deserialized.getGroups()[i];
                     assertEquals(clusterSearchShardsGroup.getShardId(), deserializedGroup.getShardId());
-                    assertEquals(clusterSearchShardsGroup.getIndex(), deserializedGroup.getIndex());
                     assertArrayEquals(clusterSearchShardsGroup.getShards(), deserializedGroup.getShards());
                 }
                 if (version.onOrAfter(ClusterSearchShardsResponse.V_5_1_0_UNRELEASED)) {

--- a/core/src/test/java/org/elasticsearch/cluster/shards/ClusterSearchShardsIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/shards/ClusterSearchShardsIT.java
@@ -56,16 +56,16 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
         ensureGreen();
         ClusterSearchShardsResponse response = client().admin().cluster().prepareSearchShards("test").execute().actionGet();
         assertThat(response.getGroups().length, equalTo(1));
-        assertThat(response.getGroups()[0].getIndex(), equalTo("test"));
-        assertThat(response.getGroups()[0].getShardId(), equalTo(0));
+        assertThat(response.getGroups()[0].getShardId().getIndexName(), equalTo("test"));
+        assertThat(response.getGroups()[0].getShardId().getId(), equalTo(0));
         assertThat(response.getGroups()[0].getShards().length, equalTo(1));
         assertThat(response.getNodes().length, equalTo(1));
         assertThat(response.getGroups()[0].getShards()[0].currentNodeId(), equalTo(response.getNodes()[0].getId()));
 
         response = client().admin().cluster().prepareSearchShards("test").setRouting("A").execute().actionGet();
         assertThat(response.getGroups().length, equalTo(1));
-        assertThat(response.getGroups()[0].getIndex(), equalTo("test"));
-        assertThat(response.getGroups()[0].getShardId(), equalTo(0));
+        assertThat(response.getGroups()[0].getShardId().getIndexName(), equalTo("test"));
+        assertThat(response.getGroups()[0].getShardId().getId(), equalTo(0));
         assertThat(response.getGroups()[0].getShards().length, equalTo(1));
         assertThat(response.getNodes().length, equalTo(1));
         assertThat(response.getGroups()[0].getShards()[0].currentNodeId(), equalTo(response.getNodes()[0].getId()));
@@ -79,7 +79,7 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
 
         ClusterSearchShardsResponse response = client().admin().cluster().prepareSearchShards("test").execute().actionGet();
         assertThat(response.getGroups().length, equalTo(4));
-        assertThat(response.getGroups()[0].getIndex(), equalTo("test"));
+        assertThat(response.getGroups()[0].getShardId().getIndexName(), equalTo("test"));
         assertThat(response.getNodes().length, equalTo(1));
         assertThat(response.getGroups()[0].getShards()[0].currentNodeId(), equalTo(response.getNodes()[0].getId()));
 
@@ -88,7 +88,7 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
 
         response = client().admin().cluster().prepareSearchShards("test").setPreference("_shards:2").execute().actionGet();
         assertThat(response.getGroups().length, equalTo(1));
-        assertThat(response.getGroups()[0].getShardId(), equalTo(2));
+        assertThat(response.getGroups()[0].getShardId().getId(), equalTo(2));
     }
 
     public void testMultipleIndicesAllocation() throws Exception {
@@ -109,10 +109,10 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
         boolean seenTest1 = false;
         boolean seenTest2 = false;
         for (ClusterSearchShardsGroup group : response.getGroups()) {
-            if (group.getIndex().equals("test1")) {
+            if (group.getShardId().getIndexName().equals("test1")) {
                 seenTest1 = true;
                 assertThat(group.getShards().length, equalTo(2));
-            } else if (group.getIndex().equals("test2")) {
+            } else if (group.getShardId().getIndexName().equals("test2")) {
                 seenTest2 = true;
                 assertThat(group.getShards().length, equalTo(2));
             } else {


### PR DESCRIPTION
- ClusterSearchShardsGroup to return ShardId rather than the int shard id and index separately. ShardId also holds the Index object which holds the index uuid that is useful to retrieve in some cases
- Make ClusterSearchShardsResponse empty constructor public, otherwise the response cannot be created and read from the stream input unless done from the same package
- adjust visibility of ClusterSearchShards members: some could be private or package private rather than public
