### PR TITLE
Remove subrequests method from CompositeIndicesRequest

### DIFF
--- a/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/TransportNoopBulkAction.java
+++ b/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/TransportNoopBulkAction.java
@@ -46,7 +46,7 @@ public class TransportNoopBulkAction extends HandledTransportAction<BulkRequest,
 
     @Override
     protected void doExecute(BulkRequest request, ActionListener<BulkResponse> listener) {
-        final int itemCount = request.subRequests().size();
+        final int itemCount = request.requests().size();
         // simulate at least a realistic amount of data that gets serialized
         BulkItemResponse[] bulkItemResponses = new BulkItemResponse[itemCount];
         for (int idx = 0; idx < itemCount; idx++) {

--- a/core/src/main/java/org/elasticsearch/action/CompositeIndicesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/CompositeIndicesRequest.java
@@ -19,18 +19,11 @@
 
 package org.elasticsearch.action;
 
-import java.util.List;
-
 /**
- * Needs to be implemented by all {@link org.elasticsearch.action.ActionRequest} subclasses that are composed of multiple subrequests
- * which relate to one or more indices. Allows to retrieve those subrequests and reason about them separately. A composite request is
- * executed by its own transport action class (e.g. {@link org.elasticsearch.action.search.TransportMultiSearchAction}), which goes
- * through all the subrequests and delegates their execution to the appropriate transport action (e.g.
- * {@link org.elasticsearch.action.search.TransportSearchAction}) for each single item.
+ * Marker interface that needs to be implemented by all {@link org.elasticsearch.action.ActionRequest} subclasses that are composed of
+ * multiple sub-requests which relate to one or more indices.  A composite request is executed by its own transport action class
+ * (e.g. {@link org.elasticsearch.action.search.TransportMultiSearchAction}), which goes through all sub-requests and delegates their
+ * execution to the appropriate transport action (e.g. {@link org.elasticsearch.action.search.TransportSearchAction}) for each single item.
  */
 public interface CompositeIndicesRequest {
-    /**
-     * Returns the subrequests that a composite request is composed of
-     */
-    List<? extends IndicesRequest> subRequests();
 }

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -211,11 +211,6 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
         return this.requests;
     }
 
-    @Override
-    public List<? extends IndicesRequest> subRequests() {
-        return requests.stream().collect(Collectors.toList());
-    }
-
     /**
      * The list of optional payloads associated with requests in the same order as the requests. Note, elements within
      * it might be null if no payload has been provided.

--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -284,11 +284,6 @@ public class MultiGetRequest extends ActionRequest implements Iterable<MultiGetR
         return validationException;
     }
 
-    @Override
-    public List<? extends IndicesRequest> subRequests() {
-        return items;
-    }
-
     /**
      * Sets the preference to execute the search. Defaults to randomize across shards. Can be set to
      * <tt>_local</tt> to prefer local shards, <tt>_primary</tt> to execute only on primary shards, or

--- a/core/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
@@ -22,7 +22,6 @@ package org.elasticsearch.action.search;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
-import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -81,11 +80,6 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
     }
 
     public List<SearchRequest> requests() {
-        return this.requests;
-    }
-
-    @Override
-    public List<? extends IndicesRequest> subRequests() {
         return this.requests;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsRequest.java
@@ -23,7 +23,6 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
-import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.RealtimeRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.Nullable;
@@ -74,11 +73,6 @@ public class MultiTermVectorsRequest extends ActionRequest implements Iterable<T
             }
         }
         return validationException;
-    }
-
-    @Override
-    public List<? extends IndicesRequest> subRequests() {
-        return requests;
     }
 
     @Override

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequest.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequest.java
@@ -22,7 +22,6 @@ package org.elasticsearch.script.mustache;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
-import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -59,15 +58,6 @@ public class MultiSearchTemplateRequest extends ActionRequest implements Composi
 
     public List<SearchTemplateRequest> requests() {
         return this.requests;
-    }
-
-    @Override
-    public List<? extends IndicesRequest> subRequests() {
-        List<IndicesRequest> indicesRequests = new ArrayList<>();
-        for (SearchTemplateRequest request : requests) {
-            indicesRequests.addAll(request.subRequests());
-        }
-        return indicesRequests;
     }
 
     @Override

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/SearchTemplateRequest.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/SearchTemplateRequest.java
@@ -22,15 +22,12 @@ package org.elasticsearch.script.mustache;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
-import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.script.ScriptType;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
@@ -165,16 +162,5 @@ public class SearchTemplateRequest extends ActionRequest implements CompositeInd
         if (hasParams) {
             out.writeMap(scriptParams);
         }
-    }
-
-    @Override
-    public List<? extends IndicesRequest> subRequests() {
-        //if we are simulating no index is involved in the request
-        if (simulate) {
-            assert request == null;
-            return Collections.emptyList();
-        }
-        //composite request as it delegates to search, but it holds one single action (search itself)
-        return Collections.singletonList(request);
     }
 }

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/MultiPercolateRequest.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/MultiPercolateRequest.java
@@ -22,7 +22,6 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
-import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -162,11 +161,6 @@ public class MultiPercolateRequest extends ActionRequest implements CompositeInd
         }
 
         return this;
-    }
-
-    @Override
-    public List<? extends IndicesRequest> subRequests() {
-        return requests;
     }
 
     private void parsePercolateAction(XContentParser parser, PercolateRequest percolateRequest, boolean allowExplicitIndex) throws IOException {

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.reindex;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
-import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -31,11 +30,7 @@ import org.elasticsearch.index.reindex.remote.RemoteInfo;
 import org.elasticsearch.tasks.TaskId;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 
-import static java.util.Collections.singletonList;
-import static java.util.Collections.unmodifiableList;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.index.VersionType.INTERNAL;
 
@@ -170,24 +165,5 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
             b.append('[').append(destination.type()).append(']');
         }
         return b.toString();
-    }
-
-    // CompositeIndicesRequest implementation so plugins can reason about the request. This is really just a best effort thing.
-    /**
-     * Accessor to get the underlying {@link IndicesRequest}s that this request wraps. Note that this method is <strong>not
-     * accurate</strong> since it returns a prototype {@link IndexRequest} and not the actual requests that will be issued as part of the
-     * execution of this request. Additionally, scripts can modify the underlying {@link IndexRequest} and change values such as the index,
-     * type, {@link org.elasticsearch.action.support.IndicesOptions}. In short - only use this for very course reasoning about the request.
-     *
-     * @return a list comprising of the {@link SearchRequest} and the prototype {@link IndexRequest}
-     */
-    @Override
-    public List<? extends IndicesRequest> subRequests() {
-        assert getSearchRequest() != null;
-        assert getDestination() != null;
-        if (remoteInfo != null) {
-            return singletonList(getDestination());
-        }
-        return unmodifiableList(Arrays.asList(getSearchRequest(), getDestination()));
     }
 }


### PR DESCRIPTION
This method is not used anywhere and is not needed for the time being.