### PR TITLE
Use a fresh recovery id when retrying recoveries

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -188,6 +188,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING,
                     RecoverySettings.INDICES_RECOVERY_RETRY_DELAY_STATE_SYNC_SETTING,
                     RecoverySettings.INDICES_RECOVERY_RETRY_DELAY_NETWORK_SETTING,
+                    RecoverySettings.INDICES_RECOVERY_RETRY_CLEANUP_TIMEOUT_SETTING,
                     RecoverySettings.INDICES_RECOVERY_ACTIVITY_TIMEOUT_SETTING,
                     RecoverySettings.INDICES_RECOVERY_INTERNAL_ACTION_TIMEOUT_SETTING,
                     RecoverySettings.INDICES_RECOVERY_INTERNAL_LONG_ACTION_TIMEOUT_SETTING,

--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -188,7 +188,6 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING,
                     RecoverySettings.INDICES_RECOVERY_RETRY_DELAY_STATE_SYNC_SETTING,
                     RecoverySettings.INDICES_RECOVERY_RETRY_DELAY_NETWORK_SETTING,
-                    RecoverySettings.INDICES_RECOVERY_RETRY_CLEANUP_TIMEOUT_SETTING,
                     RecoverySettings.INDICES_RECOVERY_ACTIVITY_TIMEOUT_SETTING,
                     RecoverySettings.INDICES_RECOVERY_INTERNAL_ACTION_TIMEOUT_SETTING,
                     RecoverySettings.INDICES_RECOVERY_INTERNAL_LONG_ACTION_TIMEOUT_SETTING,

--- a/core/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -266,7 +266,7 @@ public class PeerRecoveryTargetService extends AbstractComponent implements Inde
             Throwable cause = ExceptionsHelper.unwrapCause(e);
             if (cause instanceof CancellableThreads.ExecutionCancelledException) {
                 // this can also come from the source wrapped in a RemoteTransportException
-                onGoingRecoveries.failRecovery(request.recoveryId(), new RecoveryFailedException(request,
+                onGoingRecoveries.failRecovery(recoveryId, new RecoveryFailedException(request,
                     "source has canceled the recovery", cause), false);
                 return;
             }
@@ -286,13 +286,13 @@ public class PeerRecoveryTargetService extends AbstractComponent implements Inde
             if (cause instanceof IllegalIndexShardStateException || cause instanceof IndexNotFoundException ||
                 cause instanceof ShardNotFoundException) {
                 // if the target is not ready yet, retry
-                retryRecovery(request.recoveryId(), "remote shard not ready", recoverySettings.retryDelayStateSync(),
+                retryRecovery(recoveryId, "remote shard not ready", recoverySettings.retryDelayStateSync(),
                     recoverySettings.activityTimeout());
                 return;
             }
 
             if (cause instanceof DelayRecoveryException) {
-                retryRecovery(request.recoveryId(), cause, recoverySettings.retryDelayStateSync(),
+                retryRecovery(recoveryId, cause, recoverySettings.retryDelayStateSync(),
                     recoverySettings.activityTimeout());
                 return;
             }
@@ -300,17 +300,17 @@ public class PeerRecoveryTargetService extends AbstractComponent implements Inde
             if (cause instanceof ConnectTransportException) {
                 logger.debug("delaying recovery of {} for [{}] due to networking error [{}]", request.shardId(),
                     recoverySettings.retryDelayNetwork(), cause.getMessage());
-                retryRecovery(request.recoveryId(), cause.getMessage(), recoverySettings.retryDelayNetwork(),
+                retryRecovery(recoveryId, cause.getMessage(), recoverySettings.retryDelayNetwork(),
                     recoverySettings.activityTimeout());
                 return;
             }
 
             if (cause instanceof AlreadyClosedException) {
-                onGoingRecoveries.failRecovery(request.recoveryId(),
+                onGoingRecoveries.failRecovery(recoveryId,
                     new RecoveryFailedException(request, "source shard is closed", cause), false);
                 return;
             }
-            onGoingRecoveries.failRecovery(request.recoveryId(), new RecoveryFailedException(request, e), true);
+            onGoingRecoveries.failRecovery(recoveryId, new RecoveryFailedException(request, e), true);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -140,157 +140,164 @@ public class PeerRecoveryTargetService extends AbstractComponent implements Inde
         threadPool.generic().execute(new RecoveryRunner(recoveryId));
     }
 
-    protected void retryRecovery(final RecoveryRef recoveryRef, final Throwable reason, TimeValue retryAfter,
-                                 TimeValue retryCleanupTimeout, final StartRecoveryRequest currentRequest) {
+    protected void retryRecovery(final long recoveryId, final Throwable reason, TimeValue retryAfter, TimeValue activityTimeout) {
         logger.trace(
             (Supplier<?>) () -> new ParameterizedMessage(
-                "will retry recovery with id [{}] in [{}]", recoveryRef.status().recoveryId(), retryAfter), reason);
-        retryRecovery(recoveryRef, retryAfter, retryCleanupTimeout, currentRequest);
+                "will retry recovery with id [{}] in [{}]", recoveryId, retryAfter), reason);
+        retryRecovery(recoveryId, retryAfter, activityTimeout);
     }
 
-    protected void retryRecovery(final RecoveryRef recoveryRef, final String reason, TimeValue retryAfter,
-                                 TimeValue retryCleanupTimeout, final StartRecoveryRequest currentRequest) {
-        logger.trace("will retry recovery with id [{}] in [{}] (reason [{}])", recoveryRef.status().recoveryId(), retryAfter, reason);
-        retryRecovery(recoveryRef, retryAfter, retryCleanupTimeout, currentRequest);
+    protected void retryRecovery(final long recoveryId, final String reason, TimeValue retryAfter, TimeValue activityTimeout) {
+        logger.trace("will retry recovery with id [{}] in [{}] (reason [{}])", recoveryId, retryAfter, reason);
+        retryRecovery(recoveryId, retryAfter, activityTimeout);
     }
 
-    private void retryRecovery(final RecoveryRef recoveryRef, TimeValue retryAfter, TimeValue retryCleanupTimeout,
-                               final StartRecoveryRequest currentRequest) {
-        RecoveryTarget newTarget = onGoingRecoveries.resetRecovery(recoveryRef, retryCleanupTimeout, currentRequest);
+    private void retryRecovery(final long recoveryId, TimeValue retryAfter, TimeValue activityTimeout) {
+        RecoveryTarget newTarget = onGoingRecoveries.resetRecovery(recoveryId, activityTimeout);
         if (newTarget != null) {
             threadPool.schedule(retryAfter, ThreadPool.Names.GENERIC, new RecoveryRunner(newTarget.recoveryId()));
         }
     }
 
-    private void doRecovery(final RecoveryRef recoveryRef) {
-        RecoveryTarget recoveryTarget = recoveryRef.status();
-        assert recoveryTarget.sourceNode() != null : "can't do a recovery without a source node";
-
-        logger.trace("collecting local files for {}", recoveryTarget);
-        Store.MetadataSnapshot metadataSnapshot = null;
-        try {
-            if (recoveryTarget.indexShard().indexSettings().isOnSharedFilesystem()) {
-                // we are not going to copy any files, so don't bother listing files, potentially running
-                // into concurrency issues with the primary changing files underneath us.
-                metadataSnapshot = Store.MetadataSnapshot.EMPTY;
-            } else {
-                metadataSnapshot = recoveryTarget.indexShard().snapshotStoreMetadata();
-            }
-        } catch (org.apache.lucene.index.IndexNotFoundException e) {
-            // happens on an empty folder. no need to log
-            metadataSnapshot = Store.MetadataSnapshot.EMPTY;
-        } catch (IOException e) {
-            logger.warn("error while listing local files, recover as if there are none", e);
-            metadataSnapshot = Store.MetadataSnapshot.EMPTY;
-        } catch (Exception e) {
-            // this will be logged as warning later on...
-            logger.trace("unexpected error while listing local files, failing recovery", e);
-            onGoingRecoveries.failRecovery(recoveryTarget.recoveryId(),
-                    new RecoveryFailedException(recoveryTarget.state(), "failed to list local files", e), true);
+    private void doRecovery(final long recoveryId) {
+        RecoveryRef recoveryRef = onGoingRecoveries.getRecovery(recoveryId);
+        if (recoveryRef == null) {
+            logger.trace("not running recovery with id [{}] - can't find it (probably finished)", recoveryId);
             return;
         }
-        logger.trace("{} local file count: [{}]", recoveryTarget, metadataSnapshot.size());
-        final StartRecoveryRequest request = new StartRecoveryRequest(recoveryTarget.shardId(), recoveryTarget.sourceNode(),
-                clusterService.localNode(), metadataSnapshot, recoveryTarget.state().getPrimary(), recoveryTarget.recoveryId());
-
-        final AtomicReference<RecoveryResponse> responseHolder = new AtomicReference<>();
         try {
-            logger.trace("[{}][{}] starting recovery from {}", request.shardId().getIndex().getName(), request.shardId().id(), request
-                    .sourceNode());
-            recoveryTarget.indexShard().prepareForIndexRecovery();
-            recoveryTarget.CancellableThreads().execute(() -> responseHolder.set(
-                    transportService.submitRequest(request.sourceNode(), PeerRecoverySourceService.Actions.START_RECOVERY, request,
-                            new FutureTransportResponseHandler<RecoveryResponse>() {
-                                @Override
-                                public RecoveryResponse newInstance() {
-                                    return new RecoveryResponse();
-                                }
-                            }).txGet()));
-            final RecoveryResponse recoveryResponse = responseHolder.get();
-            assert responseHolder != null;
-            final TimeValue recoveryTime = new TimeValue(recoveryTarget.state().getTimer().time());
-            // do this through ongoing recoveries to remove it from the collection
-            onGoingRecoveries.markRecoveryAsDone(recoveryTarget.recoveryId());
-            if (logger.isTraceEnabled()) {
-                StringBuilder sb = new StringBuilder();
-                sb.append('[').append(request.shardId().getIndex().getName()).append(']').append('[').append(request.shardId().id())
-                        .append("] ");
-                sb.append("recovery completed from ").append(request.sourceNode()).append(", took[").append(recoveryTime).append("]\n");
-                sb.append("   phase1: recovered_files [").append(recoveryResponse.phase1FileNames.size()).append("]").append(" with " +
-                        "total_size of [").append(new ByteSizeValue(recoveryResponse.phase1TotalSize)).append("]")
-                        .append(", took [").append(timeValueMillis(recoveryResponse.phase1Time)).append("], throttling_wait [").append
-                        (timeValueMillis(recoveryResponse.phase1ThrottlingWaitTime)).append(']')
-                        .append("\n");
-                sb.append("         : reusing_files   [").append(recoveryResponse.phase1ExistingFileNames.size()).append("] with " +
-                        "total_size of [").append(new ByteSizeValue(recoveryResponse.phase1ExistingTotalSize)).append("]\n");
-                sb.append("   phase2: start took [").append(timeValueMillis(recoveryResponse.startTime)).append("]\n");
-                sb.append("         : recovered [").append(recoveryResponse.phase2Operations).append("]").append(" transaction log " +
-                        "operations")
-                        .append(", took [").append(timeValueMillis(recoveryResponse.phase2Time)).append("]")
-                        .append("\n");
-                logger.trace("{}", sb);
-            } else {
-                logger.debug("{} recovery done from [{}], took [{}]", request.shardId(), recoveryTarget.sourceNode(), recoveryTime);
-            }
-        } catch (CancellableThreads.ExecutionCancelledException e) {
-            logger.trace("recovery cancelled", e);
-        } catch (Exception e) {
-            if (logger.isTraceEnabled()) {
-                logger.trace(
-                    (Supplier<?>) () -> new ParameterizedMessage(
-                        "[{}][{}] Got exception on recovery",
-                        request.shardId().getIndex().getName(),
-                        request.shardId().id()),
-                    e);
-            }
-            Throwable cause = ExceptionsHelper.unwrapCause(e);
-            if (cause instanceof CancellableThreads.ExecutionCancelledException) {
-                // this can also come from the source wrapped in a RemoteTransportException
-                onGoingRecoveries.failRecovery(recoveryTarget.recoveryId(), new RecoveryFailedException(request, "source has canceled the" +
-                        " recovery", cause), false);
+            RecoveryTarget recoveryTarget = recoveryRef.target();
+            assert recoveryTarget.sourceNode() != null : "can't do a recovery without a source node";
+
+            logger.trace("collecting local files for {}", recoveryTarget.sourceNode());
+            Store.MetadataSnapshot metadataSnapshot;
+            try {
+                if (recoveryTarget.indexShard().indexSettings().isOnSharedFilesystem()) {
+                    // we are not going to copy any files, so don't bother listing files, potentially running
+                    // into concurrency issues with the primary changing files underneath us.
+                    metadataSnapshot = Store.MetadataSnapshot.EMPTY;
+                } else {
+                    metadataSnapshot = recoveryTarget.indexShard().snapshotStoreMetadata();
+                }
+            } catch (org.apache.lucene.index.IndexNotFoundException e) {
+                // happens on an empty folder. no need to log
+                metadataSnapshot = Store.MetadataSnapshot.EMPTY;
+            } catch (IOException e) {
+                logger.warn("error while listing local files, recover as if there are none", e);
+                metadataSnapshot = Store.MetadataSnapshot.EMPTY;
+            } catch (Exception e) {
+                // this will be logged as warning later on...
+                logger.trace("unexpected error while listing local files, failing recovery", e);
+                onGoingRecoveries.failRecovery(recoveryTarget.recoveryId(),
+                        new RecoveryFailedException(recoveryTarget.state(), "failed to list local files", e), true);
                 return;
             }
-            if (cause instanceof RecoveryEngineException) {
-                // unwrap an exception that was thrown as part of the recovery
-                cause = cause.getCause();
-            }
-            // do it twice, in case we have double transport exception
-            cause = ExceptionsHelper.unwrapCause(cause);
-            if (cause instanceof RecoveryEngineException) {
-                // unwrap an exception that was thrown as part of the recovery
-                cause = cause.getCause();
-            }
+            logger.trace("{} local file count: [{}]", recoveryTarget, metadataSnapshot.size());
+            final StartRecoveryRequest request = new StartRecoveryRequest(recoveryTarget.shardId(), recoveryTarget.sourceNode(),
+                    clusterService.localNode(), metadataSnapshot, recoveryTarget.state().getPrimary(), recoveryTarget.recoveryId());
 
-            // here, we would add checks against exception that need to be retried (and not removeAndClean in this case)
+            final AtomicReference<RecoveryResponse> responseHolder = new AtomicReference<>();
+            try {
+                logger.trace("[{}][{}] starting recovery from {}", request.shardId().getIndex().getName(), request.shardId().id(), request
+                        .sourceNode());
+                recoveryTarget.indexShard().prepareForIndexRecovery();
+                recoveryTarget.CancellableThreads().execute(() -> responseHolder.set(
+                        transportService.submitRequest(request.sourceNode(), PeerRecoverySourceService.Actions.START_RECOVERY, request,
+                                new FutureTransportResponseHandler<RecoveryResponse>() {
+                                    @Override
+                                    public RecoveryResponse newInstance() {
+                                        return new RecoveryResponse();
+                                    }
+                                }).txGet()));
+                final RecoveryResponse recoveryResponse = responseHolder.get();
+                assert responseHolder != null;
+                final TimeValue recoveryTime = new TimeValue(recoveryTarget.state().getTimer().time());
+                // do this through ongoing recoveries to remove it from the collection
+                onGoingRecoveries.markRecoveryAsDone(recoveryTarget.recoveryId());
+                if (logger.isTraceEnabled()) {
+                    StringBuilder sb = new StringBuilder();
+                    sb.append('[').append(request.shardId().getIndex().getName()).append(']').append('[').append(request.shardId().id())
+                            .append("] ");
+                    sb.append("recovery completed from ").append(request.sourceNode()).append(", took[").append(recoveryTime).append("]\n");
+                    sb.append("   phase1: recovered_files [").append(recoveryResponse.phase1FileNames.size()).append("]").append(" with " +
+                            "total_size of [").append(new ByteSizeValue(recoveryResponse.phase1TotalSize)).append("]")
+                            .append(", took [").append(timeValueMillis(recoveryResponse.phase1Time)).append("], throttling_wait [").append
+                            (timeValueMillis(recoveryResponse.phase1ThrottlingWaitTime)).append(']')
+                            .append("\n");
+                    sb.append("         : reusing_files   [").append(recoveryResponse.phase1ExistingFileNames.size()).append("] with " +
+                            "total_size of [").append(new ByteSizeValue(recoveryResponse.phase1ExistingTotalSize)).append("]\n");
+                    sb.append("   phase2: start took [").append(timeValueMillis(recoveryResponse.startTime)).append("]\n");
+                    sb.append("         : recovered [").append(recoveryResponse.phase2Operations).append("]").append(" transaction log " +
+                            "operations")
+                            .append(", took [").append(timeValueMillis(recoveryResponse.phase2Time)).append("]")
+                            .append("\n");
+                    logger.trace("{}", sb);
+                } else {
+                    logger.debug("{} recovery done from [{}], took [{}]", request.shardId(), recoveryTarget.sourceNode(), recoveryTime);
+                }
+            } catch (CancellableThreads.ExecutionCancelledException e) {
+                logger.trace("recovery cancelled", e);
+            } catch (Exception e) {
+                recoveryRef.close(); // close early so that retry can wait for shard to be finished processing
+                if (logger.isTraceEnabled()) {
+                    logger.trace(
+                        (Supplier<?>) () -> new ParameterizedMessage(
+                            "[{}][{}] Got exception on recovery",
+                            request.shardId().getIndex().getName(),
+                            request.shardId().id()),
+                        e);
+                }
+                Throwable cause = ExceptionsHelper.unwrapCause(e);
+                if (cause instanceof CancellableThreads.ExecutionCancelledException) {
+                    // this can also come from the source wrapped in a RemoteTransportException
+                    onGoingRecoveries.failRecovery(recoveryTarget.recoveryId(), new RecoveryFailedException(request,
+                        "source has canceled the recovery", cause), false);
+                    return;
+                }
+                if (cause instanceof RecoveryEngineException) {
+                    // unwrap an exception that was thrown as part of the recovery
+                    cause = cause.getCause();
+                }
+                // do it twice, in case we have double transport exception
+                cause = ExceptionsHelper.unwrapCause(cause);
+                if (cause instanceof RecoveryEngineException) {
+                    // unwrap an exception that was thrown as part of the recovery
+                    cause = cause.getCause();
+                }
 
-            if (cause instanceof IllegalIndexShardStateException || cause instanceof IndexNotFoundException || cause instanceof
-                    ShardNotFoundException) {
-                // if the target is not ready yet, retry
-                retryRecovery(recoveryRef, "remote shard not ready", recoverySettings.retryDelayStateSync(),
-                    recoverySettings.retryCleanupTimeout(), request);
-                return;
-            }
+                // here, we would add checks against exception that need to be retried (and not removeAndClean in this case)
 
-            if (cause instanceof DelayRecoveryException) {
-                retryRecovery(recoveryRef, cause, recoverySettings.retryDelayStateSync(),
-                    recoverySettings.retryCleanupTimeout(), request);
-                return;
-            }
+                if (cause instanceof IllegalIndexShardStateException || cause instanceof IndexNotFoundException ||
+                    cause instanceof ShardNotFoundException) {
+                    // if the target is not ready yet, retry
+                    retryRecovery(recoveryTarget.recoveryId(), "remote shard not ready", recoverySettings.retryDelayNetwork(),
+                        recoverySettings.activityTimeout());
+                    return;
+                }
 
-            if (cause instanceof ConnectTransportException) {
-                logger.debug("delaying recovery of {} for [{}] due to networking error [{}]", recoveryTarget.shardId(), recoverySettings
-                        .retryDelayNetwork(), cause.getMessage());
-                retryRecovery(recoveryRef, cause.getMessage(), recoverySettings.retryDelayNetwork(),
-                    recoverySettings.retryCleanupTimeout(), request);
-                return;
-            }
+                if (cause instanceof DelayRecoveryException) {
+                    retryRecovery(recoveryTarget.recoveryId(), cause, recoverySettings.retryDelayNetwork(),
+                        recoverySettings.activityTimeout());
+                    return;
+                }
 
-            if (cause instanceof AlreadyClosedException) {
-                onGoingRecoveries.failRecovery(recoveryTarget.recoveryId(), new RecoveryFailedException(request, "source shard is " +
-                        "closed", cause), false);
-                return;
+                if (cause instanceof ConnectTransportException) {
+                    logger.debug("delaying recovery of {} for [{}] due to networking error [{}]", recoveryTarget.shardId(),
+                        recoverySettings.retryDelayNetwork(), cause.getMessage());
+                    retryRecovery(recoveryTarget.recoveryId(), cause.getMessage(), recoverySettings.retryDelayNetwork(),
+                        recoverySettings.activityTimeout());
+                    return;
+                }
+
+                if (cause instanceof AlreadyClosedException) {
+                    onGoingRecoveries.failRecovery(recoveryTarget.recoveryId(),
+                        new RecoveryFailedException(request, "source shard is closed", cause), false);
+                    return;
+                }
+                onGoingRecoveries.failRecovery(recoveryTarget.recoveryId(), new RecoveryFailedException(request, e), true);
             }
-            onGoingRecoveries.failRecovery(recoveryTarget.recoveryId(), new RecoveryFailedException(request, e), true);
+        } finally {
+            recoveryRef.close();
         }
     }
 
@@ -306,7 +313,7 @@ public class PeerRecoveryTargetService extends AbstractComponent implements Inde
         public void messageReceived(RecoveryPrepareForTranslogOperationsRequest request, TransportChannel channel) throws Exception {
             try (RecoveryRef recoveryRef = onGoingRecoveries.getRecoverySafe(request.recoveryId(), request.shardId()
             )) {
-                recoveryRef.status().prepareForTranslogOperations(request.totalTranslogOps(), request.getMaxUnsafeAutoIdTimestamp());
+                recoveryRef.target().prepareForTranslogOperations(request.totalTranslogOps(), request.getMaxUnsafeAutoIdTimestamp());
             }
             channel.sendResponse(TransportResponse.Empty.INSTANCE);
         }
@@ -318,7 +325,7 @@ public class PeerRecoveryTargetService extends AbstractComponent implements Inde
         public void messageReceived(RecoveryFinalizeRecoveryRequest request, TransportChannel channel) throws Exception {
             try (RecoveryRef recoveryRef =
                      onGoingRecoveries.getRecoverySafe(request.recoveryId(), request.shardId())) {
-                recoveryRef.status().finalizeRecovery(request.globalCheckpoint());
+                recoveryRef.target().finalizeRecovery(request.globalCheckpoint());
             }
             channel.sendResponse(TransportResponse.Empty.INSTANCE);
         }
@@ -330,7 +337,7 @@ public class PeerRecoveryTargetService extends AbstractComponent implements Inde
         public void messageReceived(RecoveryWaitForClusterStateRequest request, TransportChannel channel) throws Exception {
             try (RecoveryRef recoveryRef = onGoingRecoveries.getRecoverySafe(request.recoveryId(), request.shardId()
             )) {
-                recoveryRef.status().ensureClusterStateVersion(request.clusterStateVersion());
+                recoveryRef.target().ensureClusterStateVersion(request.clusterStateVersion());
             }
             channel.sendResponse(TransportResponse.Empty.INSTANCE);
         }
@@ -343,7 +350,7 @@ public class PeerRecoveryTargetService extends AbstractComponent implements Inde
             try (RecoveryRef recoveryRef =
                          onGoingRecoveries.getRecoverySafe(request.recoveryId(), request.shardId())) {
                 final ClusterStateObserver observer = new ClusterStateObserver(clusterService, null, logger, threadPool.getThreadContext());
-                final RecoveryTarget recoveryTarget = recoveryRef.status();
+                final RecoveryTarget recoveryTarget = recoveryRef.target();
                 try {
                     recoveryTarget.indexTranslogOperations(request.operations(), request.totalTranslogOps());
                     channel.sendResponse(TransportResponse.Empty.INSTANCE);
@@ -449,7 +456,7 @@ public class PeerRecoveryTargetService extends AbstractComponent implements Inde
         public void messageReceived(RecoveryFilesInfoRequest request, TransportChannel channel) throws Exception {
             try (RecoveryRef recoveryRef = onGoingRecoveries.getRecoverySafe(request.recoveryId(), request.shardId()
             )) {
-                recoveryRef.status().receiveFileInfo(request.phase1FileNames, request.phase1FileSizes, request.phase1ExistingFileNames,
+                recoveryRef.target().receiveFileInfo(request.phase1FileNames, request.phase1FileSizes, request.phase1ExistingFileNames,
                         request.phase1ExistingFileSizes, request.totalTranslogOps);
                 channel.sendResponse(TransportResponse.Empty.INSTANCE);
             }
@@ -462,7 +469,7 @@ public class PeerRecoveryTargetService extends AbstractComponent implements Inde
         public void messageReceived(RecoveryCleanFilesRequest request, TransportChannel channel) throws Exception {
             try (RecoveryRef recoveryRef = onGoingRecoveries.getRecoverySafe(request.recoveryId(), request.shardId()
             )) {
-                recoveryRef.status().cleanFiles(request.totalTranslogOps(), request.sourceMetaSnapshot());
+                recoveryRef.target().cleanFiles(request.totalTranslogOps(), request.sourceMetaSnapshot());
                 channel.sendResponse(TransportResponse.Empty.INSTANCE);
             }
         }
@@ -477,8 +484,8 @@ public class PeerRecoveryTargetService extends AbstractComponent implements Inde
         public void messageReceived(final RecoveryFileChunkRequest request, TransportChannel channel) throws Exception {
             try (RecoveryRef recoveryRef = onGoingRecoveries.getRecoverySafe(request.recoveryId(), request.shardId()
             )) {
-                final RecoveryTarget status = recoveryRef.status();
-                final RecoveryState.Index indexState = status.state().getIndex();
+                final RecoveryTarget recoveryTarget = recoveryRef.target();
+                final RecoveryState.Index indexState = recoveryTarget.state().getIndex();
                 if (request.sourceThrottleTimeInNanos() != RecoveryState.Index.UNKNOWN) {
                     indexState.addSourceThrottling(request.sourceThrottleTimeInNanos());
                 }
@@ -491,11 +498,11 @@ public class PeerRecoveryTargetService extends AbstractComponent implements Inde
                         bytesSinceLastPause.addAndGet(-bytes);
                         long throttleTimeInNanos = rateLimiter.pause(bytes);
                         indexState.addTargetThrottling(throttleTimeInNanos);
-                        status.indexShard().recoveryStats().addThrottleTime(throttleTimeInNanos);
+                        recoveryTarget.indexShard().recoveryStats().addThrottleTime(throttleTimeInNanos);
                     }
                 }
 
-                status.writeFileChunk(request.metadata(), request.position(), request.content(),
+                recoveryTarget.writeFileChunk(request.metadata(), request.position(), request.content(),
                         request.lastChunk(), request.totalTranslogOps()
                 );
             }
@@ -519,7 +526,7 @@ public class PeerRecoveryTargetService extends AbstractComponent implements Inde
                         (Supplier<?>) () -> new ParameterizedMessage(
                             "unexpected error during recovery [{}], failing shard", recoveryId), e);
                     onGoingRecoveries.failRecovery(recoveryId,
-                            new RecoveryFailedException(recoveryRef.status().state(), "unexpected error", e),
+                            new RecoveryFailedException(recoveryRef.target().state(), "unexpected error", e),
                             true // be safe
                     );
                 } else {
@@ -532,16 +539,7 @@ public class PeerRecoveryTargetService extends AbstractComponent implements Inde
 
         @Override
         public void doRun() {
-            RecoveryRef recoveryRef = onGoingRecoveries.getRecovery(recoveryId);
-            if (recoveryRef == null) {
-                logger.trace("not running recovery with id [{}] - can't find it (probably finished)", recoveryId);
-                return;
-            }
-            try {
-                doRecovery(recoveryRef);
-            } finally {
-                recoveryRef.close();
-            }
+            doRecovery(recoveryId);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -49,13 +49,6 @@ public class RecoverySettings extends AbstractComponent {
         Setting.positiveTimeSetting("indices.recovery.retry_delay_network", TimeValue.timeValueSeconds(5),
             Property.Dynamic, Property.NodeScope);
 
-    /**
-     * how long to wait for previous attempt to release resources when retrying
-     */
-    public static final Setting<TimeValue> INDICES_RECOVERY_RETRY_CLEANUP_TIMEOUT_SETTING =
-        Setting.positiveTimeSetting("indices.recovery.retry_cleanup_timeout", TimeValue.timeValueSeconds(60),
-            Property.Dynamic, Property.NodeScope);
-
     /** timeout value to use for requests made as part of the recovery process */
     public static final Setting<TimeValue> INDICES_RECOVERY_INTERNAL_ACTION_TIMEOUT_SETTING =
         Setting.positiveTimeSetting("indices.recovery.internal_action_timeout", TimeValue.timeValueMinutes(15),
@@ -76,7 +69,7 @@ public class RecoverySettings extends AbstractComponent {
      */
     public static final Setting<TimeValue> INDICES_RECOVERY_ACTIVITY_TIMEOUT_SETTING =
         Setting.timeSetting("indices.recovery.recovery_activity_timeout",
-                INDICES_RECOVERY_INTERNAL_LONG_ACTION_TIMEOUT_SETTING::get, TimeValue.timeValueSeconds(0),
+            INDICES_RECOVERY_INTERNAL_LONG_ACTION_TIMEOUT_SETTING::get, TimeValue.timeValueSeconds(0),
             Property.Dynamic, Property.NodeScope);
 
     public static final ByteSizeValue DEFAULT_CHUNK_SIZE = new ByteSizeValue(512, ByteSizeUnit.KB);
@@ -85,7 +78,6 @@ public class RecoverySettings extends AbstractComponent {
     private volatile SimpleRateLimiter rateLimiter;
     private volatile TimeValue retryDelayStateSync;
     private volatile TimeValue retryDelayNetwork;
-    private volatile TimeValue retryCleanupTimeout;
     private volatile TimeValue activityTimeout;
     private volatile TimeValue internalActionTimeout;
     private volatile TimeValue internalActionLongTimeout;
@@ -99,7 +91,6 @@ public class RecoverySettings extends AbstractComponent {
         // doesn't have to be fast as nodes are reconnected every 10s by default (see InternalClusterService.ReconnectToNodes)
         // and we want to give the master time to remove a faulty node
         this.retryDelayNetwork = INDICES_RECOVERY_RETRY_DELAY_NETWORK_SETTING.get(settings);
-        this.retryCleanupTimeout = INDICES_RECOVERY_RETRY_CLEANUP_TIMEOUT_SETTING.get(settings);
 
         this.internalActionTimeout = INDICES_RECOVERY_INTERNAL_ACTION_TIMEOUT_SETTING.get(settings);
         this.internalActionLongTimeout = INDICES_RECOVERY_INTERNAL_LONG_ACTION_TIMEOUT_SETTING.get(settings);
@@ -118,7 +109,6 @@ public class RecoverySettings extends AbstractComponent {
         clusterSettings.addSettingsUpdateConsumer(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING, this::setMaxBytesPerSec);
         clusterSettings.addSettingsUpdateConsumer(INDICES_RECOVERY_RETRY_DELAY_STATE_SYNC_SETTING, this::setRetryDelayStateSync);
         clusterSettings.addSettingsUpdateConsumer(INDICES_RECOVERY_RETRY_DELAY_NETWORK_SETTING, this::setRetryDelayNetwork);
-        clusterSettings.addSettingsUpdateConsumer(INDICES_RECOVERY_RETRY_CLEANUP_TIMEOUT_SETTING, this::setRetryCleanupTimeout);
         clusterSettings.addSettingsUpdateConsumer(INDICES_RECOVERY_INTERNAL_ACTION_TIMEOUT_SETTING, this::setInternalActionTimeout);
         clusterSettings.addSettingsUpdateConsumer(INDICES_RECOVERY_INTERNAL_LONG_ACTION_TIMEOUT_SETTING, this::setInternalActionLongTimeout);
         clusterSettings.addSettingsUpdateConsumer(INDICES_RECOVERY_ACTIVITY_TIMEOUT_SETTING, this::setActivityTimeout);
@@ -134,10 +124,6 @@ public class RecoverySettings extends AbstractComponent {
 
     public TimeValue retryDelayStateSync() {
         return retryDelayStateSync;
-    }
-
-    public TimeValue retryCleanupTimeout() {
-        return retryCleanupTimeout;
     }
 
     public TimeValue activityTimeout() {
@@ -168,10 +154,6 @@ public class RecoverySettings extends AbstractComponent {
 
     public void setRetryDelayNetwork(TimeValue retryDelayNetwork) {
         this.retryDelayNetwork = retryDelayNetwork;
-    }
-
-    public void setRetryCleanupTimeout(TimeValue retryCleanupTimeout) {
-        this.retryCleanupTimeout = retryCleanupTimeout;
     }
 
     public void setActivityTimeout(TimeValue activityTimeout) {

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -49,6 +49,13 @@ public class RecoverySettings extends AbstractComponent {
         Setting.positiveTimeSetting("indices.recovery.retry_delay_network", TimeValue.timeValueSeconds(5),
             Property.Dynamic, Property.NodeScope);
 
+    /**
+     * how long to wait for previous attempt to release resources when retrying
+     */
+    public static final Setting<TimeValue> INDICES_RECOVERY_RETRY_CLEANUP_TIMEOUT_SETTING =
+        Setting.positiveTimeSetting("indices.recovery.retry_cleanup_timeout", TimeValue.timeValueSeconds(60),
+            Property.Dynamic, Property.NodeScope);
+
     /** timeout value to use for requests made as part of the recovery process */
     public static final Setting<TimeValue> INDICES_RECOVERY_INTERNAL_ACTION_TIMEOUT_SETTING =
         Setting.positiveTimeSetting("indices.recovery.internal_action_timeout", TimeValue.timeValueMinutes(15),
@@ -78,6 +85,7 @@ public class RecoverySettings extends AbstractComponent {
     private volatile SimpleRateLimiter rateLimiter;
     private volatile TimeValue retryDelayStateSync;
     private volatile TimeValue retryDelayNetwork;
+    private volatile TimeValue retryCleanupTimeout;
     private volatile TimeValue activityTimeout;
     private volatile TimeValue internalActionTimeout;
     private volatile TimeValue internalActionLongTimeout;
@@ -91,6 +99,7 @@ public class RecoverySettings extends AbstractComponent {
         // doesn't have to be fast as nodes are reconnected every 10s by default (see InternalClusterService.ReconnectToNodes)
         // and we want to give the master time to remove a faulty node
         this.retryDelayNetwork = INDICES_RECOVERY_RETRY_DELAY_NETWORK_SETTING.get(settings);
+        this.retryCleanupTimeout = INDICES_RECOVERY_RETRY_CLEANUP_TIMEOUT_SETTING.get(settings);
 
         this.internalActionTimeout = INDICES_RECOVERY_INTERNAL_ACTION_TIMEOUT_SETTING.get(settings);
         this.internalActionLongTimeout = INDICES_RECOVERY_INTERNAL_LONG_ACTION_TIMEOUT_SETTING.get(settings);
@@ -109,6 +118,7 @@ public class RecoverySettings extends AbstractComponent {
         clusterSettings.addSettingsUpdateConsumer(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING, this::setMaxBytesPerSec);
         clusterSettings.addSettingsUpdateConsumer(INDICES_RECOVERY_RETRY_DELAY_STATE_SYNC_SETTING, this::setRetryDelayStateSync);
         clusterSettings.addSettingsUpdateConsumer(INDICES_RECOVERY_RETRY_DELAY_NETWORK_SETTING, this::setRetryDelayNetwork);
+        clusterSettings.addSettingsUpdateConsumer(INDICES_RECOVERY_RETRY_CLEANUP_TIMEOUT_SETTING, this::setRetryCleanupTimeout);
         clusterSettings.addSettingsUpdateConsumer(INDICES_RECOVERY_INTERNAL_ACTION_TIMEOUT_SETTING, this::setInternalActionTimeout);
         clusterSettings.addSettingsUpdateConsumer(INDICES_RECOVERY_INTERNAL_LONG_ACTION_TIMEOUT_SETTING, this::setInternalActionLongTimeout);
         clusterSettings.addSettingsUpdateConsumer(INDICES_RECOVERY_ACTIVITY_TIMEOUT_SETTING, this::setActivityTimeout);
@@ -124,6 +134,10 @@ public class RecoverySettings extends AbstractComponent {
 
     public TimeValue retryDelayStateSync() {
         return retryDelayStateSync;
+    }
+
+    public TimeValue retryCleanupTimeout() {
+        return retryCleanupTimeout;
     }
 
     public TimeValue activityTimeout() {
@@ -154,6 +168,10 @@ public class RecoverySettings extends AbstractComponent {
 
     public void setRetryDelayNetwork(TimeValue retryDelayNetwork) {
         this.retryDelayNetwork = retryDelayNetwork;
+    }
+
+    public void setRetryCleanupTimeout(TimeValue retryCleanupTimeout) {
+        this.retryCleanupTimeout = retryCleanupTimeout;
     }
 
     public void setActivityTimeout(TimeValue activityTimeout) {

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -148,6 +148,8 @@ public class RecoverySourceHandler {
 
             // engine was just started at the end of phase 1
             if (shard.state() == IndexShardState.RELOCATED) {
+                assert request.isPrimaryRelocation() == false :
+                    "recovery target should not retry primary relocation if previous attempt made it past finalization step";
                 /**
                  * The primary shard has been relocated while we copied files. This means that we can't guarantee any more that all
                  * operations that were replicated during the file copy (when the target engine was not yet opened) will be present in the

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.Callback;
 import org.elasticsearch.common.util.CancellableThreads;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
@@ -55,6 +56,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -87,12 +91,10 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
     // last time this status was accessed
     private volatile long lastAccessTime = System.nanoTime();
 
-    private final Map<String, String> tempFileNames = ConcurrentCollections.newConcurrentMap();
+    // latch that can be used to blockingly wait for RecoveryTarget to be closed
+    private final CountDownLatch closedLatch = new CountDownLatch(1);
 
-    private RecoveryTarget(RecoveryTarget copyFrom) { // copy constructor
-        this(copyFrom.indexShard, copyFrom.sourceNode, copyFrom.listener, copyFrom.cancellableThreads, copyFrom.recoveryId,
-            copyFrom.ensureClusterStateVersionCallback);
-    }
+    private final Map<String, String> tempFileNames = ConcurrentCollections.newConcurrentMap();
 
     public RecoveryTarget(IndexShard indexShard, DiscoveryNode sourceNode, PeerRecoveryTargetService.RecoveryListener listener,
                           Callback<Long> ensureClusterStateVersionCallback) {
@@ -124,6 +126,13 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
         // make sure the store is not released until we are done.
         store.incRef();
         indexShard.recoveryStats().incCurrentAsTarget();
+    }
+
+    /**
+     * returns a fresh RecoveryTarget to retry recovery from the same source node onto the same IndexShard and using the same listener
+     */
+    public RecoveryTarget retryCopy() {
+        return new RecoveryTarget(this.indexShard, this.sourceNode, this.listener, this.ensureClusterStateVersionCallback);
     }
 
     public long recoveryId() {
@@ -177,19 +186,33 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
     }
 
     /**
-     * Closes the current recovery target and returns a
-     * clone to reset the ongoing recovery.
-     * Note: the returned target must be canceled, failed or finished
-     * in order to release all it's reference.
+     * Closes the current recovery target and waits up to a certain timeout for resources to be freed
      */
-    RecoveryTarget resetRecovery() throws IOException {
+    void resetRecovery(TimeValue timeout) throws IOException, TimeoutException {
         ensureRefCount();
         if (finished.compareAndSet(false, true)) {
+            logger.debug("reset of recovery with shard {} and id [{}]", shardId, recoveryId);
             // release the initial reference. recovery files will be cleaned as soon as ref count goes to zero, potentially now
             decRef();
+            try {
+                if (closedLatch.await(timeout.millis(), TimeUnit.MILLISECONDS) == false) {
+                    throw new TimeoutException("timed out while waiting on previous recovery attempt to release resources");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while waiting on previous recovery attempt to release resources", e);
+            }
+            RecoveryState.Stage stage = indexShard.recoveryState().getStage();
+            if (indexShard.recoveryState().getPrimary() && (stage == RecoveryState.Stage.FINALIZE || stage == RecoveryState.Stage.DONE)) {
+                // once primary relocation has moved past the finalization step, the relocation source can be moved to RELOCATED state
+                // and start indexing as primary into the target shard (see TransportReplicationAction). Resetting the target shard in this
+                // state could mean that indexing is halted until the recovery retry attempt is completed and could also destroy existing
+                // documents indexed and acknowledged before the reset.
+                assert stage != RecoveryState.Stage.DONE : "recovery should not have completed when it's being reset";
+                throw new IllegalStateException("cannot reset recovery as previous attempt made it past finalization step");
+            }
+            indexShard.performRecoveryRestart();
         }
-        indexShard.performRecoveryRestart();
-        return new RecoveryTarget(this);
     }
 
     /**
@@ -220,7 +243,7 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
     public void fail(RecoveryFailedException e, boolean sendShardFailure) {
         if (finished.compareAndSet(false, true)) {
             try {
-                listener.onRecoveryFailure(state(), e, sendShardFailure);
+                notifyListener(e, sendShardFailure);
             } finally {
                 try {
                     cancellableThreads.cancel("failed recovery [" + ExceptionsHelper.stackTrace(e) + "]");
@@ -230,6 +253,10 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
                 }
             }
         }
+    }
+
+    public void notifyListener(RecoveryFailedException e, boolean sendShardFailure) {
+        listener.onRecoveryFailure(state(), e, sendShardFailure);
     }
 
     /** mark the current recovery as done */
@@ -310,6 +337,7 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
             store.decRef();
             indexShard.recoveryStats().decCurrentAsTarget();
         }
+        closedLatch.countDown();
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -36,7 +36,6 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.Callback;
 import org.elasticsearch.common.util.CancellableThreads;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
@@ -49,7 +48,6 @@ import org.elasticsearch.index.store.StoreFileMetaData;
 import org.elasticsearch.index.translog.Translog;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -58,8 +56,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 

--- a/core/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -31,8 +31,8 @@ import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RecoverySource.PeerRecoverySource;
 import org.elasticsearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
@@ -42,6 +42,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.recovery.RecoveryStats;
 import org.elasticsearch.index.store.Store;
@@ -55,12 +56,12 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.store.MockFSDirectoryService;
 import org.elasticsearch.test.store.MockFSIndexStore;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.Transport;
-import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
@@ -73,6 +74,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.node.RecoverySettingsChunkSizePlugin.CHUNK_SIZE_SETTING;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -593,7 +596,8 @@ public class IndexRecoveryIT extends ESIntegTestCase {
                 PeerRecoveryTargetService.Actions.CLEAN_FILES,
                 //RecoveryTarget.Actions.TRANSLOG_OPS, <-- may not be sent if already flushed
                 PeerRecoveryTargetService.Actions.PREPARE_TRANSLOG,
-                PeerRecoveryTargetService.Actions.FINALIZE
+                PeerRecoveryTargetService.Actions.FINALIZE,
+                PeerRecoveryTargetService.Actions.WAIT_CLUSTERSTATE
         };
         final String recoveryActionToBlock = randomFrom(recoveryActions);
         final boolean dropRequests = randomBoolean();
@@ -651,6 +655,130 @@ public class IndexRecoveryIT extends ESIntegTestCase {
                 throw new ConnectTransportException(connection.getNode(), "DISCONNECT: prevented " + action + " request");
             }
             super.sendRequest(connection, requestId, action, request, options);
+        }
+    }
+
+    /**
+     * Tests scenario where recovery target successfully sends recovery request to source but then the channel gets closed while
+     * the source is working on the recovery process.
+     */
+    @TestLogging("_root:DEBUG,org.elasticsearch.indices.recovery:TRACE")
+    public void testDisconnectsDuringRecovery() throws Exception {
+        boolean primaryRelocation = randomBoolean();
+        final String indexName = "test";
+        final Settings nodeSettings = Settings.builder()
+            .put(RecoverySettings.INDICES_RECOVERY_RETRY_DELAY_NETWORK_SETTING.getKey(), TimeValue.timeValueMillis(randomIntBetween(0, 100)))
+            .build();
+        TimeValue disconnectAfterDelay = TimeValue.timeValueMillis(randomIntBetween(0, 100));
+        // start a master node
+        String masterNodeName = internalCluster().startMasterOnlyNode(nodeSettings);
+
+        final String blueNodeName = internalCluster().startNode(Settings.builder().put("node.attr.color", "blue").put(nodeSettings).build());
+        final String redNodeName = internalCluster().startNode(Settings.builder().put("node.attr.color", "red").put(nodeSettings).build());
+
+        client().admin().indices().prepareCreate(indexName)
+            .setSettings(
+                Settings.builder()
+                    .put(IndexMetaData.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "color", "blue")
+                    .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            ).get();
+
+        List<IndexRequestBuilder> requests = new ArrayList<>();
+        int numDocs = scaledRandomIntBetween(25, 250);
+        for (int i = 0; i < numDocs; i++) {
+            requests.add(client().prepareIndex(indexName, "type").setSource("{}"));
+        }
+        indexRandom(true, requests);
+        ensureSearchable(indexName);
+        assertHitCount(client().prepareSearch(indexName).get(), numDocs);
+
+        MockTransportService masterTransportService = (MockTransportService) internalCluster().getInstance(TransportService.class, masterNodeName);
+        MockTransportService blueMockTransportService = (MockTransportService) internalCluster().getInstance(TransportService.class, blueNodeName);
+        MockTransportService redMockTransportService = (MockTransportService) internalCluster().getInstance(TransportService.class, redNodeName);
+
+        redMockTransportService.addDelegate(blueMockTransportService, new MockTransportService.DelegateTransport(redMockTransportService.original()) {
+            private final AtomicInteger count = new AtomicInteger();
+
+            @Override
+            protected void sendRequest(Connection connection, long requestId, String action, TransportRequest request,
+                                       TransportRequestOptions options) throws IOException {
+                logger.info("--> sending request {} on {}", action, connection.getNode());
+                if (PeerRecoverySourceService.Actions.START_RECOVERY.equals(action) && count.incrementAndGet() == 1) {
+                    // ensures that it's considered as valid recovery attempt by source
+                    try {
+                        awaitBusy(() -> client(blueNodeName).admin().cluster().prepareState().setLocal(true).get()
+                            .getState().getRoutingTable().index("test").shard(0).getAllInitializingShards().isEmpty() == false);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    super.sendRequest(connection, requestId, action, request, options);
+                    try {
+                        Thread.sleep(disconnectAfterDelay.millis());
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    throw new ConnectTransportException(connection.getNode(), "DISCONNECT: simulation disconnect after successfully sending " + action + " request");
+                } else {
+                    super.sendRequest(connection, requestId, action, request, options);
+                }
+            }
+        });
+
+        final AtomicBoolean seenWaitForClusterState = new AtomicBoolean();
+        blueMockTransportService.addDelegate(redMockTransportService, new MockTransportService.DelegateTransport(blueMockTransportService.original()) {
+            @Override
+            protected void sendRequest(Connection connection, long requestId, String action, TransportRequest request,
+                                       TransportRequestOptions options) throws IOException {
+                logger.info("--> sending request {} on {}", action, connection.getNode());
+                if (action.equals(PeerRecoveryTargetService.Actions.WAIT_CLUSTERSTATE)) {
+                    seenWaitForClusterState.set(true);
+                }
+                super.sendRequest(connection, requestId, action, request, options);
+            }
+        });
+
+        for (MockTransportService mockTransportService : Arrays.asList(redMockTransportService, blueMockTransportService)) {
+            mockTransportService.addDelegate(masterTransportService, new MockTransportService.DelegateTransport(mockTransportService.original()) {
+                @Override
+                protected void sendRequest(Connection connection, long requestId, String action, TransportRequest request,
+                                           TransportRequestOptions options) throws IOException {
+                    logger.info("--> sending request {} on {}", action, connection.getNode());
+                    if (primaryRelocation == false || seenWaitForClusterState.get() == false) {
+                        assertNotEquals(action, ShardStateAction.SHARD_FAILED_ACTION_NAME);
+                    }
+                    super.sendRequest(connection, requestId, action, request, options);
+                }
+            });
+        }
+
+        if (primaryRelocation) {
+            logger.info("--> starting primary relocation recovery from blue to red");
+            client().admin().indices().prepareUpdateSettings(indexName).setSettings(
+                Settings.builder()
+                    .put(IndexMetaData.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "color", "red")
+            ).get();
+
+            ensureGreen(); // also waits for relocation / recovery to complete
+            // if a primary relocation fails after the source shard has been marked as relocated, both source and target are failed. If the
+            // source shard is moved back to started because the target fails first, it's possible that there is a cluster state where the
+            // shard is marked as started again (and ensureGreen returns), but while applying the cluster state the primary is failed and
+            // will be reallocated. The cluster will thus become green, then red, then green again. Triggering a refresh here before
+            // searching helps, as in contrast to search actions, refresh waits for the closed shard to be reallocated.
+            client().admin().indices().prepareRefresh(indexName).get();
+        } else {
+            logger.info("--> starting replica recovery from blue to red");
+            client().admin().indices().prepareUpdateSettings(indexName).setSettings(
+                Settings.builder()
+                    .put(IndexMetaData.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "color", "red,blue")
+                    .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
+            ).get();
+
+            ensureGreen();
+        }
+
+        for (int i = 0; i < 10; i++) {
+            assertHitCount(client().prepareSearch(indexName).get(), numDocs);
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -596,8 +596,7 @@ public class IndexRecoveryIT extends ESIntegTestCase {
                 PeerRecoveryTargetService.Actions.CLEAN_FILES,
                 //RecoveryTarget.Actions.TRANSLOG_OPS, <-- may not be sent if already flushed
                 PeerRecoveryTargetService.Actions.PREPARE_TRANSLOG,
-                PeerRecoveryTargetService.Actions.FINALIZE,
-                PeerRecoveryTargetService.Actions.WAIT_CLUSTERSTATE
+                PeerRecoveryTargetService.Actions.FINALIZE
         };
         final String recoveryActionToBlock = randomFrom(recoveryActions);
         final boolean dropRequests = randomBoolean();


### PR DESCRIPTION
Recoveries are tracked on the target node using RecoveryTarget objects that are kept in a RecoveriesCollection. Each recovery has a unique id that is communicated from the recovery target to the source so that it can call back to the target and execute actions using the right recovery context.  In case of a network disconnect, recoveries are retried. At the moment, the same recovery id is reused for the restarted recovery. This can lead to confusion though if the disconnect is unilateral and the recovery source continues with the recovery process. If the target reuses the same recovery id while doing a second attempt, there might be two concurrent recoveries running on the source for the same target.

This PR changes the recovery retry process to use a fresh recovery id. It also waits for the first recovery attempt to be fully finished (all resources locally freed) to further prevent concurrent access to the shard. Finally, in case of primary relocation, it also fails a second recovery attempt if the first attempt moved past the finalization step, as the relocation source can then be moved to RELOCATED state and start indexing as primary into the target shard (see TransportReplicationAction). Resetting the target shard in this state could mean that indexing is halted until the recovery retry attempt is completed and could also destroy existing documents indexed and acknowledged before the reset.

Relates to #22043