### PR TITLE
Fix for loop that is bad and should feel bad

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodeResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodeResponse.java
@@ -86,8 +86,8 @@ public class ClusterStatsNodeResponse extends BaseNodeResponse {
         this.nodeStats = NodeStats.readNodeStats(in);
         int size = in.readVInt();
         shardsStats = new ShardStats[size];
-        for (size--; size >= 0; size--) {
-            shardsStats[size] = ShardStats.readShardStats(in);
+        for (int i = 0; i < size; i++) {
+            shardsStats[i] = ShardStats.readShardStats(in);
         }
     }
 


### PR DESCRIPTION
This commit fixes a for loop that reverses the order of shard stats
coming off the wire, and is really hard to read anyway (with the
post-increment in the loop initializer).