### PR TITLE
Don't carry ShardRouting around when not needed in AbstractSearchAsyncAction

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -131,7 +131,7 @@ abstract class AbstractSearchAsyncAction<FirstResult extends SearchPhaseResult> 
                 sendExecuteFirstPhase(node, transportRequest , new ActionListener<FirstResult>() {
                         @Override
                         public void onResponse(FirstResult result) {
-                            onFirstPhaseResult(shardIndex, shard, result, shardIt);
+                            onFirstPhaseResult(shardIndex, shard.currentNodeId(), result, shardIt);
                         }
 
                         @Override
@@ -143,8 +143,8 @@ abstract class AbstractSearchAsyncAction<FirstResult extends SearchPhaseResult> 
         }
     }
 
-    void onFirstPhaseResult(int shardIndex, ShardRouting shard, FirstResult result, ShardIterator shardIt) {
-        result.shardTarget(new SearchShardTarget(shard.currentNodeId(), shard.index(), shard.id()));
+    private void onFirstPhaseResult(int shardIndex, String nodeId, FirstResult result, ShardIterator shardIt) {
+        result.shardTarget(new SearchShardTarget(nodeId, shardIt.shardId()));
         processFirstPhaseResult(shardIndex, result);
         // we need to increment successful ops first before we compare the exit condition otherwise if we
         // are fast we could concurrently update totalOps but then preempt one of the threads which can
@@ -173,11 +173,11 @@ abstract class AbstractSearchAsyncAction<FirstResult extends SearchPhaseResult> 
         }
     }
 
-    void onFirstPhaseResult(final int shardIndex, @Nullable ShardRouting shard, @Nullable String nodeId,
+    private void onFirstPhaseResult(final int shardIndex, @Nullable ShardRouting shard, @Nullable String nodeId,
                             final ShardIterator shardIt, Exception e) {
         // we always add the shard failure for a specific shard instance
         // we do make sure to clean it on a successful response from a shard
-        SearchShardTarget shardTarget = new SearchShardTarget(nodeId, shardIt.shardId().getIndex(), shardIt.shardId().getId());
+        SearchShardTarget shardTarget = new SearchShardTarget(nodeId, shardIt.shardId());
         addShardFailure(shardIndex, shardTarget, e);
 
         if (totalOps.incrementAndGet() == expectedTotalOps) {

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -871,7 +871,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         ShardId shardId = shardStatus.key;
                         ShardSnapshotStatus status = shardStatus.value;
                         if (status.state().failed()) {
-                            failures.add(new ShardSearchFailure(status.reason(), new SearchShardTarget(status.nodeId(), shardId.getIndex(), shardId.id())));
+                            failures.add(new ShardSearchFailure(status.reason(), new SearchShardTarget(status.nodeId(), shardId)));
                             shardFailures.add(new SnapshotShardFailure(status.nodeId(), shardId, status.reason()));
                         }
                     }


### PR DESCRIPTION
This PR replaces the `ShardRouting` argument in `AbstractSearchAsyncAction#onFirstPhaseResult` with the more contained `String nodeId` argument, as that is the only info retrieved from it. The `ShardId` can also be read directly from the `ShardIterator` that's already provided as an argument, plus there is no need to create new instances of `ShardId` by providing the index and the int shard_id separately, the whole `ShardId` should be passed around when possible.

The `SearchShardTarget` constructor that takes shard_id and index separately stays only for testing purposes.