### PR TITLE
Improve handling of unreleased versions

### DIFF
--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -49,9 +49,8 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_UUID_NA_VAL
  */
 public class ElasticsearchException extends RuntimeException implements ToXContent, Writeable {
 
-    public static final Version V_5_1_0_UNRELEASED = Version.fromId(5010099);
-    public static final Version V_5_0_2_UNRELEASED = Version.fromId(5000299);
-    public static final Version UNKNOWN_VERSION_ADDED = Version.fromId(0);
+    static final Version UNKNOWN_VERSION_ADDED = Version.fromId(0);
+
     /**
      * Passed in the {@link Params} of {@link #toXContent(XContentBuilder, org.elasticsearch.common.xcontent.ToXContent.Params, Throwable)}
      * to control if the {@code caused_by} element should render. Unlike most parameters to {@code toXContent} methods this parameter is
@@ -720,9 +719,9 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         STATUS_EXCEPTION(org.elasticsearch.ElasticsearchStatusException.class, org.elasticsearch.ElasticsearchStatusException::new, 145,
             UNKNOWN_VERSION_ADDED),
         TASK_CANCELLED_EXCEPTION(org.elasticsearch.tasks.TaskCancelledException.class,
-            org.elasticsearch.tasks.TaskCancelledException::new, 146, V_5_1_0_UNRELEASED),
+            org.elasticsearch.tasks.TaskCancelledException::new, 146, Version.V_5_1_0_UNRELEASED),
         SHARD_LOCK_OBTAIN_FAILED_EXCEPTION(org.elasticsearch.env.ShardLockObtainFailedException.class,
-                                           org.elasticsearch.env.ShardLockObtainFailedException::new, 147, V_5_0_2_UNRELEASED);
+                                           org.elasticsearch.env.ShardLockObtainFailedException::new, 147, Version.V_5_0_2_UNRELEASED);
 
 
         final Class<? extends ElasticsearchException> exceptionClass;
@@ -864,4 +863,5 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         }
         return sb.toString();
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -95,18 +95,18 @@ public class Version {
     public static final Version V_5_0_0 = new Version(V_5_0_0_ID, org.apache.lucene.util.Version.LUCENE_6_2_0);
     public static final int V_5_0_1_ID = 5000199;
     public static final Version V_5_0_1 = new Version(V_5_0_1_ID, org.apache.lucene.util.Version.LUCENE_6_2_1);
-    public static final int V_6_0_0_alpha1_ID = 6000001;
-    public static final Version V_6_0_0_alpha1 = new Version(V_6_0_0_alpha1_ID, org.apache.lucene.util.Version.LUCENE_6_3_0);
-    public static final Version CURRENT = V_6_0_0_alpha1;
+    public static final int V_5_0_2_ID_UNRELEASED = 5000299;
+    public static final Version V_5_0_2_UNRELEASED = new Version(V_5_0_2_ID_UNRELEASED, org.apache.lucene.util.Version.LUCENE_6_2_1);
+    public static final int V_5_1_0_ID_UNRELEASED = 5010099;
+    public static final Version V_5_1_0_UNRELEASED = new Version(V_5_1_0_ID_UNRELEASED, org.apache.lucene.util.Version.LUCENE_6_3_0);
+    public static final int V_5_2_0_ID_UNRELEASED = 5020099;
+    public static final Version V_5_2_0_UNRELEASED = new Version(V_5_2_0_ID_UNRELEASED, org.apache.lucene.util.Version.LUCENE_6_3_0);
+    public static final int V_6_0_0_alpha1_ID_UNRELEASED = 6000001;
+    public static final Version V_6_0_0_alpha1_UNRELEASED =
+        new Version(V_6_0_0_alpha1_ID_UNRELEASED, org.apache.lucene.util.Version.LUCENE_6_3_0);
+    public static final Version CURRENT = V_6_0_0_alpha1_UNRELEASED;
 
-    /* NOTE: don't add unreleased version to this list except of the version assigned to CURRENT.
-     * If you need a version that doesn't exist here for instance V_5_1_0 then go and create such a version
-     * as a constant where you need it:
-     * <pre>
-     *   public static final Version V_5_1_0_UNRELEASED = Version.fromId(5010099);
-     * </pre>
-     * Then go to VersionsTest.java and add a test for this constant VersionTests#testUnknownVersions().
-     * This is particularly useful if you are building a feature that needs a BWC layer for this unreleased version etc.*/
+    // unreleased versions must be added to the above list with the suffix _UNRELEASED (with the exception of CURRENT)
 
     static {
         assert CURRENT.luceneVersion.equals(org.apache.lucene.util.Version.LATEST) : "Version must be upgraded to ["
@@ -119,8 +119,14 @@ public class Version {
 
     public static Version fromId(int id) {
         switch (id) {
-            case V_6_0_0_alpha1_ID:
-                return V_6_0_0_alpha1;
+            case V_6_0_0_alpha1_ID_UNRELEASED:
+                return V_6_0_0_alpha1_UNRELEASED;
+            case V_5_2_0_ID_UNRELEASED:
+                return V_5_2_0_UNRELEASED;
+            case V_5_1_0_ID_UNRELEASED:
+                return V_5_1_0_UNRELEASED;
+            case V_5_0_2_ID_UNRELEASED:
+                return V_5_0_2_UNRELEASED;
             case V_5_0_1_ID:
                 return V_5_0_1;
             case V_5_0_0_ID:
@@ -308,8 +314,8 @@ public class Version {
     public Version minimumCompatibilityVersion() {
         final int bwcMajor;
         final int bwcMinor;
-        if (this.onOrAfter(Version.V_6_0_0_alpha1)) {
-            bwcMajor = major-1;
+        if (this.onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
+            bwcMajor = major - 1;
             bwcMinor = 0; // TODO we have to move this to the latest released minor of the last major but for now we just keep
         } else {
             bwcMajor = major;

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 public class ClusterSearchShardsRequest extends MasterNodeReadRequest<ClusterSearchShardsRequest> implements IndicesRequest.Replaceable {
-    public static final Version V_5_1_0_UNRELEASED = Version.fromId(5010099);
+
     private String[] indices = Strings.EMPTY_ARRAY;
     @Nullable
     private String routing;
@@ -134,7 +134,7 @@ public class ClusterSearchShardsRequest extends MasterNodeReadRequest<ClusterSea
         routing = in.readOptionalString();
         preference = in.readOptionalString();
 
-        if (in.getVersion().onOrBefore(V_5_1_0_UNRELEASED)) {
+        if (in.getVersion().onOrBefore(Version.V_5_1_0_UNRELEASED)) {
             //types
             in.readStringArray();
         }
@@ -153,7 +153,7 @@ public class ClusterSearchShardsRequest extends MasterNodeReadRequest<ClusterSea
         out.writeOptionalString(routing);
         out.writeOptionalString(preference);
 
-        if (out.getVersion().onOrBefore(V_5_1_0_UNRELEASED)) {
+        if (out.getVersion().onOrBefore(Version.V_5_1_0_UNRELEASED)) {
             //types
             out.writeStringArray(Strings.EMPTY_ARRAY);
         }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponse.java
@@ -33,7 +33,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ClusterSearchShardsResponse extends ActionResponse implements ToXContent {
-    public static final Version V_5_1_0_UNRELEASED = Version.fromId(5010099);
 
     private ClusterSearchShardsGroup[] groups;
     private DiscoveryNode[] nodes;
@@ -73,7 +72,7 @@ public class ClusterSearchShardsResponse extends ActionResponse implements ToXCo
         for (int i = 0; i < nodes.length; i++) {
             nodes[i] = new DiscoveryNode(in);
         }
-        if (in.getVersion().onOrAfter(V_5_1_0_UNRELEASED)) {
+        if (in.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             int size = in.readVInt();
             indicesAndFilters = new HashMap<>();
             for (int i = 0; i < size; i++) {
@@ -95,7 +94,7 @@ public class ClusterSearchShardsResponse extends ActionResponse implements ToXCo
         for (DiscoveryNode node : nodes) {
             node.writeTo(out);
         }
-        if (out.getVersion().onOrAfter(V_5_1_0_UNRELEASED)) {
+        if (out.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             out.writeVInt(indicesAndFilters.size());
             for (Map.Entry<String, AliasFilter> entry : indicesAndFilters.entrySet()) {
                 out.writeString(entry.getKey());
@@ -132,4 +131,5 @@ public class ClusterSearchShardsResponse extends ActionResponse implements ToXCo
         builder.endArray();
         return builder;
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -471,7 +471,7 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
         cause = in.readString();
         name = in.readString();
 
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
+        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
             indexPatterns = in.readList(StreamInput::readString);
         } else {
             indexPatterns = Collections.singletonList(in.readString());
@@ -501,7 +501,7 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
         super.writeTo(out);
         out.writeString(cause);
         out.writeString(name);
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
+        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
             out.writeStringList(indexPatterns);
         } else {
             out.writeString(indexPatterns.size() > 0 ? indexPatterns.get(0) : "");

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
@@ -302,7 +302,7 @@ public class BulkItemResponse implements Streamable, StatusToXContent {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         id = in.readVInt();
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
+        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
             opType = OpType.fromId(in.readByte());
         } else {
             opType = OpType.fromString(in.readString());
@@ -328,7 +328,7 @@ public class BulkItemResponse implements Streamable, StatusToXContent {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVInt(id);
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
+        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
             out.writeByte(opType.getId());
         } else {
             out.writeString(opType.getLowercase());

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
@@ -208,7 +208,7 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
     public IndexTemplateMetaData readFrom(StreamInput in) throws IOException {
         Builder builder = new Builder(in.readString());
         builder.order(in.readInt());
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
+        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
             builder.patterns(in.readList(StreamInput::readString));
         } else {
             builder.patterns(Collections.singletonList(in.readString()));
@@ -239,7 +239,7 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
         out.writeInt(order);
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
+        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
             out.writeStringList(patterns);
         } else {
             out.writeString(patterns.size() > 0 ? patterns.get(0) : "");

--- a/core/src/main/java/org/elasticsearch/common/transport/TransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/TransportAddress.java
@@ -69,7 +69,7 @@ public final class TransportAddress implements Writeable {
      * Read from a stream.
      */
     public TransportAddress(StreamInput in) throws IOException {
-        if (in.getVersion().before(Version.V_6_0_0_alpha1)) { // bwc layer for 5.x where we had more than one transport address
+        if (in.getVersion().before(Version.V_6_0_0_alpha1_UNRELEASED)) { // bwc layer for 5.x where we had more than one transport address
             final short i = in.readShort();
             if(i != 1) { // we fail hard to ensure nobody tries to use some custom transport address impl even if that is difficult to add
                 throw new AssertionError("illegal transport ID from node of version: " + in.getVersion()  + " got: " + i + " expected: 1");
@@ -85,7 +85,7 @@ public final class TransportAddress implements Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().before(Version.V_6_0_0_alpha1)) {
+        if (out.getVersion().before(Version.V_6_0_0_alpha1_UNRELEASED)) {
             out.writeShort((short)1); // this maps to InetSocketTransportAddress in 5.x
         }
         byte[] bytes = address.getAddress().getAddress();  // 4 bytes (IPv4) or 16 bytes (IPv6)

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -414,7 +414,7 @@ public class InternalEngine extends Engine {
             final long expectedVersion,
             final boolean deleted) {
         if (op.versionType() == VersionType.FORCE) {
-            if (engineConfig.getIndexSettings().getIndexVersionCreated().onOrAfter(Version.V_6_0_0_alpha1)) {
+            if (engineConfig.getIndexSettings().getIndexVersionCreated().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
                 // If index was created in 5.0 or later, 'force' is not allowed at all
                 throw new IllegalArgumentException("version type [FORCE] may not be used for indices created after 6.0");
             } else if (op.origin() != Operation.Origin.LOCAL_TRANSLOG_RECOVERY) {
@@ -528,7 +528,7 @@ public class InternalEngine extends Engine {
     }
 
     private boolean assertSequenceNumber(final Engine.Operation.Origin origin, final long seqNo) {
-        if (engineConfig.getIndexSettings().getIndexVersionCreated().before(Version.V_6_0_0_alpha1) && origin == Operation.Origin.LOCAL_TRANSLOG_RECOVERY) {
+        if (engineConfig.getIndexSettings().getIndexVersionCreated().before(Version.V_6_0_0_alpha1_UNRELEASED) && origin == Operation.Origin.LOCAL_TRANSLOG_RECOVERY) {
             // legacy support
             assert seqNo == SequenceNumbersService.UNASSIGNED_SEQ_NO : "old op recovering but it already has a seq no." +
                 " index version: " + engineConfig.getIndexSettings().getIndexVersionCreated() + ". seq no: " + seqNo;

--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -71,9 +71,8 @@ import java.util.TreeMap;
  * them either using DisMax or a plain boolean query (see {@link #useDisMax(boolean)}).
  */
 public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQueryBuilder> {
-    public static final String NAME = "query_string";
 
-    public static final Version V_5_1_0_UNRELEASED = Version.fromId(5010099);
+    public static final String NAME = "query_string";
 
     public static final boolean DEFAULT_AUTO_GENERATE_PHRASE_QUERIES = false;
     public static final int DEFAULT_MAX_DETERMINED_STATES = Operations.DEFAULT_MAX_DETERMINIZED_STATES;
@@ -219,11 +218,11 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         autoGeneratePhraseQueries = in.readBoolean();
         allowLeadingWildcard = in.readOptionalBoolean();
         analyzeWildcard = in.readOptionalBoolean();
-        if (in.getVersion().before(V_5_1_0_UNRELEASED)) {
+        if (in.getVersion().before(Version.V_5_1_0_UNRELEASED)) {
             in.readBoolean(); // lowercase_expanded_terms
         }
         enablePositionIncrements = in.readBoolean();
-        if (in.getVersion().before(V_5_1_0_UNRELEASED)) {
+        if (in.getVersion().before(Version.V_5_1_0_UNRELEASED)) {
             in.readString(); // locale
         }
         fuzziness = new Fuzziness(in);
@@ -239,7 +238,7 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         timeZone = in.readOptionalTimeZone();
         escape = in.readBoolean();
         maxDeterminizedStates = in.readVInt();
-        if (in.getVersion().onOrAfter(V_5_1_0_UNRELEASED)) {
+        if (in.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             splitOnWhitespace = in.readBoolean();
             useAllFields = in.readOptionalBoolean();
         } else {
@@ -263,11 +262,11 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         out.writeBoolean(this.autoGeneratePhraseQueries);
         out.writeOptionalBoolean(this.allowLeadingWildcard);
         out.writeOptionalBoolean(this.analyzeWildcard);
-        if (out.getVersion().before(V_5_1_0_UNRELEASED)) {
+        if (out.getVersion().before(Version.V_5_1_0_UNRELEASED)) {
             out.writeBoolean(true); // lowercase_expanded_terms
         }
         out.writeBoolean(this.enablePositionIncrements);
-        if (out.getVersion().before(V_5_1_0_UNRELEASED)) {
+        if (out.getVersion().before(Version.V_5_1_0_UNRELEASED)) {
             out.writeString(Locale.ROOT.toLanguageTag()); // locale
         }
         this.fuzziness.writeTo(out);
@@ -283,7 +282,7 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         out.writeOptionalTimeZone(timeZone);
         out.writeBoolean(this.escape);
         out.writeVInt(this.maxDeterminizedStates);
-        if (out.getVersion().onOrAfter(V_5_1_0_UNRELEASED)) {
+        if (out.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             out.writeBoolean(this.splitOnWhitespace);
             out.writeOptionalBoolean(this.useAllFields);
         }
@@ -1058,4 +1057,5 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
 
         return query;
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -79,6 +79,7 @@ import java.util.TreeMap;
  * > online documentation</a>.
  */
 public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQueryStringBuilder> {
+
     /** Default for using lenient query parsing.*/
     public static final boolean DEFAULT_LENIENT = false;
     /** Default for wildcard analysis.*/
@@ -90,8 +91,6 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
 
     /** Name for (de-)serialization. */
     public static final String NAME = "simple_query_string";
-
-    public static final Version V_5_1_0_UNRELEASED = Version.fromId(5010099);
 
     private static final ParseField MINIMUM_SHOULD_MATCH_FIELD = new ParseField("minimum_should_match");
     private static final ParseField ANALYZE_WILDCARD_FIELD = new ParseField("analyze_wildcard");
@@ -160,19 +159,19 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
         flags = in.readInt();
         analyzer = in.readOptionalString();
         defaultOperator = Operator.readFromStream(in);
-        if (in.getVersion().before(V_5_1_0_UNRELEASED)) {
+        if (in.getVersion().before(Version.V_5_1_0_UNRELEASED)) {
             in.readBoolean(); // lowercase_expanded_terms
         }
         settings.lenient(in.readBoolean());
-        if (in.getVersion().onOrAfter(V_5_1_0_UNRELEASED)) {
+        if (in.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             this.lenientSet = in.readBoolean();
         }
         settings.analyzeWildcard(in.readBoolean());
-        if (in.getVersion().before(V_5_1_0_UNRELEASED)) {
+        if (in.getVersion().before(Version.V_5_1_0_UNRELEASED)) {
             in.readString(); // locale
         }
         minimumShouldMatch = in.readOptionalString();
-        if (in.getVersion().onOrAfter(V_5_1_0_UNRELEASED)) {
+        if (in.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             settings.quoteFieldSuffix(in.readOptionalString());
             useAllFields = in.readOptionalBoolean();
         }
@@ -189,19 +188,19 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
         out.writeInt(flags);
         out.writeOptionalString(analyzer);
         defaultOperator.writeTo(out);
-        if (out.getVersion().before(V_5_1_0_UNRELEASED)) {
+        if (out.getVersion().before(Version.V_5_1_0_UNRELEASED)) {
             out.writeBoolean(true); // lowercase_expanded_terms
         }
         out.writeBoolean(settings.lenient());
-        if (out.getVersion().onOrAfter(V_5_1_0_UNRELEASED)) {
+        if (out.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             out.writeBoolean(lenientSet);
         }
         out.writeBoolean(settings.analyzeWildcard());
-        if (out.getVersion().before(V_5_1_0_UNRELEASED)) {
+        if (out.getVersion().before(Version.V_5_1_0_UNRELEASED)) {
             out.writeString(Locale.ROOT.toLanguageTag()); // locale
         }
         out.writeOptionalString(minimumShouldMatch);
-        if (out.getVersion().onOrAfter(V_5_1_0_UNRELEASED)) {
+        if (out.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             out.writeOptionalString(settings.quoteFieldSuffix());
             out.writeOptionalBoolean(useAllFields);
         }
@@ -603,4 +602,5 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
                 && (flags == other.flags)
                 && (useAllFields == other.useAllFields);
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/index/store/StoreStats.java
+++ b/core/src/main/java/org/elasticsearch/index/store/StoreStats.java
@@ -74,7 +74,7 @@ public class StoreStats implements Streamable, ToXContent {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         sizeInBytes = in.readVLong();
-        if (in.getVersion().before(Version.V_6_0_0_alpha1)) {
+        if (in.getVersion().before(Version.V_6_0_0_alpha1_UNRELEASED)) {
             in.readVLong(); // throttleTimeInNanos
         }
     }
@@ -82,7 +82,7 @@ public class StoreStats implements Streamable, ToXContent {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(sizeInBytes);
-        if (out.getVersion().before(Version.V_6_0_0_alpha1)) {
+        if (out.getVersion().before(Version.V_6_0_0_alpha1_UNRELEASED)) {
             out.writeVLong(0L); // throttleTimeInNanos
         }
     }

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
 import java.util.Objects;
 
 public class OsStats implements Writeable, ToXContent {
-    public static final Version V_5_1_0 = Version.fromId(5010099);
+
     private final long timestamp;
     private final Cpu cpu;
     private final Mem mem;
@@ -52,7 +52,7 @@ public class OsStats implements Writeable, ToXContent {
         this.cpu = new Cpu(in);
         this.mem = new Mem(in);
         this.swap = new Swap(in);
-        if (in.getVersion().onOrAfter(V_5_1_0)) {
+        if (in.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             this.cgroup = in.readOptionalWriteable(Cgroup::new);
         } else {
             this.cgroup = null;
@@ -65,7 +65,7 @@ public class OsStats implements Writeable, ToXContent {
         cpu.writeTo(out);
         mem.writeTo(out);
         swap.writeTo(out);
-        if (out.getVersion().onOrAfter(V_5_1_0)) {
+        if (out.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             out.writeOptionalWriteable(cgroup);
         }
     }

--- a/core/src/main/java/org/elasticsearch/script/Script.java
+++ b/core/src/main/java/org/elasticsearch/script/Script.java
@@ -92,11 +92,6 @@ public final class Script implements ToXContent, Writeable {
     public static final ParseField PARAMS_PARSE_FIELD = new ParseField("params");
 
     /**
-     * Unreleased version used for {@link Script} non-null members format of read/write.
-     */
-    public static final Version V_5_1_0_UNRELEASED = Version.fromId(5010099);
-
-    /**
      * Helper class used by {@link ObjectParser} to store mutable {@link Script} variables and then
      * construct an immutable {@link Script} object based on parsed XContent.
      */
@@ -382,7 +377,7 @@ public final class Script implements ToXContent, Writeable {
         // Version 5.1+ requires all Script members to be non-null and supports the potential
         // for more options than just XContentType.  Reorders the read in contents to be in
         // same order as the constructor.
-        if (in.getVersion().onOrAfter(V_5_1_0_UNRELEASED)) {
+        if (in.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             this.type = ScriptType.readFrom(in);
             this.lang = in.readString();
             this.idOrCode = in.readString();
@@ -434,7 +429,7 @@ public final class Script implements ToXContent, Writeable {
         // Version 5.1+ requires all Script members to be non-null and supports the potential
         // for more options than just XContentType.  Reorders the written out contents to be in
         // same order as the constructor.
-        if (out.getVersion().onOrAfter(V_5_1_0_UNRELEASED)) {
+        if (out.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             type.writeTo(out);
             out.writeString(lang);
             out.writeString(idOrCode);

--- a/core/src/main/java/org/elasticsearch/search/internal/AliasFilter.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/AliasFilter.java
@@ -36,7 +36,7 @@ import java.util.Objects;
  * Represents a {@link QueryBuilder} and a list of alias names that filters the builder is composed of.
  */
 public final class AliasFilter implements Writeable {
-    public static final Version V_5_1_0 = Version.fromId(5010099);
+
     private final String[] aliases;
     private final QueryBuilder filter;
     private final boolean reparseAliases;
@@ -49,7 +49,7 @@ public final class AliasFilter implements Writeable {
 
     public AliasFilter(StreamInput input) throws IOException {
         aliases = input.readStringArray();
-        if (input.getVersion().onOrAfter(V_5_1_0)) {
+        if (input.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             filter = input.readOptionalNamedWriteable(QueryBuilder.class);
             reparseAliases = false;
         } else {
@@ -78,7 +78,7 @@ public final class AliasFilter implements Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringArray(aliases);
-        if (out.getVersion().onOrAfter(V_5_1_0)) {
+        if (out.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             out.writeOptionalNamedWriteable(filter);
         }
     }

--- a/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -842,9 +842,9 @@ public class ExceptionSerializationTests extends ESTestCase {
         ShardLockObtainFailedException orig = new ShardLockObtainFailedException(shardId, "boom");
         Version version = VersionUtils.randomVersionBetween(random(),
             Version.V_5_0_0, Version.CURRENT);
-        if (version.before(ElasticsearchException.V_5_0_2_UNRELEASED)) {
+        if (version.before(Version.V_5_0_2_UNRELEASED)) {
             // remove this once 5_0_2 is released randomVersionBetween asserts that this version is in the constant table..
-            version = ElasticsearchException.V_5_0_2_UNRELEASED;
+            version = Version.V_5_0_2_UNRELEASED;
         }
         ShardLockObtainFailedException ex = serialize(orig, version);
         assertEquals(orig.getMessage(), ex.getMessage());

--- a/core/src/test/java/org/elasticsearch/VersionTests.java
+++ b/core/src/test/java/org/elasticsearch/VersionTests.java
@@ -19,24 +19,19 @@
 
 package org.elasticsearch;
 
-import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsRequest;
-import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.query.QueryStringQueryBuilder;
-import org.elasticsearch.index.query.SimpleQueryStringBuilder;
-import org.elasticsearch.monitor.os.OsStats;
-import org.elasticsearch.script.Script;
-import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 import org.hamcrest.Matchers;
 
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import static org.elasticsearch.Version.V_2_2_0;
 import static org.elasticsearch.Version.V_5_0_0_alpha1;
@@ -135,11 +130,11 @@ public class VersionTests extends ESTestCase {
         assertThat(Version.V_5_0_0_alpha1.minimumCompatibilityVersion(), equalTo(Version.V_5_0_0_alpha1));
         // from 6.0 on we are supporting the latest minor of the previous major... this might fail once we add a new version ie. 5.x is
         // released since we need to bump the supported minor in Version#minimumCompatibilityVersion()
-        Version lastVersion = VersionUtils.getPreviousVersion(Version.V_6_0_0_alpha1);
-        assertEquals(lastVersion.major, Version.V_6_0_0_alpha1.minimumCompatibilityVersion().major);
+        Version lastVersion = VersionUtils.getPreviousVersion(Version.V_6_0_0_alpha1_UNRELEASED);
+        assertEquals(lastVersion.major, Version.V_6_0_0_alpha1_UNRELEASED.minimumCompatibilityVersion().major);
         assertEquals("did you miss to bump the minor in Version#minimumCompatibilityVersion()",
-                lastVersion.minor, Version.V_6_0_0_alpha1.minimumCompatibilityVersion().minor);
-        assertEquals(0, Version.V_6_0_0_alpha1.minimumCompatibilityVersion().revision);
+                lastVersion.minor, Version.V_6_0_0_alpha1_UNRELEASED.minimumCompatibilityVersion().minor);
+        assertEquals(0, Version.V_6_0_0_alpha1_UNRELEASED.minimumCompatibilityVersion().revision);
     }
 
     public void testToString() {
@@ -206,7 +201,7 @@ public class VersionTests extends ESTestCase {
 
     public void testParseLenient() {
         // note this is just a silly sanity check, we test it in lucene
-        for (Version version : VersionUtils.allVersions()) {
+        for (Version version : VersionUtils.allReleasedVersions()) {
             org.apache.lucene.util.Version luceneVersion = version.luceneVersion;
             String string = luceneVersion.toString().toUpperCase(Locale.ROOT)
                     .replaceFirst("^LUCENE_(\\d+)_(\\d+)$", "$1.$2");
@@ -215,20 +210,27 @@ public class VersionTests extends ESTestCase {
     }
 
     public void testAllVersionsMatchId() throws Exception {
+        final Set<Version> releasedVersions = new HashSet<>(VersionUtils.allReleasedVersions());
+        final Set<Version> unreleasedVersions = new HashSet<>(VersionUtils.allUnreleasedVersions());
         Map<String, Version> maxBranchVersions = new HashMap<>();
         for (java.lang.reflect.Field field : Version.class.getFields()) {
-            if (field.getName().endsWith("_ID")) {
+            if (field.getName().matches("_ID(_UNRELEASED)?")) {
                 assertTrue(field.getName() + " should be static", Modifier.isStatic(field.getModifiers()));
                 assertTrue(field.getName() + " should be final", Modifier.isFinal(field.getModifiers()));
                 int versionId = (Integer)field.get(Version.class);
 
-                String constantName = field.getName().substring(0, field.getName().length() - 3);
+                String constantName = field.getName().substring(0, field.getName().indexOf("_ID"));
                 java.lang.reflect.Field versionConstant = Version.class.getField(constantName);
                 assertTrue(constantName + " should be static", Modifier.isStatic(versionConstant.getModifiers()));
                 assertTrue(constantName + " should be final", Modifier.isFinal(versionConstant.getModifiers()));
 
-                Version v = (Version) versionConstant.get(Version.class);
+                Version v = (Version) versionConstant.get(null);
                 logger.debug("Checking {}", v);
+                if (field.getName().endsWith("_UNRELEASED")) {
+                    assertTrue(unreleasedVersions.contains(v));
+                } else {
+                    assertTrue(releasedVersions.contains(v));
+                }
                 assertEquals("Version id " + field.getName() + " does not point to " + constantName, v, Version.fromId(versionId));
                 assertEquals("Version " + constantName + " does not have correct id", versionId, v.id);
                 if (v.major >= 2) {
@@ -261,8 +263,8 @@ public class VersionTests extends ESTestCase {
 
     // this test ensures we never bump the lucene version in a bugfix release
     public void testLuceneVersionIsSameOnMinorRelease() {
-        for (Version version : VersionUtils.allVersions()) {
-            for (Version other : VersionUtils.allVersions()) {
+        for (Version version : VersionUtils.allReleasedVersions()) {
+            for (Version other : VersionUtils.allReleasedVersions()) {
                 if (other.onOrAfter(version)) {
                     assertTrue("lucene versions must be "  + other + " >= " + version,
                         other.luceneVersion.onOrAfter(version.luceneVersion));
@@ -276,34 +278,16 @@ public class VersionTests extends ESTestCase {
             }
         }
     }
-    private  static final Version V_20_0_0_UNRELEASED = new Version(20000099, Version.CURRENT.luceneVersion);
-
-    // see comment in Version.java about this test
-    public void testUnknownVersions() {
-        assertUnknownVersion(V_20_0_0_UNRELEASED);
-        expectThrows(AssertionError.class, () -> assertUnknownVersion(Version.CURRENT));
-        assertUnknownVersion(AliasFilter.V_5_1_0); // once we released 5.1.0 and it's added to Version.java we need to remove this constant
-        assertUnknownVersion(OsStats.V_5_1_0); // once we released 5.1.0 and it's added to Version.java we need to remove this constant
-        assertUnknownVersion(QueryStringQueryBuilder.V_5_1_0_UNRELEASED);
-        assertUnknownVersion(SimpleQueryStringBuilder.V_5_1_0_UNRELEASED);
-        assertUnknownVersion(ElasticsearchException.V_5_1_0_UNRELEASED);
-        assertUnknownVersion(ElasticsearchException.V_5_0_2_UNRELEASED);
-        // once we released 5.0.0 and it's added to Version.java we need to remove this constant
-        assertUnknownVersion(Script.V_5_1_0_UNRELEASED);
-        // once we released 5.0.0 and it's added to Version.java we need to remove this constant
-        assertUnknownVersion(ClusterSearchShardsRequest.V_5_1_0_UNRELEASED);
-        assertUnknownVersion(ClusterSearchShardsResponse.V_5_1_0_UNRELEASED);
-    }
 
     public static void assertUnknownVersion(Version version) {
         assertFalse("Version " + version + " has been releaed don't use a new instance of this version",
-            VersionUtils.allVersions().contains(version));
+            VersionUtils.allReleasedVersions().contains(version));
     }
 
     public void testIsCompatible() {
         assertTrue(isCompatible(Version.CURRENT, Version.CURRENT.minimumCompatibilityVersion()));
-        assertTrue(isCompatible(Version.V_5_0_0, Version.V_6_0_0_alpha1));
-        assertFalse(isCompatible(Version.V_2_0_0, Version.V_6_0_0_alpha1));
+        assertTrue(isCompatible(Version.V_5_0_0, Version.V_6_0_0_alpha1_UNRELEASED));
+        assertFalse(isCompatible(Version.V_2_0_0, Version.V_6_0_0_alpha1_UNRELEASED));
         assertFalse(isCompatible(Version.V_2_0_0, Version.V_5_0_0));
     }
 

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponseTests.java
@@ -94,7 +94,7 @@ public class ClusterSearchShardsResponseTests extends ESTestCase {
                     assertEquals(clusterSearchShardsGroup.getIndex(), deserializedGroup.getIndex());
                     assertArrayEquals(clusterSearchShardsGroup.getShards(), deserializedGroup.getShards());
                 }
-                if (version.onOrAfter(ClusterSearchShardsResponse.V_5_1_0_UNRELEASED)) {
+                if (version.onOrAfter(Version.V_5_1_0_UNRELEASED)) {
                     assertEquals(clusterSearchShardsResponse.getIndicesAndFilters(), deserialized.getIndicesAndFilters());
                 } else {
                     assertNull(deserialized.getIndicesAndFilters());

--- a/core/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityIT.java
@@ -185,7 +185,7 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
 
     public void testAllVersionsTested() throws Exception {
         SortedSet<String> expectedVersions = new TreeSet<>();
-        for (Version v : VersionUtils.allVersions()) {
+        for (Version v : VersionUtils.allReleasedVersions()) {
             if (VersionUtils.isSnapshot(v)) continue;  // snapshots are unreleased, so there is no backcompat yet
             if (v.isRelease() == false) continue; // no guarantees for prereleases
             if (v.onOrBefore(Version.V_2_0_0_beta1)) continue; // we can only test back one major lucene version

--- a/core/src/test/java/org/elasticsearch/bwcompat/RestoreBackwardsCompatIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/RestoreBackwardsCompatIT.java
@@ -95,7 +95,7 @@ public class RestoreBackwardsCompatIT extends AbstractSnapshotIntegTestCase {
         }
 
         SortedSet<String> expectedVersions = new TreeSet<>();
-        for (Version v : VersionUtils.allVersions()) {
+        for (Version v : VersionUtils.allReleasedVersions()) {
             if (VersionUtils.isSnapshot(v)) continue;  // snapshots are unreleased, so there is no backcompat yet
             if (v.isRelease() == false) continue; // no guarantees for prereleases
             if (v.onOrBefore(Version.V_2_0_0_beta1)) continue; // we can only test back one major lucene version

--- a/core/src/test/java/org/elasticsearch/cluster/routing/RoutingBackwardCompatibilityTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/RoutingBackwardCompatibilityTests.java
@@ -55,7 +55,7 @@ public class RoutingBackwardCompatibilityTests extends ESTestCase {
 
                 OperationRouting operationRouting = new OperationRouting(Settings.EMPTY, new ClusterSettings(Settings.EMPTY,
                     ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
-                for (Version version : VersionUtils.allVersions()) {
+                for (Version version : VersionUtils.allReleasedVersions()) {
                     if (version.onOrAfter(Version.V_2_0_0) == false) {
                         // unsupported version, no need to test
                         continue;

--- a/core/src/test/java/org/elasticsearch/codecs/CodecTests.java
+++ b/core/src/test/java/org/elasticsearch/codecs/CodecTests.java
@@ -48,7 +48,7 @@ public class CodecTests extends ESSingleNodeTestCase {
 
     public void testAcceptPostingsFormat() throws IOException {
         int i = 0;
-        for (Version v : VersionUtils.allVersions()) {
+        for (Version v : VersionUtils.allReleasedVersions()) {
             if (v.onOrAfter(Version.V_2_0_0) == false) {
                 // no need to test, we don't support upgrading from these versions
                 continue;
@@ -82,7 +82,7 @@ public class CodecTests extends ESSingleNodeTestCase {
 
     public void testAcceptDocValuesFormat() throws IOException {
         int i = 0;
-        for (Version v : VersionUtils.allVersions()) {
+        for (Version v : VersionUtils.allReleasedVersions()) {
             if (v.onOrAfter(Version.V_2_0_0) == false) {
                 // no need to test, we don't support upgrading from these versions
                 continue;

--- a/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldCopyToMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldCopyToMapperTests.java
@@ -27,9 +27,6 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.MapperTestUtils;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 
@@ -92,7 +89,7 @@ public class MultiFieldCopyToMapperTests extends ESTestCase {
     private static Tuple<List<Version>, List<Version>> versionsWithAndWithoutExpectedExceptions() {
         List<Version> versionsWithException = new ArrayList<>();
         List<Version> versionsWithoutException = new ArrayList<>();
-        for (Version version : VersionUtils.allVersions()) {
+        for (Version version : VersionUtils.allReleasedVersions()) {
             if (version.after(Version.V_2_1_0) ||
                 (version.after(Version.V_2_0_1) && version.before(Version.V_2_1_0))) {
                 versionsWithException.add(version);

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.reindex;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.search.SearchRequest;
@@ -38,8 +39,8 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
 import static org.elasticsearch.common.unit.TimeValue.timeValueMinutes;
 
-public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScrollRequest<Self>>
-        extends ActionRequest {
+public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScrollRequest<Self>> extends ActionRequest {
+
     public static final int SIZE_ALL_MATCHES = -1;
     private static final TimeValue DEFAULT_SCROLL_TIMEOUT = timeValueMinutes(5);
     private static final int DEFAULT_SCROLL_SIZE = 1000;
@@ -401,7 +402,7 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
         retryBackoffInitialTime = new TimeValue(in);
         maxRetries = in.readVInt();
         requestsPerSecond = in.readFloat();
-        if (in.getVersion().onOrAfter(BulkByScrollTask.V_5_1_0_UNRELEASED)) {
+        if (in.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             slices = in.readVInt();
         } else {
             slices = 1;
@@ -420,12 +421,12 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
         retryBackoffInitialTime.writeTo(out);
         out.writeVInt(maxRetries);
         out.writeFloat(requestsPerSecond);
-        if (out.getVersion().onOrAfter(BulkByScrollTask.V_5_1_0_UNRELEASED)) {
+        if (out.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             out.writeVInt(slices);
         } else {
             if (slices > 1) {
                 throw new IllegalArgumentException("Attempting to send sliced reindex-style request to a node that doesn't support "
-                        + "it. Version is [" + out.getVersion() + "] but must be [" + BulkByScrollTask.V_5_1_0_UNRELEASED + "]");
+                        + "it. Version is [" + out.getVersion() + "] but must be [" + Version.V_5_1_0_UNRELEASED + "]");
             }
         }
     }
@@ -444,4 +445,5 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
             b.append(Arrays.toString(searchRequest.types()));
         }
     }
+
 }

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
@@ -45,7 +45,6 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueNanos;
  * Task storing information about a currently running BulkByScroll request.
  */
 public abstract class BulkByScrollTask extends CancellableTask {
-    static final Version V_5_1_0_UNRELEASED = Version.fromId(5010099);
 
     public BulkByScrollTask(long id, String type, String action, String description, TaskId parentTaskId) {
         super(id, type, action, description, parentTaskId);
@@ -107,7 +106,7 @@ public abstract class BulkByScrollTask extends CancellableTask {
         public Status(Integer sliceId, long total, long updated, long created, long deleted, int batches, long versionConflicts, long noops,
                 long bulkRetries, long searchRetries, TimeValue throttled, float requestsPerSecond, @Nullable String reasonCancelled,
                 TimeValue throttledUntil) {
-            this.sliceId = sliceId == null ? null : checkPositive(sliceId, "sliceId"); 
+            this.sliceId = sliceId == null ? null : checkPositive(sliceId, "sliceId");
             this.total = checkPositive(total, "total");
             this.updated = checkPositive(updated, "updated");
             this.created = checkPositive(created, "created");
@@ -187,7 +186,7 @@ public abstract class BulkByScrollTask extends CancellableTask {
         }
 
         public Status(StreamInput in) throws IOException {
-            if (in.getVersion().onOrAfter(V_5_1_0_UNRELEASED)) {
+            if (in.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
                 sliceId = in.readOptionalVInt();
             } else {
                 sliceId = null;
@@ -205,7 +204,7 @@ public abstract class BulkByScrollTask extends CancellableTask {
             requestsPerSecond = in.readFloat();
             reasonCancelled = in.readOptionalString();
             throttledUntil = new TimeValue(in);
-            if (in.getVersion().onOrAfter(V_5_1_0_UNRELEASED)) {
+            if (in.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
                 sliceStatuses = in.readList(stream -> stream.readOptionalWriteable(StatusOrException::new));
             } else {
                 sliceStatuses = emptyList();
@@ -214,7 +213,7 @@ public abstract class BulkByScrollTask extends CancellableTask {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(V_5_1_0_UNRELEASED)) {
+            if (out.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
                 out.writeOptionalVInt(sliceId);
             }
             out.writeVLong(total);
@@ -230,7 +229,7 @@ public abstract class BulkByScrollTask extends CancellableTask {
             out.writeFloat(requestsPerSecond);
             out.writeOptionalString(reasonCancelled);
             throttledUntil.writeTo(out);
-            if (out.getVersion().onOrAfter(V_5_1_0_UNRELEASED)) {
+            if (out.getVersion().onOrAfter(Version.V_5_1_0_UNRELEASED)) {
                 out.writeVInt(sliceStatuses.size());
                 for (StatusOrException sliceStatus : sliceStatuses) {
                     out.writeOptionalWriteable(sliceStatus);
@@ -512,4 +511,5 @@ public abstract class BulkByScrollTask extends CancellableTask {
             return Objects.hash(status, exception);
         }
     }
+
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/BulkByScrollTaskTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/BulkByScrollTaskTests.java
@@ -155,8 +155,4 @@ public class BulkByScrollTaskTests extends ESTestCase {
         assertEquals(reasonCancelled, merged.getReasonCancelled());
     }
 
-    public void testUnknownVersions() {
-        assertThat("5.1.0 has been defined, remove the temporary constant", VersionUtils.allVersions(),
-                not(hasItem(BulkByScrollTask.V_5_1_0_UNRELEASED)));
-    }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RoundTripTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RoundTripTests.java
@@ -356,7 +356,7 @@ public class RoundTripTests extends ESTestCase {
         assertEquals(expected.getRequestsPerSecond(), actual.getRequestsPerSecond(), 0f);
         assertEquals(expected.getReasonCancelled(), actual.getReasonCancelled());
         assertEquals(expected.getThrottledUntil(), actual.getThrottledUntil());
-        if (version.onOrAfter(BulkByScrollTask.V_5_1_0_UNRELEASED)) {
+        if (version.onOrAfter(Version.V_5_1_0_UNRELEASED)) {
             assertThat(actual.getSliceStatuses(), hasSize(expected.getSliceStatuses().size()));
             for (int i = 0; i < expected.getSliceStatuses().size(); i++) {
                 BulkByScrollTask.StatusOrException sliceStatus = expected.getSliceStatuses().get(i);

--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -29,45 +29,70 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /** Utilities for selecting versions in tests */
 public class VersionUtils {
 
-    private static final List<Version> SORTED_VERSIONS;
+    private static final List<Version> RELEASED_VERSIONS;
+    private static final List<Version> UNRELEASED_VERSIONS;
+
     static {
-        Field[] declaredFields = Version.class.getFields();
-        Set<Integer> ids = new HashSet<>();
-        for (Field field : declaredFields) {
+        final Field[] declaredFields = Version.class.getFields();
+        final Set<Integer> releasedIdsSet = new HashSet<>();
+        final Set<Integer> unreleasedIdsSet = new HashSet<>();
+        for (final Field field : declaredFields) {
             final int mod = field.getModifiers();
             if (Modifier.isStatic(mod) && Modifier.isFinal(mod) && Modifier.isPublic(mod)) {
                 if (field.getType() == Version.class) {
+                    final int id;
                     try {
-                        Version object = (Version) field.get(null);
-                        ids.add(object.id);
-                    } catch (IllegalAccessException e) {
+                        id = ((Version) field.get(null)).id;
+                    } catch (final IllegalAccessException e) {
                         throw new RuntimeException(e);
+                    }
+                    assert field.getName().matches("(V(_\\d+)+(_(alpha|beta|rc)\\d+)?(_UNRELEASED)?|CURRENT)") : field.getName();
+                    if (field.getName().equals("CURRENT") || field.getName().endsWith("UNRELEASED")) {
+                        unreleasedIdsSet.add(id);
+                    } else {
+                        releasedIdsSet.add(id);
                     }
                 }
             }
         }
-        List<Integer> idList = new ArrayList<>(ids);
-        Collections.sort(idList);
-        List<Version> version = new ArrayList<>();
-        for (Integer integer : idList) {
-            version.add(Version.fromId(integer));
-        }
-        SORTED_VERSIONS = Collections.unmodifiableList(version);
+
+        // treat current as released for BWC testing
+        unreleasedIdsSet.remove(Version.CURRENT.id);
+        releasedIdsSet.add(Version.CURRENT.id);
+
+        RELEASED_VERSIONS =
+            Collections.unmodifiableList(releasedIdsSet.stream().sorted().map(Version::fromId).collect(Collectors.toList()));
+        UNRELEASED_VERSIONS =
+            Collections.unmodifiableList(unreleasedIdsSet.stream().sorted().map(Version::fromId).collect(Collectors.toList()));
     }
 
-    /** Returns immutable list of all known versions. */
-    public static List<Version> allVersions() {
-        return Collections.unmodifiableList(SORTED_VERSIONS);
+    /**
+     * Returns an immutable, sorted list containing all released versions.
+     *
+     * @return all released versions
+     */
+    public static List<Version> allReleasedVersions() {
+        return RELEASED_VERSIONS;
+    }
+
+    /**
+     * Returns an immutable, sorted list containing all unreleased versions.
+     *
+     * @return all unreleased versions
+     */
+    public static List<Version> allUnreleasedVersions() {
+        return UNRELEASED_VERSIONS;
     }
 
     public static Version getPreviousVersion(Version version) {
-        int index = SORTED_VERSIONS.indexOf(version);
+        int index = RELEASED_VERSIONS.indexOf(version);
         assert index > 0;
-        return SORTED_VERSIONS.get(index - 1);
+        return RELEASED_VERSIONS.get(index - 1);
     }
 
     /** Returns the {@link Version} before the {@link Version#CURRENT} */
@@ -79,23 +104,23 @@ public class VersionUtils {
 
     /** Returns the oldest {@link Version} */
     public static Version getFirstVersion() {
-        return SORTED_VERSIONS.get(0);
+        return RELEASED_VERSIONS.get(0);
     }
 
     /** Returns a random {@link Version} from all available versions. */
     public static Version randomVersion(Random random) {
-        return SORTED_VERSIONS.get(random.nextInt(SORTED_VERSIONS.size()));
+        return RELEASED_VERSIONS.get(random.nextInt(RELEASED_VERSIONS.size()));
     }
 
     /** Returns a random {@link Version} between <code>minVersion</code> and <code>maxVersion</code> (inclusive). */
     public static Version randomVersionBetween(Random random, Version minVersion, Version maxVersion) {
         int minVersionIndex = 0;
         if (minVersion != null) {
-            minVersionIndex = SORTED_VERSIONS.indexOf(minVersion);
+            minVersionIndex = RELEASED_VERSIONS.indexOf(minVersion);
         }
-        int maxVersionIndex = SORTED_VERSIONS.size() - 1;
+        int maxVersionIndex = RELEASED_VERSIONS.size() - 1;
         if (maxVersion != null) {
-            maxVersionIndex = SORTED_VERSIONS.indexOf(maxVersion);
+            maxVersionIndex = RELEASED_VERSIONS.indexOf(maxVersion);
         }
         if (minVersionIndex == -1) {
             throw new IllegalArgumentException("minVersion [" + minVersion + "] does not exist.");
@@ -106,7 +131,7 @@ public class VersionUtils {
         } else {
             // minVersionIndex is inclusive so need to add 1 to this index
             int range = maxVersionIndex + 1 - minVersionIndex;
-            return SORTED_VERSIONS.get(minVersionIndex + random.nextInt(range));
+            return RELEASED_VERSIONS.get(minVersionIndex + random.nextInt(range));
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -52,6 +52,8 @@ public class VersionUtils {
                         throw new RuntimeException(e);
                     }
                     assert field.getName().matches("(V(_\\d+)+(_(alpha|beta|rc)\\d+)?(_UNRELEASED)?|CURRENT)") : field.getName();
+                    // note that below we remove CURRENT and add it to released; we do it this way because there are two constants that
+                    // correspond to CURRENT, CURRENT itself and the actual version that CURRENT points to
                     if (field.getName().equals("CURRENT") || field.getName().endsWith("UNRELEASED")) {
                         unreleasedIdsSet.add(id);
                     } else {
@@ -61,9 +63,12 @@ public class VersionUtils {
             }
         }
 
-        // treat current as released for BWC testing
+        // treat CURRENT as released for BWC testing
         unreleasedIdsSet.remove(Version.CURRENT.id);
         releasedIdsSet.add(Version.CURRENT.id);
+
+        // unreleasedIdsSet and releasedIdsSet should be disjoint
+        assert unreleasedIdsSet.stream().filter(releasedIdsSet::contains).collect(Collectors.toSet()).isEmpty();
 
         RELEASED_VERSIONS =
             Collections.unmodifiableList(releasedIdsSet.stream().sorted().map(Version::fromId).collect(Collectors.toList()));

--- a/test/framework/src/test/java/org/elasticsearch/test/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/VersionUtilsTests.java
@@ -27,7 +27,7 @@ import java.util.List;
 public class VersionUtilsTests extends ESTestCase {
 
     public void testAllVersionsSorted() {
-        List<Version> allVersions = VersionUtils.allVersions();
+        List<Version> allVersions = VersionUtils.allReleasedVersions();
         for (int i = 0, j = 1; j < allVersions.size(); ++i, ++j) {
             assertTrue(allVersions.get(i).before(allVersions.get(j)));
         }
@@ -54,9 +54,9 @@ public class VersionUtilsTests extends ESTestCase {
         got = VersionUtils.randomVersionBetween(random(), null, Version.V_5_0_0_alpha1);
         assertTrue(got.onOrAfter(VersionUtils.getFirstVersion()));
         assertTrue(got.onOrBefore(Version.V_5_0_0_alpha1));
-        got = VersionUtils.randomVersionBetween(random(), null, VersionUtils.allVersions().get(0));
+        got = VersionUtils.randomVersionBetween(random(), null, VersionUtils.allReleasedVersions().get(0));
         assertTrue(got.onOrAfter(VersionUtils.getFirstVersion()));
-        assertTrue(got.onOrBefore(VersionUtils.allVersions().get(0)));
+        assertTrue(got.onOrBefore(VersionUtils.allReleasedVersions().get(0)));
 
         // unbounded upper
         got = VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, null);


### PR DESCRIPTION
Today when handling unreleased versions for backwards compatilibity
support, we scatted version constants across the code base and add some
asserts to support removing these constants when the version in question
is actually released. This commit improves this situation, enabling us
to just add a single unreleased version constant that can be renamed
when the version is actually released. This should make maintenance of
these versions simpler.