### PR TITLE
Include unindexed field in FieldStats response

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.fieldstats;
 
 import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.StringHelper;
 import org.elasticsearch.Version;
@@ -50,6 +51,16 @@ public abstract class FieldStats<T> implements Writeable, ToXContent {
     protected T minValue;
     protected T maxValue;
 
+    /**
+     * Builds a FieldStats where min and max value are not available for the field.
+     * @param type The native type of this FieldStats
+     * @param maxDoc Max number of docs
+     * @param docCount  the number of documents that have at least one term for this field, or -1 if this information isn't available for this field.
+     * @param sumDocFreq  the sum of {@link TermsEnum#docFreq()} for all terms in this field, or -1 if this information isn't available for this field.
+     * @param sumTotalTermFreq the sum of {@link TermsEnum#totalTermFreq} for all terms in this field, or -1 if this measure isn't available for this field.
+     * @param isSearchable true if this field is searchable
+     * @param isAggregatable true if this field is aggregatable
+     */
     FieldStats(byte type, long maxDoc, long docCount, long sumDocFreq, long sumTotalTermFreq,
                boolean isSearchable, boolean isAggregatable) {
         this.type = type;
@@ -62,6 +73,18 @@ public abstract class FieldStats<T> implements Writeable, ToXContent {
         this.hasMinMax = false;
     }
 
+    /**
+     * Builds a FieldStats with min and max value for the field.
+     * @param type The native type of this FieldStats
+     * @param maxDoc Max number of docs
+     * @param docCount  the number of documents that have at least one term for this field, or -1 if this information isn't available for this field.
+     * @param sumDocFreq  the sum of {@link TermsEnum#docFreq()} for all terms in this field, or -1 if this information isn't available for this field.
+     * @param sumTotalTermFreq the sum of {@link TermsEnum#totalTermFreq} for all terms in this field, or -1 if this measure isn't available for this field.
+     * @param isSearchable true if this field is searchable
+     * @param isAggregatable true if this field is aggregatable
+     * @param minValue the minimum value indexed in this field
+     * @param maxValue the maximum value indexed in this field
+     */
     FieldStats(byte type,
                long maxDoc, long docCount, long sumDocFreq, long sumTotalTermFreq,
                boolean isSearchable, boolean isAggregatable, T minValue, T maxValue) {

--- a/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
@@ -55,9 +55,12 @@ public abstract class FieldStats<T> implements Writeable, ToXContent {
      * Builds a FieldStats where min and max value are not available for the field.
      * @param type The native type of this FieldStats
      * @param maxDoc Max number of docs
-     * @param docCount  the number of documents that have at least one term for this field, or -1 if this information isn't available for this field.
-     * @param sumDocFreq  the sum of {@link TermsEnum#docFreq()} for all terms in this field, or -1 if this information isn't available for this field.
-     * @param sumTotalTermFreq the sum of {@link TermsEnum#totalTermFreq} for all terms in this field, or -1 if this measure isn't available for this field.
+     * @param docCount  the number of documents that have at least one term for this field,
+     *                  or -1 if this information isn't available for this field.
+     * @param sumDocFreq  the sum of {@link TermsEnum#docFreq()} for all terms in this field,
+     *                    or -1 if this information isn't available for this field.
+     * @param sumTotalTermFreq the sum of {@link TermsEnum#totalTermFreq} for all terms in this field,
+     *                         or -1 if this measure isn't available for this field.
      * @param isSearchable true if this field is searchable
      * @param isAggregatable true if this field is aggregatable
      */
@@ -77,9 +80,12 @@ public abstract class FieldStats<T> implements Writeable, ToXContent {
      * Builds a FieldStats with min and max value for the field.
      * @param type The native type of this FieldStats
      * @param maxDoc Max number of docs
-     * @param docCount  the number of documents that have at least one term for this field, or -1 if this information isn't available for this field.
-     * @param sumDocFreq  the sum of {@link TermsEnum#docFreq()} for all terms in this field, or -1 if this information isn't available for this field.
-     * @param sumTotalTermFreq the sum of {@link TermsEnum#totalTermFreq} for all terms in this field, or -1 if this measure isn't available for this field.
+     * @param docCount  the number of documents that have at least one term for this field,
+     *                  or -1 if this information isn't available for this field.
+     * @param sumDocFreq  the sum of {@link TermsEnum#docFreq()} for all terms in this field,
+     *                    or -1 if this information isn't available for this field.
+     * @param sumTotalTermFreq the sum of {@link TermsEnum#totalTermFreq} for all terms in this field,
+     *                         or -1 if this measure isn't available for this field.
      * @param isSearchable true if this field is searchable
      * @param isAggregatable true if this field is aggregatable
      * @param minValue the minimum value indexed in this field
@@ -720,5 +726,4 @@ public abstract class FieldStats<T> implements Writeable, ToXContent {
     private static final String MIN_VALUE_AS_STRING_FIELD = "min_value_as_string";
     private static final String MAX_VALUE_FIELD = "max_value";
     private static final String MAX_VALUE_AS_STRING_FIELD = "max_value_as_string";
-
 }

--- a/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
@@ -267,15 +267,12 @@ public abstract class FieldStats<T> implements Writeable, ToXContent {
         isAggregatable |= other.isAggregatable;
 
         assert type == other.getType();
-        if (other.hasMinMax == false) {
-            return;
-        }
-        if (hasMinMax == false) {
-            hasMinMax = true;
-            minValue = (T) other.minValue;
-            maxValue = (T) other.maxValue;
-        } else {
+        if (hasMinMax && other.hasMinMax) {
             updateMinMax((T) other.minValue, (T) other.maxValue);
+        } else {
+            hasMinMax = false;
+            minValue = null;
+            maxValue = null;
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
@@ -299,9 +300,13 @@ public class DateFieldMapper extends FieldMapper {
         @Override
         public FieldStats.Date stats(IndexReader reader) throws IOException {
             String field = name();
+            FieldInfo fi = org.apache.lucene.index.MultiFields.getMergedFieldInfos(reader).fieldInfo(name());
+            if (fi == null) {
+                return null;
+            }
             long size = PointValues.size(reader, field);
             if (size == 0) {
-                return null;
+                return new FieldStats.Date(reader.maxDoc(), 0, -1, -1, isSearchable(), isAggregatable());
             }
             int docCount = PointValues.getDocCount(reader, field);
             byte[] min = PointValues.getMinPackedValue(reader, field);

--- a/core/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -23,6 +23,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
@@ -213,9 +214,13 @@ public class IpFieldMapper extends FieldMapper {
         @Override
         public FieldStats.Ip stats(IndexReader reader) throws IOException {
             String field = name();
+            FieldInfo fi = org.apache.lucene.index.MultiFields.getMergedFieldInfos(reader).fieldInfo(name());
+            if (fi == null) {
+                return null;
+            }
             long size = PointValues.size(reader, field);
             if (size == 0) {
-                return null;
+                return new FieldStats.Ip(reader.maxDoc(), 0, -1, -1, isSearchable(), isAggregatable());
             }
             int docCount = PointValues.getDocCount(reader, field);
             byte[] min = PointValues.getMinPackedValue(reader, field);

--- a/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -20,18 +20,19 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.search.BooleanClause.Occur;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.BoostQuery;
 import org.elasticsearch.action.fieldstats.FieldStats;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.joda.DateMathParser;
@@ -375,14 +376,16 @@ public abstract class MappedFieldType extends FieldType {
      */
     public FieldStats stats(IndexReader reader) throws IOException {
         int maxDoc = reader.maxDoc();
-        Terms terms = MultiFields.getTerms(reader, name());
-        if (terms == null) {
+        FieldInfo fi = MultiFields.getMergedFieldInfos(reader).fieldInfo(name());
+        if (fi == null) {
             return null;
         }
+        Terms terms = MultiFields.getTerms(reader, name());
+        if (terms == null) {
+            return new FieldStats.Text(maxDoc, 0, -1, -1, isSearchable(), isAggregatable());
+        }
         FieldStats stats = new FieldStats.Text(maxDoc, terms.getDocCount(),
-            terms.getSumDocFreq(), terms.getSumTotalTermFreq(),
-            isSearchable(), isAggregatable(),
-            terms.getMin(), terms.getMax());
+            terms.getSumDocFreq(), terms.getSumTotalTermFreq(), isSearchable(), isAggregatable(), terms.getMin(), terms.getMax());
         return stats;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -27,6 +27,7 @@ import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
@@ -227,14 +228,18 @@ public class NumberFieldMapper extends FieldMapper {
             @Override
             FieldStats.Double stats(IndexReader reader, String fieldName,
                                     boolean isSearchable, boolean isAggregatable) throws IOException {
+                FieldInfo fi = org.apache.lucene.index.MultiFields.getMergedFieldInfos(reader).fieldInfo(fieldName);
+                if (fi == null) {
+                    return null;
+                }
                 long size = PointValues.size(reader, fieldName);
                 if (size == 0) {
-                    return null;
+                    return new FieldStats.Double(reader.maxDoc(), 0, -1, -1, isSearchable, isAggregatable);
                 }
                 int docCount = PointValues.getDocCount(reader, fieldName);
                 byte[] min = PointValues.getMinPackedValue(reader, fieldName);
                 byte[] max = PointValues.getMaxPackedValue(reader, fieldName);
-                return new FieldStats.Double(reader.maxDoc(),docCount, -1L, size,
+                return new FieldStats.Double(reader.maxDoc(), docCount, -1L, size,
                     isSearchable, isAggregatable,
                     HalfFloatPoint.decodeDimension(min, 0), HalfFloatPoint.decodeDimension(max, 0));
             }
@@ -311,9 +316,13 @@ public class NumberFieldMapper extends FieldMapper {
             @Override
             FieldStats.Double stats(IndexReader reader, String fieldName,
                                     boolean isSearchable, boolean isAggregatable) throws IOException {
+                FieldInfo fi = org.apache.lucene.index.MultiFields.getMergedFieldInfos(reader).fieldInfo(fieldName);
+                if (fi == null) {
+                    return null;
+                }
                 long size = PointValues.size(reader, fieldName);
                 if (size == 0) {
-                    return null;
+                    return new FieldStats.Double(reader.maxDoc(), 0, -1, -1, isSearchable, isAggregatable);
                 }
                 int docCount = PointValues.getDocCount(reader, fieldName);
                 byte[] min = PointValues.getMinPackedValue(reader, fieldName);
@@ -395,9 +404,13 @@ public class NumberFieldMapper extends FieldMapper {
             @Override
             FieldStats.Double stats(IndexReader reader, String fieldName,
                                     boolean isSearchable, boolean isAggregatable) throws IOException {
+                FieldInfo fi = org.apache.lucene.index.MultiFields.getMergedFieldInfos(reader).fieldInfo(fieldName);
+                if (fi == null) {
+                    return null;
+                }
                 long size = PointValues.size(reader, fieldName);
                 if (size == 0) {
-                    return null;
+                    return new FieldStats.Double(reader.maxDoc(),0, -1, -1, isSearchable, isAggregatable);
                 }
                 int docCount = PointValues.getDocCount(reader, fieldName);
                 byte[] min = PointValues.getMinPackedValue(reader, fieldName);
@@ -613,9 +626,13 @@ public class NumberFieldMapper extends FieldMapper {
             @Override
             FieldStats.Long stats(IndexReader reader, String fieldName,
                                   boolean isSearchable, boolean isAggregatable) throws IOException {
+                FieldInfo fi = org.apache.lucene.index.MultiFields.getMergedFieldInfos(reader).fieldInfo(fieldName);
+                if (fi == null) {
+                    return null;
+                }
                 long size = PointValues.size(reader, fieldName);
                 if (size == 0) {
-                    return null;
+                    return new FieldStats.Long(reader.maxDoc(), 0, -1, -1, isSearchable, isAggregatable);
                 }
                 int docCount = PointValues.getDocCount(reader, fieldName);
                 byte[] min = PointValues.getMinPackedValue(reader, fieldName);
@@ -709,9 +726,13 @@ public class NumberFieldMapper extends FieldMapper {
             @Override
             FieldStats.Long stats(IndexReader reader, String fieldName,
                                   boolean isSearchable, boolean isAggregatable) throws IOException {
+                FieldInfo fi = org.apache.lucene.index.MultiFields.getMergedFieldInfos(reader).fieldInfo(fieldName);
+                if (fi == null) {
+                    return null;
+                }
                 long size = PointValues.size(reader, fieldName);
                 if (size == 0) {
-                    return null;
+                    return new FieldStats.Long(reader.maxDoc(), 0, -1, -1, isSearchable, isAggregatable);
                 }
                 int docCount = PointValues.getDocCount(reader, fieldName);
                 byte[] min = PointValues.getMinPackedValue(reader, fieldName);

--- a/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
@@ -602,7 +602,7 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
     }
 
     public void testSerialization() throws IOException {
-        for (Version version : new Version[] {Version.CURRENT, Version.V_5_1_0_UNRELEASED}){
+        for (Version version : new Version[] {Version.CURRENT, Version.V_5_0_1}){
             for (int i = 0; i < 20; i++) {
                 assertSerialization(randomFieldStats(version.onOrAfter(Version.V_5_2_0_UNRELEASED)), version);
             }

--- a/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
@@ -48,7 +48,6 @@ import static org.elasticsearch.action.fieldstats.IndexConstraint.Comparison.LTE
 import static org.elasticsearch.action.fieldstats.IndexConstraint.Property.MAX;
 import static org.elasticsearch.action.fieldstats.IndexConstraint.Property.MIN;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 
 public class FieldStatsTests extends ESSingleNodeTestCase {
     public void testByte() {
@@ -101,27 +100,28 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
 
         FieldStatsResponse result = client().prepareFieldStats()
             .setFields("field_index", "field_dv", "field_stored", "field_source").get();
-        assertThat(result.getAllFieldStats().size(), equalTo(3));
+        assertEquals(result.getAllFieldStats().size(), 3);
         for (String field : new String[] {"field_index", "field_dv", "field_stored"}) {
-            assertThat(result.getAllFieldStats().get(field).getMaxDoc(), equalTo(11L));
-            assertThat(result.getAllFieldStats().get(field).getDisplayType(),
-                equalTo("string"));
+            FieldStats stats = result.getAllFieldStats().get(field);
+            assertEquals(stats.getMaxDoc(), 11L);
+            assertEquals(stats.getDisplayType(),
+                "string");
             if ("field_index".equals(field)) {
-                assertThat(result.getAllFieldStats().get(field).getMinValue(),
-                    equalTo(new BytesRef(String.format(Locale.ENGLISH, "%03d", 0))));
-                assertThat(result.getAllFieldStats().get(field).getMaxValue(),
-                    equalTo(new BytesRef(String.format(Locale.ENGLISH, "%03d", 10))));
-                assertThat(result.getAllFieldStats().get(field).getMinValueAsString(),
-                    equalTo(String.format(Locale.ENGLISH, "%03d", 0)));
-                assertThat(result.getAllFieldStats().get(field).getMaxValueAsString(),
-                    equalTo(String.format(Locale.ENGLISH, "%03d", 10)));
-                assertThat(result.getAllFieldStats().get(field).getDocCount(), equalTo(11L));
-                assertThat(result.getAllFieldStats().get(field).getDensity(), equalTo(100));
+                assertEquals(stats.getMinValue(),
+                    new BytesRef(String.format(Locale.ENGLISH, "%03d", 0)));
+                assertEquals(stats.getMaxValue(),
+                    new BytesRef(String.format(Locale.ENGLISH, "%03d", 10)));
+                assertEquals(stats.getMinValueAsString(),
+                    String.format(Locale.ENGLISH, "%03d", 0));
+                assertEquals(stats.getMaxValueAsString(),
+                    String.format(Locale.ENGLISH, "%03d", 10));
+                assertEquals(stats.getDocCount(), 11L);
+                assertEquals(stats.getDensity(), 100);
             } else {
-                assertThat(result.getAllFieldStats().get(field).getDocCount(), equalTo(0L));
-                assertNull(result.getAllFieldStats().get(field).getMinValue());
-                assertNull(result.getAllFieldStats().get(field).getMaxValue());
-                assertThat(result.getAllFieldStats().get(field).getDensity(), equalTo(0));
+                assertEquals(stats.getDocCount(), 0L);
+                assertNull(stats.getMinValue());
+                assertNull(stats.getMaxValue());
+                assertEquals(stats.getDensity(), 0);
             }
         }
     }
@@ -140,19 +140,20 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
         FieldStatsResponse result = client().prepareFieldStats()
             .setFields("field_index", "field_dv", "field_stored", "field_source").get();
         for (String field : new String[] {"field_index", "field_dv", "field_stored"}) {
-            assertThat(result.getAllFieldStats().get(field).getMaxDoc(), equalTo(11L));
-            assertThat(result.getAllFieldStats().get(field).getDisplayType(), equalTo("float"));
+            FieldStats stats = result.getAllFieldStats().get(field);
+            assertEquals(stats.getMaxDoc(), 11L);
+            assertEquals(stats.getDisplayType(), "float");
             if ("field_index".equals(field)) {
-                assertThat(result.getAllFieldStats().get(field).getDocCount(), equalTo(11L));
-                assertThat(result.getAllFieldStats().get(field).getDensity(), equalTo(100));
-                assertThat(result.getAllFieldStats().get(field).getMinValue(), equalTo(-1d));
-                assertThat(result.getAllFieldStats().get(field).getMaxValue(), equalTo(9d));
-                assertThat(result.getAllFieldStats().get(field).getMinValueAsString(), equalTo(Double.toString(-1)));
+                assertEquals(stats.getDocCount(), 11L);
+                assertEquals(stats.getDensity(), 100);
+                assertEquals(stats.getMinValue(), -1d);
+                assertEquals(stats.getMaxValue(), 9d);
+                assertEquals(stats.getMinValueAsString(), Double.toString(-1));
             } else {
-                assertThat(result.getAllFieldStats().get(field).getDocCount(), equalTo(0L));
-                assertNull(result.getAllFieldStats().get(field).getMinValue());
-                assertNull(result.getAllFieldStats().get(field).getMaxValue());
-                assertThat(result.getAllFieldStats().get(field).getDensity(), equalTo(0));
+                assertEquals(stats.getDocCount(), 0L);
+                assertNull(stats.getMinValue());
+                assertNull(stats.getMaxValue());
+                assertEquals(stats.getDensity(), 0);
             }
         }
     }
@@ -172,20 +173,21 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
         FieldStatsResponse result = client().prepareFieldStats()
             .setFields("field_index", "field_dv", "field_stored", "field_source").get();
         for (String field : new String[] {"field_index", "field_dv", "field_stored"}) {
-            assertThat(result.getAllFieldStats().get(field).getMaxDoc(), equalTo(11L));
-            assertThat(result.getAllFieldStats().get(field).getDisplayType(), equalTo("float"));
+            FieldStats stats = result.getAllFieldStats().get(field);
+            assertEquals(stats.getMaxDoc(), 11L);
+            assertEquals(stats.getDisplayType(), "float");
             if (field.equals("field_index")) {
-                assertThat(result.getAllFieldStats().get(field).getDocCount(), equalTo(11L));
-                assertThat(result.getAllFieldStats().get(field).getDensity(), equalTo(100));
-                assertThat(result.getAllFieldStats().get(field).getMinValue(), equalTo(-1d));
-                assertThat(result.getAllFieldStats().get(field).getMaxValue(), equalTo(9d));
-                assertThat(result.getAllFieldStats().get(field).getMinValueAsString(), equalTo(Float.toString(-1)));
-                assertThat(result.getAllFieldStats().get(field).getMaxValueAsString(), equalTo(Float.toString(9)));
+                assertEquals(stats.getDocCount(), 11L);
+                assertEquals(stats.getDensity(), 100);
+                assertEquals(stats.getMinValue(), -1d);
+                assertEquals(stats.getMaxValue(), 9d);
+                assertEquals(stats.getMinValueAsString(), Float.toString(-1));
+                assertEquals(stats.getMaxValueAsString(), Float.toString(9));
             } else {
-                assertThat(result.getAllFieldStats().get(field).getDocCount(), equalTo(0L));
-                assertNull(result.getAllFieldStats().get(field).getMinValue());
-                assertNull(result.getAllFieldStats().get(field).getMaxValue());
-                assertThat(result.getAllFieldStats().get(field).getDensity(), equalTo(0));
+                assertEquals(stats.getDocCount(), 0L);
+                assertNull(stats.getMinValue());
+                assertNull(stats.getMaxValue());
+                assertEquals(stats.getDensity(), 0);
             }
         }
     }
@@ -206,20 +208,21 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
         FieldStatsResponse result = client().prepareFieldStats()
             .setFields("field_index", "field_dv", "field_stored", "field_source").get();
         for (String field : new String[]{"field_index", "field_dv", "field_stored"}) {
-            assertThat(result.getAllFieldStats().get(field).getMaxDoc(), equalTo(11L));
-            assertThat(result.getAllFieldStats().get(field).getDisplayType(), equalTo("float"));
+            FieldStats stats = result.getAllFieldStats().get(field);
+            assertEquals(stats.getMaxDoc(), 11L);
+            assertEquals(stats.getDisplayType(), "float");
             if (field.equals("field_index")) {
-                assertThat(result.getAllFieldStats().get(field).getDocCount(), equalTo(11L));
-                assertThat(result.getAllFieldStats().get(field).getDensity(), equalTo(100));
-                assertThat(result.getAllFieldStats().get(field).getMinValue(), equalTo(-1d));
-                assertThat(result.getAllFieldStats().get(field).getMaxValue(), equalTo(9d));
-                assertThat(result.getAllFieldStats().get(field).getMinValueAsString(), equalTo(Float.toString(-1)));
-                assertThat(result.getAllFieldStats().get(field).getMaxValueAsString(), equalTo(Float.toString(9)));
+                assertEquals(stats.getDocCount(), 11L);
+                assertEquals(stats.getDensity(), 100);
+                assertEquals(stats.getMinValue(), -1d);
+                assertEquals(stats.getMaxValue(), 9d);
+                assertEquals(stats.getMinValueAsString(), Float.toString(-1));
+                assertEquals(stats.getMaxValueAsString(), Float.toString(9));
             } else {
-                assertThat(result.getAllFieldStats().get(field).getDocCount(), equalTo(0L));
-                assertNull(result.getAllFieldStats().get(field).getMinValue());
-                assertNull(result.getAllFieldStats().get(field).getMaxValue());
-                assertThat(result.getAllFieldStats().get(field).getDensity(), equalTo(0));
+                assertEquals(stats.getDocCount(), 0L);
+                assertNull(stats.getMinValue());
+                assertNull(stats.getMaxValue());
+                assertEquals(stats.getDensity(), 0);
             }
         }
     }
@@ -238,21 +241,21 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
 
         FieldStatsResponse result = client().prepareFieldStats().setFields(fieldName).get();
         long numDocs = max - min + 1;
-        assertThat(result.getAllFieldStats().get(fieldName).getMaxDoc(), equalTo(numDocs));
-        assertThat(result.getAllFieldStats().get(fieldName).getDocCount(), equalTo(numDocs));
-        assertThat(result.getAllFieldStats().get(fieldName).getDensity(), equalTo(100));
-        assertThat(result.getAllFieldStats().get(fieldName).getMinValue(), equalTo(min));
-        assertThat(result.getAllFieldStats().get(fieldName).getMaxValue(), equalTo(max));
-        assertThat(result.getAllFieldStats().get(fieldName).getMinValueAsString(),
-            equalTo(java.lang.Long.toString(min)));
-        assertThat(result.getAllFieldStats().get(fieldName).getMaxValueAsString(),
-            equalTo(java.lang.Long.toString(max)));
-        assertThat(result.getAllFieldStats().get(fieldName).isSearchable(), equalTo(true));
-        assertThat(result.getAllFieldStats().get(fieldName).isAggregatable(), equalTo(true));
+        assertEquals(result.getAllFieldStats().get(fieldName).getMaxDoc(), numDocs);
+        assertEquals(result.getAllFieldStats().get(fieldName).getDocCount(), numDocs);
+        assertEquals(result.getAllFieldStats().get(fieldName).getDensity(), 100);
+        assertEquals(result.getAllFieldStats().get(fieldName).getMinValue(), min);
+        assertEquals(result.getAllFieldStats().get(fieldName).getMaxValue(), max);
+        assertEquals(result.getAllFieldStats().get(fieldName).getMinValueAsString(),
+            java.lang.Long.toString(min));
+        assertEquals(result.getAllFieldStats().get(fieldName).getMaxValueAsString(),
+            java.lang.Long.toString(max));
+        assertEquals(result.getAllFieldStats().get(fieldName).isSearchable(), true);
+        assertEquals(result.getAllFieldStats().get(fieldName).isAggregatable(), true);
         if (fieldType.equals("float") || fieldType.equals("double") || fieldType.equals("half-float")) {
-            assertThat(result.getAllFieldStats().get(fieldName).getDisplayType(), equalTo("float"));
+            assertEquals(result.getAllFieldStats().get(fieldName).getDisplayType(), "float");
         } else {
-            assertThat(result.getAllFieldStats().get(fieldName).getDisplayType(), equalTo("integer"));
+            assertEquals(result.getAllFieldStats().get(fieldName).getDisplayType(), "integer");
         }
 
         client().admin().indices().prepareDelete("test").get();
@@ -271,13 +274,13 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
         for (FieldStats otherStat : stats) {
             stat.accumulate(otherStat);
         }
-        assertThat(stat.getMaxDoc(), equalTo(4L));
-        assertThat(stat.getDocCount(), equalTo(4L));
-        assertThat(stat.getSumDocFreq(), equalTo(4L));
-        assertThat(stat.getSumTotalTermFreq(), equalTo(4L));
-        assertThat(stat.isSearchable(), equalTo(true));
-        assertThat(stat.isAggregatable(), equalTo(false));
-        assertThat(stat.getDisplayType(), equalTo("integer"));
+        assertEquals(stat.getMaxDoc(), 4L);
+        assertEquals(stat.getDocCount(), 4L);
+        assertEquals(stat.getSumDocFreq(), 4L);
+        assertEquals(stat.getSumTotalTermFreq(), 4L);
+        assertEquals(stat.isSearchable(), true);
+        assertEquals(stat.isAggregatable(), false);
+        assertEquals(stat.getDisplayType(), "integer");
     }
 
     public void testMerge_notAvailable() {
@@ -290,26 +293,26 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
         for (FieldStats otherStat : stats) {
             stat.accumulate(otherStat);
         }
-        assertThat(stat.getMaxDoc(), equalTo(4L));
-        assertThat(stat.getDocCount(), equalTo(-1L));
-        assertThat(stat.getSumDocFreq(), equalTo(-1L));
-        assertThat(stat.getSumTotalTermFreq(), equalTo(-1L));
-        assertThat(stat.isSearchable(), equalTo(true));
-        assertThat(stat.isAggregatable(), equalTo(true));
-        assertThat(stat.getDisplayType(), equalTo("integer"));
+        assertEquals(stat.getMaxDoc(), 4L);
+        assertEquals(stat.getDocCount(), -1L);
+        assertEquals(stat.getSumDocFreq(), -1L);
+        assertEquals(stat.getSumTotalTermFreq(), -1L);
+        assertEquals(stat.isSearchable(), true);
+        assertEquals(stat.isAggregatable(), true);
+        assertEquals(stat.getDisplayType(), "integer");
 
         stats.add(new FieldStats.Long(1, -1L, -1L, -1L, false, true));
         stat = stats.remove(0);
         for (FieldStats otherStat : stats) {
             stat.accumulate(otherStat);
         }
-        assertThat(stat.getMaxDoc(), equalTo(4L));
-        assertThat(stat.getDocCount(), equalTo(-1L));
-        assertThat(stat.getSumDocFreq(), equalTo(-1L));
-        assertThat(stat.getSumTotalTermFreq(), equalTo(-1L));
-        assertThat(stat.isSearchable(), equalTo(true));
-        assertThat(stat.isAggregatable(), equalTo(true));
-        assertThat(stat.getDisplayType(), equalTo("integer"));
+        assertEquals(stat.getMaxDoc(), 4L);
+        assertEquals(stat.getDocCount(), -1L);
+        assertEquals(stat.getSumDocFreq(), -1L);
+        assertEquals(stat.getSumTotalTermFreq(), -1L);
+        assertEquals(stat.isSearchable(), true);
+        assertEquals(stat.isAggregatable(), true);
+        assertEquals(stat.getDisplayType(), "integer");
     }
 
     public void testNumberFiltering() {
@@ -323,9 +326,9 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                 .setFields("value")
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(2));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(1L));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(3L));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 2);
+        assertEquals(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), 1L);
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), 3L);
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -333,7 +336,7 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                     new IndexConstraint("value", MAX, LTE, "0"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(0));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 0);
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -341,7 +344,7 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                     new IndexConstraint("value", MAX, LT, "1"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(0));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 0);
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -349,8 +352,8 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                     new IndexConstraint("value", MAX, LTE, "1"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(1L));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 1);
+        assertEquals(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), 1L);
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -358,8 +361,8 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                     new IndexConstraint("value", MAX, LTE,  "2"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(1L));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 1);
+        assertEquals(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), 1L);
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -367,7 +370,7 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                     new IndexConstraint("value", MAX, LTE, "2"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(0));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 0);
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -375,8 +378,8 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                     new IndexConstraint("value", MAX, LTE, "3"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(3L));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 1);
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), 3L);
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -384,8 +387,8 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                     new IndexConstraint("value", MAX, LTE, "4"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(3L));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 1);
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), 3L);
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -393,7 +396,7 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                     new IndexConstraint("value", MAX, LTE, "4"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(0));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 0);
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -401,9 +404,9 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                     new IndexConstraint("value", MAX, LTE, "3"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(2));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(1L));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(3L));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 2);
+        assertEquals(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), 1L);
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), 3L);
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -411,7 +414,7 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                     new IndexConstraint("value", MAX, LT, "3"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(0));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 0);
     }
 
     public void testDateFiltering() {
@@ -431,17 +434,17 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                 .setFields("value")
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(2));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(),
-            equalTo(dateTime1.getMillis()));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(),
-            equalTo(dateTime2.getMillis()));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValueAsString(),
-            equalTo(dateTime1Str));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValueAsString(),
-            equalTo(dateTime2Str));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getDisplayType(),
-            equalTo("date"));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 2);
+        assertEquals(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(),
+            dateTime1.getMillis());
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(),
+            dateTime2.getMillis());
+        assertEquals(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValueAsString(),
+            dateTime1Str);
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValueAsString(),
+            dateTime2Str);
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getDisplayType(),
+            "date");
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -449,7 +452,7 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                     new IndexConstraint("value", MAX, LTE, "2013-12-31T00:00:00.000Z"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(0));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 0);
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -457,13 +460,13 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                     new IndexConstraint("value", MAX, LTE, "2014-01-01T00:00:00.000Z"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(),
-            equalTo(dateTime1.getMillis()));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValueAsString(),
-            equalTo(dateTime1Str));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getDisplayType(),
-            equalTo("date"));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 1);
+        assertEquals(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(),
+            dateTime1.getMillis());
+        assertEquals(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValueAsString(),
+            dateTime1Str);
+        assertEquals(response.getIndicesMergedFieldStats().get("test1").get("value").getDisplayType(),
+            "date");
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -471,11 +474,11 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                     new IndexConstraint("value", MAX, LTE, "2014-01-02T00:00:00.000Z"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(),
-            equalTo(dateTime2.getMillis()));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValueAsString(),
-            equalTo(dateTime2Str));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 1);
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(),
+            dateTime2.getMillis());
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValueAsString(),
+            dateTime2Str);
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -483,7 +486,7 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                     new IndexConstraint("value", MAX, LTE, "2014-01-03T00:00:00.000Z"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(0));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 0);
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -491,54 +494,53 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                     new IndexConstraint("value", MAX, LTE, "2014-01-02T01:00:00.000Z"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(),
-            equalTo(dateTime2.getMillis()));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValueAsString(),
-            equalTo(dateTime2Str));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getDisplayType(),
-            equalTo("date"));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 1);
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(),
+            dateTime2.getMillis());
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValueAsString(),
+            dateTime2Str);
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getDisplayType(),
+            "date");
 
         response = client().prepareFieldStats()
                 .setFields("value")
                 .setIndexContraints(new IndexConstraint("value", MIN, GTE, "2014-01-01T00:00:00.000Z"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(2));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(),
-            equalTo(dateTime1.getMillis()));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(),
-            equalTo(dateTime2.getMillis()));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValueAsString(),
-            equalTo(dateTime1Str));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValueAsString(),
-            equalTo(dateTime2Str));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getDisplayType(),
-            equalTo("date"));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 2);
+        assertEquals(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(),
+            dateTime1.getMillis());
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(),
+            dateTime2.getMillis());
+        assertEquals(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValueAsString(),
+            dateTime1Str);
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValueAsString(),
+            dateTime2Str);
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getDisplayType(),
+            "date");
 
         response = client().prepareFieldStats()
                 .setFields("value")
                 .setIndexContraints(new IndexConstraint("value", MAX, LTE, "2014-01-02T00:00:00.000Z"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(2));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(),
-            equalTo(dateTime1.getMillis()));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(),
-            equalTo(dateTime2.getMillis()));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValueAsString(),
-            equalTo(dateTime1Str));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValueAsString(),
-            equalTo(dateTime2Str));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getDisplayType(),
-            equalTo("date"));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 2);
+        assertEquals(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(),
+            dateTime1.getMillis());
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(),
+            dateTime2.getMillis());
+        assertEquals(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValueAsString(),
+            dateTime1Str);
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValueAsString(),
+            dateTime2Str);
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getDisplayType(), "date");
 
         response = client().prepareFieldStats()
             .setFields("value2")
             .setIndexContraints(new IndexConstraint("value2", MAX, LTE, "2014-01-02T00:00:00.000Z"))
             .setLevel("indices")
             .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(0));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 0);
     }
 
     public void testDateFiltering_optionalFormat() {
@@ -557,11 +559,11 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                     new IndexConstraint("value", MAX, LTE, String.valueOf(dateTime2.getMillis()), "epoch_millis"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValueAsString(),
-            equalTo("2014-01-02T00:00:00.000Z"));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getDisplayType(),
-            equalTo("date"));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 1);
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValueAsString(),
+            "2014-01-02T00:00:00.000Z");
+        assertEquals(response.getIndicesMergedFieldStats().get("test2").get("value").getDisplayType(),
+            "date");
 
         try {
             client().prepareFieldStats()
@@ -582,8 +584,8 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
             .setFields("*")
             .setLevel("indices")
             .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").size(), equalTo(0));
+        assertEquals(response.getIndicesMergedFieldStats().size(), 1);
+        assertEquals(response.getIndicesMergedFieldStats().get("test1").size(), 0);
     }
 
     public void testMetaFieldsNotIndexed() {
@@ -594,16 +596,16 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
         FieldStatsResponse response = client().prepareFieldStats()
             .setFields("_id", "_type")
             .get();
-        assertThat(response.getAllFieldStats().size(), equalTo(1));
-        assertThat(response.getAllFieldStats().get("_type").isSearchable(), equalTo(true));
-        assertThat(response.getAllFieldStats().get("_type").isAggregatable(), equalTo(true));
+        assertEquals(response.getAllFieldStats().size(), 1);
+        assertEquals(response.getAllFieldStats().get("_type").isSearchable(), true);
+        assertEquals(response.getAllFieldStats().get("_type").isAggregatable(), true);
     }
 
     public void testSerialization() throws IOException {
-        Version version = randomBoolean() ? Version.CURRENT : Version.V_5_1_0_UNRELEASED;
-        for (int i = 0; i < 20; i++) {
-            assertSerialization(randomFieldStats(version.onOrAfter(Version.V_5_2_0_UNRELEASED)),
-                version);
+        for (Version version : new Version[] {Version.CURRENT, Version.V_5_1_0_UNRELEASED}){
+            for (int i = 0; i < 20; i++) {
+                assertSerialization(randomFieldStats(version.onOrAfter(Version.V_5_2_0_UNRELEASED)), version);
+            }
         }
     }
 
@@ -678,7 +680,7 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
         StreamInput input = output.bytes().streamInput();
         input.setVersion(version);
         FieldStats deserializedStats = FieldStats.readFrom(input);
-        assertThat(stats, equalTo(deserializedStats));
-        assertThat(stats.hashCode(), equalTo(deserializedStats.hashCode()));
+        assertEquals(stats, deserializedStats);
+        assertEquals(stats.hashCode(), deserializedStats.hashCode());
     }
 }

--- a/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
@@ -313,6 +313,8 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
         assertEquals(stat.isSearchable(), true);
         assertEquals(stat.isAggregatable(), true);
         assertEquals(stat.getDisplayType(), "integer");
+        assertNull(stat.getMaxValue());
+        assertNull(stat.getMinValue());
     }
 
     public void testNumberFiltering() {

--- a/docs/reference/search/field-stats.asciidoc
+++ b/docs/reference/search/field-stats.asciidoc
@@ -299,7 +299,7 @@ Response:
 
 Field stats index constraints allows to omit all field stats for indices that don't match with the constraint. An index
 constraint can exclude indices' field stats based on the `min_value` and `max_value` statistic. This option is only
-useful if the `level` option is set to `indices`.
+useful if the `level` option is set to `indices`. Fields that are not indexed (not searchable) are always omitted when an index constraint is defined.
 
 For example index constraints can be useful to find out the min and max value of a particular property of your data in
 a time based scenario. The following request only returns field stats for the `answer_count` property for indices


### PR DESCRIPTION
This change adds non-searchable fields to the FieldStats response. These fields do not have min/max informations but they can be aggregatable. Fields that are only stored in _source (store:no, index:no, doc_values:no) will still be missing since they do not have any useful information to show. Indices and clients must be at least on V_5_2_0 to see this change.

Closes https://github.com/elastic/elasticsearch/issues/21952