### PR TITLE
Restore deprecation warning for invalid match_mapping_type values

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/DynamicTemplate.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DynamicTemplate.java
@@ -152,7 +152,7 @@ public class DynamicTemplate implements ToXContent {
                     return v;
                 }
             }
-            throw new IllegalArgumentException("No xcontent type matched on [" + value + "], possible values are "
+            throw new IllegalArgumentException("No field type matched on [" + value + "], possible values are "
                     + Arrays.toString(values()));
         }
 
@@ -208,6 +208,8 @@ public class DynamicTemplate implements ToXContent {
                 if (indexVersionCreated.onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
                     throw e;
                 } else {
+                    DEPRECATION_LOGGER.deprecated("match_mapping_type [" + matchMappingType + "] is invalid and will be ignored: "
+                            + e.getMessage());
                     // this template is on an unknown type so it will never match anything
                     // null indicates that the template should be ignored
                     return null;

--- a/core/src/test/java/org/elasticsearch/index/mapper/DynamicTemplateTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DynamicTemplateTests.java
@@ -50,14 +50,15 @@ public class DynamicTemplateTests extends ESTestCase {
         templateDef.put("mapping", Collections.singletonMap("store", true));
         // if a wrong match type is specified, we ignore the template
         assertNull(DynamicTemplate.parse("my_template", templateDef, Version.V_5_0_0_alpha5));
-
+        assertWarnings("match_mapping_type [short] is invalid and will be ignored: No field type matched on [short], " +
+                "possible values are [object, string, long, double, boolean, date, binary]");
         Map<String, Object> templateDef2 = new HashMap<>();
         templateDef2.put("match_mapping_type", "text");
         templateDef2.put("mapping", Collections.singletonMap("store", true));
         // if a wrong match type is specified, we ignore the template
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> DynamicTemplate.parse("my_template", templateDef2, Version.V_6_0_0_alpha1_UNRELEASED));
-        assertEquals("No xcontent type matched on [text], possible values are [object, string, long, double, boolean, date, binary]",
+        assertEquals("No field type matched on [text], possible values are [object, string, long, double, boolean, date, binary]",
                 e.getMessage());
     }
 


### PR DESCRIPTION
The deprecation warning gives now the same message as 5.x. The deprecation warning was previously removed, but given that we are still lenient with old indices we should still output the warning.