### PR TITLE
Support negative numbers in readVLong

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -215,20 +215,9 @@ public abstract class StreamInput extends InputStream {
 
     /**
      * Reads a long stored in variable-length format. Reads between one and nine bytes. Smaller values take fewer bytes. Negative numbers
-     * are encoded in ten bytes and trip an assertion (if called while testing) so prefer {@link #readLong()} or {@link #readZLong()} for
-     * negative numbers.
+     * are encoded in ten bytes so prefer {@link #readLong()} or {@link #readZLong()} for negative numbers.
      */
     public long readVLong() throws IOException {
-        long l = readVLongNoCheck();
-        assert l >= 0: "Prefer readLong or readZLong for negative numbers [" + l + "]";
-        return l;
-    }
-
-    /**
-     * Reads a long stored in variable-length format without asserting that it isn't negative. Package private for testing. Use
-     * {@link #readVLong()}.
-     */
-    long readVLongNoCheck() throws IOException {
         byte b = readByte();
         long i = b & 0x7FL;
         if ((b & 0x80) == 0) {

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -214,7 +214,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
-     * Reads a long stored in variable-length format. Reads between one and nine bytes. Smaller values take fewer bytes. Negative numbers
+     * Reads a long stored in variable-length format. Reads between one and ten bytes. Smaller values take fewer bytes. Negative numbers
      * are encoded in ten bytes so prefer {@link #readLong()} or {@link #readZLong()} for negative numbers.
      */
     public long readVLong() throws IOException {
@@ -267,7 +267,7 @@ public abstract class StreamInput extends InputStream {
         if (b != 0 && b != 1) {
             throw new IOException("Invalid vlong (" + Integer.toHexString(b) + " << 63) | " + Long.toHexString(i));
         }
-        i |= (b & 0x7FL) << 63;
+        i |= ((long) b) << 63;
         return i;
     }
 

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -215,7 +215,9 @@ public abstract class StreamOutput extends OutputStream {
      * negative numbers.
      */
     public void writeVLong(long i) throws IOException {
-        assert i >= 0 : "Prefer writeLong or writeZLong for negative numbers [" + i + "]";
+        if (i < 0) {
+            throw new IllegalStateException("Negative longs unsupported, use writeLong or writeZLong for negative numbers [" + i + "]");
+        }
         writeVLongNoCheck(i);
     }
 

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -210,12 +210,20 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
-     * Writes a non-negative long in a variable-length format.
-     * Writes between one and nine bytes. Smaller values take fewer bytes.
-     * Negative numbers are not supported.
+     * Writes a non-negative long in a variable-length format. Writes between one and ten bytes. Smaller values take fewer bytes. Negative
+     * numbers use ten bytes and trip assertions (if running in tests) so prefer {@link #writeLong(long)} or {@link #writeZLong(long)} for
+     * negative numbers.
      */
     public void writeVLong(long i) throws IOException {
-        assert i >= 0;
+        assert i >= 0 : "Prefer writeLong or writeZLong for negative numbers [" + i + "]";
+        writeVLongNoCheck(i);
+    }
+
+    /**
+     * Writes a long in a variable-length format without first checking if it is negative. Package private for testing. Use
+     * {@link #writeVLong(long)} instead.
+     */
+    void writeVLongNoCheck(long i) throws IOException {
         while ((i & ~0x7F) != 0) {
             writeByte((byte) ((i & 0x7f) | 0x80));
             i >>>= 7;

--- a/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -789,12 +789,14 @@ public class BytesStreamsTests extends ESTestCase {
     public void testVLong() throws IOException {
         final long value = randomLong();
         {
+            // Read works for positive and negative numbers
             BytesStreamOutput output = new BytesStreamOutput();
-            output.writeVLongNoCheck(value);
+            output.writeVLongNoCheck(value); // Use NoCheck variant so we can write negative numbers
             StreamInput input = output.bytes().streamInput();
             assertEquals(value, input.readVLong());
         }
         if (value < 0) {
+            // Write doesn't work for negative numbers
             BytesStreamOutput output = new BytesStreamOutput();
             Exception e = expectThrows(IllegalStateException.class, () -> output.writeVLong(value));
             assertEquals("Negative longs unsupported, use writeLong or writeZLong for negative numbers [" + value + "]", e.getMessage());

--- a/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.io.stream;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Constants;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -32,6 +33,7 @@ import org.joda.time.DateTimeZone;
 import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -48,6 +50,7 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 /**
  * Tests for {@link BytesStreamOutput} paging behaviour.
@@ -801,5 +804,13 @@ public class BytesStreamsTests extends ESTestCase {
             Exception e = expectThrows(IllegalStateException.class, () -> output.writeVLong(value));
             assertEquals("Negative longs unsupported, use writeLong or writeZLong for negative numbers [" + value + "]", e.getMessage());
         }
+
+        assertTrue("If we're not compatible with 5.1.1 we can drop the assertion below",
+                Version.CURRENT.minimumCompatibilityVersion().onOrBefore(Version.V_5_1_1_UNRELEASED));
+        /* Read -1 as serialized by a version of Elasticsearch that supported writing negative numbers with writeVLong. Note that this
+         * should be the same test as the first case (when value is negative) but we've kept some bytes so no matter what we do to
+         * writeVLong in the future we can be sure we can read bytes as written by Elasticsearch before 5.1.2 */
+        StreamInput in = new BytesArray(Base64.getDecoder().decode("////////////AQAAAAAAAA==")).streamInput();
+        assertEquals(-1, in.readVLong());
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -792,23 +792,12 @@ public class BytesStreamsTests extends ESTestCase {
             BytesStreamOutput output = new BytesStreamOutput();
             output.writeVLongNoCheck(value);
             StreamInput input = output.bytes().streamInput();
-            assertEquals(value, input.readVLongNoCheck());
-        }
-        {
-            BytesStreamOutput output = new BytesStreamOutput();
-            output.writeVLongNoCheck(value);
-            StreamInput input = output.bytes().streamInput();
-            if (value >= 0) {
-                assertEquals(value, input.readVLong());
-            } else {
-                AssertionError e = expectThrows(AssertionError.class, () -> input.readVLong());
-                assertEquals("Prefer readLong or readZLong for negative numbers [" + value + "]", e.getMessage());
-            }
+            assertEquals(value, input.readVLong());
         }
         if (value < 0) {
             BytesStreamOutput output = new BytesStreamOutput();
-            AssertionError e = expectThrows(AssertionError.class, () -> output.writeVLong(value));
-            assertEquals("Prefer writeLong or writeZLong for negative numbers [" + value + "]", e.getMessage());
+            Exception e = expectThrows(IllegalStateException.class, () -> output.writeVLong(value));
+            assertEquals("Negative longs unsupported, use writeLong or writeZLong for negative numbers [" + value + "]", e.getMessage());
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -50,7 +50,6 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 /**
  * Tests for {@link BytesStreamOutput} paging behaviour.


### PR DESCRIPTION
We don't *want* to use negative numbers with `writeVLong`
so throw an exception when we try. On the other
hand unforeseen bugs might cause us to write negative numbers (some versions of Elasticsearch don't have the exception, only an assertion)
so this fixes `readVLong` so that instead of reading a wrong
value and corrupting the stream it reads the negative value.
