### PR TITLE
Rename bootstrap.seccomp to bootstrap.system_call_filter

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -163,7 +163,7 @@ final class BootstrapChecks {
         }
         checks.add(new ClientJvmCheck());
         checks.add(new UseSerialGCCheck());
-        checks.add(new SystemCallFilterCheck(BootstrapSettings.SECCOMP_SETTING.get(settings)));
+        checks.add(new SystemCallFilterCheck(BootstrapSettings.SYSTEM_CALL_FILTER_SETTING.get(settings)));
         checks.add(new OnErrorCheck());
         checks.add(new OnOutOfMemoryErrorCheck());
         checks.add(new G1GCCheck());
@@ -517,7 +517,7 @@ final class BootstrapChecks {
                 "OnError [%s] requires forking but is prevented by system call filters ([%s=true]);" +
                     " upgrade to at least Java 8u92 and use ExitOnOutOfMemoryError",
                 onError(),
-                BootstrapSettings.SECCOMP_SETTING.getKey());
+                BootstrapSettings.SYSTEM_CALL_FILTER_SETTING.getKey());
         }
 
     }
@@ -542,7 +542,7 @@ final class BootstrapChecks {
                 "OnOutOfMemoryError [%s] requires forking but is prevented by system call filters ([%s=true]);" +
                     " upgrade to at least Java 8u92 and use ExitOnOutOfMemoryError",
                 onOutOfMemoryError(),
-                BootstrapSettings.SECCOMP_SETTING.getKey());
+                BootstrapSettings.SYSTEM_CALL_FILTER_SETTING.getKey());
         }
 
     }

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapSettings.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapSettings.java
@@ -33,8 +33,11 @@ public final class BootstrapSettings {
 
     public static final Setting<Boolean> MEMORY_LOCK_SETTING =
         Setting.boolSetting("bootstrap.memory_lock", false, Property.NodeScope);
+    // TODO: remove in 6.0.0
     public static final Setting<Boolean> SECCOMP_SETTING =
         Setting.boolSetting("bootstrap.seccomp", true, Property.NodeScope);
+    public static final Setting<Boolean> SYSTEM_CALL_FILTER_SETTING =
+        Setting.boolSetting("bootstrap.system_call_filter", SECCOMP_SETTING, Property.NodeScope);
     public static final Setting<Boolean> CTRLHANDLER_SETTING =
         Setting.boolSetting("bootstrap.ctrlhandler", true, Property.NodeScope);
 

--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -397,6 +397,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     PluginsService.MANDATORY_SETTING,
                     BootstrapSettings.SECURITY_FILTER_BAD_DEFAULTS_SETTING,
                     BootstrapSettings.MEMORY_LOCK_SETTING,
+                    BootstrapSettings.SYSTEM_CALL_FILTER_SETTING,
+                    // TODO: remove in 6.0.0
                     BootstrapSettings.SECCOMP_SETTING,
                     BootstrapSettings.CTRLHANDLER_SETTING,
                     IndexingMemoryController.INDEX_BUFFER_SIZE_SETTING,

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCheckTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCheckTests.java
@@ -497,8 +497,8 @@ public class BootstrapCheckTests extends ESTestCase {
             e -> assertThat(
                 e.getMessage(),
                 containsString(
-                    "OnError [" + command + "] requires forking but is prevented by system call filters ([bootstrap.seccomp=true]);"
-                        + " upgrade to at least Java 8u92 and use ExitOnOutOfMemoryError")));
+                    "OnError [" + command + "] requires forking but is prevented by system call filters " +
+                        "([bootstrap.system_call_filter=true]); upgrade to at least Java 8u92 and use ExitOnOutOfMemoryError")));
     }
 
     public void testOnOutOfMemoryErrorCheck() throws NodeValidationException {
@@ -526,7 +526,7 @@ public class BootstrapCheckTests extends ESTestCase {
                 e.getMessage(),
                 containsString(
                     "OnOutOfMemoryError [" + command + "]"
-                        + " requires forking but is prevented by system call filters ([bootstrap.seccomp=true]);"
+                        + " requires forking but is prevented by system call filters ([bootstrap.system_call_filter=true]);"
                         + " upgrade to at least Java 8u92 and use ExitOnOutOfMemoryError")));
     }
 

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapSettingsTests.java
@@ -27,7 +27,7 @@ public class BootstrapSettingsTests extends ESTestCase {
     public void testDefaultSettings() {
         assertTrue(BootstrapSettings.SECURITY_FILTER_BAD_DEFAULTS_SETTING.get(Settings.EMPTY));
         assertFalse(BootstrapSettings.MEMORY_LOCK_SETTING.get(Settings.EMPTY));
-        assertTrue(BootstrapSettings.SECCOMP_SETTING.get(Settings.EMPTY));
+        assertTrue(BootstrapSettings.SYSTEM_CALL_FILTER_SETTING.get(Settings.EMPTY));
         assertTrue(BootstrapSettings.CTRLHANDLER_SETTING.get(Settings.EMPTY));
     }
 

--- a/docs/reference/migration/migrate_5_2.asciidoc
+++ b/docs/reference/migration/migrate_5_2.asciidoc
@@ -15,6 +15,19 @@ executing potentially leaving the end-user unaware of this situation. Starting i
 starting Elasticsearch due to this bootstrap check, you need to either fix your configuration so that the system call
 filter can be installed, or *at your own risk* disable the <<system-call-filter-check,system call filter check>>.
 
+[[breaking_52_settings_changes]]
+[float]
+=== Settings changes
+
+[float]
+==== System call filter setting
+
+Elasticsearch has attempted to install a system call filter since version 2.1.0. These are enabled by default and
+could be disabled via `bootstrap.seccomp`. The naming of this setting is poor since seccomp is specific to Linux but
+Elasticsearch attempts to install a system call filter on various operating systems. Starting in Elasticsearch 5.2.0,
+this setting has been renamed to `bootstrap.system_call_filter`. The previous setting is still support but will be
+removed in Elasticsearch 6.0.0.
+
 [[breaking_52_java_api_changes]]
 [float]
 === Java API changes

--- a/docs/reference/setup/bootstrap-checks.asciidoc
+++ b/docs/reference/setup/bootstrap-checks.asciidoc
@@ -157,7 +157,7 @@ The system call filter check ensures that if system call filters are enabled,
 then they were successfully installed. To pass the system call filter check you
 must either fix any configuration errors on your system that prevented system
 call filters from installing (check your logs), or *at your own risk* disable
-system call filters by setting `bootstrap.seccomp` to `false`.
+system call filters by setting `bootstrap.system_call_filter` to `false`.
 
 === OnError and OnOutOfMemoryError checks
 


### PR DESCRIPTION
We try to install a system call filter on various operating systems
(Linux, macOS, BSD, Solaris, and Windows) but the setting
(bootstrap.seccomp) to control this is named after the Linux
implementation (seccomp). This commit replaces this setting with
bootstrap.system_call_filter. For backwards compatibility reasons, we
fallback to bootstrap.seccomp and log a deprecation message if
bootstrap.seccomp is set. We intend to remove this fallback in
6.0.0. Note that now is the time to make this change it's likely that
most users are not making this setting anyway as prior to version 5.2.0
(currently unreleased) it was not necessary to configure anything to
enable a node to start up if the system call filter failed to install
(we marched on anyway) but starting in 5.2.0 it will be necessary in
this case.

Relates #21940
