### PR TITLE
The log message of changing `max_thread_count` fixed

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1300,7 +1300,7 @@ public class IndexShard extends AbstractIndexShardComponent {
                         .getMaxThreadCount());
                 if (maxThreadCount != mergeSchedulerConfig.getMaxThreadCount()) {
                     logger.info("updating [{}] from [{}] to [{}]", MergeSchedulerConfig.MAX_THREAD_COUNT, mergeSchedulerConfig
-                            .getMaxMergeCount(), maxThreadCount);
+                            .getMaxThreadCount(), maxThreadCount);
                     mergeSchedulerConfig.setMaxThreadCount(maxThreadCount);
                     change = true;
                 }


### PR DESCRIPTION
When I change `index.merge.scheduler.max_thread_count`, an INFO massage is not printed properly. It prints MaxMergeCount rather than MaxThreadCount.

So, I made this PR.

Thanks.