### PR TITLE
Add proper descriptions to reindex, update-by-query and delete-by-query tasks.

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -446,4 +446,8 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
         }
     }
 
+    @Override
+    public String getDescription() {
+        return this.toString();
+    }
 }


### PR DESCRIPTION
Related to #21768