### PR TITLE
Remove deprecated query names: in, geo_bbox, mlt, fuzzy_match and match_fuzzy

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
@@ -58,7 +58,6 @@ import java.util.Optional;
  * */
 public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBoundingBoxQueryBuilder> {
     public static final String NAME = "geo_bounding_box";
-    public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME, "geo_bbox");
 
     /** Default type for executing this query (memory as of this writing). */
     public static final GeoExecType DEFAULT_TYPE = GeoExecType.MEMORY;
@@ -472,12 +471,12 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
                                 left = sparse.getLon();
                             } else {
                                 throw new ElasticsearchParseException("failed to parse [{}] query. unexpected field [{}]",
-                                        QUERY_NAME_FIELD.getPreferredName(), currentFieldName);
+                                        NAME, currentFieldName);
                             }
                         }
                     } else {
                         throw new ElasticsearchParseException("failed to parse [{}] query. field name expected but [{}] found",
-                                QUERY_NAME_FIELD.getPreferredName(), token);
+                                NAME, token);
                     }
                 }
             } else if (token.isValue()) {
@@ -500,7 +499,7 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
                     ignoreMalformed = parser.booleanValue();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "failed to parse [{}] query. unexpected field [{}]",
-                            QUERY_NAME_FIELD.getPreferredName(), currentFieldName);
+                            NAME, currentFieldName);
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -64,8 +64,6 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
     /** The name for the match query */
     public static final String NAME = "match";
 
-    public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME, "match_fuzzy", "fuzzy_match");
-
     /** The default mode terms are combined in a match query */
     public static final Operator DEFAULT_OPERATOR = Operator.OR;
 

--- a/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -80,7 +80,6 @@ import static org.elasticsearch.index.mapper.Uid.createUidAsBytes;
  */
 public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQueryBuilder> {
     public static final String NAME = "more_like_this";
-    public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME, "mlt");
 
     public static final int DEFAULT_MAX_QUERY_TERMS = XMoreLikeThis.DEFAULT_MAX_QUERY_TERMS;
     public static final int DEFAULT_MIN_TERM_FREQ = XMoreLikeThis.DEFAULT_MIN_TERM_FREQ;

--- a/core/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
@@ -29,7 +29,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -56,7 +55,6 @@ import java.util.stream.IntStream;
  */
 public class TermsQueryBuilder extends AbstractQueryBuilder<TermsQueryBuilder> {
     public static final String NAME = "terms";
-    public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME, "in");
 
     private final String fieldName;
     private final List<?> values;

--- a/core/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -726,7 +726,7 @@ public class SearchModule {
     }
 
     private void registerQueryParsers(List<SearchPlugin> plugins) {
-        registerQuery(new QuerySpec<>(MatchQueryBuilder.QUERY_NAME_FIELD, MatchQueryBuilder::new, MatchQueryBuilder::fromXContent));
+        registerQuery(new QuerySpec<>(MatchQueryBuilder.NAME, MatchQueryBuilder::new, MatchQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(MatchPhraseQueryBuilder.NAME, MatchPhraseQueryBuilder::new, MatchPhraseQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(MatchPhrasePrefixQueryBuilder.NAME, MatchPhrasePrefixQueryBuilder::new,
                 MatchPhrasePrefixQueryBuilder::fromXContent));
@@ -742,7 +742,7 @@ public class SearchModule {
         BooleanQuery.setMaxClauseCount(INDICES_MAX_CLAUSE_COUNT_SETTING.get(settings));
         registerQuery(new QuerySpec<>(BoolQueryBuilder.NAME, BoolQueryBuilder::new, BoolQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(TermQueryBuilder.NAME, TermQueryBuilder::new, TermQueryBuilder::fromXContent));
-        registerQuery(new QuerySpec<>(TermsQueryBuilder.QUERY_NAME_FIELD, TermsQueryBuilder::new, TermsQueryBuilder::fromXContent));
+        registerQuery(new QuerySpec<>(TermsQueryBuilder.NAME, TermsQueryBuilder::new, TermsQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(FuzzyQueryBuilder.NAME, FuzzyQueryBuilder::new, FuzzyQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(RegexpQueryBuilder.NAME, RegexpQueryBuilder::new, RegexpQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(RangeQueryBuilder.NAME, RangeQueryBuilder::new, RangeQueryBuilder::fromXContent));
@@ -760,7 +760,7 @@ public class SearchModule {
         registerQuery(new QuerySpec<>(SpanFirstQueryBuilder.NAME, SpanFirstQueryBuilder::new, SpanFirstQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(SpanNearQueryBuilder.NAME, SpanNearQueryBuilder::new, SpanNearQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(SpanOrQueryBuilder.NAME, SpanOrQueryBuilder::new, SpanOrQueryBuilder::fromXContent));
-        registerQuery(new QuerySpec<>(MoreLikeThisQueryBuilder.QUERY_NAME_FIELD, MoreLikeThisQueryBuilder::new,
+        registerQuery(new QuerySpec<>(MoreLikeThisQueryBuilder.NAME, MoreLikeThisQueryBuilder::new,
                 MoreLikeThisQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(WrapperQueryBuilder.NAME, WrapperQueryBuilder::new, WrapperQueryBuilder::fromXContent));
         // TODO Remove IndicesQuery in 6.0
@@ -777,7 +777,7 @@ public class SearchModule {
         registerQuery(new QuerySpec<>(GeoDistanceQueryBuilder.NAME, GeoDistanceQueryBuilder::new, GeoDistanceQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(GeoDistanceRangeQueryBuilder.NAME, GeoDistanceRangeQueryBuilder::new,
                 GeoDistanceRangeQueryBuilder::fromXContent));
-        registerQuery(new QuerySpec<>(GeoBoundingBoxQueryBuilder.QUERY_NAME_FIELD, GeoBoundingBoxQueryBuilder::new,
+        registerQuery(new QuerySpec<>(GeoBoundingBoxQueryBuilder.NAME, GeoBoundingBoxQueryBuilder::new,
                 GeoBoundingBoxQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(GeohashCellQuery.NAME, GeohashCellQuery.Builder::new, GeohashCellQuery.Builder::fromXContent));
         registerQuery(new QuerySpec<>(GeoPolygonQueryBuilder.NAME, GeoPolygonQueryBuilder::new, GeoPolygonQueryBuilder::fromXContent));

--- a/core/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
@@ -27,7 +27,6 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.spatial.geopoint.search.GeoPointInBBoxQuery;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -466,24 +465,6 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
         assertEquals(json, 40.01, parsed.bottomRight().getLat(), 0.0001);
         assertEquals(json, 1.0, parsed.boost(), 0.0001);
         assertEquals(json, GeoExecType.MEMORY, parsed.type());
-        String deprecatedJson =
-                "{\n" +
-                        "  \"geo_bbox\" : {\n" +
-                        "    \"pin.location\" : {\n" +
-                        "      \"top_left\" : [ -74.1, 40.73 ],\n" +
-                        "      \"bottom_right\" : [ -71.12, 40.01 ]\n" +
-                        "    },\n" +
-                        "    \"validation_method\" : \"STRICT\",\n" +
-                        "    \"type\" : \"MEMORY\",\n" +
-                        "    \"ignore_unmapped\" : false,\n" +
-                        "    \"boost\" : 1.0\n" +
-                        "  }\n" +
-                        "}";
-        QueryBuilder parsedGeoBboxShortcut = parseQuery(json, ParseFieldMatcher.EMPTY);
-        assertThat(parsedGeoBboxShortcut, equalTo(parsed));
-
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(deprecatedJson));
-        assertEquals("Deprecated field [geo_bbox] used, expected [geo_bounding_box] instead", e.getMessage());
     }
 
     public void testFromJsonCoerceFails() throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -363,34 +363,6 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
                 containsString("Deprecated field [type] used, replaced by [match_phrase and match_phrase_prefix query]"));
     }
 
-    public void testLegacyFuzzyMatchQuery() throws IOException {
-        MatchQueryBuilder expectedQB = new MatchQueryBuilder("message", "to be or not to be");
-        String type = randomFrom("fuzzy_match", "match_fuzzy");
-        String json = "{\n" +
-                "  \"" + type + "\" : {\n" +
-                "    \"message\" : {\n" +
-                "      \"query\" : \"to be or not to be\",\n" +
-                "      \"operator\" : \"OR\",\n" +
-                "      \"slop\" : 0,\n" +
-                "      \"prefix_length\" : 0,\n" +
-                "      \"max_expansions\" : 50,\n" +
-                "      \"fuzzy_transpositions\" : true,\n" +
-                "      \"lenient\" : false,\n" +
-                "      \"zero_terms_query\" : \"NONE\",\n" +
-                "      \"boost\" : 1.0\n" +
-                "    }\n" +
-                "  }\n" +
-                "}";
-        MatchQueryBuilder qb = (MatchQueryBuilder) parseQuery(json, ParseFieldMatcher.EMPTY);
-        assertThat(qb, equalTo(expectedQB));
-        checkWarningHeaders("Deprecated field [" + type + "] used, expected [match] instead",
-                "Deprecated field [slop] used, replaced by [match_phrase query]");
-
-        // Now check with strict parsing an exception is thrown
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(json, ParseFieldMatcher.STRICT));
-        assertThat(e.getMessage(), containsString("Deprecated field [" + type + "] used, expected [match] instead"));
-    }
-
     public void testFuzzinessOnNonStringField() throws Exception {
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         MatchQueryBuilder query = new MatchQueryBuilder(INT_FIELD_NAME, 42);

--- a/core/src/test/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilderTests.java
@@ -339,40 +339,5 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
 
         assertEquals(json, 2, parsed.fields().length);
         assertEquals(json, "and potentially some more text here as well", parsed.likeTexts()[0]);
-
-        String deprecatedJson =
-                "{\n" +
-                        "  \"mlt\" : {\n" +
-                        "    \"fields\" : [ \"title\", \"description\" ],\n" +
-                        "    \"like\" : [ \"and potentially some more text here as well\", {\n" +
-                        "      \"_index\" : \"imdb\",\n" +
-                        "      \"_type\" : \"movies\",\n" +
-                        "      \"_id\" : \"1\"\n" +
-                        "    }, {\n" +
-                        "      \"_index\" : \"imdb\",\n" +
-                        "      \"_type\" : \"movies\",\n" +
-                        "      \"_id\" : \"2\"\n" +
-                        "    } ],\n" +
-                        "    \"max_query_terms\" : 12,\n" +
-                        "    \"min_term_freq\" : 1,\n" +
-                        "    \"min_doc_freq\" : 5,\n" +
-                        "    \"max_doc_freq\" : 2147483647,\n" +
-                        "    \"min_word_length\" : 0,\n" +
-                        "    \"max_word_length\" : 0,\n" +
-                        "    \"minimum_should_match\" : \"30%\",\n" +
-                        "    \"boost_terms\" : 0.0,\n" +
-                        "    \"include\" : false,\n" +
-                        "    \"fail_on_unsupported_field\" : true,\n" +
-                        "    \"boost\" : 1.0\n" +
-                        "  }\n" +
-                        "}";
-
-        MoreLikeThisQueryBuilder parsedQueryMltShortcut = (MoreLikeThisQueryBuilder) parseQuery(deprecatedJson, ParseFieldMatcher.EMPTY);
-        assertThat(parsedQueryMltShortcut, equalTo(parsed));
-
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(deprecatedJson));
-        assertEquals("Deprecated field [mlt] used, expected [more_like_this] instead", e.getMessage());
-
-        checkWarningHeaders("Deprecated field [mlt] used, expected [more_like_this] instead");
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
@@ -29,7 +29,6 @@ import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -255,19 +254,6 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
         TermsQueryBuilder parsed = (TermsQueryBuilder) parseQuery(json);
         checkGeneratedJson(json, parsed);
         assertEquals(json, 2, parsed.values().size());
-
-        String deprecatedJson =
-                "{\n" +
-                        "  \"in\" : {\n" +
-                        "    \"user\" : [ \"kimchy\", \"elasticsearch\" ],\n" +
-                        "    \"boost\" : 1.0\n" +
-                        "  }\n" +
-                        "}";
-        QueryBuilder inShortcutParsed = parseQuery(json, ParseFieldMatcher.EMPTY);
-        assertThat(inShortcutParsed, equalTo(parsed));
-
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(deprecatedJson));
-        assertEquals("Deprecated field [in] used, expected [terms] instead", e.getMessage());
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -297,13 +297,8 @@ public class SearchModuleTests extends ModuleTestCase {
             "wrapper"
     };
 
-    private static final String[] DEPRECATED_QUERIES = new String[] {
-            "fuzzy_match",
-            "geo_bbox",
-            "in",
-            "match_fuzzy",
-            "mlt"
-    };
+    //add here deprecated queries to make sure we log a deprecation warnings when they are used
+    private static final String[] DEPRECATED_QUERIES = new String[] {};
 
     /**
      * Dummy test {@link AggregationBuilder} used to test registering aggregation builders.

--- a/docs/java-api/query-dsl/mlt-query.asciidoc
+++ b/docs/java-api/query-dsl/mlt-query.asciidoc
@@ -1,5 +1,5 @@
 [[java-query-dsl-mlt-query]]
-==== More Like This Query (mlt)
+==== More Like This Query
 
 See:
  * {ref}/query-dsl-mlt-query.html[More Like This Query]

--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -1,12 +1,11 @@
 [[query-dsl-mlt-query]]
 === More Like This Query
 
-The More Like This Query (MLT Query) finds documents that are "like" a given
+The More Like This Query finds documents that are "like" a given
 set of documents. In order to do so, MLT selects a set of representative terms
 of these input documents, forms a query using these terms, executes the query
 and returns the results. The user controls the input documents, how the terms
-should be selected and how the query is formed. `more_like_this` can be
-shortened to `mlt` deprecated[5.0.0,use `more_like_this` instead].
+should be selected and how the query is formed.
 
 The simplest use case consists of asking for documents that are similar to a
 provided piece of text. Here, we are asking for all movies that have some text

--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -19,9 +19,6 @@ GET /_search
 --------------------------------------------------
 // CONSOLE
 
-The `terms` query is also aliased with `in` as the filter name for
-simpler usage deprecated[5.0.0,use `terms` instead].
-
 [float]
 [[query-dsl-terms-lookup]]
 ===== Terms lookup mechanism


### PR DESCRIPTION
These query names were all deprecated in 5.0.0:
- `in` is removed in favour of `terms`
- `geo_bbox` is removed in favour of `geo_bounding_box`
- `mlt` is removed in favour of `more_like_this`
- `fuzzy_match` and `match_fuzzy` are removed in favour of `match`