### PR TITLE
Don't output null source node in RecoveryFailedException

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryFailedException.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryFailedException.java
@@ -46,7 +46,8 @@ public class RecoveryFailedException extends ElasticsearchException {
     }
 
     public RecoveryFailedException(ShardId shardId, DiscoveryNode sourceNode, DiscoveryNode targetNode, @Nullable String extraInfo, Throwable cause) {
-        super(shardId + ": Recovery failed from " + sourceNode + " into " + targetNode + (extraInfo == null ? "" : " (" + extraInfo + ")"), cause);
+        super(shardId + ": Recovery failed" + (sourceNode != null ? " from " + sourceNode : "") +
+                  " into " + targetNode + (extraInfo == null ? "" : " (" + extraInfo + ")"), cause);
     }
 
     public RecoveryFailedException(StreamInput in) throws IOException {

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryFailedException.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryFailedException.java
@@ -46,8 +46,8 @@ public class RecoveryFailedException extends ElasticsearchException {
     }
 
     public RecoveryFailedException(ShardId shardId, DiscoveryNode sourceNode, DiscoveryNode targetNode, @Nullable String extraInfo, Throwable cause) {
-        super(shardId + ": Recovery failed" + (sourceNode != null ? " from " + sourceNode : "") +
-                  " into " + targetNode + (extraInfo == null ? "" : " (" + extraInfo + ")"), cause);
+        super(shardId + ": Recovery failed " + (sourceNode != null ? "from " + sourceNode + " into " : "on ") +
+                  targetNode + (extraInfo == null ? "" : " (" + extraInfo + ")"), cause);
     }
 
     public RecoveryFailedException(StreamInput in) throws IOException {


### PR DESCRIPTION
The RecoveryFailedException's output prints the source and
target nodes for the recovery.  However, sometimes there is
no source node for the recovery, only a target node (such as
when recovering a primary shard from disk).  In this case,
we don't want to display the source node.  This commit fixes
this by displaying "Recovery failed to target node.." instead
of "Recovery failed from null to target node" which is what the
output currently displays.