### PR TITLE
Improve painless's ScriptException generation

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngineService.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngineService.java
@@ -180,8 +180,8 @@ public final class PainlessScriptEngineService extends AbstractComponent impleme
             throw convertToScriptException("compile error", scriptName, scriptSource, e,
                     // Use simple heuristics for segmenting the snippet
                     offset -> Math.max(0, offset - 25), offset -> Math.min(scriptSource.length(), offset + 25),
-                    // Don't include any extra lines
-                    ste -> true);
+                    // Don't include any non-script elements at all.
+                    element -> true);
         }
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubCallInvoke.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubCallInvoke.java
@@ -79,6 +79,8 @@ final class PSubCallInvoke extends AExpression {
             argument.write(writer, globals);
         }
 
+        // Move the line number back to this statement's line number so if there is an error in this call it'll be marked in the right spot
+        writer.writeDebugInfo(location);
         method.write(writer);
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubDefCall.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubDefCall.java
@@ -112,6 +112,9 @@ final class PSubDefCall extends AExpression {
         List<Object> args = new ArrayList<>();
         args.add(recipe.toString());
         args.addAll(pointers);
+
+        // Move the line number back to this statement's line number so if there is an error in this call it'll be marked in the right spot
+        writer.writeDebugInfo(location);
         writer.invokeDefCall(name, methodType, DefBootstrap.METHOD_CALL, args.toArray());
     }
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
@@ -75,13 +75,6 @@ public class WhenThingsGoWrongTests extends ScriptTestCase {
         assertEquals(53 + 1, exception.getStackTrace()[0].getLineNumber());
     }
 
-    public void testScriptStackFromCompileError() {
-        // NOCOMMIT also test script stack from runtime
-        IllegalArgumentException exception = expectScriptThrows(IllegalArgumentException.class, () ->
-            exec("String boolean x = null", false));
-        assertEquals(7 + 1, exception.getStackTrace()[0].getLineNumber());
-    }
-
     public void testInvalidShift() {
         expectScriptThrows(ClassCastException.class, () -> {
             exec("float x = 15F; x <<= 2; return x;");

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
@@ -75,6 +75,13 @@ public class WhenThingsGoWrongTests extends ScriptTestCase {
         assertEquals(53 + 1, exception.getStackTrace()[0].getLineNumber());
     }
 
+    public void testScriptStackFromCompileError() {
+        // NOCOMMIT also test script stack from runtime
+        IllegalArgumentException exception = expectScriptThrows(IllegalArgumentException.class, () ->
+            exec("String boolean x = null", false));
+        assertEquals(7 + 1, exception.getStackTrace()[0].getLineNumber());
+    }
+
     public void testInvalidShift() {
         expectScriptThrows(ClassCastException.class, () -> {
             exec("float x = 15F; x <<= 2; return x;");

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/20_scriptfield.yaml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/20_scriptfield.yaml
@@ -88,21 +88,3 @@ setup:
                                 x: 5
 
     - match: { hits.hits.0.fields.bar.0: 5}
-
----
-"Scripted Field with script error":
-    - do:
-        catch: request
-        search:
-          body:
-            script_fields:
-              bar:
-                script:
-                  inline: "while (true) {}"
-
-    - match: { error.root_cause.0.type: "script_exception" }
-    - match: { error.root_cause.0.reason: "compile error" }
-    - match: { error.caused_by.type: "script_exception" }
-    - match: { error.caused_by.reason: "compile error" }
-    - match: { error.caused_by.caused_by.type: "illegal_argument_exception" }
-    - match: { error.caused_by.caused_by.reason: "While loop has no escape." }

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/50_errors.yaml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/50_errors.yaml
@@ -71,6 +71,27 @@
     - match: { _shards.failures.0.reason.caused_by.type: "no_such_element_exception" }
 
 ---
+"Reach through multiline script stack":
+    - do:
+        index: test
+        search:
+            body:
+                query:
+                    script:
+                        script:
+                            inline: "return Optional.empty().orElseGet(() -> params.a.length())"
+                            lang: painless
+
+    - match: { _shards.failures.0.reason.type: script_exception }
+    - match: { _shards.failures.0.reason.reason: 'runtime error: null_pointer_exception' }
+    - match: { _shards.failures.0.reason.script_stack.0:  "... () -> params.a.length())" }
+    - match: { _shards.failures.0.reason.script_stack.1:  "                  ^---- HERE" }
+    - match: { _shards.failures.0.reason.script_stack.2: '/java.util.Optional.orElseGet\(Optional.java:\d+\)/' }
+    - match: { _shards.failures.0.reason.script_stack.3:  "return Optional.empty().orElseGet( ..." }
+    - match: { _shards.failures.0.reason.script_stack.4:  "                       ^---- HERE" }
+    - match: { _shards.failures.0.reason.caused_by.type: "null_pointer_exception" }
+
+---
 "Scripted Field with script error":
     - do:
         catch: request

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/50_errors.yaml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/50_errors.yaml
@@ -1,4 +1,4 @@
-"Syntax error":
+"setup":
     - do:
         index:
             index: test
@@ -8,6 +8,8 @@
     - do:
         indices.refresh: {}
 
+---
+"Syntax error":
     - do:
         catch: request
         index: test
@@ -20,22 +22,19 @@
                             lang: painless
 
     - match: { error.caused_by.caused_by.type: script_exception }
-    - match: { error.caused_by.caused_by.reason: compile error }
+    - match: { error.caused_by.caused_by.reason: "compile error: invalid sequence of tokens near ['String']." }
     - match: { error.caused_by.caused_by.script_stack.0: "boolean String errr; doc['num1']. ..." }
     - match: { error.caused_by.caused_by.script_stack.1: "        ^---- HERE" }
     - match: { error.caused_by.caused_by.caused_by.reason: "invalid sequence of tokens near ['String']." }
+    # Even more usefully, the root_cause has what you need to debug this:
+    - match: { error.root_cause.0.type: script_exception }
+    - match: { error.root_cause.0.reason: "compile error: invalid sequence of tokens near ['String']." }
+    - match: { error.root_cause.0.script_stack.0: "boolean String errr; doc['num1']. ..." }
+    - match: { error.root_cause.0.script_stack.1: "        ^---- HERE" }
+
 
 ---
 "Runtime error":
-    - do:
-        index:
-            index: test
-            type: test
-            id: 1
-            body: { "test": "value beck", "num1": 1.0, "bool": true }
-    - do:
-        indices.refresh: {}
-
     - do:
         index: test
         search:
@@ -47,22 +46,13 @@
                             lang: painless
 
     - match: { _shards.failures.0.reason.type: script_exception }
-    - match: { _shards.failures.0.reason.reason: runtime error }
+    - match: { _shards.failures.0.reason.reason: 'runtime error: null_pointer_exception' }
     - match: { _shards.failures.0.reason.script_stack.0: "... return errr.length()" }
     - match: { _shards.failures.0.reason.script_stack.1: "               ^---- HERE" }
     - match: { _shards.failures.0.reason.caused_by.type: "null_pointer_exception" }
 
 ---
 "Multiline script stack":
-    - do:
-        index:
-            index: test
-            type: test
-            id: 1
-            body: { "test": "value beck", "num1": 1.0, "bool": true }
-    - do:
-        indices.refresh: {}
-
     - do:
         index: test
         search:
@@ -74,8 +64,26 @@
                             lang: painless
 
     - match: { _shards.failures.0.reason.type: script_exception }
-    - match: { _shards.failures.0.reason.reason: runtime error }
+    - match: { _shards.failures.0.reason.reason: 'runtime error: No value present' }
     - match: { _shards.failures.0.reason.script_stack.0: '/java.util.Optional.get\(Optional.java:\d+\)/' }
     - match: { _shards.failures.0.reason.script_stack.1:  "return Optional.empty().get()" }
     - match: { _shards.failures.0.reason.script_stack.2:  "                       ^---- HERE" }
     - match: { _shards.failures.0.reason.caused_by.type: "no_such_element_exception" }
+
+---
+"Scripted Field with script error":
+    - do:
+        catch: request
+        search:
+          body:
+            script_fields:
+              bar:
+                script:
+                  inline: "while (true) {}"
+
+    - match: { error.root_cause.0.type: script_exception }
+    - match: { error.root_cause.0.reason: 'compile error: While loop has no escape.' }
+    - match: { error.caused_by.type: script_exception }
+    - match: { error.caused_by.reason: 'compile error: While loop has no escape.' }
+    - match: { error.caused_by.caused_by.type: illegal_argument_exception }
+    - match: { error.caused_by.caused_by.reason: While loop has no escape. }

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/50_errors.yaml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/50_errors.yaml
@@ -48,8 +48,8 @@
 
     - match: { _shards.failures.0.reason.type: script_exception }
     - match: { _shards.failures.0.reason.reason: runtime error }
-    - match: { _shards.failures.0.reason.script_stack.0: "return errr.length()" }
-    - match: { _shards.failures.0.reason.script_stack.1: "           ^---- HERE" }
+    - match: { _shards.failures.0.reason.script_stack.0: "... return errr.length()" }
+    - match: { _shards.failures.0.reason.script_stack.1: "               ^---- HERE" }
     - match: { _shards.failures.0.reason.caused_by.type: "null_pointer_exception" }
 
 ---

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/50_errors.yaml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/50_errors.yaml
@@ -9,6 +9,7 @@
         indices.refresh: {}
 
     - do:
+        catch: request
         index: test
         search:
             body:
@@ -18,6 +19,63 @@
                             inline: "boolean String errr; doc['num1'].value > 1;"
                             lang: painless
 
-    - match: { hits.total: 2 }
-    - match: { hits.hits.0.fields.sNum1.0: 2.0 }
-    - match: { hits.hits.1.fields.sNum1.0: 3.0 }
+    - match: { error.caused_by.caused_by.type: script_exception }
+    - match: { error.caused_by.caused_by.reason: compile error }
+    - match: { error.caused_by.caused_by.script_stack.0: "boolean String errr; doc['num1']. ..." }
+    - match: { error.caused_by.caused_by.script_stack.1: "        ^---- HERE" }
+    - match: { error.caused_by.caused_by.caused_by.reason: "invalid sequence of tokens near ['String']." }
+
+---
+"Runtime error":
+    - do:
+        index:
+            index: test
+            type: test
+            id: 1
+            body: { "test": "value beck", "num1": 1.0, "bool": true }
+    - do:
+        indices.refresh: {}
+
+    - do:
+        index: test
+        search:
+            body:
+                query:
+                    script:
+                        script:
+                            inline: "String errr = null; return errr.length()"
+                            lang: painless
+
+    - match: { _shards.failures.0.reason.type: script_exception }
+    - match: { _shards.failures.0.reason.reason: runtime error }
+    - match: { _shards.failures.0.reason.script_stack.0: "return errr.length()" }
+    - match: { _shards.failures.0.reason.script_stack.1: "           ^---- HERE" }
+    - match: { _shards.failures.0.reason.caused_by.type: "null_pointer_exception" }
+
+---
+"Multiline script stack":
+    - do:
+        index:
+            index: test
+            type: test
+            id: 1
+            body: { "test": "value beck", "num1": 1.0, "bool": true }
+    - do:
+        indices.refresh: {}
+
+    - do:
+        index: test
+        search:
+            body:
+                query:
+                    script:
+                        script:
+                            inline: "return Optional.empty().get()"
+                            lang: painless
+
+    - match: { _shards.failures.0.reason.type: script_exception }
+    - match: { _shards.failures.0.reason.reason: runtime error }
+    - match: { _shards.failures.0.reason.script_stack.0: '/java.util.Optional.get\(Optional.java:\d+\)/' }
+    - match: { _shards.failures.0.reason.script_stack.1:  "return Optional.empty().get()" }
+    - match: { _shards.failures.0.reason.script_stack.2:  "                       ^---- HERE" }
+    - match: { _shards.failures.0.reason.caused_by.type: "no_such_element_exception" }

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/50_errors.yaml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/50_errors.yaml
@@ -1,0 +1,23 @@
+"Syntax error":
+    - do:
+        index:
+            index: test
+            type: test
+            id: 1
+            body: { "test": "value beck", "num1": 1.0, "bool": true }
+    - do:
+        indices.refresh: {}
+
+    - do:
+        index: test
+        search:
+            body:
+                query:
+                    script:
+                        script:
+                            inline: "boolean String errr; doc['num1'].value > 1;"
+                            lang: painless
+
+    - match: { hits.total: 2 }
+    - match: { hits.hits.0.fields.sNum1.0: 2.0 }
+    - match: { hits.hits.1.fields.sNum1.0: 3.0 }


### PR DESCRIPTION
1. Added a few more tests for REST rendering of ScriptException.
2. Centralize generation of the exception to one place so I don't have to make changes in two places. Uses lambdas to plug strategies for snippet segmentation into the exception generation logic.
3. Include the cause of the ScriptException's message in the ScriptException's message. This is useful because ScriptException is often pulled into the `root_cause` element of an error report so this adds the cause of the exception to the `root_cause` element.
4. Include all unfiltered stack trace elements of the in the script_stack starting with the outermost invocation of the script. The old behavior started with the innermost invocation.
5. Moves the offset for errors during invocation back to the offset of the invocation rather than the offset of the last parameter.

Example for the stack trace element included change. Say you pass this script:
```
return Optional.empty().orElseGet(() -> params.a.length())
```
with an empty `params`. It'll `NullPointerException` all day, every day. Before this PR the `script_stack` would look like:
```
"script_stack": [
  "() -> params.a.length())",
  "              ^---- HERE"
]
```

Now it looks like:
```
"script_stack": [
  "... () -> params.a.length())",
  "                  ^---- HERE",
  "java.util.Optional.orElseGet(Optional.java:213)",
  "return Optional.empty().orElseGet( ...",
  "                       ^---- HERE"
]
```

This should make it easier to track down errors, especially in larger scripts with methods because you can find the location of error.

Relates to #21733