### PR TITLE
Prevents unsafe concurrent snapshot deletions

### DIFF
--- a/core/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/core/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -44,8 +44,14 @@ import java.util.stream.Collectors;
  */
 public final class RepositoryData implements ToXContent {
 
-    private static final long INITIAL_GEN = -1L;
-    public static final RepositoryData EMPTY = new RepositoryData(INITIAL_GEN, Collections.emptyList(), Collections.emptyMap());
+    /**
+     * The generation value indicating the repository has no index generational files.
+     */
+    public static final long EMPTY_REPO_GEN = -1L;
+    /**
+     * An instance initialized for an empty repository.
+     */
+    public static final RepositoryData EMPTY = new RepositoryData(EMPTY_REPO_GEN, Collections.emptyList(), Collections.emptyMap());
 
     /**
      * The generational id of the index file from which the repository data was read.
@@ -77,7 +83,7 @@ public final class RepositoryData implements ToXContent {
      * Creates an instance of {@link RepositoryData} on a fresh repository (one that has no index-N files).
      */
     public static RepositoryData initRepositoryData(List<SnapshotId> snapshotIds, Map<IndexId, Set<SnapshotId>> indexSnapshots) {
-        return new RepositoryData(INITIAL_GEN, snapshotIds, indexSnapshots);
+        return new RepositoryData(EMPTY_REPO_GEN, snapshotIds, indexSnapshots);
     }
 
     protected RepositoryData copy() {

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -725,7 +725,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 //      index-latest blob
                 // in a read-only repository, we can't know which of the two scenarios it is,
                 // but we will assume (1) because we can't do anything about (2) anyway
-                return -1;
+                return RepositoryData.EMPTY_REPO_GEN;
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -1397,7 +1397,7 @@ public class IndexShardTests extends IndexShardTestCase {
         public RepositoryData getRepositoryData() {
             Map<IndexId, Set<SnapshotId>> map = new HashMap<>();
             map.put(new IndexId(indexName, "blah"), emptySet());
-            return new RepositoryData(Collections.emptyList(), map);
+            return RepositoryData.initRepositoryData(Collections.emptyList(), map);
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/core/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -24,16 +24,18 @@ import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRes
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.RepositoryData;
+import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -106,25 +108,21 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
         assertThat(repository.getSnapshots().size(), equalTo(0));
         final RepositoryData emptyData = RepositoryData.EMPTY;
         repository.writeIndexGen(emptyData);
-        final RepositoryData readData = repository.getRepositoryData();
-        assertEquals(readData, emptyData);
-        assertEquals(readData.getIndices().size(), 0);
-        assertEquals(readData.getSnapshotIds().size(), 0);
+        RepositoryData repoData = repository.getRepositoryData();
+        assertEquals(repoData, emptyData);
+        assertEquals(repoData.getIndices().size(), 0);
+        assertEquals(repoData.getSnapshotIds().size(), 0);
+        assertEquals(0L, repoData.getGenId());
 
         // write to and read from an index file with snapshots but no indices
-        final int numSnapshots = randomIntBetween(1, 20);
-        final List<SnapshotId> snapshotIds = new ArrayList<>(numSnapshots);
-        for (int i = 0; i < numSnapshots; i++) {
-            snapshotIds.add(new SnapshotId(randomAsciiOfLength(8), UUIDs.randomBase64UUID()));
-        }
-        RepositoryData repositoryData = new RepositoryData(snapshotIds, Collections.emptyMap());
-        repository.writeIndexGen(repositoryData);
-        assertEquals(repository.getRepositoryData(), repositoryData);
+        repoData = addRandomSnapshotsToRepoData(repoData, false);
+        repository.writeIndexGen(repoData);
+        assertEquals(repoData, repository.getRepositoryData());
 
         // write to and read from a index file with random repository data
-        repositoryData = generateRandomRepoData();
-        repository.writeIndexGen(repositoryData);
-        assertThat(repository.getRepositoryData(), equalTo(repositoryData));
+        repoData = addRandomSnapshotsToRepoData(repository.getRepositoryData(), true);
+        repository.writeIndexGen(repoData);
+        assertEquals(repoData, repository.getRepositoryData());
     }
 
     public void testIndexGenerationalFiles() throws Exception {
@@ -138,18 +136,30 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
         assertThat(repository.readSnapshotIndexLatestBlob(), equalTo(0L));
 
         // adding more and writing to a new index generational file
-        repositoryData = generateRandomRepoData();
+        repositoryData = addRandomSnapshotsToRepoData(repository.getRepositoryData(), true);
         repository.writeIndexGen(repositoryData);
         assertEquals(repository.getRepositoryData(), repositoryData);
         assertThat(repository.latestIndexBlobId(), equalTo(1L));
         assertThat(repository.readSnapshotIndexLatestBlob(), equalTo(1L));
 
         // removing a snapshot and writing to a new index generational file
-        repositoryData = repositoryData.removeSnapshot(repositoryData.getSnapshotIds().get(0));
+        repositoryData = repository.getRepositoryData().removeSnapshot(repositoryData.getSnapshotIds().get(0));
         repository.writeIndexGen(repositoryData);
         assertEquals(repository.getRepositoryData(), repositoryData);
         assertThat(repository.latestIndexBlobId(), equalTo(2L));
         assertThat(repository.readSnapshotIndexLatestBlob(), equalTo(2L));
+    }
+
+    public void testRepositoryDataConcurrentModificationNotAllowed() throws IOException {
+        final BlobStoreRepository repository = setupRepo();
+
+        // write to index generational file
+        RepositoryData repositoryData = generateRandomRepoData();
+        repository.writeIndexGen(repositoryData);
+
+        // write repo data again to index generational file, errors because we already wrote to the
+        // N+1 generation from which this repository data instance was created
+        expectThrows(RepositoryException.class, () -> repository.writeIndexGen(repositoryData));
     }
 
     private BlobStoreRepository setupRepo() {
@@ -168,6 +178,20 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
         @SuppressWarnings("unchecked") final BlobStoreRepository repository =
             (BlobStoreRepository) repositoriesService.repository(repositoryName);
         return repository;
+    }
+
+    private RepositoryData addRandomSnapshotsToRepoData(RepositoryData repoData, boolean inclIndices) {
+        int numSnapshots = randomIntBetween(1, 20);
+        for (int i = 0; i < numSnapshots; i++) {
+            SnapshotId snapshotId = new SnapshotId(randomAsciiOfLength(8), UUIDs.randomBase64UUID());
+            int numIndices = inclIndices ? randomIntBetween(0, 20) : 0;
+            List<IndexId> indexIds = new ArrayList<>(numIndices);
+            for (int j = 0; j < numIndices; j++) {
+                indexIds.add(new IndexId(randomAsciiOfLength(8), UUIDs.randomBase64UUID()));
+            }
+            repoData = repoData.addSnapshot(snapshotId, indexIds);
+        }
+        return repoData;
     }
 
 }


### PR DESCRIPTION
The snapshot APIs prevent more than one snapshot from being taken in the
system at any given time, but nothing prevents concurrent snapshot
deletions from occuring.   If two snapshot deletion requests are
executing simultaneously, it is possible that both deletion requests
read the same index-N file, then the first deletion request will remove
the snapshot from the list found in index-N and write a new index-{N+1}
index file with the snapshot removed.  The second deletion request will
remove another snapshot from the list found in index-N, but since it is
operating based on the data it read from index-N, it does not know that
a different snapshot was removed simulatenously and the index file
updated to index-{N+1}.  Therefore, the second deletion request takes
the original snapshot list found in index-N and removes the snapshot it
is supposed to delete, and writes a new index-{N+2} file, but the new
index-{N+2} file (which is now the active index file for the repository)
still contains the snapshot that was supposed to be deleted from the
first snapshot deletion request.

This leads to various issues, including the fact that the deletion
operation also deletes all associated snapshot blobs in the repository.
When the repository tries to load its snapshot data, it sees that the
deleted snapshot from the first deletion request is still there, so
tries to load its metadata, but it fails because the blob is not found.

This commit fixes the issue by ensuring that repository data is only
written to a new index-{N+1} if the repository data was loaded from the
index-{N} file.  If it was loaded from any other index file (e.g.
index-{N-1}), then we assume we are operating on stale repository data
and throw an exception.  This still leaves a small window where two
simultaneous deletions may determine at the same time that the next
index generation is {N+1}, so both operations try to write the new index
blob to index-{N+1}.  However, repository implementations will throw an
IOException if they attempt to write to a blob that already exists, so
the operation will fail in that case too, preventing simultaneous
deletes.  Note that this solution also enables detecting concurrent 
modifications of the index file across multiple clusters that share the 
same repository.

This solution does not account for the situation where a snapshot deletion
may be in progress when a snapshot is started, potentially causing a deletion
to delete data that the snapshot requires.  The window for this is small however,
and this situation will be better solved in #19957.