### PR TITLE
Add shutdown hook for closing CLI commands

### DIFF
--- a/core/src/main/java/org/elasticsearch/cli/Command.java
+++ b/core/src/main/java/org/elasticsearch/cli/Command.java
@@ -69,7 +69,7 @@ public abstract class Command implements Closeable {
                     e.printStackTrace(pw);
                     terminal.println(sw.toString());
                 } catch (final IOException impossible) {
-                    // StringWriter#close declared a checked IOException from the Closeable interface but the Javadocs for StringWriter say
+                    // StringWriter#close declares a checked IOException from the Closeable interface but the Javadocs for StringWriter say
                     // that an exception here is impossible
                     throw new AssertionError(impossible);
                 }

--- a/core/src/main/java/org/elasticsearch/cli/Command.java
+++ b/core/src/main/java/org/elasticsearch/cli/Command.java
@@ -24,17 +24,21 @@ import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import org.apache.logging.log4j.Level;
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.common.settings.Settings;
 
+import java.io.Closeable;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Arrays;
 
 /**
  * An action to execute within a cli.
  */
-public abstract class Command {
+public abstract class Command implements Closeable {
 
     /** A description of the command, used in the help output. */
     protected final String description;
@@ -44,15 +48,34 @@ public abstract class Command {
 
     private final OptionSpec<Void> helpOption = parser.acceptsAll(Arrays.asList("h", "help"), "show help").forHelp();
     private final OptionSpec<Void> silentOption = parser.acceptsAll(Arrays.asList("s", "silent"), "show minimal output");
-    private final OptionSpec<Void> verboseOption = parser.acceptsAll(Arrays.asList("v", "verbose"), "show verbose output")
-            .availableUnless(silentOption);
+    private final OptionSpec<Void> verboseOption =
+        parser.acceptsAll(Arrays.asList("v", "verbose"), "show verbose output").availableUnless(silentOption);
 
     public Command(String description) {
         this.description = description;
     }
 
+    SetOnce<Thread> shutdownHookThread = new SetOnce<>();
+
     /** Parses options for this command from args and executes it. */
     public final int main(String[] args, Terminal terminal) throws Exception {
+        shutdownHookThread.set(new Thread(() -> {
+            try {
+                this.close();
+            } catch (final IOException e) {
+                try (
+                    final StringWriter sw = new StringWriter();
+                    final PrintWriter pw = new PrintWriter(sw)) {
+                    e.printStackTrace(pw);
+                    terminal.println(sw.toString());
+                } catch (final IOException impossible) {
+                    // StringWriter#close declared a checked IOException from the Closeable interface but the Javadocs for StringWriter say
+                    // that an exception here is impossible
+                }
+            }
+        }));
+        Runtime.getRuntime().addShutdownHook(shutdownHookThread.get());
+
         // initialize default for es.logger.level because we will not read the log4j2.properties
         final String loggerLevel = System.getProperty("es.logger.level", Level.INFO.name());
         final Settings settings = Settings.builder().put("logger.level", loggerLevel).build();
@@ -117,5 +140,10 @@ public abstract class Command {
      *
      * Any runtime user errors (like an input file that does not exist), should throw a {@link UserException}. */
     protected abstract void execute(Terminal terminal, OptionSet options) throws Exception;
+
+    @Override
+    public void close() throws IOException {
+
+    }
 
 }

--- a/core/src/main/java/org/elasticsearch/cli/Command.java
+++ b/core/src/main/java/org/elasticsearch/cli/Command.java
@@ -55,7 +55,7 @@ public abstract class Command implements Closeable {
         this.description = description;
     }
 
-    SetOnce<Thread> shutdownHookThread = new SetOnce<>();
+    final SetOnce<Thread> shutdownHookThread = new SetOnce<>();
 
     /** Parses options for this command from args and executes it. */
     public final int main(String[] args, Terminal terminal) throws Exception {

--- a/core/src/main/java/org/elasticsearch/cli/Command.java
+++ b/core/src/main/java/org/elasticsearch/cli/Command.java
@@ -71,6 +71,7 @@ public abstract class Command implements Closeable {
                 } catch (final IOException impossible) {
                     // StringWriter#close declared a checked IOException from the Closeable interface but the Javadocs for StringWriter say
                     // that an exception here is impossible
+                    throw new AssertionError(impossible);
                 }
             }
         }));

--- a/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -610,21 +610,7 @@ class InstallPluginCommand extends SettingCommand {
 
     @Override
     public void close() throws IOException {
-        IOException exception = null;
-        for (final Path pathToDeleteOnShutdown : pathsToDeleteOnShutdown) {
-            try {
-                IOUtils.rm(pathToDeleteOnShutdown);
-            } catch (final IOException e) {
-                if (exception == null) {
-                    exception = e;
-                } else {
-                    exception.addSuppressed(e);
-                }
-            }
-        }
-        if (exception != null) {
-            throw exception;
-        }
+        IOUtils.rm(pathsToDeleteOnShutdown.toArray(new Path[pathsToDeleteOnShutdown.size()]));
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/plugins/PluginCli.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginCli.java
@@ -19,27 +19,37 @@
 
 package org.elasticsearch.plugins;
 
+import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.cli.Command;
 import org.elasticsearch.cli.MultiCommand;
 import org.elasticsearch.cli.Terminal;
-import org.elasticsearch.common.logging.LogConfigurator;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.env.Environment;
-import org.elasticsearch.node.internal.InternalSettingsPreparer;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * A cli tool for adding, removing and listing plugins for elasticsearch.
  */
 public class PluginCli extends MultiCommand {
 
+    private final Collection<Command> commands;
+
     private PluginCli() {
         super("A tool for managing installed elasticsearch plugins");
         subcommands.put("list", new ListPluginsCommand());
         subcommands.put("install", new InstallPluginCommand());
         subcommands.put("remove", new RemovePluginCommand());
+        commands = Collections.unmodifiableCollection(subcommands.values());
     }
 
     public static void main(String[] args) throws Exception {
         exit(new PluginCli().main(args, Terminal.DEFAULT));
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(commands);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/plugins/RemovePluginCommand.java
+++ b/core/src/main/java/org/elasticsearch/plugins/RemovePluginCommand.java
@@ -44,7 +44,7 @@ import static org.elasticsearch.cli.Terminal.Verbosity.VERBOSE;
 /**
  * A command for the plugin cli to remove a plugin from elasticsearch.
  */
-final class RemovePluginCommand extends SettingCommand {
+class RemovePluginCommand extends SettingCommand {
 
     private final OptionSpec<String> arguments;
 

--- a/qa/evil-tests/src/test/java/org/elasticsearch/cli/CommandTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/cli/CommandTests.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.isEmptyString;
 
 public class CommandTests extends ESTestCase {
 
@@ -174,12 +175,14 @@ public class CommandTests extends ESTestCase {
         command.shutdownHookThread.get().run();
         command.shutdownHookThread.get().join();
         assertTrue(closed.get());
+        final String output = terminal.getOutput();
         if (shouldThrow) {
-            final String output = terminal.getOutput();
             // ensure that we dump the exception
             assertThat(output, containsString("java.io.IOException: fail"));
             // ensure that we dump the stack trace too
             assertThat(output, containsString("\tat org.elasticsearch.cli.CommandTests$1.close"));
+        } else {
+            assertThat(output, isEmptyString());
         }
     }
 

--- a/qa/evil-tests/src/test/java/org/elasticsearch/cli/EvilCommandTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/cli/EvilCommandTests.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cli;
+
+import joptsimple.OptionSet;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.isEmptyString;
+
+public class EvilCommandTests extends ESTestCase {
+
+    public void testCommandShutdownHook() throws Exception {
+        final AtomicBoolean closed = new AtomicBoolean();
+        final boolean shouldThrow = randomBoolean();
+        final Command command = new Command("test-command-shutdown-hook") {
+            @Override
+            protected void execute(Terminal terminal, OptionSet options) throws Exception {
+
+            }
+
+            @Override
+            public void close() throws IOException {
+                closed.set(true);
+                if (shouldThrow) {
+                    throw new IOException("fail");
+                }
+            }
+        };
+        final MockTerminal terminal = new MockTerminal();
+        command.main(new String[0], terminal);
+        assertNotNull(command.shutdownHookThread.get());
+        // successful removal here asserts that the runtime hook was installed in Command#main
+        assertTrue(Runtime.getRuntime().removeShutdownHook(command.shutdownHookThread.get()));
+        command.shutdownHookThread.get().run();
+        command.shutdownHookThread.get().join();
+        assertTrue(closed.get());
+        final String output = terminal.getOutput();
+        if (shouldThrow) {
+            // ensure that we dump the exception
+            assertThat(output, containsString("java.io.IOException: fail"));
+            // ensure that we dump the stack trace too
+            assertThat(output, containsString("\tat org.elasticsearch.cli.EvilCommandTests$1.close"));
+        } else {
+            assertThat(output, isEmptyString());
+        }
+    }
+
+}

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
@@ -603,7 +603,12 @@ public class InstallPluginCommandTests extends ESTestCase {
 
     public void testOfficialPluginsHelpSorted() throws Exception {
         MockTerminal terminal = new MockTerminal();
-        new InstallPluginCommand().main(new String[] { "--help" }, terminal);
+        new InstallPluginCommand() {
+            @Override
+            protected boolean addShutdownHook() {
+                return false;
+            }
+        }.main(new String[] { "--help" }, terminal);
         try (BufferedReader reader = new BufferedReader(new StringReader(terminal.getOutput()))) {
             String line = reader.readLine();
 
@@ -625,7 +630,12 @@ public class InstallPluginCommandTests extends ESTestCase {
 
     public void testOfficialPluginsIncludesXpack() throws Exception {
         MockTerminal terminal = new MockTerminal();
-        new InstallPluginCommand().main(new String[] { "--help" }, terminal);
+        new InstallPluginCommand() {
+            @Override
+            protected boolean addShutdownHook() {
+                return false;
+            }
+        }.main(new String[] { "--help" }, terminal);
         assertTrue(terminal.getOutput(), terminal.getOutput().contains("x-pack"));
     }
 

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/RemovePluginCommandTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/RemovePluginCommandTests.java
@@ -140,7 +140,12 @@ public class RemovePluginCommandTests extends ESTestCase {
         assertEquals("plugin fake not found; run 'elasticsearch-plugin list' to get list of installed plugins", e.getMessage());
 
         MockTerminal terminal = new MockTerminal();
-        new RemovePluginCommand().main(new String[] { "-Epath.home=" + home, "fake" }, terminal);
+        new RemovePluginCommand() {
+            @Override
+            protected boolean addShutdownHook() {
+                return false;
+            }
+        }.main(new String[] { "-Epath.home=" + home, "fake" }, terminal);
         try (BufferedReader reader = new BufferedReader(new StringReader(terminal.getOutput()))) {
             assertEquals("-> Removing fake...", reader.readLine());
             assertEquals("ERROR: plugin fake not found; run 'elasticsearch-plugin list' to get list of installed plugins",

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/ESElasticsearchCliTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/ESElasticsearchCliTestCase.java
@@ -50,6 +50,11 @@ abstract class ESElasticsearchCliTestCase extends ESTestCase {
                     init.set(true);
                     initConsumer.accept(!daemonize, pidFile, quiet, esSettings);
                 }
+
+                @Override
+                protected boolean addShutdownHook() {
+                    return false;
+                }
             }, terminal);
             assertThat(status, equalTo(expectedStatus));
             assertThat(init.get(), equalTo(expectedInit));


### PR DESCRIPTION
This commit enables CLI commands to be closeable and installs a runtime
shutdown hook to ensure that if the JVM shuts down (as opposed to
aborting) the close method is called.

It is not enough to wrap uses of commands in main methods in
try-with-resources blocks as these will not run if, say, the virtual
machine is terminated in response to SIGINT, or system shutdown event.

Closes #22111