### PR TITLE
URLRepository should throw NoSuchFileException to correctly adhere to readBlob contract

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
@@ -24,9 +24,11 @@ import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.support.AbstractBlobContainer;
 
 import java.io.BufferedInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.NoSuchFileException;
 import java.util.Map;
 
 /**
@@ -99,7 +101,11 @@ public class URLBlobContainer extends AbstractBlobContainer {
 
     @Override
     public InputStream readBlob(String name) throws IOException {
-        return new BufferedInputStream(new URL(path, name).openStream(), blobStore.bufferSizeInBytes());
+        try {
+            return new BufferedInputStream(new URL(path, name).openStream(), blobStore.bufferSizeInBytes());
+        } catch (FileNotFoundException fnfe) {
+            throw new NoSuchFileException("[" + name + "] blob not found");
+        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -100,7 +100,6 @@ import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotMissingException;
 import org.elasticsearch.snapshots.SnapshotShardFailure;
 
-import java.io.FileNotFoundException;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -488,7 +487,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     public SnapshotInfo getSnapshotInfo(final SnapshotId snapshotId) {
         try {
             return snapshotFormat.read(snapshotsBlobContainer, snapshotId.getUUID());
-        } catch (FileNotFoundException | NoSuchFileException ex) {
+        } catch (NoSuchFileException ex) {
             throw new SnapshotMissingException(metadata.name(), snapshotId, ex);
         } catch (IOException | NotXContentException ex) {
             throw new SnapshotException(metadata.name(), snapshotId, "failed to get snapshots", ex);
@@ -509,7 +508,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         }
         try {
             metaData = globalMetaDataFormat(snapshotVersion).read(snapshotsBlobContainer, snapshotId.getUUID());
-        } catch (FileNotFoundException | NoSuchFileException ex) {
+        } catch (NoSuchFileException ex) {
             throw new SnapshotMissingException(metadata.name(), snapshotId, ex);
         } catch (IOException ex) {
             throw new SnapshotException(metadata.name(), snapshotId, "failed to get snapshots", ex);
@@ -631,7 +630,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 }
             }
             return repositoryData;
-        } catch (NoSuchFileException nsfe) {
+        } catch (NoSuchFileException ex) {
             // repository doesn't have an index blob, its a new blank repo
             return RepositoryData.EMPTY;
         } catch (IOException ioe) {

--- a/core/src/test/java/org/elasticsearch/bwcompat/RestoreBackwardsCompatIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/RestoreBackwardsCompatIT.java
@@ -116,7 +116,6 @@ public class RestoreBackwardsCompatIT extends AbstractSnapshotIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/22068")
     public void testRestoreUnsupportedSnapshots() throws Exception {
         String repo = "test_repo";
         String snapshot = "test_1";

--- a/core/src/test/java/org/elasticsearch/bwcompat/RestoreBackwardsCompatIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/RestoreBackwardsCompatIT.java
@@ -209,8 +209,7 @@ public class RestoreBackwardsCompatIT extends AbstractSnapshotIntegTestCase {
             client().admin().cluster().prepareRestoreSnapshot(repo, snapshot).setRestoreGlobalState(true).setWaitForCompletion(true).get();
             fail("should have failed to restore - " + repo);
         } catch (SnapshotRestoreException ex) {
-            assertThat(ex.getMessage(), containsString("cannot restore index"));
-            assertThat(ex.getMessage(), containsString("because it cannot be upgraded"));
+            assertThat(ex.getMessage(), containsString("snapshot does not exist"));
         }
     }
 }


### PR DESCRIPTION
URLBlobContainer can in certain situations throw a FileNotFoundException. To fulfill the contract of the readBlob method it should throw a NoSuchFileException instead when the given blob cannot be found. All other BlobContainer implementations do this correctly, see e.g. FsBlobContainer: https://github.com/elastic/elasticsearch/blob/7560101ec73331acb39a042bde6130e59e4bb630/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java#L119-L120

The second commit of this PR fixes a BWC issue. PR #22004 removed BWC for pre-5.0 snapshots in 6.0, which also meant removing the capability to load pre-5.0 snapshots. In 6.0, such snapshots are now invisible and must be treated by the BWC tests in that way.

First commit also goes back to 5.x, second commit only goes to 6.0.