### PR TITLE
Throw an exception on unrecognized "match_mapping_type"

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/DynamicTemplate.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DynamicTemplate.java
@@ -205,15 +205,13 @@ public class DynamicTemplate implements ToXContent {
             try {
                 xcontentFieldType = XContentFieldType.fromString(matchMappingType);
             } catch (IllegalArgumentException e) {
-                // TODO: do this in 6.0
-                /*if (indexVersionCreated.onOrAfter(Version.V_6_0_0)) {
+                if (indexVersionCreated.onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
                     throw e;
-                }*/
-
-                DEPRECATION_LOGGER.deprecated("Ignoring unrecognized match_mapping_type: [" + matchMappingType + "]");
-                // this template is on an unknown type so it will never match anything
-                // null indicates that the template should be ignored
-                return null;
+                } else {
+                    // this template is on an unknown type so it will never match anything
+                    // null indicates that the template should be ignored
+                    return null;
+                }
             }
         }
         return new DynamicTemplate(name, pathMatch, pathUnmatch, match, unmatch, xcontentFieldType, MatchType.fromString(matchPattern), mapping);

--- a/core/src/test/java/org/elasticsearch/index/mapper/DynamicTemplateTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DynamicTemplateTests.java
@@ -49,6 +49,15 @@ public class DynamicTemplateTests extends ESTestCase {
         templateDef.put("mapping", Collections.singletonMap("store", true));
         // if a wrong match type is specified, we ignore the template
         assertNull(DynamicTemplate.parse("my_template", templateDef, Version.V_5_0_0_alpha5));
+
+        Map<String, Object> templateDef2 = new HashMap<>();
+        templateDef2.put("match_mapping_type", "text");
+        templateDef2.put("mapping", Collections.singletonMap("store", true));
+        // if a wrong match type is specified, we ignore the template
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> DynamicTemplate.parse("my_template", templateDef2, Version.V_6_0_0_alpha1_UNRELEASED));
+        assertEquals("No xcontent type matched on [text], possible values are [object, string, long, double, boolean, date, binary]",
+                e.getMessage());
     }
 
     public void testMatchAllTemplate() {

--- a/docs/reference/migration/migrate_6_0.asciidoc
+++ b/docs/reference/migration/migrate_6_0.asciidoc
@@ -28,6 +28,7 @@ way to reindex old indices is to use the `reindex` API.
 * <<breaking_60_stats_changes>>
 * <<breaking_60_rest_changes>>
 * <<breaking_60_search_changes>>
+* <<breaking_60_mappings_changes>>
 * <<breaking_60_docs_changes>>
 * <<breaking_60_cluster_changes>>
 * <<breaking_60_settings_changes>>
@@ -42,6 +43,8 @@ include::migrate_6_0/stats.asciidoc[]
 include::migrate_6_0/rest.asciidoc[]
 
 include::migrate_6_0/search.asciidoc[]
+
+include::migrate_6_0/mappings.asciidoc[]
 
 include::migrate_6_0/docs.asciidoc[]
 

--- a/docs/reference/migration/migrate_6_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_6_0/mappings.asciidoc
@@ -1,0 +1,8 @@
+[[breaking_60_mappings_changes]]
+=== Mapping changes
+
+==== Unrecognized `match_mapping_type` options not silently ignored
+
+Previously Elastiscearch would silently ignore any dynamic templates that
+included a `match_mapping_type` type that was unrecognized. An exception is now
+thrown on an unrecognized type.


### PR DESCRIPTION
When using dynamic templates, ES will now throw an exception if a
`match_mapping_type` is used that doesn't correspond to an actual type.

Relates to #17285

I was reminded of this from a recent post on discuss.elastic.co where a user had used "text" instead of "string".