### PR TITLE
Fix handling of spaces in Windows paths

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-service.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-service.bat
@@ -4,20 +4,20 @@ SETLOCAL enabledelayedexpansion
 TITLE Elasticsearch Service ${project.version}
 
 IF DEFINED JAVA_HOME (
-  SET JAVA=%JAVA_HOME%\bin\java.exe
+  SET JAVA="%JAVA_HOME%"\bin\java.exe
 ) ELSE (
   FOR %%I IN (java.exe) DO set JAVA=%%~$PATH:I
 )
-IF NOT EXIST "%JAVA%" (
+IF NOT EXIST %JAVA% (
   ECHO Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME 1>&2
   EXIT /B 1
 )
 IF DEFINED JAVA_HOME GOTO :cont
 
-IF NOT "%JAVA:~-13%" == "\bin\java.exe" (
+IF NOT %JAVA:~-13% == "\bin\java.exe" (
   FOR /f "tokens=2 delims=[]" %%I IN ('dir %JAVA%') DO @set JAVA=%%I
 )
-IF "%JAVA:~-13%" == "\bin\java.exe" (
+IF %JAVA:~-13% == "\bin\java.exe" (
   SET JAVA_HOME=%JAVA:~0,-13%
 )
 
@@ -27,14 +27,14 @@ if not "%CONF_FILE%" == "" goto conffileset
 set SCRIPT_DIR=%~dp0
 for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
 
-"%JAVA%" -Xmx50M -version > nul 2>&1
+%JAVA% -Xmx50M -version > nul 2>&1
 
 if errorlevel 1 (
 	echo Warning: Could not start JVM to detect version, defaulting to x86:
 	goto x86
 )
 
-"%JAVA%" -Xmx50M -version 2>&1 | "%windir%\System32\find" "64-Bit" >nul:
+%JAVA% -Xmx50M -version 2>&1 | "%windir%\System32\find" "64-Bit" >nul:
 
 if errorlevel 1 goto x86
 set EXECUTABLE=%ES_HOME%\bin\elasticsearch-service-x64.exe

--- a/distribution/src/main/resources/bin/elasticsearch.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.bat
@@ -54,6 +54,6 @@ IF ERRORLEVEL 1 (
 	EXIT /B %ERRORLEVEL%
 )
 
-"%JAVA%" %ES_JAVA_OPTS% %ES_PARAMS% -cp "%ES_CLASSPATH%" "org.elasticsearch.bootstrap.Elasticsearch" !newparams!
+%JAVA% %ES_JAVA_OPTS% %ES_PARAMS% -cp "%ES_CLASSPATH%" "org.elasticsearch.bootstrap.Elasticsearch" !newparams!
 
 ENDLOCAL

--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -1,11 +1,11 @@
 @echo off
 
 IF DEFINED JAVA_HOME (
-  set JAVA=%JAVA_HOME%\bin\java.exe
+  set JAVA="%JAVA_HOME%"\bin\java.exe
 ) ELSE (
   FOR %%I IN (java.exe) DO set JAVA=%%~$PATH:I
 )
-IF NOT EXIST "%JAVA%" (
+IF NOT EXIST %JAVA% (
   ECHO Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME 1>&2
   EXIT /B 1
 )


### PR DESCRIPTION
This commit fixes the handling of spaces in Windows paths. The current
mechanism works fine in a path that contains a single space, but fails
on a path that contains multiple spaces. With this commit, that is no
longer the case.

Relates #20809, relates #21525