### PR TITLE
Fix scaled_float numeric type in aggregations

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -505,7 +505,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         @Override
         public NumericType getNumericType() {
             /**
-             * {@link ScaledFloatLeafFieldData#getDoubleValues()} transforms the raw long values in `scaled float.
+             * {@link ScaledFloatLeafFieldData#getDoubleValues()} transforms the raw long values in `scaled` floats.
              */
             return NumericType.FLOAT;
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -507,7 +507,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             /**
              * {@link ScaledFloatLeafFieldData#getDoubleValues()} transforms the raw long values in `scaled` floats.
              */
-            return NumericType.FLOAT;
+            return NumericType.DOUBLE;
         }
 
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -504,7 +504,10 @@ public class ScaledFloatFieldMapper extends FieldMapper {
 
         @Override
         public NumericType getNumericType() {
-            return scaledFieldData.getNumericType();
+            /**
+             * {@link ScaledFloatLeafFieldData#getDoubleValues()} transforms the raw long values in `scaled float.
+             */
+            return NumericType.FLOAT;
         }
 
     }

--- a/core/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
@@ -182,7 +182,7 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
             // single-valued
             ft.setName("scaled_float1");
             IndexNumericFieldData fielddata = (IndexNumericFieldData) ft.fielddataBuilder().build(indexSettings, ft, null, null, null);
-            assertEquals(fielddata.getNumericType(), IndexNumericFieldData.NumericType.FLOAT);
+            assertEquals(fielddata.getNumericType(), IndexNumericFieldData.NumericType.DOUBLE);
             AtomicNumericFieldData leafFieldData = fielddata.load(reader.leaves().get(0));
             SortedNumericDoubleValues values = leafFieldData.getDoubleValues();
             values.setDocument(0);

--- a/core/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
@@ -182,6 +182,7 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
             // single-valued
             ft.setName("scaled_float1");
             IndexNumericFieldData fielddata = (IndexNumericFieldData) ft.fielddataBuilder().build(indexSettings, ft, null, null, null);
+            assertEquals(fielddata.getNumericType(), IndexNumericFieldData.NumericType.FLOAT);
             AtomicNumericFieldData leafFieldData = fielddata.load(reader.leaves().get(0));
             SortedNumericDoubleValues values = leafFieldData.getDoubleValues();
             values.setDocument(0);

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yaml
@@ -18,6 +18,9 @@ setup:
                     type: long
                   double:
                     type: double
+                  scaled_float:
+                    type: scaled_float
+                    scaling_factor: 100
                   date:
                     type: date
 
@@ -281,6 +284,52 @@ setup:
   - is_false: aggregations.double_terms.buckets.1.key_as_string
 
   - match: { aggregations.double_terms.buckets.1.doc_count: 1 }
+
+---
+"Scaled float test":
+  - do:
+      index:
+        index: test_1
+        type: test
+        id: 1
+        body: { "scaled_float": 9.99 }
+
+  - do:
+      index:
+        index: test_1
+        type: test
+        id: 2
+        body: { "scaled_float": 9.994 }
+
+  - do:
+      index:
+        index: test_1
+        type: test
+        id: 3
+        body: { "scaled_float": 8.99 }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        body: { "size" : 0, "aggs" : { "scaled_float_terms" : { "terms" : { "field" : "scaled_float" } } } }
+
+  - match: { hits.total: 3 }
+
+  - length: { aggregations.scaled_float_terms.buckets: 2 }
+
+  - match: { aggregations.scaled_float_terms.buckets.0.key: 9.99 }
+
+  - is_false: aggregations.scaled_float_terms.buckets.0.key_as_string
+
+  - match: { aggregations.scaled_float_terms.buckets.0.doc_count: 2 }
+
+  - match: { aggregations.scaled_float_terms.buckets.1.key: 8.99 }
+
+  - is_false: aggregations.scaled_float_terms.buckets.1.key_as_string
+
+  - match: { aggregations.scaled_float_terms.buckets.1.doc_count: 1 }
 
 ---
 "Date test":


### PR DESCRIPTION
`scaled_float` should be used as FLOAT in aggregations but currently they are used as LONG.
This change fixes this issue and adds a simple it test for it.

Fixes #22350