### PR TITLE
Cache results of geoip lookups

### DIFF
--- a/docs/plugins/ingest-geoip.asciidoc
+++ b/docs/plugins/ingest-geoip.asciidoc
@@ -203,3 +203,21 @@ Which returns:
 }
 --------------------------------------------------
 // TESTRESPONSE
+
+[[ingest-geoip-settings]]
+===== Settings
+
+The geoip processor can cache results. Caching is disabled by default but can be enabled with the
+setting `ingest.geoip.cache_enabled`. The cache size is controlled by .
+
+The geoip processor supports the following settings:
+
+`ingest.geoip.cache_enabled`::
+
+    Whether to enable caching of results. Defaults to `false`.
+
+`ingest.geoip.cache_size`::
+
+    The maximum number of results that should be cached. Defaults to `1000`.
+
+Note that these settings apply to all geoip processors, i.e. there is one cache for all defined processors.

--- a/docs/plugins/ingest-geoip.asciidoc
+++ b/docs/plugins/ingest-geoip.asciidoc
@@ -207,9 +207,6 @@ Which returns:
 [[ingest-geoip-settings]]
 ===== Settings
 
-The geoip processor can cache results. Caching is disabled by default but can be enabled with the
-setting `ingest.geoip.cache_enabled`. The cache size is controlled by .
-
 The geoip processor supports the following settings:
 
 `ingest.geoip.cache_enabled`::

--- a/docs/plugins/ingest-geoip.asciidoc
+++ b/docs/plugins/ingest-geoip.asciidoc
@@ -205,16 +205,12 @@ Which returns:
 // TESTRESPONSE
 
 [[ingest-geoip-settings]]
-===== Settings
+===== Node Settings
 
-The geoip processor supports the following settings:
-
-`ingest.geoip.cache_enabled`::
-
-    Whether to enable caching of results. Defaults to `false`.
+The geoip processor supports the following setting:
 
 `ingest.geoip.cache_size`::
 
     The maximum number of results that should be cached. Defaults to `1000`.
 
-Note that these settings apply to all geoip processors, i.e. there is one cache for all defined processors.
+Note that these settings are node settings and apply to all geoip processors, i.e. there is one cache for all defined geoip processors.

--- a/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
+++ b/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.ingest.geoip;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.maxmind.db.NodeCache;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.cache.Cache;
+import org.elasticsearch.common.cache.CacheBuilder;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+final class GeoIpCache implements NodeCache {
+    private final Cache<Integer, JsonNode> cache;
+
+    GeoIpCache(long maxSize) {
+        this.cache = CacheBuilder.<Integer, JsonNode>builder().setMaximumWeight(maxSize).build();
+    }
+
+    @Override
+    public JsonNode get(int key, Loader loader) throws IOException {
+        try {
+            return cache.computeIfAbsent(key, loader::load);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            throw new ElasticsearchException(cause);
+        }
+    }
+}

--- a/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
+++ b/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
@@ -26,22 +26,36 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 
+import com.maxmind.db.NoCache;
+import com.maxmind.db.NodeCache;
 import com.maxmind.geoip2.DatabaseReader;
 import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.plugins.Plugin;
 
 public class IngestGeoIpPlugin extends Plugin implements IngestPlugin, Closeable {
+    public static final Setting<Boolean> CACHE_ENABLED =
+        Setting.boolSetting("ingest.geoip.cache_enabled", false, Setting.Property.NodeScope);
+    public static final Setting<Long> CACHE_SIZE =
+        Setting.longSetting("ingest.geoip.cache_size", 1000, 0, Setting.Property.NodeScope);
 
     private Map<String, DatabaseReader> databaseReaders;
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return Arrays.asList(CACHE_ENABLED, CACHE_SIZE);
+    }
 
     @Override
     public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
@@ -50,16 +64,24 @@ public class IngestGeoIpPlugin extends Plugin implements IngestPlugin, Closeable
         }
         Path geoIpConfigDirectory = parameters.env.configFile().resolve("ingest-geoip");
         try {
-            databaseReaders = loadDatabaseReaders(geoIpConfigDirectory);
+            databaseReaders = loadDatabaseReaders(parameters, geoIpConfigDirectory);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
         return Collections.singletonMap(GeoIpProcessor.TYPE, new GeoIpProcessor.Factory(databaseReaders));
     }
 
-    static Map<String, DatabaseReader> loadDatabaseReaders(Path geoIpConfigDirectory) throws IOException {
+    static Map<String, DatabaseReader> loadDatabaseReaders(Processor.Parameters parameters, Path geoIpConfigDirectory) throws IOException {
         if (Files.exists(geoIpConfigDirectory) == false && Files.isDirectory(geoIpConfigDirectory)) {
             throw new IllegalStateException("the geoip directory [" + geoIpConfigDirectory  + "] containing databases doesn't exist");
+        }
+
+        NodeCache cache;
+        if (CACHE_ENABLED.get(parameters.env.settings())) {
+            long cacheSize = CACHE_SIZE.get(parameters.env.settings());
+            cache = new GeoIpCache(cacheSize);
+        } else {
+            cache = NoCache.getInstance();
         }
 
         Map<String, DatabaseReader> databaseReaders = new HashMap<>();
@@ -71,7 +93,8 @@ public class IngestGeoIpPlugin extends Plugin implements IngestPlugin, Closeable
                 Path databasePath = iterator.next();
                 if (Files.isRegularFile(databasePath) && pathMatcher.matches(databasePath)) {
                     try (InputStream inputStream = new GZIPInputStream(Files.newInputStream(databasePath, StandardOpenOption.READ))) {
-                        databaseReaders.put(databasePath.getFileName().toString(), new DatabaseReader.Builder(inputStream).build());
+                        databaseReaders.put(databasePath.getFileName().toString(),
+                            new DatabaseReader.Builder(inputStream).withCache(cache).build());
                     }
                 }
             }
@@ -85,4 +108,5 @@ public class IngestGeoIpPlugin extends Plugin implements IngestPlugin, Closeable
             IOUtils.close(databaseReaders.values());
         }
     }
+
 }

--- a/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
+++ b/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
@@ -45,8 +45,6 @@ import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.plugins.Plugin;
 
 public class IngestGeoIpPlugin extends Plugin implements IngestPlugin, Closeable {
-    public static final Setting<Boolean> CACHE_ENABLED =
-        Setting.boolSetting("ingest.geoip.cache_enabled", false, Setting.Property.NodeScope);
     public static final Setting<Long> CACHE_SIZE =
         Setting.longSetting("ingest.geoip.cache_size", 1000, 0, Setting.Property.NodeScope);
 

--- a/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpCacheTests.java
+++ b/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpCacheTests.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.ingest.geoip;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.maxmind.db.NodeCache;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.test.ESTestCase;
+
+public class GeoIpCacheTests extends ESTestCase {
+    public void testCachesAndEvictsResults() throws Exception {
+        GeoIpCache cache = new GeoIpCache(1);
+        final NodeCache.Loader loader = key -> new IntNode(key);
+
+        JsonNode jsonNode1 = cache.get(1, loader);
+        assertSame(jsonNode1, cache.get(1, loader));
+
+        // evict old key by adding another value
+        cache.get(2, loader);
+
+        assertNotSame(jsonNode1, cache.get(1, loader));
+    }
+
+    public void testThrowsElasticsearchException() throws Exception {
+        GeoIpCache cache = new GeoIpCache(1);
+        NodeCache.Loader loader = (int key) -> {
+            throw new IllegalArgumentException("Illegal key");
+        };
+        ElasticsearchException ex = expectThrows(ElasticsearchException.class, () -> cache.get(1, loader));
+        assertTrue("Expected cause to be of type IllegalArgumentException but was [" + ex.getCause().getClass() + "]",
+            ex.getCause() instanceof IllegalArgumentException);
+        assertEquals("Illegal key", ex.getCause().getMessage());
+    }
+}

--- a/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -20,13 +20,11 @@
 package org.elasticsearch.ingest.geoip;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+import com.maxmind.db.NoCache;
+import com.maxmind.db.NodeCache;
 import com.maxmind.geoip2.DatabaseReader;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Randomness;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.env.Environment;
-import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.StreamsUtils;
 import org.junit.AfterClass;
@@ -62,15 +60,8 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         Files.copy(new ByteArrayInputStream(StreamsUtils.copyToBytesFromClasspath("/GeoLite2-Country.mmdb.gz")),
                 geoIpConfigDir.resolve("GeoLite2-Country.mmdb.gz"));
 
-        Settings settings = Settings.builder()
-            .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
-            .put(IngestGeoIpPlugin.CACHE_ENABLED.getKey(), randomBoolean())
-            .put(IngestGeoIpPlugin.CACHE_SIZE.getKey(), randomPositiveLong())
-            .build();
-
-        databaseReaders = IngestGeoIpPlugin.loadDatabaseReaders(
-            new Processor.Parameters(new Environment(settings), null, null, null,
-                new ThreadContext(settings)), geoIpConfigDir);
+        NodeCache cache = randomFrom(NoCache.getInstance(), new GeoIpCache(randomPositiveLong()));
+        databaseReaders = IngestGeoIpPlugin.loadDatabaseReaders(geoIpConfigDir, cache);
     }
 
     @AfterClass

--- a/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -23,6 +23,10 @@ import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.maxmind.geoip2.DatabaseReader;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.StreamsUtils;
 import org.junit.AfterClass;
@@ -57,7 +61,16 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
                 geoIpConfigDir.resolve("GeoLite2-City.mmdb.gz"));
         Files.copy(new ByteArrayInputStream(StreamsUtils.copyToBytesFromClasspath("/GeoLite2-Country.mmdb.gz")),
                 geoIpConfigDir.resolve("GeoLite2-Country.mmdb.gz"));
-        databaseReaders = IngestGeoIpPlugin.loadDatabaseReaders(geoIpConfigDir);
+
+        Settings settings = Settings.builder()
+            .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
+            .put(IngestGeoIpPlugin.CACHE_ENABLED.getKey(), randomBoolean())
+            .put(IngestGeoIpPlugin.CACHE_SIZE.getKey(), randomPositiveLong())
+            .build();
+
+        databaseReaders = IngestGeoIpPlugin.loadDatabaseReaders(
+            new Processor.Parameters(new Environment(settings), null, null, null,
+                new ThreadContext(settings)), geoIpConfigDir);
     }
 
     @AfterClass


### PR DESCRIPTION
With this commit, we introduce a cache to the geoip ingest processor.
The cache is enabled by default and caches the 1000 most recent items.
The cache size is controlled by the setting `ingest.geoip.cache_size`.

Closes #22074