### PR TITLE
Update elasticsearch.in.bat to handle spaces in JAVA_HOME

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -1,7 +1,7 @@
 @echo off
 
 IF DEFINED JAVA_HOME (
-  set JAVA=%JAVA_HOME%\bin\java.exe
+  set JAVA="%JAVA_HOME%\bin\java.exe"
 ) ELSE (
   FOR %%I IN (java.exe) DO set JAVA=%%~$PATH:I
 )


### PR DESCRIPTION
I had JAVA_HOME set to a path with a space, and was getting the error "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME".  Including quotes on the `set JAVA=` line fixed this.
