### PR TITLE
Deprecate `timestamp` and `ttl` on index requests.

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -340,8 +340,10 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
                             } else if ("_parent".equals(currentFieldName) || "parent".equals(currentFieldName)) {
                                 parent = parser.text();
                             } else if ("_timestamp".equals(currentFieldName) || "timestamp".equals(currentFieldName)) {
+                                DEPRECATION_LOGGER.deprecated("The [timestamp] parameter of index requests is deprecated");
                                 timestamp = parser.text();
                             } else if ("_ttl".equals(currentFieldName) || "ttl".equals(currentFieldName)) {
+                                DEPRECATION_LOGGER.deprecated("The [ttl] parameter of index requests is deprecated");
                                 if (parser.currentToken() == XContentParser.Token.VALUE_STRING) {
                                     ttl = TimeValue.parseTimeValue(parser.text(), null, currentFieldName);
                                 } else {

--- a/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -331,11 +331,13 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
     /**
      * Sets the timestamp either as millis since the epoch, or, in the configured date format.
      */
+    @Deprecated
     public IndexRequest timestamp(String timestamp) {
         this.timestamp = timestamp;
         return this;
     }
 
+    @Deprecated
     public String timestamp() {
         return this.timestamp;
     }
@@ -343,6 +345,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
     /**
      * Sets the ttl value as a time value expression.
      */
+    @Deprecated
     public IndexRequest ttl(String ttl) {
         this.ttl = TimeValue.parseTimeValue(ttl, null, "ttl");
         return this;
@@ -351,6 +354,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
     /**
      * Sets the ttl as a {@link TimeValue} instance.
      */
+    @Deprecated
     public IndexRequest ttl(TimeValue ttl) {
         this.ttl = ttl;
         return this;
@@ -359,6 +363,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
     /**
      * Sets the relative ttl value in milliseconds. It musts be greater than 0 as it makes little sense otherwise.
      */
+    @Deprecated
     public IndexRequest ttl(long ttl) {
         this.ttl = new TimeValue(ttl);
         return this;
@@ -367,6 +372,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
     /**
      * Returns the ttl as a {@link TimeValue}
      */
+    @Deprecated
     public TimeValue ttl() {
         return this.ttl;
     }

--- a/core/src/main/java/org/elasticsearch/action/index/IndexRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexRequestBuilder.java
@@ -233,6 +233,7 @@ public class IndexRequestBuilder extends ReplicationRequestBuilder<IndexRequest,
     /**
      * Sets the timestamp either as millis since the epoch, or, in the configured date format.
      */
+    @Deprecated
     public IndexRequestBuilder setTimestamp(String timestamp) {
         request.timestamp(timestamp);
         return this;
@@ -241,6 +242,7 @@ public class IndexRequestBuilder extends ReplicationRequestBuilder<IndexRequest,
     /**
      * Sets the ttl value as a time value expression.
      */
+    @Deprecated
     public IndexRequestBuilder setTTL(String ttl) {
         request.ttl(ttl);
         return this;
@@ -249,6 +251,7 @@ public class IndexRequestBuilder extends ReplicationRequestBuilder<IndexRequest,
     /**
      * Sets the relative ttl value in milliseconds. It musts be greater than 0 as it makes little sense otherwise.
      */
+    @Deprecated
     public IndexRequestBuilder setTTL(long ttl) {
         request.ttl(ttl);
         return this;
@@ -257,6 +260,7 @@ public class IndexRequestBuilder extends ReplicationRequestBuilder<IndexRequest,
     /**
      * Sets the ttl as a {@link TimeValue} instance.
      */
+    @Deprecated
     public IndexRequestBuilder setTTL(TimeValue ttl) {
         request.ttl(ttl);
         return this;

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
@@ -360,6 +360,7 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
      * and the source of the document isn't changed then the ttl update won't take
      * effect.
      */
+    @Deprecated
     public UpdateRequestBuilder setTtl(Long ttl) {
         request.doc().ttl(ttl);
         return this;
@@ -370,6 +371,7 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
      * and the source of the document isn't changed then the ttl update won't take
      * effect.
      */
+    @Deprecated
     public UpdateRequestBuilder setTtl(String ttl) {
         request.doc().ttl(ttl);
         return this;
@@ -380,6 +382,7 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
      * and the source of the document isn't changed then the ttl update won't take
      * effect.
      */
+    @Deprecated
     public UpdateRequestBuilder setTtl(TimeValue ttl) {
         request.doc().ttl(ttl);
         return this;

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestIndexAction.java
@@ -66,8 +66,12 @@ public class RestIndexAction extends BaseRestHandler {
         IndexRequest indexRequest = new IndexRequest(request.param("index"), request.param("type"), request.param("id"));
         indexRequest.routing(request.param("routing"));
         indexRequest.parent(request.param("parent")); // order is important, set it after routing, so it will set the routing
+        if (request.hasParam("timestamp")) {
+            deprecationLogger.deprecated("The [timestamp] parameter of index requests is deprecated");
+        }
         indexRequest.timestamp(request.param("timestamp"));
         if (request.hasParam("ttl")) {
+            deprecationLogger.deprecated("The [ttl] parameter of index requests is deprecated");
             indexRequest.ttl(request.param("ttl"));
         }
         indexRequest.setPipeline(request.param("pipeline"));

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestUpdateAction.java
@@ -81,6 +81,12 @@ public class RestUpdateAction extends BaseRestHandler {
         updateRequest.version(RestActions.parseVersion(request));
         updateRequest.versionType(VersionType.fromString(request.param("version_type"), updateRequest.versionType()));
 
+        if (request.hasParam("timestamp")) {
+            deprecationLogger.deprecated("The [timestamp] parameter of index requests is deprecated");
+        }
+        if (request.hasParam("ttl")) {
+            deprecationLogger.deprecated("The [ttl] parameter of index requests is deprecated");
+        }
 
         // see if we have it in the body
         if (request.hasContent()) {


### PR DESCRIPTION
`timestamp` and `ttl` already emit deprecation warnings when they are set in
the mappings, but not when they are used in index requests. We should fix it so
that users are not caught by surprise when we stop accepting these parameters.

Relates #21670