### PR TITLE
Improve the error message if task and node isn't found

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/tasks.get/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/tasks.get/10_basic.yaml
@@ -8,3 +8,4 @@
       catch: missing
       tasks.get:
         task_id: foo:1
+  - match: {error.reason: "/task.\\[foo:1\\].belongs.to.the.node.\\[foo\\].which.isn't.part.of.the.cluster.and.there.is.no.record.of.the.task/"}


### PR DESCRIPTION
Improves the error message returned when looking up a task that
belongs to a node that is no longer part of the cluster. The new
error message tells the user that the node isn't part of the cluster.
This is useful because if you start a task and the node goes down
there isn't a record of the task at all. This hints to the user that
the task might have died with the node.

Relates to #22027