### PR TITLE
Add a generic way of checking version before serializing custom cluster object

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/AbstractNamedDiffable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/AbstractNamedDiffable.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.cluster;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -30,23 +31,23 @@ import java.io.IOException;
  * Abstract diffable object with simple diffs implementation that sends the entire object if object has changed or
  * nothing is object remained the same. Comparing to AbstractDiffable, this class also works with NamedWriteables
  */
-public abstract class AbstractNamedDiffable<T extends Diffable<T> & NamedWriteable> implements Diffable<T>, NamedWriteable {
+public abstract class AbstractNamedDiffable<T extends NamedDiffable<T>> implements Diffable<T>, NamedWriteable {
 
     @Override
     public Diff<T> diff(T previousState) {
         if (this.get().equals(previousState)) {
-            return new CompleteNamedDiff<>(previousState.getWriteableName());
+            return new CompleteNamedDiff<>(previousState.getWriteableName(), previousState.getMinimalSupportedVersion());
         } else {
             return new CompleteNamedDiff<>(get());
         }
     }
 
-    public static <T extends Diffable<T> & NamedWriteable> NamedDiff<T> readDiffFrom(Class<? extends T> tClass, String name, StreamInput in)
+    public static <T extends NamedDiffable<T>> NamedDiff<T> readDiffFrom(Class<? extends T> tClass, String name, StreamInput in)
         throws IOException {
         return new CompleteNamedDiff<>(tClass, name, in);
     }
 
-    private static class CompleteNamedDiff<T extends Diffable<T> & NamedWriteable> implements NamedDiff<T> {
+    private static class CompleteNamedDiff<T extends NamedDiffable<T>> implements NamedDiff<T> {
 
         @Nullable
         private final T part;
@@ -54,19 +55,28 @@ public abstract class AbstractNamedDiffable<T extends Diffable<T> & NamedWriteab
         private final String name;
 
         /**
+         * A non-null value is only required for write operation, if the diff was just read from the stream the version
+         * is unnecessary.
+         */
+        @Nullable
+        private final Version minimalSupportedVersion;
+
+        /**
          * Creates simple diff with changes
          */
         public CompleteNamedDiff(T part) {
             this.part = part;
             this.name = part.getWriteableName();
+            this.minimalSupportedVersion = part.getMinimalSupportedVersion();
         }
 
         /**
          * Creates simple diff without changes
          */
-        public CompleteNamedDiff(String name) {
+        public CompleteNamedDiff(String name, Version minimalSupportedVersion) {
             this.part = null;
             this.name = name;
+            this.minimalSupportedVersion = minimalSupportedVersion;
         }
 
         /**
@@ -75,14 +85,17 @@ public abstract class AbstractNamedDiffable<T extends Diffable<T> & NamedWriteab
         public CompleteNamedDiff(Class<? extends T> tClass, String name, StreamInput in) throws IOException {
             if (in.readBoolean()) {
                 this.part = in.readNamedWriteable(tClass, name);
+                this.minimalSupportedVersion = part.getMinimalSupportedVersion();
             } else {
                 this.part = null;
+                this.minimalSupportedVersion = null; // We just read this diff, so it's not going to be written
             }
             this.name = name;
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
+            assert minimalSupportedVersion != null : "shouldn't be called on diff that was de-serialized from the stream";
             if (part != null) {
                 out.writeBoolean(true);
                 part.writeTo(out);
@@ -103,6 +116,12 @@ public abstract class AbstractNamedDiffable<T extends Diffable<T> & NamedWriteab
         @Override
         public String getWriteableName() {
             return name;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            assert minimalSupportedVersion != null : "shouldn't be called on the diff that was de-serialized from the stream";
+            return minimalSupportedVersion;
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/NamedDiffable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/NamedDiffable.java
@@ -25,12 +25,11 @@ import org.elasticsearch.common.io.stream.NamedWriteable;
 /**
  * Diff that also support NamedWriteable interface
  */
-public interface NamedDiff<T extends Diffable<T>> extends Diff<T>, NamedWriteable {
+public interface NamedDiffable<T> extends Diffable<T>, NamedWriteable {
     /**
      * The minimal version of the recipient this custom object can be sent to
      */
     default Version getMinimalSupportedVersion() {
         return Version.CURRENT.minimumCompatibilityVersion();
     }
-
 }

--- a/core/src/main/java/org/elasticsearch/cluster/NamedDiffableValueSerializer.java
+++ b/core/src/main/java/org/elasticsearch/cluster/NamedDiffableValueSerializer.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Value Serializer for named diffables
+ */
+public class NamedDiffableValueSerializer<T extends NamedDiffable<T>> extends DiffableUtils.DiffableValueSerializer<String, T> {
+
+    private final Class<T> tClass;
+
+    public NamedDiffableValueSerializer(Class<T> tClass) {
+        this.tClass = tClass;
+    }
+
+    @Override
+    public T read(StreamInput in, String key) throws IOException {
+        return in.readNamedWriteable(tClass, key);
+    }
+
+    @Override
+    public boolean supportsVersion(Diff<T> value, Version version) {
+        return version.onOrAfter(((NamedDiff<?>)value).getMinimalSupportedVersion());
+    }
+
+    @Override
+    public boolean supportsVersion(T value, Version version) {
+        return version.onOrAfter(value.getMinimalSupportedVersion());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Diff<T> readDiff(StreamInput in, String key) throws IOException {
+        return in.readNamedWriteable(NamedDiff.class, key);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
+++ b/core/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
@@ -129,6 +129,11 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
     }
 
     @Override
+    public Version getMinimalSupportedVersion() {
+        return VERSION_INTRODUCED;
+    }
+
+    @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startArray(TYPE);
         for (Entry entry : entries) {

--- a/core/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
@@ -23,20 +23,31 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.RestoreInProgress;
+import org.elasticsearch.cluster.SnapshotDeletionsInProgress;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.snapshots.Snapshot;
+import org.elasticsearch.snapshots.SnapshotId;
 
 import java.util.Collections;
 
+import static org.elasticsearch.test.VersionUtils.randomVersionBetween;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class ClusterSerializationTests extends ESAllocationTestCase {
 
@@ -87,6 +98,66 @@ public class ClusterSerializationTests extends ESAllocationTestCase {
         RoutingTable target = RoutingTable.readFrom(inStream);
 
         assertThat(target.toString(), equalTo(source.toString()));
+    }
+
+    public void testSnapshotDeletionsInProgressSerialization() throws Exception {
+
+        boolean includeRestore = randomBoolean();
+
+        ClusterState.Builder builder = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .putCustom(SnapshotDeletionsInProgress.TYPE,
+                SnapshotDeletionsInProgress.newInstance(
+                    new SnapshotDeletionsInProgress.Entry(
+                        new Snapshot("repo1", new SnapshotId("snap1", UUIDs.randomBase64UUID())),
+                        randomNonNegativeLong(), randomNonNegativeLong())
+                ));
+        if (includeRestore) {
+            builder.putCustom(RestoreInProgress.TYPE,
+                new RestoreInProgress(
+                    new RestoreInProgress.Entry(
+                        new Snapshot("repo2", new SnapshotId("snap2", UUIDs.randomBase64UUID())),
+                        RestoreInProgress.State.STARTED,
+                        Collections.singletonList("index_name"),
+                        ImmutableOpenMap.of()
+                    )
+                ));
+        }
+
+        ClusterState clusterState = builder.incrementVersion().build();
+
+        Diff<ClusterState> diffs = clusterState.diff(ClusterState.EMPTY_STATE);
+
+        // serialize with current version
+        BytesStreamOutput outStream = new BytesStreamOutput();
+        diffs.writeTo(outStream);
+        StreamInput inStream = outStream.bytes().streamInput();
+        inStream = new NamedWriteableAwareStreamInput(inStream, new NamedWriteableRegistry(ClusterModule.getNamedWriteables()));
+        Diff<ClusterState> serializedDiffs = ClusterState.readDiffFrom(inStream, clusterState.nodes().getLocalNode());
+        ClusterState stateAfterDiffs = serializedDiffs.apply(ClusterState.EMPTY_STATE);
+        assertThat(stateAfterDiffs.custom(RestoreInProgress.TYPE), includeRestore ? notNullValue() : nullValue());
+        assertThat(stateAfterDiffs.custom(SnapshotDeletionsInProgress.TYPE), notNullValue());
+
+        // serialize with old version
+        outStream = new BytesStreamOutput();
+        outStream.setVersion(Version.CURRENT.minimumCompatibilityVersion());
+        diffs.writeTo(outStream);
+        inStream = outStream.bytes().streamInput();
+        inStream = new NamedWriteableAwareStreamInput(inStream, new NamedWriteableRegistry(ClusterModule.getNamedWriteables()));
+        serializedDiffs = ClusterState.readDiffFrom(inStream, clusterState.nodes().getLocalNode());
+        stateAfterDiffs = serializedDiffs.apply(ClusterState.EMPTY_STATE);
+        assertThat(stateAfterDiffs.custom(RestoreInProgress.TYPE), includeRestore ? notNullValue() : nullValue());
+        assertThat(stateAfterDiffs.custom(SnapshotDeletionsInProgress.TYPE), nullValue());
+
+        // remove the custom and try serializing again with old version
+        clusterState = ClusterState.builder(clusterState).removeCustom(SnapshotDeletionsInProgress.TYPE).incrementVersion().build();
+        outStream = new BytesStreamOutput();
+        diffs.writeTo(outStream);
+        inStream = outStream.bytes().streamInput();
+        inStream = new NamedWriteableAwareStreamInput(inStream, new NamedWriteableRegistry(ClusterModule.getNamedWriteables()));
+        serializedDiffs = ClusterState.readDiffFrom(inStream, clusterState.nodes().getLocalNode());
+        stateAfterDiffs = serializedDiffs.apply(stateAfterDiffs);
+        assertThat(stateAfterDiffs.custom(RestoreInProgress.TYPE), includeRestore ? notNullValue() : nullValue());
+        assertThat(stateAfterDiffs.custom(SnapshotDeletionsInProgress.TYPE), nullValue());
     }
 
 }


### PR DESCRIPTION
In #22313 we added a check that prevents the SnapshotDeletionsInProgress custom cluster state objects from being sent to older elasticsearch nodes. This commits make this check generic and available to other cluster state custom objects if needed.

@abeyad, could you take a look when you are back? That's the change that we discussed in #22313.
