### PR TITLE
Search shards to print out aliases array together with alias filter

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponse.java
@@ -115,7 +115,8 @@ public class ClusterSearchShardsResponse extends ActionResponse implements ToXCo
                 String index = entry.getKey();
                 builder.startObject(index);
                 AliasFilter aliasFilter = entry.getValue();
-                if (aliasFilter.getQueryBuilder() != null) {
+                if (aliasFilter.getAliases().length > 0) {
+                    builder.array("aliases", aliasFilter.getAliases());
                     builder.field("filter");
                     aliasFilter.getQueryBuilder().toXContent(builder, params);
                 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search_shards/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search_shards/10_basic.yaml
@@ -31,26 +31,38 @@
                 field:
                   type: text
           aliases:
-            test_alias_1: {}
-            test_alias_2:
+            test_alias_no_filter: {}
+            test_alias_filter_1:
               filter:
                 term:
-                  field : value
+                  field : value1
+            test_alias_filter_2:
+              filter:
+                term:
+                  field : value2
 
   - do:
       search_shards:
-        index:  test_alias_1
+        index:  test_alias_no_filter
 
   - length: { shards: 1 }
   - match: { shards.0.0.index: test_index }
   - is_true: indices.test_index
   - is_false: indices.test_index.filter
+  - is_false: indices.test_index.aliases
 
   - do:
       search_shards:
-        index:  test_alias_2
+        index:  test_alias_filter_1
 
   - length: { shards: 1 }
   - match: { shards.0.0.index: test_index }
-  - match: { indices.test_index: {filter: { term : { field: { value: value, boost: 1.0}}}}}
+  - match: { indices.test_index: {aliases: [test_alias_filter_1], filter: { term : { field: { value: value1, boost: 1.0}}}}}
 
+  - do:
+      search_shards:
+        index:  ["test_alias_filter_1","test_alias_filter_2"]
+
+  - length: { shards: 1 }
+  - match: { shards.0.0.index: test_index }
+  - match: { indices.test_index: {aliases: [test_alias_filter_1, test_alias_filter_2], filter: { bool: { should : [{ term : { field: { value: value1, boost: 1.0}}}, { term : { field: { value: value2, boost: 1.0}}}], adjust_pure_negative: true, boost: 1.0, disable_coord: false }}}}


### PR DESCRIPTION
With #21738 we added an indices section to the search shards api, that will return the concrete indices hit by the request, and eventually the corresponding alias filter.

The java API returns the `AliasFilter` object, which holds the filter itself and an array of aliases that pointed to the index in the original request. The REST layer doesn't print out the aliases array though. This commit adds the aliases array as well and tests for this.