### PR TITLE
Add option to skip kernel parameters on install

### DIFF
--- a/distribution/src/main/packaging/scripts/postinst
+++ b/distribution/src/main/packaging/scripts/postinst
@@ -52,10 +52,17 @@ case "$1" in
 esac
 
 # to pick up /usr/lib/sysctl.d/elasticsearch.conf
-if command -v /usr/lib/systemd/systemd-sysctl > /dev/null; then
-    /usr/lib/systemd/systemd-sysctl
-elif command -v /lib/systemd/systemd-sysctl > /dev/null; then
-    /lib/systemd/systemd-sysctl
+if [ "${SKIP_SET_KERNEL_PARAMETERS:-false}" == "false" ]; then
+    if command -v /usr/lib/systemd/systemd-sysctl > /dev/null; then
+        /usr/lib/systemd/systemd-sysctl
+    elif command -v /lib/systemd/systemd-sysctl > /dev/null; then
+        /lib/systemd/systemd-sysctl
+    fi
+elif [ "$SKIP_SET_KERNEL_PARAMETERS" == "true" ]; then
+    echo "skipping setting kernel parameters"
+else
+    echo "unrecognized value [$SKIP_SET_KERNEL_PARAMETERS] for SKIP_SET_KERNEL_PARAMETERS; must be unset (defaults to [false]), [false], or [true]"
+    exit 1
 fi
 
 if [ "x$IS_UPGRADE" != "xtrue" ]; then

--- a/distribution/src/main/packaging/scripts/postinst
+++ b/distribution/src/main/packaging/scripts/postinst
@@ -52,16 +52,16 @@ case "$1" in
 esac
 
 # to pick up /usr/lib/sysctl.d/elasticsearch.conf
-if [ "${SKIP_SET_KERNEL_PARAMETERS:-false}" == "false" ]; then
+if [ "${ES_SKIP_SET_KERNEL_PARAMETERS:-false}" == "false" ]; then
     if command -v /usr/lib/systemd/systemd-sysctl > /dev/null; then
         /usr/lib/systemd/systemd-sysctl
     elif command -v /lib/systemd/systemd-sysctl > /dev/null; then
         /lib/systemd/systemd-sysctl
     fi
-elif [ "$SKIP_SET_KERNEL_PARAMETERS" == "true" ]; then
+elif [ "$ES_SKIP_SET_KERNEL_PARAMETERS" == "true" ]; then
     echo "skipping setting kernel parameters"
 else
-    echo "unrecognized value [$SKIP_SET_KERNEL_PARAMETERS] for SKIP_SET_KERNEL_PARAMETERS; must be unset (defaults to [false]), [false], or [true]"
+    echo "unrecognized value [$ES_SKIP_SET_KERNEL_PARAMETERS] for ES_SKIP_SET_KERNEL_PARAMETERS; must [false] (default) or [true]"
     exit 1
 fi
 

--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -96,6 +96,7 @@ Examine +/etc/apt/sources.list.d/elasticsearch-{major-version}.list+ for the dup
 
 endif::[]
 
+include::skip-set-kernel-parameters.asciidoc[]
 
 [[install-deb]]
 ==== Download and install the Debian package manually

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -112,6 +112,8 @@ sudo rpm --install elasticsearch-{version}.rpm
 
 endif::[]
 
+include::skip-set-kernel-parameters.asciidoc[]
+
 include::init-systemd.asciidoc[]
 
 [[rpm-running-init]]

--- a/docs/reference/setup/install/skip-set-kernel-parameters.asciidoc
+++ b/docs/reference/setup/install/skip-set-kernel-parameters.asciidoc
@@ -1,2 +1,2 @@
 NOTE: On systemd-based distributions, the installation scripts will attempt to set kernel parameters (e.g.,
-`vm.max_map_count`); you can skip this by setting the environment variable `SKIP_SET_KERNEL_PARAMETERS` to `true`.
+`vm.max_map_count`); you can skip this by setting the environment variable `ES_SKIP_SET_KERNEL_PARAMETERS` to `true`.

--- a/docs/reference/setup/install/skip-set-kernel-parameters.asciidoc
+++ b/docs/reference/setup/install/skip-set-kernel-parameters.asciidoc
@@ -1,0 +1,2 @@
+NOTE: On systemd-based distributions, the installation scripts will attempt to set kernel parameters (e.g.,
+`vm.max_map_count`); you can skip this by setting the environment variable `SKIP_SET_KERNEL_PARAMETERS` to `true`.


### PR DESCRIPTION
During package install on systemd-based systems, we try to set
vm.max_map_count. On some systems (e.g., containers), users do not have
the ability to tune these parameters from within the container. This
commit provides an option for these users to skip setting such kernel
parameters.

Closes #21877