### PR TITLE
compile ScriptProcessor inline scripts when creating ingest pipelines

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
@@ -28,21 +28,21 @@ import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.common.Strings.hasLength;
 import static org.elasticsearch.ingest.ConfigurationUtils.newConfigurationException;
 import static org.elasticsearch.ingest.ConfigurationUtils.readOptionalMap;
 import static org.elasticsearch.ingest.ConfigurationUtils.readOptionalStringProperty;
-import static org.elasticsearch.ingest.ConfigurationUtils.readStringProperty;
 import static org.elasticsearch.script.ScriptType.FILE;
 import static org.elasticsearch.script.ScriptType.INLINE;
 import static org.elasticsearch.script.ScriptType.STORED;
 
 /**
- * Processor that adds new fields with their corresponding values. If the field is already present, its value
- * will be replaced with the provided one.
+ * Processor that evaluates a script with an ingest document in its context.
  */
 public final class ScriptProcessor extends AbstractProcessor {
 
@@ -51,12 +51,24 @@ public final class ScriptProcessor extends AbstractProcessor {
     private final Script script;
     private final ScriptService scriptService;
 
+    /**
+     * Processor that evaluates a script with an ingest document in its context
+     *
+     * @param tag The processor's tag.
+     * @param script The {@link Script} to execute.
+     * @param scriptService The {@link ScriptService} used to execute the script.
+     */
     ScriptProcessor(String tag, Script script, ScriptService scriptService)  {
         super(tag);
         this.script = script;
         this.scriptService = scriptService;
     }
 
+    /**
+     * Executes the script with the Ingest document in context.
+     *
+     * @param document The Ingest document passed into the script context under the "ctx" object.
+     */
     @Override
     public void execute(IngestDocument document) {
         ExecutableScript executableScript = scriptService.executable(script, ScriptContext.Standard.INGEST);
@@ -111,14 +123,25 @@ public final class ScriptProcessor extends AbstractProcessor {
             }
 
             final Script script;
+            String scriptPropertyUsed;
             if (Strings.hasLength(file)) {
                 script = new Script(FILE, lang, file, (Map<String, Object>)params);
+                scriptPropertyUsed = "file";
             } else if (Strings.hasLength(inline)) {
                 script = new Script(INLINE, lang, inline, (Map<String, Object>)params);
+                scriptPropertyUsed = "inline";
             } else if (Strings.hasLength(id)) {
                 script = new Script(STORED, lang, id, (Map<String, Object>)params);
+                scriptPropertyUsed = "id";
             } else {
                 throw newConfigurationException(TYPE, processorTag, null, "Could not initialize script");
+            }
+
+            // verify script is able to be compiled before successfully creating processor.
+            try {
+                scriptService.compile(script, ScriptContext.Standard.INGEST, script.getOptions());
+            } catch (ScriptException e) {
+                throw newConfigurationException(TYPE, processorTag, scriptPropertyUsed, e);
             }
 
             return new ScriptProcessor(processorTag, script, scriptService);

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ScriptProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ScriptProcessorTests.java
@@ -24,12 +24,10 @@ import java.util.Map;
 
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.RandomDocumentPicks;
-import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ESTestCase;
-import org.mockito.stubbing.Answer;
 
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.core.Is.is;

--- a/qa/smoke-test-ingest-with-all-dependencies/src/test/resources/rest-api-spec/test/ingest/50_script_processor_using_painless.yaml
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/test/resources/rest-api-spec/test/ingest/50_script_processor_using_painless.yaml
@@ -115,3 +115,26 @@
   - match: { _source.bytes_in: 1234 }
   - match: { _source.bytes_out: 4321 }
   - match: { _source.bytes_total: 5555 }
+
+---
+"Test script processor with syntax error in inline script":
+  - do:
+      catch: request
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "script" : {
+                  "inline": "invalid painless, hear me roar!"
+                }
+              }
+            ]
+          }
+  - match: { error.header.processor_type: "script" }
+  - match: { error.header.property_name: "inline" }
+  - match: { error.type: "script_exception" }
+  - match: { error.reason: "compile error" }
+


### PR DESCRIPTION
Inline scripts defined in Ingest Pipelines are not compiled at creation time and compile-time errors lazily occur upon initial execution of the pipeline.

WIP because it lacks tests.

Fixes #21842.