### PR TITLE
Don't close store under CancellableThreads

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveriesCollection.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveriesCollection.java
@@ -107,25 +107,17 @@ public class RecoveriesCollection {
             }
 
             // Closes the current recovery target
-            final AtomicBoolean successfulReset = new AtomicBoolean();
-            try {
-                final RecoveryTarget finalOldRecoveryTarget = oldRecoveryTarget;
-                newRecoveryTarget.CancellableThreads().executeIO(() -> successfulReset.set(finalOldRecoveryTarget.resetRecovery()));
-            } catch (CancellableThreads.ExecutionCancelledException e) {
-                // new recovery target is already cancelled (probably due to shard closing or recovery source changing)
-                assert onGoingRecoveries.containsKey(newRecoveryTarget.recoveryId()) == false;
-                logger.trace("{} recovery reset cancelled, recovery from {}, id [{}], previous id [{}]", newRecoveryTarget.shardId(),
-                    newRecoveryTarget.sourceNode(), newRecoveryTarget.recoveryId(), oldRecoveryTarget.recoveryId());
-                oldRecoveryTarget.cancel("recovery reset cancelled"); // if finalOldRecoveryTarget.resetRecovery did not even get to execute
-                return null;
-            }
-            if (successfulReset.get() == false) {
-                cancelRecovery(newRecoveryTarget.recoveryId(), "failed to reset recovery");
-                return null;
-            } else {
+            boolean successfulReset = oldRecoveryTarget.resetRecovery(activityTimeout);
+            if (successfulReset) {
                 logger.trace("{} restarted recovery from {}, id [{}], previous id [{}]", newRecoveryTarget.shardId(),
                     newRecoveryTarget.sourceNode(), newRecoveryTarget.recoveryId(), oldRecoveryTarget.recoveryId());
                 return newRecoveryTarget;
+            } else {
+                logger.trace("{} recovery could not be reset as it is already cancelled, recovery from {}, id [{}], previous id [{}]",
+                    newRecoveryTarget.shardId(), newRecoveryTarget.sourceNode(), newRecoveryTarget.recoveryId(),
+                    oldRecoveryTarget.recoveryId());
+                cancelRecovery(newRecoveryTarget.recoveryId(), "recovery cancelled during reset");
+                return null;
             }
         } catch (Exception e) {
             // fail shard to be safe

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveriesCollection.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveriesCollection.java
@@ -107,7 +107,7 @@ public class RecoveriesCollection {
             }
 
             // Closes the current recovery target
-            boolean successfulReset = oldRecoveryTarget.resetRecovery(activityTimeout);
+            boolean successfulReset = oldRecoveryTarget.resetRecovery(newRecoveryTarget.CancellableThreads());
             if (successfulReset) {
                 logger.trace("{} restarted recovery from {}, id [{}], previous id [{}]", newRecoveryTarget.shardId(),
                     newRecoveryTarget.sourceNode(), newRecoveryTarget.recoveryId(), oldRecoveryTarget.recoveryId());


### PR DESCRIPTION
#22325 changed the recovery retry logic to use unique recovery ids. The change also introduced an issue, however, which made it possible for the shard store to be closed under CancellableThreads, triggering assertions in the node locking logic. This PR limits the use of CancellableThreads only to the part where we wait on the old recovery target to be closed.

Test failure: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+5.x+multijob-darwin-compatibility/106/consoleFull

Log output:

```
1> [2017-01-04T14:29:36,961][WARN ][o.e.e.NodeEnvironment    ] [node_sd2] lock assertion failed
  1> java.nio.channels.ClosedByInterruptException: null
  1> 	at java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:202) ~[?:1.8.0_60]
  1> 	at sun.nio.ch.FileChannelImpl.size(FileChannelImpl.java:315) ~[?:?]
  1> 	at org.apache.lucene.mockfile.FilterFileChannel.size(FilterFileChannel.java:85) ~[lucene-test-framework-6.4.0-snapshot-ec38570.jar:6.4.0-snapshot-ec38570 ec385708c6e0c47440127410c1223f14703c24e1 - jim - 2016-11-29 01:11:32]
  1> 	at org.apache.lucene.mockfile.FilterFileChannel.size(FilterFileChannel.java:85) ~[lucene-test-framework-6.4.0-snapshot-ec38570.jar:6.4.0-snapshot-ec38570 ec385708c6e0c47440127410c1223f14703c24e1 - jim - 2016-11-29 01:11:32]
  1> 	at org.apache.lucene.mockfile.FilterFileChannel.size(FilterFileChannel.java:85) ~[lucene-test-framework-6.4.0-snapshot-ec38570.jar:6.4.0-snapshot-ec38570 ec385708c6e0c47440127410c1223f14703c24e1 - jim - 2016-11-29 01:11:32]
  1> 	at org.apache.lucene.store.NativeFSLockFactory$NativeFSLock.ensureValid(NativeFSLockFactory.java:170) ~[lucene-core-6.4.0-snapshot-ec38570.jar:6.4.0-snapshot-ec38570 ec385708c6e0c47440127410c1223f14703c24e1 - jim - 2016-11-29 01:11:32]
  1> 	at org.elasticsearch.env.NodeEnvironment.assertEnvIsLocked(NodeEnvironment.java:902) ~[main/:?]
  1> 	at org.elasticsearch.env.NodeEnvironment.availableShardPaths(NodeEnvironment.java:782) ~[main/:?]
  1> 	at org.elasticsearch.env.NodeEnvironment.deleteShardDirectoryUnderLock(NodeEnvironment.java:492) ~[main/:?]
  1> 	at org.elasticsearch.indices.IndicesService.deleteShardStore(IndicesService.java:657) ~[main/:?]
  1> 	at org.elasticsearch.index.IndexService.onShardClose(IndexService.java:442) ~[main/:?]
  1> 	at org.elasticsearch.index.IndexService.access$100(IndexService.java:93) ~[main/:?]
  1> 	at org.elasticsearch.index.IndexService$StoreCloseListener.handle(IndexService.java:524) ~[main/:?]
  1> 	at org.elasticsearch.index.IndexService$StoreCloseListener.handle(IndexService.java:509) ~[main/:?]
  1> 	at org.elasticsearch.index.store.Store.closeInternal(Store.java:366) ~[main/:?]
  1> 	at org.elasticsearch.index.store.Store.access$000(Store.java:126) ~[main/:?]
  1> 	at org.elasticsearch.index.store.Store$1.closeInternal(Store.java:147) ~[main/:?]
  1> 	at org.elasticsearch.common.util.concurrent.AbstractRefCounted.decRef(AbstractRefCounted.java:64) ~[main/:?]
  1> 	at org.elasticsearch.index.store.Store.decRef(Store.java:348) ~[main/:?]
  1> 	at org.elasticsearch.indices.recovery.RecoveryTarget.closeInternal(RecoveryTarget.java:330) ~[main/:?]
  1> 	at org.elasticsearch.common.util.concurrent.AbstractRefCounted.decRef(AbstractRefCounted.java:64) ~[main/:?]
  1> 	at org.elasticsearch.indices.recovery.RecoveryTarget.resetRecovery(RecoveryTarget.java:193) ~[main/:?]
  1> 	at org.elasticsearch.indices.recovery.RecoveriesCollection.lambda$resetRecovery$306(RecoveriesCollection.java:113) ~[main/:?]
  1> 	at org.elasticsearch.common.util.CancellableThreads.executeIO(CancellableThreads.java:105) ~[main/:?]
  1> 	at org.elasticsearch.indices.recovery.RecoveriesCollection.resetRecovery(RecoveriesCollection.java:113) ~[main/:?]
  1> 	at org.elasticsearch.indices.recovery.PeerRecoveryTargetService.retryRecovery(PeerRecoveryTargetService.java:156) ~[main/:?]
  1> 	at org.elasticsearch.indices.recovery.PeerRecoveryTargetService.retryRecovery(PeerRecoveryTargetService.java:152) ~[main/:?]
  1> 	at org.elasticsearch.indices.recovery.PeerRecoveryTargetService.doRecovery(PeerRecoveryTargetService.java:289) ~[main/:?]
  1> 	at org.elasticsearch.indices.recovery.PeerRecoveryTargetService.access$900(PeerRecoveryTargetService.java:73) ~[main/:?]
  1> 	at org.elasticsearch.indices.recovery.PeerRecoveryTargetService$RecoveryRunner.doRun(PeerRecoveryTargetService.java:555) ~[main/:?]
  1> 	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:527) ~[main/:?]
  1> 	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) ~[main/:?]
  1> 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[?:1.8.0_60]
  1> 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[?:1.8.0_60]
  1> 	at java.lang.Thread.run(Thread.java:745) ~[?:1.8.0_60]
```