### PR TITLE
Move IfConfig.logIfNecessary call into bootstrap

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.network.IfConfig;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.env.Environment;
@@ -206,6 +207,9 @@ final class Bootstrap {
         } catch (IOException | URISyntaxException e) {
             throw new BootstrapException(e);
         }
+
+        // Log ifconfig output before SecurityManager is installed
+        IfConfig.logIfNecessary();
 
         // install SM after natives, shutdown hooks, etc.
         try {

--- a/core/src/main/java/org/elasticsearch/common/network/IfConfig.java
+++ b/core/src/main/java/org/elasticsearch/common/network/IfConfig.java
@@ -34,17 +34,17 @@ import java.util.Locale;
 /**
  * Simple class to log {@code ifconfig}-style output at DEBUG logging.
  */
-final class IfConfig {
+public final class IfConfig {
 
     private static final Logger logger = Loggers.getLogger(IfConfig.class);
     private static final String INDENT = "        ";
 
     /** log interface configuration at debug level, if its enabled */
-    static void logIfNecessary() {
+    public static void logIfNecessary() {
         if (logger.isDebugEnabled()) {
             try {
                 doLogging();
-            } catch (IOException | SecurityException e) {
+            } catch (IOException e) {
                 logger.warn("unable to gather network information", e);
             }
         }

--- a/core/src/main/java/org/elasticsearch/common/network/NetworkService.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkService.java
@@ -90,7 +90,6 @@ public class NetworkService extends AbstractComponent {
 
     public NetworkService(Settings settings, List<CustomNameResolver> customNameResolvers) {
         super(settings);
-        IfConfig.logIfNecessary();
         this.customNameResolvers = customNameResolvers;
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -25,6 +25,7 @@ import org.elasticsearch.SecureSM;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.io.PathUtils;
+import org.elasticsearch.common.network.IfConfig;
 import org.elasticsearch.plugins.PluginInfo;
 import org.junit.Assert;
 
@@ -88,6 +89,9 @@ public class BootstrapForTesting {
         } catch (Exception e) {
             throw new RuntimeException("found jar hell in test classpath", e);
         }
+
+        // Log ifconfig output before SecurityManager is installed
+        IfConfig.logIfNecessary();
 
         // install security manager if requested
         if (systemPropertyAsBoolean("tests.security.manager", true)) {


### PR DESCRIPTION
This is related to #22116. A logIfNecessary() call makes a call to
NetworkInterface.getInterfaceAddresses() which requires SocketPermission connect
privileges. By moving this to bootstrap the logging call can be made before
installing the SecurityManager.


As a note:

IFConfig and its method need to be made public in order for this to work. Another option would be to move the class into a different package - but that would cause issues as it depends on package private methods in NetworkUtils.