### PR TITLE
Fixes GrokProcessor's ignorance of named-captures with same name.

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessor.java
@@ -68,7 +68,6 @@ public final class GrokProcessor extends AbstractProcessor {
         }
 
         matches.entrySet().stream()
-            .filter((e) -> Objects.nonNull(e.getValue()))
             .forEach((e) -> ingestDocument.setFieldValue(e.getKey(), e.getValue()));
 
         if (traceMatch) {
@@ -108,24 +107,20 @@ public final class GrokProcessor extends AbstractProcessor {
     static String combinePatterns(List<String> patterns, boolean traceMatch) {
         String combinedPattern;
         if (patterns.size() > 1) {
-            if (traceMatch) {
-                combinedPattern = "";
-                for (int i = 0; i < patterns.size(); i++) {
-                    String valueWrap = "(?<" + PATTERN_MATCH_KEY + "." + i + ">" + patterns.get(i) + ")";
-                    if (combinedPattern.equals("")) {
-                        combinedPattern = valueWrap;
-                    } else {
-                        combinedPattern = combinedPattern + "|" + valueWrap;
-                    }
+            combinedPattern = "";
+            for (int i = 0; i < patterns.size(); i++) {
+                String pattern = patterns.get(i);
+                String valueWrap;
+                if (traceMatch) {
+                    valueWrap = "(?<" + PATTERN_MATCH_KEY + "." + i + ">" + pattern + ")";
+                } else {
+                    valueWrap = "(?:" + patterns.get(i) + ")";
                 }
-            } else {
-                combinedPattern = patterns.stream().reduce("", (prefix, value) -> {
-                    if (prefix.equals("")) {
-                        return "(?:" + value + ")";
-                    } else {
-                        return prefix + "|" + "(?:" + value + ")";
-                    }
-                });
+                if (combinedPattern.equals("")) {
+                    combinedPattern = valueWrap;
+                } else {
+                    combinedPattern = combinedPattern + "|" + valueWrap;
+                }
             }
         }  else {
             combinedPattern = patterns.get(0);

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokProcessorTests.java
@@ -186,4 +186,45 @@ public class GrokProcessorTests extends ESTestCase {
         combined = GrokProcessor.combinePatterns(Arrays.asList("foo", "bar"), true);
         assertThat(combined, equalTo("(?<_ingest._grok_match_index.0>foo)|(?<_ingest._grok_match_index.1>bar)"));
     }
+
+    public void testCombineSamePatternNameAcrossPatterns() throws Exception {
+        String fieldName = RandomDocumentPicks.randomFieldName(random());
+        IngestDocument doc = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
+        doc.setFieldValue(fieldName, "1-3");
+        Map<String, String> patternBank = new HashMap<>();
+        patternBank.put("ONE", "1");
+        patternBank.put("TWO", "2");
+        patternBank.put("THREE", "3");
+        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), patternBank,
+            Arrays.asList("%{ONE:first}-%{TWO:second}", "%{ONE:first}-%{THREE:second}"), fieldName, randomBoolean(), randomBoolean());
+        processor.execute(doc);
+        assertThat(doc.getFieldValue("first", String.class), equalTo("1"));
+        assertThat(doc.getFieldValue("second", String.class), equalTo("3"));
+    }
+
+    public void testFirstWinNamedCapture() throws Exception {
+        String fieldName = RandomDocumentPicks.randomFieldName(random());
+        IngestDocument doc = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
+        doc.setFieldValue(fieldName, "12");
+        Map<String, String> patternBank = new HashMap<>();
+        patternBank.put("ONETWO", "1|2");
+        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), patternBank,
+            Collections.singletonList("%{ONETWO:first}%{ONETWO:first}"), fieldName, randomBoolean(), randomBoolean());
+        processor.execute(doc);
+        assertThat(doc.getFieldValue("first", String.class), equalTo("1"));
+    }
+
+    public void testUnmatchedNamesNotIncludedInDocument()  throws Exception {
+        String fieldName = RandomDocumentPicks.randomFieldName(random());
+        IngestDocument doc = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
+        doc.setFieldValue(fieldName, "3");
+        Map<String, String> patternBank = new HashMap<>();
+        patternBank.put("ONETWO", "1|2");
+        patternBank.put("THREE", "3");
+        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), patternBank,
+            Collections.singletonList("%{ONETWO:first}|%{THREE:second}"), fieldName, randomBoolean(), randomBoolean());
+        processor.execute(doc);
+        assertFalse(doc.hasField("first"));
+        assertThat(doc.getFieldValue("second", String.class), equalTo("3"));
+    }
 }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokTests.java
@@ -307,4 +307,14 @@ public class GrokTests extends ESTestCase {
         Grok grok = new Grok(bank, "%{MONTHDAY:greatday}");
         assertThat(grok.captures("nomatch"), nullValue());
     }
+
+    public void testMultipleNamedCapturesWithSameName() {
+        Map<String, String> bank = new HashMap<>();
+        bank.put("SINGLEDIGIT", "[0-9]");
+        Grok grok = new Grok(bank, "%{SINGLEDIGIT:num}%{SINGLEDIGIT:num}");
+
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("num", "1");
+        assertThat(grok.captures("12"), equalTo(expected));
+    }
 }


### PR DESCRIPTION
Grok was originally ignoring potential matches to named-capture groups
larger than one. For example, If you had two patterns containing the
same named field, but only the second pattern matched, it would fail to
pick this up.

This PR fixes this by exploring all potential places where a
named-capture was used and chooses the first one that matched.

Fixes #22117.