### PR TITLE
Remove some more usages of ParseFieldMatcher

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/ParseFieldMatcher.java
+++ b/core/src/main/java/org/elasticsearch/common/ParseFieldMatcher.java
@@ -36,15 +36,4 @@ public class ParseFieldMatcher {
     public ParseFieldMatcher(Settings settings) {
         //we don't do anything with the settings argument, this whole class will be soon removed
     }
-
-    /**
-     * Matches a {@link ParseField} against a field name,
-     * @param fieldName the field name found in the request while parsing
-     * @param parseField the parse field that we are looking for
-     * @throws IllegalArgumentException whenever we are in strict mode and the request contained a deprecated field
-     * @return true whenever the parse field that we are looking for was found, false otherwise
-     */
-    public boolean match(String fieldName, ParseField parseField) {
-        return parseField.match(fieldName);
-    }
 }

--- a/core/src/main/java/org/elasticsearch/common/xcontent/ObjectParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/ObjectParser.java
@@ -417,7 +417,7 @@ public final class ObjectParser<Value, Context extends ParseFieldMatcherSupplier
         }
 
         public void assertSupports(String parserName, XContentParser.Token token, String currentFieldName, ParseFieldMatcher matcher) {
-            if (matcher.match(currentFieldName, parseField) == false) {
+            if (parseField.match(currentFieldName) == false) {
                 throw new IllegalStateException("[" + parserName  + "] parsefield doesn't accept: " + currentFieldName);
             }
             if (supportedTokens.contains(token) == false) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.codecs.PostingsFormat;
-import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.suggest.document.Completion50PostingsFormat;
@@ -125,22 +124,22 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
                 if (fieldName.equals("type")) {
                     continue;
                 }
-                if (parserContext.parseFieldMatcher().match(fieldName, Fields.ANALYZER)) {
+                if (Fields.ANALYZER.match(fieldName)) {
                     indexAnalyzer = getNamedAnalyzer(parserContext, fieldNode.toString());
                     iterator.remove();
-                } else if (parserContext.parseFieldMatcher().match(fieldName, Fields.SEARCH_ANALYZER)) {
+                } else if (Fields.SEARCH_ANALYZER.match(fieldName)) {
                     searchAnalyzer = getNamedAnalyzer(parserContext, fieldNode.toString());
                     iterator.remove();
-                } else if (parserContext.parseFieldMatcher().match(fieldName, Fields.PRESERVE_SEPARATORS)) {
+                } else if (Fields.PRESERVE_SEPARATORS.match(fieldName)) {
                     builder.preserveSeparators(Boolean.parseBoolean(fieldNode.toString()));
                     iterator.remove();
-                } else if (parserContext.parseFieldMatcher().match(fieldName, Fields.PRESERVE_POSITION_INCREMENTS)) {
+                } else if (Fields.PRESERVE_POSITION_INCREMENTS.match(fieldName)) {
                     builder.preservePositionIncrements(Boolean.parseBoolean(fieldNode.toString()));
                     iterator.remove();
-                } else if (parserContext.parseFieldMatcher().match(fieldName, Fields.MAX_INPUT_LENGTH)) {
+                } else if (Fields.MAX_INPUT_LENGTH.match(fieldName)) {
                     builder.maxInputLength(Integer.parseInt(fieldNode.toString()));
                     iterator.remove();
-                } else if (parserContext.parseFieldMatcher().match(fieldName, Fields.CONTEXTS)) {
+                } else if (Fields.CONTEXTS.match(fieldName)) {
                     builder.contextMappings(ContextMappings.load(fieldNode, parserContext.indexVersionCreated()));
                     iterator.remove();
                 } else if (parseMultiField(builder, name, parserContext, fieldName, fieldNode)) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/ParentFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ParentFieldMapper.java
@@ -114,7 +114,7 @@ public class ParentFieldMapper extends MetadataFieldMapper {
                 if (fieldName.equals("type")) {
                     builder.type(fieldNode.toString());
                     iterator.remove();
-                } else if (parserContext.parseFieldMatcher().match(fieldName, FIELDDATA)) {
+                } else if (FIELDDATA.match(fieldName)) {
                     // for bw compat only
                     Map<String, String> fieldDataSettings = SettingsLoader.Helper.loadNestedFromMap(nodeMapValue(fieldNode, "fielddata"));
                     if (fieldDataSettings.containsKey("loading")) {

--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -43,7 +43,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.TreeMap;
 
 /**
@@ -152,7 +151,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
             MultiMatchQueryBuilder.Type[] values = MultiMatchQueryBuilder.Type.values();
             Type type = null;
             for (MultiMatchQueryBuilder.Type t : values) {
-                if (parseFieldMatcher.match(value, t.parseField())) {
+                if (t.parseField().match(value)) {
                     type = t;
                     break;
                 }

--- a/core/src/main/java/org/elasticsearch/index/query/support/QueryParsers.java
+++ b/core/src/main/java/org/elasticsearch/index/query/support/QueryParsers.java
@@ -59,13 +59,13 @@ public final class QueryParsers {
         if (rewriteMethod == null) {
             return defaultRewriteMethod;
         }
-        if (matcher.match(rewriteMethod, CONSTANT_SCORE)) {
+        if (CONSTANT_SCORE.match(rewriteMethod)) {
             return MultiTermQuery.CONSTANT_SCORE_REWRITE;
         }
-        if (matcher.match(rewriteMethod, SCORING_BOOLEAN)) {
+        if (SCORING_BOOLEAN.match(rewriteMethod)) {
             return MultiTermQuery.SCORING_BOOLEAN_REWRITE;
         }
-        if (matcher.match(rewriteMethod, CONSTANT_SCORE_BOOLEAN)) {
+        if (CONSTANT_SCORE_BOOLEAN.match(rewriteMethod)) {
             return MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE;
         }
 
@@ -81,13 +81,13 @@ public final class QueryParsers {
             final int size = Integer.parseInt(rewriteMethod.substring(firstDigit));
             String rewriteMethodName = rewriteMethod.substring(0, firstDigit);
 
-            if (matcher.match(rewriteMethodName, TOP_TERMS)) {
+            if (TOP_TERMS.match(rewriteMethodName)) {
                 return new MultiTermQuery.TopTermsScoringBooleanQueryRewrite(size);
             }
-            if (matcher.match(rewriteMethodName, TOP_TERMS_BOOST)) {
+            if (TOP_TERMS_BOOST.match(rewriteMethodName)) {
                 return new MultiTermQuery.TopTermsBoostOnlyBooleanQueryRewrite(size);
             }
-            if (matcher.match(rewriteMethodName, TOP_TERMS_BLENDED_FREQS)) {
+            if (TOP_TERMS_BLENDED_FREQS.match(rewriteMethodName)) {
                 return new MultiTermQuery.TopTermsBlendedFreqScoringRewrite(size);
             }
         }

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java
@@ -83,19 +83,19 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
             ParseFieldMatcher parseFieldMatcher) {
 
         for (Map.Entry<String, String> entry : request.params().entrySet()) {
-            if (parseFieldMatcher.match(entry.getKey(), Fields.QUERY)) {
+            if (Fields.QUERY.match(entry.getKey())) {
                 clearIndicesCacheRequest.queryCache(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.queryCache()));
             }
-            if (parseFieldMatcher.match(entry.getKey(), Fields.REQUEST_CACHE)) {
+            if (Fields.REQUEST_CACHE.match(entry.getKey())) {
                 clearIndicesCacheRequest.requestCache(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.requestCache()));
             }
-            if (parseFieldMatcher.match(entry.getKey(), Fields.FIELD_DATA)) {
+            if (Fields.FIELD_DATA.match(entry.getKey())) {
                 clearIndicesCacheRequest.fieldDataCache(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.fieldDataCache()));
             }
-            if (parseFieldMatcher.match(entry.getKey(), Fields.RECYCLER)) {
+            if (Fields.RECYCLER.match(entry.getKey())) {
                 clearIndicesCacheRequest.recycler(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.recycler()));
             }
-            if (parseFieldMatcher.match(entry.getKey(), Fields.FIELDS)) {
+            if (Fields.FIELDS.match(entry.getKey())) {
                 clearIndicesCacheRequest.fields(request.paramAsStringArray(entry.getKey(), clearIndicesCacheRequest.fields()));
             }
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ip/IpRangeAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ip/IpRangeAggregationBuilder.java
@@ -94,13 +94,13 @@ public final class IpRangeAggregationBuilder
             if (parser.currentToken() == Token.FIELD_NAME) {
                 continue;
             }
-            if (parseFieldMatcher.match(parser.currentName(), RangeAggregator.Range.KEY_FIELD)) {
+            if (RangeAggregator.Range.KEY_FIELD.match(parser.currentName())) {
                 key = parser.text();
-            } else if (parseFieldMatcher.match(parser.currentName(), RangeAggregator.Range.FROM_FIELD)) {
+            } else if (RangeAggregator.Range.FROM_FIELD.match(parser.currentName())) {
                 from = parser.textOrNull();
-            } else if (parseFieldMatcher.match(parser.currentName(), RangeAggregator.Range.TO_FIELD)) {
+            } else if (RangeAggregator.Range.TO_FIELD.match(parser.currentName())) {
                 to = parser.textOrNull();
-            } else if (parseFieldMatcher.match(parser.currentName(), MASK_FIELD)) {
+            } else if (MASK_FIELD.match(parser.currentName())) {
                 mask = parser.text();
             } else {
                 throw new ParsingException(parser.getTokenLocation(), "Unexpected ip range parameter: [" + parser.currentName() + "]");

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/GND.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/GND.java
@@ -119,7 +119,7 @@ public class GND extends NXYSignificanceHeuristic {
             boolean backgroundIsSuperset = true;
             XContentParser.Token token = parser.nextToken();
             while (!token.equals(XContentParser.Token.END_OBJECT)) {
-                if (context.getParseFieldMatcher().match(parser.currentName(), BACKGROUND_IS_SUPERSET)) {
+                if (BACKGROUND_IS_SUPERSET.match(parser.currentName())) {
                     parser.nextToken();
                     backgroundIsSuperset = parser.booleanValue();
                 } else {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/NXYSignificanceHeuristic.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/NXYSignificanceHeuristic.java
@@ -160,10 +160,10 @@ public abstract class NXYSignificanceHeuristic extends SignificanceHeuristic {
             boolean backgroundIsSuperset = true;
             XContentParser.Token token = parser.nextToken();
             while (!token.equals(XContentParser.Token.END_OBJECT)) {
-                if (context.getParseFieldMatcher().match(parser.currentName(), INCLUDE_NEGATIVES_FIELD)) {
+                if (INCLUDE_NEGATIVES_FIELD.match(parser.currentName())) {
                     parser.nextToken();
                     includeNegatives = parser.booleanValue();
-                } else if (context.getParseFieldMatcher().match(parser.currentName(), BACKGROUND_IS_SUPERSET)) {
+                } else if (BACKGROUND_IS_SUPERSET.match(parser.currentName())) {
                     parser.nextToken();
                     backgroundIsSuperset = parser.booleanValue();
                 } else {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregationBuilder.java
@@ -643,8 +643,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
                                 } else if (token.isValue()) {
                                     if (SearchSourceBuilder.SCRIPT_FIELD.match(currentFieldName)) {
                                         script = Script.parse(parser, context.getParseFieldMatcher(), context.getDefaultScriptLanguage());
-                                    } else if (context.getParseFieldMatcher().match(currentFieldName,
-                                            SearchSourceBuilder.IGNORE_FAILURE_FIELD)) {
+                                    } else if (SearchSourceBuilder.IGNORE_FAILURE_FIELD.match(currentFieldName)) {
                                         ignoreFailure = parser.booleanValue();
                                     } else {
                                         throw new ParsingException(parser.getTokenLocation(),

--- a/core/src/main/java/org/elasticsearch/search/suggest/SuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/SuggestionBuilder.java
@@ -269,11 +269,11 @@ public abstract class SuggestionBuilder<T extends SuggestionBuilder<T>> implemen
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token.isValue()) {
-                if (parsefieldMatcher.match(currentFieldName, TEXT_FIELD)) {
+                if (TEXT_FIELD.match(currentFieldName)) {
                     suggestText = parser.text();
-                } else if (parsefieldMatcher.match(currentFieldName, PREFIX_FIELD)) {
+                } else if (PREFIX_FIELD.match(currentFieldName)) {
                     prefix = parser.text();
-                } else if (parsefieldMatcher.match(currentFieldName, REGEX_FIELD)) {
+                } else if (PREFIX_FIELD.match(currentFieldName)) {
                     regex = parser.text();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "suggestion does not support [" + currentFieldName + "]");

--- a/core/src/main/java/org/elasticsearch/search/suggest/SuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/SuggestionBuilder.java
@@ -273,7 +273,7 @@ public abstract class SuggestionBuilder<T extends SuggestionBuilder<T>> implemen
                     suggestText = parser.text();
                 } else if (PREFIX_FIELD.match(currentFieldName)) {
                     prefix = parser.text();
-                } else if (PREFIX_FIELD.match(currentFieldName)) {
+                } else if (REGEX_FIELD.match(currentFieldName)) {
                     regex = parser.text();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "suggestion does not support [" + currentFieldName + "]");

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/LinearInterpolation.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/LinearInterpolation.java
@@ -143,17 +143,17 @@ public final class LinearInterpolation extends SmoothingModel {
             if (token == XContentParser.Token.FIELD_NAME) {
                 fieldName = parser.currentName();
             } else if (token.isValue()) {
-                if (matcher.match(fieldName, TRIGRAM_FIELD)) {
+                if (TRIGRAM_FIELD.match(fieldName)) {
                     trigramLambda = parser.doubleValue();
                     if (trigramLambda < 0) {
                         throw new IllegalArgumentException("trigram_lambda must be positive");
                     }
-                } else if (matcher.match(fieldName, BIGRAM_FIELD)) {
+                } else if (BIGRAM_FIELD.match(fieldName)) {
                     bigramLambda = parser.doubleValue();
                     if (bigramLambda < 0) {
                         throw new IllegalArgumentException("bigram_lambda must be positive");
                     }
-                } else if (matcher.match(fieldName, UNIGRAM_FIELD)) {
+                } else if (UNIGRAM_FIELD.match(fieldName)) {
                     unigramLambda = parser.doubleValue();
                     if (unigramLambda < 0) {
                         throw new IllegalArgumentException("unigram_lambda must be positive");

--- a/core/src/test/java/org/elasticsearch/search/aggregations/support/IncludeExcludeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/support/IncludeExcludeTests.java
@@ -282,10 +282,10 @@ public class IncludeExcludeTests extends ESTestCase {
         IncludeExclude exc = null;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             assertEquals(XContentParser.Token.FIELD_NAME, token);
-            if (parseFieldMatcher.match(parser.currentName(), IncludeExclude.INCLUDE_FIELD)) {
+            if (IncludeExclude.INCLUDE_FIELD.match(parser.currentName())) {
                 token = parser.nextToken();
                 inc = IncludeExclude.parseInclude(parser, parseContext);
-            } else if (parseFieldMatcher.match(parser.currentName(), IncludeExclude.EXCLUDE_FIELD)) {
+            } else if (IncludeExclude.EXCLUDE_FIELD.match(parser.currentName())) {
                 token = parser.nextToken();
                 exc = IncludeExclude.parseExclude(parser, parseContext);
             } else {

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestUpdateByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestUpdateByQueryAction.java
@@ -99,21 +99,21 @@ public class RestUpdateByQueryAction extends AbstractBulkByQueryRestHandler<Upda
                 } else {
                     throw new ElasticsearchParseException("Value must be of type String: [" + parameterName + "]");
                 }
-            } else if (parseFieldMatcher.match(parameterName, ScriptType.INLINE.getParseField())) {
+            } else if (ScriptType.INLINE.getParseField().match(parameterName)) {
                 if (parameterValue instanceof String || parameterValue == null) {
                     script = (String) parameterValue;
                     type = ScriptType.INLINE;
                 } else {
                     throw new ElasticsearchParseException("Value must be of type String: [" + parameterName + "]");
                 }
-            } else if (parseFieldMatcher.match(parameterName, ScriptType.FILE.getParseField())) {
+            } else if (ScriptType.FILE.getParseField().match(parameterName)) {
                 if (parameterValue instanceof String || parameterValue == null) {
                     script = (String) parameterValue;
                     type = ScriptType.FILE;
                 } else {
                     throw new ElasticsearchParseException("Value must be of type String: [" + parameterName + "]");
                 }
-            } else if (parseFieldMatcher.match(parameterName, ScriptType.STORED.getParseField())) {
+            } else if (ScriptType.STORED.getParseField().match(parameterName)) {
                 if (parameterValue instanceof String || parameterValue == null) {
                     script = (String) parameterValue;
                     type = ScriptType.STORED;


### PR DESCRIPTION
These are the last usages of `ParseFieldMatcher#match` hence the method can now be removed.

Relates to #19552
Relates to #22130