### PR TITLE
Properly configure Netty 3 ClientBootstrap when using custom connection profile

### DIFF
--- a/core/src/main/java/org/elasticsearch/transport/ConnectionProfile.java
+++ b/core/src/main/java/org/elasticsearch/transport/ConnectionProfile.java
@@ -82,21 +82,23 @@ public final class ConnectionProfile {
         /**
          * Sets a connect timeout for this connection profile
          */
-        public void setConnectTimeout(TimeValue connectTimeout) {
+        public Builder setConnectTimeout(TimeValue connectTimeout) {
             if (connectTimeout.millis() < 0) {
                 throw new IllegalArgumentException("connectTimeout must be non-negative but was: " + connectTimeout);
             }
             this.connectTimeout = connectTimeout;
+            return this;
         }
 
         /**
          * Sets a handshake timeout for this connection profile
          */
-        public void setHandshakeTimeout(TimeValue handshakeTimeout) {
+        public Builder setHandshakeTimeout(TimeValue handshakeTimeout) {
             if (handshakeTimeout.millis() < 0) {
                 throw new IllegalArgumentException("handshakeTimeout must be non-negative but was: " + handshakeTimeout);
             }
             this.handshakeTimeout = handshakeTimeout;
+            return this;
         }
 
         /**
@@ -104,7 +106,7 @@ public final class ConnectionProfile {
          * @param numConnections the number of connections to use in the pool for the given connection types
          * @param types a set of types that should share the given number of connections
          */
-        public void addConnections(int numConnections, TransportRequestOptions.Type... types) {
+        public Builder addConnections(int numConnections, TransportRequestOptions.Type... types) {
             if (types == null || types.length == 0) {
                 throw new IllegalArgumentException("types must not be null");
             }
@@ -116,6 +118,7 @@ public final class ConnectionProfile {
             addedTypes.addAll(Arrays.asList(types));
             handles.add(new ConnectionTypeHandle(offset, numConnections, EnumSet.copyOf(Arrays.asList(types))));
             offset += numConnections;
+            return this;
         }
 
         /**

--- a/modules/transport-netty3/src/main/java/org/elasticsearch/transport/netty3/Netty3Transport.java
+++ b/modules/transport-netty3/src/main/java/org/elasticsearch/transport/netty3/Netty3Transport.java
@@ -340,6 +340,7 @@ public class Netty3Transport extends TcpTransport<Channel> {
         return channels == null ? 0 : channels.numberOfOpenChannels();
     }
 
+    @Override
     protected NodeChannels connectToChannels(DiscoveryNode node, ConnectionProfile profile) {
         final Channel[] channels = new Channel[profile.getNumConnections()];
         final NodeChannels nodeChannels = new NodeChannels(node, channels, profile);
@@ -350,6 +351,8 @@ public class Netty3Transport extends TcpTransport<Channel> {
             final TimeValue defaultConnectTimeout = defaultConnectionProfile.getConnectTimeout();
             if (profile.getConnectTimeout() != null && profile.getConnectTimeout().equals(defaultConnectTimeout) == false) {
                 clientBootstrap = new ClientBootstrap(this.clientBootstrap.getFactory());
+                clientBootstrap.setPipelineFactory(this.clientBootstrap.getPipelineFactory());
+                clientBootstrap.setOptions(this.clientBootstrap.getOptions());
                 clientBootstrap.setOption("connectTimeoutMillis", Math.toIntExact(profile.getConnectTimeout().millis()));
                 connectTimeout = profile.getConnectTimeout();
             } else {

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4ScheduledPingTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4ScheduledPingTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
@@ -31,6 +32,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.ConnectionProfile;
 import org.elasticsearch.transport.TcpTransport;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportException;
@@ -84,8 +86,23 @@ public class Netty4ScheduledPingTests extends ESTestCase {
         DiscoveryNode nodeB =
             new DiscoveryNode("TS_B", "TS_B", serviceB.boundAddress().publishAddress(), emptyMap(), emptySet(), Version.CURRENT);
 
-        serviceA.connectToNode(nodeB);
-        serviceB.connectToNode(nodeA);
+        if (randomBoolean()) {
+            // use connection profile with different connect timeout
+            final ConnectionProfile connectionProfile = new ConnectionProfile.Builder()
+                .addConnections(1,
+                    TransportRequestOptions.Type.BULK,
+                    TransportRequestOptions.Type.PING,
+                    TransportRequestOptions.Type.RECOVERY,
+                    TransportRequestOptions.Type.REG,
+                    TransportRequestOptions.Type.STATE)
+                .setConnectTimeout(TimeValue.timeValueSeconds(42))
+                .build();
+            serviceA.connectToNode(nodeB, connectionProfile);
+            serviceB.connectToNode(nodeA, connectionProfile);
+        } else {
+            serviceA.connectToNode(nodeB);
+            serviceB.connectToNode(nodeA);
+        }
 
         assertBusy(new Runnable() {
             @Override


### PR DESCRIPTION
When opening a new connection with a custom ConnectionProfile that has a different connection timeout to the default one, the Netty 3/4 modules create a cloned copy of the default Bootstrap that contains configurations and settings to set up channels and override the connect timeout.
The Netty 4 library provides a convenience method for that, namely `Bootstrap.clone()`. Netty 3 does not have this so we have to be careful to make sure that all settings are properly copied over. This PR adds the missing configuration options to the copied Bootstrap.

This issue was only uncovered by the backport of #22277 to 5.x as this seems to be only user of the `TransportService.openConnection` method where a ConnectionProfile with a different connection timeout to the default timeout is passed.

Build failure:

https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+5.x+java9-periodic/1173/console
