### PR TITLE
Scheduled actions preserves context from scheduling time

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/Retry.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/Retry.java
@@ -142,8 +142,7 @@ public class Retry {
             assert backoff.hasNext();
             TimeValue next = backoff.next();
             logger.trace("Retry of bulk request scheduled in {} ms.", next.millis());
-            Runnable retry = () -> this.execute(bulkRequestForRetry);
-            retry = client.threadPool().getThreadContext().preserveContext(retry);
+            final Runnable retry = () -> this.execute(bulkRequestForRetry);
             scheduledRequestFuture = client.threadPool().schedule(next, ThreadPool.Names.SAME, retry);
         }
 

--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/EsScheduledThreadPoolExecutor.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/EsScheduledThreadPoolExecutor.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util.concurrent;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An extension of the {@link ScheduledThreadPoolExecutor} that preserves the context of the {@link Callable} or {@link Runnable} that is
+ * being scheduled for execution so that it can be restored when the execution occurs.
+ */
+public class EsScheduledThreadPoolExecutor extends ScheduledThreadPoolExecutor {
+
+    private final ThreadContext threadContext;
+
+    public EsScheduledThreadPoolExecutor(int corePoolSize, ThreadFactory threadFactory, RejectedExecutionHandler handler,
+                                         ThreadContext threadContext) {
+        super(corePoolSize, threadFactory, handler);
+        this.threadContext = threadContext;
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return super.schedule(threadContext.preserveContext(command), delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return super.schedule(threadContext.preserveContext(callable), delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return super.scheduleAtFixedRate(threadContext.preserveContext(command), initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return super.scheduleWithFixedDelay(threadContext.preserveContext(command), initialDelay, delay, unit);
+    }
+
+    @Override
+    public final void execute(final Runnable command) {
+        try {
+            super.execute(command);
+        } catch (EsRejectedExecutionException ex) {
+            if (command instanceof AbstractRunnable) {
+                // If we are an abstract runnable we can handle the rejection
+                // directly and don't need to rethrow it.
+                try {
+                    ((AbstractRunnable) command).onRejection(ex);
+                } finally {
+                    ((AbstractRunnable) command).onAfter();
+
+                }
+            } else {
+                throw ex;
+            }
+        }
+    }
+
+    @Override
+    protected void afterExecute(Runnable r, Throwable t) {
+        super.afterExecute(r, t);
+        assert assertDefaultContext(r);
+    }
+
+    private boolean assertDefaultContext(Runnable r) {
+        try {
+            assert threadContext.isDefaultContext() : "the thread context is not the default context and the thread [" +
+                Thread.currentThread().getName() + "] is being returned to the pool after executing [" + r + "]";
+        } catch (IllegalStateException ex) {
+            // sometimes we execute on a closed context and isDefaultContext doesn't bypass the ensureOpen checks
+            // this must not trigger an exception here since we only assert if the default is restored and
+            // we don't really care if we are closed
+            if (threadContext.isClosed() == false) {
+                throw ex;
+            }
+        }
+        return true;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutor.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutor.java
@@ -119,7 +119,7 @@ public class EsThreadPoolExecutor extends ThreadPoolExecutor {
             assert contextHolder.isDefaultContext() : "the thread context is not the default context and the thread [" +
                 Thread.currentThread().getName() + "] is being returned to the pool after executing [" + r + "]";
         } catch (IllegalStateException ex) {
-            // sometimes we execute on a closed context and isDefaultContext doen't bypass the ensureOpen checks
+            // sometimes we execute on a closed context and isDefaultContext doesn't bypass the ensureOpen checks
             // this must not trigger an exception here since we only assert if the default is restored and
             // we don't really care if we are closed
             if (contextHolder.isClosed() == false) {

--- a/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsAbortPolicy;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.common.util.concurrent.EsScheduledThreadPoolExecutor;
 import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.concurrent.XRejectedExecutionHandler;
@@ -207,7 +208,8 @@ public class ThreadPool extends AbstractComponent implements Closeable {
         executors.put(Names.SAME, new ExecutorHolder(DIRECT_EXECUTOR, new Info(Names.SAME, ThreadPoolType.DIRECT)));
         this.executors = unmodifiableMap(executors);
 
-        this.scheduler = new ScheduledThreadPoolExecutor(1, EsExecutors.daemonThreadFactory(settings, "scheduler"), new EsAbortPolicy());
+        this.scheduler = new EsScheduledThreadPoolExecutor(1, EsExecutors.daemonThreadFactory(settings, "scheduler"),
+            new EsAbortPolicy(), threadContext);
         this.scheduler.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
         this.scheduler.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
         this.scheduler.setRemoveOnCancelPolicy(true);

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByScrollAction.java
@@ -163,7 +163,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
             total = min(total, mainRequest.getSize());
         }
         task.setTotal(total);
-        AbstractRunnable prepareBulkRequestRunnable = new AbstractRunnable() {
+        final AbstractRunnable prepareBulkRequestRunnable = new AbstractRunnable() {
             @Override
             protected void doRun() throws Exception {
                 /*
@@ -178,7 +178,6 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
                 finishHim(e);
             }
         };
-        prepareBulkRequestRunnable = (AbstractRunnable) threadPool.getThreadContext().preserveContext(prepareBulkRequestRunnable);
         task.delayPrepareBulkRequest(threadPool, lastBatchStartTime, lastBatchSize, prepareBulkRequestRunnable);
     }
 

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ClientScrollableHitSource.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ClientScrollableHitSource.java
@@ -128,10 +128,7 @@ public class ClientScrollableHitSource extends ScrollableHitSource {
          */
         class RetryHelper extends AbstractRunnable implements ActionListener<SearchResponse> {
             private final Iterator<TimeValue> retries = backoffPolicy.iterator();
-            /**
-             * The runnable to run that retries in the same context as the original call.
-             */
-            private Runnable retryWithContext;
+
             private volatile int retryCount = 0;
 
             @Override
@@ -152,7 +149,7 @@ public class ClientScrollableHitSource extends ScrollableHitSource {
                         TimeValue delay = retries.next();
                         logger.trace((Supplier<?>) () -> new ParameterizedMessage("retrying rejected search after [{}]", delay), e);
                         countSearchRetry.run();
-                        threadPool.schedule(delay, ThreadPool.Names.SAME, retryWithContext);
+                        threadPool.schedule(delay, ThreadPool.Names.SAME, this);
                     } else {
                         logger.warn(
                             (Supplier<?>) () -> new ParameterizedMessage(
@@ -165,10 +162,7 @@ public class ClientScrollableHitSource extends ScrollableHitSource {
                 }
             }
         }
-        RetryHelper helper = new RetryHelper();
-        // Wrap the helper in a runnable that preserves the current context so we keep it on retry.
-        helper.retryWithContext = threadPool.getThreadContext().preserveContext(helper);
-        helper.run();
+        new RetryHelper().run();
     }
 
     private void consume(SearchResponse response, Consumer<? super Response> onResponse) {


### PR DESCRIPTION
Tasks that are created for running at a future point in time should preserve the context
from the time of the initial call to Threadpool#schedule and then restore this context
once the task has been scheduled.