### PR TITLE
Expose `ip` fields as strings in scripts.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.plain.AbstractAtomicOrdinalsFieldData;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 
@@ -38,6 +39,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 /**
  * Utility class to build global ordinals.
@@ -48,7 +50,9 @@ public enum GlobalOrdinalsBuilder {
     /**
      * Build global ordinals for the provided {@link IndexReader}.
      */
-    public static IndexOrdinalsFieldData build(final IndexReader indexReader, IndexOrdinalsFieldData indexFieldData, IndexSettings indexSettings, CircuitBreakerService breakerService, Logger logger) throws IOException {
+    public static IndexOrdinalsFieldData build(final IndexReader indexReader, IndexOrdinalsFieldData indexFieldData,
+            IndexSettings indexSettings, CircuitBreakerService breakerService, Logger logger,
+            Function<RandomAccessOrds, ScriptDocValues<?>> scriptFunction) throws IOException {
         assert indexReader.leaves().size() > 1;
         long startTimeNS = System.nanoTime();
 
@@ -71,7 +75,7 @@ public enum GlobalOrdinalsBuilder {
             );
         }
         return new InternalGlobalOrdinalsIndexFieldData(indexSettings, indexFieldData.getFieldName(),
-                atomicFD, ordinalMap, memorySizeInBytes
+                atomicFD, ordinalMap, memorySizeInBytes, scriptFunction
         );
     }
 
@@ -81,7 +85,7 @@ public enum GlobalOrdinalsBuilder {
         final AtomicOrdinalsFieldData[] atomicFD = new AtomicOrdinalsFieldData[indexReader.leaves().size()];
         final RandomAccessOrds[] subs = new RandomAccessOrds[indexReader.leaves().size()];
         for (int i = 0; i < indexReader.leaves().size(); ++i) {
-            atomicFD[i] = new AbstractAtomicOrdinalsFieldData() {
+            atomicFD[i] = new AbstractAtomicOrdinalsFieldData(AbstractAtomicOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION) {
                 @Override
                 public RandomAccessOrds getOrdinalsValues() {
                     return DocValues.emptySortedSet();
@@ -105,7 +109,7 @@ public enum GlobalOrdinalsBuilder {
         }
         final OrdinalMap ordinalMap = OrdinalMap.build(null, subs, PackedInts.DEFAULT);
         return new InternalGlobalOrdinalsIndexFieldData(indexSettings, indexFieldData.getFieldName(),
-                atomicFD, ordinalMap, 0
+                atomicFD, ordinalMap, 0, AbstractAtomicOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION
         );
     }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicOrdinalsFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicOrdinalsFieldData.java
@@ -29,13 +29,24 @@ import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Function;
 
 
 public abstract class AbstractAtomicOrdinalsFieldData implements AtomicOrdinalsFieldData {
 
+    public static final Function<RandomAccessOrds, ScriptDocValues<?>> DEFAULT_SCRIPT_FUNCTION =
+            ((Function<RandomAccessOrds, SortedBinaryDocValues>) FieldData::toString)
+            .andThen(ScriptDocValues.Strings::new);
+
+    private final Function<RandomAccessOrds, ScriptDocValues<?>> scriptFunction;
+
+    protected AbstractAtomicOrdinalsFieldData(Function<RandomAccessOrds, ScriptDocValues<?>> scriptFunction) {
+        this.scriptFunction = scriptFunction;
+    }
+
     @Override
-    public final ScriptDocValues getScriptValues() {
-        return new ScriptDocValues.Strings(getBytesValues());
+    public final ScriptDocValues<?> getScriptValues() {
+        return scriptFunction.apply(getOrdinalsValues());
     }
 
     @Override
@@ -44,7 +55,7 @@ public abstract class AbstractAtomicOrdinalsFieldData implements AtomicOrdinalsF
     }
 
     public static AtomicOrdinalsFieldData empty() {
-        return new AbstractAtomicOrdinalsFieldData() {
+        return new AbstractAtomicOrdinalsFieldData(DEFAULT_SCRIPT_FUNCTION) {
 
             @Override
             public long ramBytesUsed() {

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
@@ -97,7 +97,8 @@ public abstract class AbstractIndexOrdinalsFieldData extends AbstractIndexFieldD
 
     @Override
     public IndexOrdinalsFieldData localGlobalDirect(DirectoryReader indexReader) throws Exception {
-        return GlobalOrdinalsBuilder.build(indexReader, this, indexSettings, breakerService, logger);
+        return GlobalOrdinalsBuilder.build(indexReader, this, indexSettings, breakerService, logger,
+                AbstractAtomicOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/IndexIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/IndexIndexFieldData.java
@@ -56,6 +56,7 @@ public class IndexIndexFieldData extends AbstractIndexOrdinalsFieldData {
         private final String index;
 
         IndexAtomicFieldData(String index) {
+            super(DEFAULT_SCRIPT_FUNCTION);
             this.index = index;
         }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
@@ -38,6 +38,7 @@ public class PagedBytesAtomicFieldData extends AbstractAtomicOrdinalsFieldData {
     protected final Ordinals ordinals;
 
     public PagedBytesAtomicFieldData(PagedBytes.Reader bytes, PackedLongValues termOrdToBytesOffset, Ordinals ordinals) {
+        super(DEFAULT_SCRIPT_FUNCTION);
         this.bytes = bytes;
         this.termOrdToBytesOffset = termOrdToBytesOffset;
         this.ordinals = ordinals;

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesAtomicFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesAtomicFieldData.java
@@ -25,10 +25,12 @@ import org.apache.lucene.index.RandomAccessOrds;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.index.fielddata.AtomicFieldData;
 import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Function;
 
 /**
  * An {@link AtomicFieldData} implementation that uses Lucene {@link org.apache.lucene.index.SortedSetDocValues}.
@@ -38,7 +40,9 @@ public final class SortedSetDVBytesAtomicFieldData extends AbstractAtomicOrdinal
     private final LeafReader reader;
     private final String field;
 
-    SortedSetDVBytesAtomicFieldData(LeafReader reader, String field) {
+    SortedSetDVBytesAtomicFieldData(LeafReader reader, String field, Function<RandomAccessOrds,
+            ScriptDocValues<?>> scriptFunction) {
+        super(scriptFunction);
         this.reader = reader;
         this.field = field;
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -27,6 +27,7 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.PointValues;
+import org.apache.lucene.index.RandomAccessOrds;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
@@ -38,6 +39,8 @@ import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
@@ -45,8 +48,13 @@ import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.AbstractList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 
 /** A {@link FieldMapper} for ip addresses. */
@@ -225,10 +233,50 @@ public class IpFieldMapper extends FieldMapper {
                 InetAddressPoint.decode(min), InetAddressPoint.decode(max));
         }
 
+        private static class IpScriptDocValues extends AbstractList<String> implements ScriptDocValues<String> {
+
+            private final RandomAccessOrds values;
+
+            IpScriptDocValues(RandomAccessOrds values) {
+                this.values = values;
+            }
+
+            @Override
+            public void setNextDocId(int docId) {
+                values.setDocument(docId);
+            }
+
+            public String getValue() {
+                if (isEmpty()) {
+                    return null;
+                } else {
+                    return get(0);
+                }
+            }
+
+            @Override
+            public List<String> getValues() {
+                return Collections.unmodifiableList(this);
+            }
+
+            @Override
+            public String get(int index) {
+                BytesRef encoded = values.lookupOrd(values.ordAt(0));
+                InetAddress address = InetAddressPoint.decode(
+                        Arrays.copyOfRange(encoded.bytes, encoded.offset, encoded.offset + encoded.length));
+                return InetAddresses.toAddrString(address);
+            }
+
+            @Override
+            public int size() {
+                return values.cardinality();
+            }
+        }
+
         @Override
         public IndexFieldData.Builder fielddataBuilder() {
             failIfNoDocValues();
-            return new DocValuesIndexFieldData.Builder();
+            return new DocValuesIndexFieldData.Builder().scriptFunction(IpScriptDocValues::new);
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/index/fielddata/FieldDataCacheTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/FieldDataCacheTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.fielddata.plain.AbstractAtomicOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetDVOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.TextFieldMapper;
@@ -86,7 +87,8 @@ public class FieldDataCacheTests extends ESTestCase {
     }
 
     private SortedSetDVOrdinalsIndexFieldData createSortedDV(String fieldName, IndexFieldDataCache indexFieldDataCache) {
-        return new SortedSetDVOrdinalsIndexFieldData(createIndexSettings(), indexFieldDataCache, fieldName, new NoneCircuitBreakerService());
+        return new SortedSetDVOrdinalsIndexFieldData(createIndexSettings(), indexFieldDataCache, fieldName, new NoneCircuitBreakerService(),
+                AbstractAtomicOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION);
     }
 
     private PagedBytesIndexFieldData createPagedBytes(String fieldName, IndexFieldDataCache indexFieldDataCache) {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/IpTermsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/IpTermsIT.java
@@ -22,10 +22,45 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.AggregationTestScriptsPlugin;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+
 public class IpTermsIT extends AbstractTermsTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singleton(CustomScriptPlugin.class);
+    }
+
+    public static class CustomScriptPlugin extends AggregationTestScriptsPlugin {
+
+        @Override
+        protected Map<String, Function<Map<String, Object>, Object>> pluginScripts() {
+            Map<String, Function<Map<String, Object>, Object>> scripts = super.pluginScripts();
+
+            scripts.put("doc['ip'].value", vars -> {
+                Map<?, ?> doc = (Map<?,?>) vars.get("doc");
+                return doc.get("ip");
+            });
+
+            scripts.put("doc['ip'].values", vars -> {
+                Map<?, ?> doc = (Map<?,?>) vars.get("doc");
+                return ((ScriptDocValues<?>) doc.get("ip")).get(0);
+            });
+
+            return scripts;
+        }
+    }
 
     public void testBasics() throws Exception {
         assertAcked(prepareCreate("index").addMapping("type", "ip", "type=ip"));
@@ -51,4 +86,55 @@ public class IpTermsIT extends AbstractTermsTestCase {
         assertEquals("2001:db8::2:1", bucket2.getKeyAsString());
     }
 
+    public void testScriptValue() throws Exception {
+        assertAcked(prepareCreate("index").addMapping("type", "ip", "type=ip"));
+        indexRandom(true,
+                client().prepareIndex("index", "type", "1").setSource("ip", "192.168.1.7"),
+                client().prepareIndex("index", "type", "2").setSource("ip", "192.168.1.7"),
+                client().prepareIndex("index", "type", "3").setSource("ip", "2001:db8::2:1"));
+
+        Script script = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME,
+                "doc['ip'].value", Collections.emptyMap());
+        SearchResponse response = client().prepareSearch("index").addAggregation(
+                AggregationBuilders.terms("my_terms").script(script).executionHint(randomExecutionHint())).get();
+        assertSearchResponse(response);
+        Terms terms = response.getAggregations().get("my_terms");
+        assertEquals(2, terms.getBuckets().size());
+
+        Terms.Bucket bucket1 = terms.getBuckets().get(0);
+        assertEquals(2, bucket1.getDocCount());
+        assertEquals("192.168.1.7", bucket1.getKey());
+        assertEquals("192.168.1.7", bucket1.getKeyAsString());
+
+        Terms.Bucket bucket2 = terms.getBuckets().get(1);
+        assertEquals(1, bucket2.getDocCount());
+        assertEquals("2001:db8::2:1", bucket2.getKey());
+        assertEquals("2001:db8::2:1", bucket2.getKeyAsString());
+    }
+
+    public void testScriptValues() throws Exception {
+        assertAcked(prepareCreate("index").addMapping("type", "ip", "type=ip"));
+        indexRandom(true,
+                client().prepareIndex("index", "type", "1").setSource("ip", "192.168.1.7"),
+                client().prepareIndex("index", "type", "2").setSource("ip", "192.168.1.7"),
+                client().prepareIndex("index", "type", "3").setSource("ip", "2001:db8::2:1"));
+
+        Script script = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME,
+                "doc['ip'].values", Collections.emptyMap());
+        SearchResponse response = client().prepareSearch("index").addAggregation(
+                AggregationBuilders.terms("my_terms").script(script).executionHint(randomExecutionHint())).get();
+        assertSearchResponse(response);
+        Terms terms = response.getAggregations().get("my_terms");
+        assertEquals(2, terms.getBuckets().size());
+
+        Terms.Bucket bucket1 = terms.getBuckets().get(0);
+        assertEquals(2, bucket1.getDocCount());
+        assertEquals("192.168.1.7", bucket1.getKey());
+        assertEquals("192.168.1.7", bucket1.getKeyAsString());
+
+        Terms.Bucket bucket2 = terms.getBuckets().get(1);
+        assertEquals(1, bucket2.getDocCount());
+        assertEquals("2001:db8::2:1", bucket2.getKey());
+        assertEquals("2001:db8::2:1", bucket2.getKeyAsString());
+    }
 }

--- a/core/src/test/java/org/elasticsearch/search/fields/SearchFieldsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/fields/SearchFieldsIT.java
@@ -766,6 +766,9 @@ public class SearchFieldsIT extends ESIntegTestCase {
                             .startObject("binary_field")
                                 .field("type", "binary")
                             .endObject()
+                            .startObject("ip_field")
+                                .field("type", "ip")
+                            .endObject()
                         .endObject()
                     .endObject()
                 .endObject()
@@ -784,6 +787,7 @@ public class SearchFieldsIT extends ESIntegTestCase {
                 .field("double_field", 6.0d)
                 .field("date_field", Joda.forPattern("dateOptionalTime").printer().print(new DateTime(2012, 3, 22, 0, 0, DateTimeZone.UTC)))
                 .field("boolean_field", true)
+                .field("ip_field", "::1")
                 .endObject()).execute().actionGet();
 
         client().admin().indices().prepareRefresh().execute().actionGet();
@@ -798,14 +802,16 @@ public class SearchFieldsIT extends ESIntegTestCase {
                 .addDocValueField("float_field")
                 .addDocValueField("double_field")
                 .addDocValueField("date_field")
-                .addDocValueField("boolean_field");
+                .addDocValueField("boolean_field")
+                .addDocValueField("ip_field");
         SearchResponse searchResponse = builder.execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         Set<String> fields = new HashSet<>(searchResponse.getHits().getAt(0).fields().keySet());
         assertThat(fields, equalTo(newHashSet("byte_field", "short_field", "integer_field", "long_field",
-                "float_field", "double_field", "date_field", "boolean_field", "text_field", "keyword_field")));
+                "float_field", "double_field", "date_field", "boolean_field", "text_field", "keyword_field",
+                "ip_field")));
 
         assertThat(searchResponse.getHits().getAt(0).fields().get("byte_field").value().toString(), equalTo("1"));
         assertThat(searchResponse.getHits().getAt(0).fields().get("short_field").value().toString(), equalTo("2"));
@@ -817,6 +823,7 @@ public class SearchFieldsIT extends ESIntegTestCase {
         assertThat(searchResponse.getHits().getAt(0).fields().get("boolean_field").value(), equalTo((Object) true));
         assertThat(searchResponse.getHits().getAt(0).fields().get("text_field").value(), equalTo("foo"));
         assertThat(searchResponse.getHits().getAt(0).fields().get("keyword_field").value(), equalTo("foo"));
+        assertThat(searchResponse.getHits().getAt(0).fields().get("ip_field").value(), equalTo("::1"));
     }
 
     public void testScriptFields() throws Exception {


### PR DESCRIPTION
Currently we expose the internal representation that we use for ip addresses,
which are the ipv6 bytes. However, this is not really usable, exposes internal
implementation details and also does not work fine with other APIs that expect
that the values can be `toString`'d.

Closes #21977