### PR TITLE
Add link to foreach processor to ingest-attachment.asciidoc

### DIFF
--- a/docs/plugins/ingest-attachment.asciidoc
+++ b/docs/plugins/ingest-attachment.asciidoc
@@ -105,3 +105,5 @@ Returns this:
 NOTE: Extracting contents from binary data is a resource intensive operation and
       consumes a lot of resources. It is highly recommended to run pipelines
       using this processor in a dedicated ingest node.
+      
+NOTE: To process an array of attachments the {ref}/foreach-processor.html[foreach processor] is required.


### PR DESCRIPTION
Relates to Issue #22294

Add a Note to the foreach processor for processing an array of attachments, as this is required to be able to process an array of attachments.
