### PR TITLE
Add unit test for TribeNodeClusterStateTaskExecutor

### DIFF
--- a/core/src/test/java/org/elasticsearch/cluster/ClusterChangedEventTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterChangedEventTests.java
@@ -19,20 +19,14 @@
 
 package org.elasticsearch.cluster;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexGraveyard;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.test.ClusterStateUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TestCustomMetaData;
 
@@ -46,7 +40,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.test.ClusterStateUtils.createIndexMetadata;
 import static org.hamcrest.Matchers.equalTo;
+import static org.elasticsearch.test.ClusterStateUtils.nextState;
 
 /**
  * Tests for the {@link ClusterChangedEvent} class.
@@ -54,8 +50,6 @@ import static org.hamcrest.Matchers.equalTo;
 public class ClusterChangedEventTests extends ESTestCase {
 
     private static final ClusterName TEST_CLUSTER_NAME = new ClusterName("test");
-    private static final String NODE_ID_PREFIX = "node_";
-    private static final String INITIAL_CLUSTER_ID = UUIDs.randomBase64UUID();
     // the initial indices which every cluster state test starts out with
     private static final List<Index> initialIndices = Arrays.asList(new Index("idx1", UUIDs.randomBase64UUID()),
                                                                     new Index("idx2", UUIDs.randomBase64UUID()),
@@ -153,7 +147,7 @@ public class ClusterChangedEventTests extends ESTestCase {
             ClusterChangedEvent.indexMetaDataChanged(originalIndexMeta, newIndexMeta));
 
         // test when it doesn't exist
-        newIndexMeta = createIndexMetadata(new Index("doesntexist", UUIDs.randomBase64UUID()));
+        newIndexMeta = createIndexMetadata(new Index("doesntexist", UUIDs.randomBase64UUID()), 1);
         assertTrue("IndexMetaData that didn't previously exist should be considered changed",
             ClusterChangedEvent.indexMetaDataChanged(originalIndexMeta, newIndexMeta));
 
@@ -352,12 +346,7 @@ public class ClusterChangedEventTests extends ESTestCase {
 
     // Create a basic cluster state with a given set of indices
     private static ClusterState createState(final int numNodes, final boolean isLocalMaster, final List<Index> indices) {
-        final MetaData metaData = createMetaData(indices);
-        return ClusterState.builder(TEST_CLUSTER_NAME)
-                           .nodes(createDiscoveryNodes(numNodes, isLocalMaster))
-                           .metaData(metaData)
-                           .routingTable(createRoutingTable(1, metaData))
-                           .build();
+        return ClusterStateUtils.createState(TEST_CLUSTER_NAME, numNodes, isLocalMaster, indices, random());
     }
 
     // Create a non-initialized cluster state
@@ -368,138 +357,6 @@ public class ClusterChangedEventTests extends ESTestCase {
                            .build();
     }
 
-    private static ClusterState nextState(final ClusterState previousState, List<TestCustomMetaData> customMetaDataList) {
-        final ClusterState.Builder builder = ClusterState.builder(previousState);
-        builder.stateUUID(UUIDs.randomBase64UUID());
-        MetaData.Builder metaDataBuilder = new MetaData.Builder(previousState.metaData());
-        for (ObjectObjectCursor<String, MetaData.Custom> customMetaData : previousState.metaData().customs()) {
-            if (customMetaData.value instanceof TestCustomMetaData) {
-                metaDataBuilder.removeCustom(customMetaData.key);
-            }
-        }
-        for (TestCustomMetaData testCustomMetaData : customMetaDataList) {
-            metaDataBuilder.putCustom(testCustomMetaData.type(), testCustomMetaData);
-        }
-        builder.metaData(metaDataBuilder);
-        return builder.build();
-    }
-
-    // Create a modified cluster state from another one, but with some number of indices added and deleted.
-    private static ClusterState nextState(final ClusterState previousState, final boolean changeClusterUUID,
-                                          final List<Index> addedIndices, final List<Index> deletedIndices, final int numNodesToRemove) {
-        final ClusterState.Builder builder = ClusterState.builder(previousState);
-        builder.stateUUID(UUIDs.randomBase64UUID());
-        final MetaData.Builder metaBuilder = MetaData.builder(previousState.metaData());
-        if (changeClusterUUID || addedIndices.size() > 0 || deletedIndices.size() > 0) {
-            // there is some change in metadata cluster state
-            if (changeClusterUUID) {
-                metaBuilder.clusterUUID(UUIDs.randomBase64UUID());
-            }
-            for (Index index : addedIndices) {
-                metaBuilder.put(createIndexMetadata(index), true);
-            }
-            for (Index index : deletedIndices) {
-                metaBuilder.remove(index.getName());
-                IndexGraveyard.Builder graveyardBuilder = IndexGraveyard.builder(metaBuilder.indexGraveyard());
-                graveyardBuilder.addTombstone(index);
-                metaBuilder.indexGraveyard(graveyardBuilder.build());
-            }
-            builder.metaData(metaBuilder);
-        }
-        if (numNodesToRemove > 0) {
-            final int discoveryNodesSize = previousState.getNodes().getSize();
-            final DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(previousState.getNodes());
-            for (int i = 0; i < numNodesToRemove && i < discoveryNodesSize; i++) {
-                nodesBuilder.remove(NODE_ID_PREFIX + i);
-            }
-            builder.nodes(nodesBuilder);
-        }
-        builder.blocks(ClusterBlocks.builder().build());
-        return builder.build();
-    }
-
-    // Create the discovery nodes for a cluster state.  For our testing purposes, we want
-    // the first to be master, the second to be master eligible, the third to be a data node,
-    // and the remainder can be any kinds of nodes (master eligible, data, or both).
-    private static DiscoveryNodes createDiscoveryNodes(final int numNodes, final boolean isLocalMaster) {
-        assert (numNodes >= 3) : "the initial cluster state for event change tests should have a minimum of 3 nodes " +
-                                 "so there are a minimum of 2 master nodes for testing master change events.";
-        final DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
-        final int localNodeIndex = isLocalMaster ? 0 : randomIntBetween(1, numNodes - 1); // randomly assign the local node if not master
-        for (int i = 0; i < numNodes; i++) {
-            final String nodeId = NODE_ID_PREFIX + i;
-            Set<DiscoveryNode.Role> roles = new HashSet<>();
-            if (i == 0) {
-                // the master node
-                builder.masterNodeId(nodeId);
-                roles.add(DiscoveryNode.Role.MASTER);
-            } else if (i == 1) {
-                // the alternate master node
-                roles.add(DiscoveryNode.Role.MASTER);
-            } else if (i == 2) {
-                // we need at least one data node
-                roles.add(DiscoveryNode.Role.DATA);
-            } else {
-                // remaining nodes can be anything (except for master)
-                if (randomBoolean()) {
-                    roles.add(DiscoveryNode.Role.MASTER);
-                }
-                if (randomBoolean()) {
-                    roles.add(DiscoveryNode.Role.DATA);
-                }
-            }
-            final DiscoveryNode node = newNode(nodeId, roles);
-            builder.add(node);
-            if (i == localNodeIndex) {
-                builder.localNodeId(nodeId);
-            }
-        }
-        return builder.build();
-    }
-
-    // Create a new DiscoveryNode
-    private static DiscoveryNode newNode(final String nodeId, Set<DiscoveryNode.Role> roles) {
-        return new DiscoveryNode(nodeId, nodeId, nodeId, "host", "host_address", buildNewFakeTransportAddress(),
-            Collections.emptyMap(), roles, Version.CURRENT);
-    }
-
-    // Create the metadata for a cluster state.
-    private static MetaData createMetaData(final List<Index> indices) {
-        final MetaData.Builder builder = MetaData.builder();
-        builder.clusterUUID(INITIAL_CLUSTER_ID);
-        for (Index index : indices) {
-            builder.put(createIndexMetadata(index), true);
-        }
-        return builder.build();
-    }
-
-    // Create the index metadata for a given index.
-    private static IndexMetaData createIndexMetadata(final Index index) {
-        return createIndexMetadata(index, 1);
-    }
-
-    // Create the index metadata for a given index, with the specified version.
-    private static IndexMetaData createIndexMetadata(final Index index, final long version) {
-        final Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
-                                                    .put(IndexMetaData.SETTING_INDEX_UUID, index.getUUID())
-                                                    .build();
-        return IndexMetaData.builder(index.getName())
-                            .settings(settings)
-                            .numberOfShards(1)
-                            .numberOfReplicas(0)
-                            .creationDate(System.currentTimeMillis())
-                            .version(version)
-                            .build();
-    }
-
-    // Create the routing table for a cluster state.
-    private static RoutingTable createRoutingTable(final long version, final MetaData metaData) {
-        final RoutingTable.Builder builder = RoutingTable.builder().version(version);
-        for (ObjectCursor<IndexMetaData> cursor : metaData.indices().values()) {
-            builder.addAsNew(cursor.value);
-        }
-        return builder.build();
-    }
 
     // Create a list of indices to add
     private static List<Index> addIndices(final int numIndices, final String id) {

--- a/core/src/test/java/org/elasticsearch/tribe/TribeNodeClusterStateTaskExecutorTests.java
+++ b/core/src/test/java/org/elasticsearch/tribe/TribeNodeClusterStateTaskExecutorTests.java
@@ -1,0 +1,383 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.tribe;
+
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor.BatchResult;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.inject.Injector;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.test.ClusterStateUtils;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TestCustomMetaData;
+import org.elasticsearch.tribe.TribeService.TribeNodeClusterStateTaskExecutor;
+import org.elasticsearch.tribe.TribeServiceTests.MergableCustomMetaData1;
+import org.elasticsearch.tribe.TribeServiceTests.MergableCustomMetaData2;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TribeNodeClusterStateTaskExecutorTests extends ESTestCase {
+
+    public void testTribeUpdateNodes() throws Exception {
+        String tribeName = "t1";
+        TribeNodeClusterStateTaskExecutor executor = new TribeNodeClusterStateTaskExecutor(
+                Settings.EMPTY, Collections.emptyList(), tribeName, Collections.emptySet(), logger);
+        // add tribe with three nodes
+        ClusterState state = ClusterStateUtils.createState(new ClusterName("cluster1"),
+                3, false, Collections.emptyList(), random());
+        BatchResult<ClusterChangedEvent> batchResult =
+                executor.execute(createSimpleClusterState("tribe-node"),
+                        Collections.singletonList(new ClusterChangedEvent("test", state, state)));
+        assertNotNull(batchResult.resultingState);
+        assertThat(batchResult.resultingState.nodes().getSize(), equalTo(state.nodes().getSize()));
+        for (DiscoveryNode node : batchResult.resultingState.nodes()) {
+            Map<String, String> nodeAttributes = node.getAttributes();
+            assertTrue(nodeAttributes.containsKey(TribeService.TRIBE_NAME_SETTING.getKey()));
+            assertThat(nodeAttributes.get(TribeService.TRIBE_NAME_SETTING.getKey()), equalTo(tribeName));
+        }
+
+        // remove one node
+        ClusterState nextState = ClusterStateUtils.nextState(state, true, Collections.emptyList(), Collections.emptyList(), 1);
+        batchResult = executor.execute(batchResult.resultingState,
+                Collections.singletonList(new ClusterChangedEvent("test", nextState, state)));
+        assertNotNull(batchResult.resultingState);
+        assertThat(batchResult.resultingState.nodes().getSize(), equalTo(nextState.nodes().getSize()));
+        for (DiscoveryNode node : batchResult.resultingState.nodes()) {
+            Map<String, String> nodeAttributes = node.getAttributes();
+            assertTrue(nodeAttributes.containsKey(TribeService.TRIBE_NAME_SETTING.getKey()));
+            assertThat(nodeAttributes.get(TribeService.TRIBE_NAME_SETTING.getKey()), equalTo(tribeName));
+        }
+
+        // add one node
+        batchResult = executor.execute(createSimpleClusterState("tribe-node"),
+                Collections.singletonList(new ClusterChangedEvent("test", state, nextState)));
+        assertNotNull(batchResult.resultingState);
+        assertThat(batchResult.resultingState.nodes().getSize(), equalTo(state.nodes().getSize()));
+        for (DiscoveryNode node : batchResult.resultingState.nodes()) {
+            Map<String, String> nodeAttributes = node.getAttributes();
+            assertTrue(nodeAttributes.containsKey(TribeService.TRIBE_NAME_SETTING.getKey()));
+            assertThat(nodeAttributes.get(TribeService.TRIBE_NAME_SETTING.getKey()), equalTo(tribeName));
+        }
+    }
+
+    public void testTribeUpdateIndices() throws Exception {
+        String tribeName = "t1";
+        TribeNodeClusterStateTaskExecutor executor = new TribeNodeClusterStateTaskExecutor(
+                Settings.EMPTY, Collections.emptyList(), tribeName, Collections.emptySet(), logger);
+        Index initialIndex = new Index("index1", "index1UUID");
+        ClusterState state = ClusterStateUtils.createState(new ClusterName("c1"), 3, false,
+                Collections.singletonList(initialIndex), random());
+        BatchResult<ClusterChangedEvent> batchResult =
+                executor.execute(createSimpleClusterState("tribe-node"),
+                        Collections.singletonList(new ClusterChangedEvent("test", state, state)));
+        assertNotNull(batchResult.resultingState);
+
+        // test index metadata has been added to tribe state
+        assertThat(batchResult.resultingState.metaData().getIndices().size(), equalTo(state.metaData().indices().size()));
+        assertNotNull(batchResult.resultingState.metaData().index(initialIndex));
+        assertNotNull(batchResult.resultingState.routingTable().index(initialIndex));
+
+        ClusterState nextState = ClusterStateUtils.nextState(state, true, Collections.emptyList(),
+                Collections.singletonList(initialIndex), 0);
+
+        batchResult = executor.execute(createSimpleClusterState("tribe-node"),
+                Collections.singletonList(new ClusterChangedEvent("test", nextState, state)));
+        assertNotNull(batchResult.resultingState);
+
+        assertThat(batchResult.resultingState.metaData().getIndices().size(), equalTo(nextState.metaData().indices().size()));
+        assertNull(batchResult.resultingState.metaData().index(initialIndex));
+        assertNull(batchResult.resultingState.routingTable().index(initialIndex));
+    }
+
+    public void testTribeNodeCustomMetaData() throws Exception {
+        TribeClusterStateExecutorHolder[] tribeClusterStateExecutorHolders = generateTribeClusterStateExecutors(new String[]{"t1"},
+                (tribeName, initialState) ->
+                        Collections.singletonList(generateAddingCustomMetaDataEvent(initialState, new MergableCustomMetaData1("data")))
+        );
+
+        ClusterState tribeState = createSimpleClusterState("tribe-node");
+        BatchResult<ClusterChangedEvent> batchResult = tribeClusterStateExecutorHolders[0].executor.execute(tribeState,
+                tribeClusterStateExecutorHolders[0].clusterChangedEvents);
+        MetaData.Custom custom = batchResult.resultingState.metaData().custom(MergableCustomMetaData1.TYPE);
+        assertNotNull(custom);
+        assertThat(((TestCustomMetaData) custom).getData(), equalTo("data"));
+    }
+
+    public void testTribeNodeWithSingleClusterCustomMetaDataBatched() throws Exception {
+        TribeClusterStateExecutorHolder[] tribeClusterStateExecutorHolders = generateTribeClusterStateExecutors(new String[]{"t1"},
+                (tribeName, initialState) -> {
+                    List<ClusterChangedEvent> events = new ArrayList<>();
+                    List<TestCustomMetaData> changedCustoms = new ArrayList<>();
+                    changedCustoms.addAll(generateMergableMD1(randomIntBetween(1, 5)));
+                    changedCustoms.addAll(generateMergableMD2(randomIntBetween(1, 5)));
+                    Collections.shuffle(changedCustoms, random());
+                    ClusterState lastState = initialState;
+                    for (TestCustomMetaData changedCustom : changedCustoms) {
+                        ClusterChangedEvent event = generateAddingCustomMetaDataEvent(lastState, changedCustom);
+                        lastState = event.state();
+                        events.add(event);
+                    }
+                    return events;
+                }
+        );
+
+        List<ClusterState> latestStates = Stream.of(tribeClusterStateExecutorHolders)
+                .map(holder -> holder.clusterChangedEvents)
+                .map(clusterChangedEvents -> clusterChangedEvents.get(clusterChangedEvents.size() - 1).state())
+                .collect(Collectors.toList());
+
+        ClusterState tribeState = createSimpleClusterState("tribe-node");
+        BatchResult<ClusterChangedEvent> batchResult = tribeClusterStateExecutorHolders[0].executor.execute(tribeState,
+                tribeClusterStateExecutorHolders[0].clusterChangedEvents);
+        ImmutableOpenMap<String, MetaData.Custom> customs = batchResult.resultingState.metaData().customs();
+        assertTrue(customs.containsKey(MergableCustomMetaData1.TYPE));
+        TestCustomMetaData testCustomMetaData = (TestCustomMetaData) customs.get(MergableCustomMetaData1.TYPE);
+        assertThat(testCustomMetaData, equalTo(
+                getMergedCustomMetaData(MergableCustomMetaData1.TYPE, latestStates)));
+        assertTrue(customs.containsKey(MergableCustomMetaData2.TYPE));
+        testCustomMetaData = (TestCustomMetaData) customs.get(MergableCustomMetaData2.TYPE);
+        assertThat(testCustomMetaData, equalTo(
+                getMergedCustomMetaData(MergableCustomMetaData2.TYPE, latestStates)));
+    }
+
+    public void testTribeNodeWithMultipleClusterCustomMetaDataBatched() throws Exception {
+        int nClusters = randomIntBetween(2, 5);
+        String[] tribeNames = new String[nClusters];
+        for (int i = 0; i < nClusters; i++) {
+            tribeNames[i] = "t_" + String.valueOf(i);
+        }
+        TribeClusterStateExecutorHolder[] tribeClusterStateExecutorHolders = generateTribeClusterStateExecutors(tribeNames,
+                (tribeName, initialState) -> {
+                    List<ClusterChangedEvent> events = new ArrayList<>();
+                    List<TestCustomMetaData> changedCustoms = new ArrayList<>();
+                    changedCustoms.addAll(generateMergableMD1(randomIntBetween(1, 5)));
+                    changedCustoms.addAll(generateMergableMD2(randomIntBetween(1, 5)));
+                    Collections.shuffle(changedCustoms, random());
+                    ClusterState lastState = initialState;
+                    for (TestCustomMetaData changedCustom : changedCustoms) {
+                        ClusterChangedEvent event = generateAddingCustomMetaDataEvent(lastState, changedCustom);
+                        lastState = event.state();
+                        events.add(event);
+                    }
+                    return events;
+                }
+        );
+        ClusterState tribeState = createSimpleClusterState("tribe-node");
+        for (TribeClusterStateExecutorHolder tribeClusterStateExecutorHolder : tribeClusterStateExecutorHolders) {
+            BatchResult<ClusterChangedEvent> batchResult = tribeClusterStateExecutorHolder.executor.execute(tribeState,
+                    tribeClusterStateExecutorHolder.clusterChangedEvents);
+            tribeState = batchResult.resultingState;
+        }
+        List<ClusterState> latestStates = Stream.of(tribeClusterStateExecutorHolders)
+                .map(holder -> holder.clusterChangedEvents)
+                .map(clusterChangedEvents -> clusterChangedEvents.get(clusterChangedEvents.size() - 1).state())
+                .collect(Collectors.toList());
+
+        ImmutableOpenMap<String, MetaData.Custom> customs = tribeState.metaData().customs();
+        assertTrue(customs.containsKey(MergableCustomMetaData1.TYPE));
+        TestCustomMetaData testCustomMetaData = (TestCustomMetaData) customs.get(MergableCustomMetaData1.TYPE);
+        assertThat(testCustomMetaData, equalTo(
+                getMergedCustomMetaData(MergableCustomMetaData1.TYPE, latestStates)));
+        assertTrue(customs.containsKey(MergableCustomMetaData2.TYPE));
+        testCustomMetaData = (TestCustomMetaData) customs.get(MergableCustomMetaData2.TYPE);
+        assertThat(testCustomMetaData, equalTo(
+                getMergedCustomMetaData(MergableCustomMetaData2.TYPE, latestStates)));
+    }
+
+    public void testTribeNdeWithMultipleClusterIndicesAddAndDelete() throws Exception {
+        int nClusters = randomIntBetween(2, 5);
+        String[] tribeNames = new String[nClusters];
+        for (int i = 0; i < nClusters; i++) {
+            tribeNames[i] = "t_" + String.valueOf(i);
+        }
+        final int nIndex = randomIntBetween(2, 5);
+        final int deleteIndex = randomIntBetween(0, nIndex - 1);
+        TribeClusterStateExecutorHolder[] tribeClustersAddingIndices = generateTribeClusterStateExecutors(tribeNames,
+                (tribeName, initialState) -> {
+                    List<ClusterChangedEvent> events = new ArrayList<>();
+                    ClusterState lastState = initialState;
+                    for (int i = 0; i < nIndex; i++) {
+                        String indexName = tribeName + "_index_" + String.valueOf(i);
+                        Index index = new Index(indexName, indexName + "UUID");
+                        ClusterChangedEvent event = generateAddingIndexEvent(lastState, index);
+                        lastState = event.state();
+                        events.add(event);
+                        if (deleteIndex == i) {
+                            // delete a random index after adding
+                            ClusterChangedEvent deleteEvent = generateDeletingIndexEvent(lastState, index);
+                            lastState = deleteEvent.state();
+                            events.add(deleteEvent);
+                        }
+                    }
+                    return events;
+                }
+        );
+        ClusterState tribeState = createSimpleClusterState("tribe-node");
+        for (TribeClusterStateExecutorHolder tribeClusterStateExecutorHolder : tribeClustersAddingIndices) {
+            BatchResult<ClusterChangedEvent> batchResult = tribeClusterStateExecutorHolder.executor.execute(tribeState,
+                    tribeClusterStateExecutorHolder.clusterChangedEvents);
+            tribeState = batchResult.resultingState;
+        }
+
+        for (String tribeName : tribeNames) {
+            for (int i = 0; i < nIndex; i++) {
+                String indexName = tribeName + "_index_" + String.valueOf(i);
+                Index index = new Index(indexName, indexName + "UUID");
+                if (i != deleteIndex) {
+                    assertNotNull(tribeState.metaData().index(index));
+                    assertNotNull(tribeState.routingTable().index(index));
+                } else {
+                    assertNull(tribeState.metaData().index(index));
+                    assertNull(tribeState.routingTable().index(index));
+                }
+            }
+        }
+    }
+
+    private static TribeService.MergableCustomMetaData getMergedCustomMetaData(String type, List<ClusterState> states) {
+        TribeService.MergableCustomMetaData mergedCustom = null;
+        for (ClusterState state : states) {
+            MetaData.Custom custom = state.metaData().custom(type);
+            assertNotNull(custom);
+            assertThat(custom, instanceOf(TribeService.MergableCustomMetaData.class));
+            if (mergedCustom != null) {
+                mergedCustom = (TribeService.MergableCustomMetaData) mergedCustom.merge(custom);
+            } else {
+                mergedCustom = ((TribeService.MergableCustomMetaData) custom);
+            }
+        }
+        return mergedCustom;
+    }
+
+    private TribeClusterStateExecutorHolder[] generateTribeClusterStateExecutors(String[] tribeNames,
+                                                                                 BiFunction<String, ClusterState,
+                                                                                         List<ClusterChangedEvent>>
+                                                                                         getClusterChangedEvents) {
+        List<Node> nodes = new ArrayList<>();
+        TribeNodeClusterStateTaskExecutor[] tribeExecutors = new TribeNodeClusterStateTaskExecutor[tribeNames.length];
+        List<ClusterChangedEvent>[] clusterChangedEvents = (List<ClusterChangedEvent>[]) new ArrayList[tribeNames.length];
+        for (int i = 0; i < tribeNames.length; i++) {
+            String tribeName = tribeNames[i];
+            ClusterState initialState = ClusterStateUtils.createState(
+                    new ClusterName("cluster-" + tribeName), 3, false, Collections.emptyList(), random());
+            List<ClusterChangedEvent> changedEvents = new ArrayList<>(getClusterChangedEvents.apply(tribeName, initialState));
+            clusterChangedEvents[i] = changedEvents;
+            ClusterState latestState = changedEvents.get(changedEvents.size() - 1).state();
+            nodes.add(mockNodeWithState(latestState));
+        }
+        for (int i = 0; i < tribeNames.length; i++) {
+            tribeExecutors[i] = new TribeNodeClusterStateTaskExecutor(
+                Settings.EMPTY, nodes, tribeNames[i], Collections.emptySet(), logger);
+        }
+        TribeClusterStateExecutorHolder[] holders = new TribeClusterStateExecutorHolder[tribeNames.length];
+        for (int i = 0; i < tribeNames.length; i++) {
+            holders[i] = new TribeClusterStateExecutorHolder(tribeExecutors[i], clusterChangedEvents[i]);
+        }
+        return holders;
+    }
+
+    private static class TribeClusterStateExecutorHolder {
+        final TribeNodeClusterStateTaskExecutor executor;
+        final List<ClusterChangedEvent> clusterChangedEvents;
+
+        private TribeClusterStateExecutorHolder(TribeNodeClusterStateTaskExecutor executor,
+                                                List<ClusterChangedEvent> clusterChangedEvents) {
+            this.executor = executor;
+            this.clusterChangedEvents = clusterChangedEvents;
+        }
+    }
+
+    private static List<MergableCustomMetaData1> generateMergableMD1(int size) {
+        List<MergableCustomMetaData1> customMetaData = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            customMetaData.add(new MergableCustomMetaData1(randomAsciiOfLength(10)));
+        }
+        return customMetaData;
+    }
+
+    private static List<MergableCustomMetaData2> generateMergableMD2(int size) {
+        List<MergableCustomMetaData2> customMetaData = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            customMetaData.add(new MergableCustomMetaData2(randomAsciiOfLength(10)));
+        }
+        return customMetaData;
+    }
+
+    private static ClusterChangedEvent generateAddingCustomMetaDataEvent(ClusterState initialState, TestCustomMetaData customMetaData) {
+        ClusterState nextState = ClusterStateUtils.nextState(initialState, Collections.singletonList(customMetaData));
+        return new ClusterChangedEvent("adding custom metadata", nextState, initialState);
+    }
+
+    private static ClusterChangedEvent generateAddingIndexEvent(ClusterState initialState, Index indexToAdd) {
+        List<Index> newIndices = new ArrayList<>();
+        for (ObjectCursor<IndexMetaData> existingIndices : initialState.metaData().getIndices().values()) {
+            newIndices.add(existingIndices.value.getIndex());
+        }
+        newIndices.add(indexToAdd);
+        ClusterState nextState = ClusterStateUtils.createState(initialState.getClusterName(), 3, false, newIndices, random());
+        return new ClusterChangedEvent("adding index", nextState, initialState);
+    }
+
+    private static ClusterChangedEvent generateDeletingIndexEvent(ClusterState initialState, Index indexToDelete) {
+        List<Index> newIndices = new ArrayList<>();
+        for (ObjectCursor<IndexMetaData> existingIndices : initialState.metaData().getIndices().values()) {
+            Index index = existingIndices.value.getIndex();
+            if (index.equals(indexToDelete) == false) {
+                newIndices.add(index);
+            }
+        }
+        ClusterState nextState = ClusterStateUtils.createState(initialState.getClusterName(), 3, false, newIndices, random());
+        return new ClusterChangedEvent("delete index", nextState, initialState);
+    }
+
+    private static Node mockNodeWithState(ClusterState state) {
+        Node mockNode = mock(Node.class);
+        Injector mockInjector = mock(Injector.class);
+        ClusterService mockClusterService = mock(ClusterService.class);
+        when(mockClusterService.state()).thenReturn(state);
+        when(mockInjector.getInstance(ClusterService.class)).thenReturn(mockClusterService);
+        when(mockNode.injector()).thenReturn(mockInjector);
+        return mockNode;
+    }
+
+    private static ClusterState createSimpleClusterState(String clusterName) {
+        return ClusterState.builder(new ClusterName(clusterName)).build();
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/ClusterStateUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ClusterStateUtils.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.IndexGraveyard;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import static org.elasticsearch.test.ESTestCase.buildNewFakeTransportAddress;
+
+public class ClusterStateUtils {
+    private static final String NODE_ID_PREFIX = "node_";
+    private static final String INITIAL_CLUSTER_ID = UUIDs.randomBase64UUID();
+
+    // Create a basic cluster state with a given set of indices
+    public static ClusterState createState(ClusterName clusterName, final int numNodes, final boolean isLocalMaster,
+                                           final List<Index> indices, Random random) {
+        final MetaData metaData = createMetaData(indices);
+        return ClusterState.builder(clusterName)
+                .nodes(createDiscoveryNodes(numNodes, isLocalMaster, random))
+                .metaData(metaData)
+                .routingTable(createRoutingTable(1, metaData))
+                .build();
+    }
+
+    public static ClusterState nextState(final ClusterState previousState, List<TestCustomMetaData> customMetaDataList) {
+        final ClusterState.Builder builder = ClusterState.builder(previousState);
+        builder.stateUUID(UUIDs.randomBase64UUID());
+        MetaData.Builder metaDataBuilder = new MetaData.Builder(previousState.metaData());
+        /*for (ObjectObjectCursor<String, MetaData.Custom> customMetaData : previousState.metaData().customs()) {
+            if (customMetaData.value instanceof TestCustomMetaData) {
+                metaDataBuilder.removeCustom(customMetaData.key);
+            }
+        }*/
+        for (TestCustomMetaData testCustomMetaData : customMetaDataList) {
+            metaDataBuilder.putCustom(testCustomMetaData.type(), testCustomMetaData);
+        }
+        builder.metaData(metaDataBuilder);
+        return builder.build();
+    }
+
+    // Create a modified cluster state from another one, but with some number of indices added and deleted.
+    public static ClusterState nextState(final ClusterState previousState, final boolean changeClusterUUID,
+                                          final List<Index> addedIndices, final List<Index> deletedIndices, final int numNodesToRemove) {
+        final ClusterState.Builder builder = ClusterState.builder(previousState);
+        builder.stateUUID(UUIDs.randomBase64UUID());
+        final MetaData.Builder metaBuilder = MetaData.builder(previousState.metaData());
+        if (changeClusterUUID || addedIndices.size() > 0 || deletedIndices.size() > 0) {
+            // there is some change in metadata cluster state
+            if (changeClusterUUID) {
+                metaBuilder.clusterUUID(UUIDs.randomBase64UUID());
+            }
+            for (Index index : addedIndices) {
+                metaBuilder.put(createIndexMetadata(index), true);
+            }
+            for (Index index : deletedIndices) {
+                metaBuilder.remove(index.getName());
+                IndexGraveyard.Builder graveyardBuilder = IndexGraveyard.builder(metaBuilder.indexGraveyard());
+                graveyardBuilder.addTombstone(index);
+                metaBuilder.indexGraveyard(graveyardBuilder.build());
+            }
+            builder.metaData(metaBuilder);
+        }
+        if (numNodesToRemove > 0) {
+            final int discoveryNodesSize = previousState.getNodes().getSize();
+            final DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(previousState.getNodes());
+            for (int i = 0; i < numNodesToRemove && i < discoveryNodesSize; i++) {
+                nodesBuilder.remove(NODE_ID_PREFIX + i);
+            }
+            builder.nodes(nodesBuilder);
+        }
+        builder.blocks(ClusterBlocks.builder().build());
+        return builder.build();
+    }
+
+    // Create the metadata for a cluster state.
+    private static MetaData createMetaData(final List<Index> indices) {
+        final MetaData.Builder builder = MetaData.builder();
+        builder.clusterUUID(INITIAL_CLUSTER_ID);
+        for (Index index : indices) {
+            builder.put(createIndexMetadata(index), true);
+        }
+        return builder.build();
+    }
+
+    // Create the index metadata for a given index.
+    private static IndexMetaData createIndexMetadata(final Index index) {
+        return createIndexMetadata(index, 1);
+    }
+
+    // Create the index metadata for a given index, with the specified version.
+    public static IndexMetaData createIndexMetadata(final Index index, final long version) {
+        final Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetaData.SETTING_INDEX_UUID, index.getUUID())
+                .build();
+        return IndexMetaData.builder(index.getName())
+                .settings(settings)
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .creationDate(System.currentTimeMillis())
+                .version(version)
+                .build();
+    }
+
+    // Create the discovery nodes for a cluster state.  For our testing purposes, we want
+    // the first to be master, the second to be master eligible, the third to be a data node,
+    // and the remainder can be any kinds of nodes (master eligible, data, or both).
+    private static DiscoveryNodes createDiscoveryNodes(final int numNodes, final boolean isLocalMaster, final Random random) {
+        assert (numNodes >= 3) : "the initial cluster state for event change tests should have a minimum of 3 nodes " +
+                "so there are a minimum of 2 master nodes for testing master change events.";
+        final DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
+        final int localNodeIndex = isLocalMaster ? 0 :
+                RandomNumbers.randomIntBetween(random, 1, numNodes - 1); // randomly assign the local node if not master
+        for (int i = 0; i < numNodes; i++) {
+            final String nodeId = NODE_ID_PREFIX + i;
+            Set<DiscoveryNode.Role> roles = new HashSet<>();
+            if (i == 0) {
+                // the master node
+                builder.masterNodeId(nodeId);
+                roles.add(DiscoveryNode.Role.MASTER);
+            } else if (i == 1) {
+                // the alternate master node
+                roles.add(DiscoveryNode.Role.MASTER);
+            } else if (i == 2) {
+                // we need at least one data node
+                roles.add(DiscoveryNode.Role.DATA);
+            } else {
+                // remaining nodes can be anything (except for master)
+                if (random.nextBoolean()) {
+                    roles.add(DiscoveryNode.Role.MASTER);
+                }
+                if (random.nextBoolean()) {
+                    roles.add(DiscoveryNode.Role.DATA);
+                }
+            }
+            final DiscoveryNode node = newNode(nodeId, roles);
+            builder.add(node);
+            if (i == localNodeIndex) {
+                builder.localNodeId(nodeId);
+            }
+        }
+        return builder.build();
+    }
+
+    private static DiscoveryNode newNode(final String nodeId, Set<DiscoveryNode.Role> roles) {
+        return new DiscoveryNode(nodeId, nodeId, nodeId, "host", "host_address", buildNewFakeTransportAddress(),
+                Collections.emptyMap(), roles, Version.CURRENT);
+    }
+
+    // Create the routing table for a cluster state.
+    private static RoutingTable createRoutingTable(final long version, final MetaData metaData) {
+        final RoutingTable.Builder builder = RoutingTable.builder().version(version);
+        for (ObjectCursor<IndexMetaData> cursor : metaData.indices().values()) {
+            builder.addAsNew(cursor.value);
+        }
+        return builder.build();
+    }
+}


### PR DESCRIPTION
This commit makes TribeNodeClusterStateTaskExecutor a static class
for unit testing. TribeNodeClusterStateTaskExecutor is responsible
for applying cluster state updates to the tribe node state whenever
an underlying cluster state is updated (i.e. adding/removing indices,
updating nodes and merging custom metadata). The unit tests ensure
the tribe state is properly updating when underlying cluster state
tasks are seen by the tribe node in batches or as a single update.

NOTE: still need to add tests for updating tribe state with index-level 
settings (block index metadata, block index read/write, on conflict)

relates #21552