### PR TITLE
Enables the ability to inject serialized json fields into root of document

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -1473,6 +1473,7 @@ Converts a JSON string into a structured JSON object.
 | Name           | Required  | Default  | Description
 | `field`        | yes       | -        | The field to be parsed
 | `target_field` | no        | `field`  | The field to insert the converted structured object into
+| `add_to_root`  | no        | false    | Flag that forces the serialized json to be injected into the top level of the document. `target_field` must not be set when this option is chosen.
 |======
 
 [source,js]

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JsonProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JsonProcessorFactoryTests.java
@@ -48,6 +48,19 @@ public class JsonProcessorFactoryTests extends ESTestCase {
         assertThat(jsonProcessor.getTargetField(), equalTo(randomTargetField));
     }
 
+    public void testCreateWithAddToRoot() throws Exception {
+        String processorTag = randomAsciiOfLength(10);
+        String randomField = randomAsciiOfLength(10);
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", randomField);
+        config.put("add_to_root", true);
+        JsonProcessor jsonProcessor = FACTORY.create(null, processorTag, config);
+        assertThat(jsonProcessor.getTag(), equalTo(processorTag));
+        assertThat(jsonProcessor.getField(), equalTo(randomField));
+        assertThat(jsonProcessor.getTargetField(), equalTo(randomField));
+        assertTrue(jsonProcessor.isAddToRoot());
+    }
+
     public void testCreateWithDefaultTarget() throws Exception {
         String processorTag = randomAsciiOfLength(10);
         String randomField = randomAsciiOfLength(10);
@@ -65,5 +78,17 @@ public class JsonProcessorFactoryTests extends ESTestCase {
         ElasticsearchException exception = expectThrows(ElasticsearchParseException.class,
             () -> FACTORY.create(null, processorTag, config));
         assertThat(exception.getMessage(), equalTo("[field] required property is missing"));
+    }
+
+    public void testCreateWithBothTargetFieldAndAddToRoot() throws Exception {
+        String randomField = randomAsciiOfLength(10);
+        String randomTargetField = randomAsciiOfLength(5);
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", randomField);
+        config.put("target_field", randomTargetField);
+        config.put("add_to_root", true);
+        ElasticsearchException exception = expectThrows(ElasticsearchParseException.class,
+            () -> FACTORY.create(null, randomAsciiOfLength(10), config));
+        assertThat(exception.getMessage(), equalTo("[target_field] Cannot set a target field while also setting `add_to_root` to true"));
     }
 }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JsonProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JsonProcessorTests.java
@@ -39,7 +39,7 @@ public class JsonProcessorTests extends ESTestCase {
         String processorTag = randomAsciiOfLength(3);
         String randomField = randomAsciiOfLength(3);
         String randomTargetField = randomAsciiOfLength(2);
-        JsonProcessor jsonProcessor = new JsonProcessor(processorTag, randomField, randomTargetField);
+        JsonProcessor jsonProcessor = new JsonProcessor(processorTag, randomField, randomTargetField, false);
         Map<String, Object> document = new HashMap<>();
 
         Map<String, Object> randomJsonMap = RandomDocumentPicks.randomSource(random());
@@ -54,7 +54,7 @@ public class JsonProcessorTests extends ESTestCase {
     }
 
     public void testInvalidJson() {
-        JsonProcessor jsonProcessor = new JsonProcessor("tag", "field", "target_field");
+        JsonProcessor jsonProcessor = new JsonProcessor("tag", "field", "target_field", false);
         Map<String, Object> document = new HashMap<>();
         document.put("field", "invalid json");
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
@@ -66,11 +66,34 @@ public class JsonProcessorTests extends ESTestCase {
     }
 
     public void testFieldMissing() {
-        JsonProcessor jsonProcessor = new JsonProcessor("tag", "field", "target_field");
+        JsonProcessor jsonProcessor = new JsonProcessor("tag", "field", "target_field", false);
         Map<String, Object> document = new HashMap<>();
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
 
         Exception exception = expectThrows(IllegalArgumentException.class, () -> jsonProcessor.execute(ingestDocument));
         assertThat(exception.getMessage(), equalTo("field [field] not present as part of path [field]"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testAddToRoot() throws Exception {
+        String processorTag = randomAsciiOfLength(3);
+        String randomTargetField = randomAsciiOfLength(2);
+        JsonProcessor jsonProcessor = new JsonProcessor(processorTag, "a", randomTargetField, true);
+        Map<String, Object> document = new HashMap<>();
+
+        String json = "{\"a\": 1, \"b\": 2}";
+        document.put("a", json);
+        document.put("c", "see");
+
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        jsonProcessor.execute(ingestDocument);
+
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("a", 1);
+        expected.put("b", 2);
+        expected.put("c", "see");
+        IngestDocument expectedIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), expected);
+
+        assertIngestDocument(ingestDocument, expectedIngestDocument);
     }
 }


### PR DESCRIPTION
The JSON processor has an optional field called "target_field".
If you don't specify target_field then target_field becomes what you specified as "field".
There isn't anyway to add the fields to the root of a document. By
setting `add_to_root`, now serialized fields will be inserted into the
top-level fields of the ingest document.

Closes #21898.