### PR TITLE
Add unit tests for toXContent methods in ReplicationResponse

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -242,7 +242,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
         if (forcedRefresh) {
             builder.field("forced_refresh", forcedRefresh);
         }
-        shardInfo.toXContent(builder, params);
+        builder.field("_shards", shardInfo);
         if (getSeqNo() >= 0) {
             builder.field("_seq_no", getSeqNo());
         }

--- a/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -242,7 +242,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
         if (forcedRefresh) {
             builder.field("forced_refresh", forcedRefresh);
         }
-        builder.field("_shards", shardInfo);
+        shardInfo.toXContent(builder, params);
         if (getSeqNo() >= 0) {
             builder.field("_seq_no", getSeqNo());
         }

--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
@@ -67,6 +67,7 @@ public class ReplicationResponse extends ActionResponse {
 
     public static class ShardInfo implements Streamable, ToXContent {
 
+        private static final String _SHARDS = "_shards";
         private static final String TOTAL = "total";
         private static final String SUCCESSFUL = "successful";
         private static final String FAILED = "failed";
@@ -170,7 +171,7 @@ public class ReplicationResponse extends ActionResponse {
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.startObject();
+            builder.startObject(_SHARDS);
             builder.field(TOTAL, total);
             builder.field(SUCCESSFUL, successful);
             builder.field(FAILED, getFailed());
@@ -337,27 +338,6 @@ public class ReplicationResponse extends ActionResponse {
                 builder.endObject();
                 return builder;
             }
-
-            private static class Fields {
-
-                private static final String _INDEX = "_index";
-                private static final String _SHARD = "_shard";
-                private static final String _NODE = "_node";
-                private static final String REASON = "reason";
-                private static final String STATUS = "status";
-                private static final String PRIMARY = "primary";
-
-            }
-        }
-
-        private static class Fields {
-
-            private static final String _SHARDS = "_shards";
-            private static final String TOTAL = "total";
-            private static final String SUCCESSFUL = "successful";
-            private static final String FAILED = "failed";
-            private static final String FAILURES = "failures";
-
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
@@ -67,6 +67,11 @@ public class ReplicationResponse extends ActionResponse {
 
     public static class ShardInfo implements Streamable, ToXContent {
 
+        private static final String TOTAL = "total";
+        private static final String SUCCESSFUL = "successful";
+        private static final String FAILED = "failed";
+        private static final String FAILURES = "failures";
+
         private int total;
         private int successful;
         private Failure[] failures = EMPTY;
@@ -165,12 +170,12 @@ public class ReplicationResponse extends ActionResponse {
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.startObject(Fields._SHARDS);
-            builder.field(Fields.TOTAL, total);
-            builder.field(Fields.SUCCESSFUL, successful);
-            builder.field(Fields.FAILED, getFailed());
+            builder.startObject();
+            builder.field(TOTAL, total);
+            builder.field(SUCCESSFUL, successful);
+            builder.field(FAILED, getFailed());
             if (failures.length > 0) {
-                builder.startArray(Fields.FAILURES);
+                builder.startArray(FAILURES);
                 for (Failure failure : failures) {
                     failure.toXContent(builder, params);
                 }
@@ -196,6 +201,13 @@ public class ReplicationResponse extends ActionResponse {
         }
 
         public static class Failure implements ShardOperationFailedException, ToXContent {
+
+            private static final String _INDEX = "_index";
+            private static final String _SHARD = "_shard";
+            private static final String _NODE = "_node";
+            private static final String REASON = "reason";
+            private static final String STATUS = "status";
+            private static final String PRIMARY = "primary";
 
             private ShardId shardId;
             private String nodeId;
@@ -313,15 +325,15 @@ public class ReplicationResponse extends ActionResponse {
             @Override
             public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
                 builder.startObject();
-                builder.field(Fields._INDEX, shardId.getIndexName());
-                builder.field(Fields._SHARD, shardId.id());
-                builder.field(Fields._NODE, nodeId);
-                builder.field(Fields.REASON);
+                builder.field(_INDEX, shardId.getIndexName());
+                builder.field(_SHARD, shardId.id());
+                builder.field(_NODE, nodeId);
+                builder.field(REASON);
                 builder.startObject();
                 ElasticsearchException.toXContent(builder, params, cause);
                 builder.endObject();
-                builder.field(Fields.STATUS, status);
-                builder.field(Fields.PRIMARY, primary);
+                builder.field(STATUS, status);
+                builder.field(PRIMARY, primary);
                 builder.endObject();
                 return builder;
             }

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationResponseTests.java
@@ -21,6 +21,9 @@ package org.elasticsearch.action.support.replication;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.RoutingMissingException;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.IndexShardRecoveringException;
 import org.elasticsearch.index.shard.ShardId;
@@ -28,13 +31,14 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
-import static org.hamcrest.CoreMatchers.equalTo;
 
 public class ReplicationResponseTests extends ESTestCase {
 
@@ -42,9 +46,7 @@ public class ReplicationResponseTests extends ESTestCase {
         final int total = 5;
         final int successful = randomIntBetween(1, total);
         final ReplicationResponse.ShardInfo shardInfo = new ReplicationResponse.ShardInfo(total, successful);
-        assertThat(
-            shardInfo.toString(),
-            equalTo(String.format(Locale.ROOT, "ShardInfo{total=5, successful=%d, failures=[]}", successful)));
+        assertEquals(String.format(Locale.ROOT, "ShardInfo{total=5, successful=%d, failures=[]}", successful), shardInfo.toString());
     }
 
     public void testShardInfoEqualsAndHashcode() {
@@ -111,6 +113,156 @@ public class ReplicationResponseTests extends ESTestCase {
         };
 
         checkEqualsAndHashCode(randomFailure(), copy, mutate);
+    }
+
+    public void testShardInfoToXContent() throws IOException {
+        ReplicationResponse.ShardInfo shardInfo = new ReplicationResponse.ShardInfo(10, 10);
+
+        try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
+            shardInfo.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            assertEquals("{\"total\":10,\"successful\":10,\"failed\":0}", builder.string());
+        }
+    }
+
+    public void testShardInfoWithFailureToXContent() throws IOException {
+        ReplicationResponse.ShardInfo shardInfo = new ReplicationResponse.ShardInfo(2, 1,
+                new ReplicationResponse.ShardInfo.Failure(new ShardId("_index", "_uuid", 1), "_node_id",
+                        new IllegalStateException("failure cause"), RestStatus.LOCKED, true));
+
+        try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
+            shardInfo.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            assertEquals("{"
+                + "\"total\":2,"
+                + "\"successful\":1,"
+                + "\"failed\":1,"
+                + "\"failures\":["
+                    + "{"
+                    + "\"_index\":\"_index\","
+                    + "\"_shard\":1,"
+                    + "\"_node\":\"_node_id\","
+                    + "\"reason\":{\"type\":\"illegal_state_exception\",\"reason\":\"failure cause\"},"
+                    + "\"status\":\"LOCKED\","
+                    + "\"primary\":true"
+                    + "}"
+                + "]"
+            + "}", builder.string());
+        }
+    }
+
+    public void testRandomShardInfoToXContent() throws IOException {
+        final ReplicationResponse.ShardInfo shardInfo = randomShardInfo();
+
+        // Build the expected JSON from the random ShardInfo
+        StringBuilder expectedJson = new StringBuilder();
+        expectedJson.append("{");
+        expectedJson.append("\"total\":").append(shardInfo.getTotal()).append(",");
+        expectedJson.append("\"successful\":").append(shardInfo.getSuccessful()).append(",");
+        expectedJson.append("\"failed\":").append(shardInfo.getFailed());
+        if (shardInfo.getFailures() != null && shardInfo.getFailures().length > 0) {
+            expectedJson.append(",\"failures\":[");
+            for (int i = 0; i < shardInfo.getFailures().length; i++) {
+                ReplicationResponse.ShardInfo.Failure failure = shardInfo.getFailures()[i];
+                appendExpectedFailure(expectedJson, failure);
+                if (i + 1 < shardInfo.getFailures().length) {
+                    expectedJson.append(",");
+                }
+            }
+            expectedJson.append("]");
+        }
+        expectedJson.append("}");
+
+        // Checks that the printed shardInfo matches the expected JSON
+        try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
+            shardInfo.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            assertEquals(expectedJson.toString(), builder.string());
+        }
+    }
+
+    public void testFailureToXContent() throws IOException {
+        ReplicationResponse.ShardInfo.Failure shardInfoFailure =
+                new ReplicationResponse.ShardInfo.Failure(new ShardId("_index", "_uuid", 0), "_node_id",
+                        new IllegalStateException("failure cause"), RestStatus.FORBIDDEN, false);
+
+        try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
+            shardInfoFailure.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            assertEquals("{"
+                + "\"_index\":\"_index\","
+                + "\"_shard\":0,"
+                + "\"_node\":\"_node_id\","
+                + "\"reason\":{"
+                    + "\"type\":\"illegal_state_exception\","
+                    + "\"reason\":\"failure cause\""
+                + "},"
+                + "\"status\":\"FORBIDDEN\","
+                + "\"primary\":false"
+            + "}", builder.string());
+        }
+    }
+
+    public void testRandomFailureToXContent() throws IOException {
+        ReplicationResponse.ShardInfo.Failure shardInfoFailure = randomFailure();
+
+        // Build the expected JSON from the random ShardInfo.Failure
+        StringBuilder expectedJson = new StringBuilder();
+        appendExpectedFailure(expectedJson, shardInfoFailure);
+
+        try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
+            shardInfoFailure.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            assertEquals(expectedJson.toString(), builder.string());
+        }
+    }
+
+    /**
+     * Builds the expected JSON for a given ShardInfo.Failure
+     */
+    private static void appendExpectedFailure(StringBuilder stringBuilder, ReplicationResponse.ShardInfo.Failure failure) {
+        stringBuilder.append('{');
+        stringBuilder.append("\"_index\":\"").append(failure.index()).append("\",");
+        stringBuilder.append("\"_shard\":").append(failure.shardId()).append(',');
+        stringBuilder.append("\"_node\":\"").append(failure.nodeId()).append("\",");
+        if (failure.getCause() != null) {
+            stringBuilder.append("\"reason\":");
+            appendExpectedCause(stringBuilder, failure.getCause());
+            stringBuilder.append(',');
+        }
+        stringBuilder.append("\"status\":\"").append(failure.status()).append("\",");
+        stringBuilder.append("\"primary\":").append(failure.primary());
+        stringBuilder.append('}');
+    }
+
+    /**
+     * Builds the expected JSON for a given Throwable when printed within a ShardInfo.Failure
+     */
+    private static void appendExpectedCause(StringBuilder stringBuilder, Throwable cause) {
+        stringBuilder.append('{');
+        stringBuilder.append("\"type\":\"").append(ElasticsearchException.getExceptionName(cause)).append("\",");
+        stringBuilder.append("\"reason\":\"").append(cause.getMessage()).append("\"");
+        if (cause instanceof ElasticsearchException) {
+            ElasticsearchException ex = (ElasticsearchException) cause;
+            if (ex.getHeaderKeys().isEmpty() == false) {
+                stringBuilder.append(',');
+                Iterator<String> headers = ex.getHeaderKeys().iterator();
+                while (headers.hasNext()) {
+                    String name = headers.next();
+                    List<String> values = ex.getHeader(name);
+                    stringBuilder.append("\"").append(name.replaceFirst("es.", "")).append("\":");
+                    if (values != null && values.isEmpty() == false) {
+                        if (values.size() == 1) {
+                            stringBuilder.append("\"").append(values.get(0)).append("\"");
+                        }
+                        if (headers.hasNext()) {
+                            stringBuilder.append(',');
+                        }
+                    }
+                }
+            }
+            if (ex.getCause() != null) {
+                stringBuilder.append(',');
+                stringBuilder.append("\"caused_by\":");
+                appendExpectedCause(stringBuilder, ex.getCause());
+            }
+        }
+        stringBuilder.append('}');
     }
 
     private static ReplicationResponse.ShardInfo randomShardInfo() {


### PR DESCRIPTION
This commit adds unit tests for the `toXContent()` methods of the inner classes  `ReplicationResponse.ShardInfo` and `ReplicationResponse.ShardInfo.Failure`.