### PR TITLE
Update Java API docs for 5.1/5.0

### DIFF
--- a/docs/java-api/aggregations/metrics/scripted-metric-aggregation.asciidoc
+++ b/docs/java-api/aggregations/metrics/scripted-metric-aggregation.asciidoc
@@ -12,43 +12,32 @@ Here is an example on how to create the aggregation request:
 [source,java]
 --------------------------------------------------
 ScriptedMetricAggregationBuilder aggregation = AggregationBuilders
-        .scriptedMetric("agg")
-        .initScript(new Script("_agg['heights'] = []"))
-        .mapScript(new Script("if (doc['gender'].value == \"male\") " +
-                "{ _agg.heights.add(doc['height'].value) } " +
-                "else " +
-                "{ _agg.heights.add(-1 * doc['height'].value) }"));
+    .scriptedMetric("agg")
+    .initScript(new Script("params._agg.heights = []"))
+    .mapScript(new Script("params._agg.heights.add(doc.gender.value == 'male' ? doc.height.value : -1.0 * doc.height.value)"));
 --------------------------------------------------
 
 You can also specify a `combine` script which will be executed on each shard:
 
 [source,java]
 --------------------------------------------------
-ScriptedMetricAggregationBuilder aggregation =
-        AggregationBuilders
-                .scriptedMetric("agg")
-                .initScript(new Script("_agg['heights'] = []"))
-                .mapScript(new Script("if (doc['gender'].value == \"male\") " +
-                        "{ _agg.heights.add(doc['height'].value) } " +
-                        "else " +
-                        "{ _agg.heights.add(-1 * doc['height'].value) }"))
-                .combineScript(new Script("heights_sum = 0; for (t in _agg.heights) { heights_sum += t }; return heights_sum"));
+ScriptedMetricAggregationBuilder aggregation = AggregationBuilders
+    .scriptedMetric("agg")
+    .initScript(new Script("params._agg.heights = []"))
+    .mapScript(new Script("params._agg.heights.add(doc.gender.value == 'male' ? doc.height.value : -1.0 * doc.height.value)"))
+    .combineScript(new Script("double heights_sum = 0.0; for (t in params._agg.heights) { heights_sum += t } return heights_sum"));
 --------------------------------------------------
 
 You can also specify a `reduce` script which will be executed on the node which gets the request:
 
 [source,java]
 --------------------------------------------------
-ScriptedMetricAggregationBuilder aggregation =
-        AggregationBuilders
-                .scriptedMetric("agg")
-                .initScript(new Script("_agg['heights'] = []"))
-                .mapScript(new Script("if (doc['gender'].value == \"male\") " +
-                        "{ _agg.heights.add(doc['height'].value) } " +
-                        "else " +
-                        "{ _agg.heights.add(-1 * doc['height'].value) }"))
-                .combineScript(new Script("heights_sum = 0; for (t in _agg.heights) { heights_sum += t }; return heights_sum"))
-                .reduceScript(new Script("heights_sum = 0; for (a in _aggs) { heights_sum += a }; return heights_sum"));
+ScriptedMetricAggregationBuilder aggregation = AggregationBuilders
+    .scriptedMetric("agg")
+    .initScript(new Script("params._agg.heights = []"))
+    .mapScript(new Script("params._agg.heights.add(doc.gender.value == 'male' ? doc.height.value : -1.0 * doc.height.value)"))
+    .combineScript(new Script("double heights_sum = 0.0; for (t in params._agg.heights) { heights_sum += t } return heights_sum"))
+    .reduceScript(new Script("double heights_sum = 0.0; for (a in params._aggs) { heights_sum += a } return heights_sum"));
 --------------------------------------------------
 
 

--- a/docs/java-api/query-dsl/script-query.asciidoc
+++ b/docs/java-api/query-dsl/script-query.asciidoc
@@ -25,13 +25,13 @@ You can use it then with:
 --------------------------------------------------
 QueryBuilder qb = scriptQuery(
     new Script(
-        "myscript",                            <1>
-        ScriptType.FILE,                       <2>
-        "painless",                            <3>
+        ScriptType.FILE,                       <1>
+        "painless",                            <2>
+        "myscript",                            <3>
         Collections.singletonMap("param1", 5)) <4>
 );
 --------------------------------------------------
-<1> Script name
-<2> Script type: either `ScriptType.FILE`, `ScriptType.INLINE` or `ScriptType.INDEXED`
-<3> Scripting engine
+<1> Script type: either `ScriptType.FILE`, `ScriptType.INLINE` or `ScriptType.INDEXED`
+<2> Scripting engine
+<3> Script name
 <4> Parameters as a `Map` of `<String, Object>`

--- a/docs/java-api/search.asciidoc
+++ b/docs/java-api/search.asciidoc
@@ -216,7 +216,7 @@ To execute a stored templates, use `ScriptService.ScriptType.STORED`:
 --------------------------------------------------
 SearchResponse sr = new SearchTemplateRequestBuilder(client)
         .setScript("template_gender")                       <1>
-        .setScriptType(ScriptService.ScriptType.STORED)     <2>
+        .setScriptType(ScriptType.STORED)     <2>
         .setScriptParams(template_params)                   <3>
         .setRequest(new SearchRequest())                    <4>
         .get()                                              <5>
@@ -241,7 +241,7 @@ sr = new SearchTemplateRequestBuilder(client)
                 "            }\n" +
                 "        }\n" +
                 "}")
-        .setScriptType(ScriptService.ScriptType.INLINE)    <2>
+        .setScriptType(ScriptType.INLINE)    <2>
         .setScriptParams(template_params)                  <3>
         .setRequest(new SearchRequest())                   <4>
         .get()                                             <5>


### PR DESCRIPTION
For 6.0/5.2/5.1/5.0:

* We are now using painless as our language so I made sure that scripts can be run actually

For 6.0/5.2/5.1:

* From 5.1 we changed the order of `Script` class ctor.
* From 5.1, we can't use anymore `ScriptService.ScriptType` but `ScriptType`.
