### PR TITLE
Mappings: Fix get mapping when no indexes exist to not fail in response generation

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
@@ -66,20 +66,21 @@ public class RestGetMappingAction extends BaseRestHandler {
         return channel -> client.admin().indices().getMappings(getMappingsRequest, new RestBuilderListener<GetMappingsResponse>(channel) {
             @Override
             public RestResponse buildResponse(GetMappingsResponse response, XContentBuilder builder) throws Exception {
-                builder.startObject();
+
                 ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> mappingsByIndex = response.getMappings();
                 if (mappingsByIndex.isEmpty()) {
                     if (indices.length != 0 && types.length != 0) {
-                        return new BytesRestResponse(OK, builder.endObject());
+                        return new BytesRestResponse(OK, builder.startObject().endObject());
                     } else if (indices.length != 0) {
                         return new BytesRestResponse(channel, new IndexNotFoundException(indices[0]));
                     } else if (types.length != 0) {
                         return new BytesRestResponse(channel, new TypeMissingException("_all", types[0]));
                     } else {
-                        return new BytesRestResponse(OK, builder.endObject());
+                        return new BytesRestResponse(OK, builder.startObject().endObject());
                     }
                 }
 
+                builder.startObject();
                 for (ObjectObjectCursor<String, ImmutableOpenMap<String, MappingMetaData>> indexEntry : mappingsByIndex) {
                     if (indexEntry.value.isEmpty()) {
                         continue;

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/20_missing_type.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/20_missing_type.yaml
@@ -17,3 +17,11 @@
         type: not_test_type
  
   - match: { '': {}}
+
+---
+"Type missing when no types exist":
+  - do:
+      catch: missing
+      indices.get_mapping:
+        type: not_test_type
+ 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/30_missing_index.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/30_missing_index.yaml
@@ -6,4 +6,10 @@
         index: test_index
         type: not_test_type
   
+---
+"Index missing, no indexes, no types":
+  - do:
+      catch: missing
+      indices.get_mapping:
+        index: test_index
 


### PR DESCRIPTION
When there are no indexes, get mapping has a series of special cases.
Two of those expect the response object already started, and the other
two respond with an exception. Those two cases (types passed in but no
indexes and vice versa) would fail in their error response generation
because it did not expect an object to already be started in the json
generator. This change moves the object start to where it is needed for
the empty responses.

closes #21916