### PR TITLE
Optimize single-valued fields in function_score.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/fielddata/GeoPointValues.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/GeoPointValues.java
@@ -30,7 +30,7 @@ public abstract class GeoPointValues {
      * Get the {@link GeoPoint} associated with <code>docID</code>.
      * The returned {@link GeoPoint} might be reused across calls.
      * If the given <code>docID</code> does not have a value then the returned
-     * geo point mught have both latitude and longitude set to 0.
+     * geo point will have both latitude and longitude set to 0.
      */
     public abstract GeoPoint get(int docID);
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/SingletonMultiGeoPointValues.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/SingletonMultiGeoPointValues.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.fielddata;
 
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.Bits.MatchAllBits;
 import org.elasticsearch.common.geo.GeoPoint;
 
 final class SingletonMultiGeoPointValues extends MultiGeoPointValues {
@@ -31,13 +32,13 @@ final class SingletonMultiGeoPointValues extends MultiGeoPointValues {
 
     SingletonMultiGeoPointValues(GeoPointValues in, Bits docsWithField) {
         this.in = in;
-        this.docsWithField = docsWithField;
+        this.docsWithField = docsWithField instanceof MatchAllBits ? null : docsWithField;
     }
 
     @Override
     public void setDocument(int docID) {
         value = in.get(docID);
-        if (value.lat() == Double.NaN && value.lon() == Double.NaN || (docsWithField != null && !docsWithField.get(docID))) {
+        if (docsWithField != null && value.lat() == 0 && value.lon() == 0 && docsWithField.get(docID) == false) {
             count = 0;
         } else {
             count = 1;

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointArrayAtomicFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointArrayAtomicFieldData.java
@@ -78,7 +78,7 @@ public abstract class GeoPointArrayAtomicFieldData extends AbstractAtomicGeoPoin
                         if (ord >= 0) {
                             return point.resetFromIndexHash(indexedPoints.get(ord));
                         }
-                        return point.reset(Double.NaN, Double.NaN);
+                        return point.reset(0, 0);
                     }
                 };
                 return FieldData.singleton(values, DocValues.docsWithValue(singleOrds, maxDoc));
@@ -136,7 +136,7 @@ public abstract class GeoPointArrayAtomicFieldData extends AbstractAtomicGeoPoin
                     if (set == null || set.get(docID)) {
                         return point.resetFromIndexHash(indexedPoint.get(docID));
                     }
-                    return point.reset(Double.NaN, Double.NaN);
+                    return point.reset(0, 0);
                 }
             };
             return FieldData.singleton(values, set);

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointArrayLegacyAtomicFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointArrayLegacyAtomicFieldData.java
@@ -82,7 +82,7 @@ public abstract class GeoPointArrayLegacyAtomicFieldData extends AbstractAtomicG
                         if (ord >= 0) {
                             return point.reset(lat.get(ord), lon.get(ord));
                         }
-                        return point.reset(Double.NaN, Double.NaN);
+                        return point.reset(0, 0);
                     }
                 };
                 return FieldData.singleton(values, DocValues.docsWithValue(singleOrds, maxDoc));
@@ -96,7 +96,7 @@ public abstract class GeoPointArrayLegacyAtomicFieldData extends AbstractAtomicG
                         if (ord >= 0) {
                             return point.reset(lat.get(ord), lon.get(ord));
                         }
-                        return point.reset(Double.NaN, Double.NaN);
+                        return point.reset(0, 0);
                     }
 
                     @Override
@@ -152,7 +152,7 @@ public abstract class GeoPointArrayLegacyAtomicFieldData extends AbstractAtomicG
                     if (set == null || set.get(docID)) {
                         return point.reset(lat.get(docID), lon.get(docID));
                     }
-                    return point.reset(Double.NaN, Double.NaN);
+                    return point.reset(0, 0);
                 }
             };
             return FieldData.singleton(values, set);

--- a/core/src/test/java/org/elasticsearch/index/fielddata/plain/LatLonPointDVAtomicFieldDataTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/plain/LatLonPointDVAtomicFieldDataTests.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.fielddata.plain;
+
+import org.apache.lucene.geo.GeoEncodingUtils;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FixedBitSet;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.index.fielddata.MultiGeoPointValues;
+import org.elasticsearch.test.ESTestCase;
+
+public class LatLonPointDVAtomicFieldDataTests extends ESTestCase {
+
+    public void testSingleValued() {
+        final NumericDocValues encodedValues = new NumericDocValues() {
+            @Override
+            public long get(int docID) {
+                if (docID == 0) {
+                    return 42;
+                } else if (docID == 1) {
+                    return 0;
+                } else {
+                    throw new IndexOutOfBoundsException();
+                }
+            }
+        };
+        Bits bits = new Bits.MatchAllBits(2);
+        LatLonPointDVAtomicFieldData fd = new LatLonPointDVAtomicFieldData(DocValues.singleton(encodedValues, bits));
+        MultiGeoPointValues values = fd.getGeoPointValues();
+        values.setDocument(0);
+        assertEquals(1, values.count());
+        GeoPoint point = values.valueAt(0);
+        assertEquals(GeoEncodingUtils.decodeLatitude((int)(42L >>> 32)), point.lat(), 0d);
+        assertEquals(GeoEncodingUtils.decodeLongitude((int)(42L)), point.lon(), 0d);
+        values.setDocument(1);
+        assertEquals(1, values.count());
+        point = values.valueAt(0);
+        assertEquals(GeoEncodingUtils.decodeLatitude((int)(0L >>> 32)), point.lat(), 0d);
+        assertEquals(GeoEncodingUtils.decodeLongitude((int)(0L)), point.lon(), 0d);
+
+        FixedBitSet bits2 = new FixedBitSet(2);
+        bits2.set(0);
+        fd = new LatLonPointDVAtomicFieldData(DocValues.singleton(encodedValues, bits2));
+        values = fd.getGeoPointValues();
+        values.setDocument(0);
+        assertEquals(1, values.count());
+        point = values.valueAt(0);
+        assertEquals(GeoEncodingUtils.decodeLatitude((int)(42L >>> 32)), point.lat(), 0d);
+        assertEquals(GeoEncodingUtils.decodeLongitude((int)(42L)), point.lon(), 0d);
+        values.setDocument(1);
+        assertEquals(0, values.count());
+    }
+
+    public void testMultiValued() {
+        final SortedNumericDocValues encodedValues = new SortedNumericDocValues() {
+            int doc;
+
+            @Override
+            public void setDocument(int doc) {
+                this.doc = doc;
+            }
+
+            @Override
+            public int count() {
+                if (doc == 0) {
+                    return 2;
+                } else {
+                    return 0;
+                }
+            }
+
+            @Override
+            public long valueAt(int index) {
+                if (doc == 0 && index == 0) {
+                    return 42;
+                } else if (doc == 0 && index == 1) {
+                    return 62;
+                } else {
+                    throw new IndexOutOfBoundsException();
+                }
+            }
+        };
+        LatLonPointDVAtomicFieldData fd = new LatLonPointDVAtomicFieldData(encodedValues);
+        MultiGeoPointValues values = fd.getGeoPointValues();
+        values.setDocument(0);
+        assertEquals(2, values.count());
+        GeoPoint point = values.valueAt(0);
+        assertEquals(GeoEncodingUtils.decodeLatitude((int)(42L >>> 32)), point.lat(), 0d);
+        assertEquals(GeoEncodingUtils.decodeLongitude((int)(42L)), point.lon(), 0d);
+        point = values.valueAt(1);
+        assertEquals(GeoEncodingUtils.decodeLatitude((int)(62L >>> 32)), point.lat(), 0d);
+        assertEquals(GeoEncodingUtils.decodeLongitude((int)(62L)), point.lon(), 0d);
+        values.setDocument(1);
+        assertEquals(0, values.count());
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreTests.java
@@ -39,6 +39,7 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
@@ -54,8 +55,10 @@ import org.elasticsearch.common.lucene.search.function.WeightFactorFunction;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.AtomicFieldData;
 import org.elasticsearch.index.fielddata.AtomicNumericFieldData;
+import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
@@ -176,21 +179,32 @@ public class FunctionScoreTests extends ESTestCase {
 
                 @Override
                 public SortedNumericDoubleValues getDoubleValues() {
-                    return new SortedNumericDoubleValues() {
-                        @Override
-                        public void setDocument(int doc) {
-                        }
+                    if (randomBoolean()) {
+                        return new SortedNumericDoubleValues() {
+                            @Override
+                            public void setDocument(int doc) {
+                            }
 
-                        @Override
-                        public double valueAt(int index) {
-                            return 1;
-                        }
+                            @Override
+                            public double valueAt(int index) {
+                                return 1;
+                            }
 
-                        @Override
-                        public int count() {
-                            return 1;
-                        }
-                    };
+                            @Override
+                            public int count() {
+                                return 1;
+                            }
+                        };
+                    } else {
+                        return FieldData.singleton(new NumericDoubleValues() {
+
+                            @Override
+                            public double get(int docID) {
+                                return 1;
+                            }
+
+                        }, new Bits.MatchAllBits(1));
+                    }
                 }
 
                 @Override


### PR DESCRIPTION
`function_score` consumes all fields through their multi-valued API, which can
be a bit slow for single-valued fields, which I expect to be the common case.

This also fixes the default value of geo-points in the missing case to be `[0,0]`
as per the javadocs of `GeoPointValues` rather than `[NaN,NaN]`.