### PR TITLE
Begin centralizing XContentParser creation into RestRequest

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -19,20 +19,14 @@
 
 package org.elasticsearch.action;
 
-import java.io.IOException;
+import org.elasticsearch.common.CheckedConsumer;
+
 import java.util.function.Consumer;
 
 /**
  * A listener for action responses or failures.
  */
 public interface ActionListener<Response> {
-
-    /** A consumer interface which allows throwing checked exceptions. */
-    @FunctionalInterface
-    interface CheckedConsumer<T> {
-        void accept(T t) throws Exception;
-    }
-
     /**
      * Handle action response. This response may constitute a failure or a
      * success but it is up to the listener to make that decision.
@@ -53,7 +47,8 @@ public interface ActionListener<Response> {
      * @param <Response> the type of the response
      * @return a listener that listens for responses and invokes the consumer when received
      */
-    static <Response> ActionListener<Response> wrap(CheckedConsumer<Response> onResponse, Consumer<Exception> onFailure) {
+    static <Response> ActionListener<Response> wrap(CheckedConsumer<Response, ? extends Exception> onResponse,
+            Consumer<Exception> onFailure) {
         return new ActionListener<Response>() {
             @Override
             public void onResponse(Response response) {

--- a/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsRequest.java
@@ -24,10 +24,8 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 
@@ -74,41 +72,39 @@ public class FieldStatsRequest extends BroadcastRequest<FieldStatsRequest> {
         this.indexConstraints = indexConstraints;
     }
 
-    public void source(BytesReference content) throws IOException {
+    public void source(XContentParser parser) throws IOException {
         List<IndexConstraint> indexConstraints = new ArrayList<>();
         List<String> fields = new ArrayList<>();
-        try (XContentParser parser = XContentHelper.createParser(content)) {
-            String fieldName = null;
-            Token token = parser.nextToken();
-            assert token == Token.START_OBJECT;
-            for (token = parser.nextToken(); token != Token.END_OBJECT; token = parser.nextToken()) {
-                switch (token) {
-                    case FIELD_NAME:
-                        fieldName = parser.currentName();
-                        break;
-                    case START_OBJECT:
-                        if ("index_constraints".equals(fieldName)) {
-                            parseIndexConstraints(indexConstraints, parser);
-                        } else {
-                            throw new IllegalArgumentException("unknown field [" + fieldName + "]");
-                        }
-                        break;
-                    case START_ARRAY:
-                        if ("fields".equals(fieldName)) {
-                            while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                                if (token.isValue()) {
-                                    fields.add(parser.text());
-                                } else {
-                                    throw new IllegalArgumentException("unexpected token [" + token + "]");
-                                }
+        String fieldName = null;
+        Token token = parser.nextToken();
+        assert token == Token.START_OBJECT;
+        for (token = parser.nextToken(); token != Token.END_OBJECT; token = parser.nextToken()) {
+            switch (token) {
+                case FIELD_NAME:
+                    fieldName = parser.currentName();
+                    break;
+                case START_OBJECT:
+                    if ("index_constraints".equals(fieldName)) {
+                        parseIndexConstraints(indexConstraints, parser);
+                    } else {
+                        throw new IllegalArgumentException("unknown field [" + fieldName + "]");
+                    }
+                    break;
+                case START_ARRAY:
+                    if ("fields".equals(fieldName)) {
+                        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                            if (token.isValue()) {
+                                fields.add(parser.text());
+                            } else {
+                                throw new IllegalArgumentException("unexpected token [" + token + "]");
                             }
-                        } else {
-                            throw new IllegalArgumentException("unknown field [" + fieldName + "]");
                         }
-                        break;
-                    default:
-                        throw new IllegalArgumentException("unexpected token [" + token + "]");
-                }
+                    } else {
+                        throw new IllegalArgumentException("unknown field [" + fieldName + "]");
+                    }
+                    break;
+                default:
+                    throw new IllegalArgumentException("unexpected token [" + token + "]");
             }
         }
         this.fields = fields.toArray(new String[fields.size()]);

--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -30,13 +30,10 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.lucene.uid.Versions;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
@@ -317,32 +314,19 @@ public class MultiGetRequest extends ActionRequest implements Iterable<MultiGetR
         return this;
     }
 
-
-    public MultiGetRequest add(@Nullable String defaultIndex, @Nullable String defaultType, @Nullable String[] defaultFields, @Nullable FetchSourceContext defaultFetchSource, byte[] data, int from, int length) throws Exception {
-        return add(defaultIndex, defaultType, defaultFields, defaultFetchSource, new BytesArray(data, from, length), true);
-    }
-
-    public MultiGetRequest add(@Nullable String defaultIndex, @Nullable String defaultType, @Nullable String[] defaultFields, @Nullable FetchSourceContext defaultFetchSource, BytesReference data) throws Exception {
-        return add(defaultIndex, defaultType, defaultFields, defaultFetchSource, data, true);
-    }
-
-    public MultiGetRequest add(@Nullable String defaultIndex, @Nullable String defaultType, @Nullable String[] defaultFields, @Nullable FetchSourceContext defaultFetchSource, BytesReference data, boolean allowExplicitIndex) throws Exception {
-        return add(defaultIndex, defaultType, defaultFields, defaultFetchSource, null, data, allowExplicitIndex);
-    }
-
-    public MultiGetRequest add(@Nullable String defaultIndex, @Nullable String defaultType, @Nullable String[] defaultFields, @Nullable FetchSourceContext defaultFetchSource, @Nullable String defaultRouting, BytesReference data, boolean allowExplicitIndex) throws IOException {
-        try (XContentParser parser = XContentFactory.xContent(data).createParser(data)) {
-            XContentParser.Token token;
-            String currentFieldName = null;
-            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                if (token == XContentParser.Token.FIELD_NAME) {
-                    currentFieldName = parser.currentName();
-                } else if (token == XContentParser.Token.START_ARRAY) {
-                    if ("docs".equals(currentFieldName)) {
-                        parseDocuments(parser, this.items, defaultIndex, defaultType, defaultFields, defaultFetchSource, defaultRouting, allowExplicitIndex);
-                    } else if ("ids".equals(currentFieldName)) {
-                        parseIds(parser, this.items, defaultIndex, defaultType, defaultFields, defaultFetchSource, defaultRouting);
-                    }
+    public MultiGetRequest add(@Nullable String defaultIndex, @Nullable String defaultType, @Nullable String[] defaultFields,
+            @Nullable FetchSourceContext defaultFetchSource, @Nullable String defaultRouting, XContentParser parser,
+            boolean allowExplicitIndex) throws IOException {
+        XContentParser.Token token;
+        String currentFieldName = null;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                if ("docs".equals(currentFieldName)) {
+                    parseDocuments(parser, this.items, defaultIndex, defaultType, defaultFields, defaultFetchSource, defaultRouting, allowExplicitIndex);
+                } else if ("ids".equals(currentFieldName)) {
+                    parseIds(parser, this.items, defaultIndex, defaultType, defaultFields, defaultFetchSource, defaultRouting);
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsRequest.java
@@ -26,10 +26,8 @@ import org.elasticsearch.action.CompositeIndicesRequest;
 import org.elasticsearch.action.RealtimeRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -88,43 +86,41 @@ public class MultiTermVectorsRequest extends ActionRequest implements Iterable<T
         return requests;
     }
 
-    public void add(TermVectorsRequest template, BytesReference data) throws IOException {
+    public void add(TermVectorsRequest template, @Nullable XContentParser parser) throws IOException {
         XContentParser.Token token;
         String currentFieldName = null;
-        if (data.length() > 0) {
-            try (XContentParser parser = XContentFactory.xContent(data).createParser(data)) {
-                while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                    if (token == XContentParser.Token.FIELD_NAME) {
-                        currentFieldName = parser.currentName();
-                    } else if (token == XContentParser.Token.START_ARRAY) {
-                        if ("docs".equals(currentFieldName)) {
-                            while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                                if (token != XContentParser.Token.START_OBJECT) {
-                                    throw new IllegalArgumentException("docs array element should include an object");
-                                }
-                                TermVectorsRequest termVectorsRequest = new TermVectorsRequest(template);
-                                TermVectorsRequest.parseRequest(termVectorsRequest, parser);
-                                add(termVectorsRequest);
+        if (parser != null) {
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    currentFieldName = parser.currentName();
+                } else if (token == XContentParser.Token.START_ARRAY) {
+                    if ("docs".equals(currentFieldName)) {
+                        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                            if (token != XContentParser.Token.START_OBJECT) {
+                                throw new IllegalArgumentException("docs array element should include an object");
                             }
-                        } else if ("ids".equals(currentFieldName)) {
-                            while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                                if (!token.isValue()) {
-                                    throw new IllegalArgumentException("ids array element should only contain ids");
-                                }
-                                ids.add(parser.text());
+                            TermVectorsRequest termVectorsRequest = new TermVectorsRequest(template);
+                            TermVectorsRequest.parseRequest(termVectorsRequest, parser);
+                            add(termVectorsRequest);
+                        }
+                    } else if ("ids".equals(currentFieldName)) {
+                        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                            if (!token.isValue()) {
+                                throw new IllegalArgumentException("ids array element should only contain ids");
                             }
-                        } else {
-                            throw new ElasticsearchParseException("no parameter named [{}] and type ARRAY", currentFieldName);
+                            ids.add(parser.text());
                         }
-                    } else if (token == XContentParser.Token.START_OBJECT && currentFieldName != null) {
-                        if ("parameters".equals(currentFieldName)) {
-                            TermVectorsRequest.parseRequest(template, parser);
-                        } else {
-                            throw new ElasticsearchParseException("no parameter named [{}] and type OBJECT", currentFieldName);
-                        }
-                    } else if (currentFieldName != null) {
-                        throw new ElasticsearchParseException("_mtermvectors: Parameter [{}] not supported", currentFieldName);
+                    } else {
+                        throw new ElasticsearchParseException("no parameter named [{}] and type ARRAY", currentFieldName);
                     }
+                } else if (token == XContentParser.Token.START_OBJECT && currentFieldName != null) {
+                    if ("parameters".equals(currentFieldName)) {
+                        TermVectorsRequest.parseRequest(template, parser);
+                    } else {
+                        throw new ElasticsearchParseException("no parameter named [{}] and type OBJECT", currentFieldName);
+                    }
+                } else if (currentFieldName != null) {
+                    throw new ElasticsearchParseException("_mtermvectors: Parameter [{}] not supported", currentFieldName);
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/common/CheckedConsumer.java
+++ b/core/src/main/java/org/elasticsearch/common/CheckedConsumer.java
@@ -19,12 +19,12 @@
 
 package org.elasticsearch.common;
 
-import java.io.IOException;
 import java.util.function.Consumer;
 
 /**
- * Like {@link Consumer} but can throw an {@link IOException}.
+ * A {@link Consumer}-like interface which allows throwing checked exceptions.
  */
-public interface IOConsumer<T> {
-    void accept(T t) throws IOException;
+@FunctionalInterface
+public interface CheckedConsumer<T, E extends Exception> {
+    void accept(T t) throws E;
 }

--- a/core/src/main/java/org/elasticsearch/common/IOConsumer.java
+++ b/core/src/main/java/org/elasticsearch/common/IOConsumer.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+
+/**
+ * Like {@link Consumer} but can throw an {@link IOException}.
+ */
+public interface IOConsumer<T> {
+    void accept(T t) throws IOException;
+}

--- a/core/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -275,6 +275,16 @@ public abstract class RestRequest implements ToXContent.Params {
     }
 
     /**
+     * Get the content of the request or the contents of the {@code source} param.
+     *
+     * @deprecated Use this only to support deprecated code. Prefer {@link #contentOrSourceParamParser()}.
+     */
+    @Deprecated
+    public final BytesReference contentOrSourceParam() {
+        return contentOrSource();
+    }
+
+    /**
      * The String representation of the body if there is one or the {@code source} parameter if there isn't a body.
      */
     public final String contentOrSourceParamString() throws IOException {

--- a/core/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -236,11 +236,12 @@ public abstract class RestRequest implements ToXContent.Params {
     }
 
     /**
-     * The content type for the body if there is one or the source {@code source} parameter if there isn't a body or null if there isn't
-     * any content or the type can't be guessed.
+     * The {@linkplain XContentType} of either the request body or the {@code source} param if either exists and can be guessed, otherwise
+     * {@code null}. Only use this if you need to do something different if the request is plain text. Use
+     * {@link #contentOrSourceParamParser()} if you need a parser.
      */
     @Nullable
-    public final XContentType contentOrSourceParamContentType() {
+    public final XContentType contentOrSourceParamXContentType() {
         BytesReference content = contentOrSource();
         return content == null ? null : XContentFactory.xContentType(content);
     }

--- a/core/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -22,7 +22,7 @@ package org.elasticsearch.rest;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Booleans;
-import org.elasticsearch.common.IOConsumer;
+import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -251,8 +251,8 @@ public abstract class RestRequest implements ToXContent.Params {
 
     /**
      * A parser for the contents of this request if it has contents, otherwise a parser for the {@code source} parameter if there is one,
-     * otherwise throws an {@link ElasticsearchParseException}. Use {@link #withContentOrSourceParamParserOrNull(IOConsumer)} instead if you
-     * need to handle the absence request content gracefully.
+     * otherwise throws an {@link ElasticsearchParseException}. Use {@link #withContentOrSourceParamParserOrNull(CheckedConsumer)} instead
+     * if you need to handle the absence request content gracefully.
      */
     public final XContentParser contentOrSourceParamParser() throws IOException {
         BytesReference content = contentOrSourceParam();
@@ -267,7 +267,7 @@ public abstract class RestRequest implements ToXContent.Params {
      * parameter if there is one, otherwise with {@code null}. Use {@link #contentOrSourceParamParser()} if you should throw an exception
      * back to the user when there isn't request content.
      */
-    public final void withContentOrSourceParamParserOrNull(IOConsumer<XContentParser> withParser) throws IOException {
+    public final void withContentOrSourceParamParserOrNull(CheckedConsumer<XContentParser, IOException> withParser) throws IOException {
         XContentParser parser = null;
         BytesReference content = contentOrSourceParam();
         if (content.length() > 0) {
@@ -283,7 +283,7 @@ public abstract class RestRequest implements ToXContent.Params {
 
     /**
      * Get the content of the request or the contents of the {@code source} param. Prefer {@link #contentOrSourceParamParser()} or
-     * {@link #withContentOrSourceParamParserOrNull(IOConsumer)} if you need a parser.
+     * {@link #withContentOrSourceParamParserOrNull(CheckedConsumer)} if you need a parser.
      */
     public final BytesReference contentOrSourceParam() {
         if (hasContent()) {

--- a/core/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -282,9 +282,8 @@ public abstract class RestRequest implements ToXContent.Params {
     }
 
     /**
-     * Get the content of the request or the contents of the {@code source} param. Prefer {@link #contentOrSourceParamParser()} if possible
-     * prefer methods like {@link #contentOrSourceParamParser()} and {@link #contentOrSourceParamXContentType()}. This should be private
-     * but isn't to support mostly legacy APIs.
+     * Get the content of the request or the contents of the {@code source} param. Prefer {@link #contentOrSourceParamParser()} or
+     * {@link #withContentOrSourceParamParserOrNull(IOConsumer)} if you need a parser.
      */
     public final BytesReference contentOrSourceParam() {
         if (hasContent()) {
@@ -295,13 +294,5 @@ public abstract class RestRequest implements ToXContent.Params {
             return new BytesArray(source);
         }
         return BytesArray.EMPTY;
-    }
-
-    /**
-     * The String representation of the body if there is one or the {@code source} parameter if there isn't content. Use this only if you
-     * aren't need to process raw strings.
-     */
-    public final String contentOrSourceParamString() throws IOException {
-        return contentOrSourceParam().utf8ToString();
     }
 }

--- a/core/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -19,8 +19,10 @@
 
 package org.elasticsearch.rest;
 
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Booleans;
+import org.elasticsearch.common.IOConsumer;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -272,6 +274,19 @@ public abstract class RestRequest implements ToXContent.Params {
             return null;
         }
         return XContentFactory.xContent(content).createParser(content);
+    }
+
+    /**
+     * TODO
+     */
+    @Nullable
+    public final void withContentOrSourceParamParserOrNull(IOConsumer<XContentParser> withParser) throws IOException {
+        XContentParser parser = contentOrSourceParamParserOrNull();
+        try {
+            withParser.accept(parser);
+        } finally {
+            IOUtils.close(parser);
+        }
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.net.SocketAddress;
@@ -236,17 +235,6 @@ public abstract class RestRequest implements ToXContent.Params {
      */
     public final boolean hasContentOrSourceParam() {
         return hasContent() || hasParam("source");
-    }
-
-    /**
-     * The {@linkplain XContentType} of either the request body or the {@code source} param if either exists and can be guessed, otherwise
-     * {@code null}. Only use this if you need to do something different if the request is plain text. Use
-     * {@link #contentOrSourceParamParser()} if you need a parser.
-     */
-    @Nullable
-    public final XContentType contentOrSourceParamXContentType() {
-        BytesReference content = contentOrSourceParam();
-        return content == null ? null : XContentFactory.xContentType(content);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -265,7 +265,7 @@ public abstract class RestRequest implements ToXContent.Params {
     /**
      * A parser for the contents of this request if it has contents, otherwise a parser for the {@code source} parameter if there is one,
      * otherwise {@code null}. Use {@link #contentOrSourceParamParser()} if you should throw an exception back to the user when there isn't
-     * a body.
+     * a body. See also {@link #withContentOrSourceParamParserOrNull(IOConsumer)} which may cleaner to use.
      */
     @Nullable
     public final XContentParser contentOrSourceParamParserOrNull() throws IOException {
@@ -277,7 +277,8 @@ public abstract class RestRequest implements ToXContent.Params {
     }
 
     /**
-     * TODO
+     * Helper around {@link #contentOrSourceParamParserOrNull()} that closes the parser for you. This is just syntactic sugar to ease
+     * handling the nullable parser.
      */
     @Nullable
     public final void withContentOrSourceParamParserOrNull(IOConsumer<XContentParser> withParser) throws IOException {

--- a/core/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -251,8 +251,8 @@ public abstract class RestRequest implements ToXContent.Params {
 
     /**
      * A parser for the contents of this request if it has contents, otherwise a parser for the {@code source} parameter if there is one,
-     * otherwise throws an {@link ElasticsearchParseException}. Use {@link #contentOrSourceParamParserOrNull()} instead if you need to
-     * handle the absence of a body gracefully.
+     * otherwise throws an {@link ElasticsearchParseException}. Use {@link #withContentOrSourceParamParserOrNull(IOConsumer)} instead if you
+     * need to handle the absence request content gracefully.
      */
     public final XContentParser contentOrSourceParamParser() throws IOException {
         BytesReference content = contentOrSourceParam();
@@ -265,7 +265,7 @@ public abstract class RestRequest implements ToXContent.Params {
     /**
      * Call a consumer with the parser for the contents of this request if it has contents, otherwise with a parser for the {@code source}
      * parameter if there is one, otherwise with {@code null}. Use {@link #contentOrSourceParamParser()} if you should throw an exception
-     * back to the user when there isn't a body.
+     * back to the user when there isn't request content.
      */
     public final void withContentOrSourceParamParserOrNull(IOConsumer<XContentParser> withParser) throws IOException {
         XContentParser parser = null;
@@ -283,7 +283,8 @@ public abstract class RestRequest implements ToXContent.Params {
 
     /**
      * Get the content of the request or the contents of the {@code source} param. Prefer {@link #contentOrSourceParamParser()} if possible
-     * prefer methods like {@link #contentOrSourceParamParser()} and {@link #contentOrSourceParamXContentType()}.
+     * prefer methods like {@link #contentOrSourceParamParser()} and {@link #contentOrSourceParamXContentType()}. This should be private
+     * but isn't to support mostly legacy APIs.
      */
     public final BytesReference contentOrSourceParam() {
         if (hasContent()) {

--- a/core/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -290,11 +290,9 @@ public abstract class RestRequest implements ToXContent.Params {
     }
 
     /**
-     * Get the content of the request or the contents of the {@code source} param.
-     *
-     * @deprecated Use this only to support deprecated code. Prefer {@link #contentOrSourceParamParser()}.
+     * Get the content of the request or the contents of the {@code source} param. Prefer {@link #contentOrSourceParamParser()} if possible
+     * to centralize parser construction.
      */
-    @Deprecated
     public final BytesReference contentOrSourceParam() {
         return contentOrSource();
     }

--- a/core/src/main/java/org/elasticsearch/rest/action/RestActions.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/RestActions.java
@@ -243,13 +243,6 @@ public class RestActions {
     }
 
     /**
-     * Returns <code>true</code> if either payload or source parameter is present. Otherwise <code>false</code>
-     */
-    public static boolean hasBodyContent(final RestRequest request) {
-        return request.hasContent() || request.hasParam("source");
-    }
-
-    /**
      * {@code NodesResponseRestBuilderListener} automatically translates any {@link BaseNodesResponse} (multi-node) response that is
      * {@link ToXContent}-compatible into a {@link RestResponse} with the necessary header info (e.g., "cluster_name").
      * <p>

--- a/core/src/main/java/org/elasticsearch/rest/action/RestActions.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/RestActions.java
@@ -26,8 +26,6 @@ import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.action.support.nodes.BaseNodeResponse;
 import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.common.ParseFieldMatcher;
-import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContent.Params;
@@ -195,25 +193,6 @@ public class RestActions {
             queryBuilder.defaultOperator(Operator.fromString(defaultOperator));
         }
         return queryBuilder;
-    }
-
-    /**
-     * Get Rest content from either payload or source parameter
-     * @param request Rest request
-     * @return rest content
-     */
-    public static BytesReference getRestContent(RestRequest request) {
-        assert request != null;
-
-        BytesReference content = request.content();
-        if (!request.hasContent()) {
-            String source = request.param("source");
-            if (source != null) {
-                content = new BytesArray(source);
-            }
-        }
-
-        return content;
     }
 
     public static QueryBuilder getQueryContent(XContentParser requestParser, IndicesQueriesRegistry indicesQueriesRegistry,

--- a/core/src/main/java/org/elasticsearch/rest/action/RestActions.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/RestActions.java
@@ -35,7 +35,6 @@ import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -227,19 +226,6 @@ public class RestActions {
         } catch (IOException e) {
             throw new ElasticsearchException("failed to parse source", e);
         }
-    }
-
-    /**
-     * guesses the content type from either payload or source parameter
-     * @param request Rest request
-     * @return rest content type or <code>null</code> if not applicable.
-     */
-    public static XContentType guessBodyContentType(final RestRequest request) {
-        final BytesReference restContent = RestActions.getRestContent(request);
-        if (restContent == null) {
-            return null;
-        }
-        return XContentFactory.xContentType(restContent);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/rest/action/RestActions.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/RestActions.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.rest.action;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.ShardOperationFailedException;
@@ -33,7 +32,6 @@ import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -218,14 +216,10 @@ public class RestActions {
         return content;
     }
 
-    public static QueryBuilder getQueryContent(BytesReference source, IndicesQueriesRegistry indicesQueriesRegistry,
+    public static QueryBuilder getQueryContent(XContentParser requestParser, IndicesQueriesRegistry indicesQueriesRegistry,
                                                ParseFieldMatcher parseFieldMatcher) {
-        try (XContentParser requestParser = XContentFactory.xContent(source).createParser(source)) {
-            QueryParseContext context = new QueryParseContext(indicesQueriesRegistry, requestParser, parseFieldMatcher);
-            return context.parseTopLevelQueryBuilder();
-        } catch (IOException e) {
-            throw new ElasticsearchException("failed to parse source", e);
-        }
+        QueryParseContext context = new QueryParseContext(indicesQueriesRegistry, requestParser, parseFieldMatcher);
+        return context.parseTopLevelQueryBuilder();
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterAllocationExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterAllocationExplainAction.java
@@ -24,12 +24,10 @@ import org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplai
 import org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplainResponse;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.BytesRestResponse;
@@ -37,7 +35,6 @@ import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.rest.action.RestBuilderListener;
 
 import java.io.IOException;
@@ -61,8 +58,7 @@ public class RestClusterAllocationExplainAction extends BaseRestHandler {
             // Empty request signals "explain the first unassigned shard you find"
             req = new ClusterAllocationExplainRequest();
         } else {
-            BytesReference content = RestActions.getRestContent(request);
-            try (XContentParser parser = XContentFactory.xContent(content).createParser(content)) {
+            try (XContentParser parser = request.contentOrSourceParamParser()) {
                 req = ClusterAllocationExplainRequest.parse(parser);
             } catch (IOException e) {
                 logger.debug("failed to parse allocation explain request", e);

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterAllocationExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterAllocationExplainAction.java
@@ -57,7 +57,7 @@ public class RestClusterAllocationExplainAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         ClusterAllocationExplainRequest req;
-        if (RestActions.hasBodyContent(request) == false) {
+        if (request.hasContentOrSourceParam() == false) {
             // Empty request signals "explain the first unassigned shard you find"
             req = new ClusterAllocationExplainRequest();
         } else {

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeAction.java
@@ -22,15 +22,12 @@ import org.elasticsearch.action.admin.indices.analyze.AnalyzeRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParseFieldMatcher;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.rest.action.RestToXContentListener;
 
 import java.io.IOException;
@@ -67,91 +64,92 @@ public class RestAnalyzeAction extends BaseRestHandler {
 
         AnalyzeRequest analyzeRequest = new AnalyzeRequest(request.param("index"));
 
-        buildFromContent(RestActions.getRestContent(request), analyzeRequest, parseFieldMatcher);
+        try (XContentParser parser = request.contentOrSourceParamParser()) {
+            buildFromContent(parser, analyzeRequest, parseFieldMatcher);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to parse request body", e);
+        }
 
         return channel -> client.admin().indices().analyze(analyzeRequest, new RestToXContentListener<>(channel));
     }
 
-    static void buildFromContent(BytesReference content, AnalyzeRequest analyzeRequest, ParseFieldMatcher parseFieldMatcher) {
-        try (XContentParser parser = XContentHelper.createParser(content)) {
-            if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
-                throw new IllegalArgumentException("Malformed content, must start with an object");
-            } else {
-                XContentParser.Token token;
-                String currentFieldName = null;
-                while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                    if (token == XContentParser.Token.FIELD_NAME) {
-                        currentFieldName = parser.currentName();
-                    } else if (parseFieldMatcher.match(currentFieldName, Fields.TEXT) && token == XContentParser.Token.VALUE_STRING) {
-                        analyzeRequest.text(parser.text());
-                    } else if (parseFieldMatcher.match(currentFieldName, Fields.TEXT) && token == XContentParser.Token.START_ARRAY) {
-                        List<String> texts = new ArrayList<>();
-                        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                            if (token.isValue() == false) {
-                                throw new IllegalArgumentException(currentFieldName + " array element should only contain text");
-                            }
-                            texts.add(parser.text());
+    static void buildFromContent(XContentParser parser, AnalyzeRequest analyzeRequest, ParseFieldMatcher parseFieldMatcher)
+            throws IOException {
+        if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
+            throw new IllegalArgumentException("Malformed content, must start with an object");
+        } else {
+            XContentParser.Token token;
+            String currentFieldName = null;
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    currentFieldName = parser.currentName();
+                } else if (parseFieldMatcher.match(currentFieldName, Fields.TEXT) && token == XContentParser.Token.VALUE_STRING) {
+                    analyzeRequest.text(parser.text());
+                } else if (parseFieldMatcher.match(currentFieldName, Fields.TEXT) && token == XContentParser.Token.START_ARRAY) {
+                    List<String> texts = new ArrayList<>();
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        if (token.isValue() == false) {
+                            throw new IllegalArgumentException(currentFieldName + " array element should only contain text");
                         }
-                        analyzeRequest.text(texts.toArray(new String[texts.size()]));
-                    } else if (parseFieldMatcher.match(currentFieldName, Fields.ANALYZER) && token == XContentParser.Token.VALUE_STRING) {
-                        analyzeRequest.analyzer(parser.text());
-                    } else if (parseFieldMatcher.match(currentFieldName, Fields.FIELD) && token == XContentParser.Token.VALUE_STRING) {
-                        analyzeRequest.field(parser.text());
-                    } else if (parseFieldMatcher.match(currentFieldName, Fields.TOKENIZER)) {
-                        if (token == XContentParser.Token.VALUE_STRING) {
-                            analyzeRequest.tokenizer(parser.text());
-                        } else if (token == XContentParser.Token.START_OBJECT) {
-                            analyzeRequest.tokenizer(parser.map());
-                        } else {
-                            throw new IllegalArgumentException(currentFieldName + " should be tokenizer's name or setting");
-                        }
-                    } else if (parseFieldMatcher.match(currentFieldName, Fields.TOKEN_FILTERS)
-                            && token == XContentParser.Token.START_ARRAY) {
-                        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                            if (token == XContentParser.Token.VALUE_STRING) {
-                                analyzeRequest.addTokenFilter(parser.text());
-                            } else if (token == XContentParser.Token.START_OBJECT) {
-                                analyzeRequest.addTokenFilter(parser.map());
-                            } else {
-                                throw new IllegalArgumentException(currentFieldName
-                                        + " array element should contain filter's name or setting");
-                            }
-                        }
-                    } else if (parseFieldMatcher.match(currentFieldName, Fields.CHAR_FILTERS)
-                            && token == XContentParser.Token.START_ARRAY) {
-                        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                            if (token == XContentParser.Token.VALUE_STRING) {
-                                analyzeRequest.addCharFilter(parser.text());
-                            } else if (token == XContentParser.Token.START_OBJECT) {
-                                analyzeRequest.addCharFilter(parser.map());
-                            } else {
-                                throw new IllegalArgumentException(currentFieldName
-                                        + " array element should contain char filter's name or setting");
-                            }
-                        }
-                    } else if (parseFieldMatcher.match(currentFieldName, Fields.EXPLAIN)) {
-                        if (parser.isBooleanValue()) {
-                            analyzeRequest.explain(parser.booleanValue());
-                        } else {
-                            throw new IllegalArgumentException(currentFieldName + " must be either 'true' or 'false'");
-                        }
-                    } else if (parseFieldMatcher.match(currentFieldName, Fields.ATTRIBUTES) && token == XContentParser.Token.START_ARRAY) {
-                        List<String> attributes = new ArrayList<>();
-                        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                            if (token.isValue() == false) {
-                                throw new IllegalArgumentException(currentFieldName + " array element should only contain attribute name");
-                            }
-                            attributes.add(parser.text());
-                        }
-                        analyzeRequest.attributes(attributes.toArray(new String[attributes.size()]));
-                    } else {
-                        throw new IllegalArgumentException("Unknown parameter ["
-                                + currentFieldName + "] in request body or parameter is of the wrong type[" + token + "] ");
+                        texts.add(parser.text());
                     }
+                    analyzeRequest.text(texts.toArray(new String[texts.size()]));
+                } else if (parseFieldMatcher.match(currentFieldName, Fields.ANALYZER) && token == XContentParser.Token.VALUE_STRING) {
+                    analyzeRequest.analyzer(parser.text());
+                } else if (parseFieldMatcher.match(currentFieldName, Fields.FIELD) && token == XContentParser.Token.VALUE_STRING) {
+                    analyzeRequest.field(parser.text());
+                } else if (parseFieldMatcher.match(currentFieldName, Fields.TOKENIZER)) {
+                    if (token == XContentParser.Token.VALUE_STRING) {
+                        analyzeRequest.tokenizer(parser.text());
+                    } else if (token == XContentParser.Token.START_OBJECT) {
+                        analyzeRequest.tokenizer(parser.map());
+                    } else {
+                        throw new IllegalArgumentException(currentFieldName + " should be tokenizer's name or setting");
+                    }
+                } else if (parseFieldMatcher.match(currentFieldName, Fields.TOKEN_FILTERS)
+                        && token == XContentParser.Token.START_ARRAY) {
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        if (token == XContentParser.Token.VALUE_STRING) {
+                            analyzeRequest.addTokenFilter(parser.text());
+                        } else if (token == XContentParser.Token.START_OBJECT) {
+                            analyzeRequest.addTokenFilter(parser.map());
+                        } else {
+                            throw new IllegalArgumentException(currentFieldName
+                                    + " array element should contain filter's name or setting");
+                        }
+                    }
+                } else if (parseFieldMatcher.match(currentFieldName, Fields.CHAR_FILTERS)
+                        && token == XContentParser.Token.START_ARRAY) {
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        if (token == XContentParser.Token.VALUE_STRING) {
+                            analyzeRequest.addCharFilter(parser.text());
+                        } else if (token == XContentParser.Token.START_OBJECT) {
+                            analyzeRequest.addCharFilter(parser.map());
+                        } else {
+                            throw new IllegalArgumentException(currentFieldName
+                                    + " array element should contain char filter's name or setting");
+                        }
+                    }
+                } else if (parseFieldMatcher.match(currentFieldName, Fields.EXPLAIN)) {
+                    if (parser.isBooleanValue()) {
+                        analyzeRequest.explain(parser.booleanValue());
+                    } else {
+                        throw new IllegalArgumentException(currentFieldName + " must be either 'true' or 'false'");
+                    }
+                } else if (parseFieldMatcher.match(currentFieldName, Fields.ATTRIBUTES) && token == XContentParser.Token.START_ARRAY) {
+                    List<String> attributes = new ArrayList<>();
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        if (token.isValue() == false) {
+                            throw new IllegalArgumentException(currentFieldName + " array element should only contain attribute name");
+                        }
+                        attributes.add(parser.text());
+                    }
+                    analyzeRequest.attributes(attributes.toArray(new String[attributes.size()]));
+                } else {
+                    throw new IllegalArgumentException("Unknown parameter ["
+                            + currentFieldName + "] in request body or parameter is of the wrong type[" + token + "] ");
                 }
             }
-        } catch (IOException e) {
-            throw new IllegalArgumentException("Failed to parse request body", e);
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryAction.java
@@ -74,7 +74,7 @@ public class RestValidateQueryAction extends BaseRestHandler {
         validateQueryRequest.rewrite(request.paramAsBoolean("rewrite", false));
 
         Exception bodyParsingException = null;
-        XContentParser parser = request.contentOrSourceParamParser();
+        XContentParser parser = request.contentOrSourceParamParserOrNull();
         try {
             if (parser != null) {
                 try {

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryAction.java
@@ -78,14 +78,12 @@ public class RestValidateQueryAction extends BaseRestHandler {
             request.withContentOrSourceParamParserOrNull(parser -> {
                 if (parser != null) {
                     validateQueryRequest.query(RestActions.getQueryContent(parser, indicesQueriesRegistry, parseFieldMatcher));
+                } else if (request.hasParam("q")) {
+                    validateQueryRequest.query(RestActions.urlParamsToQueryBuilder(request));
                 }
             });
         } catch (Exception e) {
             bodyParsingException = e;
-        }
-        if (validateQueryRequest.query() == null && request.hasParam("q")) {
-            QueryBuilder queryBuilder = RestActions.urlParamsToQueryBuilder(request);
-            validateQueryRequest.query(queryBuilder);
         }
 
         final Exception finalBodyParsingException = bodyParsingException;

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryAction.java
@@ -72,7 +72,7 @@ public class RestValidateQueryAction extends BaseRestHandler {
         validateQueryRequest.rewrite(request.paramAsBoolean("rewrite", false));
 
         Exception bodyParsingException = null;
-        if (RestActions.hasBodyContent(request)) {
+        if (request.hasContentOrSourceParam()) {
             try {
                 validateQueryRequest.query(
                     RestActions.getQueryContent(RestActions.getRestContent(request), indicesQueriesRegistry, parseFieldMatcher));

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.rest.action.cat;
 
-import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -28,7 +27,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.indices.query.IndicesQueriesRegistry;
 import org.elasticsearch.rest.RestController;
@@ -67,8 +65,7 @@ public class RestCountAction extends AbstractCatAction {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().size(0);
         countRequest.source(searchSourceBuilder);
         try {
-            XContentParser parser = request.contentOrSourceParamParserOrNull();
-            try {
+            request.withContentOrSourceParamParserOrNull(parser -> {
                 if (parser == null) {
                     QueryBuilder queryBuilder = RestActions.urlParamsToQueryBuilder(request);
                     if (queryBuilder != null) {
@@ -77,9 +74,7 @@ public class RestCountAction extends AbstractCatAction {
                 } else {
                     searchSourceBuilder.query(RestActions.getQueryContent(parser, indicesQueriesRegistry, parseFieldMatcher));
                 }
-            } finally {
-                IOUtils.close(parser);
-            }
+            });
         } catch (IOException e) {
             throw new ElasticsearchException("Couldn't parse query", e);
         }

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
@@ -19,14 +19,16 @@
 
 package org.elasticsearch.rest.action.cat;
 
+import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.Table;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.indices.query.IndicesQueriesRegistry;
 import org.elasticsearch.rest.RestController;
@@ -35,6 +37,8 @@ import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.rest.action.RestResponseListener;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+import java.io.IOException;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
@@ -60,16 +64,24 @@ public class RestCountAction extends AbstractCatAction {
     public RestChannelConsumer doCatRequest(final RestRequest request, final NodeClient client) {
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         SearchRequest countRequest = new SearchRequest(indices);
-        String source = request.param("source");
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().size(0);
         countRequest.source(searchSourceBuilder);
-        if (source != null) {
-            searchSourceBuilder.query(RestActions.getQueryContent(new BytesArray(source), indicesQueriesRegistry, parseFieldMatcher));
-        } else {
-            QueryBuilder queryBuilder = RestActions.urlParamsToQueryBuilder(request);
-            if (queryBuilder != null) {
-                searchSourceBuilder.query(queryBuilder);
+        try {
+            XContentParser parser = request.contentOrSourceParamParserOrNull();
+            try {
+                if (parser == null) {
+                    QueryBuilder queryBuilder = RestActions.urlParamsToQueryBuilder(request);
+                    if (queryBuilder != null) {
+                        searchSourceBuilder.query(queryBuilder);
+                    }
+                } else {
+                    searchSourceBuilder.query(RestActions.getQueryContent(parser, indicesQueriesRegistry, parseFieldMatcher));
+                }
+            } finally {
+                IOUtils.close(parser);
             }
+        } catch (IOException e) {
+            throw new ElasticsearchException("Couldn't parse query", e);
         }
         return channel -> client.search(countRequest, new RestResponseListener<SearchResponse>(channel) {
             @Override

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestCountAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestCountAction.java
@@ -68,7 +68,7 @@ public class RestCountAction extends BaseRestHandler {
         countRequest.indicesOptions(IndicesOptions.fromRequest(request, countRequest.indicesOptions()));
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().size(0);
         countRequest.source(searchSourceBuilder);
-        if (RestActions.hasBodyContent(request)) {
+        if (request.hasContentOrSourceParam()) {
             BytesReference restContent = RestActions.getRestContent(request);
             searchSourceBuilder.query(RestActions.getQueryContent(restContent, indicesQueriesRegistry, parseFieldMatcher));
         } else {

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestCountAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestCountAction.java
@@ -69,8 +69,7 @@ public class RestCountAction extends BaseRestHandler {
         countRequest.indicesOptions(IndicesOptions.fromRequest(request, countRequest.indicesOptions()));
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().size(0);
         countRequest.source(searchSourceBuilder);
-        XContentParser parser = request.contentOrSourceParamParserOrNull();
-        try {
+        request.withContentOrSourceParamParserOrNull(parser -> {
             if (parser == null) {
                 QueryBuilder queryBuilder = RestActions.urlParamsToQueryBuilder(request);
                 if (queryBuilder != null) {
@@ -79,9 +78,7 @@ public class RestCountAction extends BaseRestHandler {
             } else {
                 searchSourceBuilder.query(RestActions.getQueryContent(parser, indicesQueriesRegistry, parseFieldMatcher));
             }
-        } finally {
-            IOUtils.close(parser);
-        }
+        });
         countRequest.routing(request.param("routing"));
         float minScore = request.paramAsFloat("min_score", -1f);
         if (minScore != -1f) {

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestMultiGetAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestMultiGetAction.java
@@ -24,10 +24,10 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
@@ -70,8 +70,10 @@ public class RestMultiGetAction extends BaseRestHandler {
         }
 
         FetchSourceContext defaultFetchSource = FetchSourceContext.parseFromRestRequest(request);
-        multiGetRequest.add(request.param("index"), request.param("type"), sFields, defaultFetchSource,
-            request.param("routing"), RestActions.getRestContent(request), allowExplicitIndex);
+        try (XContentParser parser = request.contentOrSourceParamParser()) {
+            multiGetRequest.add(request.param("index"), request.param("type"), sFields, defaultFetchSource,
+                request.param("routing"), parser, allowExplicitIndex);
+        }
 
         return channel -> client.multiGet(multiGetRequest, new RestToXContentListener<>(channel));
     }

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestMultiTermVectorsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestMultiTermVectorsAction.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.rest.action.RestToXContentListener;
 
 import java.io.IOException;
@@ -58,7 +57,7 @@ public class RestMultiTermVectorsAction extends BaseRestHandler {
         template.type(request.param("type"));
         RestTermVectorsAction.readURIParameters(template, request);
         multiTermVectorsRequest.ids(Strings.commaDelimitedListToStringArray(request.param("ids")));
-        multiTermVectorsRequest.add(template, RestActions.getRestContent(request));
+        request.withContentOrSourceParamParserOrNull(p -> multiTermVectorsRequest.add(template, p));
 
         return channel -> client.multiTermVectors(multiTermVectorsRequest, new RestToXContentListener<MultiTermVectorsResponse>(channel));
     }

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestTermVectorsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestTermVectorsAction.java
@@ -65,8 +65,7 @@ public class RestTermVectorsAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         TermVectorsRequest termVectorsRequest = new TermVectorsRequest(request.param("index"), request.param("type"), request.param("id"));
         if (request.hasContentOrSourceParam()) {
-            try (XContentParser parser = XContentFactory.xContent(RestActions.guessBodyContentType(request))
-                .createParser(RestActions.getRestContent(request))) {
+            try (XContentParser parser = request.contentOrSourceParamParser()) {
                 TermVectorsRequest.parseRequest(termVectorsRequest, parser);
             }
         }

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestTermVectorsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestTermVectorsAction.java
@@ -64,7 +64,7 @@ public class RestTermVectorsAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         TermVectorsRequest termVectorsRequest = new TermVectorsRequest(request.param("index"), request.param("type"), request.param("id"));
-        if (RestActions.hasBodyContent(request)) {
+        if (request.hasContentOrSourceParam()) {
             try (XContentParser parser = XContentFactory.xContent(RestActions.guessBodyContentType(request))
                 .createParser(RestActions.getRestContent(request))) {
                 TermVectorsRequest.parseRequest(termVectorsRequest, parser);

--- a/core/src/main/java/org/elasticsearch/rest/action/ingest/RestPutPipelineAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/ingest/RestPutPipelineAction.java
@@ -42,7 +42,7 @@ public class RestPutPipelineAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
-        PutPipelineRequest request = new PutPipelineRequest(restRequest.param("id"), RestActions.getRestContent(restRequest));
+        PutPipelineRequest request = new PutPipelineRequest(restRequest.param("id"), restRequest.contentOrSourceParam());
         request.masterNodeTimeout(restRequest.paramAsTime("master_timeout", request.masterNodeTimeout()));
         request.timeout(restRequest.paramAsTime("timeout", request.timeout()));
         return channel -> client.admin().cluster().putPipeline(request, new AcknowledgedRestListener<>(channel));

--- a/core/src/main/java/org/elasticsearch/rest/action/ingest/RestSimulatePipelineAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/ingest/RestSimulatePipelineAction.java
@@ -44,7 +44,7 @@ public class RestSimulatePipelineAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
-        SimulatePipelineRequest request = new SimulatePipelineRequest(RestActions.getRestContent(restRequest));
+        SimulatePipelineRequest request = new SimulatePipelineRequest(restRequest.contentOrSourceParam());
         request.setId(restRequest.param("id"));
         request.setVerbose(restRequest.paramAsBoolean("verbose", false));
         return channel -> client.admin().cluster().simulatePipeline(request, new RestToXContentListener<>(channel));

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -56,15 +55,14 @@ public class RestClearScrollAction extends BaseRestHandler {
         ClearScrollRequest clearRequest = new ClearScrollRequest();
         clearRequest.setScrollIds(Arrays.asList(splitScrollIds(scrollIds)));
         if (request.hasContentOrSourceParam()) {
-            XContentType type = RestActions.guessBodyContentType(request);
-           if (type == null) {
-               scrollIds = RestActions.getRestContent(request).utf8ToString();
-               clearRequest.setScrollIds(Arrays.asList(splitScrollIds(scrollIds)));
-           } else {
-               // NOTE: if rest request with xcontent body has request parameters, these parameters does not override xcontent value
-               clearRequest.setScrollIds(null);
-               buildFromContent(RestActions.getRestContent(request), clearRequest);
-           }
+            if (request.contentOrSourceParamXContentType() == null) {
+                scrollIds = RestActions.getRestContent(request).utf8ToString();
+                clearRequest.setScrollIds(Arrays.asList(splitScrollIds(scrollIds)));
+            } else {
+                // NOTE: if rest request with xcontent body has request parameters, these parameters does not override xcontent value
+                clearRequest.setScrollIds(null);
+                buildFromContent(RestActions.getRestContent(request), clearRequest);
+            }
         }
 
         return channel -> client.clearScroll(clearRequest, new RestStatusToXContentListener<ClearScrollResponse>(channel));

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
@@ -23,8 +23,10 @@ import org.elasticsearch.action.search.ClearScrollRequest;
 import org.elasticsearch.action.search.ClearScrollResponse;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
@@ -51,9 +53,10 @@ public class RestClearScrollAction extends BaseRestHandler {
         String scrollIds = request.param("scroll_id");
         ClearScrollRequest clearRequest = new ClearScrollRequest();
         clearRequest.setScrollIds(Arrays.asList(splitScrollIds(scrollIds)));
-        if (request.hasContentOrSourceParam()) {
-            if (request.contentOrSourceParamXContentType() == null) {
-                scrollIds = request.contentOrSourceParamString();
+        BytesReference body = request.contentOrSourceParam();
+        if (body != null) {
+            if (XContentFactory.xContentType(body)  == null) {
+                scrollIds = body.utf8ToString();
                 clearRequest.setScrollIds(Arrays.asList(splitScrollIds(scrollIds)));
             } else {
                 // NOTE: if rest request with xcontent body has request parameters, these parameters does not override xcontent value

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
@@ -55,7 +55,7 @@ public class RestClearScrollAction extends BaseRestHandler {
         String scrollIds = request.param("scroll_id");
         ClearScrollRequest clearRequest = new ClearScrollRequest();
         clearRequest.setScrollIds(Arrays.asList(splitScrollIds(scrollIds)));
-        if (RestActions.hasBodyContent(request)) {
+        if (request.hasContentOrSourceParam()) {
             XContentType type = RestActions.guessBodyContentType(request);
            if (type == null) {
                scrollIds = RestActions.getRestContent(request).utf8ToString();

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
@@ -54,8 +54,8 @@ public class RestClearScrollAction extends BaseRestHandler {
         ClearScrollRequest clearRequest = new ClearScrollRequest();
         clearRequest.setScrollIds(Arrays.asList(splitScrollIds(scrollIds)));
         BytesReference body = request.contentOrSourceParam();
-        if (body != null) {
-            if (XContentFactory.xContentType(body)  == null) {
+        if (body.length() > 0) {
+            if (XContentFactory.xContentType(body) == null) {
                 scrollIds = body.utf8ToString();
                 clearRequest.setScrollIds(Arrays.asList(splitScrollIds(scrollIds)));
             } else {

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestExplainAction.java
@@ -69,7 +69,7 @@ public class RestExplainAction extends BaseRestHandler {
         explainRequest.routing(request.param("routing"));
         explainRequest.preference(request.param("preference"));
         String queryString = request.param("q");
-        if (RestActions.hasBodyContent(request)) {
+        if (request.hasContentOrSourceParam()) {
             BytesReference restContent = RestActions.getRestContent(request);
             explainRequest.query(RestActions.getQueryContent(restContent, indicesQueriesRegistry, parseFieldMatcher));
         } else if (queryString != null) {

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestExplainAction.java
@@ -70,17 +70,14 @@ public class RestExplainAction extends BaseRestHandler {
         explainRequest.routing(request.param("routing"));
         explainRequest.preference(request.param("preference"));
         String queryString = request.param("q");
-        XContentParser parser = request.contentOrSourceParamParserOrNull();
-        try {
+        request.withContentOrSourceParamParserOrNull(parser -> {
             if (parser != null) {
                 explainRequest.query(RestActions.getQueryContent(parser, indicesQueriesRegistry, parseFieldMatcher));
             } else if (queryString != null) {
                 QueryBuilder query = RestActions.urlParamsToQueryBuilder(request);
                 explainRequest.query(query);
             }
-        } finally {
-            IOUtils.close(parser);
-        }
+        });
 
         if (request.param("fields") != null) {
             throw new IllegalArgumentException("The parameter [fields] is no longer supported, " +

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestExplainAction.java
@@ -20,14 +20,15 @@
 package org.elasticsearch.rest.action.search;
 
 import org.apache.lucene.search.Explanation;
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.action.explain.ExplainRequest;
 import org.elasticsearch.action.explain.ExplainResponse;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.indices.query.IndicesQueriesRegistry;
@@ -69,12 +70,16 @@ public class RestExplainAction extends BaseRestHandler {
         explainRequest.routing(request.param("routing"));
         explainRequest.preference(request.param("preference"));
         String queryString = request.param("q");
-        if (request.hasContentOrSourceParam()) {
-            BytesReference restContent = RestActions.getRestContent(request);
-            explainRequest.query(RestActions.getQueryContent(restContent, indicesQueriesRegistry, parseFieldMatcher));
-        } else if (queryString != null) {
-            QueryBuilder query = RestActions.urlParamsToQueryBuilder(request);
-            explainRequest.query(query);
+        XContentParser parser = request.contentOrSourceParamParserOrNull();
+        try {
+            if (parser != null) {
+                explainRequest.query(RestActions.getQueryContent(parser, indicesQueriesRegistry, parseFieldMatcher));
+            } else if (queryString != null) {
+                QueryBuilder query = RestActions.urlParamsToQueryBuilder(request);
+                explainRequest.query(query);
+            }
+        } finally {
+            IOUtils.close(parser);
         }
 
         if (request.param("fields") != null) {

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -36,7 +36,6 @@ import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.search.SearchRequestParsers;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -115,7 +114,7 @@ public class RestMultiSearchAction extends BaseRestHandler {
         String searchType = request.param("search_type");
         String routing = request.param("routing");
 
-        final BytesReference data = RestActions.getRestContent(request);
+        final BytesReference data = request.contentOrSourceParam();
 
         XContent xContent = XContentFactory.xContent(data);
         int from = 0;

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -88,10 +88,10 @@ public class RestMultiSearchAction extends BaseRestHandler {
             multiRequest.maxConcurrentSearchRequests(restRequest.paramAsInt("max_concurrent_searches", 0));
         }
 
-        parseMultiLineRequest(restRequest, multiRequest.indicesOptions(), allowExplicitIndex, (searchRequest, bytes) -> {
-            try (XContentParser requestParser = XContentFactory.xContent(bytes).createParser(bytes)) {
-                final QueryParseContext queryParseContext = new QueryParseContext(searchRequestParsers.queryParsers,
-                    requestParser, parseFieldMatcher);
+        parseMultiLineRequest(restRequest, multiRequest.indicesOptions(), allowExplicitIndex, (searchRequest, parser) -> {
+            try {
+                final QueryParseContext queryParseContext = new QueryParseContext(searchRequestParsers.queryParsers, parser,
+                        parseFieldMatcher);
                 searchRequest.source(SearchSourceBuilder.fromXContent(queryParseContext,
                     searchRequestParsers.aggParsers, searchRequestParsers.suggesters, searchRequestParsers.searchExtParsers));
                 multiRequest.add(searchRequest);
@@ -107,7 +107,7 @@ public class RestMultiSearchAction extends BaseRestHandler {
      * Parses a multi-line {@link RestRequest} body, instanciating a {@link SearchRequest} for each line and applying the given consumer.
      */
     public static void parseMultiLineRequest(RestRequest request, IndicesOptions indicesOptions, boolean allowExplicitIndex,
-                                             BiConsumer<SearchRequest, BytesReference> consumer) throws IOException {
+                                             BiConsumer<SearchRequest, XContentParser> consumer) throws IOException {
 
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         String[] types = Strings.splitStringByCommaToArray(request.param("type"));
@@ -186,7 +186,10 @@ public class RestMultiSearchAction extends BaseRestHandler {
             if (nextMarker == -1) {
                 break;
             }
-            consumer.accept(searchRequest, data.slice(from, nextMarker - from));
+            BytesReference bytes = data.slice(from, nextMarker - from);
+            try (XContentParser parser = XContentFactory.xContent(bytes).createParser(bytes)) {
+                consumer.accept(searchRequest, parser);
+            }
             // move pointers
             from = nextMarker + 1;
         }

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -74,7 +74,7 @@ public class RestSearchAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         SearchRequest searchRequest = new SearchRequest();
-        BytesReference restContent = RestActions.hasBodyContent(request) ? RestActions.getRestContent(request) : null;
+        BytesReference restContent = request.hasContentOrSourceParam() ? RestActions.getRestContent(request) : null;
         parseSearchRequest(searchRequest, request, searchRequestParsers, parseFieldMatcher, restContent);
 
         return channel -> client.search(searchRequest, new RestStatusToXContentListener<>(channel));

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.rest.action.search;
 
-import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -73,12 +72,8 @@ public class RestSearchAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         SearchRequest searchRequest = new SearchRequest();
-        XContentParser parser = request.contentOrSourceParamParserOrNull();
-        try {
-            parseSearchRequest(searchRequest, request, searchRequestParsers, parseFieldMatcher, parser);
-        } finally {
-            IOUtils.close(parser);
-        }
+        request.withContentOrSourceParamParserOrNull(parser ->
+            parseSearchRequest(searchRequest, request, searchRequestParsers, parseFieldMatcher, parser));
 
         return channel -> client.search(searchRequest, new RestStatusToXContentListener<>(channel));
     }

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -84,13 +84,10 @@ public class RestSearchAction extends BaseRestHandler {
     }
 
     /**
-     * Parses the rest request on top of the SearchRequest, preserving values
-     * that are not overridden by the rest request.
+     * Parses the rest request on top of the SearchRequest, preserving values that are not overridden by the rest request.
      *
-     * @param restContent
-     *            override body content to use for the request. If null body
-     *            content is read from the request using
-     *            RestAction.hasBodyContent.
+     * @param requestContentParser body of the request to read. This method does not attempt to read the body from the {@code request}
+     *        parameter
      */
     public static void parseSearchRequest(SearchRequest searchRequest, RestRequest request, SearchRequestParsers searchRequestParsers,
                                           ParseFieldMatcher parseFieldMatcher, XContentParser requestContentParser) throws IOException {

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
@@ -61,8 +62,8 @@ public class RestSearchScrollAction extends BaseRestHandler {
         }
 
         BytesReference body = request.contentOrSourceParam();
-        if (body != null) {
-            if (request.contentOrSourceParamXContentType() == null) {
+        if (body.length() > 0) {
+            if (XContentFactory.xContentType(body) == null) {
                 if (scrollId == null) {
                     scrollId = body.utf8ToString();
                     searchScrollRequest.scrollId(scrollId);

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
@@ -64,7 +64,7 @@ public class RestSearchScrollAction extends BaseRestHandler {
             searchScrollRequest.scroll(new Scroll(parseTimeValue(scroll, null, "scroll")));
         }
 
-        if (RestActions.hasBodyContent(request)) {
+        if (request.hasContentOrSourceParam()) {
             XContentType type = XContentFactory.xContentType(RestActions.getRestContent(request));
             if (type == null) {
                 if (scrollId == null) {

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.rest.action.search;
 
 import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -59,10 +60,11 @@ public class RestSearchScrollAction extends BaseRestHandler {
             searchScrollRequest.scroll(new Scroll(parseTimeValue(scroll, null, "scroll")));
         }
 
-        if (request.hasContentOrSourceParam()) {
+        BytesReference body = request.contentOrSourceParam();
+        if (body != null) {
             if (request.contentOrSourceParamXContentType() == null) {
                 if (scrollId == null) {
-                    scrollId = request.contentOrSourceParamString();
+                    scrollId = body.utf8ToString();
                     searchScrollRequest.scrollId(scrollId);
                 }
             } else {

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestSuggestAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestSuggestAction.java
@@ -70,7 +70,7 @@ public class RestSuggestAction extends BaseRestHandler {
         final SearchRequest searchRequest = new SearchRequest(
                 Strings.splitStringByCommaToArray(request.param("index")), new SearchSourceBuilder());
         searchRequest.indicesOptions(IndicesOptions.fromRequest(request, searchRequest.indicesOptions()));
-        if (RestActions.hasBodyContent(request)) {
+        if (request.hasContentOrSourceParam()) {
             final BytesReference sourceBytes = RestActions.getRestContent(request);
             try (XContentParser parser = XContentFactory.xContent(sourceBytes).createParser(sourceBytes)) {
                 final QueryParseContext context = new QueryParseContext(searchRequestParsers.queryParsers, parser, parseFieldMatcher);

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestSuggestAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestSuggestAction.java
@@ -24,11 +24,9 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -37,7 +35,6 @@ import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.rest.action.RestBuilderListener;
 import org.elasticsearch.search.SearchRequestParsers;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -70,14 +67,9 @@ public class RestSuggestAction extends BaseRestHandler {
         final SearchRequest searchRequest = new SearchRequest(
                 Strings.splitStringByCommaToArray(request.param("index")), new SearchSourceBuilder());
         searchRequest.indicesOptions(IndicesOptions.fromRequest(request, searchRequest.indicesOptions()));
-        if (request.hasContentOrSourceParam()) {
-            final BytesReference sourceBytes = RestActions.getRestContent(request);
-            try (XContentParser parser = XContentFactory.xContent(sourceBytes).createParser(sourceBytes)) {
-                final QueryParseContext context = new QueryParseContext(searchRequestParsers.queryParsers, parser, parseFieldMatcher);
-                searchRequest.source().suggest(SuggestBuilder.fromXContent(context, searchRequestParsers.suggesters));
-            }
-        } else {
-            throw new IllegalArgumentException("no content or source provided to execute suggestion");
+        try (XContentParser parser = request.contentOrSourceParamParser()) {
+            final QueryParseContext context = new QueryParseContext(searchRequestParsers.queryParsers, parser, parseFieldMatcher);
+            searchRequest.source().suggest(SuggestBuilder.fromXContent(context, searchRequestParsers.suggesters));
         }
         searchRequest.routing(request.param("routing"));
         searchRequest.preference(request.param("preference"));

--- a/core/src/test/java/org/elasticsearch/action/fieldstats/FieldStatsRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/fieldstats/FieldStatsRequestTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.fieldstats;
 
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.StreamsUtils;
 
@@ -34,11 +35,11 @@ import static org.hamcrest.Matchers.equalTo;
 public class FieldStatsRequestTests extends ESTestCase {
 
     public void testFieldsParsing() throws Exception {
-        byte[] data =
+        BytesArray data = new BytesArray(
             StreamsUtils.copyToBytesFromClasspath("/org/elasticsearch/action/fieldstats/" +
-                "fieldstats-index-constraints-request.json");
+                "fieldstats-index-constraints-request.json"));
         FieldStatsRequest request = new FieldStatsRequest();
-        request.source(new BytesArray(data));
+        request.source(XContentFactory.xContent(data).createParser(data));
 
         assertThat(request.getFields().length, equalTo(5));
         assertThat(request.getFields()[0], equalTo("field1"));

--- a/core/src/test/java/org/elasticsearch/action/termvectors/TermVectorsUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/action/termvectors/TermVectorsUnitTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.AllFieldMapper;
@@ -289,16 +290,16 @@ public class TermVectorsUnitTests extends ESTestCase {
     }
 
     public void testMultiParser() throws Exception {
-        byte[] data = StreamsUtils.copyToBytesFromClasspath("/org/elasticsearch/action/termvectors/multiRequest1.json");
-        BytesReference bytes = new BytesArray(data);
+        byte[] bytes = StreamsUtils.copyToBytesFromClasspath("/org/elasticsearch/action/termvectors/multiRequest1.json");
+        XContentParser data = XContentHelper.createParser(new BytesArray(bytes));
         MultiTermVectorsRequest request = new MultiTermVectorsRequest();
-        request.add(new TermVectorsRequest(), bytes);
+        request.add(new TermVectorsRequest(), data);
         checkParsedParameters(request);
 
-        data = StreamsUtils.copyToBytesFromClasspath("/org/elasticsearch/action/termvectors/multiRequest2.json");
-        bytes = new BytesArray(data);
+        bytes = StreamsUtils.copyToBytesFromClasspath("/org/elasticsearch/action/termvectors/multiRequest2.json");
+        data = XContentHelper.createParser(new BytesArray(bytes));
         request = new MultiTermVectorsRequest();
-        request.add(new TermVectorsRequest(), bytes);
+        request.add(new TermVectorsRequest(), data);
         checkParsedParameters(request);
     }
 
@@ -325,10 +326,10 @@ public class TermVectorsUnitTests extends ESTestCase {
 
     // issue #12311
     public void testMultiParserFilter() throws Exception {
-        byte[] data = StreamsUtils.copyToBytesFromClasspath("/org/elasticsearch/action/termvectors/multiRequest3.json");
-        BytesReference bytes = new BytesArray(data);
+        byte[] bytes = StreamsUtils.copyToBytesFromClasspath("/org/elasticsearch/action/termvectors/multiRequest3.json");
+        XContentParser data = XContentHelper.createParser(new BytesArray(bytes));
         MultiTermVectorsRequest request = new MultiTermVectorsRequest();
-        request.add(new TermVectorsRequest(), bytes);
+        request.add(new TermVectorsRequest(), data);
         checkParsedFilterParameters(request);
     }
 

--- a/core/src/test/java/org/elasticsearch/rest/RestRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/RestRequestTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -46,19 +45,6 @@ public class RestRequestTests extends ESTestCase {
         assertEquals(true, new ContentRestRequest("stuff", emptyMap()).hasContentOrSourceParam());
         assertEquals(true, new ContentRestRequest("stuff", singletonMap("source", "stuff2")).hasContentOrSourceParam());
         assertEquals(true, new ContentRestRequest("", singletonMap("source", "stuff")).hasContentOrSourceParam());
-    }
-
-    public void testContentOrSourceParamXContentType() throws IOException {
-        assertNull(new ContentRestRequest("", emptyMap()).contentOrSourceParamXContentType());
-        assertNull(new ContentRestRequest("stuff", emptyMap()).contentOrSourceParamXContentType());
-        assertNull(new ContentRestRequest("stuff", singletonMap("source", "stuff2")).contentOrSourceParamXContentType());
-        assertNull(new ContentRestRequest("", singletonMap("source", "stuff")).contentOrSourceParamXContentType());
-        assertEquals(XContentType.JSON, new ContentRestRequest("{}", emptyMap()).contentOrSourceParamXContentType());
-        assertEquals(XContentType.JSON, new ContentRestRequest("{}", singletonMap("source", "stuff2")).contentOrSourceParamXContentType());
-        assertEquals(XContentType.JSON, new ContentRestRequest("", singletonMap("source", "{}")).contentOrSourceParamXContentType());
-        assertEquals(XContentType.YAML, new ContentRestRequest("---", emptyMap()).contentOrSourceParamXContentType());
-        assertEquals(XContentType.YAML, new ContentRestRequest("---", singletonMap("source", "stuff2")).contentOrSourceParamXContentType());
-        assertEquals(XContentType.YAML, new ContentRestRequest("", singletonMap("source", "---")).contentOrSourceParamXContentType());
     }
 
     public void testContentOrSourceParamParserOrNull() throws IOException {

--- a/core/src/test/java/org/elasticsearch/rest/RestRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/RestRequestTests.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+
+public class RestRequestTests extends ESTestCase {
+    public void testContentOrSourceParamParserOrNull() throws IOException {
+        assertNull(new ContentRestRequest("", emptyMap()).contentOrSourceParamParserOrNull());
+        assertEquals(emptyMap(), new ContentRestRequest("{}", emptyMap()).contentOrSourceParamParserOrNull().map());
+        assertEquals(emptyMap(), new ContentRestRequest("", singletonMap("source", "{}")).contentOrSourceParamParserOrNull().map());
+    }
+
+    public void testContentOrSourceParamParser() throws IOException {
+        Exception e = expectThrows(ElasticsearchParseException.class, () ->
+            new ContentRestRequest("", emptyMap()).contentOrSourceParamParser());
+        assertEquals("Body required", e.getMessage());
+        assertEquals(emptyMap(), new ContentRestRequest("{}", emptyMap()).contentOrSourceParamParser().map());
+        assertEquals(emptyMap(), new ContentRestRequest("", singletonMap("source", "{}")).contentOrSourceParamParser().map());
+    }
+
+    private static final class ContentRestRequest extends RestRequest {
+        private final BytesArray content;
+        public ContentRestRequest(String content, Map<String, String> params) {
+            super(params, "not used by this test");
+            this.content = new BytesArray(content);
+        }
+
+        @Override
+        public boolean hasContent() {
+            return Strings.hasLength(content);
+        }
+        
+        @Override
+        public BytesReference content() {
+            return content;
+        }
+
+        @Override
+        public String uri() {
+            throw new UnsupportedOperationException("Not used by this test");
+        }
+
+        @Override
+        public Method method() {
+            throw new UnsupportedOperationException("Not used by this test");
+        }
+
+        @Override
+        public Iterable<Entry<String, String>> headers() {
+            throw new UnsupportedOperationException("Not used by this test");
+        }
+
+        @Override
+        public String header(String name) {
+            throw new UnsupportedOperationException("Not used by this test");
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/scroll/RestClearScrollActionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/scroll/RestClearScrollActionTests.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.scroll;
+
+import org.elasticsearch.action.search.ClearScrollRequest;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.search.RestClearScrollAction;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.Mockito.mock;
+
+public class RestClearScrollActionTests extends ESTestCase {
+    public void testParseClearScrollRequest() throws Exception {
+        XContentParser content = XContentHelper.createParser(XContentFactory.jsonBuilder()
+                .startObject()
+                    .array("scroll_id", "value_1", "value_2")
+                .endObject().bytes());
+        ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
+        RestClearScrollAction.buildFromContent(content, clearScrollRequest);
+        assertThat(clearScrollRequest.scrollIds(), contains("value_1", "value_2"));
+    }
+
+    public void testParseClearScrollRequestWithInvalidJsonThrowsException() throws Exception {
+        RestClearScrollAction action = new RestClearScrollAction(Settings.EMPTY, mock(RestController.class));
+        RestRequest request = new FakeRestRequest.Builder().withContent(new BytesArray("{invalid_json}")).build();
+        Exception e = expectThrows(IllegalArgumentException.class, () -> action.prepareRequest(request, null));
+        assertThat(e.getMessage(), equalTo("Failed to parse request body"));
+    }
+
+    public void testParseClearScrollRequestWithUnknownParamThrowsException() throws Exception {
+        XContentParser invalidContent = XContentHelper.createParser(XContentFactory.jsonBuilder()
+                .startObject()
+                    .array("scroll_id", "value_1", "value_2")
+                    .field("unknown", "keyword")
+                .endObject().bytes());
+        ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
+
+        Exception e = expectThrows(IllegalArgumentException.class,
+                () -> RestClearScrollAction.buildFromContent(invalidContent, clearScrollRequest));
+        assertThat(e.getMessage(), startsWith("Unknown parameter [unknown]"));
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/search/scroll/RestSearchScrollActionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/scroll/RestSearchScrollActionTests.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.scroll;
+
+import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.search.RestSearchScrollAction;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.Mockito.mock;
+
+public class RestSearchScrollActionTests extends ESTestCase {
+    public void testParseSearchScrollRequest() throws Exception {
+        XContentParser content = XContentHelper.createParser(XContentFactory.jsonBuilder()
+            .startObject()
+                .field("scroll_id", "SCROLL_ID")
+                .field("scroll", "1m")
+            .endObject().bytes());
+
+        SearchScrollRequest searchScrollRequest = new SearchScrollRequest();
+        RestSearchScrollAction.buildFromContent(content, searchScrollRequest);
+
+        assertThat(searchScrollRequest.scrollId(), equalTo("SCROLL_ID"));
+        assertThat(searchScrollRequest.scroll().keepAlive(), equalTo(TimeValue.parseTimeValue("1m", null, "scroll")));
+    }
+
+    public void testParseSearchScrollRequestWithInvalidJsonThrowsException() throws Exception {
+        RestSearchScrollAction action = new RestSearchScrollAction(Settings.EMPTY, mock(RestController.class));
+        RestRequest request = new FakeRestRequest.Builder().withContent(new BytesArray("{invalid_json}")).build();
+        Exception e = expectThrows(IllegalArgumentException.class, () -> action.prepareRequest(request, null));
+        assertThat(e.getMessage(), equalTo("Failed to parse request body"));
+    }
+
+    public void testParseSearchScrollRequestWithUnknownParamThrowsException() throws Exception {
+        SearchScrollRequest searchScrollRequest = new SearchScrollRequest();
+        XContentParser invalidContent = XContentHelper.createParser(XContentFactory.jsonBuilder()
+                .startObject()
+                    .field("scroll_id", "value_2")
+                    .field("unknown", "keyword")
+                .endObject().bytes());
+
+        Exception e = expectThrows(IllegalArgumentException.class,
+                () -> RestSearchScrollAction.buildFromContent(invalidContent, searchScrollRequest));
+        assertThat(e.getMessage(), startsWith("Unknown parameter [unknown]"));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/scroll/SearchScrollIT.java
+++ b/core/src/test/java/org/elasticsearch/search/scroll/SearchScrollIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.scroll;
 
-import org.elasticsearch.action.search.ClearScrollRequest;
 import org.elasticsearch.action.search.ClearScrollResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -38,7 +37,6 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.rest.action.search.RestClearScrollAction;
 import org.elasticsearch.rest.action.search.RestSearchScrollAction;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.FieldSortBuilder;
@@ -60,7 +58,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoSe
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThrows;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
@@ -534,43 +531,6 @@ public class SearchScrollIT extends ESIntegTestCase {
 
         try {
             RestSearchScrollAction.buildFromContent(invalidContent, searchScrollRequest);
-            fail("expected parseContent failure");
-        } catch (Exception e) {
-            assertThat(e, instanceOf(IllegalArgumentException.class));
-            assertThat(e.getMessage(), startsWith("Unknown parameter [unknown]"));
-        }
-    }
-
-    public void testParseClearScrollRequest() throws Exception {
-        BytesReference content = XContentFactory.jsonBuilder().startObject()
-            .array("scroll_id", "value_1", "value_2")
-            .endObject().bytes();
-        ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
-        RestClearScrollAction.buildFromContent(content, clearScrollRequest);
-        assertThat(clearScrollRequest.scrollIds(), contains("value_1", "value_2"));
-    }
-
-    public void testParseClearScrollRequestWithInvalidJsonThrowsException() throws Exception {
-        ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
-
-        try {
-            RestClearScrollAction.buildFromContent(new BytesArray("{invalid_json}"), clearScrollRequest);
-            fail("expected parseContent failure");
-        } catch (Exception e) {
-            assertThat(e, instanceOf(IllegalArgumentException.class));
-            assertThat(e.getMessage(), equalTo("Failed to parse request body"));
-        }
-    }
-
-    public void testParseClearScrollRequestWithUnknownParamThrowsException() throws Exception {
-        BytesReference invalidContent = XContentFactory.jsonBuilder().startObject()
-            .array("scroll_id", "value_1", "value_2")
-            .field("unknown", "keyword")
-            .endObject().bytes();
-        ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
-
-        try {
-            RestClearScrollAction.buildFromContent(invalidContent, clearScrollRequest);
             fail("expected parseContent failure");
         } catch (Exception e) {
             assertThat(e, instanceOf(IllegalArgumentException.class));

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
@@ -55,7 +55,7 @@ public class RestMultiSearchTemplateAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        if (RestActions.hasBodyContent(request) == false) {
+        if (request.hasContentOrSourceParam() == false) {
             throw new ElasticsearchException("request body is required");
         }
 

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestRenderSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestRenderSearchTemplateAction.java
@@ -22,10 +22,10 @@ package org.elasticsearch.script.mustache;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.script.ScriptType;
 
@@ -48,7 +48,10 @@ public class RestRenderSearchTemplateAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         // Creates the render template request
-        SearchTemplateRequest renderRequest = RestSearchTemplateAction.parse(RestActions.getRestContent(request));
+        SearchTemplateRequest renderRequest;
+        try (XContentParser parser = request.contentOrSourceParamParser()) {
+            renderRequest = RestSearchTemplateAction.parse(parser);
+        }
         renderRequest.setSimulate(true);
 
         String id = request.param("id");

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestSearchTemplateAction.java
@@ -97,7 +97,7 @@ public class RestSearchTemplateAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        if (RestActions.hasBodyContent(request) == false) {
+        if (request.hasContentOrSourceParam() == false) {
             throw new ElasticsearchException("request body is required");
         }
 

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestSearchTemplateAction.java
@@ -26,18 +26,15 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.ParseFieldMatcherSupplier;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.rest.action.RestStatusToXContentListener;
 import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.script.ScriptType;
@@ -50,7 +47,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 public class RestSearchTemplateAction extends BaseRestHandler {
 
-    private static ObjectParser<SearchTemplateRequest, ParseFieldMatcherSupplier> PARSER;
+    private static final ObjectParser<SearchTemplateRequest, ParseFieldMatcherSupplier> PARSER;
     static {
         PARSER = new ObjectParser<>("search_template");
         PARSER.declareField((parser, request, s) ->
@@ -106,15 +103,16 @@ public class RestSearchTemplateAction extends BaseRestHandler {
         RestSearchAction.parseSearchRequest(searchRequest, request, searchRequestParsers, parseFieldMatcher, null);
 
         // Creates the search template request
-        SearchTemplateRequest searchTemplateRequest = parse(RestActions.getRestContent(request));
+        SearchTemplateRequest searchTemplateRequest;
+        try (XContentParser parser = request.contentOrSourceParamParser()) {
+            searchTemplateRequest = PARSER.parse(parser, new SearchTemplateRequest(), () -> ParseFieldMatcher.EMPTY);
+        }
         searchTemplateRequest.setRequest(searchRequest);
 
         return channel -> client.execute(SearchTemplateAction.INSTANCE, searchTemplateRequest, new RestStatusToXContentListener<>(channel));
     }
 
-    public static SearchTemplateRequest parse(BytesReference bytes) throws IOException {
-        try (XContentParser parser = XContentHelper.createParser(bytes)) {
-            return PARSER.parse(parser, new SearchTemplateRequest(), () -> ParseFieldMatcher.STRICT);
-        }
+    public static SearchTemplateRequest parse(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, new SearchTemplateRequest(), () -> ParseFieldMatcher.EMPTY);
     }
 }

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/SearchTemplateIT.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/SearchTemplateIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -95,7 +96,7 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
         searchRequest.indices("_all");
         String query = "{" + "  \"inline\" : \"{ \\\"size\\\": \\\"{{size}}\\\", \\\"query\\\":{\\\"match_all\\\":{}}}\","
                 + "  \"params\":{" + "    \"size\": 1" + "  }" + "}";
-        SearchTemplateRequest request = RestSearchTemplateAction.parse(new BytesArray(query));
+        SearchTemplateRequest request = RestSearchTemplateAction.parse(XContentHelper.createParser(new BytesArray(query)));
         request.setRequest(searchRequest);
         SearchTemplateResponse searchResponse = client().execute(SearchTemplateAction.INSTANCE, request).get();
         assertThat(searchResponse.getResponse().getHits().hits().length, equalTo(1));
@@ -111,7 +112,7 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
         String templateString = "{"
                 + "  \"inline\" : \"{ {{#use_size}} \\\"size\\\": \\\"{{size}}\\\", {{/use_size}} \\\"query\\\":{\\\"match_all\\\":{}}}\","
                 + "  \"params\":{" + "    \"size\": 1," + "    \"use_size\": true" + "  }" + "}";
-        SearchTemplateRequest request = RestSearchTemplateAction.parse(new BytesArray(templateString));
+        SearchTemplateRequest request = RestSearchTemplateAction.parse(XContentHelper.createParser(new BytesArray(templateString)));
         request.setRequest(searchRequest);
         SearchTemplateResponse searchResponse = client().execute(SearchTemplateAction.INSTANCE, request).get();
         assertThat(searchResponse.getResponse().getHits().hits().length, equalTo(1));
@@ -127,7 +128,7 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
         String templateString = "{"
                 + "  \"inline\" : \"{ \\\"query\\\":{\\\"match_all\\\":{}} {{#use_size}}, \\\"size\\\": \\\"{{size}}\\\" {{/use_size}} }\","
                 + "  \"params\":{" + "    \"size\": 1," + "    \"use_size\": true" + "  }" + "}";
-        SearchTemplateRequest request = RestSearchTemplateAction.parse(new BytesArray(templateString));
+        SearchTemplateRequest request = RestSearchTemplateAction.parse(XContentHelper.createParser(new BytesArray(templateString)));
         request.setRequest(searchRequest);
         SearchTemplateResponse searchResponse = client().execute(SearchTemplateAction.INSTANCE, request).get();
         assertThat(searchResponse.getResponse().getHits().hits().length, equalTo(1));

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/SearchTemplateRequestTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/SearchTemplateRequestTests.java
@@ -21,10 +21,12 @@ package org.elasticsearch.script.mustache;
 
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.IOException;
 import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -50,7 +52,7 @@ public class SearchTemplateRequestTests extends ESTestCase {
                 "  }" +
                 "}";
 
-        SearchTemplateRequest request = RestSearchTemplateAction.parse(newBytesReference(source));
+        SearchTemplateRequest request = RestSearchTemplateAction.parse(newParser(source));
         assertThat(request.getScript(), equalTo("{\"query\":{\"terms\":{\"status\":[\"{{#status}}\",\"{{.}}\",\"{{/status}}\"]}}}"));
         assertThat(request.getScriptType(), equalTo(ScriptType.INLINE));
         assertThat(request.getScriptParams(), nullValue());
@@ -69,7 +71,7 @@ public class SearchTemplateRequestTests extends ESTestCase {
                 "    }" +
                 "}";
 
-        SearchTemplateRequest request = RestSearchTemplateAction.parse(newBytesReference(source));
+        SearchTemplateRequest request = RestSearchTemplateAction.parse(newParser(source));
         assertThat(request.getScript(), equalTo("{\"query\":{\"match\":{\"{{my_field}}\":\"{{my_value}}\"}},\"size\":\"{{my_size}}\"}"));
         assertThat(request.getScriptType(), equalTo(ScriptType.INLINE));
         assertThat(request.getScriptParams().size(), equalTo(3));
@@ -81,7 +83,7 @@ public class SearchTemplateRequestTests extends ESTestCase {
     public void testParseInlineTemplateAsString() throws Exception {
         String source = "{'inline' : '{\\\"query\\\":{\\\"bool\\\":{\\\"must\\\":{\\\"match\\\":{\\\"foo\\\":\\\"{{text}}\\\"}}}}}'}";
 
-        SearchTemplateRequest request = RestSearchTemplateAction.parse(newBytesReference(source));
+        SearchTemplateRequest request = RestSearchTemplateAction.parse(newParser(source));
         assertThat(request.getScript(), equalTo("{\"query\":{\"bool\":{\"must\":{\"match\":{\"foo\":\"{{text}}\"}}}}}"));
         assertThat(request.getScriptType(), equalTo(ScriptType.INLINE));
         assertThat(request.getScriptParams(), nullValue());
@@ -92,7 +94,7 @@ public class SearchTemplateRequestTests extends ESTestCase {
         String source = "{'inline' : '{\\\"query\\\":{\\\"match\\\":{\\\"{{field}}\\\":\\\"{{value}}\\\"}}}', " +
                 "'params': {'status': ['pending', 'published']}}";
 
-        SearchTemplateRequest request = RestSearchTemplateAction.parse(newBytesReference(source));
+        SearchTemplateRequest request = RestSearchTemplateAction.parse(newParser(source));
         assertThat(request.getScript(), equalTo("{\"query\":{\"match\":{\"{{field}}\":\"{{value}}\"}}}"));
         assertThat(request.getScriptType(), equalTo(ScriptType.INLINE));
         assertThat(request.getScriptParams().size(), equalTo(1));
@@ -103,7 +105,7 @@ public class SearchTemplateRequestTests extends ESTestCase {
     public void testParseFileTemplate() throws Exception {
         String source = "{'file' : 'fileTemplate'}";
 
-        SearchTemplateRequest request = RestSearchTemplateAction.parse(newBytesReference(source));
+        SearchTemplateRequest request = RestSearchTemplateAction.parse(newParser(source));
         assertThat(request.getScript(), equalTo("fileTemplate"));
         assertThat(request.getScriptType(), equalTo(ScriptType.FILE));
         assertThat(request.getScriptParams(), nullValue());
@@ -112,7 +114,7 @@ public class SearchTemplateRequestTests extends ESTestCase {
     public void testParseFileTemplateWithParams() throws Exception {
         String source = "{'file' : 'template_foo', 'params' : {'foo': 'bar', 'size': 500}}";
 
-        SearchTemplateRequest request = RestSearchTemplateAction.parse(newBytesReference(source));
+        SearchTemplateRequest request = RestSearchTemplateAction.parse(newParser(source));
         assertThat(request.getScript(), equalTo("template_foo"));
         assertThat(request.getScriptType(), equalTo(ScriptType.FILE));
         assertThat(request.getScriptParams().size(), equalTo(2));
@@ -123,7 +125,7 @@ public class SearchTemplateRequestTests extends ESTestCase {
     public void testParseStoredTemplate() throws Exception {
         String source = "{'id' : 'storedTemplate'}";
 
-        SearchTemplateRequest request = RestSearchTemplateAction.parse(newBytesReference(source));
+        SearchTemplateRequest request = RestSearchTemplateAction.parse(newParser(source));
         assertThat(request.getScript(), equalTo("storedTemplate"));
         assertThat(request.getScriptType(), equalTo(ScriptType.STORED));
         assertThat(request.getScriptParams(), nullValue());
@@ -132,7 +134,7 @@ public class SearchTemplateRequestTests extends ESTestCase {
     public void testParseStoredTemplateWithParams() throws Exception {
         String source = "{'id' : 'another_template', 'params' : {'bar': 'foo'}}";
 
-        SearchTemplateRequest request = RestSearchTemplateAction.parse(newBytesReference(source));
+        SearchTemplateRequest request = RestSearchTemplateAction.parse(newParser(source));
         assertThat(request.getScript(), equalTo("another_template"));
         assertThat(request.getScriptType(), equalTo(ScriptType.STORED));
         assertThat(request.getScriptParams().size(), equalTo(1));
@@ -141,14 +143,14 @@ public class SearchTemplateRequestTests extends ESTestCase {
 
     public void testParseWrongTemplate() {
         // Unclosed template id
-        expectThrows(ParsingException.class, () -> RestSearchTemplateAction.parse(newBytesReference("{'id' : 'another_temp }")));
+        expectThrows(ParsingException.class, () -> RestSearchTemplateAction.parse(newParser("{'id' : 'another_temp }")));
     }
 
     /**
-     * Creates a {@link BytesReference} with the given string while replacing single quote to double quotes.
+     * Creates a {@link XContentParser} with the given String while replacing single quote to double quotes.
      */
-    private static BytesReference newBytesReference(String s) {
+    private static XContentParser newParser(String s) throws IOException {
         assertNotNull(s);
-        return new BytesArray(s.replace("'", "\""));
+        return XContentHelper.createParser(new BytesArray(s.replace("'", "\"")));
     }
 }

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/RestMultiPercolateAction.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/RestMultiPercolateAction.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.rest.action.RestToXContentListener;
 
 import java.io.IOException;
@@ -60,7 +59,7 @@ public class RestMultiPercolateAction extends BaseRestHandler {
         multiPercolateRequest.indicesOptions(IndicesOptions.fromRequest(restRequest, multiPercolateRequest.indicesOptions()));
         multiPercolateRequest.indices(Strings.splitStringByCommaToArray(restRequest.param("index")));
         multiPercolateRequest.documentType(restRequest.param("type"));
-        multiPercolateRequest.add(RestActions.getRestContent(restRequest), allowExplicitIndex);
+        multiPercolateRequest.add(restRequest.contentOrSourceParam(), allowExplicitIndex);
         return channel -> client.execute(MultiPercolateAction.INSTANCE, multiPercolateRequest, new RestToXContentListener<>(channel));
     }
 

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/RestPercolateAction.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/RestPercolateAction.java
@@ -65,7 +65,7 @@ public class RestPercolateAction extends BaseRestHandler {
         percolateRequest.documentType(restRequest.param("type"));
         percolateRequest.routing(restRequest.param("routing"));
         percolateRequest.preference(restRequest.param("preference"));
-        percolateRequest.source(RestActions.getRestContent(restRequest));
+        percolateRequest.source(restRequest.contentOrSourceParam());
 
         percolateRequest.indicesOptions(IndicesOptions.fromRequest(restRequest, percolateRequest.indicesOptions()));
         return channel -> executePercolate(client, percolateRequest, channel);
@@ -89,7 +89,7 @@ public class RestPercolateAction extends BaseRestHandler {
         percolateRequest.getRequest(getRequest);
         percolateRequest.routing(restRequest.param("percolate_routing"));
         percolateRequest.preference(restRequest.param("percolate_preference"));
-        percolateRequest.source(RestActions.getRestContent(restRequest));
+        percolateRequest.source(restRequest.contentOrSourceParam());
 
         percolateRequest.indicesOptions(IndicesOptions.fromRequest(restRequest, percolateRequest.indicesOptions()));
         return channel -> executePercolate(client, percolateRequest, channel);

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByQueryRestHandler.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByQueryRestHandler.java
@@ -58,7 +58,8 @@ public abstract class AbstractBulkByQueryRestHandler<
         int scrollSize = searchRequest.source().size();
         searchRequest.source().size(SIZE_ALL_MATCHES);
 
-        XContentParser searchRequestParser = extractRequestSpecificFieldsAndReturnSearchCompatibleParser(restRequest, bodyConsumers);
+        XContentParser searchRequestParser = extractRequestSpecificFieldsAndReturnSearchCompatibleParser(
+                restRequest.contentOrSourceParamParserOrNull(), bodyConsumers);
         try {
             RestSearchAction.parseSearchRequest(searchRequest, restRequest, searchRequestParsers, parseFieldMatcher, searchRequestParser);
         } finally {
@@ -86,9 +87,8 @@ public abstract class AbstractBulkByQueryRestHandler<
      * should get better when SearchRequest has full ObjectParser support
      * then we can delegate and stuff.
      */
-    private XContentParser extractRequestSpecificFieldsAndReturnSearchCompatibleParser(RestRequest restRequest,
+    private XContentParser extractRequestSpecificFieldsAndReturnSearchCompatibleParser(XContentParser parser,
                                       Map<String, Consumer<Object>> bodyConsumers) throws IOException {
-        XContentParser parser = restRequest.contentOrSourceParamParserOrNull();
         if (parser == null) {
             return parser;
         }

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByQueryRestHandler.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByQueryRestHandler.java
@@ -89,7 +89,7 @@ public abstract class AbstractBulkByQueryRestHandler<
          * should get better when SearchRequest has full ObjectParser support
          * then we can delegate and stuff.
          */
-        BytesReference content = RestActions.hasBodyContent(restRequest) ? RestActions.getRestContent(restRequest) : null;
+        BytesReference content = restRequest.hasContentOrSourceParam() ? RestActions.getRestContent(restRequest) : null;
         if ((content != null) && (consumers != null && consumers.size() > 0)) {
             Tuple<XContentType, Map<String, Object>> body = XContentHelper.convertToMap(content, false);
             boolean modified = false;


### PR DESCRIPTION
To get #22003 in cleanly we need to centralize as much `XContentParser` creation as possible into `RestRequest`. That'll mean we have to plumb the `NamedXContentRegistry` into fewer places.

This removes `RestAction.hasBody`, `RestAction.guessBodyContentType`, and `RestActions.getRestContent`, moving callers over to `RestRequest.hasContentOrSourceParam`, `RestRequest.contentOrSourceParam`, and `RestRequest.contentOrSourceParamParser` and `RestRequest.withContentOrSourceParamParserOrNull`. The idea is to use `withContentOrSourceParamParserOrNull` if you need to handle requests without any sort of body content and to use `contentOrSourceParamParser` otherwise.

I believe the vast majority of this PR to be purely mechanical but I know I've made the following behavioral change (I'll add more if I think of more):
* If you make a request to an endpoint that requires a request body and has cut over to the new APIs instead of getting `Failed to derive xcontent` you'll get `Body required`.
* Template parsing is now non-strict by default. This is important because we need to be able to deprecate things without requests failing.