### PR TITLE
extra <3> tag removed.

### DIFF
--- a/docs/reference/search/request/post-filter.asciidoc
+++ b/docs/reference/search/request/post-filter.asciidoc
@@ -115,7 +115,7 @@ GET /shirts/_search
       },
       "aggs": {
         "models": {
-          "terms": { "field": "model" } <3>
+          "terms": { "field": "model" }
         }
       }
     }


### PR DESCRIPTION
the last example had two <3> tags, one of which had been explained in the previous example, and I guess it's left there after the copy/paste.