### PR TITLE
Add cleanIdeaBuildDir gradle task that cleans the idea build directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,6 +204,14 @@ allprojects {
       }
     }
   }
+
+  task cleanIdeaBuildDir(type: Delete) {
+    delete 'build-idea'
+  }
+  cleanIdeaBuildDir.setGroup("ide")
+  cleanIdeaBuildDir.setDescription("Deletes the IDEA build directory.")
+
+  tasks.cleanIdea.dependsOn(cleanIdeaBuildDir)
 }
 
 idea {


### PR DESCRIPTION
It looks to me like there is no gradle task that cleans the idea build directory. There are times when wiping out the build directory is very useful. I added a task and made cleanIdea depend on it.