### PR TITLE
Allow an index to be partitioned with custom routing

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportShrinkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportShrinkAction.java
@@ -131,8 +131,8 @@ public class TransportShrinkAction extends TransportMasterNodeAction<ShrinkReque
             }
 
         }
-        if (IndexMetaData.INDEX_PARTITION_SIZE_SETTING.exists(targetIndexSettings)) {
-            throw new IllegalArgumentException("cannot provide a partition size value when shrinking an index");
+        if (IndexMetaData.INDEX_ROUTING_PARTITION_SIZE_SETTING.exists(targetIndexSettings)) {
+            throw new IllegalArgumentException("cannot provide a routing partition size value when shrinking an index");
         }
         targetIndex.cause("shrink_index");
         Settings.Builder settingsBuilder = Settings.builder().put(targetIndexSettings);

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportShrinkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportShrinkAction.java
@@ -131,6 +131,9 @@ public class TransportShrinkAction extends TransportMasterNodeAction<ShrinkReque
             }
 
         }
+        if (IndexMetaData.INDEX_PARTITION_SIZE_SETTING.exists(targetIndexSettings)) {
+            throw new IllegalArgumentException("cannot provide a partition size value when shrinking an index");
+        }
         targetIndex.cause("shrink_index");
         Settings.Builder settingsBuilder = Settings.builder().put(targetIndexSettings);
         settingsBuilder.put("index.number_of_shards", numShards);

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -814,6 +814,11 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
             return routingNumShards == null ? numberOfShards() : routingNumShards;
         }
 
+        /**
+         * Returns the number of shards.
+         *
+         * @return the provided value or -1 if it has not been set.
+         */
         public int numberOfShards() {
             return settings.getAsInt(SETTING_NUMBER_OF_SHARDS, -1);
         }
@@ -823,6 +828,11 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
             return this;
         }
 
+        /**
+         * Returns the number of replicas.
+         *
+         * @return the provided value or -1 if it has not been set.
+         */
         public int numberOfReplicas() {
             return settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, -1);
         }
@@ -832,6 +842,11 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
             return this;
         }
 
+        /**
+         * Returns the routing partition size.
+         *
+         * @return the provided value or -1 if it has not been set.
+         */
         public int routingPartitionSize() {
             return settings.getAsInt(SETTING_ROUTING_PARTITION_SIZE, -1);
         }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -980,12 +980,8 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
                 throw new IllegalArgumentException("must specify non-negative number of shards for index [" + index + "]");
             }
 
-            Integer maybeRoutingPartitionSize = settings.getAsInt(SETTING_ROUTING_PARTITION_SIZE, null);
-            if (maybeRoutingPartitionSize == null) {
-                maybeRoutingPartitionSize = 1;
-            }
-            int routingPartitionSize = maybeRoutingPartitionSize;
-            if (routingPartitionSize <= 0 || (routingPartitionSize != 1 && routingPartitionSize >= getRoutingNumShards())) {
+            int routingPartitionSize = INDEX_ROUTING_PARTITION_SIZE_SETTING.get(settings);
+            if (routingPartitionSize != 1 && routingPartitionSize >= getRoutingNumShards()) {
                 throw new IllegalArgumentException("routing partition size [" + routingPartitionSize + "] should be a positive number"
                         + " less than the number of shards [" + getRoutingNumShards() + "] for [" + index + "]");
             }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cluster.metadata;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
 import org.apache.lucene.util.CollectionUtil;
@@ -583,6 +584,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
             // now copy all similarity / analysis settings - this overrides all settings from the user unless they
             // wanna add extra settings
             .put(sourceMetaData.getSettings().filter(analysisSimilarityPredicate))
+            .put(IndexMetaData.SETTING_PARTITION_SIZE, sourceMetaData.getPartitionSize())
             .put(IndexMetaData.INDEX_SHRINK_SOURCE_NAME.getKey(), shrinkFromIndex.getName())
             .put(IndexMetaData.INDEX_SHRINK_SOURCE_UUID.getKey(), shrinkFromIndex.getUUID());
     }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -584,7 +584,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
             // now copy all similarity / analysis settings - this overrides all settings from the user unless they
             // wanna add extra settings
             .put(sourceMetaData.getSettings().filter(analysisSimilarityPredicate))
-            .put(IndexMetaData.SETTING_PARTITION_SIZE, sourceMetaData.getPartitionSize())
+            .put(IndexMetaData.SETTING_ROUTING_PARTITION_SIZE, sourceMetaData.getRoutingPartitionSize())
             .put(IndexMetaData.INDEX_SHRINK_SOURCE_NAME.getKey(), shrinkFromIndex.getName())
             .put(IndexMetaData.INDEX_SHRINK_SOURCE_UUID.getKey(), shrinkFromIndex.getUUID());
     }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
@@ -196,7 +196,7 @@ public class MetaDataIndexTemplateService extends AbstractComponent {
         final String temporaryIndexName = UUIDs.randomBase64UUID();
         try {
             // use the provided values, otherwise just pick valid dummy values
-            int dummyPartitionSize = request.settings.getAsInt(IndexMetaData.SETTING_ROUTING_PARTITION_SIZE, 1);
+            int dummyPartitionSize = IndexMetaData.INDEX_ROUTING_PARTITION_SIZE_SETTING.get(request.settings);
             int dummyShards = request.settings.getAsInt(IndexMetaData.SETTING_NUMBER_OF_SHARDS,
                     dummyPartitionSize == 1 ? 1 : dummyPartitionSize + 1);
 

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.cluster.metadata;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
@@ -194,12 +195,16 @@ public class MetaDataIndexTemplateService extends AbstractComponent {
         Index createdIndex = null;
         final String temporaryIndexName = UUIDs.randomBase64UUID();
         try {
+            // use the provided values, otherwise just pick valid dummy values
+            int dummyPartitionSize = request.settings.getAsInt(IndexMetaData.SETTING_PARTITION_SIZE, 1);
+            int dummyShards = request.settings.getAsInt(IndexMetaData.SETTING_NUMBER_OF_SHARDS,
+                    dummyPartitionSize == 1 ? 1 : dummyPartitionSize + 1);
 
             //create index service for parsing and validating "mappings"
             Settings dummySettings = Settings.builder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(request.settings)
-                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, dummyShards)
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
                 .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
                 .build();

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
@@ -196,7 +196,7 @@ public class MetaDataIndexTemplateService extends AbstractComponent {
         final String temporaryIndexName = UUIDs.randomBase64UUID();
         try {
             // use the provided values, otherwise just pick valid dummy values
-            int dummyPartitionSize = request.settings.getAsInt(IndexMetaData.SETTING_PARTITION_SIZE, 1);
+            int dummyPartitionSize = request.settings.getAsInt(IndexMetaData.SETTING_ROUTING_PARTITION_SIZE, 1);
             int dummyShards = request.settings.getAsInt(IndexMetaData.SETTING_NUMBER_OF_SHARDS,
                     dummyPartitionSize == 1 ? 1 : dummyPartitionSize + 1);
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -223,7 +223,7 @@ public class OperationRouting extends AbstractComponent {
         final int partitionOffset;
 
         if (routing == null) {
-            assert(!indexMetaData.isRoutingPartitionedIndex());
+            assert(indexMetaData.isRoutingPartitionedIndex() == false) : "A routing value is required for gets from a partitioned index";
             effectiveRouting = id;
         } else {
             effectiveRouting = routing;

--- a/core/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -92,8 +92,9 @@ public class OperationRouting extends AbstractComponent {
             final Set<String> effectiveRouting = routing.get(index);
             if (effectiveRouting != null) {
                 for (String r : effectiveRouting) {
-                    if (indexMetaData.isPartitionedIndex()) {
-                        for (int partitionOffset = 0; partitionOffset < indexMetaData.getPartitionSize(); partitionOffset++) {
+                    if (indexMetaData.isRoutingPartitionedIndex()) {
+                        final int routingPartitionSize = indexMetaData.getRoutingPartitionSize();
+                        for (int partitionOffset = 0; partitionOffset < routingPartitionSize; partitionOffset++) {
                             set.add(shardRoutingTable(indexRouting, generatePartitionedShardId(indexMetaData, r, partitionOffset)));
                         }
                     } else {
@@ -222,7 +223,7 @@ public class OperationRouting extends AbstractComponent {
     }
 
     static int generateShardId(IndexMetaData indexMetaData, @Nullable String id, @Nullable String routing) {
-        if (indexMetaData.isPartitionedIndex()) {
+        if (indexMetaData.isRoutingPartitionedIndex()) {
             if (routing == null) {
                 throw new IllegalArgumentException("expected a routing value on partitioned index [" + indexMetaData.getIndex().getName() + "]");
             }
@@ -246,7 +247,7 @@ public class OperationRouting extends AbstractComponent {
     }
 
     private static int calculatePartitionOffset(IndexMetaData indexMetaData, String id) {
-        return Math.floorMod(Murmur3HashFunction.hash(id), indexMetaData.getPartitionSize());
+        return Math.floorMod(Murmur3HashFunction.hash(id), indexMetaData.getRoutingPartitionSize());
     }
 
     private static int calculateScaledShardId(IndexMetaData indexMetaData, int hash) {

--- a/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -69,7 +69,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexMetaData.INDEX_AUTO_EXPAND_REPLICAS_SETTING,
         IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING,
         IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING,
-        IndexMetaData.INDEX_PARTITION_SIZE_SETTING,
+        IndexMetaData.INDEX_ROUTING_PARTITION_SIZE_SETTING,
         IndexMetaData.INDEX_SHADOW_REPLICAS_SETTING,
         IndexMetaData.INDEX_SHARED_FILESYSTEM_SETTING,
         IndexMetaData.INDEX_READ_ONLY_SETTING,

--- a/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -69,6 +69,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexMetaData.INDEX_AUTO_EXPAND_REPLICAS_SETTING,
         IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING,
         IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING,
+        IndexMetaData.INDEX_PARTITION_SIZE_SETTING,
         IndexMetaData.INDEX_SHADOW_REPLICAS_SETTING,
         IndexMetaData.INDEX_SHARED_FILESYSTEM_SETTING,
         IndexMetaData.INDEX_READ_ONLY_SETTING,

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -383,7 +383,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             MapperUtils.collect(newMapper.mapping().root(), objectMappers, fieldMappers);
             checkFieldUniqueness(newMapper.type(), objectMappers, fieldMappers, fullPathObjectMappers, fieldTypes);
             checkObjectsCompatibility(objectMappers, updateAllTypes, fullPathObjectMappers);
-        checkPartitionedIndexConstraints(newMapper);
+            checkPartitionedIndexConstraints(newMapper);
 
             // update lookup data-structures
             // this will in particular make sure that the merged fields are compatible with other types

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -599,7 +599,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     }
 
     private void checkPartitionedIndexConstraints(DocumentMapper newMapper) {
-        if (indexSettings.getIndexMetaData().isPartitionedIndex()) {
+        if (indexSettings.getIndexMetaData().isRoutingPartitionedIndex()) {
             if (newMapper.parentFieldMapper().active()) {
                 throw new IllegalArgumentException("mapping type name [" + newMapper.type() + "] cannot have a "
                         + "_parent field for the partitioned index [" + indexSettings.getIndex().getName() + "]");

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.hppc.ObjectHashSet;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
+
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.DelegatingAnalyzerWrapper;
@@ -382,6 +383,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             MapperUtils.collect(newMapper.mapping().root(), objectMappers, fieldMappers);
             checkFieldUniqueness(newMapper.type(), objectMappers, fieldMappers, fullPathObjectMappers, fieldTypes);
             checkObjectsCompatibility(objectMappers, updateAllTypes, fullPathObjectMappers);
+        checkPartitionedIndexConstraints(newMapper);
 
             // update lookup data-structures
             // this will in particular make sure that the merged fields are compatible with other types
@@ -593,6 +595,20 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         if (depth > maxDepth) {
             throw new IllegalArgumentException("Limit of mapping depth [" + maxDepth + "] in index [" + index().getName()
                     + "] has been exceeded due to object field [" + objectPath + "]");
+        }
+    }
+
+    private void checkPartitionedIndexConstraints(DocumentMapper newMapper) {
+        if (indexSettings.getIndexMetaData().isPartitionedIndex()) {
+            if (newMapper.parentFieldMapper().active()) {
+                throw new IllegalArgumentException("mapping type name [" + newMapper.type() + "] cannot have a "
+                        + "_parent field for the partitioned index [" + indexSettings.getIndex().getName() + "]");
+            }
+
+            if (!newMapper.routingFieldMapper().required()) {
+                throw new IllegalArgumentException("mapping type [" + newMapper.type() + "] must have routing "
+                        + "required for partitioned index [" + indexSettings.getIndex().getName() + "]");
+            }
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
@@ -48,6 +48,7 @@ import org.elasticsearch.test.ESIntegTestCase.Scope;
 import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -499,5 +500,32 @@ public class CreateIndexIT extends ESIntegTestCase {
                        .put(SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), Integer.toString(numReplicas + 1))
                        .build();
         assertFalse(client().admin().indices().prepareCreate("test-idx-3").setSettings(settings).setTimeout("100ms").get().isShardsAcked());
+    }
+
+    public void testInvalidPartitionSize() {
+        BiFunction<Integer, Integer, Boolean> createPartitionedIndex = (shards, partition_size) -> {
+            CreateIndexResponse response;
+
+            try {
+                response = prepareCreate("test_" + shards + "_" + partition_size)
+                    .setSettings(Settings.builder()
+                        .put("index.number_of_shards", shards)
+                        .put("index.partition_size", partition_size))
+                    .execute().actionGet();
+            } catch (IllegalStateException | IllegalArgumentException e) {
+                return false;
+            }
+
+            return response.isAcknowledged();
+        };
+
+        assertFalse(createPartitionedIndex.apply(3, 6));
+        assertFalse(createPartitionedIndex.apply(3, 0));
+        assertFalse(createPartitionedIndex.apply(3, 3));
+
+        assertTrue(createPartitionedIndex.apply(3, 1));
+        assertTrue(createPartitionedIndex.apply(3, 2));
+
+        assertTrue(createPartitionedIndex.apply(1, 1));
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
@@ -503,14 +503,14 @@ public class CreateIndexIT extends ESIntegTestCase {
     }
 
     public void testInvalidPartitionSize() {
-        BiFunction<Integer, Integer, Boolean> createPartitionedIndex = (shards, partition_size) -> {
+        BiFunction<Integer, Integer, Boolean> createPartitionedIndex = (shards, partitionSize) -> {
             CreateIndexResponse response;
 
             try {
-                response = prepareCreate("test_" + shards + "_" + partition_size)
+                response = prepareCreate("test_" + shards + "_" + partitionSize)
                     .setSettings(Settings.builder()
                         .put("index.number_of_shards", shards)
-                        .put("index.partition_size", partition_size))
+                        .put("index.routing_partition_size", partitionSize))
                     .execute().actionGet();
             } catch (IllegalStateException | IllegalArgumentException e) {
                 return false;

--- a/core/src/test/java/org/elasticsearch/cluster/routing/OperationRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/OperationRoutingTests.java
@@ -109,7 +109,7 @@ public class OperationRoutingTests extends ESTestCase{
         IndexMetaData metaData = IndexMetaData.builder("test")
                 .settings(settings(Version.CURRENT))
                 .numberOfShards(6)
-                .partitionSize(2)
+                .routingPartitionSize(2)
                 .numberOfReplicas(1)
                 .build();
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -241,4 +241,37 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
                 MergeReason.MAPPING_UPDATE, random().nextBoolean());
         assertTrue(indexService.mapperService().allEnabled()); // this returns true if any of the types has _all enabled
     }
+
+     public void testPartitionedConstraints() {
+        // partitioned index must have routing
+         IllegalArgumentException noRoutingException = expectThrows(IllegalArgumentException.class, () -> {
+            client().admin().indices().prepareCreate("test-index")
+                    .addMapping("type", "{\"type\":{}}")
+                    .setSettings(Settings.builder()
+                        .put("index.number_of_shards", 4)
+                        .put("index.partition_size", 2))
+                    .execute().actionGet();
+        });
+        assertTrue(noRoutingException.getMessage(), noRoutingException.getMessage().contains("must have routing"));
+
+        // partitioned index cannot have parent/child relationships
+        IllegalArgumentException parentException = expectThrows(IllegalArgumentException.class, () -> {
+            client().admin().indices().prepareCreate("test-index")
+                    .addMapping("parent", "{\"parent\":{\"_routing\":{\"required\":true}}}")
+                    .addMapping("child", "{\"child\": {\"_routing\":{\"required\":true}, \"_parent\": {\"type\": \"parent\"}}}")
+                    .setSettings(Settings.builder()
+                        .put("index.number_of_shards", 4)
+                        .put("index.partition_size", 2))
+                    .execute().actionGet();
+        });
+        assertTrue(parentException.getMessage(), parentException.getMessage().contains("cannot have a _parent field"));
+
+        // valid partitioned index
+        assertTrue(client().admin().indices().prepareCreate("test-index")
+            .addMapping("type", "{\"type\":{\"_routing\":{\"required\":true}}}")
+            .setSettings(Settings.builder()
+                .put("index.number_of_shards", 4)
+                .put("index.partition_size", 2))
+            .execute().actionGet().isAcknowledged());
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -249,7 +249,7 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
                     .addMapping("type", "{\"type\":{}}")
                     .setSettings(Settings.builder()
                         .put("index.number_of_shards", 4)
-                        .put("index.partition_size", 2))
+                        .put("index.routing_partition_size", 2))
                     .execute().actionGet();
         });
         assertTrue(noRoutingException.getMessage(), noRoutingException.getMessage().contains("must have routing"));
@@ -261,7 +261,7 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
                     .addMapping("child", "{\"child\": {\"_routing\":{\"required\":true}, \"_parent\": {\"type\": \"parent\"}}}")
                     .setSettings(Settings.builder()
                         .put("index.number_of_shards", 4)
-                        .put("index.partition_size", 2))
+                        .put("index.routing_partition_size", 2))
                     .execute().actionGet();
         });
         assertTrue(parentException.getMessage(), parentException.getMessage().contains("cannot have a _parent field"));
@@ -271,7 +271,7 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
             .addMapping("type", "{\"type\":{\"_routing\":{\"required\":true}}}")
             .setSettings(Settings.builder()
                 .put("index.number_of_shards", 4)
-                .put("index.partition_size", 2))
+                .put("index.routing_partition_size", 2))
             .execute().actionGet().isAcknowledged());
     }
 }

--- a/core/src/test/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
@@ -37,7 +37,6 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.indices.InvalidAliasNameException;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ESIntegTestCase;
-
 import org.junit.After;
 
 import java.io.IOException;
@@ -306,7 +305,6 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
                 "get template with " + Arrays.toString(names));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/8802")
     public void testBrokenMapping() throws Exception {
         // clean all templates setup by the framework.
         client().admin().indices().prepareDeleteTemplate("*").get();
@@ -763,5 +761,64 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 1);
         assertEquals("value1", searchResponse.getHits().getAt(0).field("field1").value().toString());
         assertNull(searchResponse.getHits().getAt(0).field("field2"));
+    }
+
+    public void testPartitionedTemplate() throws Exception {
+        // clean all templates setup by the framework.
+        client().admin().indices().prepareDeleteTemplate("*").get();
+
+        // check get all templates on an empty index.
+        GetIndexTemplatesResponse response = client().admin().indices().prepareGetTemplates().get();
+        assertThat(response.getIndexTemplates(), empty());
+
+        // provide more partitions than shards
+        IllegalArgumentException eBadSettings = expectThrows(IllegalArgumentException.class,
+            () -> client().admin().indices().preparePutTemplate("template_1")
+                .setPatterns(Collections.singletonList("te*"))
+                .setSettings(Settings.builder()
+                    .put("index.number_of_shards", "5")
+                    .put("index.partition_size", "6"))
+                .get());
+        assertThat(eBadSettings.getMessage(), containsString("partition size [6] should be a positive number "
+                + "less than the number of shards [5]"));
+
+        // provide an invalid mapping for a partitioned index
+        IllegalArgumentException eBadMapping = expectThrows(IllegalArgumentException.class,
+            () -> client().admin().indices().preparePutTemplate("template_2")
+                .setPatterns(Collections.singletonList("te*"))
+                .addMapping("type", "{\"type\":{\"_routing\":{\"required\":false}}}")
+                .setSettings(Settings.builder()
+                    .put("index.number_of_shards", "6")
+                    .put("index.partition_size", "3"))
+                .get());
+        assertThat(eBadMapping.getMessage(), containsString("must have routing required for partitioned index"));
+
+        // no templates yet
+        response = client().admin().indices().prepareGetTemplates().get();
+        assertEquals(0, response.getIndexTemplates().size());
+
+        // a valid configuration that only provides the partition size
+        assertAcked(client().admin().indices().preparePutTemplate("just_partitions")
+            .setPatterns(Collections.singletonList("te*"))
+            .setSettings(Settings.builder()
+                .put("index.partition_size", "6"))
+            .get());
+
+        // create an index with too few shards
+        IllegalArgumentException eBadIndex = expectThrows(IllegalArgumentException.class,
+                () -> prepareCreate("test_bad", Settings.builder()
+            .put("index.number_of_shards", 5))
+            .get());
+
+        assertThat(eBadIndex.getMessage(), containsString("partition size [6] should be a positive number "
+                + "less than the number of shards [5]"));
+
+        // finally, create a valid index
+        prepareCreate("test_good", Settings.builder()
+            .put("index.number_of_shards", 7))
+            .get();
+
+        GetSettingsResponse getSettingsResponse = client().admin().indices().prepareGetSettings("test_good").get();
+        assertEquals("6", getSettingsResponse.getIndexToSettings().get("test_good").getAsMap().get("index.partition_size"));
     }
 }

--- a/core/src/test/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
@@ -777,7 +777,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
                 .setPatterns(Collections.singletonList("te*"))
                 .setSettings(Settings.builder()
                     .put("index.number_of_shards", "5")
-                    .put("index.partition_size", "6"))
+                    .put("index.routing_partition_size", "6"))
                 .get());
         assertThat(eBadSettings.getMessage(), containsString("partition size [6] should be a positive number "
                 + "less than the number of shards [5]"));
@@ -789,7 +789,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
                 .addMapping("type", "{\"type\":{\"_routing\":{\"required\":false}}}")
                 .setSettings(Settings.builder()
                     .put("index.number_of_shards", "6")
-                    .put("index.partition_size", "3"))
+                    .put("index.routing_partition_size", "3"))
                 .get());
         assertThat(eBadMapping.getMessage(), containsString("must have routing required for partitioned index"));
 
@@ -801,7 +801,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         assertAcked(client().admin().indices().preparePutTemplate("just_partitions")
             .setPatterns(Collections.singletonList("te*"))
             .setSettings(Settings.builder()
-                .put("index.partition_size", "6"))
+                .put("index.routing_partition_size", "6"))
             .get());
 
         // create an index with too few shards
@@ -819,6 +819,6 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
             .get();
 
         GetSettingsResponse getSettingsResponse = client().admin().indices().prepareGetSettings("test_good").get();
-        assertEquals("6", getSettingsResponse.getIndexToSettings().get("test_good").getAsMap().get("index.partition_size"));
+        assertEquals("6", getSettingsResponse.getIndexToSettings().get("test_good").getAsMap().get("index.routing_partition_size"));
     }
 }

--- a/core/src/test/java/org/elasticsearch/routing/PartitionedRoutingIT.java
+++ b/core/src/test/java/org/elasticsearch/routing/PartitionedRoutingIT.java
@@ -41,7 +41,7 @@ public class PartitionedRoutingIT extends ESIntegTestCase {
                 client().admin().indices().prepareCreate(index)
                     .setSettings(Settings.builder()
                         .put("index.number_of_shards", shards)
-                        .put("index.partition_size", partitionSize))
+                        .put("index.routing_partition_size", partitionSize))
                     .addMapping("type", "{\"type\":{\"_routing\":{\"required\":true}}}")
                     .execute().actionGet();
                 ensureGreen();
@@ -66,7 +66,7 @@ public class PartitionedRoutingIT extends ESIntegTestCase {
         client().admin().indices().prepareCreate(index)
             .setSettings(Settings.builder()
                 .put("index.number_of_shards", currentShards)
-                .put("index.partition_size", partitionSize))
+                .put("index.routing_partition_size", partitionSize))
             .addMapping("type", "{\"type\":{\"_routing\":{\"required\":true}}}")
             .execute().actionGet();
         ensureGreen();
@@ -79,7 +79,7 @@ public class PartitionedRoutingIT extends ESIntegTestCase {
             verifyGets(index, routingToDocumentIds);
             verifyBroadSearches(index, routingToDocumentIds, currentShards);
 
-            // we need the floor and ceiling of the partition_size / factor since the partition size of the shrunken
+            // we need the floor and ceiling of the routing_partition_size / factor since the partition size of the shrunken
             // index will be one of those, depending on the routing value
             verifyRoutedSearches(index, routingToDocumentIds,
                 Math.floorDiv(partitionSize, factor) == 0 ?

--- a/core/src/test/java/org/elasticsearch/routing/PartitionedRoutingIT.java
+++ b/core/src/test/java/org/elasticsearch/routing/PartitionedRoutingIT.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.routing;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.mockito.internal.util.collections.Sets;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class PartitionedRoutingIT extends ESIntegTestCase {
+
+    public void testVariousPartitionSizes() throws Exception {
+        for (int shards = 1; shards <= 4; shards++) {
+            for (int partitionSize = 1; partitionSize < shards; partitionSize++) {
+                String index = "index_" + shards + "_" + partitionSize;
+
+                client().admin().indices().prepareCreate(index)
+                    .setSettings(Settings.builder()
+                        .put("index.number_of_shards", shards)
+                        .put("index.partition_size", partitionSize))
+                    .addMapping("type", "{\"type\":{\"_routing\":{\"required\":true}}}")
+                    .execute().actionGet();
+                ensureGreen();
+
+                Map<String, Set<String>> routingToDocumentIds = generateRoutedDocumentIds(index);
+
+                verifyGets(index, routingToDocumentIds);
+                verifyBroadSearches(index, routingToDocumentIds, shards);
+                verifyRoutedSearches(index, routingToDocumentIds, Sets.newSet(partitionSize));
+            }
+        }
+    }
+
+    public void testShrinking() throws Exception {
+        // creates random routing groups and repeatedly halves the index until it is down to 1 shard
+        // verifying that the count is correct for each shrunken index
+        final int partitionSize = 3;
+        final int originalShards = 8;
+        int currentShards = originalShards;
+        String index = "index_" + currentShards;
+
+        client().admin().indices().prepareCreate(index)
+            .setSettings(Settings.builder()
+                .put("index.number_of_shards", currentShards)
+                .put("index.partition_size", partitionSize))
+            .addMapping("type", "{\"type\":{\"_routing\":{\"required\":true}}}")
+            .execute().actionGet();
+        ensureGreen();
+
+        Map<String, Set<String>> routingToDocumentIds = generateRoutedDocumentIds(index);
+
+        while (true) {
+            int factor = originalShards / currentShards;
+
+            verifyGets(index, routingToDocumentIds);
+            verifyBroadSearches(index, routingToDocumentIds, currentShards);
+
+            // we need the floor and ceiling of the partition_size / factor since the partition size of the shrunken
+            // index will be one of those, depending on the routing value
+            verifyRoutedSearches(index, routingToDocumentIds,
+                Math.floorDiv(partitionSize, factor) == 0 ?
+                    Sets.newSet(1, 2) :
+                    Sets.newSet(Math.floorDiv(partitionSize, factor), -Math.floorDiv(-partitionSize, factor)));
+
+            client().admin().indices().prepareUpdateSettings(index)
+                .setSettings(Settings.builder()
+                    .put("index.routing.allocation.require._name", client().admin().cluster().prepareState().get().getState().nodes()
+                        .getDataNodes().values().toArray(DiscoveryNode.class)[0].getName())
+                    .put("index.blocks.write", true)).get();
+            ensureGreen();
+
+            currentShards = Math.floorDiv(currentShards, 2);
+
+            if (currentShards == 0) {
+                break;
+            }
+
+            String previousIndex = index;
+            index = "index_" + currentShards;
+
+            logger.info("--> shrinking index [" + previousIndex + "] to [" + index + "]");
+            client().admin().indices().prepareShrinkIndex(previousIndex, index)
+                .setSettings(Settings.builder()
+                    .put("index.number_of_shards", currentShards)
+                    .build()).get();
+            ensureGreen();
+        }
+    }
+
+    private void verifyRoutedSearches(String index, Map<String, Set<String>> routingToDocumentIds, Set<Integer> expectedShards) {
+        for (Map.Entry<String, Set<String>> routingEntry : routingToDocumentIds.entrySet()) {
+            String routing = routingEntry.getKey();
+            int expectedDocuments = routingEntry.getValue().size();
+
+            SearchResponse response  = client().prepareSearch()
+                .setQuery(QueryBuilders.termQuery("_routing", routing))
+                .setRouting(routing)
+                .setIndices(index)
+                .setSize(100)
+                .execute().actionGet();
+
+            logger.info("--> routed search on index [" + index + "] visited [" + response.getTotalShards()
+                + "] shards for routing [" + routing + "] and got hits [" + response.getHits().totalHits() + "]");
+
+            assertTrue(response.getTotalShards() + " was not in " + expectedShards + " for " + index,
+                    expectedShards.contains(response.getTotalShards()));
+            assertEquals(expectedDocuments, response.getHits().totalHits());
+
+            Set<String> found = new HashSet<>();
+            response.getHits().forEach(h -> found.add(h.getId()));
+
+            assertEquals(routingEntry.getValue(), found);
+        }
+    }
+
+    private void verifyBroadSearches(String index, Map<String, Set<String>> routingToDocumentIds, int expectedShards) {
+        for (Map.Entry<String, Set<String>> routingEntry : routingToDocumentIds.entrySet()) {
+            String routing = routingEntry.getKey();
+            int expectedDocuments = routingEntry.getValue().size();
+
+            SearchResponse response  = client().prepareSearch()
+                .setQuery(QueryBuilders.termQuery("_routing", routing))
+                .setIndices(index)
+                .setSize(100)
+                .execute().actionGet();
+
+            assertEquals(expectedShards, response.getTotalShards());
+            assertEquals(expectedDocuments, response.getHits().totalHits());
+
+            Set<String> found = new HashSet<>();
+            response.getHits().forEach(h -> found.add(h.getId()));
+
+            assertEquals(routingEntry.getValue(), found);
+        }
+    }
+
+    private void verifyGets(String index, Map<String, Set<String>> routingToDocumentIds) {
+        for (Map.Entry<String, Set<String>> routingEntry : routingToDocumentIds.entrySet()) {
+            String routing = routingEntry.getKey();
+
+            for (String id : routingEntry.getValue()) {
+                assertTrue(client().prepareGet(index, "type", id).setRouting(routing).execute().actionGet().isExists());
+            }
+        }
+    }
+
+    private Map<String, Set<String>> generateRoutedDocumentIds(String index) {
+        Map<String, Set<String>> routingToDocumentIds = new HashMap<>();
+        int numRoutingValues = randomIntBetween(5, 15);
+
+        for (int i = 0; i < numRoutingValues; i++) {
+            String routingValue = String.valueOf(i);
+            int numDocuments = randomIntBetween(10, 100);
+            routingToDocumentIds.put(String.valueOf(routingValue), new HashSet<>());
+
+            for (int k = 0; k < numDocuments; k++) {
+                String id = routingValue + "_" + String.valueOf(k);
+                routingToDocumentIds.get(routingValue).add(id);
+
+                client().prepareIndex(index, "type", id)
+                    .setRouting(routingValue)
+                    .setSource("foo", "bar")
+                    .get();
+            }
+        }
+
+        client().admin().indices().prepareRefresh(index).get();
+
+        return routingToDocumentIds;
+    }
+
+
+}

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -79,11 +79,12 @@ Checking shards may take a lot of time on large indices.
     which uses https://en.wikipedia.org/wiki/DEFLATE[DEFLATE] for a higher
     compression ratio, at the expense of slower stored fields performance.
 
-`index.routing_partition_size`::
+[[routing-partition-size]] `index.routing_partition_size`::
 
     The number of shards a custom <<mapping-routing-field,routing>> value can go to.
     Defaults to 1 and can only be set at index creation time. This value must be less
     than the `index.number_of_shards` unless the `index.number_of_shards` value is also 1.
+    See <<routing-index-partition>> for more details about how this setting is used.
 
 [float]
 [[dynamic-index-settings]]

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -79,6 +79,12 @@ Checking shards may take a lot of time on large indices.
     which uses https://en.wikipedia.org/wiki/DEFLATE[DEFLATE] for a higher
     compression ratio, at the expense of slower stored fields performance.
 
+`index.routing_partition_size`::
+
+    The number of shards a custom <<mapping-routing-field,routing>> value can go to.
+    Defaults to 1 and can only be set at index creation time. This value must be less
+    than the `index.number_of_shards` unless the `index.number_of_shards` value is also 1.
+
 [float]
 [[dynamic-index-settings]]
 === Dynamic index settings

--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -110,13 +110,14 @@ different `_routing` values.
 
 It is up to the user to ensure that IDs are unique across the index.
 
+[[routing-index-partition]]
 ==== Routing to an index partition
 
 An index can be configured such that custom routing values will go to a subset of the shards rather
 than a single shard. This helps mitigate the risk of ending up with an imbalanced cluster while still
 reducing the impact of searches.
 
-This is done by providing the index level setting `index.routing_partition_size` at index creation.
+This is done by providing the index level setting <<routing-partition-size,`index.routing_partition_size`>> at index creation.
 As the partition size increases, the more evenly distributed the data will become at the
 expense of having to search more shards per request.
 

--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -109,3 +109,28 @@ documents with the same `_id` might end up on different shards if indexed with
 different `_routing` values.
 
 It is up to the user to ensure that IDs are unique across the index.
+
+==== Routing to an index partition
+
+An index can be configured such that custom routing values will go to a subset of the shards rather
+than a single shard. This helps mitigate the risk of ending up with an imbalanced cluster while still
+reducing the impact of searches.
+
+This is done by providing the index level setting `index.routing_partition_size` at index creation.
+As the partition size increases, the more evenly distributed the data will become at the
+expense of having to search more shards per request.
+
+When this setting is present, the formula for calculating the shard becomes:
+
+    shard_num = (hash(_routing) + hash(_id) % routing_partition_size) % num_primary_shards
+
+That is, the `_routing` field is used to calculate a set of shards within the index and then the
+`_id` is used to pick a shard within that set.
+
+To enable this feature, the `index.routing_partition_size` should have a value greater than 1 and
+less than `index.number_of_shards`.
+
+Once enabled, the partitioned index will have the following limitations:
+
+*   Mappings with parent-child relationships cannot be created within it.
+*   All mappings within the index must have the `_routing` field marked as required.


### PR DESCRIPTION
This change makes it possible for custom routing values to go to a subset of shards rather than
just a single shard. This enables the ability to utilize the spatial locality that custom routing can
provide while mitigating the likelihood of ending up with an imbalanced cluster or suffering
from a hot shard.

This is ideal for large multi-tenant indices with custom routing that suffer from one or both of
the following:
- The big tenants cannot fit into a single shard or there is so many of them that they will likely
end up on the same shard
- Tenants often have a surge in write traffic and a single shard cannot process it fast enough

Beyond that, this should also be useful for use cases where most queries are done under the context
of a specific field (e.g. a category) since it gives a hint at how the data can be stored to minimize
the number of shards to check per query. While a similar solution can be achieved with multiple
concrete indices or aliases per value today, those approaches breakdown for high cardinally fields.

A partitioned index enforces that mappings have routing required, that the partition size does not
change when shrinking an index (the partitions will shrink proportionally), and rejects mappings
that have parent/child relationships.

Closes #21585