### PR TITLE
Another fix for handling of paths on Windows

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-service.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-service.bat
@@ -4,7 +4,7 @@ SETLOCAL enabledelayedexpansion
 TITLE Elasticsearch Service ${project.version}
 
 IF DEFINED JAVA_HOME (
-  SET JAVA="%JAVA_HOME%"\bin\java.exe
+  SET JAVA="%JAVA_HOME%\bin\java.exe"
 ) ELSE (
   FOR %%I IN (java.exe) DO set JAVA=%%~$PATH:I
 )
@@ -121,19 +121,19 @@ echo Installing service      :  "%SERVICE_ID%"
 echo Using JAVA_HOME (%ARCH%):  "%JAVA_HOME%"
 
 rem Check JVM server dll first
-if exist "%JAVA_HOME%"\jre\bin\server\jvm.dll (
+if exist "%JAVA_HOME%\jre\bin\server\jvm.dll" (
 	set JVM_DLL=\jre\bin\server\jvm.dll
 	goto foundJVM
 )
 
 rem Check 'server' JRE (JRE installed on Windows Server)
-if exist "%JAVA_HOME%"\bin\server\jvm.dll (
+if exist "%JAVA_HOME%\bin\server\jvm.dll" (
 	set JVM_DLL=\bin\server\jvm.dll
 	goto foundJVM
 )
 
 rem Fallback to 'client' JRE
-if exist "%JAVA_HOME%"\bin\client\jvm.dll (
+if exist "%JAVA_HOME%\bin\client\jvm.dll" (
 	set JVM_DLL=\bin\client\jvm.dll
 	echo Warning: JAVA_HOME points to a JRE and not JDK installation; a client (not a server^) JVM will be used...
 ) else (

--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -1,7 +1,7 @@
 @echo off
 
 IF DEFINED JAVA_HOME (
-  set JAVA="%JAVA_HOME%"\bin\java.exe
+  set JAVA="%JAVA_HOME%\bin\java.exe"
 ) ELSE (
   FOR %%I IN (java.exe) DO set JAVA=%%~$PATH:I
 )


### PR DESCRIPTION
A previous fix for the handling of paths on Windows related to paths
containing multiple spaces introduced a issue where if JAVA_HOME ends
with a backslash, then Elasticsearch will refuse to start. This is not a
critical bug as a workaround exists (remove the trailing backslash), but
should be fixed nevertheless. This commit addresses this situation while
not regressing the previous fix.

Relates #21921
