### PR TITLE
Add system call filter bootstrap check

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCheck.java
@@ -471,19 +471,10 @@ final class BootstrapCheck {
 
     }
 
-    abstract static class IsSeccompInstalledCheck implements BootstrapCheck.Check {
-
-        // visible for testing
-        boolean isSeccompInstalled() {
-            return Natives.isSeccompInstalled();
-        }
-
-    }
-
     /**
      * Bootstrap check that if system call filters are enabled, then system call filters must have installed successfully.
      */
-    static class SystemCallFilterCheck extends IsSeccompInstalledCheck {
+    static class SystemCallFilterCheck implements BootstrapCheck.Check {
 
         private final boolean areSystemCallFiltersEnabled;
 
@@ -496,6 +487,11 @@ final class BootstrapCheck {
             return areSystemCallFiltersEnabled && !isSeccompInstalled();
         }
 
+        // visible for testing
+        boolean isSeccompInstalled() {
+            return Natives.isSeccompInstalled();
+        }
+
         @Override
         public String errorMessage() {
             return "system call filters failed to install; " +
@@ -504,11 +500,16 @@ final class BootstrapCheck {
 
     }
 
-    abstract static class MightForkCheck extends IsSeccompInstalledCheck {
+    abstract static class MightForkCheck implements BootstrapCheck.Check {
 
         @Override
         public boolean check() {
             return isSeccompInstalled() && mightFork();
+        }
+
+        // visible for testing
+        boolean isSeccompInstalled() {
+            return Natives.isSeccompInstalled();
         }
 
         // visible for testing

--- a/docs/reference/setup/bootstrap-checks.asciidoc
+++ b/docs/reference/setup/bootstrap-checks.asciidoc
@@ -146,6 +146,18 @@ you're using, or you've explicitly specified it with `-XX:+UseSerialGC`). Note
 that the default JVM configuration that ship with Elasticsearch configures
 Elasticsearch to use the CMS collector.
 
+=== System call filter check
+
+Elasticsearch installs system call filters of various flavors depending on the
+operating system (e.g., seccomp on Linux). These system call filters are
+installed to prevent the ability to execute system calls related to forking as
+a defense mechanism against arbitrary code execution attacks on Elasticsearch
+The system call filter check ensures that if system call filters are enabled,
+then they were successfully installed. To pass the system call filter check you
+must either fix any configuration errors on your system that prevented system
+call filters from installing (check your logs), or *at your own risk* disable
+system call filters by setting `bootstrap.seccomp` to `false`.
+
 === OnError and OnOutOfMemoryError checks
 
 The JVM options `OnError` and `OnOutOfMemoryError` enable executing


### PR DESCRIPTION
Today if system call filters fail to install on startup, we log a
message but otherwise march on. This might leave users without system
call filters installed not knowing that they have implicitly accepted
the additional risk. We should not be lenient like this, instead clearly
informing the user that they have to either fix their configuration or
accept the risk of not having system call filters installed. This commit
adds a bootstrap check that if system call filters are enabled, they
must successfully install.