### PR TITLE
Reject external versioning and explicit version numbers on create

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -529,8 +529,8 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
         }
         out.writeBytesReference(source);
         out.writeByte(opType.getId());
-        // ES versions below 5.1.1 don't know about resolveVersionDefaults but resolve the version eagerly (which messes with validation).
-        if (out.getVersion().before(Version.V_5_1_1_UNRELEASED)) {
+        // ES versions below 5.1.2 don't know about resolveVersionDefaults but resolve the version eagerly (which messes with validation).
+        if (out.getVersion().before(Version.V_5_1_2_UNRELEASED)) {
             out.writeLong(resolveVersionDefaults());
         } else {
             out.writeLong(version);

--- a/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -79,7 +79,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
 
     private OpType opType = OpType.INDEX;
 
-    private long version = Versions.MATCH_ANY;
+    private long version = Versions.NOT_SET;
     private VersionType versionType = VersionType.INTERNAL;
 
     private XContentType contentType = Requests.INDEX_CONTENT_TYPE;
@@ -140,9 +140,15 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
             validationException = addValidationError("source is missing", validationException);
         }
 
+        final long resolvedVersion = resolveVersionDefaults();
         if (opType() == OpType.CREATE) {
-            if (versionType != VersionType.INTERNAL || version != Versions.MATCH_DELETED) {
-                validationException = addValidationError("create operations do not support versioning. use index instead", validationException);
+            if (versionType != VersionType.INTERNAL) {
+                validationException = addValidationError("create operations only support internal versioning. use index instead", validationException);
+                return validationException;
+            }
+
+            if (resolvedVersion != Versions.MATCH_DELETED) {
+                validationException = addValidationError("create operations do not support explicit versions. use index instead", validationException);
                 return validationException;
             }
         }
@@ -151,8 +157,8 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
             addValidationError("an id is required for a " + opType() + " operation", validationException);
         }
 
-        if (!versionType.validateVersionForWrites(version)) {
-            validationException = addValidationError("illegal version value [" + version + "] for version type [" + versionType.name() + "]", validationException);
+        if (!versionType.validateVersionForWrites(resolvedVersion)) {
+            validationException = addValidationError("illegal version value [" + resolvedVersion + "] for version type [" + versionType.name() + "]", validationException);
         }
 
         if (versionType == VersionType.FORCE) {
@@ -164,7 +170,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
                             id.getBytes(StandardCharsets.UTF_8).length, validationException);
         }
 
-        if (id == null && (versionType == VersionType.INTERNAL && version == Versions.MATCH_ANY) == false) {
+        if (id == null && (versionType == VersionType.INTERNAL && resolvedVersion == Versions.MATCH_ANY) == false) {
             validationException = addValidationError("an id must be provided if version type or value are set", validationException);
         }
 
@@ -387,10 +393,6 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
             throw new IllegalArgumentException("opType must be 'create' or 'index', found: [" + opType + "]");
         }
         this.opType = opType;
-        if (opType == OpType.CREATE) {
-            version(Versions.MATCH_DELETED);
-            versionType(VersionType.INTERNAL);
-        }
         return this;
     }
 
@@ -435,7 +437,23 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
 
     @Override
     public long version() {
-        return this.version;
+        return resolveVersionDefaults();
+    }
+
+    /**
+     * Resolves the version based on operation type {@link #opType()}. Not explicitly setting any version if OpType == CREATE corresponds
+     * to setting Versions.MATCH_DELETED and not explicitly setting any version if OpType == INDEX corresponds to setting Versions.MATCH_ANY
+     */
+    private long resolveVersionDefaults() {
+        if (version == Versions.NOT_SET) {
+            if (opType == OpType.CREATE) {
+                return Versions.MATCH_DELETED;
+            } else {
+                return Versions.MATCH_ANY;
+            }
+        } else {
+            return this.version;
+        }
     }
 
     @Override
@@ -512,7 +530,12 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
         }
         out.writeBytesReference(source);
         out.writeByte(opType.getId());
-        out.writeLong(version);
+        // ES versions below 5.1.1 don't know about Versions.NOT_SET but resolve the version eagerly (which messes with validation).
+        if (out.getVersion().before(Version.V_5_1_1_UNRELEASED)) {
+            out.writeLong(resolveVersionDefaults());
+        } else {
+            out.writeLong(version);
+        }
         out.writeByte(versionType.getValue());
         out.writeOptionalString(pipeline);
         out.writeBoolean(isRetry);

--- a/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -435,14 +435,17 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
         return this;
     }
 
+    /**
+     * Returns stored version. If currently stored version is {@link Versions#MATCH_ANY} and
+     * opType is {@link OpType#CREATE}, returns {@link Versions#MATCH_DELETED}.
+     */
     @Override
     public long version() {
         return resolveVersionDefaults();
     }
 
     /**
-     * Resolves the version based on operation type {@link #opType()}. Not explicitly setting any version if OpType == CREATE corresponds
-     * to setting Versions.MATCH_DELETED.
+     * Resolves the version based on operation type {@link #opType()}.
      */
     private long resolveVersionDefaults() {
         if (opType == OpType.CREATE && version == Versions.MATCH_ANY) {

--- a/core/src/main/java/org/elasticsearch/common/lucene/uid/Versions.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/uid/Versions.java
@@ -60,6 +60,12 @@ public class Versions {
      */
     public static final long MATCH_DELETED = -4L;
 
+    /**
+     * used to indicate that the version field is not set. Should never be exposed to the engine but can be used internally by the
+     * request classes.
+     */
+    public static final long NOT_SET = -5L;
+
     // TODO: is there somewhere else we can store these?
     static final ConcurrentMap<Object, CloseableThreadLocal<PerThreadIDAndVersionLookup>> lookupStates = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
 

--- a/core/src/main/java/org/elasticsearch/common/lucene/uid/Versions.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/uid/Versions.java
@@ -60,12 +60,6 @@ public class Versions {
      */
     public static final long MATCH_DELETED = -4L;
 
-    /**
-     * used to indicate that the version field is not set. Should never be exposed to the engine but can be used internally by the
-     * request classes.
-     */
-    public static final long NOT_SET = -5L;
-
     // TODO: is there somewhere else we can store these?
     static final ConcurrentMap<Object, CloseableThreadLocal<PerThreadIDAndVersionLookup>> lookupStates = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/create/30_internal_version.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/create/30_internal_version.yaml
@@ -18,3 +18,18 @@
           id:     1
           body:   { foo: bar }
 
+---
+"Internal versioning with explicit version":
+
+ - do:
+      create:
+          index:          test
+          type:           test
+          id:             3
+          body:           { foo: bar }
+          version:        5
+          ignore:         400
+
+ - match: { status: 400 }
+ - match: { error.type: action_request_validation_exception }
+ - match: { error.reason: "Validation Failed: 1: create operations do not support explicit versions. use index instead;" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/create/35_external_version.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/create/35_external_version.yaml
@@ -1,0 +1,34 @@
+---
+"External version":
+
+ - skip:
+      version: " - 5.0.99"
+      reason: validation logic only fixed from 5.1 onwards
+
+ - do:
+      create:
+          index:          test
+          type:           test
+          id:             1
+          body:           { foo: bar }
+          version_type:   external
+          version:        0
+          ignore:         400
+
+ - match: { status: 400 }
+ - match: { error.type: action_request_validation_exception }
+ - match: { error.reason: "Validation Failed: 1: create operations only support internal versioning. use index instead;" }
+
+ - do:
+      create:
+          index:          test
+          type:           test
+          id:             2
+          body:           { foo: bar }
+          version_type:   external
+          version:        5
+          ignore:         400
+
+ - match: { status: 400 }
+ - match: { error.type: action_request_validation_exception }
+ - match: { error.reason: "Validation Failed: 1: create operations only support internal versioning. use index instead;" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/create/35_external_version.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/create/35_external_version.yaml
@@ -2,8 +2,8 @@
 "External version":
 
  - skip:
-      version: " - 5.0.99"
-      reason: validation logic only fixed from 5.1 onwards
+      version: " - 5.1.1"
+      reason: validation logic only fixed from 5.1.2 onwards
 
  - do:
       create:


### PR DESCRIPTION
Indexing requests with operation type `create` currently auto-convert external versioning to internal versioning and silently ignore the version number instead of failing with an error message:

```
$ curl -XPOST "http://localhost:9200/index/type/1/_create?version=42&version_type=external" -d '
> {"data":"test data"}
> '
{"_index":"index","_type":"type","_id":"1","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"created":true}
```

This PR tries to fix the validation logic in the least invasive way. The first commit shows an earlier attempt to fix this that I believe to be cleaner but will potentially break more usages of IndexRequest (among others it breaks RestIndexAction that sets by default `MATCH_ANY` if no version can be found).