### PR TITLE
Detect nodes being blocked by GC-disrupted node

### DIFF
--- a/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
@@ -628,7 +628,7 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
 
         String oldMasterNode = internalCluster().getMasterName();
         // a very long GC, but it's OK as we remove the disruption when it has had an effect
-        SingleNodeDisruption masterNodeDisruption = new IntermittentLongGCDisruption(oldMasterNode, random(), 100, 200, 30000, 60000);
+        SingleNodeDisruption masterNodeDisruption = new IntermittentLongGCDisruption(random(), oldMasterNode, 100, 200, 30000, 60000);
         internalCluster().setDisruptionScheme(masterNodeDisruption);
         masterNodeDisruption.startDisrupting();
 

--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/IntermittentLongGCDisruption.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/IntermittentLongGCDisruption.java
@@ -39,19 +39,6 @@ public class IntermittentLongGCDisruption extends LongGCDisruption {
     final long delayDurationMax;
 
 
-    public IntermittentLongGCDisruption(Random random) {
-        this(null, random);
-    }
-
-    public IntermittentLongGCDisruption(String disruptedNode, Random random) {
-        this(disruptedNode, random, 100, 200, 300, 20000);
-    }
-
-    public IntermittentLongGCDisruption(String disruptedNode, Random random, long intervalBetweenDelaysMin,
-                                        long intervalBetweenDelaysMax, long delayDurationMin, long delayDurationMax) {
-        this(random, disruptedNode, intervalBetweenDelaysMin, intervalBetweenDelaysMax, delayDurationMin, delayDurationMax);
-    }
-
     public IntermittentLongGCDisruption(Random random, String disruptedNode, long intervalBetweenDelaysMin, long intervalBetweenDelaysMax,
                                         long delayDurationMin, long delayDurationMax) {
         super(random, disruptedNode);
@@ -88,19 +75,15 @@ public class IntermittentLongGCDisruption extends LongGCDisruption {
     }
 
     private void simulateLongGC(final TimeValue duration) throws InterruptedException {
-        final String disruptionNodeCopy = disruptedNode;
-        if (disruptionNodeCopy == null) {
-            return;
-        }
-        logger.info("node [{}] goes into GC for for [{}]", disruptionNodeCopy, duration);
+        logger.info("node [{}] goes into GC for for [{}]", disruptedNode, duration);
         final Set<Thread> nodeThreads = new HashSet<>();
         try {
-            while (stopNodeThreads(disruptionNodeCopy, nodeThreads)) ;
+            while (stopNodeThreads(nodeThreads)) ;
             if (!nodeThreads.isEmpty()) {
                 Thread.sleep(duration.millis());
             }
         } finally {
-            logger.info("node [{}] resumes from GC", disruptionNodeCopy);
+            logger.info("node [{}] resumes from GC", disruptedNode);
             resumeThreads(nodeThreads);
         }
     }
@@ -109,13 +92,13 @@ public class IntermittentLongGCDisruption extends LongGCDisruption {
 
         @Override
         public void run() {
-            while (disrupting && disruptedNode != null) {
+            while (disrupting) {
                 try {
                     TimeValue duration = new TimeValue(delayDurationMin + random.nextInt((int) (delayDurationMax - delayDurationMin)));
                     simulateLongGC(duration);
 
                     duration = new TimeValue(intervalBetweenDelaysMin + random.nextInt((int) (intervalBetweenDelaysMax - intervalBetweenDelaysMin)));
-                    if (disrupting && disruptedNode != null) {
+                    if (disrupting) {
                         Thread.sleep(duration.millis());
                     }
                 } catch (InterruptedException e) {

--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/LongGCDisruptionTest.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/LongGCDisruptionTest.java
@@ -18,11 +18,15 @@
  */
 package org.elasticsearch.test.disruption;
 
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.test.ESTestCase;
 
+import java.lang.management.ThreadInfo;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
 
@@ -146,6 +150,96 @@ public class LongGCDisruptionTest extends ESTestCase {
             assertBusy(() -> assertThat(ops.get(), greaterThan(first)));
         } finally {
             stop.set(true);
+        }
+    }
+
+    public void testBlockDetection() throws Exception {
+        final String disruptedNodeName = "disrupted_node";
+        final String blockedNodeName = "blocked_node";
+        CountDownLatch waitForBlockDetectionResult = new CountDownLatch(1);
+        AtomicReference<ThreadInfo> blockDetectionResult = new AtomicReference<>();
+        LongGCDisruption disruption = new LongGCDisruption(random(), disruptedNodeName) {
+            @Override
+            protected Pattern[] getUnsafeClasses() {
+                return new Pattern[0];
+            }
+
+            @Override
+            protected void onBlockDetected(ThreadInfo blockedThread, @Nullable ThreadInfo blockingThread) {
+                blockDetectionResult.set(blockedThread);
+                waitForBlockDetectionResult.countDown();
+            }
+
+            @Override
+            protected long getBlockDetectionIntervalInMillis() {
+                return 10L;
+            }
+        };
+        if (disruption.isBlockDetectionSupported() == false) {
+            return;
+        }
+        final AtomicBoolean stop = new AtomicBoolean();
+        final CountDownLatch underLock = new CountDownLatch(1);
+        final CountDownLatch pauseUnderLock = new CountDownLatch(1);
+        final LockedExecutor lockedExecutor = new LockedExecutor();
+        final AtomicLong ops = new AtomicLong();
+        try {
+            for (int i = 0; i < 5; i++) {
+                // at least one locked and one none lock thread
+                final boolean lockedExec = (i < 4 && randomBoolean()) || i == 0;
+                Thread thread = new Thread(() -> {
+                    while (stop.get() == false) {
+                        if (lockedExec) {
+                            lockedExecutor.executeLocked(() -> {
+                                try {
+                                    underLock.countDown();
+                                    ops.incrementAndGet();
+                                    pauseUnderLock.await();
+                                } catch (InterruptedException e) {
+
+                                }
+                            });
+                        } else {
+                            ops.incrementAndGet();
+                        }
+                    }
+                });
+
+                thread.setName("[" + disruptedNodeName + "][" + i + "]");
+                thread.start();
+            }
+
+            for (int i = 0; i < 5; i++) {
+                // at least one locked and one none lock thread
+                final boolean lockedExec = (i < 4 && randomBoolean()) || i == 0;
+                Thread thread = new Thread(() -> {
+                    while (stop.get() == false) {
+                        if (lockedExec) {
+                            lockedExecutor.executeLocked(() -> {
+                                ops.incrementAndGet();
+                            });
+                        } else {
+                            ops.incrementAndGet();
+                        }
+                    }
+                });
+                thread.setName("[" + blockedNodeName + "][" + i + "]");
+                thread.start();
+            }
+            // make sure some threads of test_node are under lock
+            underLock.await();
+            disruption.startDisrupting();
+            waitForBlockDetectionResult.await(30, TimeUnit.SECONDS);
+            disruption.stopDisrupting();
+
+            ThreadInfo threadInfo = blockDetectionResult.get();
+            assertNotNull(threadInfo);
+            assertThat(threadInfo.getThreadName(), containsString("[" + blockedNodeName + "]"));
+            assertThat(threadInfo.getLockOwnerName(), containsString("[" + disruptedNodeName + "]"));
+            assertThat(threadInfo.getLockInfo().getClassName(), containsString(ReentrantLock.class.getName()));
+        } finally {
+            stop.set(true);
+            pauseUnderLock.countDown();
         }
     }
 }


### PR DESCRIPTION
The disruption type `LongGCDisruption` simulates GCs on a node by suspending all the threads of that node. If the suspended threads are in a code section with shared JVM locks, however, it can prevent the other nodes from doing their thing. The class `LongGCDisruption` has a list of class names for which we know that this can occur. Whenever a test using the GC disruption type fails in mysterious ways, it becomes a long guessing game to find the offending class. This PR adds code to
`LongGCDisruption` to automatically detect these situations, fail the test early and report the offending class and all relevant context.