### PR TITLE
Recognize `NORELEASE` as the same as `norelease`

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/ForbiddenPatternsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/ForbiddenPatternsTask.groovy
@@ -59,11 +59,16 @@ public class ForbiddenPatternsTask extends DefaultTask {
         filesFilter.exclude('**/*.png')
 
         // add mandatory rules
-        patterns.put('nocommit', /nocommit/)
+        patterns.put('nocommit', /nocommit|NOCOMMIT/)
+        patterns.put('nocommit should be all lowercase or all uppercase',
+            /((?i)nocommit)(?<!(nocommit|NOCOMMIT))/)
         patterns.put('tab', /\t/)
         if (System.getProperty('build.snapshot', 'true').equals('false')) {
-            patterns.put('norelease', /norelease/)
+            patterns.put('norelease', /norelease|NORELEASE/)
         }
+        patterns.put('norelease should be all lowercase or all uppercase',
+            /((?i)norelease)(?<!(norelease|NORELEASE))/)
+
 
         inputs.property("excludes", filesFilter.excludes)
         inputs.property("rules", patterns)


### PR DESCRIPTION
Changes the build to recognize `NORELEASE` as well as `NOCOMMIT` to
mean the same thing as `norelease` and `nocommit` respectively. This
is useful because people have been using them that way but haven't
realized that only the lowercase versions worked.

This also explicitly forbids silly things like `NoReLeAsE` and
`noCOMMIT`, failing the build and telling you to spell them properly.