### PR TITLE
Fix MapperService.allEnabled().

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -377,6 +377,8 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         this.hasNested = hasNested;
         this.fullPathObjectMappers = fullPathObjectMappers;
         this.parentTypes = parentTypes;
+        // this is only correct because types cannot be removed and we do not
+        // allow to disable an existing _all field
         this.allEnabled |= mapper.allFieldMapper().enabled();
 
         assert assertSerialization(newMapper);

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -153,7 +153,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     }
 
     /**
-     * Returns true if the "_all" field is enabled for the type
+     * Returns true if the "_all" field is enabled on any type.
      */
     public boolean allEnabled() {
         return this.allEnabled;
@@ -377,7 +377,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         this.hasNested = hasNested;
         this.fullPathObjectMappers = fullPathObjectMappers;
         this.parentTypes = parentTypes;
-        this.allEnabled = mapper.allFieldMapper().enabled();
+        this.allEnabled |= mapper.allFieldMapper().enabled();
 
         assert assertSerialization(newMapper);
         assert assertMappersShareSameFieldType();


### PR DESCRIPTION
It returns whether the last merged mapping has `_all` enabled rather than
whether any of the types has `_all` enabled.