### PR TITLE
Send error_trace by default when testing

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpdateSettingsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpdateSettingsAction.java
@@ -40,6 +40,7 @@ import static org.elasticsearch.common.util.set.Sets.newHashSet;
 
 public class RestUpdateSettingsAction extends BaseRestHandler {
     private static final Set<String> VALUES_TO_EXCLUDE = unmodifiableSet(newHashSet(
+            "error_trace",
             "pretty",
             "timeout",
             "master_timeout",

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestExplainAction.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.rest.action.search;
 
 import org.apache.lucene.search.Explanation;
-import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.action.explain.ExplainRequest;
 import org.elasticsearch.action.explain.ExplainResponse;
 import org.elasticsearch.client.node.NodeClient;
@@ -28,7 +27,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.indices.query.IndicesQueriesRegistry;

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -600,7 +600,8 @@ invalid `size` parameter to the `_search` API:
 POST /twitter/_search?size=surprise_me
 ----------------------------------------------------------------------
 // CONSOLE
-// TEST[catch:request]
+// TEST[s/surprise_me/surprise_me&error_trace=false/ catch:request]
+// Since the test system sends error_trace=true by default we have to override
 
 The response looks like:
 

--- a/docs/reference/modules/scripting/painless-debugging.asciidoc
+++ b/docs/reference/modules/scripting/painless-debugging.asciidoc
@@ -65,7 +65,7 @@ POST /hockey/player/1/_update
 }
 ---------------------------------------------------------
 // CONSOLE
-// TEST[continued catch:/painless_explain_error/]
+// TEST[continued s/_update/_update?error_trace=false/ catch:/painless_explain_error/]
 
 The response looks like:
 

--- a/docs/reference/modules/scripting/painless-debugging.asciidoc
+++ b/docs/reference/modules/scripting/painless-debugging.asciidoc
@@ -33,7 +33,9 @@ POST /hockey/player/1/_explain
 }
 ---------------------------------------------------------
 // CONSOLE
-// TEST[catch:/painless_explain_error/]
+// TEST[s/_explain/_explain?error_trace=false/ catch:/painless_explain_error/]
+// The test system sends error_trace=true by default for easier debugging so
+// we have to override it to get a normal shaped response
 
 Which shows that the class of `doc.first` is
 `org.elasticsearch.index.fielddata.ScriptDocValues$Longs` by responding with:

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
@@ -55,8 +55,11 @@ import java.util.Set;
  */
 public class ClientYamlTestClient {
     private static final Logger logger = Loggers.getLogger(ClientYamlTestClient.class);
-    //query_string params that don't need to be declared in the spec, they are supported by default
-    private static final Set<String> ALWAYS_ACCEPTED_QUERY_STRING_PARAMS = Sets.newHashSet("pretty", "source", "filter_path");
+    /**
+     * Query params that don't need to be declared in the spec, they are supported by default.
+     */
+    private static final Set<String> ALWAYS_ACCEPTED_QUERY_STRING_PARAMS = Sets.newHashSet(
+            "error_trace", "filter_path", "pretty", "source");
 
     private final ClientYamlSuiteRestSpec restSpec;
     private final RestClient restClient;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
@@ -55,6 +55,7 @@ public class ClientYamlTestExecutionContext {
                                     Map<String, String> headers) throws IOException {
         //makes a copy of the parameters before modifying them for this specific request
         HashMap<String, String> requestParams = new HashMap<>(params);
+        requestParams.put("error_trace", "true"); // By default ask for error traces, this my be overridden by params
         for (Map.Entry<String, String> entry : requestParams.entrySet()) {
             if (stash.containsStashedValue(entry.getValue())) {
                 entry.setValue(stash.getValue(entry.getValue()).toString());

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
@@ -55,7 +55,7 @@ public class ClientYamlTestExecutionContext {
                                     Map<String, String> headers) throws IOException {
         //makes a copy of the parameters before modifying them for this specific request
         HashMap<String, String> requestParams = new HashMap<>(params);
-        requestParams.put("error_trace", "true"); // By default ask for error traces, this my be overridden by params
+        requestParams.putIfAbsent("error_trace", "true"); // By default ask for error traces, this my be overridden by params
         for (Map.Entry<String, String> entry : requestParams.entrySet()) {
             if (stash.containsStashedValue(entry.getValue())) {
                 entry.setValue(stash.getValue(entry.getValue()).toString());

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
@@ -180,7 +180,9 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
 
     @Override
     protected void afterIfFailed(List<Throwable> errors) {
-        logger.info("Stash dump on failure [{}]", XContentHelper.toString(restTestExecutionContext.stash()));
+        // Dump the stash on failure. Instead of dumping it in true json we escape `\n`s so stack traces are easier to read
+        logger.info("Stash dump on failure [{}]",
+                XContentHelper.toString(restTestExecutionContext.stash()).replace("\\n", "\n").replace("\\t", "\t"));
         super.afterIfFailed(errors);
     }
 


### PR DESCRIPTION
Sends the `error_trace` parameter with all requests sent by the
yaml test framework, including the doc snippet tests. This can be
overridden by settings `error_trace: false`. While this drift's
core's handling of the yaml tests from the client's slightly this
should only be a problem if we have a test that tests Elasticsearch's
default value for `error_trace` which we don't. And the extra data
when debugging a failure is very welcome.

This also escapes `\n` and `\t` in the `Stash dump on failure` so
the `stack_trace` is more readable.

Also fixes `RestUpdateSettingsAction` to not think of the `error_trace`
parameter as a setting.