### PR TITLE
Refer to system call filter instead of seccomp

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -97,7 +97,7 @@ final class Bootstrap {
     }
 
     /** initialize native resources */
-    public static void initializeNatives(Path tmpFile, boolean mlockAll, boolean seccomp, boolean ctrlHandler) {
+    public static void initializeNatives(Path tmpFile, boolean mlockAll, boolean systemCallFilter, boolean ctrlHandler) {
         final Logger logger = Loggers.getLogger(Bootstrap.class);
 
         // check if the user is running as root, and bail
@@ -105,9 +105,9 @@ final class Bootstrap {
             throw new RuntimeException("can not run elasticsearch as root");
         }
 
-        // enable secure computing mode
-        if (seccomp) {
-            Natives.trySeccomp(tmpFile);
+        // enable system call filter
+        if (systemCallFilter) {
+            Natives.tryInstallSystemCallFilter(tmpFile);
         }
 
         // mlockall if requested

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -463,12 +463,12 @@ final class BootstrapChecks {
 
         @Override
         public boolean check() {
-            return areSystemCallFiltersEnabled && !isSeccompInstalled();
+            return areSystemCallFiltersEnabled && !isSystemCallFilterInstalled();
         }
 
         // visible for testing
-        boolean isSeccompInstalled() {
-            return Natives.isSeccompInstalled();
+        boolean isSystemCallFilterInstalled() {
+            return Natives.isSystemCallFilterInstalled();
         }
 
         @Override
@@ -483,12 +483,12 @@ final class BootstrapChecks {
 
         @Override
         public boolean check() {
-            return isSeccompInstalled() && mightFork();
+            return isSystemCallFilterInstalled() && mightFork();
         }
 
         // visible for testing
-        boolean isSeccompInstalled() {
-            return Natives.isSeccompInstalled();
+        boolean isSystemCallFilterInstalled() {
+            return Natives.isSystemCallFilterInstalled();
         }
 
         // visible for testing

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java
@@ -24,16 +24,16 @@ import org.elasticsearch.common.SuppressForbidden;
 import java.util.Dictionary;
 import java.util.Enumeration;
 
-/** 
- * Exposes system startup information 
+/**
+ * Exposes system startup information
  */
 @SuppressForbidden(reason = "exposes read-only view of system properties")
 public final class BootstrapInfo {
 
     /** no instantiation */
     private BootstrapInfo() {}
-    
-    /** 
+
+    /**
      * Returns true if we successfully loaded native libraries.
      * <p>
      * If this returns false, then native operations such as locking
@@ -42,19 +42,19 @@ public final class BootstrapInfo {
     public static boolean isNativesAvailable() {
         return Natives.JNA_AVAILABLE;
     }
-    
-    /** 
+
+    /**
      * Returns true if we were able to lock the process's address space.
      */
     public static boolean isMemoryLocked() {
         return Natives.isMemoryLocked();
     }
-    
+
     /**
-     * Returns true if secure computing mode is enabled (supported systems only)
+     * Returns true if system call filter is installed (supported systems only)
      */
-    public static boolean isSeccompInstalled() {
-        return Natives.isSeccompInstalled();
+    public static boolean isSystemCallFilterInstalled() {
+        return Natives.isSystemCallFilterInstalled();
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/bootstrap/JNANatives.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/JNANatives.java
@@ -43,11 +43,11 @@ class JNANatives {
 
     // Set to true, in case native mlockall call was successful
     static boolean LOCAL_MLOCKALL = false;
-    // Set to true, in case native seccomp call was successful
-    static boolean LOCAL_SECCOMP = false;
+    // Set to true, in case native system call filter install was successful
+    static boolean LOCAL_SYSTEM_CALL_FILTER = false;
     // Set to true, in case policy can be applied to all threads of the process (even existing ones)
     // otherwise they are only inherited for new threads (ES app threads)
-    static boolean LOCAL_SECCOMP_ALL = false;
+    static boolean LOCAL_SYSTEM_CALL_FILTER_ALL = false;
     // set to the maximum number of threads that can be created for
     // the user ID that owns the running Elasticsearch process
     static long MAX_NUMBER_OF_THREADS = -1;
@@ -210,12 +210,12 @@ class JNANatives {
         }
     }
 
-    static void trySeccomp(Path tmpFile) {
+    static void tryInstallSystemCallFilter(Path tmpFile) {
         try {
-            int ret = Seccomp.init(tmpFile);
-            LOCAL_SECCOMP = true;
+            int ret = SystemCallFilter.init(tmpFile);
+            LOCAL_SYSTEM_CALL_FILTER = true;
             if (ret == 1) {
-                LOCAL_SECCOMP_ALL = true;
+                LOCAL_SYSTEM_CALL_FILTER_ALL = true;
             }
         } catch (Exception e) {
             // this is likely to happen unless the kernel is newish, its a best effort at the moment

--- a/core/src/main/java/org/elasticsearch/bootstrap/Natives.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Natives.java
@@ -91,12 +91,12 @@ final class Natives {
         return JNANatives.LOCAL_MLOCKALL;
     }
 
-    static void trySeccomp(Path tmpFile) {
+    static void tryInstallSystemCallFilter(Path tmpFile) {
         if (!JNA_AVAILABLE) {
-            logger.warn("cannot install syscall filters because JNA is not available");
+            logger.warn("cannot install system call filter because JNA is not available");
             return;
         }
-        JNANatives.trySeccomp(tmpFile);
+        JNANatives.tryInstallSystemCallFilter(tmpFile);
     }
 
     static void trySetMaxNumberOfThreads() {
@@ -115,10 +115,10 @@ final class Natives {
         JNANatives.trySetMaxSizeVirtualMemory();
     }
 
-    static boolean isSeccompInstalled() {
+    static boolean isSystemCallFilterInstalled() {
         if (!JNA_AVAILABLE) {
             return false;
         }
-        return JNANatives.LOCAL_SECCOMP;
+        return JNANatives.LOCAL_SYSTEM_CALL_FILTER;
     }
 }

--- a/core/src/main/java/org/elasticsearch/bootstrap/Spawner.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Spawner.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Locale;
 
 /**
- * Spawns native plugin controller processes if present.  Will only work prior to seccomp being set up.
+ * Spawns native plugin controller processes if present.  Will only work prior to a system call filter being installed.
  */
 final class Spawner implements Closeable {
 

--- a/core/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
@@ -43,8 +43,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Installs a limited form of secure computing mode,
- * to filters system calls to block process execution.
+ * Installs a system call filter to block process execution.
  * <p>
  * This is supported on Linux, Solaris, FreeBSD, OpenBSD, Mac OS X, and Windows.
  * <p>
@@ -91,8 +90,8 @@ import java.util.Map;
  *      https://docs.oracle.com/cd/E23824_01/html/821-1456/prbac-2.html</a>
  */
 // not an example of how to write code!!!
-final class Seccomp {
-    private static final Logger logger = Loggers.getLogger(Seccomp.class);
+final class SystemCallFilter {
+    private static final Logger logger = Loggers.getLogger(SystemCallFilter.class);
 
     // Linux implementation, based on seccomp(2) or prctl(2) with bpf filtering
 

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCheckTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCheckTests.java
@@ -409,11 +409,11 @@ public class BootstrapCheckTests extends ESTestCase {
     }
 
     public void testSystemCallFilterCheck() throws NodeValidationException {
-        final AtomicBoolean isSecompInstalled = new AtomicBoolean();
+        final AtomicBoolean isSystemCallFilterInstalled = new AtomicBoolean();
         final BootstrapChecks.SystemCallFilterCheck systemCallFilterEnabledCheck = new BootstrapChecks.SystemCallFilterCheck(true) {
             @Override
-            boolean isSeccompInstalled() {
-                return isSecompInstalled.get();
+            boolean isSystemCallFilterInstalled() {
+                return isSystemCallFilterInstalled.get();
             }
         };
 
@@ -425,28 +425,28 @@ public class BootstrapCheckTests extends ESTestCase {
             containsString("system call filters failed to install; " +
                 "check the logs and fix your configuration or disable system call filters at your own risk"));
 
-        isSecompInstalled.set(true);
+        isSystemCallFilterInstalled.set(true);
         BootstrapChecks.check(true, Collections.singletonList(systemCallFilterEnabledCheck), "testSystemCallFilterCheck");
 
         final BootstrapChecks.SystemCallFilterCheck systemCallFilterNotEnabledCheck = new BootstrapChecks.SystemCallFilterCheck(false) {
             @Override
-            boolean isSeccompInstalled() {
-                return isSecompInstalled.get();
+            boolean isSystemCallFilterInstalled() {
+                return isSystemCallFilterInstalled.get();
             }
         };
-        isSecompInstalled.set(false);
+        isSystemCallFilterInstalled.set(false);
         BootstrapChecks.check(true, Collections.singletonList(systemCallFilterNotEnabledCheck), "testSystemCallFilterCheck");
-        isSecompInstalled.set(true);
+        isSystemCallFilterInstalled.set(true);
         BootstrapChecks.check(true, Collections.singletonList(systemCallFilterNotEnabledCheck), "testSystemCallFilterCheck");
     }
 
     public void testMightForkCheck() throws NodeValidationException {
-        final AtomicBoolean isSeccompInstalled = new AtomicBoolean();
+        final AtomicBoolean isSystemCallFilterInstalled = new AtomicBoolean();
         final AtomicBoolean mightFork = new AtomicBoolean();
         final BootstrapChecks.MightForkCheck check = new BootstrapChecks.MightForkCheck() {
             @Override
-            boolean isSeccompInstalled() {
-                return isSeccompInstalled.get();
+            boolean isSystemCallFilterInstalled() {
+                return isSystemCallFilterInstalled.get();
             }
 
             @Override
@@ -462,19 +462,19 @@ public class BootstrapCheckTests extends ESTestCase {
 
         runMightForkTest(
             check,
-            isSeccompInstalled,
+            isSystemCallFilterInstalled,
             () -> mightFork.set(false),
             () -> mightFork.set(true),
             e -> assertThat(e.getMessage(), containsString("error")));
     }
 
     public void testOnErrorCheck() throws NodeValidationException {
-        final AtomicBoolean isSeccompInstalled = new AtomicBoolean();
+        final AtomicBoolean isSystemCallFilterInstalled = new AtomicBoolean();
         final AtomicReference<String> onError = new AtomicReference<>();
         final BootstrapChecks.MightForkCheck check = new BootstrapChecks.OnErrorCheck() {
             @Override
-            boolean isSeccompInstalled() {
-                return isSeccompInstalled.get();
+            boolean isSystemCallFilterInstalled() {
+                return isSystemCallFilterInstalled.get();
             }
 
             @Override
@@ -486,7 +486,7 @@ public class BootstrapCheckTests extends ESTestCase {
         final String command = randomAsciiOfLength(16);
         runMightForkTest(
             check,
-            isSeccompInstalled,
+            isSystemCallFilterInstalled,
             () -> onError.set(randomBoolean() ? "" : null),
             () -> onError.set(command),
             e -> assertThat(
@@ -497,12 +497,12 @@ public class BootstrapCheckTests extends ESTestCase {
     }
 
     public void testOnOutOfMemoryErrorCheck() throws NodeValidationException {
-        final AtomicBoolean isSeccompInstalled = new AtomicBoolean();
+        final AtomicBoolean isSystemCallFilterInstalled = new AtomicBoolean();
         final AtomicReference<String> onOutOfMemoryError = new AtomicReference<>();
         final BootstrapChecks.MightForkCheck check = new BootstrapChecks.OnOutOfMemoryErrorCheck() {
             @Override
-            boolean isSeccompInstalled() {
-                return isSeccompInstalled.get();
+            boolean isSystemCallFilterInstalled() {
+                return isSystemCallFilterInstalled.get();
             }
 
             @Override
@@ -514,7 +514,7 @@ public class BootstrapCheckTests extends ESTestCase {
         final String command = randomAsciiOfLength(16);
         runMightForkTest(
             check,
-            isSeccompInstalled,
+            isSystemCallFilterInstalled,
             () -> onOutOfMemoryError.set(randomBoolean() ? "" : null),
             () -> onOutOfMemoryError.set(command),
             e -> assertThat(
@@ -527,15 +527,15 @@ public class BootstrapCheckTests extends ESTestCase {
 
     private void runMightForkTest(
         final BootstrapChecks.MightForkCheck check,
-        final AtomicBoolean isSeccompInstalled,
+        final AtomicBoolean isSystemCallFilterInstalled,
         final Runnable disableMightFork,
         final Runnable enableMightFork,
         final Consumer<NodeValidationException> consumer) throws NodeValidationException {
 
         final String methodName = Thread.currentThread().getStackTrace()[2].getMethodName();
 
-        // if seccomp is disabled, nothing should happen
-        isSeccompInstalled.set(false);
+        // if system call filter is disabled, nothing should happen
+        isSystemCallFilterInstalled.set(false);
         if (randomBoolean()) {
             disableMightFork.run();
         } else {
@@ -543,16 +543,15 @@ public class BootstrapCheckTests extends ESTestCase {
         }
         BootstrapChecks.check(true, Collections.singletonList(check), methodName);
 
-        // if seccomp is enabled, but we will not fork, nothing should
+        // if system call filter is enabled, but we will not fork, nothing should
         // happen
-        isSeccompInstalled.set(true);
+        isSystemCallFilterInstalled.set(true);
         disableMightFork.run();
         BootstrapChecks.check(true, Collections.singletonList(check), methodName);
 
-        // if seccomp is enabled, and we might fork, the check should
-        // be enforced, regardless of bootstrap checks being enabled or
-        // not
-        isSeccompInstalled.set(true);
+        // if system call filter is enabled, and we might fork, the check should be enforced, regardless of bootstrap checks being enabled
+        // or not
+        isSystemCallFilterInstalled.set(true);
         enableMightFork.run();
 
         final NodeValidationException e = expectThrows(

--- a/core/src/test/java/org/elasticsearch/bootstrap/SpawnerTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/SpawnerTests.java
@@ -25,7 +25,7 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.Locale;
 
 /**
- * Doesn't actually test spawning a process, as seccomp is installed before tests run and forbids it.
+ * Doesn't actually test spawning a process, as a system call filter is installed before tests run and forbids it.
  */
 public class SpawnerTests extends ESTestCase {
 
@@ -48,4 +48,5 @@ public class SpawnerTests extends ESTestCase {
         assertEquals("windows-x86_64", Spawner.makePlatformName("Windows 8.1", "amd64"));
         assertEquals("sunos-x86_64", Spawner.makePlatformName("SunOS", "amd64"));
     }
+
 }

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/SystemCallFilterTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/SystemCallFilterTests.java
@@ -22,30 +22,30 @@ package org.elasticsearch.bootstrap;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.test.ESTestCase;
 
-/** Simple tests seccomp filter is working. */
-public class SeccompTests extends ESTestCase {
-    
+/** Simple tests system call filter is working. */
+public class SystemCallFilterTests extends ESTestCase {
+
     /** command to try to run in tests */
     static final String EXECUTABLE = Constants.WINDOWS ? "calc" : "ls";
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        assumeTrue("requires seccomp filter installation", Natives.isSeccompInstalled());
+        assumeTrue("requires system call filter installation", Natives.isSystemCallFilterInstalled());
         // otherwise security manager will block the execution, no fun
         assumeTrue("cannot test with security manager enabled", System.getSecurityManager() == null);
         // otherwise, since we don't have TSYNC support, rules are not applied to the test thread
         // (randomizedrunner class initialization happens in its own thread, after the test thread is created)
         // instead we just forcefully run it for the test thread here.
-        if (!JNANatives.LOCAL_SECCOMP_ALL) {
+        if (!JNANatives.LOCAL_SYSTEM_CALL_FILTER_ALL) {
             try {
-                Seccomp.init(createTempDir());
+                SystemCallFilter.init(createTempDir());
             } catch (Exception e) {
-                throw new RuntimeException("unable to forcefully apply seccomp to test thread", e);
+                throw new RuntimeException("unable to forcefully apply system call filter to test thread", e);
             }
         }
     }
-    
+
     public void testNoExecution() throws Exception {
         try {
             Runtime.getRuntime().exec(EXECUTABLE);
@@ -63,11 +63,11 @@ public class SeccompTests extends ESTestCase {
                     at java.lang.UNIXProcess.<init>(UNIXProcess.java:248)
                     at java.lang.ProcessImpl.start(ProcessImpl.java:134)
                     at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
-                    ... 
+                    ...
             */
         }
     }
-    
+
     // make sure thread inherits this too (its documented that way)
     public void testNoExecutionFromThread() throws Exception {
         Thread t = new Thread() {

--- a/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
+++ b/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
@@ -39,9 +39,8 @@ import java.util.concurrent.TimeUnit;
 /**
  * Create a simple "daemon controller", put it in the right place and check that it runs.
  *
- * Extends LuceneTestCase rather than ESTestCase as ESTestCase installs seccomp, and that
- * prevents the Spawner class doing its job.  Also needs to run in a separate JVM to other
- * tests that extend ESTestCase for the same reason.
+ * Extends LuceneTestCase rather than ESTestCase as ESTestCase installs a system call filter, and that prevents the Spawner class doing its
+ * job. Also needs to run in a separate JVM to other tests that extend ESTestCase for the same reason.
  */
 public class SpawnerNoBootstrapTests extends LuceneTestCase {
 


### PR DESCRIPTION
Today in the codebase we refer to seccomp everywhere instead of system
call filter even if we are not specifically referring to Linux. This
commit is a purely mechanical change to refer to system call filter
where appropriate instead of the general seccomp, and only leaves
seccomp in place when actually referring to the Linux implementation.

Relates #22226
