### PR TITLE
Trim in-sync allocations set only when it grows

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/IndexMetaDataUpdater.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/IndexMetaDataUpdater.java
@@ -22,6 +22,7 @@ package org.elasticsearch.cluster.routing.allocation;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingChangesObserver;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -174,10 +175,13 @@ public class IndexMetaDataUpdater extends RoutingChangesObserver.AbstractRouting
             // Prevent set of inSyncAllocationIds to grow unboundedly. This can happen for example if we don't write to a primary
             // but repeatedly shut down nodes that have active replicas.
             // We use number_of_replicas + 1 (= possible active shard copies) to bound the inSyncAllocationIds set
+            // Only trim the set of allocation ids when it grows, otherwise we might trim too eagerly when the number
+            // of replicas was decreased while shards were unassigned.
             int maxActiveShards = oldIndexMetaData.getNumberOfReplicas() + 1; // +1 for the primary
-            if (inSyncAllocationIds.size() > maxActiveShards) {
+            IndexShardRoutingTable newShardRoutingTable = newRoutingTable.shardRoutingTable(shardId);
+            if (inSyncAllocationIds.size() > oldInSyncAllocationIds.size() && inSyncAllocationIds.size() > maxActiveShards) {
                 // trim entries that have no corresponding shard routing in the cluster state (i.e. trim unavailable copies)
-                List<ShardRouting> assignedShards = newRoutingTable.shardRoutingTable(shardId).assignedShards();
+                List<ShardRouting> assignedShards = newShardRoutingTable.assignedShards();
                 assert assignedShards.size() <= maxActiveShards :
                     "cannot have more assigned shards " + assignedShards + " than maximum possible active shards " + maxActiveShards;
                 Set<String> assignedAllocations = assignedShards.stream().map(s -> s.allocationId().getId()).collect(Collectors.toSet());
@@ -187,16 +191,12 @@ public class IndexMetaDataUpdater extends RoutingChangesObserver.AbstractRouting
                     .collect(Collectors.toSet());
             }
 
-            // only update in-sync allocation ids if there is at least one entry remaining. Assume for example that there only
-            // ever was a primary active and now it failed. If we were to remove the allocation id from the in-sync set, this would
-            // create an empty primary on the next allocation (see ShardRouting#allocatedPostIndexCreate)
-            if (inSyncAllocationIds.isEmpty() && oldInSyncAllocationIds.isEmpty() == false) {
-                assert updates.firstFailedPrimary != null :
-                    "in-sync set became empty but active primary wasn't failed: " + oldInSyncAllocationIds;
-                if (updates.firstFailedPrimary != null) {
-                    // add back allocation id of failed primary
-                    inSyncAllocationIds.add(updates.firstFailedPrimary.allocationId().getId());
-                }
+            // only remove allocation id of failed active primary if there is at least one active shard remaining. Assume for example that
+            // the primary fails but there is no new primary to fail over to. If we were to remove the allocation id of the primary from the
+            // in-sync set, this could create an empty primary on the next allocation.
+            if (newShardRoutingTable.activeShards().isEmpty() && updates.firstFailedPrimary != null) {
+                // add back allocation id of failed primary
+                inSyncAllocationIds.add(updates.firstFailedPrimary.allocationId().getId());
             }
 
             assert inSyncAllocationIds.isEmpty() == false || oldInSyncAllocationIds.isEmpty() :


### PR DESCRIPTION
This PR makes two changes to how the in-sync allocations set is updated:
- the set is only trimmed when it grows. This prevents trimming too eagerly when the number of replicas was decreased while shards were unassigned.
- the allocation id of an active primary that failed is only removed from the in-sync set if another replica gets promoted to primary. This prevents the situation where the only available shard copy in the cluster gets removed the in-sync set.

Relates to #21719