### PR TITLE
NPE is raised when defining a non existing type within attachments type

### DIFF
--- a/plugins/mapper-attachments/src/main/java/org/elasticsearch/mapper/attachments/AttachmentMapper.java
+++ b/plugins/mapper-attachments/src/main/java/org/elasticsearch/mapper/attachments/AttachmentMapper.java
@@ -305,6 +305,9 @@ public class AttachmentMapper extends FieldMapper {
                 type = "text";
             }
             Mapper.TypeParser typeParser = parserContext.typeParser(type);
+            if (typeParser == null) {
+                throw new MapperParsingException("Type [" + type + "] is not supported. Check your [" + propName + "] field.");
+            }
             Mapper.Builder<?, ?> mapperBuilder = typeParser.parse(propName, propNode, parserContext);
 
             return mapperBuilder;

--- a/plugins/mapper-attachments/src/test/java/org/elasticsearch/mapper/attachments/WrongAttachmentMapperTests.java
+++ b/plugins/mapper-attachments/src/test/java/org/elasticsearch/mapper/attachments/WrongAttachmentMapperTests.java
@@ -48,7 +48,7 @@ public class WrongAttachmentMapperTests extends AttachmentUnitTestCase {
 
         try {
             mapperParser.parse("person", new CompressedXContent(mapping));
-            fail("We should have raised an IllegalArgumentException");
+            fail("We should have raised a MapperParsingException");
         } catch (MapperParsingException e) {
             assertThat(e.getMessage(), is("Type [nonexistingtype] is not supported. Check your [content] field."));
         }

--- a/plugins/mapper-attachments/src/test/java/org/elasticsearch/mapper/attachments/WrongAttachmentMapperTests.java
+++ b/plugins/mapper-attachments/src/test/java/org/elasticsearch/mapper/attachments/WrongAttachmentMapperTests.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.mapper.attachments;
+
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.MapperTestUtils;
+import org.elasticsearch.index.mapper.DocumentMapperParser;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.junit.Before;
+
+import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
+import static org.hamcrest.Matchers.is;
+
+/**
+ *
+ */
+public class WrongAttachmentMapperTests extends AttachmentUnitTestCase {
+
+    private DocumentMapperParser mapperParser;
+
+    @Before
+    public void setupMapperParser() throws Exception {
+        mapperParser = MapperTestUtils.newMapperService(createTempDir(), Settings.EMPTY,
+            getIndicesModuleWithRegisteredAttachmentMapper()).documentMapperParser();
+
+    }
+
+    public void testSimpleMappings() throws Exception {
+        String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/attachment/test/unit/wrong-mapping/wrong-mapping.json");
+
+        try {
+            mapperParser.parse("person", new CompressedXContent(mapping));
+            fail("We should have raised an IllegalArgumentException");
+        } catch (MapperParsingException e) {
+            assertThat(e.getMessage(), is("Type [nonexistingtype] is not supported. Check your [content] field."));
+        }
+    }
+}

--- a/plugins/mapper-attachments/src/test/resources/org/elasticsearch/index/mapper/attachment/test/unit/wrong-mapping/wrong-mapping.json
+++ b/plugins/mapper-attachments/src/test/resources/org/elasticsearch/index/mapper/attachment/test/unit/wrong-mapping/wrong-mapping.json
@@ -1,0 +1,14 @@
+{
+    "person": {
+        "properties": {
+            "file": {
+                "type": "attachment",
+                "fields": {
+                    "content": {
+                        "type": "nonexistingtype"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
When you send a wrong type for a sub field of an attachments field, it raises a `NullPointerException`.

```
DELETE test
PUT test/_mapping
{
    "person": {
        "properties": {
            "file": {
                "type": "attachment",
                "fields": {
                    "content": {
                        "type": "nonexistingtype"
                    }
                }
            }
        }
    }
}
```

This fix now sends back to the user a comprehensive error message:

```json
{
   "error":{
      "root_cause":[
         {
            "type":"mapper_parsing_exception",
            "reason":"Type [nonexistingtype] is not supported. Check your [content] field."
         }
      ],
      "type":"mapper_parsing_exception",
      "reason":"Failed to parse mapping [doc]: Type [nonexistingtype] is not supported. Check your [content] field.",
      "caused_by":{
         "type":"mapper_parsing_exception",
         "reason":"Type [nonexistingtype] is not supported. Check your [content] field."
      }
   },
   "status":400
}
```