### PR TITLE
HLClient: First additions to search interface

### DIFF
--- a/client/highlevel-rest/src/main/java/org/elasticsearch/client/ClientSearchHit.java
+++ b/client/highlevel-rest/src/main/java/org/elasticsearch/client/ClientSearchHit.java
@@ -189,8 +189,7 @@ public class ClientSearchHit implements SearchHit {
 
     @Override
     public Explanation getExplanation() {
-        // TODO
-        return null;
+        return explanation();
     }
 
     @Override
@@ -237,46 +236,50 @@ public class ClientSearchHit implements SearchHit {
         return highlightFields();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public Object[] sortValues() {
-        // TODO
-        return null;
+        return ((List<Object>) this.objectPath.evaluate("sort")).toArray();
     }
 
     @Override
     public Object[] getSortValues() {
-        // TODO
-        return null;
+        return sortValues();
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public String[] matchedQueries() {
-        // TODO
-        return null;
+        List<String> matched = (List<String>) this.objectPath.evaluate("matched_queries");
+        return matched.toArray(new String[matched.size()]);
     }
 
     @Override
     public String[] getMatchedQueries() {
-        // TODO
-        return null;
+        return matchedQueries();
     }
 
     @Override
     public SearchShardTarget shard() {
-        // TODO
+        // TODO, not sure this will work
         return null;
     }
 
     @Override
     public SearchShardTarget getShard() {
-        // TODO
-        return null;
+        return shard();
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Map<String, SearchHits> getInnerHits() {
-        // TODO
-        return null;
+        Map<String, Object> originalMap = (Map<String, Object>) this.objectPath.evaluate("inner_hits");
+        Map<String, SearchHits> innerHits = new HashMap<>(originalMap.size());
+        for (Entry<String, Object> original : originalMap.entrySet()) {
+            SearchHits hits = new ClientSearchHits((Map<String, Object>) original.getValue());
+            innerHits.put(original.getKey(), hits);
+        }
+        return innerHits;
     }
 
     private static String mapToString(Map<String, Object> map) {

--- a/client/highlevel-rest/src/main/java/org/elasticsearch/client/ClientSearchHit.java
+++ b/client/highlevel-rest/src/main/java/org/elasticsearch/client/ClientSearchHit.java
@@ -33,10 +33,14 @@ import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
+import org.elasticsearch.search.internal.InternalSearchHitField;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 public class ClientSearchHit implements SearchHit {
 
@@ -74,7 +78,7 @@ public class ClientSearchHit implements SearchHit {
 
     @Override
     public float score() {
-        return ((Double) this.objectPath.evaluate("_score")).floatValue();
+        return this.objectPath.evaluateDouble("_score").floatValue();
     }
 
     @Override
@@ -84,7 +88,7 @@ public class ClientSearchHit implements SearchHit {
 
     @Override
     public String index() {
-        return (String) this.objectPath.evaluate("_index");
+        return this.objectPath.evaluateString("_index");
     }
 
     @Override
@@ -94,7 +98,7 @@ public class ClientSearchHit implements SearchHit {
 
     @Override
     public String id() {
-        return (String) this.objectPath.evaluate("_id");
+        return this.objectPath.evaluateString("_id");
     }
 
     @Override
@@ -104,7 +108,7 @@ public class ClientSearchHit implements SearchHit {
 
     @Override
     public String type() {
-        return (String) this.objectPath.evaluate("_type");
+        return this.objectPath.evaluateString("_type");
     }
 
     @Override
@@ -120,7 +124,7 @@ public class ClientSearchHit implements SearchHit {
 
     @Override
     public long version() {
-        Long version = this.objectPath.evaluateAsLong("_version");
+        Long version = this.objectPath.evaluateLong("_version");
         if (version == null) {
             return -1L; // same as returned by InternalSearchHit if version not set
         }
@@ -191,20 +195,23 @@ public class ClientSearchHit implements SearchHit {
 
     @Override
     public SearchHitField field(String fieldName) {
-        // TODO
-        return null;
+        return fields().get(fieldName);
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Map<String, SearchHitField> fields() {
-        // TODO
-        return null;
+        Map<String, Object> originalMap = (Map<String, Object>) this.objectPath.evaluate("fields");
+        Map<String, SearchHitField> fields = new HashMap<>(originalMap.size());
+        for (Entry<String, Object> original : originalMap.entrySet()) {
+            fields.put(original.getKey(), new InternalSearchHitField(original.getKey(), (List<Object>) original.getValue()));
+        }
+        return fields;
     }
 
     @Override
     public Map<String, SearchHitField> getFields() {
-        // TODO
-        return null;
+        return fields();
     }
 
     @Override

--- a/client/highlevel-rest/src/main/java/org/elasticsearch/client/ClientSearchHit.java
+++ b/client/highlevel-rest/src/main/java/org/elasticsearch/client/ClientSearchHit.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.search.SearchHit;
@@ -72,8 +73,7 @@ public class ClientSearchHit implements SearchHit {
 
     @Override
     public Iterator<SearchHitField> iterator() {
-        // TODO
-        return null;
+        return fields().values().iterator();
     }
 
     @Override
@@ -215,15 +215,26 @@ public class ClientSearchHit implements SearchHit {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Map<String, HighlightField> highlightFields() {
-        // TODO
-        return null;
+        Map<String, Object> originalMap = (Map<String, Object>) this.objectPath.evaluate("highlight");
+        Map<String, HighlightField> fields = new HashMap<>(originalMap.size());
+        for (Entry<String, Object> original : originalMap.entrySet()) {
+            List<String> fragments = (List<String>) original.getValue();
+            Text[] asText = new Text[fragments.size()];
+            int i = 0;
+            for (String fragment : fragments) {
+                asText[i] = new Text(fragment);
+                i++;
+            }
+            fields.put(original.getKey(), new HighlightField(original.getKey(), asText));
+        }
+        return fields;
     }
 
     @Override
     public Map<String, HighlightField> getHighlightFields() {
-        // TODO
-        return null;
+        return highlightFields();
     }
 
     @Override

--- a/client/highlevel-rest/src/main/java/org/elasticsearch/client/ClientSearchHits.java
+++ b/client/highlevel-rest/src/main/java/org/elasticsearch/client/ClientSearchHits.java
@@ -64,7 +64,7 @@ public class ClientSearchHits implements SearchHits {
 
     @Override
     public long totalHits() {
-        return this.objectPath.evaluateAsLong("total");
+        return this.objectPath.evaluateLong("total");
     }
 
     @Override
@@ -74,7 +74,7 @@ public class ClientSearchHits implements SearchHits {
 
     @Override
     public float maxScore() {
-        return ((Double) this.objectPath.evaluate("max_score")).floatValue();
+        return this.objectPath.evaluateDouble("max_score").floatValue();
     }
 
     @Override

--- a/client/highlevel-rest/src/main/java/org/elasticsearch/client/SearchResponse.java
+++ b/client/highlevel-rest/src/main/java/org/elasticsearch/client/SearchResponse.java
@@ -70,28 +70,28 @@ public class SearchResponse {
      * How long the search took in milliseconds.
      */
     public long getTookInMillis() {
-        return this.object.evaluateAsLong(org.elasticsearch.action.search.SearchResponse.Fields.TOOK);
+        return this.object.evaluateLong(org.elasticsearch.action.search.SearchResponse.Fields.TOOK);
     }
 
     /**
      * The total number of shards the search was executed on.
      */
     public int getTotalShards() {
-        return (Integer) get("_shards.total");
+        return this.object.evaluateInteger("_shards.total");
     }
 
     /**
      * The successful number of shards the search was executed on.
      */
     public int getSuccessfulShards() {
-        return (Integer) get("_shards.successful");
+        return this.object.evaluateInteger("_shards.successful");
     }
 
     /**
      * The failed number of shards the search was executed on.
      */
     public int getFailedShards() {
-        return (Integer) get("_shards.failed");
+        return this.object.evaluateInteger("_shards.failed");
     }
 
     /**

--- a/client/highlevel-rest/src/main/java/org/elasticsearch/client/XContentAccessor.java
+++ b/client/highlevel-rest/src/main/java/org/elasticsearch/client/XContentAccessor.java
@@ -67,12 +67,53 @@ public class XContentAccessor {
     }
 
     /**
+     * Returns the String corresponding to the provided path if present, null otherwise
+     */
+    public String evaluateString(String path) {
+        return (String) evaluate(path);
+    }
+
+    /**
+     * Returns the String corresponding to the provided path if present, null otherwise
+     */
+    public Integer evaluateInteger(String path) {
+        return (Integer) evaluate(path);
+    }
+
+    /**
+     * Returns the Float corresponding to the provided path if present, null otherwise
+     */
+    public Float evaluateFloat(String path) {
+        return (Float) evaluate(path);
+    }
+
+    /**
+     * Returns the Double value corresponding to the provided path if present, null otherwise.
+     * If the object it a {@link Float}, its double value is returned.
+     * If it is neither {@link Float}, {@link Double} or <tt>null</tt>
+     * we throw an {@link IllegalArgumentException}
+     */
+    public Double evaluateDouble(String path) {
+        Object obj = evaluate(path);
+        if (obj == null) {
+            return null;
+        }
+        if (obj instanceof Double) {
+            return ((Double) obj);
+        }
+        if (obj instanceof Float) {
+            return ((Float) obj).doubleValue();
+        }
+        throw new IllegalArgumentException("Object under [" + path + "] should be Double, Float or null.");
+    }
+
+    /**
      * Returns the object corresponding to the provided path if present, null
      * otherwise. If the object it an {@link Integer}, its long value is
      * returned. If it is neither {@link Integer}, {@link Long} or <tt>null</tt>
      * we throw an {@link IllegalArgumentException}
      */
-    public Long evaluateAsLong(String path) {
+    public Long evaluateLong(String path) {
         Object obj = evaluate(path);
         if (obj == null) {
             return null;

--- a/client/highlevel-rest/src/main/java/org/elasticsearch/client/XContentAccessor.java
+++ b/client/highlevel-rest/src/main/java/org/elasticsearch/client/XContentAccessor.java
@@ -27,10 +27,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * TODO: shameless rip off ObjectPath in the yaml tests, maybe think about
+ * TODO: started as a clone off ObjectPath in the yaml tests, maybe think about
  * extracting common functionality or rework this class to better fit the
  * purpose in the client project Holds an {@link XContent} object as {@link Map}
- * and allows to extract specific values from it given their path
  */
 public class XContentAccessor {
 
@@ -89,22 +88,9 @@ public class XContentAccessor {
 
     /**
      * Returns the Double value corresponding to the provided path if present, null otherwise.
-     * If the object it a {@link Float}, its double value is returned.
-     * If it is neither {@link Float}, {@link Double} or <tt>null</tt>
-     * we throw an {@link IllegalArgumentException}
      */
     public Double evaluateDouble(String path) {
-        Object obj = evaluate(path);
-        if (obj == null) {
-            return null;
-        }
-        if (obj instanceof Double) {
-            return ((Double) obj);
-        }
-        if (obj instanceof Float) {
-            return ((Float) obj).doubleValue();
-        }
-        throw new IllegalArgumentException("Object under [" + path + "] should be Double, Float or null.");
+        return (Double) evaluate(path);
     }
 
     /**


### PR DESCRIPTION
Implementing a few more of the access methods in ClientSearchHits/ClientSearchHit which are implementations of the common SearchHit(s) interfaces in core.

This is a PR against a feature branch.