### PR TITLE
FiltersAggregationBuilder: rewriting filter queries, the same way as in FilterAggregationBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersAggregationBuilder.java
@@ -173,7 +173,12 @@ public class FiltersAggregationBuilder extends AbstractAggregationBuilder<Filter
     @Override
     protected AggregatorFactory<?> doBuild(AggregationContext context, AggregatorFactory<?> parent, Builder subFactoriesBuilder)
             throws IOException {
-        return new FiltersAggregatorFactory(name, type, filters, keyed, otherBucket, otherBucketKey, context, parent,
+        List<KeyedFilter> rewrittenFilters = new ArrayList<>();
+        for(KeyedFilter kf : filters) {
+            rewrittenFilters.add(new KeyedFilter(kf.key(), QueryBuilder.rewriteQuery(kf.filter(), 
+                    context.searchContext().getQueryShardContext())));
+        }
+        return new FiltersAggregatorFactory(name, type, rewrittenFilters, keyed, otherBucket, otherBucketKey, context, parent,
                 subFactoriesBuilder, metaData);
     }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/60_filters.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/60_filters.yaml
@@ -1,0 +1,52 @@
+setup:
+  - do:
+      indices.create:
+          index: test
+          body:
+            settings:
+              number_of_shards: 1
+              number_of_replicas: 0
+            mappings:
+              post:
+                properties:
+                  title:
+                    type: text
+
+  - do:
+        index:
+          index: test
+          type: test
+          id: 1
+          body: { "title" : "foo bar baz" }
+
+  - do:
+      index:
+        index: test
+        type: test
+        id: 2
+        body: { "title" : "foo foo foo" }
+
+  - do:
+      index:
+        index: test
+        type: test
+        id: 3
+        body: { "title" : "bar baz bax" }
+
+  - do:
+      indices.refresh: {}
+
+---
+"Filters aggs with wrapper query":
+  - skip:
+    version: " - 5.1.1"
+    reason:  Using filters aggs that needs rewriting, this was fixed in 5.1.2
+
+  - do:
+      search:
+        body: {"size": 0, "aggs": {"titles": {"filters": {"filters" : {"titleterms" : {"wrapper" : {"query": "eyJ0ZXJtcyIgOiB7ICJ0aXRsZSI6IFsiZm9vIl0gfX0="}}}}}}}
+
+  # validate result
+  - match: { hits.total: 3 }
+  - length: { aggregations.titles.buckets: 1 }
+  - match: { aggregations.titles.buckets.titleterms.doc_count: 2 }


### PR DESCRIPTION
We use wrapper queries for user-supplied filters aggregations. In 5 `WrapperQueryBuilder` forces query to be rewritten, but it doesn't happen in `FiltersAggregationBuilder`. However, since 5.1 it was implemented in `FilterAggregationBuilder` and this pull request does basically the same, but for a list of filters instead of a single filter.

Example:
For these three documents:
```
curl -XPUT localhost:9200/test/test/1?pretty -d '{"title":"foo bar baz"}'
curl -XPUT localhost:9200/test/test/2?pretty -d '{"title":"foo foo foo"}'
curl -XPUT localhost:9200/test/test/3?pretty -d '{"title":"bar baz bax"}'
```

You'll get a proper response for this request:
```
curl -XGET localhost:9200/test/test/_search?pretty -d '{
  "size":0,
  "aggs": {
    "titles": {
      "filters": {
        "filters" : {
          "titleterms" : {
            "terms" : {
              "title": ["foo"]
            }
          }
        }
      }
    }
  }
}'
```

But for this one, equivalent, but making use of the wrapper query you'll get unsupported operation exception:
```
curl -XGET localhost:9200/test/test/_search?pretty -d '{
  "size":0,
  "aggs": {
    "titles": {
      "filters": {
        "filters" : {
          "titleterms" : {
            "wrapper" : {
              "query": "InRlcm1zIiA6IHsgInRpdGxlIjogWyJmb28iXSB9"
            }
          }
        }
      }
    }
  }
}'
```

Response:
```
{
  "error" : {
  "root_cause" : [
    {
    "type" : "unsupported_operation_exception",
    "reason" : "this query must be rewritten first"
    }
  ],
  "type" : "search_phase_execution_exception",
  "reason" : "all shards failed",
  "phase" : "query",
  "grouped" : true,
  "failed_shards" : [
    {
    "shard" : 0,
    "index" : "test",
    "node" : "TazxVGAYRki28XXNUgmdAg",
    "reason" : {
      "type" : "unsupported_operation_exception",
      "reason" : "this query must be rewritten first"
    }
    }
  ],
  "caused_by" : {
    "type" : "unsupported_operation_exception",
    "reason" : "this query must be rewritten first"
  }
  },
  "status" : 500
}
```

Stacktrace:
```
Caused by: java.lang.UnsupportedOperationException: this query must be rewritten first
	at org.elasticsearch.index.query.WrapperQueryBuilder.doToQuery(WrapperQueryBuilder.java:149) ~[elasticsearch-5.1.1.jar:5.1.1]
	at org.elasticsearch.index.query.AbstractQueryBuilder.toQuery(AbstractQueryBuilder.java:97) ~[elasticsearch-5.1.1.jar:5.1.1]
	at org.elasticsearch.index.query.AbstractQueryBuilder.toFilter(AbstractQueryBuilder.java:119) ~[elasticsearch-5.1.1.jar:5.1.1]
	at org.elasticsearch.search.aggregations.bucket.filters.FiltersAggregatorFactory.<init>(FiltersAggregatorFactory.java:58) ~[elasticsearch-5.1.1.jar:5.1.1]
	at org.elasticsearch.search.aggregations.bucket.filters.FiltersAggregationBuilder.doBuild(FiltersAggregationBuilder.java:176) ~[elasticsearch-5.1.1.jar:5.1.1]
	at org.elasticsearch.search.aggregations.AbstractAggregationBuilder.build(AbstractAggregationBuilder.java:126) ~[elasticsearch-5.1.1.jar:5.1.1]
	at org.elasticsearch.search.aggregations.AggregatorFactories$Builder.build(AggregatorFactories.java:211) ~[elasticsearch-5.1.1.jar:5.1.1]
(...)
```