### PR TITLE
Backport gradle changes made in #22371

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -21,6 +21,7 @@ package org.elasticsearch.gradle
 import nebula.plugin.extraconfigurations.ProvidedBasePlugin
 import org.elasticsearch.gradle.precommit.PrecommitTasks
 import org.gradle.api.GradleException
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -54,6 +55,9 @@ class BuildPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
+        if (project.pluginManager.hasPlugin('elasticsearch.standalone-test')) {
+              throw new InvalidUserDataException('elasticsearch.standalone-test and elasticsearch.build are mutually exclusive')
+        }
         project.pluginManager.apply('java')
         project.pluginManager.apply('carrotsearch.randomized-testing')
         // these plugins add lots of info to our jars

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -55,8 +55,10 @@ class BuildPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        if (project.pluginManager.hasPlugin('elasticsearch.standalone-test')) {
-              throw new InvalidUserDataException('elasticsearch.standalone-test and elasticsearch.build are mutually exclusive')
+        if (project.pluginManager.hasPlugin('elasticsearch.standalone-rest-test')) {
+              throw new InvalidUserDataException('elasticsearch.standalone-test, '
+                + 'elasticearch.standalone-rest-test, and elasticsearch.build '
+                + 'are mutually exclusive')
         }
         project.pluginManager.apply('java')
         project.pluginManager.apply('carrotsearch.randomized-testing')

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
@@ -30,6 +30,7 @@ public class DocsTestPlugin extends RestTestPlugin {
 
     @Override
     public void apply(Project project) {
+        project.pluginManager.apply('elasticsearch.standalone-test')
         super.apply(project)
         Map<String, String> defaultSubstitutions = [
             /* These match up with the asciidoc syntax for substitutions but

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
@@ -30,7 +30,7 @@ public class DocsTestPlugin extends RestTestPlugin {
 
     @Override
     public void apply(Project project) {
-        project.pluginManager.apply('elasticsearch.standalone-test')
+        project.pluginManager.apply('elasticsearch.standalone-rest-test')
         super.apply(project)
         Map<String, String> defaultSubstitutions = [
             /* These match up with the asciidoc syntax for substitutions but

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestTestPlugin.groovy
@@ -18,15 +18,29 @@
  */
 package org.elasticsearch.gradle.test
 
+import org.elasticsearch.gradle.BuildPlugin
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-/** A plugin to add rest integration tests. Used for qa projects.  */
+/**
+ * Adds support for starting an Elasticsearch cluster before running integration
+ * tests. Used in conjunction with {@link StandaloneTestBasePlugin} for qa
+ * projects and in conjunction with {@link BuildPlugin} for testing the rest
+ * client.
+ */
 public class RestTestPlugin implements Plugin<Project> {
+    List REQUIRED_PLUGINS = [
+        'elasticsearch.build',
+        'elasticsearch.standalone-test']
 
     @Override
     public void apply(Project project) {
-        project.pluginManager.apply(StandaloneTestBasePlugin)
+        if (false == REQUIRED_PLUGINS.any {project.pluginManager.hasPlugin(it)}) {
+            throw new InvalidUserDataException('elasticsearch.rest-test '
+                + 'requires either elasticsearch.build or '
+                + 'elasticsearch.standalone-test')
+        }
 
         RestIntegTestTask integTest = project.tasks.create('integTest', RestIntegTestTask.class)
         integTest.cluster.distribution = 'zip' // rest tests should run with the real zip

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestTestPlugin.groovy
@@ -25,14 +25,14 @@ import org.gradle.api.Project
 
 /**
  * Adds support for starting an Elasticsearch cluster before running integration
- * tests. Used in conjunction with {@link StandaloneTestBasePlugin} for qa
+ * tests. Used in conjunction with {@link StandaloneRestTestPlugin} for qa
  * projects and in conjunction with {@link BuildPlugin} for testing the rest
  * client.
  */
 public class RestTestPlugin implements Plugin<Project> {
     List REQUIRED_PLUGINS = [
         'elasticsearch.build',
-        'elasticsearch.standalone-test']
+        'elasticsearch.standalone-rest-test']
 
     @Override
     public void apply(Project project) {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneRestTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneRestTestPlugin.groovy
@@ -29,13 +29,19 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaBasePlugin
 
-/** Configures the build to have a rest integration test.  */
-public class StandaloneTestBasePlugin implements Plugin<Project> {
+/**
+ * Configures the build to compile tests against Elasticsearch's test framework
+ * and run REST tests. Use BuildPlugin if you want to build main code as well
+ * as tests.
+ */
+public class StandaloneRestTestPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
         if (project.pluginManager.hasPlugin('elasticsearch.build')) {
-            throw new InvalidUserDataException('elasticsearch.standalone-test and elasticsearch.build are mutually exclusive')
+            throw new InvalidUserDataException('elasticsearch.standalone-test, '
+                + 'elasticsearch.standalone-test, and elasticsearch.build are '
+                + 'mutually exclusive')
         }
         project.pluginManager.apply(JavaBasePlugin)
         project.pluginManager.apply(RandomizedTestingPlugin)

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneTestBasePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneTestBasePlugin.groovy
@@ -24,6 +24,7 @@ import com.carrotsearch.gradle.junit4.RandomizedTestingPlugin
 import org.elasticsearch.gradle.BuildPlugin
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.precommit.PrecommitTasks
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaBasePlugin
@@ -33,6 +34,9 @@ public class StandaloneTestBasePlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        if (project.pluginManager.hasPlugin('elasticsearch.build')) {
+            throw new InvalidUserDataException('elasticsearch.standalone-test and elasticsearch.build are mutually exclusive')
+        }
         project.pluginManager.apply(JavaBasePlugin)
         project.pluginManager.apply(RandomizedTestingPlugin)
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneTestPlugin.groovy
@@ -25,12 +25,15 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaBasePlugin
 
-/** A plugin to add tests only. Used for QA tests that run arbitrary unit tests. */
+/**
+ * Configures the build to compile against Elasticsearch's test framework and
+ * run integration and unit tests. Use BuildPlugin if you want to build main
+ * code as well as tests. */
 public class StandaloneTestPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        project.pluginManager.apply(StandaloneTestBasePlugin)
+        project.pluginManager.apply(StandaloneRestTestPlugin)
 
         Map testOptions = [
             name: 'test',

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/elasticsearch.standalone-rest-test.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/elasticsearch.standalone-rest-test.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+implementation-class=org.elasticsearch.gradle.test.StandaloneRestTestPlugin

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -1,5 +1,5 @@
 /*
- // * Licensed to Elasticsearch under one or more contributor
+ * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright
  * ownership. Elasticsearch licenses this file to you under

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Licensed to Elasticsearch under one or more contributor
+ // * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright
  * ownership. Elasticsearch licenses this file to you under
@@ -104,7 +104,7 @@ subprojects {
   /*****************************************************************************
    *                            Rest test config                               *
    *****************************************************************************/
-  apply plugin: 'elasticsearch.standalone-test'
+  apply plugin: 'elasticsearch.standalone-rest-test'
   apply plugin: 'elasticsearch.rest-test'
   project.integTest {
     dependsOn project.assemble

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -79,7 +79,7 @@ project.rootProject.subprojects.findAll { it.path.startsWith(':modules:') }.each
   restTestExpansions['expected.modules.count'] += 1
 }
 
-// Integ tests work over the rest http layer, so we need a transport included with the integ test zip. 
+// Integ tests work over the rest http layer, so we need a transport included with the integ test zip.
 // All transport modules are included so that they may be randomized for testing
 task buildTransportModules(type: Sync) {
   into 'build/transport-modules'
@@ -104,6 +104,7 @@ subprojects {
   /*****************************************************************************
    *                            Rest test config                               *
    *****************************************************************************/
+  apply plugin: 'elasticsearch.standalone-test'
   apply plugin: 'elasticsearch.rest-test'
   project.integTest {
     dependsOn project.assemble
@@ -116,7 +117,7 @@ subprojects {
       mustRunAfter ':distribution:integ-test-zip:integTest#stop'
     }
   }
-  
+
   processTestResources {
     inputs.properties(project(':distribution').restTestExpansions)
     MavenFilteringHack.filter(it, project(':distribution').restTestExpansions)

--- a/qa/backwards-5.0/build.gradle
+++ b/qa/backwards-5.0/build.gradle
@@ -1,3 +1,23 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+apply plugin: 'elasticsearch.standalone-test'
 apply plugin: 'elasticsearch.rest-test'
 
 /* This project runs the core REST tests against a 2 node cluster where one of the nodes has a different minor.

--- a/qa/backwards-5.0/build.gradle
+++ b/qa/backwards-5.0/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 /* This project runs the core REST tests against a 2 node cluster where one of the nodes has a different minor.

--- a/qa/evil-tests/build.gradle
+++ b/qa/evil-tests/build.gradle
@@ -42,7 +42,7 @@ thirdPartyAudit.excludes = [
   'com.google.common.cache.Striped64$Cell',
   'com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator',
   'com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator$1',
-  
+
   // missing class
   'com.ibm.icu.lang.UCharacter',
 ]

--- a/qa/no-bootstrap-tests/build.gradle
+++ b/qa/no-bootstrap-tests/build.gradle
@@ -23,4 +23,3 @@
  */
 
 apply plugin: 'elasticsearch.standalone-test'
-

--- a/qa/smoke-test-client/build.gradle
+++ b/qa/smoke-test-client/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 // TODO: this test works, but it isn't really a rest test...should we have another plugin for "non rest test that just needs N clusters?"

--- a/qa/smoke-test-client/build.gradle
+++ b/qa/smoke-test-client/build.gradle
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+apply plugin: 'elasticsearch.standalone-test'
 apply plugin: 'elasticsearch.rest-test'
 
 // TODO: this test works, but it isn't really a rest test...should we have another plugin for "non rest test that just needs N clusters?"

--- a/qa/smoke-test-http/build.gradle
+++ b/qa/smoke-test-http/build.gradle
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+apply plugin: 'elasticsearch.standalone-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {

--- a/qa/smoke-test-http/build.gradle
+++ b/qa/smoke-test-http/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/ContextAndHeaderTransportIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/ContextAndHeaderTransportIT.java
@@ -22,7 +22,6 @@ package org.elasticsearch.http;
 import org.apache.http.message.BasicHeader;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -322,7 +321,7 @@ public class ContextAndHeaderTransportIT extends HttpSmokeTestCase {
         }
 
         @Override
-        protected boolean apply(String action, ActionRequest request, ActionListener listener) {
+        protected boolean apply(String action, ActionRequest request, ActionListener<?> listener) {
             requests.add(new RequestAndHeaders(threadPool.getThreadContext().getHeaders(), request));
             return true;
         }

--- a/qa/smoke-test-ingest-disabled/build.gradle
+++ b/qa/smoke-test-ingest-disabled/build.gradle
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+apply plugin: 'elasticsearch.standalone-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {

--- a/qa/smoke-test-ingest-disabled/build.gradle
+++ b/qa/smoke-test-ingest-disabled/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {

--- a/qa/smoke-test-ingest-with-all-dependencies/build.gradle
+++ b/qa/smoke-test-ingest-with-all-dependencies/build.gradle
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+apply plugin: 'elasticsearch.standalone-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {

--- a/qa/smoke-test-ingest-with-all-dependencies/build.gradle
+++ b/qa/smoke-test-ingest-with-all-dependencies/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {

--- a/qa/smoke-test-multinode/build.gradle
+++ b/qa/smoke-test-multinode/build.gradle
@@ -1,4 +1,23 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
+apply plugin: 'elasticsearch.standalone-test'
 apply plugin: 'elasticsearch.rest-test'
 
 integTest {

--- a/qa/smoke-test-multinode/build.gradle
+++ b/qa/smoke-test-multinode/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 integTest {

--- a/qa/smoke-test-plugins/build.gradle
+++ b/qa/smoke-test-plugins/build.gradle
@@ -19,6 +19,7 @@
 
 import org.elasticsearch.gradle.MavenFilteringHack
 
+apply plugin: 'elasticsearch.standalone-test'
 apply plugin: 'elasticsearch.rest-test'
 
 ext.pluginsCount = 0
@@ -40,4 +41,3 @@ processTestResources {
   inputs.properties(expansions)
   MavenFilteringHack.filter(it, expansions)
 }
-

--- a/qa/smoke-test-plugins/build.gradle
+++ b/qa/smoke-test-plugins/build.gradle
@@ -19,7 +19,7 @@
 
 import org.elasticsearch.gradle.MavenFilteringHack
 
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 ext.pluginsCount = 0

--- a/qa/smoke-test-reindex-with-painless/build.gradle
+++ b/qa/smoke-test-reindex-with-painless/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 integTest {

--- a/qa/smoke-test-reindex-with-painless/build.gradle
+++ b/qa/smoke-test-reindex-with-painless/build.gradle
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+apply plugin: 'elasticsearch.standalone-test'
 apply plugin: 'elasticsearch.rest-test'
 
 integTest {

--- a/qa/smoke-test-tribe-node/build.gradle
+++ b/qa/smoke-test-tribe-node/build.gradle
@@ -21,6 +21,7 @@ import org.elasticsearch.gradle.test.ClusterConfiguration
 import org.elasticsearch.gradle.test.ClusterFormationTasks
 import org.elasticsearch.gradle.test.NodeInfo
 
+apply plugin: 'elasticsearch.standalone-test'
 apply plugin: 'elasticsearch.rest-test'
 
 List<NodeInfo> oneNodes

--- a/qa/smoke-test-tribe-node/build.gradle
+++ b/qa/smoke-test-tribe-node/build.gradle
@@ -21,7 +21,7 @@ import org.elasticsearch.gradle.test.ClusterConfiguration
 import org.elasticsearch.gradle.test.ClusterFormationTasks
 import org.elasticsearch.gradle.test.NodeInfo
 
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 List<NodeInfo> oneNodes


### PR DESCRIPTION
This is the backport of the gradle changes made as part of #22371.

Backporting these gradle changes will make backporting the high level rest client submodule easier in the future when ready (it is currently under development in master), by simply copying its directory from master to 5.x ideally.