### PR TITLE
Add missing skip declarations for the "warnings" feature into the YAML tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/10_analyze.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/10_analyze.yaml
@@ -40,6 +40,7 @@ setup:
 ---
 "Index and field":
     - skip:
+        features: "warnings"
         version: " - 5.0.99"
         reason:  text was deprecated in 5.1.0
     - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/10_index.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/10_index.yaml
@@ -117,6 +117,7 @@ setup:
 ---
 "Indices stats warns on percolate":
   - skip:
+      features: "warnings"
       version: " - 5.0.99"
       reason:  The warning was introduced in 5.1
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/10_basic.yaml
@@ -38,6 +38,7 @@
 ---
 "Node stats warns on percolate":
   - skip:
+      features: "warnings"
       version: " - 5.0.99"
       reason:  The warning was introduced in 5.1
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search_shards/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search_shards/10_basic.yaml
@@ -14,9 +14,9 @@
 ---
 "Search shards with type":
   - skip:
-    features: "warnings"
-    version: " - 5.0.99"
-    reason: type was deprecated in 5.1.0
+      features: "warnings"
+      version: " - 5.0.99"
+      reason: type was deprecated in 5.1.0
 
   - do:
       indices.create:


### PR DESCRIPTION
Some tests on the 5.x branch have used only the `version` declaration for a skip,
not the `features` version, causing runners which have not yet
implemented the feature to fail.

Related: f4f62a1