### PR TITLE
then -> than

### DIFF
--- a/docs/reference/search/suggesters/term-suggest.asciidoc
+++ b/docs/reference/search/suggesters/term-suggest.asciidoc
@@ -45,7 +45,7 @@ doesn't take the query into account that is part of request.
 +
      ** `missing`:  Only provide suggestions for suggest text terms that are
                     not in the index. This is the default.
-     ** `popular`:  Only suggest suggestions that occur in more docs then
+     ** `popular`:  Only suggest suggestions that occur in more docs than
                     the original suggest text term.
      ** `always`:   Suggest any matching suggestions based on terms in the
                     suggest text.


### PR DESCRIPTION
typo fix.

Also, I'd rather have something like this:

> popular - suggestion will be returned only, when the suggested word is more popular than the word entered by user (this means that suggested word is more frequent in the index)

mentioned [here](http://elasticsearchserverbook.com/elasticsearch-0-90-using-suggester/).