### PR TITLE
Fix Fuziness typo in multimatch error message and associated tests

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -657,7 +657,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
 
         if (fuzziness != null && (type == Type.CROSS_FIELDS || type == Type.PHRASE || type == Type.PHRASE_PREFIX)) {
             throw new ParsingException(parser.getTokenLocation(),
-                    "Fuziness not allowed for type [" + type.parseField.getPreferredName() + "]");
+                    "Fuzziness not allowed for type [" + type.parseField.getPreferredName() + "]");
         }
 
         return Optional.of(new MultiMatchQueryBuilder(value)

--- a/core/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -271,7 +271,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
                     "}";
 
             ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(json));
-            assertEquals("Fuziness not allowed for type [" + type +"]", e.getMessage());
+            assertEquals("Fuzziness not allowed for type [" + type +"]", e.getMessage());
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -396,7 +396,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         assertThat(e.getMessage(), containsString("would result in more than 10000 states"));
     }
 
-    public void testToQueryFuzzyQueryAutoFuziness() throws Exception {
+    public void testToQueryFuzzyQueryAutoFuzziness() throws Exception {
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
 
         int length = randomIntBetween(1, 10);


### PR DESCRIPTION
Saw a typo in error message when using multi-match with fuzziness, fixed it.
