### PR TITLE
Small typo fix in the docs.

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -767,7 +767,7 @@ such a case, `target_field` will still be updated with the unconverted field val
 --------------------------------------------------
 {
   "convert": {
-    "field" : "foo"
+    "field" : "foo",
     "type": "integer"
   }
 }


### PR DESCRIPTION
There is a small typo in the convert processor code example.