### PR TITLE
Add support for "include_segment_file_sizes" in indices stats REST handler

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
@@ -34,7 +34,6 @@ import org.elasticsearch.rest.action.RestActions.NodesResponseRestListener;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -180,8 +179,8 @@ public class RestNodesStatsAction extends BaseRestHandler {
         if (nodesStatsRequest.indices().isSet(Flag.Indexing) && (request.hasParam("types"))) {
             nodesStatsRequest.indices().types(request.paramAsStringArray("types", null));
         }
-        if (nodesStatsRequest.indices().isSet(Flag.Segments) && (request.hasParam("include_segment_file_sizes"))) {
-            nodesStatsRequest.indices().includeSegmentFileSizes(true);
+        if (nodesStatsRequest.indices().isSet(Flag.Segments)) {
+            nodesStatsRequest.indices().includeSegmentFileSizes(request.paramAsBoolean("include_segment_file_sizes", false));
         }
 
         return channel -> client.admin().cluster().nodesStats(nodesStatsRequest, new NodesResponseRestListener<>(channel));

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsAction.java
@@ -37,7 +37,6 @@ import org.elasticsearch.rest.action.RestBuilderListener;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -136,8 +135,8 @@ public class RestIndicesStatsAction extends BaseRestHandler {
                     request.paramAsStringArray("fielddata_fields", request.paramAsStringArray("fields", Strings.EMPTY_ARRAY)));
         }
 
-        if (indicesStatsRequest.segments() && request.hasParam("include_segment_file_sizes")) {
-            indicesStatsRequest.includeSegmentFileSizes(true);
+        if (indicesStatsRequest.segments()) {
+            indicesStatsRequest.includeSegmentFileSizes(request.paramAsBoolean("include_segment_file_sizes", false));
         }
 
         return channel -> client.admin().indices().stats(indicesStatsRequest, new RestBuilderListener<IndicesStatsResponse>(channel) {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
@@ -52,6 +52,11 @@
         "types" : {
           "type" : "list",
           "description" : "A comma-separated list of document types for the `indexing` index metric"
+        },
+        "include_segment_file_sizes": {
+          "type": "boolean",
+          "description": "Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested)",
+          "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
@@ -63,6 +63,11 @@
         "timeout": {
           "type" : "time",
           "description" : "Explicit operation timeout"
+        },
+        "include_segment_file_sizes": {
+          "type": "boolean",
+          "description": "Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested)",
+          "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/11_metric.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/11_metric.yaml
@@ -121,3 +121,46 @@ setup:
   - is_false:  _all.total.translog
   - is_true:   _all.total.recovery
 
+---
+"Metric - _all include_segment_file_sizes":
+  - do:
+      indices.stats: { metric: _all, include_segment_file_sizes: true }
+
+  - is_true:   _all.total.docs
+  - is_true:   _all.total.store
+  - is_true:   _all.total.indexing
+  - is_true:   _all.total.get
+  - is_true:   _all.total.search
+  - is_true:   _all.total.merges
+  - is_true:   _all.total.refresh
+  - is_true:   _all.total.flush
+  - is_true:   _all.total.warmer
+  - is_true:   _all.total.query_cache
+  - is_true:   _all.total.fielddata
+  - is_true:   _all.total.completion
+  - is_true:   _all.total.segments
+  - is_true:   _all.total.translog
+  - is_true:   _all.total.recovery
+  - is_true:   _all.total.segments.file_sizes
+
+---
+"Metric - segments include_segment_file_sizes":
+  - do:
+      indices.stats: { metric: segments, include_segment_file_sizes: true }
+
+  - is_false:  _all.total.docs
+  - is_false:  _all.total.store
+  - is_false:  _all.total.indexing
+  - is_false:  _all.total.get
+  - is_false:  _all.total.search
+  - is_false:  _all.total.merges
+  - is_false:  _all.total.refresh
+  - is_false:  _all.total.flush
+  - is_false:  _all.total.warmer
+  - is_false:  _all.total.query_cache
+  - is_false:  _all.total.fielddata
+  - is_false:  _all.total.completion
+  - is_true:   _all.total.segments
+  - is_false:  _all.total.translog
+  - is_false:  _all.total.recovery
+  - is_true:   _all.total.segments.file_sizes

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yaml
@@ -1,0 +1,211 @@
+---
+"Metric - blank":
+  - do:
+      cluster.state: {}
+
+  - set: { master_node: master }
+
+  - do:
+      nodes.stats: {}
+
+  - is_true:  nodes.$master.indices.docs
+  - is_true:  nodes.$master.indices.store
+  - is_true:  nodes.$master.indices.indexing
+  - is_true:  nodes.$master.indices.get
+  - is_true:  nodes.$master.indices.search
+  - is_true:  nodes.$master.indices.merges
+  - is_true:  nodes.$master.indices.refresh
+  - is_true:  nodes.$master.indices.flush
+  - is_true:  nodes.$master.indices.warmer
+  - is_true:  nodes.$master.indices.query_cache
+  - is_true:  nodes.$master.indices.fielddata
+  - is_true:  nodes.$master.indices.completion
+  - is_true:  nodes.$master.indices.segments
+  - is_true:  nodes.$master.indices.translog
+  - is_true:  nodes.$master.indices.recovery
+
+---
+"Metric - _all":
+  - do:
+      cluster.state: {}
+
+  - set: { master_node: master }
+
+  - do:
+      nodes.stats: { metric: _all }
+
+  - is_true:  nodes.$master.indices.docs
+  - is_true:  nodes.$master.indices.store
+  - is_true:  nodes.$master.indices.indexing
+  - is_true:  nodes.$master.indices.get
+  - is_true:  nodes.$master.indices.search
+  - is_true:  nodes.$master.indices.merges
+  - is_true:  nodes.$master.indices.refresh
+  - is_true:  nodes.$master.indices.flush
+  - is_true:  nodes.$master.indices.warmer
+  - is_true:  nodes.$master.indices.query_cache
+  - is_true:  nodes.$master.indices.fielddata
+  - is_true:  nodes.$master.indices.completion
+  - is_true:  nodes.$master.indices.segments
+  - is_true:  nodes.$master.indices.translog
+  - is_true:  nodes.$master.indices.recovery
+
+---
+"Metric - indices _all":
+  - do:
+      cluster.state: {}
+
+  - set: { master_node: master }
+
+  - do:
+      nodes.stats: { metric: indices, index_metric: _all }
+
+  - is_true:  nodes.$master.indices.docs
+  - is_true:  nodes.$master.indices.store
+  - is_true:  nodes.$master.indices.indexing
+  - is_true:  nodes.$master.indices.get
+  - is_true:  nodes.$master.indices.search
+  - is_true:  nodes.$master.indices.merges
+  - is_true:  nodes.$master.indices.refresh
+  - is_true:  nodes.$master.indices.flush
+  - is_true:  nodes.$master.indices.warmer
+  - is_true:  nodes.$master.indices.query_cache
+  - is_true:  nodes.$master.indices.fielddata
+  - is_true:  nodes.$master.indices.completion
+  - is_true:  nodes.$master.indices.segments
+  - is_true:  nodes.$master.indices.translog
+  - is_true:  nodes.$master.indices.recovery
+
+---
+"Metric - one":
+  - do:
+      cluster.state: {}
+
+  - set: { master_node: master }
+
+  - do:
+      nodes.stats: { metric: indices, index_metric: docs }
+
+  - is_true:   nodes.$master.indices.docs
+  - is_false:  nodes.$master.indices.store
+  - is_false:  nodes.$master.indices.indexing
+  - is_false:  nodes.$master.indices.get
+  - is_false:  nodes.$master.indices.search
+  - is_false:  nodes.$master.indices.merges
+  - is_false:  nodes.$master.indices.refresh
+  - is_false:  nodes.$master.indices.flush
+  - is_false:  nodes.$master.indices.warmer
+  - is_false:  nodes.$master.indices.query_cache
+  - is_false:  nodes.$master.indices.fielddata
+  - is_false:  nodes.$master.indices.completion
+  - is_false:  nodes.$master.indices.segments
+  - is_false:  nodes.$master.indices.translog
+  - is_false:  nodes.$master.indices.recovery
+
+---
+"Metric - multi":
+  - do:
+      cluster.state: {}
+
+  - set: { master_node: master }
+
+  - do:
+      nodes.stats: { metric: indices, index_metric: [ store, get, merge ] }
+
+  - is_false:  nodes.$master.indices.docs
+  - is_true:   nodes.$master.indices.store
+  - is_false:  nodes.$master.indices.indexing
+  - is_true:   nodes.$master.indices.get
+  - is_false:  nodes.$master.indices.search
+  - is_true:   nodes.$master.indices.merges
+  - is_false:  nodes.$master.indices.refresh
+  - is_false:  nodes.$master.indices.flush
+  - is_false:  nodes.$master.indices.warmer
+  - is_false:  nodes.$master.indices.query_cache
+  - is_false:  nodes.$master.indices.fielddata
+  - is_false:  nodes.$master.indices.completion
+  - is_false:  nodes.$master.indices.segments
+  - is_false:  nodes.$master.indices.translog
+  - is_false:  nodes.$master.indices.recovery
+
+
+---
+"Metric - recovery":
+  - do:
+      cluster.state: {}
+
+  - set: { master_node: master }
+
+  - do:
+      nodes.stats: { metric: indices, index_metric: [ recovery ] }
+
+  - is_false:  nodes.$master.indices.docs
+  - is_false:  nodes.$master.indices.store
+  - is_false:  nodes.$master.indices.indexing
+  - is_false:  nodes.$master.indices.get
+  - is_false:  nodes.$master.indices.search
+  - is_false:  nodes.$master.indices.merges
+  - is_false:  nodes.$master.indices.refresh
+  - is_false:  nodes.$master.indices.flush
+  - is_false:  nodes.$master.indices.warmer
+  - is_false:  nodes.$master.indices.query_cache
+  - is_false:  nodes.$master.indices.fielddata
+  - is_false:  nodes.$master.indices.completion
+  - is_false:  nodes.$master.indices.segments
+  - is_false:  nodes.$master.indices.translog
+  - is_true:   nodes.$master.indices.recovery
+
+---
+"Metric - _all include_segment_file_sizes":
+  - do:
+      cluster.state: {}
+
+  - set: { master_node: master }
+
+  - do:
+      nodes.stats: { metric: indices, index_metric: _all, include_segment_file_sizes: true }
+
+  - is_true:   nodes.$master.indices.docs
+  - is_true:   nodes.$master.indices.store
+  - is_true:   nodes.$master.indices.indexing
+  - is_true:   nodes.$master.indices.get
+  - is_true:   nodes.$master.indices.search
+  - is_true:   nodes.$master.indices.merges
+  - is_true:   nodes.$master.indices.refresh
+  - is_true:   nodes.$master.indices.flush
+  - is_true:   nodes.$master.indices.warmer
+  - is_true:   nodes.$master.indices.query_cache
+  - is_true:   nodes.$master.indices.fielddata
+  - is_true:   nodes.$master.indices.completion
+  - is_true:   nodes.$master.indices.segments
+  - is_true:   nodes.$master.indices.translog
+  - is_true:   nodes.$master.indices.recovery
+  - is_true:   nodes.$master.indices.segments.file_sizes
+
+---
+"Metric - segments include_segment_file_sizes":
+  - do:
+      cluster.state: {}
+
+  - set: { master_node: master }
+
+  - do:
+      nodes.stats: { metric: indices, index_metric: segments, include_segment_file_sizes: true }
+
+  - is_false:  nodes.$master.indices.docs
+  - is_false:  nodes.$master.indices.store
+  - is_false:  nodes.$master.indices.indexing
+  - is_false:  nodes.$master.indices.get
+  - is_false:  nodes.$master.indices.search
+  - is_false:  nodes.$master.indices.merges
+  - is_false:  nodes.$master.indices.refresh
+  - is_false:  nodes.$master.indices.flush
+  - is_false:  nodes.$master.indices.warmer
+  - is_false:  nodes.$master.indices.query_cache
+  - is_false:  nodes.$master.indices.fielddata
+  - is_false:  nodes.$master.indices.completion
+  - is_true:   nodes.$master.indices.segments
+  - is_false:  nodes.$master.indices.translog
+  - is_false:  nodes.$master.indices.recovery
+  - is_true:   nodes.$master.indices.segments.file_sizes
+


### PR DESCRIPTION
Fix for #21878

Adds `include_segment_file_sizes` to acceptable parameters in the `RestIndicesStatsAction` REST handler.

Thanks!