### PR TITLE
Add Optional support to Setting

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -45,6 +45,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -868,6 +869,16 @@ public class Setting<T> extends ToXContentToBytes {
                 throw new IllegalArgumentException("Failed to parse value [" + s + "] for setting [" + key + "] must be >= " + minValue);
             }
             return d;
+        }, properties);
+    }
+
+    public static <T> Setting<Optional<T>> optional(String key, Function<String, T> parserIfNotNull, Property... properties) {
+        return new Setting<>(key, (String) null, s -> {
+            if (s == null) {
+                return Optional.empty();
+            } else {
+                return Optional.of(parserIfNotNull.apply(s));
+            }
         }, properties);
     }
 

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -24,11 +24,14 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.test.ESTestCase;
+import org.joda.time.DateTimeZone;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
@@ -529,5 +532,18 @@ public class SettingTests extends ESTestCase {
         setting = Setting.timeSetting("foo", (s) -> TimeValue.timeValueMillis(random.getMillis() * factor), TimeValue.ZERO);
         assertThat(setting.get(Settings.builder().put("foo", "12h").build()), equalTo(TimeValue.timeValueHours(12)));
         assertThat(setting.get(Settings.EMPTY).getMillis(), equalTo(random.getMillis() * factor));
+    }
+
+    public void testOptionalOfDateTimeZone() {
+        final Setting<Optional<DateTimeZone>> setting = Setting.optional("foo-tz", DateTimeZone::forID);
+
+        assertThat(setting.get(Settings.EMPTY).isPresent(), equalTo(false));
+
+        final DateTimeZone tz = randomDateTimeZone();
+        final Settings settings = Settings.builder().put("foo-tz", tz.getID()).build();
+        final Optional<DateTimeZone> optTimeZone = setting.get(settings);
+        assertThat(optTimeZone.isPresent(), equalTo(true));
+        assertThat(optTimeZone.get(), equalTo(tz));
+
     }
 }


### PR DESCRIPTION
`Setting.optional` is a form of `Setting` that differentiates between specified (`Optional.isPresent()`) and unspecified (`Optional.empty()`).
Allows for a more functional code-style when the system behaviour under the default configuration is more complex than simply returning a default value.