### PR TITLE
Remove deprecated `minimum_number_should_match` in BoolQueryBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -56,7 +56,7 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
     private static final String SHOULD = "should";
     private static final String MUST = "must";
     private static final ParseField DISABLE_COORD_FIELD = new ParseField("disable_coord");
-    private static final ParseField MINIMUM_SHOULD_MATCH = new ParseField("minimum_should_match", "minimum_number_should_match");
+    private static final ParseField MINIMUM_SHOULD_MATCH = new ParseField("minimum_should_match");
     private static final ParseField ADJUST_PURE_NEGATIVE = new ParseField("adjust_pure_negative");
 
     private final List<QueryBuilder> mustClauses = new ArrayList<>();
@@ -209,7 +209,8 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
     }
 
     /**
-     * Sets the minimum should match using the special syntax (for example, supporting percentage).
+     * Sets the minimum should match parameter using the special syntax (for example, supporting percentage).
+     * @see BoolQueryBuilder#minimumShouldMatch(int)
      */
     public BoolQueryBuilder minimumShouldMatch(String minimumShouldMatch) {
         this.minimumShouldMatch = minimumShouldMatch;
@@ -217,7 +218,17 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
     }
 
     /**
-     * Sets the minimum should match as an integer value.
+     * Specifies a minimum number of the optional (should) boolean clauses which must be satisfied.
+     * <p>
+     * By default no optional clauses are necessary for a match
+     * (unless there are no required clauses).  If this method is used,
+     * then the specified number of clauses is required.
+     * <p>
+     * Use of this method is totally independent of specifying that
+     * any specific clauses are required (or prohibited).  This number will
+     * only be compared against the number of matching optional clauses.
+     *
+     * @param minimumShouldMatch the number of optional clauses that must match
      */
     public BoolQueryBuilder minimumShouldMatch(int minimumShouldMatch) {
         this.minimumShouldMatch = Integer.toString(minimumShouldMatch);

--- a/docs/reference/migration/migrate_6_0/search.asciidoc
+++ b/docs/reference/migration/migrate_6_0/search.asciidoc
@@ -26,6 +26,9 @@
 * Support for empty query objects (`{ }`) has been removed from the query DSL.
   An error is thrown whenever an empty query object is provided.
 
+* The deprecated `minimum_number_should_match` parameter in the `bool` query has
+  been removed, use `minimum_should_match` instead.
+
 ==== Search shards API
 
 The search shards API no longer accepts the `type` url parameter, which didn't


### PR DESCRIPTION
After deprecating getters and setters and the query DSL parameter in 5.x,
support for `minimum_number_should_match` can be removed entirely. Also
consolidated comments with the ones on 5.x branch and added an entry to the
migration docs.