### PR TITLE
Fixed command line for development environment

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -48,7 +48,7 @@ Elasticsearch can be quickly started for development or testing use with the fol
 
 ["source","sh",subs="attributes"]
 --------------------------------------------
-docker run -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" {docker-image}
+docker run -p 9200:9200 {docker-image} -E "http.host=0.0.0.0" -E "transport.host=127.0.0.1"
 --------------------------------------------
 
 endif::[]

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -48,7 +48,7 @@ Elasticsearch can be quickly started for development or testing use with the fol
 
 ["source","sh",subs="attributes"]
 --------------------------------------------
-docker run -p 9200:9200 {docker-image} -E "http.host=0.0.0.0" -E "transport.host=127.0.0.1"
+docker run -p 9200:9200 {docker-image} -E "http.bind_host=0.0.0.0" -E "http.publish_host=127.0.0.1" -E "transport.host=127.0.0.1"
 --------------------------------------------
 
 endif::[]


### PR DESCRIPTION
-e is for environment variable which do not seems to be be used by es to override settings. -E is passed to the command, which is what we want.

The original command line does not change the elastiscsearch instance configuration.

Moreover, with this configuration http.publish_host expose the public ip of the container, thus preventing the use of a SniffingConnectionPool on the host. While not really usefull on a development machine with a single node, it avoids using different connection pool based on the environment.