### PR TITLE
Replace strict parsing mode with response headers assertions

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/ParseField.java
+++ b/core/src/main/java/org/elasticsearch/common/ParseField.java
@@ -101,14 +101,10 @@ public class ParseField {
     /**
      * @param fieldName
      *            the field name to match against this {@link ParseField}
-     * @param strict
-     *            if true an exception will be thrown if a deprecated field name
-     *            is given. If false the deprecated name will be matched but a
-     *            message will also be logged to the {@link DeprecationLogger}
      * @return true if <code>fieldName</code> matches any of the acceptable
      *         names for this {@link ParseField}.
      */
-    boolean match(String fieldName, boolean strict) {
+    public boolean match(String fieldName) {
         Objects.requireNonNull(fieldName, "fieldName cannot be null");
         // if this parse field has not been completely deprecated then try to
         // match the preferred name
@@ -128,11 +124,7 @@ public class ParseField {
                     // message to indicate what should be used instead
                     msg = "Deprecated field [" + fieldName + "] used, replaced by [" + allReplacedWith + "]";
                 }
-                if (strict) {
-                    throw new IllegalArgumentException(msg);
-                } else {
-                    DEPRECATION_LOGGER.deprecated(msg);
-                }
+                DEPRECATION_LOGGER.deprecated(msg);
                 return true;
             }
         }

--- a/core/src/main/java/org/elasticsearch/common/ParseFieldMatcher.java
+++ b/core/src/main/java/org/elasticsearch/common/ParseFieldMatcher.java
@@ -22,38 +22,29 @@ package org.elasticsearch.common;
 import org.elasticsearch.common.settings.Settings;
 
 /**
- * Matcher to use in combination with {@link ParseField} while parsing requests. Matches a {@link ParseField}
- * against a field name and throw deprecation exception depending on the current value of the {@link #PARSE_STRICT} setting.
+ * Matcher to use in combination with {@link ParseField} while parsing requests.
+ *
+ * @deprecated This class used to be useful to parse in strict mode and emit errors rather than deprecation warnings. Now that we return
+ * warnings as response headers all the time, it is no longer useful and will soon be removed. The removal is in progress and there is
+ * already no strict mode in fact. Use {@link ParseField} directly.
  */
+@Deprecated
 public class ParseFieldMatcher {
-    public static final String PARSE_STRICT = "index.query.parse.strict";
-    public static final ParseFieldMatcher EMPTY = new ParseFieldMatcher(false);
-    public static final ParseFieldMatcher STRICT = new ParseFieldMatcher(true);
-
-    private final boolean strict;
+    public static final ParseFieldMatcher EMPTY = new ParseFieldMatcher(Settings.EMPTY);
+    public static final ParseFieldMatcher STRICT = new ParseFieldMatcher(Settings.EMPTY);
 
     public ParseFieldMatcher(Settings settings) {
-        this(settings.getAsBoolean(PARSE_STRICT, false));
-    }
-
-    public ParseFieldMatcher(boolean strict) {
-        this.strict = strict;
-    }
-
-    /** Should deprecated settings be rejected? */
-    public boolean isStrict() {
-        return strict;
+        //we don't do anything with the settings argument, this whole class will be soon removed
     }
 
     /**
-     * Matches a {@link ParseField} against a field name, and throws deprecation exception depending on the current
-     * value of the {@link #PARSE_STRICT} setting.
+     * Matches a {@link ParseField} against a field name,
      * @param fieldName the field name found in the request while parsing
      * @param parseField the parse field that we are looking for
      * @throws IllegalArgumentException whenever we are in strict mode and the request contained a deprecated field
      * @return true whenever the parse field that we are looking for was found, false otherwise
      */
     public boolean match(String fieldName, ParseField parseField) {
-        return parseField.match(fieldName, strict);
+        return parseField.match(fieldName);
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -21,7 +21,6 @@ package org.elasticsearch.common.logging;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.SuppressLoggerChecks;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 
@@ -42,7 +41,7 @@ public class DeprecationLogger {
      *
      * https://tools.ietf.org/html/rfc7234#section-5.5
      */
-    public static final String DEPRECATION_HEADER = "Warning";
+    public static final String WARNING_HEADER = "Warning";
 
     /**
      * This is set once by the {@code Node} constructor, but it uses {@link CopyOnWriteArraySet} to ensure that tests can run in parallel.
@@ -128,7 +127,7 @@ public class DeprecationLogger {
 
             while (iterator.hasNext()) {
                 try {
-                    iterator.next().addResponseHeader(DEPRECATION_HEADER, formattedMessage);
+                    iterator.next().addResponseHeader(WARNING_HEADER, formattedMessage);
                 } catch (IllegalStateException e) {
                     // ignored; it should be removed shortly
                 }

--- a/core/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -25,7 +25,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.joda.FormatDateTimeFormatter;
 import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
@@ -43,7 +42,6 @@ import java.util.Set;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.isArray;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.lenientNodeBooleanValue;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeFloatValue;
-import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeIntegerValue;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeMapValue;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeStringValue;
 
@@ -59,16 +57,11 @@ public class TypeParsers {
     private static final Set<String> BOOLEAN_STRINGS = new HashSet<>(Arrays.asList("true", "false"));
 
     public static boolean nodeBooleanValue(String name, Object node, Mapper.TypeParser.ParserContext parserContext) {
-        // Hook onto ParseFieldMatcher so that parsing becomes strict when setting index.query.parse.strict
-        if (parserContext.parseFieldMatcher().isStrict()) {
-            return XContentMapValues.nodeBooleanValue(node);
-        } else {
-            // TODO: remove this leniency in 6.0
-            if (BOOLEAN_STRINGS.contains(node.toString()) == false) {
-                DEPRECATION_LOGGER.deprecated("Expected a boolean for property [{}] but got [{}]", name, node);
-            }
-            return XContentMapValues.lenientNodeBooleanValue(node);
+        // TODO: remove this leniency in 6.0
+        if (BOOLEAN_STRINGS.contains(node.toString()) == false) {
+            DEPRECATION_LOGGER.deprecated("Expected a boolean for property [{}] but got [{}]", name, node);
         }
+        return XContentMapValues.lenientNodeBooleanValue(node);
     }
 
     private static void parseAnalyzersAndTermVectors(FieldMapper.Builder builder, String name, Map<String, Object> fieldNode, Mapper.TypeParser.ParserContext parserContext) {
@@ -211,10 +204,10 @@ public class TypeParsers {
                 throw new MapperParsingException("[" + propName + "] must not have a [null] value");
             }
             if (propName.equals("store")) {
-                builder.store(parseStore(name, propNode.toString(), parserContext));
+                builder.store(parseStore(propNode.toString()));
                 iterator.remove();
             } else if (propName.equals("index")) {
-                builder.index(parseIndex(name, propNode.toString(), parserContext));
+                builder.index(parseIndex(name, propNode.toString()));
                 iterator.remove();
             } else if (propName.equals(DOC_VALUES)) {
                 builder.docValues(nodeBooleanValue(DOC_VALUES, propNode, parserContext));
@@ -346,7 +339,7 @@ public class TypeParsers {
         }
     }
 
-    public static boolean parseIndex(String fieldName, String index, Mapper.TypeParser.ParserContext parserContext) throws MapperParsingException {
+    private static boolean parseIndex(String fieldName, String index) throws MapperParsingException {
         switch (index) {
         case "true":
             return true;
@@ -355,31 +348,23 @@ public class TypeParsers {
         case "not_analyzed":
         case "analyzed":
         case "no":
-            if (parserContext.parseFieldMatcher().isStrict() == false) {
-                DEPRECATION_LOGGER.deprecated("Expected a boolean for property [index] but got [{}]", index);
-                return "no".equals(index) == false;
-            } else {
-                throw new IllegalArgumentException("Can't parse [index] value [" + index + "] for field [" + fieldName + "], expected [true] or [false]");
-            }
+            DEPRECATION_LOGGER.deprecated("Expected a boolean for property [index] but got [{}]", index);
+            return "no".equals(index) == false;
         default:
             throw new IllegalArgumentException("Can't parse [index] value [" + index + "] for field [" + fieldName + "], expected [true] or [false]");
         }
     }
 
-    public static boolean parseStore(String fieldName, String store, Mapper.TypeParser.ParserContext parserContext) throws MapperParsingException {
-        if (parserContext.parseFieldMatcher().isStrict()) {
-            return XContentMapValues.nodeBooleanValue(store);
+    private static boolean parseStore(String store) throws MapperParsingException {
+        if (BOOLEAN_STRINGS.contains(store) == false) {
+            DEPRECATION_LOGGER.deprecated("Expected a boolean for property [store] but got [{}]", store);
+        }
+        if ("no".equals(store)) {
+            return false;
+        } else if ("yes".equals(store)) {
+            return true;
         } else {
-            if (BOOLEAN_STRINGS.contains(store) == false) {
-                DEPRECATION_LOGGER.deprecated("Expected a boolean for property [store] but got [{}]", store);
-            }
-            if ("no".equals(store)) {
-                return false;
-            } else if ("yes".equals(store)) {
-                return true;
-            } else {
-                return lenientNodeBooleanValue(store);
-            }
+            return lenientNodeBooleanValue(store);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
@@ -62,9 +62,9 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
     private static final ParseField TYPE_FIELD = new ParseField("type");
     private static final ParseField VALIDATION_METHOD_FIELD = new ParseField("validation_method");
     private static final ParseField COERCE_FIELD =new ParseField("coerce", "normalize")
-            .withAllDeprecated("use field validation_method instead");
+            .withAllDeprecated("validation_method");
     private static final ParseField IGNORE_MALFORMED_FIELD = new ParseField("ignore_malformed")
-            .withAllDeprecated("use field validation_method instead");
+            .withAllDeprecated("validation_method");
     private static final ParseField FIELD_FIELD = new ParseField("field");
     private static final ParseField TOP_FIELD = new ParseField("top");
     private static final ParseField BOTTOM_FIELD = new ParseField("bottom");

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
@@ -66,10 +66,8 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
     public static final boolean DEFAULT_IGNORE_UNMAPPED = false;
 
     private static final ParseField VALIDATION_METHOD_FIELD = new ParseField("validation_method");
-    private static final ParseField IGNORE_MALFORMED_FIELD = new ParseField("ignore_malformed")
-            .withAllDeprecated("use validation_method instead");
-    private static final ParseField COERCE_FIELD = new ParseField("coerce", "normalize")
-            .withAllDeprecated("use validation_method instead");
+    private static final ParseField IGNORE_MALFORMED_FIELD = new ParseField("ignore_malformed").withAllDeprecated("validation_method");
+    private static final ParseField COERCE_FIELD = new ParseField("coerce", "normalize").withAllDeprecated("validation_method");
     @Deprecated
     private static final ParseField OPTIMIZE_BBOX_FIELD = new ParseField("optimize_bbox")
             .withAllDeprecated("no replacement: `optimize_bbox` is no longer supported due to recent improvements");

--- a/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
@@ -49,10 +49,8 @@ public class GeoPolygonQueryBuilder extends AbstractQueryBuilder<GeoPolygonQuery
      */
     public static final boolean DEFAULT_IGNORE_UNMAPPED = false;
 
-    private static final ParseField COERCE_FIELD = new ParseField("coerce", "normalize")
-            .withAllDeprecated("use validation_method instead");
-    private static final ParseField IGNORE_MALFORMED_FIELD = new ParseField("ignore_malformed")
-            .withAllDeprecated("use validation_method instead");
+    private static final ParseField COERCE_FIELD = new ParseField("coerce", "normalize").withAllDeprecated("validation_method");
+    private static final ParseField IGNORE_MALFORMED_FIELD = new ParseField("ignore_malformed").withAllDeprecated("validation_method");
     private static final ParseField VALIDATION_METHOD = new ParseField("validation_method");
     private static final ParseField POINTS_FIELD = new ParseField("points");
     private static final ParseField IGNORE_UNMAPPED_FIELD = new ParseField("ignore_unmapped");

--- a/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -74,10 +74,8 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
     private static final ParseField UNIT_FIELD = new ParseField("unit");
     private static final ParseField DISTANCE_TYPE_FIELD = new ParseField("distance_type");
     private static final ParseField VALIDATION_METHOD_FIELD = new ParseField("validation_method");
-    private static final ParseField IGNORE_MALFORMED_FIELD = new ParseField("ignore_malformed")
-            .withAllDeprecated("use validation_method instead");
-    private static final ParseField COERCE_FIELD = new ParseField("coerce", "normalize")
-            .withAllDeprecated("use validation_method instead");
+    private static final ParseField IGNORE_MALFORMED_FIELD = new ParseField("ignore_malformed").withAllDeprecated("validation_method");
+    private static final ParseField COERCE_FIELD = new ParseField("coerce", "normalize").withAllDeprecated("validation_method");
     private static final ParseField SORTMODE_FIELD = new ParseField("mode", "sort_mode");
 
     private final String fieldName;

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/template/BWCTemplateTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/template/BWCTemplateTests.java
@@ -42,12 +42,14 @@ public class BWCTemplateTests extends ESSingleNodeTestCase {
         client().prepareIndex("packetbeat-foo", "doc", "1").setSource("message", "foo").get();
         client().prepareIndex("filebeat-foo", "doc", "1").setSource("message", "foo").get();
         client().prepareIndex("winlogbeat-foo", "doc", "1").setSource("message", "foo").get();
+        assertWarnings("Deprecated field [template] used, replaced by [index_patterns]");
     }
 
     public void testLogstashTemplatesBWC() throws Exception {
         String ls5x = copyToStringFromClasspath("/org/elasticsearch/action/admin/indices/template/logstash-5.0.template.json");
         client().admin().indices().preparePutTemplate("logstash-5x").setSource(ls5x).get();
         client().prepareIndex("logstash-foo", "doc", "1").setSource("message", "foo").get();
+        assertWarnings("Deprecated field [template] used, replaced by [index_patterns]");
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/common/ParseFieldTests.java
+++ b/core/src/test/java/org/elasticsearch/common/ParseFieldTests.java
@@ -20,7 +20,6 @@ package org.elasticsearch.common;
 
 import org.elasticsearch.test.ESTestCase;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
@@ -33,32 +32,16 @@ public class ParseFieldTests extends ESTestCase {
         String[] deprecated = new String[]{"barFoo", "bar_foo", "Foobar"};
         ParseField withDeprecations = field.withDeprecation(deprecated);
         assertThat(field, not(sameInstance(withDeprecations)));
-        assertThat(field.match(name, false), is(true));
-        assertThat(field.match("foo bar", false), is(false));
+        assertThat(field.match(name), is(true));
+        assertThat(field.match("foo bar"), is(false));
         for (String deprecatedName : deprecated) {
-            assertThat(field.match(deprecatedName, false), is(false));
+            assertThat(field.match(deprecatedName), is(false));
         }
 
-        assertThat(withDeprecations.match(name, false), is(true));
-        assertThat(withDeprecations.match("foo bar", false), is(false));
+        assertThat(withDeprecations.match(name), is(true));
+        assertThat(withDeprecations.match("foo bar"), is(false));
         for (String deprecatedName : deprecated) {
-            assertThat(withDeprecations.match(deprecatedName, false), is(true));
-        }
-
-        // now with strict mode
-        assertThat(field.match(name, true), is(true));
-        assertThat(field.match("foo bar", true), is(false));
-        for (String deprecatedName : deprecated) {
-            assertThat(field.match(deprecatedName, true), is(false));
-        }
-
-        assertThat(withDeprecations.match(name, true), is(true));
-        assertThat(withDeprecations.match("foo bar", true), is(false));
-        for (String deprecatedName : deprecated) {
-            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
-                withDeprecations.match(deprecatedName, true);
-            });
-            assertThat(e.getMessage(), containsString("used, expected [foo_bar] instead"));
+            assertThat(withDeprecations.match(deprecatedName), is(true));
         }
     }
 
@@ -84,13 +67,8 @@ public class ParseFieldTests extends ESTestCase {
             field = new ParseField(name).withAllDeprecated("like");
         }
 
-        // strict mode off
-        assertThat(field.match(randomFrom(allValues), false), is(true));
-        assertThat(field.match("not a field name", false), is(false));
-
-        // now with strict mode
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> field.match(randomFrom(allValues), true));
-        assertThat(e.getMessage(), containsString(" used, replaced by [like]"));
+        assertThat(field.match(randomFrom(allValues)), is(true));
+        assertThat(field.match("not a field name"), is(false));
     }
 
     public void testGetAllNamesIncludedDeprecated() {

--- a/core/src/test/java/org/elasticsearch/common/logging/DeprecationLoggerTests.java
+++ b/core/src/test/java/org/elasticsearch/common/logging/DeprecationLoggerTests.java
@@ -41,6 +41,12 @@ public class DeprecationLoggerTests extends ESTestCase {
 
     private final DeprecationLogger logger = new DeprecationLogger(Loggers.getLogger(getClass()));
 
+    @Override
+    protected boolean enableWarningsCheck() {
+        //this is a low level test for the deprecation logger, setup and checks are done manually
+        return false;
+    }
+
     public void testAddsHeaderWithThreadContext() throws IOException {
         String msg = "A simple message [{}]";
         String param = randomAsciiOfLengthBetween(1, 5);
@@ -54,7 +60,7 @@ public class DeprecationLoggerTests extends ESTestCase {
             Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
 
             assertEquals(1, responseHeaders.size());
-            assertEquals(formatted, responseHeaders.get(DeprecationLogger.DEPRECATION_HEADER).get(0));
+            assertEquals(formatted, responseHeaders.get(DeprecationLogger.WARNING_HEADER).get(0));
         }
     }
 
@@ -74,7 +80,7 @@ public class DeprecationLoggerTests extends ESTestCase {
 
             assertEquals(1, responseHeaders.size());
 
-            List<String> responses = responseHeaders.get(DeprecationLogger.DEPRECATION_HEADER);
+            List<String> responses = responseHeaders.get(DeprecationLogger.WARNING_HEADER);
 
             assertEquals(2, responses.size());
             assertEquals(formatted, responses.get(0));
@@ -93,7 +99,7 @@ public class DeprecationLoggerTests extends ESTestCase {
             logger.deprecated(expected);
 
             Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
-            List<String> responses = responseHeaders.get(DeprecationLogger.DEPRECATION_HEADER);
+            List<String> responses = responseHeaders.get(DeprecationLogger.WARNING_HEADER);
 
             // ensure it works (note: concurrent tests may be adding to it, but in different threads, so it should have no impact)
             assertThat(responses, hasSize(atLeast(1)));
@@ -104,7 +110,7 @@ public class DeprecationLoggerTests extends ESTestCase {
             logger.deprecated(unexpected);
 
             responseHeaders = threadContext.getResponseHeaders();
-            responses = responseHeaders.get(DeprecationLogger.DEPRECATION_HEADER);
+            responses = responseHeaders.get(DeprecationLogger.WARNING_HEADER);
 
             assertThat(responses, hasSize(atLeast(1)));
             assertThat(responses, hasItem(expected));

--- a/core/src/test/java/org/elasticsearch/index/analysis/AnalysisRegistryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/AnalysisRegistryTests.java
@@ -104,7 +104,7 @@ public class AnalysisRegistryTests extends ESTestCase {
         assertTrue(e.getMessage().contains("[index.analysis.analyzer.default_index] is not supported"));
     }
 
-    public void testBackCompatOverrideDefaultIndexAnalyzer() {
+    public void testBackCompatOverrideDefaultIndexAnalyzer() throws IOException {
         Version version = VersionUtils.randomVersionBetween(random(), VersionUtils.getFirstVersion(),
                 VersionUtils.getPreviousVersion(Version.V_5_0_0_alpha1));
         Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, version).build();
@@ -113,6 +113,8 @@ public class AnalysisRegistryTests extends ESTestCase {
         assertThat(indexAnalyzers.getDefaultIndexAnalyzer().analyzer(), instanceOf(EnglishAnalyzer.class));
         assertThat(indexAnalyzers.getDefaultSearchAnalyzer().analyzer(), instanceOf(StandardAnalyzer.class));
         assertThat(indexAnalyzers.getDefaultSearchQuoteAnalyzer().analyzer(), instanceOf(StandardAnalyzer.class));
+        assertWarnings("setting [index.analysis.analyzer.default_index] is deprecated, use [index.analysis.analyzer.default] " +
+                "instead for index [index]");
     }
 
     public void testOverrideDefaultSearchAnalyzer() {
@@ -125,7 +127,7 @@ public class AnalysisRegistryTests extends ESTestCase {
         assertThat(indexAnalyzers.getDefaultSearchQuoteAnalyzer().analyzer(), instanceOf(EnglishAnalyzer.class));
     }
 
-    public void testBackCompatOverrideDefaultIndexAndSearchAnalyzer() {
+    public void testBackCompatOverrideDefaultIndexAndSearchAnalyzer() throws IOException {
         Version version = VersionUtils.randomVersionBetween(random(), VersionUtils.getFirstVersion(),
                 VersionUtils.getPreviousVersion(Version.V_5_0_0_alpha1));
         Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, version).build();
@@ -137,6 +139,8 @@ public class AnalysisRegistryTests extends ESTestCase {
         assertThat(indexAnalyzers.getDefaultIndexAnalyzer().analyzer(), instanceOf(EnglishAnalyzer.class));
         assertThat(indexAnalyzers.getDefaultSearchAnalyzer().analyzer(), instanceOf(EnglishAnalyzer.class));
         assertThat(indexAnalyzers.getDefaultSearchQuoteAnalyzer().analyzer(), instanceOf(EnglishAnalyzer.class));
+        assertWarnings("setting [index.analysis.analyzer.default_index] is deprecated, use [index.analysis.analyzer.default] " +
+                "instead for index [index]");
     }
 
     public void testConfigureCamelCaseTokenFilter() throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/mapper/DynamicTemplateTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DynamicTemplateTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.DynamicTemplate.XContentFieldType;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,7 +44,7 @@ public class DynamicTemplateTests extends ESTestCase {
         assertEquals("Illegal dynamic template parameter: [random_param]", e.getMessage());
     }
 
-    public void testParseUnknownMatchType() {
+    public void testParseUnknownMatchType() throws IOException {
         Map<String, Object> templateDef = new HashMap<>();
         templateDef.put("match_mapping_type", "short");
         templateDef.put("mapping", Collections.singletonMap("store", true));

--- a/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -160,12 +160,13 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
         assertThat(e.getMessage(), containsString("Limit of mapping depth [1] in index [test1] has been exceeded"));
     }
 
-    public void testUnmappedFieldType() {
+    public void testUnmappedFieldType() throws IOException {
         MapperService mapperService = createIndex("index").mapperService();
         assertThat(mapperService.unmappedFieldType("keyword"), instanceOf(KeywordFieldType.class));
         assertThat(mapperService.unmappedFieldType("long"), instanceOf(NumberFieldType.class));
         // back compat
         assertThat(mapperService.unmappedFieldType("string"), instanceOf(KeywordFieldType.class));
+        assertWarnings("[unmapped_type:string] should be replaced with [unmapped_type:keyword]");
     }
 
     public void testMergeWithMap() throws Throwable {
@@ -206,9 +207,7 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
             .startObject("properties")
             .startObject("field")
             .field("type", "text")
-            .startObject("norms")
-            .field("enabled", false)
-            .endObject()
+            .field("norms", false)
             .endObject()
             .endObject().endObject().bytes());
 

--- a/core/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
@@ -422,7 +422,7 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
                 "}";
 
         parseQuery(json);
-        assertWarningHeaders("Deprecated field [coerce] used, replaced by [validation_method]");
+        assertWarnings("Deprecated field [coerce] used, replaced by [validation_method]");
     }
 
     public void testFromJsonIgnoreMalformedIsDeprecated() throws IOException {
@@ -440,7 +440,7 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
                 "  }\n" +
                 "}";
         parseQuery(json);
-        assertWarningHeaders("Deprecated field [ignore_malformed] used, replaced by [validation_method]");
+        assertWarnings("Deprecated field [ignore_malformed] used, replaced by [validation_method]");
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
@@ -19,13 +19,8 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.spatial.geopoint.search.GeoPointInBBoxQuery;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -40,7 +35,6 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.equalTo;
 
 public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBoundingBoxQueryBuilder> {
     /** Randomly generate either NaN or one of the two infinity values. */
@@ -118,7 +112,7 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
 
     public void testExceptionOnMissingTypes() throws IOException {
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length == 0);
-        QueryShardException e = expectThrows(QueryShardException.class, () -> super.testToQuery());
+        QueryShardException e = expectThrows(QueryShardException.class, super::testToQuery);
         assertEquals("failed to find geo_point field [mapped_geo_point]", e.getMessage());
     }
 
@@ -412,7 +406,7 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
         assertEquals(json, GeoExecType.MEMORY, parsed.type());
     }
 
-    public void testFromJsonCoerceFails() throws IOException {
+    public void testFromJsonCoerceIsDeprecated() throws IOException {
         String json =
                 "{\n" +
                 "  \"geo_bounding_box\" : {\n" +
@@ -426,11 +420,12 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
                 "    \"boost\" : 1.0\n" +
                 "  }\n" +
                 "}";
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(json));
-        assertTrue(e.getMessage().startsWith("Deprecated field "));
+
+        parseQuery(json);
+        assertWarningHeaders("Deprecated field [coerce] used, replaced by [validation_method]");
     }
 
-    public void testFromJsonIgnoreMalformedFails() throws IOException {
+    public void testFromJsonIgnoreMalformedIsDeprecated() throws IOException {
         String json =
                 "{\n" +
                 "  \"geo_bounding_box\" : {\n" +
@@ -444,8 +439,8 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
                 "    \"boost\" : 1.0\n" +
                 "  }\n" +
                 "}";
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(json));
-        assertTrue(e.getMessage().startsWith("Deprecated field "));
+        parseQuery(json);
+        assertWarningHeaders("Deprecated field [ignore_malformed] used, replaced by [validation_method]");
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -330,7 +330,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "  }\n" +
                 "}";
         parseQuery(json);
-        assertWarningHeaders("Deprecated field [optimize_bbox] used, replaced by [no replacement: " +
+        assertWarnings("Deprecated field [optimize_bbox] used, replaced by [no replacement: " +
                 "`optimize_bbox` is no longer supported due to recent improvements]");
     }
 
@@ -347,7 +347,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "  }\n" +
                 "}";
         parseQuery(json);
-        assertWarningHeaders("Deprecated field [coerce] used, replaced by [validation_method]");
+        assertWarnings("Deprecated field [coerce] used, replaced by [validation_method]");
     }
 
     public void testFromJsonIgnoreMalformedIsDeprecated() throws IOException {
@@ -363,7 +363,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "  }\n" +
                 "}";
         parseQuery(json);
-        assertWarningHeaders("Deprecated field [ignore_malformed] used, replaced by [validation_method]");
+        assertWarnings("Deprecated field [ignore_malformed] used, replaced by [validation_method]");
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -316,7 +316,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
         assertEquals(json, 12000.0, parsed.distance(), 0.0001);
     }
 
-    public void testOptimizeBboxFails() throws IOException {
+    public void testOptimizeBboxIsDeprecated() throws IOException {
         String json =
             "{\n" +
                 "  \"geo_distance\" : {\n" +
@@ -329,11 +329,12 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "    \"boost\" : 1.0\n" +
                 "  }\n" +
                 "}";
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(json));
-        assertTrue(e.getMessage().startsWith("Deprecated field "));
+        parseQuery(json);
+        assertWarningHeaders("Deprecated field [optimize_bbox] used, replaced by [no replacement: " +
+                "`optimize_bbox` is no longer supported due to recent improvements]");
     }
 
-    public void testFromCoerceFails() throws IOException {
+    public void testFromCoerceIsDeprecated() throws IOException {
         String json =
                 "{\n" +
                 "  \"geo_distance\" : {\n" +
@@ -345,11 +346,11 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "    \"boost\" : 1.0\n" +
                 "  }\n" +
                 "}";
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(json));
-        assertTrue(e.getMessage().startsWith("Deprecated field "));
+        parseQuery(json);
+        assertWarningHeaders("Deprecated field [coerce] used, replaced by [validation_method]");
     }
 
-    public void testFromJsonIgnoreMalformedFails() throws IOException {
+    public void testFromJsonIgnoreMalformedIsDeprecated() throws IOException {
         String json =
                 "{\n" +
                 "  \"geo_distance\" : {\n" +
@@ -361,8 +362,8 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "    \"boost\" : 1.0\n" +
                 "  }\n" +
                 "}";
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(json));
-        assertTrue(e.getMessage().startsWith("Deprecated field "));
+        parseQuery(json);
+        assertWarningHeaders("Deprecated field [ignore_malformed] used, replaced by [validation_method]");
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
@@ -139,8 +139,8 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
         builder.field("normalize", true); // deprecated
         builder.endObject();
         builder.endObject();
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(builder.string()));
-        assertEquals("Deprecated field [normalize] used, replaced by [use validation_method instead]", e.getMessage());
+        parseQuery(builder.string());
+        assertWarningHeaders("Deprecated field [normalize] used, replaced by [validation_method]");
     }
 
     public void testParsingAndToQueryParsingExceptions() throws IOException {
@@ -265,9 +265,8 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
                 "    \"boost\" : 1.0\n" +
                 "  }\n" +
                 "}";
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(json));
-        assertTrue(e.getMessage().startsWith("Deprecated field "));
-
+        parseQuery(json);
+        assertWarningHeaders("Deprecated field [ignore_malformed] used, replaced by [validation_method]");
     }
 
     public void testFromJsonCoerceDeprecated() throws IOException {
@@ -282,8 +281,8 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
                 "    \"boost\" : 1.0\n" +
                 "  }\n" +
                 "}";
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(json));
-        assertTrue(e.getMessage().startsWith("Deprecated field "));
+        parseQuery(json);
+        assertWarningHeaders("Deprecated field [coerce] used, replaced by [validation_method]");
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
@@ -140,7 +140,7 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
         builder.endObject();
         builder.endObject();
         parseQuery(builder.string());
-        assertWarningHeaders("Deprecated field [normalize] used, replaced by [validation_method]");
+        assertWarnings("Deprecated field [normalize] used, replaced by [validation_method]");
     }
 
     public void testParsingAndToQueryParsingExceptions() throws IOException {
@@ -266,7 +266,7 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
                 "  }\n" +
                 "}";
         parseQuery(json);
-        assertWarningHeaders("Deprecated field [ignore_malformed] used, replaced by [validation_method]");
+        assertWarnings("Deprecated field [ignore_malformed] used, replaced by [validation_method]");
     }
 
     public void testFromJsonCoerceDeprecated() throws IOException {
@@ -282,7 +282,7 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
                 "  }\n" +
                 "}";
         parseQuery(json);
-        assertWarningHeaders("Deprecated field [coerce] used, replaced by [validation_method]");
+        assertWarnings("Deprecated field [coerce] used, replaced by [validation_method]");
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/HasParentQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/HasParentQueryBuilderTests.java
@@ -23,7 +23,6 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
-import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -151,7 +150,7 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
         builder.endObject();
         HasParentQueryBuilder queryBuilder = (HasParentQueryBuilder) parseQuery(builder.string());
         assertEquals("foo", queryBuilder.type());
-        assertWarningHeaders("Deprecated field [type] used, expected [parent_type] instead");
+        assertWarnings("Deprecated field [type] used, expected [parent_type] instead");
     }
 
     public void testToQueryInnerQueryType() throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/query/HasParentQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/HasParentQueryBuilderTests.java
@@ -149,12 +149,9 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
         builder.field("type", "foo"); // deprecated
         builder.endObject();
         builder.endObject();
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(builder.string()));
-        assertEquals("Deprecated field [type] used, expected [parent_type] instead", e.getMessage());
-
-        HasParentQueryBuilder queryBuilder = (HasParentQueryBuilder) parseQuery(builder.string(), ParseFieldMatcher.EMPTY);
+        HasParentQueryBuilder queryBuilder = (HasParentQueryBuilder) parseQuery(builder.string());
         assertEquals("foo", queryBuilder.type());
-        checkWarningHeaders("Deprecated field [type] used, expected [parent_type] instead");
+        assertWarningHeaders("Deprecated field [type] used, expected [parent_type] instead");
     }
 
     public void testToQueryInnerQueryType() throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
@@ -164,11 +164,8 @@ public class IdsQueryBuilderTests extends AbstractQueryTestCase<IdsQueryBuilder>
         IdsQueryBuilder parsed = (IdsQueryBuilder) parseQuery(contentString, ParseFieldMatcher.EMPTY);
         assertEquals(testQuery, parsed);
 
-        ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(contentString));
-        checkWarningHeaders("Deprecated field [_type] used, expected [type] instead");
-        assertEquals("Deprecated field [_type] used, expected [type] instead", e.getMessage());
-        assertEquals(3, e.getLineNumber());
-        assertEquals(19, e.getColumnNumber());
+        parseQuery(contentString);
+        assertWarningHeaders("Deprecated field [_type] used, expected [type] instead");
 
         //array of types can also be called types rather than type
         final String contentString2 = "{\n" +
@@ -180,10 +177,7 @@ public class IdsQueryBuilderTests extends AbstractQueryTestCase<IdsQueryBuilder>
         parsed = (IdsQueryBuilder) parseQuery(contentString2, ParseFieldMatcher.EMPTY);
         assertEquals(testQuery, parsed);
 
-        e = expectThrows(ParsingException.class, () -> parseQuery(contentString2));
-        checkWarningHeaders("Deprecated field [types] used, expected [type] instead");
-        assertEquals("Deprecated field [types] used, expected [type] instead", e.getMessage());
-        assertEquals(3, e.getLineNumber());
-        assertEquals(19, e.getColumnNumber());
+        parseQuery(contentString2);
+        assertWarningHeaders("Deprecated field [types] used, expected [type] instead");
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
@@ -165,7 +165,7 @@ public class IdsQueryBuilderTests extends AbstractQueryTestCase<IdsQueryBuilder>
         assertEquals(testQuery, parsed);
 
         parseQuery(contentString);
-        assertWarningHeaders("Deprecated field [_type] used, expected [type] instead");
+        assertWarnings("Deprecated field [_type] used, expected [type] instead");
 
         //array of types can also be called types rather than type
         final String contentString2 = "{\n" +
@@ -178,6 +178,6 @@ public class IdsQueryBuilderTests extends AbstractQueryTestCase<IdsQueryBuilder>
         assertEquals(testQuery, parsed);
 
         parseQuery(contentString2);
-        assertWarningHeaders("Deprecated field [types] used, expected [type] instead");
+        assertWarnings("Deprecated field [types] used, expected [type] instead");
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -318,7 +318,7 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
 
         assertSerialization(qb);
 
-        assertWarningHeaders("Deprecated field [type] used, replaced by [match_phrase and match_phrase_prefix query]",
+        assertWarnings("Deprecated field [type] used, replaced by [match_phrase and match_phrase_prefix query]",
                 "Deprecated field [slop] used, replaced by [match_phrase query]");
     }
 
@@ -347,7 +347,7 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
 
         assertEquals(json, expectedQB, qb);
         assertSerialization(qb);
-        assertWarningHeaders("Deprecated field [type] used, replaced by [match_phrase and match_phrase_prefix query]",
+        assertWarnings("Deprecated field [type] used, replaced by [match_phrase and match_phrase_prefix query]",
                 "Deprecated field [slop] used, replaced by [match_phrase query]");
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -318,13 +318,8 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
 
         assertSerialization(qb);
 
-        checkWarningHeaders("Deprecated field [type] used, replaced by [match_phrase and match_phrase_prefix query]",
+        assertWarningHeaders("Deprecated field [type] used, replaced by [match_phrase and match_phrase_prefix query]",
                 "Deprecated field [slop] used, replaced by [match_phrase query]");
-
-        // Now check with strict parsing an exception is thrown
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(json, ParseFieldMatcher.STRICT));
-        assertThat(e.getMessage(),
-                containsString("Deprecated field [type] used, replaced by [match_phrase and match_phrase_prefix query]"));
     }
 
     public void testLegacyMatchPhraseQuery() throws IOException {
@@ -351,16 +346,9 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
         checkGeneratedJson(json, qb);
 
         assertEquals(json, expectedQB, qb);
-
         assertSerialization(qb);
-
-        checkWarningHeaders("Deprecated field [type] used, replaced by [match_phrase and match_phrase_prefix query]",
+        assertWarningHeaders("Deprecated field [type] used, replaced by [match_phrase and match_phrase_prefix query]",
                 "Deprecated field [slop] used, replaced by [match_phrase query]");
-
-        // Now check with strict parsing an exception is thrown
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(json, ParseFieldMatcher.STRICT));
-        assertThat(e.getMessage(),
-                containsString("Deprecated field [type] used, replaced by [match_phrase and match_phrase_prefix query]"));
     }
 
     public void testFuzzinessOnNonStringField() throws Exception {

--- a/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -26,7 +26,6 @@ import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermRangeQuery;
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.lucene.BytesRefs;
@@ -39,7 +38,6 @@ import org.elasticsearch.test.AbstractQueryTestCase;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.chrono.ISOChronology;
-import org.locationtech.spatial4j.shape.SpatialRelation;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -388,14 +386,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 "  }\n" +
                 "}";
 
-        // non strict parsing should accept "_name" on top level
-        assertNotNull(parseQuery(json, ParseFieldMatcher.EMPTY));
-
-        // with strict parsing, ParseField will throw exception
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> parseQuery(deprecatedJson, ParseFieldMatcher.STRICT));
-        assertEquals("Deprecated field [_name] used, replaced by [query name is not supported in short version of range query]",
-                e.getMessage());
+        assertNotNull(parseQuery(deprecatedJson));
+        assertWarningHeaders("Deprecated field [_name] used, replaced by [query name is not supported in short version of range query]");
     }
 
     public void testRewriteDateToMatchAll() throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -387,7 +387,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 "}";
 
         assertNotNull(parseQuery(deprecatedJson));
-        assertWarningHeaders("Deprecated field [_name] used, replaced by [query name is not supported in short version of range query]");
+        assertWarnings("Deprecated field [_name] used, replaced by [query name is not supported in short version of range query]");
     }
 
     public void testRewriteDateToMatchAll() throws IOException {

--- a/core/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
@@ -136,6 +136,10 @@ public class AnalysisModuleTests extends ModuleTestCase {
         IndexAnalyzers indexAnalyzers = getIndexAnalyzers(newRegistry, settings);
         assertThat(indexAnalyzers.get("default").analyzer(), is(instanceOf(KeywordAnalyzer.class)));
         assertThat(indexAnalyzers.get("default_search").analyzer(), is(instanceOf(EnglishAnalyzer.class)));
+        assertWarnings("setting [index.analysis.analyzer.foobar.alias] is only allowed on index [test] because it was created before " +
+                        "5.x; analyzer aliases can no longer be created on new indices.",
+                "setting [index.analysis.analyzer.foobar_search.alias] is only allowed on index [test] because it was created before " +
+                        "5.x; analyzer aliases can no longer be created on new indices.");
     }
 
     public void testAnalyzerAliasReferencesAlias() throws IOException {
@@ -154,6 +158,10 @@ public class AnalysisModuleTests extends ModuleTestCase {
         assertThat(indexAnalyzers.get("default").analyzer(), is(instanceOf(GermanAnalyzer.class)));
         // analyzer types are bound early before we resolve aliases
         assertThat(indexAnalyzers.get("default_search").analyzer(), is(instanceOf(StandardAnalyzer.class)));
+        assertWarnings("setting [index.analysis.analyzer.foobar.alias] is only allowed on index [test] because it was created before " +
+                "5.x; analyzer aliases can no longer be created on new indices.",
+                "setting [index.analysis.analyzer.foobar_search.alias] is only allowed on index [test] because it was created before " +
+                        "5.x; analyzer aliases can no longer be created on new indices.");
     }
 
     public void testAnalyzerAliasDefault() throws IOException {
@@ -168,6 +176,8 @@ public class AnalysisModuleTests extends ModuleTestCase {
         IndexAnalyzers indexAnalyzers = getIndexAnalyzers(newRegistry, settings);
         assertThat(indexAnalyzers.get("default").analyzer(), is(instanceOf(KeywordAnalyzer.class)));
         assertThat(indexAnalyzers.get("default_search").analyzer(), is(instanceOf(KeywordAnalyzer.class)));
+        assertWarnings("setting [index.analysis.analyzer.foobar.alias] is only allowed on index [test] because it was created before " +
+                "5.x; analyzer aliases can no longer be created on new indices.");
     }
 
     public void testAnalyzerAliasMoreThanOnce() throws IOException {
@@ -183,6 +193,10 @@ public class AnalysisModuleTests extends ModuleTestCase {
         AnalysisRegistry newRegistry = getNewRegistry(settings);
         IllegalStateException ise = expectThrows(IllegalStateException.class, () -> getIndexAnalyzers(newRegistry, settings));
         assertEquals("alias [default] is already used by [foobar]", ise.getMessage());
+        assertWarnings("setting [index.analysis.analyzer.foobar.alias] is only allowed on index [test] because it was created before " +
+                "5.x; analyzer aliases can no longer be created on new indices.",
+                "setting [index.analysis.analyzer.foobar1.alias] is only allowed on index [test] because it was created before " +
+                        "5.x; analyzer aliases can no longer be created on new indices.");
     }
 
     public void testAnalyzerAliasNotAllowedPost5x() throws IOException {
@@ -353,6 +367,8 @@ public class AnalysisModuleTests extends ModuleTestCase {
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), equalTo("analyzer name must not start with '_'. got \"_invalid_name\""));
         }
+        assertWarnings("setting [index.analysis.analyzer.valid_name.alias] is only allowed on index [test] because it was " +
+                "created before 5.x; analyzer aliases can no longer be created on new indices.");
     }
 
     public void testDeprecatedPositionOffsetGap() throws IOException {

--- a/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -324,6 +324,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
                 assertEquals(2, searchSourceBuilder.indexBoosts().size());
                 assertEquals(new SearchSourceBuilder.IndexBoost("foo", 1.0f), searchSourceBuilder.indexBoosts().get(0));
                 assertEquals(new SearchSourceBuilder.IndexBoost("bar", 2.0f), searchSourceBuilder.indexBoosts().get(1));
+                assertWarnings("Object format in indices_boost is deprecated, please use array format instead");
             }
         }
 

--- a/core/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
@@ -25,9 +25,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -67,22 +65,16 @@ import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.watcher.ResourceWatcherService;
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
 
 public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends ESTestCase {
 
@@ -91,7 +83,6 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
     private static final int NUMBER_OF_TESTBUILDERS = 20;
     static IndicesQueriesRegistry indicesQueriesRegistry;
     private static ScriptService scriptService;
-    private ThreadContext threadContext;
 
     @BeforeClass
     public static void init() throws IOException {
@@ -121,39 +112,6 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
     public static void afterClass() throws Exception {
         namedWriteableRegistry = null;
         indicesQueriesRegistry = null;
-    }
-
-    @Before
-    public void beforeTest() {
-        this.threadContext = new ThreadContext(Settings.EMPTY);
-        DeprecationLogger.setThreadContext(threadContext);
-    }
-
-    @After
-    public void afterTest() throws IOException {
-        //Check that there are no unaccounted warning headers. These should be checked with assertWarningHeaders(String...) in the
-        //appropriate test
-        final List<String> warnings = threadContext.getResponseHeaders().get(DeprecationLogger.DEPRECATION_HEADER);
-        assertNull("unexpected warning headers", warnings);
-        DeprecationLogger.removeThreadContext(this.threadContext);
-        this.threadContext.close();
-    }
-
-    protected void assertWarningHeaders(String... expectedWarnings) {
-        final List<String> actualWarnings = threadContext.getResponseHeaders().get(DeprecationLogger.DEPRECATION_HEADER);
-        assertThat(actualWarnings, hasSize(expectedWarnings.length));
-        for (String msg : expectedWarnings) {
-            assertThat(actualWarnings, hasItem(equalTo(msg)));
-        }
-        // "clear" current warning headers by setting a new ThreadContext
-        DeprecationLogger.removeThreadContext(this.threadContext);
-        try {
-            this.threadContext.close();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        this.threadContext = new ThreadContext(Settings.EMPTY);
-        DeprecationLogger.setThreadContext(this.threadContext);
     }
 
     /** Returns random sort that is put under test */

--- a/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTests.java
@@ -267,17 +267,15 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
                 "  } ],\n" +
                 "  \"unit\" : \"m\",\n" +
                 "  \"distance_type\" : \"sloppy_arc\",\n" +
-                "  \"mode\" : \"SUM\",\n" +
+                "  \"mode\" : \"MAX\",\n" +
                 "  \"coerce\" : true\n" +
                 "}";
         XContentParser itemParser = createParser(JsonXContent.jsonXContent, json);
         itemParser.nextToken();
 
-        QueryParseContext context = new QueryParseContext(indicesQueriesRegistry, itemParser, ParseFieldMatcher.STRICT);
-
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> GeoDistanceSortBuilder.fromXContent(context, ""));
-        assertTrue(e.getMessage().startsWith("Deprecated field "));
-        
+        QueryParseContext context = new QueryParseContext(indicesQueriesRegistry, itemParser, ParseFieldMatcher.EMPTY);
+        GeoDistanceSortBuilder.fromXContent(context, "");
+        assertWarningHeaders("Deprecated field [coerce] used, replaced by [validation_method]");
     }
 
     public void testIgnoreMalformedIsDeprecated() throws IOException {
@@ -288,17 +286,15 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
                 "  } ],\n" +
                 "  \"unit\" : \"m\",\n" +
                 "  \"distance_type\" : \"sloppy_arc\",\n" +
-                "  \"mode\" : \"SUM\",\n" +
+                "  \"mode\" : \"MAX\",\n" +
                 "  \"ignore_malformed\" : true\n" +
                 "}";
         XContentParser itemParser = createParser(JsonXContent.jsonXContent, json);
         itemParser.nextToken();
 
-        QueryParseContext context = new QueryParseContext(indicesQueriesRegistry, itemParser, ParseFieldMatcher.STRICT);
-
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> GeoDistanceSortBuilder.fromXContent(context, ""));
-        assertTrue(e.getMessage().startsWith("Deprecated field "));
-        
+        QueryParseContext context = new QueryParseContext(indicesQueriesRegistry, itemParser, ParseFieldMatcher.EMPTY);
+        GeoDistanceSortBuilder.fromXContent(context, "");
+        assertWarningHeaders("Deprecated field [ignore_malformed] used, replaced by [validation_method]");
     }
 
     public void testSortModeSumIsRejectedInJSON() throws IOException {
@@ -455,8 +451,8 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
         sortBuilder.field("unit", "km");
         sortBuilder.field("sort_mode", "max");
         sortBuilder.endObject();
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> parse(sortBuilder));
-        assertEquals("Deprecated field [sort_mode] used, expected [mode] instead", ex.getMessage());
+        parse(sortBuilder);
+        assertWarningHeaders("Deprecated field [sort_mode] used, expected [mode] instead");
     }
 
     private GeoDistanceSortBuilder parse(XContentBuilder sortBuilder) throws Exception {

--- a/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTests.java
@@ -275,7 +275,7 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
 
         QueryParseContext context = new QueryParseContext(indicesQueriesRegistry, itemParser, ParseFieldMatcher.EMPTY);
         GeoDistanceSortBuilder.fromXContent(context, "");
-        assertWarningHeaders("Deprecated field [coerce] used, replaced by [validation_method]");
+        assertWarnings("Deprecated field [coerce] used, replaced by [validation_method]");
     }
 
     public void testIgnoreMalformedIsDeprecated() throws IOException {
@@ -294,7 +294,7 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
 
         QueryParseContext context = new QueryParseContext(indicesQueriesRegistry, itemParser, ParseFieldMatcher.EMPTY);
         GeoDistanceSortBuilder.fromXContent(context, "");
-        assertWarningHeaders("Deprecated field [ignore_malformed] used, replaced by [validation_method]");
+        assertWarnings("Deprecated field [ignore_malformed] used, replaced by [validation_method]");
     }
 
     public void testSortModeSumIsRejectedInJSON() throws IOException {
@@ -452,7 +452,7 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
         sortBuilder.field("sort_mode", "max");
         sortBuilder.endObject();
         parse(sortBuilder);
-        assertWarningHeaders("Deprecated field [sort_mode] used, expected [mode] instead");
+        assertWarnings("Deprecated field [sort_mode] used, expected [mode] instead");
     }
 
     private GeoDistanceSortBuilder parse(XContentBuilder sortBuilder) throws Exception {

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheScriptEngineTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheScriptEngineTests.java
@@ -87,7 +87,7 @@ public class MustacheScriptEngineTests extends ESTestCase {
                 + "\"params\":{\"template\":\"all\"}"
                 + "}";
         XContentParser parser = createParser(JsonXContent.jsonXContent, templateString);
-        Script script = Script.parse(parser, new ParseFieldMatcher(false));
+        Script script = Script.parse(parser, ParseFieldMatcher.EMPTY);
         CompiledScript compiledScript = new CompiledScript(ScriptType.INLINE, null, "mustache",
                 qe.compile(null, script.getIdOrCode(), Collections.emptyMap()));
         ExecutableScript executableScript = qe.executable(compiledScript, script.getParams());
@@ -103,7 +103,7 @@ public class MustacheScriptEngineTests extends ESTestCase {
                 + "  }"
                 + "}";
         XContentParser parser = createParser(JsonXContent.jsonXContent, templateString);
-        Script script = Script.parse(parser, new ParseFieldMatcher(false));
+        Script script = Script.parse(parser, ParseFieldMatcher.EMPTY);
         CompiledScript compiledScript = new CompiledScript(ScriptType.INLINE, null, "mustache",
                 qe.compile(null, script.getIdOrCode(), Collections.emptyMap()));
         ExecutableScript executableScript = qe.executable(compiledScript, script.getParams());

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/TemplateQueryBuilderTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/TemplateQueryBuilderTests.java
@@ -63,7 +63,7 @@ public class TemplateQueryBuilderTests extends AbstractQueryTestCase<TemplateQue
      * Instead of having to check them once in every single test, this is done here after each test is run
      */
     @After void checkWarningHeaders() throws IOException {
-        checkWarningHeaders("[template] query is deprecated, use search template api instead");
+        assertWarningHeaders("[template] query is deprecated, use search template api instead");
     }
 
     @Override

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/TemplateQueryBuilderTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/TemplateQueryBuilderTests.java
@@ -59,11 +59,12 @@ public class TemplateQueryBuilderTests extends AbstractQueryTestCase<TemplateQue
     private QueryBuilder templateBase;
 
     /**
-     * All tests create deprecation warnings when an new {@link TemplateQueryBuilder} is created.
-     * Instead of having to check them once in every single test, this is done here after each test is run
+     * All tests in this class cause deprecation warnings when a new {@link TemplateQueryBuilder} is created.
+     * Instead of having to check them in every single test, we do it after each test is run
      */
-    @After void checkWarningHeaders() throws IOException {
-        assertWarningHeaders("[template] query is deprecated, use search template api instead");
+    @After
+    public void checkWarning() throws IOException {
+        assertWarnings("[template] query is deprecated, use search template api instead");
     }
 
     @Override

--- a/plugins/discovery-file/src/test/java/org/elasticsearch/discovery/file/FileBasedDiscoveryPluginTests.java
+++ b/plugins/discovery-file/src/test/java/org/elasticsearch/discovery/file/FileBasedDiscoveryPluginTests.java
@@ -23,17 +23,23 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.IOException;
+
 public class FileBasedDiscoveryPluginTests extends ESTestCase {
 
-    public void testHostsProviderBwc() {
+    public void testHostsProviderBwc() throws IOException {
         FileBasedDiscoveryPlugin plugin = new FileBasedDiscoveryPlugin(Settings.EMPTY);
         Settings additionalSettings = plugin.additionalSettings();
         assertEquals("file", additionalSettings.get(DiscoveryModule.DISCOVERY_HOSTS_PROVIDER_SETTING.getKey()));
+        assertWarnings("Using discovery.type setting to set hosts provider is deprecated. " +
+                "Set \"discovery.zen.hosts_provider: file\" instead");
     }
 
-    public void testHostsProviderExplicit() {
+    public void testHostsProviderExplicit() throws IOException {
         Settings settings = Settings.builder().put(DiscoveryModule.DISCOVERY_HOSTS_PROVIDER_SETTING.getKey(), "foo").build();
         FileBasedDiscoveryPlugin plugin = new FileBasedDiscoveryPlugin(settings);
         assertEquals(Settings.EMPTY, plugin.additionalSettings());
+        assertWarnings("Using discovery.type setting to set hosts provider is deprecated. " +
+                "Set \"discovery.zen.hosts_provider: file\" instead");
     }
 }

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.repositories.s3;
 
-import java.io.IOException;
-
 import com.amazonaws.Protocol;
 import com.amazonaws.services.s3.AbstractAmazonS3;
 import com.amazonaws.services.s3.AmazonS3;
@@ -33,6 +31,8 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
+
+import java.io.IOException;
 
 import static org.elasticsearch.repositories.s3.S3Repository.Repositories;
 import static org.elasticsearch.repositories.s3.S3Repository.Repository;
@@ -111,11 +111,14 @@ public class S3RepositoryTests extends ESTestCase {
             .put(Repository.BASE_PATH_SETTING.getKey(), "/foo/bar").build());
         S3Repository s3repo = new S3Repository(metadata, Settings.EMPTY, new DummyS3Service());
         assertEquals("foo/bar/", s3repo.basePath().buildAsString()); // make sure leading `/` is removed and trailing is added
-
+        assertWarnings("S3 repository base_path" +
+                " trimming the leading `/`, and leading `/` will not be supported for the S3 repository in future releases");
         metadata = new RepositoryMetaData("dummy-repo", "mock", Settings.EMPTY);
         Settings settings = Settings.builder().put(Repositories.BASE_PATH_SETTING.getKey(), "/foo/bar").build();
         s3repo = new S3Repository(metadata, settings, new DummyS3Service());
         assertEquals("foo/bar/", s3repo.basePath().buildAsString()); // make sure leading `/` is removed and trailing is added
+        assertWarnings("S3 repository base_path" +
+                " trimming the leading `/`, and leading `/` will not be supported for the S3 repository in future releases");
     }
 
     public void testDefaultBufferSize() {

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
@@ -96,6 +96,7 @@ public class EvilLoggerTests extends ESTestCase {
             Level.WARN,
             "org.elasticsearch.common.logging.DeprecationLogger.deprecated",
             "This is a deprecation message");
+        assertWarnings("This is a deprecation message");
     }
 
     public void testFindAppender() throws IOException, UserException {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -339,6 +339,13 @@ public abstract class ESIntegTestCase extends ESTestCase {
         initializeSuiteScope();
     }
 
+    @Override
+    protected final boolean enableWarningsCheck() {
+        //In an integ test it doesn't make sense to keep track of warnings: if the cluster is external the warnings are in another jvm,
+        //if the cluster is internal the deprecation logger is shared across all nodes
+        return false;
+    }
+
     protected final void beforeInternal() throws Exception {
         final Scope currentClusterScope = getCurrentClusterScope();
         switch (currentClusterScope) {


### PR DESCRIPTION
This is the first step towards removing `ParseFieldMatcher`. The only reason to have this class is strict parsing, which is only used in our test infra. Because it depends on a setting (although this setting was never settable by users), we were moved all of the `ParseField` checks to `ParseFieldMatcher` when it was introduced (see #11859), which was quite an intrusive change in our parsing code. We now have a deprecation logger, and we return warning headers whenever some deprecated feature is used throughout the execution of a request. The functionality of strict parsing can either be moved to clients, or re-implemented without the need for `ParseFieldMatcher`, by rather leveraging our current infrastructure based on `ThreadContext` and `DeprecationLogger`. Another disadvantage of `ParseFieldMatcher` is that it's completely decoupled from the deprecation logger, hence it became hard to keep the two in sync. Also, we ended up creating many copies of `ParseFieldMatcher` in our codebase that cause confusion.

This PR deprecates `ParseFieldMatcher` and makes it not useful as it removes support for strict parsing. All tests that used to rely on strict parsing are now moved to checking warning headers, introduced first with #20993 in query tests. Even more, we can now move the warnings check from `AbstractQueryTestCase` to `ESTestCase` and test more closely deprecation warnings, as well as easily catch which tests use deprecated features. This can only be leveraged in unit tests or single node test (where the only node runs in the same jvm as the test).

Once this change goes in, we can go and step by step remove all the usages of `ParseFieldMatcher`, which will be a mechanical change (a big one), and finally remove the class.

Relates to #19552
