### PR TITLE
Remove unnecessary class casting

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/dfs/AggregatedDfs.java
+++ b/core/src/main/java/org/elasticsearch/search/dfs/AggregatedDfs.java
@@ -85,10 +85,10 @@ public class AggregatedDfs implements Streamable {
         out.writeVInt(termStatistics.size());
 
         for (ObjectObjectCursor<Term, TermStatistics> c : termStatistics()) {
-            Term term = (Term) c.key;
+            Term term = c.key;
             out.writeString(term.field());
             out.writeBytesRef(term.bytes());
-            TermStatistics stats = (TermStatistics) c.value;
+            TermStatistics stats = c.value;
             out.writeBytesRef(stats.term());
             out.writeVLong(stats.docFreq());
             out.writeVLong(DfsSearchResult.addOne(stats.totalTermFreq()));


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

This is a mirror PR. We don't need the class casting actually because the java generic already told us the object types. Thanks. 

