### PR TITLE
Move all protocol parsing logic into TcpTransport

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/compress/CompressorFactory.java
+++ b/core/src/main/java/org/elasticsearch/common/compress/CompressorFactory.java
@@ -85,7 +85,7 @@ public class CompressorFactory {
     public static BytesReference uncompress(BytesReference bytes) throws IOException {
         Compressor compressor = compressor(bytes);
         if (compressor == null) {
-            throw new NotCompressedException();
+            throw new NotCompressedException("no compressor found");
         }
         return uncompress(bytes, compressor);
     }
@@ -96,5 +96,13 @@ public class CompressorFactory {
         Streams.copy(compressed, bStream);
         compressed.close();
         return bStream.bytes();
+    }
+
+    /**
+     * Returns a new stream to decompress the given stream.
+     * @throws NotCompressedException if the given stream is not compressed
+     */
+    public static StreamInput uncompress(StreamInput input) throws IOException {
+        return COMPRESSOR.streamInput(input);
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/compress/DeflateCompressor.java
+++ b/core/src/main/java/org/elasticsearch/common/compress/DeflateCompressor.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.compress;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.Compressor;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
@@ -79,7 +80,8 @@ public class DeflateCompressor implements Compressor {
             len += read;
         }
         if (len != HEADER.length || Arrays.equals(headerBytes, HEADER) == false) {
-            throw new IllegalArgumentException("Input stream is not compressed with DEFLATE!");
+            throw new NotCompressedException("Input stream is not compressed with DEFLATE! expected expected "
+                + new BytesRef(HEADER).toString() + " but got: " + new BytesRef(headerBytes));
         }
 
         final boolean nowrap = true;

--- a/core/src/main/java/org/elasticsearch/common/compress/DeflateCompressor.java
+++ b/core/src/main/java/org/elasticsearch/common/compress/DeflateCompressor.java
@@ -80,7 +80,7 @@ public class DeflateCompressor implements Compressor {
             len += read;
         }
         if (len != HEADER.length || Arrays.equals(headerBytes, HEADER) == false) {
-            throw new NotCompressedException("Input stream is not compressed with DEFLATE! expected expected "
+            throw new NotCompressedException("Input stream is not compressed with DEFLATE! expected "
                 + new BytesRef(HEADER).toString() + " but got: " + new BytesRef(headerBytes));
         }
 

--- a/core/src/main/java/org/elasticsearch/common/compress/NotCompressedException.java
+++ b/core/src/main/java/org/elasticsearch/common/compress/NotCompressedException.java
@@ -22,10 +22,10 @@ package org.elasticsearch.common.compress;
 /** Exception indicating that we were expecting something compressed, which
  *  was not compressed or corrupted so that the compression format could not
  *  be detected. */
-public class NotCompressedException extends RuntimeException {
+public class NotCompressedException extends IllegalArgumentException {
 
-    public NotCompressedException() {
-        super();
+    public NotCompressedException(String msg) {
+        super(msg);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/core/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -1083,19 +1083,19 @@ public abstract class TcpTransport<Channel> extends AbstractLifecycleComponent i
      */
     public static int validateMessageHeader(StreamInput input) throws IOException {
         assert input.markSupported();
-        final int sizeHeaderLength = TcpHeader.MARKER_BYTES_SIZE + TcpHeader.MESSAGE_LENGTH_SIZE;
         final int available = input.available();
-        if (available < sizeHeaderLength) {
+        if (available < TcpHeader.MARKER_BYTES_SIZE ) {
             throw new IllegalStateException("message size must be >= to the header size");
         }
         int offset = 0;
         byte firstByte = input.readByte();
         byte secondByte = input.readByte();
         if (firstByte != 'E' || secondByte != 'S') {
-            byte[] b = new byte[Math.min(input.available(), 8)];
+            byte[] b = new byte[8];
             b[0] = firstByte;
             b[1] = secondByte;
-            input.readBytes(b, 2, b.length-2);
+            int size = Math.min(input.available(), 6);
+            input.readBytes(b, 2, size);
             BytesReference buffer = new BytesArray(b);
             // special handling for what is probably HTTP
             if (bufferStartsWith(buffer, offset, "GET ") ||

--- a/core/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/core/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -1133,10 +1133,6 @@ public abstract class TcpTransport<Channel> extends AbstractLifecycleComponent i
             throw new IllegalArgumentException("transport content length received [" + new ByteSizeValue(dataLen) + "] exceeded ["
                     + new ByteSizeValue(NINETY_PER_HEAP_SIZE) + "]");
         }
-
-        if (available < dataLen + sizeHeaderLength) {
-            throw new IllegalStateException("buffer must be >= to the message size but wasn't");
-        }
         return dataLen + TcpHeader.MESSAGE_LENGTH_SIZE;
     }
 

--- a/core/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/core/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -34,7 +34,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.component.Lifecycle;
-import org.elasticsearch.common.compress.Compressor;
 import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.compress.NotCompressedException;
 import org.elasticsearch.common.io.ReleasableBytesStream;
@@ -1072,21 +1071,32 @@ public abstract class TcpTransport<Channel> extends AbstractLifecycleComponent i
     }
 
     /**
-     * Validates the first N bytes of the message header and returns <code>false</code> if the message is
-     * a ping message and has no payload ie. isn't a real user level message.
+     * Validates the first N bytes of the message header and returns a positive message size if the stream contains a valid message.
+     * If the message is a ping message <code>-1</code> is returned instead. Ping requests are uni-directional and don't receive a response.
+     * The stream can be discarded if the case of a ping. Once this method returns with a positive message size the stream can passed on
+     * to {@link #messageReceived(StreamInput, Object, String, InetSocketAddress)}.
      *
      * @throws IllegalStateException if the message is too short, less than the header or less that the header plus the message size
      * @throws HttpOnTransportException if the message has no valid header and appears to be a HTTP message
      * @throws IllegalArgumentException if the message is greater that the maximum allowed frame size. This is dependent on the available
      * memory.
      */
-    public static boolean validateMessageHeader(BytesReference buffer) throws IOException {
+    public static int validateMessageHeader(StreamInput input) throws IOException {
+        assert input.markSupported();
         final int sizeHeaderLength = TcpHeader.MARKER_BYTES_SIZE + TcpHeader.MESSAGE_LENGTH_SIZE;
-        if (buffer.length() < sizeHeaderLength) {
+        final int available = input.available();
+        if (available < sizeHeaderLength) {
             throw new IllegalStateException("message size must be >= to the header size");
         }
         int offset = 0;
-        if (buffer.get(offset) != 'E' || buffer.get(offset + 1) != 'S') {
+        byte firstByte = input.readByte();
+        byte secondByte = input.readByte();
+        if (firstByte != 'E' || secondByte != 'S') {
+            byte[] b = new byte[Math.min(input.available(), 8)];
+            b[0] = firstByte;
+            b[1] = secondByte;
+            input.readBytes(b, 2, b.length-2);
+            BytesReference buffer = new BytesArray(b);
             // special handling for what is probably HTTP
             if (bufferStartsWith(buffer, offset, "GET ") ||
                     bufferStartsWith(buffer, offset, "POST ") ||
@@ -1107,17 +1117,14 @@ public abstract class TcpTransport<Channel> extends AbstractLifecycleComponent i
                     + Integer.toHexString(buffer.get(offset + 2) & 0xFF) + ","
                     + Integer.toHexString(buffer.get(offset + 3) & 0xFF) + ")");
         }
-
-        final int dataLen;
-        try (StreamInput input = buffer.streamInput()) {
-            input.skip(TcpHeader.MARKER_BYTES_SIZE);
-            dataLen = input.readInt();
-            if (dataLen == PING_DATA_SIZE) {
-                // discard the messages we read and continue, this is achieved by skipping the bytes
-                // and returning null
-                return false;
-            }
+        input.mark(4);
+        final int dataLen = input.readInt();
+        if (dataLen == PING_DATA_SIZE) {
+            // discard the messages we read and continue, this is achieved by skipping the bytes
+            // and returning null
+            return PING_DATA_SIZE;
         }
+        input.reset();
         if (dataLen <= 0) {
             throw new StreamCorruptedException("invalid data length: " + dataLen);
         }
@@ -1127,10 +1134,10 @@ public abstract class TcpTransport<Channel> extends AbstractLifecycleComponent i
                     + new ByteSizeValue(NINETY_PER_HEAP_SIZE) + "]");
         }
 
-        if (buffer.length() < dataLen + sizeHeaderLength) {
+        if (available < dataLen + sizeHeaderLength) {
             throw new IllegalStateException("buffer must be >= to the message size but wasn't");
         }
-        return true;
+        return dataLen + TcpHeader.MESSAGE_LENGTH_SIZE;
     }
 
     private static boolean bufferStartsWith(BytesReference buffer, int offset, String method) {
@@ -1169,35 +1176,26 @@ public abstract class TcpTransport<Channel> extends AbstractLifecycleComponent i
     /**
      * This method handles the message receive part for both request and responses
      */
-    public final void messageReceived(BytesReference reference, Channel channel, String profileName,
-                                      InetSocketAddress remoteAddress, int messageLengthBytes) throws IOException {
+    public final void messageReceived(StreamInput streamIn, Channel channel, String profileName,
+                                      InetSocketAddress remoteAddress) throws IOException {
+        final int messageLengthBytes = streamIn.readInt();
         final int totalMessageSize = messageLengthBytes + TcpHeader.MARKER_BYTES_SIZE + TcpHeader.MESSAGE_LENGTH_SIZE;
         transportServiceAdapter.addBytesReceived(totalMessageSize);
         // we have additional bytes to read, outside of the header
         boolean hasMessageBytesToRead = (totalMessageSize - TcpHeader.HEADER_SIZE) > 0;
-        StreamInput streamIn = reference.streamInput();
         boolean success = false;
         try (ThreadContext.StoredContext tCtx = threadPool.getThreadContext().stashContext()) {
             long requestId = streamIn.readLong();
             byte status = streamIn.readByte();
             Version version = Version.fromId(streamIn.readInt());
             if (TransportStatus.isCompress(status) && hasMessageBytesToRead && streamIn.available() > 0) {
-                Compressor compressor;
                 try {
-                    final int bytesConsumed = TcpHeader.REQUEST_ID_SIZE + TcpHeader.STATUS_SIZE + TcpHeader.VERSION_ID_SIZE;
-                    compressor = CompressorFactory.compressor(reference.slice(bytesConsumed, reference.length() - bytesConsumed));
+                    streamIn = CompressorFactory.uncompress(streamIn);
                 } catch (NotCompressedException ex) {
-                    int maxToRead = Math.min(reference.length(), 10);
-                    StringBuilder sb = new StringBuilder("stream marked as compressed, but no compressor found, first [").append(maxToRead)
-                        .append("] content bytes out of [").append(reference.length())
-                        .append("] readable bytes with message size [").append(messageLengthBytes).append("] ").append("] are [");
-                    for (int i = 0; i < maxToRead; i++) {
-                        sb.append(reference.get(i)).append(",");
-                    }
-                    sb.append("]");
-                    throw new IllegalStateException(sb.toString());
+                    StringBuilder sb = new StringBuilder("stream marked as compressed, but no compressor found, " +
+                        "readable bytes with message size [").append(messageLengthBytes).append("] ").append("] are [");
+                    throw new IllegalStateException(sb.toString(), ex);
                 }
-                streamIn = compressor.streamInput(streamIn);
             }
             if (version.isCompatible(getCurrentVersion()) == false) {
                 throw new IllegalStateException("Received message from unsupported version: [" + version

--- a/core/src/test/java/org/elasticsearch/common/compress/DeflateCompressTests.java
+++ b/core/src/test/java/org/elasticsearch/common/compress/DeflateCompressTests.java
@@ -432,7 +432,7 @@ public class DeflateCompressTests extends ESTestCase {
     public void testDecompressNonCompressedBinary() throws IOException {
         NotCompressedException helloworld = expectThrows(NotCompressedException.class,
             () -> compressor.streamInput(new BytesArray("helloworld").streamInput()));
-        assertEquals("Input stream is not compressed with DEFLATE! expected expected [44 46 4c 0] but got: [68 65 6c 6c]",
+        assertEquals("Input stream is not compressed with DEFLATE! expected [44 46 4c 0] but got: [68 65 6c 6c]",
             helloworld.getMessage());
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/compress/DeflateCompressTests.java
+++ b/core/src/test/java/org/elasticsearch/common/compress/DeflateCompressTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.compress;
 
 import org.apache.lucene.util.LineFileDocs;
 import org.apache.lucene.util.TestUtil;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.ByteBufferStreamInput;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -426,5 +427,12 @@ public class DeflateCompressTests extends ESTestCase {
         uncompressedOut.close();
 
         assertArrayEquals(bytes, uncompressedOut.toByteArray());
+    }
+
+    public void testDecompressNonCompressedBinary() throws IOException {
+        NotCompressedException helloworld = expectThrows(NotCompressedException.class,
+            () -> compressor.streamInput(new BytesArray("helloworld").streamInput()));
+        assertEquals("Input stream is not compressed with DEFLATE! expected expected [44 46 4c 0] but got: [68 65 6c 6c]",
+            helloworld.getMessage());
     }
 }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/ByteBufStreamInput.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/ByteBufStreamInput.java
@@ -147,4 +147,11 @@ class ByteBufStreamInput extends StreamInput {
     public void close() throws IOException {
         // nothing to do here
     }
+
+    /**
+     * Consumes all pending bytes of this stream
+     */
+    void consumeFully() {
+        buffer.readerIndex(endIndex);
+    }
 }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/ByteBufStreamInput.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/ByteBufStreamInput.java
@@ -137,9 +137,9 @@ class ByteBufStreamInput extends StreamInput {
 
     @Override
     public void readBytes(byte[] b, int offset, int len) throws IOException {
-        int read = read(b, offset, len);
+        final int read = read(b, offset, len);
         if (read < len) {
-            throw new IndexOutOfBoundsException();
+            throw new IndexOutOfBoundsException("failed to read " + len + " bytes max bytes to read: " + read);
         }
     }
 

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageChannelHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageChannelHandler.java
@@ -23,9 +23,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.util.ReferenceCountUtil;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.transport.TcpHeader;
 import org.elasticsearch.transport.TransportServiceAdapter;
 import org.elasticsearch.transport.Transports;
 
@@ -59,22 +56,19 @@ final class Netty4MessageChannelHandler extends ChannelDuplexHandler {
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         Transports.assertTransportThread();
-        if (!(msg instanceof ByteBuf)) {
+        if (!(msg instanceof ByteBufStreamInput)) {
             ctx.fireChannelRead(msg);
             return;
         }
-        final ByteBuf buffer = (ByteBuf) msg;
-        final int remainingMessageSize = buffer.getInt(buffer.readerIndex() - TcpHeader.MESSAGE_LENGTH_SIZE);
-        final int expectedReaderIndex = buffer.readerIndex() + remainingMessageSize;
-        InetSocketAddress remoteAddress = (InetSocketAddress) ctx.channel().remoteAddress();
+        final ByteBufStreamInput input = (ByteBufStreamInput) msg;
         try {
+            final InetSocketAddress remoteAddress = (InetSocketAddress) ctx.channel().remoteAddress();
             // netty always copies a buffer, either in NioWorker in its read handler, where it copies to a fresh
-            // buffer, or in the cumulation buffer, which is cleaned each time so it could be bigger than the actual size
-            BytesReference reference = Netty4Utils.toBytesReference(buffer, remainingMessageSize);
-            transport.messageReceived(reference, ctx.channel(), profileName, remoteAddress, remainingMessageSize);
+            // buffer, or in the cumulative buffer, which is cleaned each time so it could be bigger than the actual size
+            transport.messageReceived(input, ctx.channel(), profileName, remoteAddress);
         } finally {
             // Set the expected position of the buffer, no matter what happened
-            buffer.readerIndex(expectedReaderIndex);
+            input.consumeFully();
         }
     }
 

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4SizeHeaderFrameDecoder.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4SizeHeaderFrameDecoder.java
@@ -33,14 +33,17 @@ final class Netty4SizeHeaderFrameDecoder extends ByteToMessageDecoder {
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
         try {
-            ByteBufStreamInput input = new ByteBufStreamInput(in, in.readableBytes());
+            final ByteBufStreamInput input = new ByteBufStreamInput(in, in.readableBytes());
             int size = TcpTransport.validateMessageHeader(input);
             if (size == -1) { // that's a ping - we just ignore it.
                 return;
             } else {
+                if (in.readableBytes() < size) {
+                    throw new IllegalStateException("buffer must be >= to the message size but wasn't");
+                }
                 // we have to make a copy here and limit it's size since the buffer might contain more
                 // data that will be processed later
-                ByteBufStreamInput byteBufStreamInput = new ByteBufStreamInput(in, size);
+                final ByteBufStreamInput byteBufStreamInput = new ByteBufStreamInput(in, size);
                 out.add(byteBufStreamInput);
             }
         } catch (IllegalArgumentException ex) {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4SizeHeaderFrameDecoder.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4SizeHeaderFrameDecoder.java
@@ -38,6 +38,8 @@ final class Netty4SizeHeaderFrameDecoder extends ByteToMessageDecoder {
             if (size == -1) { // that's a ping - we just ignore it.
                 return;
             } else {
+                // we have to make a copy here and limit it's size since the buffer might contain more
+                // data that will be processed later
                 ByteBufStreamInput byteBufStreamInput = new ByteBufStreamInput(in, size);
                 out.add(byteBufStreamInput);
             }

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/ByteBufBytesReferenceTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/ByteBufBytesReferenceTests.java
@@ -24,7 +24,9 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.AbstractBytesReferenceTestCase;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
 
+import java.io.EOFException;
 import java.io.IOException;
 
 public class ByteBufBytesReferenceTests extends AbstractBytesReferenceTestCase {
@@ -76,4 +78,12 @@ public class ByteBufBytesReferenceTests extends AbstractBytesReferenceTestCase {
         assertEquals(utf8ToString, byteBufBytesReference.utf8ToString());
     }
 
+    public void testConsumeFully() throws IOException {
+        BytesReference bytesReference = newBytesReference(randomIntBetween(10, 3 * PAGE_SIZE));
+        ByteBufStreamInput input = (ByteBufStreamInput)bytesReference.streamInput();
+        assertTrue(input.available() > 0);
+        input.consumeFully();
+        assertEquals(0, input.available());
+        expectThrows(IndexOutOfBoundsException.class, () -> input.readByte());
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -1438,7 +1438,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         service.registerRequestHandler("action", TestRequest::new, ThreadPool.Names.SAME,
             (request, channel) -> {
                 requestProcessed.set(true);
-                channel.sendResponse(TransportResponse.Empty.INSTANCE);
+                channel.sendResponse(new TestResponse());
             });
 
         DiscoveryNode node =


### PR DESCRIPTION
Today we still leak some knowledge about how to parse the es wire protocol
into the actual implementation (mock / netty4). This commit moves all
the remaining logic into the TcpTransport to make the protocol logic
entirely transparent.