### PR TITLE
Descriptions for scripting 'enabled'

### DIFF
--- a/docs/reference/modules/scripting/security.asciidoc
+++ b/docs/reference/modules/scripting/security.asciidoc
@@ -51,8 +51,8 @@ Each of these settings takes one of these values:
 
 
 [horizontal]
-`false`::   Scripting is enabled.
-`true`::    Scripting is disabled.
+`false`::   Scripting is disabled.
+`true`::    Scripting is enabled.
 
 The default values are the following:
 


### PR DESCRIPTION
The `Script source settings` section currently states that `false` means scripting is ENABLED.
The other sections seem to indicate that `false` means scripting is DISABLED.

If the current documentation is correct, that would imply that `inline` and `stored` scripting are ENABLED by default, which seems to conflict with all the other sections in the document.
