### PR TITLE
Disable disk watermarks on REST tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -286,6 +286,9 @@ class ClusterFormationTasks {
         esConfig['node.max_local_storage_nodes'] = node.config.numNodes
         esConfig['http.port'] = node.config.httpPort
         esConfig['transport.tcp.port'] =  node.config.transportPort
+        // Default the watermarks to absurdly low to prevent the tests from failing on nodes without enough disk space
+        esConfig['cluster.routing.allocation.disk.watermark.low'] = '1b'
+        esConfig['cluster.routing.allocation.disk.watermark.high'] = '1b'
         esConfig.putAll(node.config.settings)
 
         Task writeConfig = project.tasks.create(name: name, type: DefaultTask, dependsOn: setup)

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yaml
@@ -1,26 +1,8 @@
 ---
-setup:
-  # Disable the disk threshold decider so the test doesn't fail if the disk is
-  # > 85% full
-    - do:
-        cluster.put_settings:
-          body:
-            persistent:
-              cluster.routing.allocation.disk.threshold_enabled: false
-          flat_settings: true
-
----
-teardown:
-  # Reset the disk threshold decider so we don't leave anything behind.
-    - do:
-        cluster.put_settings:
-          body:
-            persistent:
-              cluster.routing.allocation.disk.threshold_enabled: null
-          flat_settings: true
-
----
 "Shrink index via API":
+  - skip:
+      features: always
+      reason:  Fails consistently for Nik and sometimes for Jenkins. Skip until we can get it passing consistently.
   # creates an index with one document solely allocated on the master node
   # and shrinks it into a new index with a single shard
   # we don't do the relocation to a single node after the index is created

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yaml
@@ -1,8 +1,5 @@
 ---
 "Shrink index via API":
-  - skip:
-      features: always
-      reason:  Fails consistently for Nik and sometimes for Jenkins. Skip until we can get it passing consistently.
   # creates an index with one document solely allocated on the master node
   # and shrinks it into a new index with a single shard
   # we don't do the relocation to a single node after the index is created


### PR DESCRIPTION
REST tests use the default OOTB low/high disk watermarks of 85%/90%, which can make some tests fail if run on a machine with a fuller disk. This PR changes the watermarks in the same way as in IntegTestCase so that they're essentially ignored.