### PR TITLE
Minor clean-ups in MockBigArrays

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
@@ -48,7 +48,6 @@ public class MockBigArrays extends BigArrays {
      */
     private static final boolean TRACK_ALLOCATIONS = false;
 
-    private static final Set<BigArrays> INSTANCES = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<BigArrays, Boolean>()));
     private static final ConcurrentMap<Object, Object> ACQUIRED_ARRAYS = new ConcurrentHashMap<>();
 
     public static void ensureAllArraysAreReleased() throws Exception {
@@ -88,7 +87,6 @@ public class MockBigArrays extends BigArrays {
             seed = 0;
         }
         random = new Random(seed);
-        INSTANCES.add(this);
     }
 
 
@@ -247,15 +245,13 @@ public class MockBigArrays extends BigArrays {
 
     private abstract static class AbstractArrayWrapper {
 
-        final BigArray in;
-        boolean clearOnResize;
-        AtomicReference<AssertionError> originalRelease;
+        final boolean clearOnResize;
+        private final AtomicReference<AssertionError> originalRelease;
 
-        AbstractArrayWrapper(BigArray in, boolean clearOnResize) {
-            ACQUIRED_ARRAYS.put(this, TRACK_ALLOCATIONS ? new RuntimeException() : Boolean.TRUE);
-            this.in = in;
+        AbstractArrayWrapper(boolean clearOnResize) {
             this.clearOnResize = clearOnResize;
-            originalRelease = new AtomicReference<>();
+            this.originalRelease = new AtomicReference<>();
+            ACQUIRED_ARRAYS.put(this, TRACK_ALLOCATIONS ? new RuntimeException() : Boolean.TRUE);
         }
 
         protected abstract BigArray getDelegate();
@@ -267,7 +263,7 @@ public class MockBigArrays extends BigArrays {
         }
 
         public long ramBytesUsed() {
-            return in.ramBytesUsed();
+            return getDelegate().ramBytesUsed();
         }
 
         public void close() {
@@ -286,7 +282,7 @@ public class MockBigArrays extends BigArrays {
         private final ByteArray in;
 
         ByteArrayWrapper(ByteArray in, boolean clearOnResize) {
-            super(in, clearOnResize);
+            super(clearOnResize);
             this.in = in;
         }
 
@@ -336,7 +332,7 @@ public class MockBigArrays extends BigArrays {
         private final IntArray in;
 
         IntArrayWrapper(IntArray in, boolean clearOnResize) {
-            super(in, clearOnResize);
+            super(clearOnResize);
             this.in = in;
         }
 
@@ -381,7 +377,7 @@ public class MockBigArrays extends BigArrays {
         private final LongArray in;
 
         LongArrayWrapper(LongArray in, boolean clearOnResize) {
-            super(in, clearOnResize);
+            super(clearOnResize);
             this.in = in;
         }
 
@@ -427,7 +423,7 @@ public class MockBigArrays extends BigArrays {
         private final FloatArray in;
 
         FloatArrayWrapper(FloatArray in, boolean clearOnResize) {
-            super(in, clearOnResize);
+            super(clearOnResize);
             this.in = in;
         }
 
@@ -472,7 +468,7 @@ public class MockBigArrays extends BigArrays {
         private final DoubleArray in;
 
         DoubleArrayWrapper(DoubleArray in, boolean clearOnResize) {
-            super(in, clearOnResize);
+            super(clearOnResize);
             this.in = in;
         }
 
@@ -517,7 +513,7 @@ public class MockBigArrays extends BigArrays {
         private final ObjectArray<T> in;
 
         ObjectArrayWrapper(ObjectArray<T> in) {
-            super(in, false);
+            super(false);
             this.in = in;
         }
 


### PR DESCRIPTION
Removes an unused static variable and an unused instance variable.