### PR TITLE
RestHighLevelClient to not implement Closeable

### DIFF
--- a/client/highlevel-rest/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/highlevel-rest/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -19,39 +19,31 @@
 
 package org.elasticsearch.client;
 
-import org.apache.http.HttpHost;
 import org.apache.http.entity.StringEntity;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.Objects;
 
-public class RestHighLevelClient implements Closeable {
+/**
+ * High level REST client that wraps an instance of the low level {@link RestClient} and allows to build requests and read responses.
+ * The provided {@link RestClient} is externally built and closed.
+ */
+public final class RestHighLevelClient {
 
-    private RestClient restClient;
+    private final RestClient client;
 
-    public RestHighLevelClient(String host, int port) {
-        this.restClient = RestClient.builder(new HttpHost(host, port)).build();
-    }
-
-    public RestHighLevelClient(RestClient restClient) {
-        this.restClient = Objects.requireNonNull(restClient);
-    }
-
-    @Override
-    public void close() throws IOException {
-        this.restClient.close();
-        this.restClient = null;
+    public RestHighLevelClient(RestClient client) {
+        this.client = Objects.requireNonNull(client);
     }
 
     public SearchResponse performSearchRequest(SearchRequest request) throws IOException {
         StringEntity entity = new StringEntity(request.searchSource().toString());
-        return new SearchResponse(this.restClient.performRequest("GET", buildSearchEndpoint(request), request.urlParams, entity));
+        return new SearchResponse(this.client.performRequest("GET", buildSearchEndpoint(request), request.urlParams, entity));
     }
 
     public void performSearchRequestAsync(SearchRequest request, ResponseListener responseListener) throws IOException {
         StringEntity entity = new StringEntity(request.searchSource().toString());
-        this.restClient.performRequestAsync("GET", buildSearchEndpoint(request), request.urlParams, entity, responseListener);
+        this.client.performRequestAsync("GET", buildSearchEndpoint(request), request.urlParams, entity, responseListener);
     }
 
     private static String buildSearchEndpoint(SearchRequest request) {

--- a/client/highlevel-rest/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/highlevel-rest/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -26,15 +26,15 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Objects;
 
-public class HighlevelClient implements Closeable {
+public class RestHighLevelClient implements Closeable {
 
     private RestClient restClient;
 
-    public HighlevelClient(String host, int port) {
+    public RestHighLevelClient(String host, int port) {
         this.restClient = RestClient.builder(new HttpHost(host, port)).build();
     }
 
-    public HighlevelClient(RestClient restClient) {
+    public RestHighLevelClient(RestClient restClient) {
         this.restClient = Objects.requireNonNull(restClient);
     }
 

--- a/client/highlevel-rest/src/test/java/org/elasticsearch/client/HLClientSearchIT.java
+++ b/client/highlevel-rest/src/test/java/org/elasticsearch/client/HLClientSearchIT.java
@@ -45,11 +45,11 @@ import static org.hamcrest.Matchers.greaterThan;
 
 public class HLClientSearchIT extends ESRestTestCase {
 
-    private HighlevelClient aClient;
+    private RestHighLevelClient aClient;
 
     @Before
     public void init() {
-        this.aClient =  new HighlevelClient(client());
+        this.aClient =  new RestHighLevelClient(client());
     }
 
     public void createTestDoc() throws IOException {

--- a/client/highlevel-rest/src/test/java/org/elasticsearch/client/HLClientSearchIT.java
+++ b/client/highlevel-rest/src/test/java/org/elasticsearch/client/HLClientSearchIT.java
@@ -32,7 +32,6 @@ import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.elasticsearch.search.sort.ScoreSortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.rest.ESRestTestCase;
-import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -45,11 +44,11 @@ import static org.hamcrest.Matchers.greaterThan;
 
 public class HLClientSearchIT extends ESRestTestCase {
 
-    private RestHighLevelClient aClient;
+    private RestHighLevelClient highLevelClient;
 
     @Before
     public void init() {
-        this.aClient =  new RestHighLevelClient(client());
+        this.highLevelClient = new RestHighLevelClient(client());
     }
 
     public void createTestDoc() throws IOException {
@@ -89,7 +88,7 @@ public class HLClientSearchIT extends ESRestTestCase {
 
     public void testSearch() throws IOException {
         createTestDoc();
-        SearchResponse searchResponse = aClient.performSearchRequest(new SearchRequest(
+        SearchResponse searchResponse = highLevelClient.performSearchRequest(new SearchRequest(
                 new SearchSourceBuilder()
                 .query(new MatchQueryBuilder("content", "buzz").queryName("buzz_query"))
                 .version(true)
@@ -133,10 +132,5 @@ public class HLClientSearchIT extends ESRestTestCase {
         //only string based formats are supported, no cbor nor smile
         XContentType xContentType = randomFrom(XContentType.JSON, XContentType.YAML);
         return XContentBuilder.builder(XContentFactory.xContent(xContentType));
-    }
-
-    @After
-    public void shutDown() throws IOException {
-        this.aClient.close();
     }
 }


### PR DESCRIPTION
The `RestHighLevelClient` should accept an instance of the low-level client externally created, and managed. The high level client shouldn't create nor close the underlying low level client, this way it also doesn't need to implement `Closeable`.