### PR TITLE
expand `/_cat/nodes` to return information about hard drive

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -272,9 +272,9 @@ public class RestNodesAction extends AbstractCatAction {
             table.addCell(info == null ? null : info.getBuild().shortHash());
             table.addCell(jvmInfo == null ? null : jvmInfo.version());
             
-            long diskUsed = fsInfo.getTotal().getTotal().getBytes() - fsInfo.getTotal().getAvailable().getBytes();
-            double diskUsedRatio = (double) diskUsed / (double) Math.max(
-                fsInfo.getTotal().getTotal().getBytes(), diskUsed); // prevent division by Zero
+            long diskTotal = fsInfo.getTotal().getTotal().getBytes();
+            long diskUsed = diskTotal - fsInfo.getTotal().getAvailable().getBytes();
+            double diskUsedRatio = diskTotal == 0 ? 1.0 : (double) diskUsed / diskTotal;
             table.addCell(fsInfo == null ? null : fsInfo.getTotal().getTotal());
             table.addCell(fsInfo == null ? null : new ByteSizeValue(diskUsed));
             table.addCell(fsInfo == null ? null : fsInfo.getTotal().getAvailable());

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.Table;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.http.HttpInfo;
 import org.elasticsearch.index.cache.query.QueryCacheStats;
 import org.elasticsearch.index.cache.request.RequestCacheStats;
@@ -124,7 +125,10 @@ public class RestNodesAction extends AbstractCatAction {
         table.addCell("version", "default:false;alias:v;desc:es version");
         table.addCell("build", "default:false;alias:b;desc:es build hash");
         table.addCell("jdk", "default:false;alias:j;desc:jdk version");
-        table.addCell("disk.avail", "default:false;alias:d,disk,diskAvail;text-align:right;desc:available disk space");
+        table.addCell("disk.total", "default:false;alias:dt,diskTotal;text-align:right;desc:total disk space");
+        table.addCell("disk.used", "default:false;alias:du,diskUsed;text-align:right;desc:used disk space");
+        table.addCell("disk.avail", "default:false;alias:d,da,disk,diskAvail;text-align:right;desc:available disk space");
+        table.addCell("disk.used_percent", "default:false;alias:dup,diskUsedPercent;text-align:right;desc:used disk space percentage");
         table.addCell("heap.current", "default:false;alias:hc,heapCurrent;text-align:right;desc:used heap");
         table.addCell("heap.percent", "alias:hp,heapPercent;text-align:right;desc:used heap ratio");
         table.addCell("heap.max", "default:false;alias:hm,heapMax;text-align:right;desc:max configured heap");
@@ -267,7 +271,15 @@ public class RestNodesAction extends AbstractCatAction {
             table.addCell(node.getVersion().toString());
             table.addCell(info == null ? null : info.getBuild().shortHash());
             table.addCell(jvmInfo == null ? null : jvmInfo.version());
+            
+            long diskUsed = fsInfo.getTotal().getTotal().getBytes() - fsInfo.getTotal().getAvailable().getBytes();
+            double diskUsedRatio = (double) diskUsed / (double) Math.max(
+                fsInfo.getTotal().getTotal().getBytes(), diskUsed); // prevent division by Zero
+            table.addCell(fsInfo == null ? null : fsInfo.getTotal().getTotal());
+            table.addCell(fsInfo == null ? null : new ByteSizeValue(diskUsed));
             table.addCell(fsInfo == null ? null : fsInfo.getTotal().getAvailable());
+            table.addCell(fsInfo == null ? null : String.format(Locale.ROOT, "%.2f", 100.0 * diskUsedRatio));
+            
             table.addCell(jvmStats == null ? null : jvmStats.getMem().getHeapUsed());
             table.addCell(jvmStats == null ? null : jvmStats.getMem().getHeapUsedPercent());
             table.addCell(jvmInfo == null ? null : jvmInfo.getMem().getHeapMax());

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -71,7 +71,10 @@ veJR 127.0.0.1 59938 {version} *
 |`version` |`v` |No |Elasticsearch version |{version}
 |`build` |`b` |No |Elasticsearch Build hash |5c03844
 |`jdk` |`j` |No |Running Java version |1.8.0
-|`disk.avail` |`d`, `disk`, `diskAvail` |No |Available disk space |1.8gb
+|`disk.total` |`dt`, `diskTotal` |No |Total disk space| 458.3gb
+|`disk.used` |`du`, `diskUsed` |No |Used disk space| 259.8gb
+|`disk.avail` |`d`, `disk`, `diskAvail` |No |Available disk space |198.4gb
+|`disk.used_percent` |`dup`, `diskUsedPercent` |No |Used disk space percentage |56.71
 |`heap.current` |`hc`, `heapCurrent` |No |Used heap |311.2mb
 |`heap.percent` |`hp`, `heapPercent` |Yes |Used heap percentage |7
 |`heap.max` |`hm`, `heapMax` |No |Maximum configured heap |1015.6mb

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yml
@@ -58,6 +58,12 @@
       $body: |
                /^      http \n ((\d{1,3}\.){3}\d{1,3}:\d{1,5}\n)+  $/
 
+---
+"Additional disk information":
+  - skip:
+      version: " - 5.5.99"
+      reason:  additional disk info added in 5.6.0
+
   - do:
       cat.nodes:
           h: diskAvail,diskTotal,diskUsed,diskUsedPercent

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yml
@@ -60,7 +60,20 @@
 
   - do:
       cat.nodes:
-          h: disk,diskAvail,diskTotal,diskUsed,diskUsedPercent
+          h: diskAvail,diskTotal,diskUsed,diskUsedPercent
+          v: true
+
+  - match:
+      # leading whitespace on columns and optional whitespace on values is necessary
+      # because `diskAvail` is right aligned and text representation of disk size might be
+      # longer so it's padded with leading whitespace
+      $body: |
+               /^  \s* diskAvail            \s+ diskTotal            \s+ diskUsed            \s+ diskUsedPercent            \n
+                  (\s* \d+(\.\d+)?[ptgmk]?b \s+ \d+(\.\d+)?[ptgmk]?b \s+ \d+(\.\d+)?[ptgmk]?b\s+ (100\.00 | \d{1,2}\.\d{2}) \n)+  $/
+
+  - do:
+      cat.nodes:
+          h: disk,dt,du,dup
           v: true
 
   - match:
@@ -68,8 +81,8 @@
       # because `disk` is right aligned and text representation of disk size might be
       # longer so it's padded with leading whitespace
       $body: |
-               /^  \s* disk                 \s+ diskAvail            \s+ diskTotal            \s+ diskUsed            \s+ diskUsedPercent            \n
-                  (\s* \d+(\.\d+)?[ptgmk]?b \s+ \d+(\.\d+)?[ptgmk]?b \s+ \d+(\.\d+)?[ptgmk]?b \s+ \d+(\.\d+)?[ptgmk]?b\s+ (100\.00 | \d{1,2}\.\d{2}) \n)+  $/
+               /^  \s* disk                 \s+ dt                   \s+ du                  \s+ dup                        \n
+                  (\s* \d+(\.\d+)?[ptgmk]?b \s+ \d+(\.\d+)?[ptgmk]?b \s+ \d+(\.\d+)?[ptgmk]?b\s+ (100\.00 | \d{1,2}\.\d{2}) \n)+  $/
 
 ---
 "Test cat nodes output with full_id set":

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yml
@@ -58,6 +58,19 @@
       $body: |
                /^      http \n ((\d{1,3}\.){3}\d{1,3}:\d{1,5}\n)+  $/
 
+  - do:
+      cat.nodes:
+          h: disk,diskAvail,diskTotal,diskUsed,diskUsedPercent
+          v: true
+
+  - match:
+      # leading whitespace on columns and optional whitespace on values is necessary
+      # because `disk` is right aligned and text representation of disk size might be
+      # longer so it's padded with leading whitespace
+      $body: |
+               /^  \s* disk                 \s+ diskAvail            \s+ diskTotal            \s+ diskUsed            \s+ diskUsedPercent            \n
+                  (\s* \d+(\.\d+)?[ptgmk]?b \s+ \d+(\.\d+)?[ptgmk]?b \s+ \d+(\.\d+)?[ptgmk]?b \s+ \d+(\.\d+)?[ptgmk]?b\s+ (100\.00 | \d{1,2}\.\d{2}) \n)+  $/
+
 ---
 "Test cat nodes output with full_id set":
   - skip:


### PR DESCRIPTION
Expand `/_cat/nodes` with already present information about
available disk space `diskAvail` (alias: `d`, `disk`) by:

* `diskTotal` (alias `dt`): total disk space
* `diskUsed` (alias `du`): used disk space (`diskTotal - diskAvail`)
* `diskUsedPercent` (alias `dup`): used disk space percentage

Note: The available disk space is the number of bytes available
to the node's Java virtual machine. The size might by smaller
than the real one. That means the used disk space (percentage)
is larger.

The value of `diskAvail` is backtracked to:
```
org.elasticsearch.monitor.fs.FsProbe:

129:    public static FsInfo.Path getFSInfo(NodePath nodePath) throws IOException {
130:        FsInfo.Path fsPath = new FsInfo.Path();
131:        fsPath.path = nodePath.path.toAbsolutePath().toString();
132:
133:        // NOTE: we use already cached (on node startup) FileStore and spins
134:        // since recomputing these once per second (default) could be costly,
135:        // and they should not change:
136:        fsPath.total = nodePath.fileStore.getTotalSpace();
137:        fsPath.free = nodePath.fileStore.getUnallocatedSpace();
138:        fsPath.available = nodePath.fileStore.getUsableSpace();
139:        fsPath.type = nodePath.fileStore.type();
140:        fsPath.mount = nodePath.fileStore.toString();
141:        fsPath.spins = nodePath.spins;
142:        return fsPath;
143:    }
```
where `nodePath.fileStore` is of type `java.nio.file.FileStore`

Closes #21679.