### PR TITLE
remove unsupported object properties from template mapping

### DIFF
--- a/core/src/main/java/org/elasticsearch/gateway/MetaStateService.java
+++ b/core/src/main/java/org/elasticsearch/gateway/MetaStateService.java
@@ -120,10 +120,10 @@ public class MetaStateService extends AbstractComponent {
         // ES 2.0 now requires units for all time and byte-sized settings, so we add the default unit if it's missing
         // TODO: can we somehow only do this for pre-2.0 cluster state?
         if (globalState != null) {
-            return MetaData.addDefaultUnitsIfNeeded(logger, globalState);
-        } else {
-            return null;
+            globalState = MetaData.addDefaultUnitsIfNeeded(logger, globalState);
+            globalState = MetaData.removeInvalidObjectPropertiesIfNeeded(logger, globalState);
         }
+        return globalState;
     }
 
     /**


### PR DESCRIPTION
When creating a template in version 1.7.x with a mapping that contains optional properties, creating a new index with a newer version, e.g. 2.4.x will fail, because the property validation is more strict.

Steps to reproduce:

Start ES 1.7.x

```
http://localhost:9200
PUT /_template/test
{
  "template": "t*",
  "mappings": {
    "default": {
      "dynamic": true,
      "properties": {
        "o": {
          "dynamic": true,
          "type": "object",
          "dynamic": true,
          "store": false,
          "index": "not_analyzed",
          "doc_values": false,
          "properties": {
            "x": {
              "doc_values": true,
              "type": "integer"
            },
            "y": {
              "doc_values": true,
              "type": "integer"
            }
          }
        }
      }
    }
  }
}

http://localhost:9200
PUT /t1/default/1
{
  "o": {
    "x": 1,
    "y": 2
  }
}
```

stop and start ES 2.4.x

```
http://localhost:9200
PUT /t2/default/1
{
  "o": {
    "x": 1,
    "y": 2
  }
}
```

fails with:

```
HTTP/1.1 400 Bad Request
Content-Type: application/json; charset=UTF-8
Content-Length: 573

{
    "error": {
        "caused_by": {
            "reason": "Mapping definition for [o] has unsupported parameters:  [index : not_analyzed] [store : false] [doc_values : false]",
            "type": "mapper_parsing_exception"
        },
        "reason": "Failed to parse mapping [default]: Mapping definition for [o] has unsupported parameters:  [index : not_analyzed] [store : false] [doc_values : false]",
        "root_cause": [
            {
                "reason": "Mapping definition for [o] has unsupported parameters:  [index : not_analyzed] [store : false] [doc_values : false]",
                "type": "mapper_parsing_exception"
            }
        ],
        "type": "mapper_parsing_exception"
    },
    "status": 400
}
```

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?

