### PR TITLE
Add support for supplying timeout to _msearch via headers.

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -114,6 +115,7 @@ public class RestMultiSearchAction extends BaseRestHandler {
         String[] types = Strings.splitStringByCommaToArray(request.param("type"));
         String searchType = request.param("search_type");
         String routing = request.param("routing");
+        String timeout = request.param("timeout");
 
         final BytesReference data = RestActions.getRestContent(request);
 
@@ -148,6 +150,12 @@ public class RestMultiSearchAction extends BaseRestHandler {
             if (searchType != null) {
                 searchRequest.searchType(searchType);
             }
+            if (timeout != null) {
+                if (searchRequest.source() == null) {
+                    searchRequest.source(new SearchSourceBuilder());
+                }
+                searchRequest.source().timeout(new TimeValue(Long.parseLong(timeout)));
+            }
 
             IndicesOptions defaultOptions = IndicesOptions.strictExpandOpenAndForbidClosed();
 
@@ -173,6 +181,13 @@ public class RestMultiSearchAction extends BaseRestHandler {
                             searchRequest.preference(nodeStringValue(value, null));
                         } else if ("routing".equals(entry.getKey())) {
                             searchRequest.routing(nodeStringValue(value, null));
+                        } else if ("timeout".equals(entry.getKey())) {
+                            if (timeout != null) {
+                                if (searchRequest.source() == null) {
+                                    searchRequest.source(new SearchSourceBuilder());
+                                }
+                                searchRequest.source().timeout(new TimeValue(Long.parseLong(nodeStringValue(value, null))));
+                            }
                         }
                     }
                     defaultOptions = IndicesOptions.fromMap(source, defaultOptions);


### PR DESCRIPTION
The goal here is to add the same support for a timeout as in the search API as per #11310

One note:

Adding a timeout like so to the list of requests works already without code changes:

    {"index" : "test" }
    {"query" : {"match_all" : {}}, "from" : 0, "size" : 10, "timeout": "1000m"}


