### PR TITLE
build: do not use cached snapshots for backwards compatibility tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -39,6 +39,7 @@ import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.Exec
 
 import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
 
 /**
  * A helper for creating tasks to build a cluster that is used by a task, and tear down the cluster when the task is finished.
@@ -91,6 +92,8 @@ class ClusterFormationTasks {
                 configureBwcPluginDependency("${task.name}_elasticsearchBwcPlugins", project, entry.getValue(),
                         project.configurations.elasticsearchBwcPlugins, config.bwcVersion)
             }
+            project.configurations.elasticsearchBwcDistro.resolutionStrategy.cacheChangingModulesFor(0, TimeUnit.SECONDS)
+            project.configurations.elasticsearchBwcPlugins.resolutionStrategy.cacheChangingModulesFor(0, TimeUnit.SECONDS)
         }
         for (int i = 0; i < config.numNodes; i++) {
             // we start N nodes and out of these N nodes there might be M bwc nodes.


### PR DESCRIPTION
The backwards compatibility tests rely on gradle's built-in mechanisms for resolving dependencies to get the zip of the older version we test against. By default, this will cache snapshots for 24 hours, which can lead to unexpected failures in CI. This change makes the special configurations for backwards compatibility always update their snapshots by setting the amount of time to cache to 0 seconds.