### PR TITLE
[docs] Add missing RUN command from custom docker config

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -248,7 +248,7 @@ In some environments, it may make more sense to prepare a custom image containin
 FROM docker.elastic.co/elasticsearch/elasticsearch:{version}
 ADD elasticsearch.yml /usr/share/elasticsearch/config/
 USER root
-chown elasticsearch:elasticsearch config/elasticsearch.yml
+RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
 USER elasticsearch
 --------------------------------------------
 


### PR DESCRIPTION
As it's good to get this correction included in our docs as soon as possible, I am creating this PR in lieu of https://github.com/elastic/elasticsearch/pull/21808 untill @vshank77 has had a chance to sign the CLA with the same email address as that used in his commit.

Originally reported by Shankar Vasudevan (@vshank77).