### PR TITLE
Added ability to remove pipelines via wildcards (#22149)

### DIFF
--- a/core/src/main/java/org/elasticsearch/ingest/PipelineStore.java
+++ b/core/src/main/java/org/elasticsearch/ingest/PipelineStore.java
@@ -41,9 +41,11 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public class PipelineStore extends AbstractComponent implements ClusterStateApplier {
 
@@ -111,17 +113,29 @@ public class PipelineStore extends AbstractComponent implements ClusterStateAppl
             return currentState;
         }
         Map<String, PipelineConfiguration> pipelines = currentIngestMetadata.getPipelines();
-        if (pipelines.containsKey(request.getId()) == false) {
-            throw new ResourceNotFoundException("pipeline [{}] is missing", request.getId());
-        } else {
-            pipelines = new HashMap<>(pipelines);
-            pipelines.remove(request.getId());
-            ClusterState.Builder newState = ClusterState.builder(currentState);
-            newState.metaData(MetaData.builder(currentState.getMetaData())
-                    .putCustom(IngestMetadata.TYPE, new IngestMetadata(pipelines))
-                    .build());
-            return newState.build();
+        Set<String> toRemove = new HashSet<>();
+        for (String pipelineKey : pipelines.keySet()) {
+            if (Regex.simpleMatch(request.getId(), pipelineKey)) {
+                toRemove.add(pipelineKey);
+            }
         }
+        if (pipelines.isEmpty()) {
+            // if its a match all pattern, and no pipelines are found (we have none),
+            // don't fail with exception
+            if (Regex.isMatchAllPattern(request.getId())) {
+                return currentState;
+            }
+            throw new ResourceNotFoundException("pipeline [{}] is missing", request.getId());
+        }
+        final Map<String, PipelineConfiguration> pipelinesCopy = new HashMap<>(pipelines);
+        for (String key : toRemove) {
+            pipelinesCopy.remove(key);
+        }
+        ClusterState.Builder newState = ClusterState.builder(currentState);
+        newState.metaData(MetaData.builder(currentState.getMetaData())
+                .putCustom(IngestMetadata.TYPE, new IngestMetadata(pipelinesCopy))
+                .build());
+        return newState.build();
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/ingest/PipelineStore.java
+++ b/core/src/main/java/org/elasticsearch/ingest/PipelineStore.java
@@ -119,13 +119,10 @@ public class PipelineStore extends AbstractComponent implements ClusterStateAppl
                 toRemove.add(pipelineKey);
             }
         }
-        if (pipelines.isEmpty()) {
-            // if its a match all pattern, and no pipelines are found (we have none),
-            // don't fail with exception
-            if (Regex.isMatchAllPattern(request.getId())) {
-                return currentState;
-            }
+        if (toRemove.isEmpty() && Regex.isMatchAllPattern(request.getId()) == false) {
             throw new ResourceNotFoundException("pipeline [{}] is missing", request.getId());
+        } else if (toRemove.isEmpty()) {
+            return currentState;
         }
         final Map<String, PipelineConfiguration> pipelinesCopy = new HashMap<>(pipelines);
         for (String key : toRemove) {

--- a/core/src/test/java/org/elasticsearch/ingest/PipelineStoreTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/PipelineStoreTests.java
@@ -199,6 +199,7 @@ public class PipelineStoreTests extends ESTestCase {
         );
         pipelines.put("p1", new PipelineConfiguration("p1", definition));
         pipelines.put("p2", new PipelineConfiguration("p2", definition));
+        pipelines.put("q1", new PipelineConfiguration("q1", definition));
         IngestMetadata ingestMetadata = new IngestMetadata(pipelines);
         ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).build();
         ClusterState previousClusterState = clusterState;
@@ -207,6 +208,7 @@ public class PipelineStoreTests extends ESTestCase {
         store.innerUpdatePipelines(previousClusterState, clusterState);
         assertThat(store.get("p1"), notNullValue());
         assertThat(store.get("p2"), notNullValue());
+        assertThat(store.get("q1"), notNullValue());
 
         // Delete pipeline matching wildcard
         DeletePipelineRequest deleteRequest = new DeletePipelineRequest("p*");
@@ -215,9 +217,7 @@ public class PipelineStoreTests extends ESTestCase {
         store.innerUpdatePipelines(previousClusterState, clusterState);
         assertThat(store.get("p1"), nullValue());
         assertThat(store.get("p2"), nullValue());
-
-        // No exception when using delete all wildcard
-        store.innerDelete(new DeletePipelineRequest("*"), clusterState);
+        assertThat(store.get("q1"), notNullValue());
 
         // Exception if we used name which does not exist
         try {
@@ -225,6 +225,41 @@ public class PipelineStoreTests extends ESTestCase {
             fail("exception expected");
         } catch (ResourceNotFoundException e) {
             assertThat(e.getMessage(), equalTo("pipeline [unknown] is missing"));
+        }
+
+        // match all wildcard works on last remaining pipeline
+        DeletePipelineRequest matchAllDeleteRequest = new DeletePipelineRequest("*");
+        previousClusterState = clusterState;
+        clusterState = store.innerDelete(matchAllDeleteRequest, clusterState);
+        store.innerUpdatePipelines(previousClusterState, clusterState);
+        assertThat(store.get("p1"), nullValue());
+        assertThat(store.get("p2"), nullValue());
+        assertThat(store.get("q1"), nullValue());
+
+        // match all wildcard does not throw exception if none match
+        store.innerDelete(matchAllDeleteRequest, clusterState);
+    }
+
+    public void testDeleteWithExistingUnmatchedPipelines() {
+        HashMap<String, PipelineConfiguration> pipelines = new HashMap<>();
+        BytesArray definition = new BytesArray(
+            "{\"processors\": [{\"set\" : {\"field\": \"_field\", \"value\": \"_value\"}}]}"
+        );
+        pipelines.put("p1", new PipelineConfiguration("p1", definition));
+        IngestMetadata ingestMetadata = new IngestMetadata(pipelines);
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).build();
+        ClusterState previousClusterState = clusterState;
+        clusterState = ClusterState.builder(clusterState).metaData(MetaData.builder()
+            .putCustom(IngestMetadata.TYPE, ingestMetadata)).build();
+        store.innerUpdatePipelines(previousClusterState, clusterState);
+        assertThat(store.get("p1"), notNullValue());
+
+        DeletePipelineRequest deleteRequest = new DeletePipelineRequest("z*");
+        try {
+            store.innerDelete(deleteRequest, clusterState);
+            fail("exception expected");
+        } catch (ResourceNotFoundException e) {
+            assertThat(e.getMessage(), equalTo("pipeline [z*] is missing"));
         }
     }
 

--- a/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/20_crud.yaml
+++ b/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/20_crud.yaml
@@ -50,6 +50,46 @@ teardown:
       catch: missing
       ingest.get_pipeline:
         id: "my_pipeline"
+---
+"Test wildcard pipeline delete":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "set" : {
+                  "field" : "field2",
+                  "value": "_value"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      ingest.get_pipeline:
+        id: "my_pipeline"
+  - match: { my_pipeline.description: "_description" }
+
+  - do:
+      ingest.delete_pipeline:
+        id: "my_*"
+  - match: { acknowledged: true }
+
+  - do:
+      catch: missing
+      ingest.get_pipeline:
+        id: "my_pipeline"
+
+  - do:
+      catch: missing
+      ingest.delete_pipeline:
+        id: "my_*"
+  - match: { "error.type": "resource_not_found_exception" }
+  - match: { "error.reason": "pipeline [my_*] is missing" }
 
 ---
 "Test Get All Pipelines":


### PR DESCRIPTION
Closes #22149

This commit is adding an ability to remove pipelines with wildcards. I used a similar approach as in templates. When deleting using single asterisk it won't throw the exception. If the user specifies a name of the pipeline which cannot be found, the exception is thrown (included unit test).