### PR TITLE
Fix a VerifyError bug in Painless

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EComp.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EComp.java
@@ -148,13 +148,8 @@ public final class EComp extends AExpression {
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        if (promotedType.sort == Sort.DEF) {
-            left.expected = left.actual;
-            right.expected = right.actual;
-        } else {
-            left.expected = promotedType;
-            right.expected = promotedType;
-        }
+        left.expected = promotedType;
+        right.expected = promotedType;
 
         left = left.cast(variables);
         right = right.cast(variables);
@@ -246,13 +241,8 @@ public final class EComp extends AExpression {
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        if (promotedType.sort == Sort.DEF) {
-            left.expected = left.actual;
-            right.expected = right.actual;
-        } else {
-            left.expected = promotedType;
-            right.expected = promotedType;
-        }
+        left.expected = promotedType;
+        right.expected = promotedType;
 
         left = left.cast(variables);
         right = right.cast(variables);

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/EqualsTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/EqualsTests.java
@@ -129,6 +129,13 @@ public class EqualsTests extends ScriptTestCase {
         assertEquals(0, exec("def a = 1; Object b = new HashMap(); if (a === (Object)b) return 1; else return 0;"));
     }
 
+    public void testBranchEqualsDefAndPrimitive() {
+        assertEquals(true, exec("def x = 1000; int y = 1000; return x == y;"));
+        assertEquals(false, exec("def x = 1000; int y = 1000; return x === y;"));
+        assertEquals(true, exec("def x = 1000; int y = 1000; return y == x;"));
+        assertEquals(false, exec("def x = 1000; int y = 1000; return y === x;"));
+    }
+
     public void testBranchNotEquals() {
         assertEquals(1, exec("def a = (char)'a'; def b = (char)'b'; if (a != b) return 1; else return 0;"));
         assertEquals(0, exec("def a = (char)'a'; def b = (char)'a'; if (a != b) return 1; else return 0;"));
@@ -137,6 +144,13 @@ public class EqualsTests extends ScriptTestCase {
         assertEquals(0, exec("def a = (char)'a'; Object b = a; if (a !== b) return 1; else return 0;"));
         assertEquals(0, exec("def a = 1; Number b = a; Number c = a; if (c !== b) return 1; else return 0;"));
         assertEquals(1, exec("def a = 1; Object b = new HashMap(); if (a !== (Object)b) return 1; else return 0;"));
+    }
+
+    public void testBranchNotEqualsDefAndPrimitive() {
+        assertEquals(false, exec("def x = 1000; int y = 1000; return x != y;"));
+        assertEquals(true, exec("def x = 1000; int y = 1000; return x !== y;"));
+        assertEquals(false, exec("def x = 1000; int y = 1000; return y != x;"));
+        assertEquals(true, exec("def x = 1000; int y = 1000; return y !== x;"));
     }
 
     public void testRightHandNull() {


### PR DESCRIPTION
There is a bug in Painless that causes a VerifyError when scripts using the === operator were comparing a def type against a primitive type since the primitive type wasn't being appropriately boxed.