### PR TITLE
Add migration docs for system call filter check

### DIFF
--- a/docs/reference/migration/index.asciidoc
+++ b/docs/reference/migration/index.asciidoc
@@ -20,6 +20,8 @@ As a general rule:
 See <<setup-upgrade>> for more info.
 --
 
+include::migrate_5_2.asciidoc[]
+
 include::migrate_5_1.asciidoc[]
 
 include::migrate_5_0.asciidoc[]

--- a/docs/reference/migration/migrate_5_2.asciidoc
+++ b/docs/reference/migration/migrate_5_2.asciidoc
@@ -1,0 +1,16 @@
+[[breaking-changes-5.2]]
+== Breaking changes in 5.2
+
+[[breaking_52_packaging_changes]]
+[float]
+=== Packaging changes
+
+[float]
+==== System call bootstrap check
+
+Elasticsearch has attempted to install a system call filter since version 2.1.0. On some systems, installing this
+system call filter could fail. Previous versions of Elasticsearch would log a warning, but would otherwise continue
+executing potentially leaving the end-user unaware of this situation. Starting in Elasticsearch 5.2.0, there is now a
+<<bootstrap-checks,bootstrap check>> for success of installing the system call filter. If you encounter an issue
+starting Elasticsearch due to this bootstrap check, you need to either fix your configuration so that the system call
+filter can be installed, or *at your own risk* disable the <<system-call-filter-check,system call filter check>>.

--- a/docs/reference/setup/bootstrap-checks.asciidoc
+++ b/docs/reference/setup/bootstrap-checks.asciidoc
@@ -146,6 +146,7 @@ you're using, or you've explicitly specified it with `-XX:+UseSerialGC`). Note
 that the default JVM configuration that ship with Elasticsearch configures
 Elasticsearch to use the CMS collector.
 
+[[system-call-filter-check]]
 === System call filter check
 
 Elasticsearch installs system call filters of various flavors depending on the


### PR DESCRIPTION
This commit adds a note to the migration docs regarding the system call
filter check.

Relates #21940
