### PR TITLE
Document the `locale` option of the `date` field.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/joda/FormatDateTimeFormatter.java
+++ b/core/src/main/java/org/elasticsearch/common/joda/FormatDateTimeFormatter.java
@@ -22,6 +22,7 @@ package org.elasticsearch.common.joda;
 import org.joda.time.format.DateTimeFormatter;
 
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * A simple wrapper around {@link DateTimeFormatter} that retains the
@@ -43,9 +44,9 @@ public class FormatDateTimeFormatter {
 
     public FormatDateTimeFormatter(String format, DateTimeFormatter parser, DateTimeFormatter printer, Locale locale) {
         this.format = format;
-        this.locale = locale;
-        this.printer = locale == null ? printer.withDefaultYear(1970) : printer.withLocale(locale).withDefaultYear(1970);
-        this.parser = locale == null ? parser.withDefaultYear(1970) : parser.withLocale(locale).withDefaultYear(1970);
+        this.locale = Objects.requireNonNull(locale, "A locale is required as JODA otherwise uses the default locale");
+        this.printer = printer.withLocale(locale).withDefaultYear(1970);
+        this.parser = parser.withLocale(locale).withDefaultYear(1970);
     }
 
     public String format() {

--- a/docs/reference/mapping/types/date.asciidoc
+++ b/docs/reference/mapping/types/date.asciidoc
@@ -106,6 +106,12 @@ The following parameters are accepted by `date` fields:
     The date format(s) that can be parsed.  Defaults to
     `strict_date_optional_time||epoch_millis`.
 
+`locale`::
+
+    The locale to use when parsing dates since months do not have the same names
+    and/or abbreviations in all languages. The default is the
+    https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html#ROOT[`ROOT` locale],
+
 <<ignore-malformed,`ignore_malformed`>>::
 
     If `true`, malformed numbers are ignored. If `false` (default), malformed


### PR DESCRIPTION
This also adds another level of protection against using the default locale.
Relates to https://discuss.elastic.co/t/mapping-for-12h-date-format/68433/3.