### PR TITLE
Add an attachment foreach example to ingest-node.asciidoc

### DIFF
--- a/docs/plugins/ingest-attachment.asciidoc
+++ b/docs/plugins/ingest-attachment.asciidoc
@@ -104,3 +104,56 @@ Returns this:
 NOTE: Extracting contents from binary data is a resource intensive operation and
       consumes a lot of resources. It is highly recommended to run pipelines
       using this processor in a dedicated ingest node.
+
+
+[[ingest-attachment-with-arrays]]
+==== Using the Attachment Processor with arrays
+
+To use the attachment processor within an array of attachments the
+{ref}/foreach-processor.html[foreach processor] is required. This
+enables the attachment processor to be run on the individual elements
+of the array.
+
+For example, given the following source:
+
+[source,js]
+--------------------------------------------------
+{
+  "attachments" : [
+    {
+      "filename" : "ipsum.txt",
+      "data" : "dGhpcyBpcwpqdXN0IHNvbWUgdGV4dAo="
+    },
+    {
+      "filename" : "test.txt",
+      "data" : "VGhpcyBpcyBhIHRlc3QK"
+    }
+  ]
+}
+--------------------------------------------------
+
+In this case, we want to process the data field in each element
+of the attachments field and insert
+the properties into the document so the following `foreach`
+processor is used:
+
+[source,js]
+--------------------------------------------------
+{
+  "foreach": {
+    "field": "attachments",
+    "processor": {
+      "attachment": {
+        "target_field": "_ingest._value.attachment",
+        "field": "_ingest._value.data"
+      }
+    }
+  }
+}
+--------------------------------------------------
+Note that the `target_field` needs to be set, otherwise the
+default value is used which is a top level field `attachment`. The
+properties on this top level field will contain the value of the
+first attachment only. However, by specifying the
+`target_field` on to a value on `_ingest._value` it will correctly
+associate the properties with the correct attachment.

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -1135,6 +1135,51 @@ In this example, if the `remove` processor does fail, then
 the array elements that have been processed thus far will
 be updated.
 
+
+Another example, using the attachment processor:
+
+[source,js]
+--------------------------------------------------
+{
+  "attachments" : [
+    {
+      "filename" : "ipsum.txt",
+      "data" : "dGhpcyBpcwpqdXN0IHNvbWUgdGV4dAo="
+    },
+    {
+      "filename" : "test.txt",
+      "data" : "VGhpcyBpcyBhIHRlc3QK"
+    }
+  ]
+}
+--------------------------------------------------
+
+In this case, we want to process the attachment and insert
+the properties into the document so the following `foreach`
+processor is used:
+
+[source,js]
+--------------------------------------------------
+{
+  "foreach": {
+    "field": "attachments",
+    "processor": {
+      "attachment": {
+        "target_field": "_ingest._value.attachment",
+        "field": "_ingest._value.data"
+      }
+    }
+  }
+}
+--------------------------------------------------
+Note that the `target_field` needs to be set, otherwise the
+default value is used which is a top level field `attachment`. The
+properties on this top level field will contain the value of the
+first attachment only. However, by specifying the
+`target_field` on to a value on `_ingest._value` it will correctly
+associate the properties with the correct attachment.
+
+
 [[grok-processor]]
 === Grok Processor
 

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -1135,49 +1135,8 @@ In this example, if the `remove` processor does fail, then
 the array elements that have been processed thus far will
 be updated.
 
+Another advanced example can be found in {plugins}/using-ingest-attachment.html[attachment processor documentation].
 
-Another example, using the attachment processor:
-
-[source,js]
---------------------------------------------------
-{
-  "attachments" : [
-    {
-      "filename" : "ipsum.txt",
-      "data" : "dGhpcyBpcwpqdXN0IHNvbWUgdGV4dAo="
-    },
-    {
-      "filename" : "test.txt",
-      "data" : "VGhpcyBpcyBhIHRlc3QK"
-    }
-  ]
-}
---------------------------------------------------
-
-In this case, we want to process the attachment and insert
-the properties into the document so the following `foreach`
-processor is used:
-
-[source,js]
---------------------------------------------------
-{
-  "foreach": {
-    "field": "attachments",
-    "processor": {
-      "attachment": {
-        "target_field": "_ingest._value.attachment",
-        "field": "_ingest._value.data"
-      }
-    }
-  }
-}
---------------------------------------------------
-Note that the `target_field` needs to be set, otherwise the
-default value is used which is a top level field `attachment`. The
-properties on this top level field will contain the value of the
-first attachment only. However, by specifying the
-`target_field` on to a value on `_ingest._value` it will correctly
-associate the properties with the correct attachment.
 
 
 [[grok-processor]]


### PR DESCRIPTION
Relates to Issue #22294

Added an example to the foreach processor when dealing with attachments noting the requirement to use the target_field option with the attachment processor to ensure the properties extracted from the attachment are added in the correct location.
