### PR TITLE
Sub-fields should not accept `include_in_all` parameter

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -229,6 +229,9 @@ public class TypeParsers {
                 builder.indexOptions(nodeIndexOptionValue(propNode));
                 iterator.remove();
             } else if (propName.equals("include_in_all")) {
+                if(parserContext.isWithinMultiField()) {
+                    throw new MapperParsingException("sub-fields shouldn't contain property: include_in_all, and current node is:" + name);
+                }
                 builder.includeInAll(nodeBooleanValue("include_in_all", propNode, parserContext));
                 iterator.remove();
             } else if (propName.equals("similarity")) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -229,10 +229,11 @@ public class TypeParsers {
                 builder.indexOptions(nodeIndexOptionValue(propNode));
                 iterator.remove();
             } else if (propName.equals("include_in_all")) {
-                if(parserContext.isWithinMultiField()) {
-                    throw new MapperParsingException("sub-fields shouldn't contain property: include_in_all, and current node is:" + name);
+                if (parserContext.isWithinMultiField()) {
+                    throw new MapperParsingException("include_in_all in multi fields is not allowed. Found the include_in_all in field [" + name + "] which is within a multi field.");
+                } else {
+                    builder.includeInAll(nodeBooleanValue("include_in_all", propNode, parserContext));
                 }
-                builder.includeInAll(nodeBooleanValue("include_in_all", propNode, parserContext));
                 iterator.remove();
             } else if (propName.equals("similarity")) {
                 SimilarityProvider similarityProvider = resolveSimilarity(parserContext, name, propNode.toString());

--- a/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldIncludeInAllMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldIncludeInAllMapperTests.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -11,24 +29,18 @@ import java.io.IOException;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-/**
- * Created by makeyang on 2016/12/8.
- */
-public class MultiFieldIncludeInAllMapperTests extends ESTestCase {
-    public void testExceptionForCopyToInMultiFields() throws IOException {
-        XContentBuilder mapping = createMappinmgWithIncludeInAllInMultiField();
 
-        // first check that for newer versions we throw exception if copy_to is found withing multi field
+public class MultiFieldIncludeInAllMapperTests extends ESTestCase {
+    public void testExceptionForIncludeInAllInMultiFields() throws IOException {
+        XContentBuilder mapping = createMappingWithIncludeInAllInMultiField();
+
+        // first check that for newer versions we throw exception if include_in_all is found withing multi field
         MapperService mapperService = MapperTestUtils.newMapperService(createTempDir(), Settings.EMPTY);
-        try {
-            mapperService.parse("type", new CompressedXContent(mapping.string()), true);
-            fail("Parsing should throw an exception because the mapping contains a include_in_all in a multi field");
-        } catch (MapperParsingException e) {
-            assertThat(e.getMessage(), equalTo("include_in_all in multi fields is not allowed. Found the include_in_all in field [c] which is within a multi field."));
-        }
+        Exception e = expectThrows(MapperParsingException.class, () -> mapperService.parse("type", new CompressedXContent(mapping.string()), true));
+        assertThat(e.getMessage(), equalTo("include_in_all in multi fields is not allowed. Found the include_in_all in field [c] which is within a multi field."));
     }
 
-    private static XContentBuilder createMappinmgWithIncludeInAllInMultiField() throws IOException {
+    private static XContentBuilder createMappingWithIncludeInAllInMultiField() throws IOException {
         XContentBuilder mapping = jsonBuilder();
         mapping.startObject()
                 .startObject("type")

--- a/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldIncludeInAllMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldIncludeInAllMapperTests.java
@@ -1,0 +1,53 @@
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.MapperTestUtils;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+/**
+ * Created by makeyang on 2016/12/8.
+ */
+public class MultiFieldIncludeInAllMapperTests extends ESTestCase {
+    public void testExceptionForCopyToInMultiFields() throws IOException {
+        XContentBuilder mapping = createMappinmgWithIncludeInAllInMultiField();
+
+        // first check that for newer versions we throw exception if copy_to is found withing multi field
+        MapperService mapperService = MapperTestUtils.newMapperService(createTempDir(), Settings.EMPTY);
+        try {
+            mapperService.parse("type", new CompressedXContent(mapping.string()), true);
+            fail("Parsing should throw an exception because the mapping contains a include_in_all in a multi field");
+        } catch (MapperParsingException e) {
+            assertThat(e.getMessage(), equalTo("include_in_all in multi fields is not allowed. Found the include_in_all in field [c] which is within a multi field."));
+        }
+    }
+
+    private static XContentBuilder createMappinmgWithIncludeInAllInMultiField() throws IOException {
+        XContentBuilder mapping = jsonBuilder();
+        mapping.startObject()
+                .startObject("type")
+                .startObject("properties")
+                .startObject("a")
+                .field("type", "text")
+                .endObject()
+                .startObject("b")
+                .field("type", "text")
+                .startObject("fields")
+                .startObject("c")
+                .field("type", "text")
+                .field("include_in_all", false)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+        return mapping;
+    }
+}


### PR DESCRIPTION
Throw an exception when specifying `include_in_all` on multi-fields

Closes https://github.com/elastic/elasticsearch/issues/21710