### PR TITLE
Un-deprecate fuzzy query

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -28,8 +28,6 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -43,15 +41,9 @@ import java.util.Optional;
 
 /**
  * A Query that does fuzzy matching for a specific value.
- *
- * @deprecated Fuzzy queries are not useful enough. This class will be removed with Elasticsearch 4.0. In most cases you may want to use
- * a match query with the fuzziness parameter for strings or range queries for numeric and date fields.
  */
-@Deprecated
 public class FuzzyQueryBuilder extends AbstractQueryBuilder<FuzzyQueryBuilder> implements MultiTermQueryBuilder {
     public static final String NAME = "fuzzy";
-
-    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(FuzzyQueryBuilder.class));
 
     /** Default maximum edit distance. Defaults to AUTO. */
     public static final Fuzziness DEFAULT_FUZZINESS = Fuzziness.AUTO;
@@ -155,7 +147,6 @@ public class FuzzyQueryBuilder extends AbstractQueryBuilder<FuzzyQueryBuilder> i
      * @param value The value of the term
      */
     public FuzzyQueryBuilder(String fieldName, Object value) {
-        DEPRECATION_LOGGER.deprecated("{} query is deprecated. Instead use the [match] query with fuzziness parameter", NAME);
         if (Strings.isEmpty(fieldName)) {
             throw new IllegalArgumentException("field name cannot be null or empty");
         }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -197,13 +197,9 @@ public abstract class QueryBuilders {
      * @param name  The name of the field
      * @param value The value of the term
      *
-     * @deprecated Fuzzy queries are not useful enough and will be removed with Elasticsearch 4.0. In most cases you may want to use
-     * a match query with the fuzziness parameter for strings or range queries for numeric and date fields.
-     *
      * @see #matchQuery(String, Object)
      * @see #rangeQuery(String)
      */
-    @Deprecated
     public static FuzzyQueryBuilder fuzzyQuery(String name, String value) {
         return new FuzzyQueryBuilder(name, value);
     }
@@ -214,13 +210,9 @@ public abstract class QueryBuilders {
      * @param name  The name of the field
      * @param value The value of the term
      *
-     * @deprecated Fuzzy queries are not useful enough and will be removed with Elasticsearch 4.0. In most cases you may want to use
-     * a match query with the fuzziness parameter for strings or range queries for numeric and date fields.
-     *
      * @see #matchQuery(String, Object)
      * @see #rangeQuery(String)
      */
-    @Deprecated
     public static FuzzyQueryBuilder fuzzyQuery(String name, Object value) {
         return new FuzzyQueryBuilder(name, value);
     }

--- a/core/src/test/java/org/elasticsearch/index/query/FuzzyQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/FuzzyQueryBuilderTests.java
@@ -27,8 +27,6 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.AbstractQueryTestCase;
-import org.junit.After;
-import org.junit.internal.AssumptionViolatedException;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -39,20 +37,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuilder> {
-
-    private boolean testSkipped = false;
-
-    /**
-     * All tests create deprecation warnings when an new FuzzyQueryBuilder is created. Instead of having to check them once
-     * in every single test, this is done here after each test is run
-     */
-    @After
-    void checkWarningHeaders() throws IOException {
-        // only check that warning headers got created for tests that satisfied certain assumptions and were thus not skipped
-        if (testSkipped == false) {
-            checkWarningHeaders("fuzzy query is deprecated. Instead use the [match] query with fuzziness parameter");
-        }
-    }
 
     @Override
     protected FuzzyQueryBuilder doCreateTestQueryBuilder() {
@@ -114,13 +98,7 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
     }
 
     public void testToQueryWithStringField() throws IOException {
-        try {
-            assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
-        } catch (AssumptionViolatedException e) {
-            // we need to know that this test was skipped in @After checkWarningHeaders(), because no warnings will be generated
-            testSkipped = true;
-            throw e;
-        }
+        assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         String query = "{\n" +
                 "    \"fuzzy\":{\n" +
                 "        \"" + STRING_FIELD_NAME + "\":{\n" +
@@ -143,13 +121,7 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
     }
 
     public void testToQueryWithNumericField() throws IOException {
-        try {
-            assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
-        } catch (AssumptionViolatedException e) {
-            // we need to know that this test was skipped in @After checkWarningHeaders(), because no warnings will be generated
-            testSkipped = true;
-            throw e;
-        }
+        assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         String query = "{\n" +
                 "    \"fuzzy\":{\n" +
                 "        \"" + INT_FIELD_NAME + "\":{\n" +

--- a/core/src/test/java/org/elasticsearch/index/query/RandomQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomQueryBuilder.java
@@ -62,7 +62,7 @@ public class RandomQueryBuilder {
         // for now, only use String Rangequeries for MultiTerm test, numeric and date makes little sense
         // see issue #12123 for discussion
         MultiTermQueryBuilder multiTermQueryBuilder;
-        switch(RandomNumbers.randomIntBetween(r, 0, 2)) {
+        switch(RandomNumbers.randomIntBetween(r, 0, 3)) {
             case 0:
                 RangeQueryBuilder stringRangeQuery = new RangeQueryBuilder(AbstractQueryTestCase.STRING_FIELD_NAME);
                 stringRangeQuery.from("a" + RandomStrings.randomAsciiOfLengthBetween(r, 1, 10));
@@ -74,6 +74,10 @@ public class RandomQueryBuilder {
                 break;
             case 2:
                 multiTermQueryBuilder = new WildcardQueryBuilderTests().createTestQueryBuilder();
+                break;
+            case 3:
+                multiTermQueryBuilder = new FuzzyQueryBuilder(AbstractQueryTestCase.STRING_FIELD_NAME,
+                        RandomStrings.randomAsciiOfLengthBetween(r, 1, 10));
                 break;
             default:
                 throw new UnsupportedOperationException();

--- a/core/src/test/java/org/elasticsearch/search/profile/query/RandomQueryGenerator.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/query/RandomQueryGenerator.java
@@ -195,7 +195,6 @@ public class RandomQueryGenerator {
         return q;
     }
 
-    @Deprecated
     private static QueryBuilder randomFuzzyQuery(List<String> fields) {
 
         QueryBuilder q = QueryBuilders.fuzzyQuery(randomField(fields), randomQueryString(1));

--- a/docs/java-api/query-dsl/fuzzy-query.asciidoc
+++ b/docs/java-api/query-dsl/fuzzy-query.asciidoc
@@ -1,8 +1,6 @@
 [[java-query-dsl-fuzzy-query]]
 ==== Fuzzy Query
 
-deprecated[3.0.0, Will be removed without a replacement for `string` fields. Note that the `fuzziness` parameter is still supported for match queries and in suggesters. Use range queries for `date` and `numeric` fields instead.]
-
 See {ref}/query-dsl-fuzzy-query.html[Fuzzy Query]
 
 [source,java]

--- a/docs/reference/query-dsl/fuzzy-query.asciidoc
+++ b/docs/reference/query-dsl/fuzzy-query.asciidoc
@@ -1,8 +1,6 @@
 [[query-dsl-fuzzy-query]]
 === Fuzzy Query
 
-deprecated[5.0.0, Will be removed in 6.0. Use match queries with fuzziness instead]
-
 The fuzzy query uses similarity based on Levenshtein edit distance.
 
 ==== String fields
@@ -24,7 +22,6 @@ GET /_search
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[warning:fuzzy query is deprecated. Instead use the [match] query with fuzziness parameter]
 
 Or with more advanced settings:
 
@@ -46,7 +43,6 @@ GET /_search
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[warning:fuzzy query is deprecated. Instead use the [match] query with fuzziness parameter]
 
 [float]
 ===== Parameters


### PR DESCRIPTION
When we decided to deprecate and remove fuzzy query in #15760, we didn't realize we would take away the possibility for users to use a fuzzy query as part of a span query, which is not possible using match query (designed to be the replacement for fuzzy query as it supports fuzziness). This means we have to go back and un-deprecate fuzzy query, which will not be removed anymore.

Closes #15760