### PR TITLE
Add Migration Note for Stored Scripts

### DIFF
--- a/docs/reference/migration/migrate_5_1.asciidoc
+++ b/docs/reference/migration/migrate_5_1.asciidoc
@@ -1,6 +1,15 @@
 [[breaking-changes-5.1]]
 == Breaking changes in 5.1
 
+[[breaking_51_scripting_api_changes]]
+[float]
+=== Scripting API changes
+
+==== Stored scripts
+
+Use the parameter 'stored' in place of 'id' when using stored scripts in a query.
+See <<modules-scripting-stored-scripts,stored scripts>> for examples.
+
 [[breaking_51_index_api_changes]]
 [float]
 === Indices API changes

--- a/docs/reference/migration/migrate_5_1.asciidoc
+++ b/docs/reference/migration/migrate_5_1.asciidoc
@@ -7,7 +7,10 @@
 
 ==== Stored scripts
 
-Use the parameter 'stored' in place of 'id' when using stored scripts in a query.
+Using `id` to refer to a stored script has been deprecated. Use `stored` instead.
+
+"script": { "lang": "painless", "stored": "my-stored-script-id" }
+
 See <<modules-scripting-stored-scripts,stored scripts>> for examples.
 
 [[breaking_51_index_api_changes]]

--- a/docs/reference/modules/scripting/using.asciidoc
+++ b/docs/reference/modules/scripting/using.asciidoc
@@ -54,10 +54,10 @@ GET my_index/_search
     setting `script.default_lang` to the appropriate language.
 
 
-`inline`, `id`, `file`::
+`inline`, `stored`, `file`::
 
     Specifies the source of the script.  An `inline` script is specified
-    `inline` as in the example above, a stored script with the specified `id`
+    `inline` as in the example above, a stored script with the specified `stored`
     is retrieved from the cluster state (see <<modules-scripting-stored-scripts,Stored Scripts>>),
     and a `file` script is retrieved from a file in the `config/scripts`
     directory (see <<modules-scripting-file-scripts, File Scripts>>).


### PR DESCRIPTION
Added a migration note for stored scripts related to using the parameter 'stored' in place of 'id' during scripting queries.