### PR TITLE
Test fix for def equals in Painless

### DIFF
--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/EqualsTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/EqualsTests.java
@@ -128,13 +128,12 @@ public class EqualsTests extends ScriptTestCase {
         assertEquals(1, exec("def a = 1; Number b = a; Number c = a; if (c === b) return 1; else return 0;"));
         assertEquals(0, exec("def a = 1; Object b = new HashMap(); if (a === (Object)b) return 1; else return 0;"));
     }
-
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/21801")
+    
     public void testBranchEqualsDefAndPrimitive() {
         assertEquals(true, exec("def x = 1000; int y = 1000; return x == y;"));
-        assertEquals(false, exec("def x = 1000; int y = 1000; return x === y;"));
+        exec("def x = 1000; int y = 1000; return x === y;");
         assertEquals(true, exec("def x = 1000; int y = 1000; return y == x;"));
-        assertEquals(false, exec("def x = 1000; int y = 1000; return y === x;"));
+        exec("def x = 1000; int y = 1000; return y === x;");
     }
 
     public void testBranchNotEquals() {
@@ -147,12 +146,11 @@ public class EqualsTests extends ScriptTestCase {
         assertEquals(1, exec("def a = 1; Object b = new HashMap(); if (a !== (Object)b) return 1; else return 0;"));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/21801")
     public void testBranchNotEqualsDefAndPrimitive() {
         assertEquals(false, exec("def x = 1000; int y = 1000; return x != y;"));
-        assertEquals(true, exec("def x = 1000; int y = 1000; return x !== y;"));
+        exec("def x = 1000; int y = 1000; return x !== y;");
         assertEquals(false, exec("def x = 1000; int y = 1000; return y != x;"));
-        assertEquals(true, exec("def x = 1000; int y = 1000; return y !== x;"));
+        exec("def x = 1000; int y = 1000; return y !== x;");
     }
 
     public void testRightHandNull() {


### PR DESCRIPTION
I was under the impression that Integer caching in Java would only go from the range -128 through 127, but this appears to not be the case.  I have removed the results check for the tests in question, and now just run the code to ensure it compiles appropriately which was the original issue anyway.

Relates #21801