### PR TITLE
Do not lose host information when pinging

### DIFF
--- a/core/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
@@ -72,9 +72,12 @@ public class DiscoveryNodeTests extends ESTestCase {
         in.setVersion(Version.V_5_0_0);
         DiscoveryNode serialized = new DiscoveryNode(in);
         assertEquals(transportAddress.address().getHostString(), serialized.getHostName());
-        assertNotEquals(transportAddress.address().getHostString(), serialized.getAddress().address().getHostString());
+        assertEquals(transportAddress.address().getHostString(), serialized.getAddress().address().getHostString());
         assertEquals(transportAddress.getAddress(), serialized.getHostAddress());
         assertEquals(transportAddress.getAddress(), serialized.getAddress().getAddress());
         assertEquals(transportAddress.getPort(), serialized.getAddress().getPort());
+        assertFalse("if the minimum compatibility version moves past 5.0.3, remove the special casing in DiscoverNode(StreamInput) and " +
+                "the TransportAddress(StreamInput, String) constructor",
+            Version.CURRENT.minimumCompatibilityVersion().onOrAfter(Version.V_5_0_3_UNRELEASED));
     }
 }


### PR DESCRIPTION
In #21828, serialization of the host string was added to preserve this information when
a TransportAddress gets serialized. However, there is still a case where this did not always
work. In UnicastZenPings, DiscoveryNode instances are created for the ping hosts with the
minimum compatibility version, which is currently less than the version required to preserve
the host information. This means that when a node is received from a PingResponse that the
host information is no longer set correctly on the InetSocketAddress contained in the
DiscoveryNode.

This commit adds a workaround for this situation by allowing the host string to be passed
into the TransportAddress constructor that takes a StreamInput and using that as the host
for the InetAddress that is created during deserialization.