### PR TITLE
Fix ShardInfo#toString

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ActionWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionWriteResponse.java
@@ -161,7 +161,11 @@ public class ActionWriteResponse extends ActionResponse {
 
         @Override
         public String toString() {
-            return Strings.toString(this);
+            return "ShardInfo{" +
+                "total=" + total +
+                ", successful=" + successful +
+                ", failures=" + Arrays.toString(failures) +
+                '}';
         }
 
         public static ShardInfo readShardInfo(StreamInput in) throws IOException {

--- a/core/src/main/java/org/elasticsearch/action/ActionWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionWriteResponse.java
@@ -35,6 +35,7 @@ import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Arrays;
 
 /**
  * Base class for write action responses.


### PR DESCRIPTION

This pull request is suggested to fix some JsonGenerationException corrected in 5.x but not backported to 2.x

Following the issues : 
- https://github.com/elastic/elasticsearch/issues/20853

and 

- https://discuss.elastic.co/t/java-api-vs-jackson-dependencies-can-it-be-a-problem/68460

Original fix in the 5.x branch is:
- https://github.com/elastic/elasticsearch/pull/21319/commits/5faf26da634017890d7f2beaff029331f7facfee


