### PR TITLE
Moving ObjectPath from test framework to elasticsearch core

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/ObjectPath.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/ObjectPath.java
@@ -16,10 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.test.rest.yaml;
-
-import org.elasticsearch.common.xcontent.XContent;
-import org.elasticsearch.common.xcontent.XContentParser;
+package org.elasticsearch.common.xcontent;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -46,21 +43,18 @@ public class ObjectPath {
         this.object = object;
     }
 
-    /**
-     * Returns the object corresponding to the provided path if present, null otherwise
-     */
-    public Object evaluate(String path) throws IOException {
-        return evaluate(path, Stash.EMPTY);
+    public Object getObject() {
+        return this.object;
     }
 
     /**
      * Returns the object corresponding to the provided path if present, null otherwise
      */
-    public Object evaluate(String path, Stash stash) throws IOException {
+    public Object evaluate(String path) {
         String[] parts = parsePath(path);
         Object object = this.object;
         for (String part : parts) {
-            object = evaluate(part, object, stash);
+            object = evaluate(part, object);
             if (object == null) {
                 return null;
             }
@@ -69,11 +63,7 @@ public class ObjectPath {
     }
 
     @SuppressWarnings("unchecked")
-    private Object evaluate(String key, Object object, Stash stash) throws IOException {
-        if (stash.containsStashedValue(key)) {
-            key = stash.getValue(key).toString();
-        }
-
+    public static Object evaluate(String key, Object object) {
         if (object instanceof Map) {
             return ((Map<String, Object>) object).get(key);
         }
@@ -92,7 +82,7 @@ public class ObjectPath {
         throw new IllegalArgumentException("no object found for [" + key + "] within object of class [" + object.getClass() + "]");
     }
 
-    private String[] parsePath(String path) {
+    public static String[] parsePath(String path) {
         List<String> list = new ArrayList<>();
         StringBuilder current = new StringBuilder();
         boolean escape = false;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestResponse.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestResponse.java
@@ -22,6 +22,7 @@ import org.apache.http.Header;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.common.xcontent.ObjectPath;
 import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
@@ -37,7 +38,7 @@ public class ClientYamlTestResponse {
 
     private final Response response;
     private final String body;
-    private ObjectPath parsedResponse;
+    private StashableObjectPath parsedResponse;
 
     ClientYamlTestResponse(Response response) throws IOException {
         this.response = response;
@@ -60,7 +61,7 @@ public class ClientYamlTestResponse {
             XContentType xContentType = XContentType.fromMediaTypeOrFormat(contentType);
             //skip parsing if we got text back (e.g. if we called _cat apis)
             if (xContentType == XContentType.JSON || xContentType == XContentType.YAML) {
-                this.parsedResponse = ObjectPath.createFromXContent(xContentType.xContent(), body);
+                this.parsedResponse = new StashableObjectPath(ObjectPath.createFromXContent(xContentType.xContent(), body));
             }
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Stash.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Stash.java
@@ -22,6 +22,7 @@ package org.elasticsearch.test.rest.yaml;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.xcontent.ObjectPath;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/StashableObjectPath.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/StashableObjectPath.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.rest.yaml;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.xcontent.ObjectPath;
+
+import java.io.IOException;;
+
+public class StashableObjectPath {
+
+    private ObjectPath objectPath;
+
+    public StashableObjectPath(ObjectPath objectPath) {
+        this.objectPath = objectPath;
+    }
+
+    public Object evaluate(String path) {
+        return evaluate(path, Stash.EMPTY);
+    }
+
+    /**
+     * Returns the object corresponding to the provided path if present, null otherwise
+     */
+    public Object evaluate(String path, Stash stash) {
+        String[] parts = ObjectPath.parsePath(path);
+        Object object = this.objectPath.getObject();
+        for (String part : parts) {
+            if (stash.containsStashedValue(part)) {
+                try {
+                    part = stash.getValue(part).toString();
+                } catch (IOException e) {
+                    throw new ElasticsearchException(e);
+                }
+            }
+            object = ObjectPath.evaluate(part, object);
+            if (object == null) {
+                return null;
+            }
+        }
+        return object;
+    }
+}

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/StashableObjectPathTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/StashableObjectPathTests.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.rest.yaml;
+
+import org.elasticsearch.common.xcontent.ObjectPath;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class StashableObjectPathTests extends ESTestCase {
+
+    private static XContentBuilder randomXContentBuilder() throws IOException {
+        //only string based formats are supported, no cbor nor smile
+        XContentType xContentType = randomFrom(XContentType.JSON, XContentType.YAML);
+        return XContentBuilder.builder(XContentFactory.xContent(xContentType));
+    }
+
+    public void testEvaluateStashInPropertyName() throws Exception {
+        XContentBuilder xContentBuilder = randomXContentBuilder();
+        xContentBuilder.startObject();
+        xContentBuilder.startObject("field1");
+        xContentBuilder.startObject("elements");
+        xContentBuilder.field("element1", "value1");
+        xContentBuilder.endObject();
+        xContentBuilder.endObject();
+        xContentBuilder.endObject();
+        StashableObjectPath objectPath = new StashableObjectPath(
+                ObjectPath.createFromXContent(xContentBuilder.contentType().xContent(), xContentBuilder.string()));
+        try {
+            objectPath.evaluate("field1.$placeholder.element1");
+            fail("evaluate should have failed due to unresolved placeholder");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("stashed value not found for key [placeholder]"));
+        }
+
+        // Stashed value is whole property name
+        Stash stash = new Stash();
+        stash.stashValue("placeholder", "elements");
+        Object object = objectPath.evaluate("field1.$placeholder.element1", stash);
+        assertThat(object, notNullValue());
+        assertThat(object.toString(), equalTo("value1"));
+
+        // Stash key has dots
+        Map<String, Object> stashedObject = new HashMap<>();
+        stashedObject.put("subobject", "elements");
+        stash.stashValue("object", stashedObject);
+        object = objectPath.evaluate("field1.$object\\.subobject.element1", stash);
+        assertThat(object, notNullValue());
+        assertThat(object.toString(), equalTo("value1"));
+
+        // Stashed value is part of property name
+        stash.stashValue("placeholder", "ele");
+        object = objectPath.evaluate("field1.${placeholder}ments.element1", stash);
+        assertThat(object, notNullValue());
+        assertThat(object.toString(), equalTo("value1"));
+
+        // Stashed value is inside of property name
+        stash.stashValue("placeholder", "le");
+        object = objectPath.evaluate("field1.e${placeholder}ments.element1", stash);
+        assertThat(object, notNullValue());
+        assertThat(object.toString(), equalTo("value1"));
+
+        // Multiple stashed values in property name
+        stash.stashValue("placeholder", "le");
+        stash.stashValue("placeholder2", "nts");
+        object = objectPath.evaluate("field1.e${placeholder}me${placeholder2}.element1", stash);
+        assertThat(object, notNullValue());
+        assertThat(object.toString(), equalTo("value1"));
+
+        // Stashed value is part of property name and has dots
+        stashedObject.put("subobject", "ele");
+        stash.stashValue("object", stashedObject);
+        object = objectPath.evaluate("field1.${object\\.subobject}ments.element1", stash);
+        assertThat(object, notNullValue());
+        assertThat(object.toString(), equalTo("value1"));
+    }
+}


### PR DESCRIPTION
For the improved rest client we would like to be able to use ObjectPath for generic access to maps parsed from xcontent of responses. In order to be able to do so, this change moves it into core. The part of the class that was used to deal with stashed values from previous responses stays in the test framework as its own new utility class StashableObjectPath.