### PR TITLE
Do not allow custom analyzers to have the same names as built-in analyzers

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
@@ -270,10 +270,10 @@ public final class AnalysisRegistry implements Closeable {
             String name = entry.getKey();
             Settings currentSettings = entry.getValue();
             String typeName = currentSettings.get("type");
+            if (settings.getIndexVersionCreated().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED) && defaultInstance.containsKey(name)) {
+                throw new IllegalArgumentException("Custom analysis component [" + name + "] may not reuse the name of a built-in component");
+            }
             if (analyzer) {
-                if(defaultInstance.containsKey(name)) {
-                    throw new IllegalArgumentException("do not allow custom analyzers to have the same names [" + name + "] as built-in analyzers");
-                }
                 T factory;
                 if (typeName == null) {
                     if (currentSettings.get("tokenizer") != null) {

--- a/core/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
@@ -271,6 +271,9 @@ public final class AnalysisRegistry implements Closeable {
             Settings currentSettings = entry.getValue();
             String typeName = currentSettings.get("type");
             if (analyzer) {
+                if(defaultInstance.containsKey(name)) {
+                    throw new IllegalArgumentException("do not allow custom analyzers to have the same names [" + name + "] as built-in analyzers");
+                }
                 T factory;
                 if (typeName == null) {
                     if (currentSettings.get("tokenizer") != null) {

--- a/core/src/test/java/org/elasticsearch/index/analysis/AnalysisRegistryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/AnalysisRegistryTests.java
@@ -241,7 +241,7 @@ public class AnalysisRegistryTests extends ESTestCase {
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", indexSettings);
         AnalysisRegistry registry = new AnalysisRegistry(new Environment(settings), emptyMap(), emptyMap(), emptyMap(), emptyMap());
         Exception e = expectThrows(IllegalArgumentException.class, () -> registry.buildAnalyzerFactories(idxSettings));
-        assertThat(e.getMessage(), equalTo("do not allow custom analyzers to have the same names [standard] as built-in analyzers"));
+        assertThat(e.getMessage(), equalTo("Custom analysis component [standard] may not reuse the name of a built-in component"));
 
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/analysis/AnalysisRegistryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/AnalysisRegistryTests.java
@@ -233,4 +233,15 @@ public class AnalysisRegistryTests extends ESTestCase {
         indexAnalyzers.close();
         indexAnalyzers.close();
     }
+
+    public void testSameAnalyzerNameWithBuiltInAnalyzer() throws IOException {
+        Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build();
+        Settings indexSettings = Settings.builder()
+                .put("index.analysis.analyzer.standard.tokenizer", "standard").build();
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", indexSettings);
+        AnalysisRegistry registry = new AnalysisRegistry(new Environment(settings), emptyMap(), emptyMap(), emptyMap(), emptyMap());
+        Exception e = expectThrows(IllegalArgumentException.class, () -> registry.buildAnalyzerFactories(idxSettings));
+        assertThat(e.getMessage(), equalTo("do not allow custom analyzers to have the same names [standard] as built-in analyzers"));
+
+    }
 }


### PR DESCRIPTION
throw execption when custom analyzers have the same names as built-in analyzers according to issue:
https://github.com/elastic/elasticsearch/issues/22263
