### PR TITLE
Add support for ca-central-1 region to EC2 and S3 plugins

### DIFF
--- a/docs/plugins/discovery-ec2.asciidoc
+++ b/docs/plugins/discovery-ec2.asciidoc
@@ -124,7 +124,7 @@ The available values are:
 * `eu-central` (`eu-central-1`) for EU (Frankfurt)
 * `sa-east` (`sa-east-1`) for South America (São Paulo)
 * `cn-north` (`cn-north-1`) for China (Beijing)
-* `ca-central-1` (`ca-central-1`) for Canada (Central)
+* `ca-central` (`ca-central-1`) for Canada (Central)
 
 [[discovery-ec2-usage-signer]]
 ===== EC2 Signer API

--- a/docs/plugins/discovery-ec2.asciidoc
+++ b/docs/plugins/discovery-ec2.asciidoc
@@ -124,6 +124,7 @@ The available values are:
 * `eu-central` (`eu-central-1`) for EU (Frankfurt)
 * `sa-east` (`sa-east-1`) for South America (São Paulo)
 * `cn-north` (`cn-north-1`) for China (Beijing)
+* `ca-central-1` (`ca-central-1`) for Canada (Central)
 
 [[discovery-ec2-usage-signer]]
 ===== EC2 Signer API

--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -129,7 +129,7 @@ The available values are:
 * `eu-central` (`eu-central-1`) for EU (Frankfurt)
 * `sa-east` (`sa-east-1`) for South America (São Paulo)
 * `cn-north` (`cn-north-1`) for China (Beijing)
-* `ca-central-1` (`ca-central-1`) for Canada (Central)
+* `ca-central` (`ca-central-1`) for Canada (Central)
 
 [[repository-s3-usage-signer]]
 ===== S3 Signer API

--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -129,6 +129,7 @@ The available values are:
 * `eu-central` (`eu-central-1`) for EU (Frankfurt)
 * `sa-east` (`sa-east-1`) for South America (São Paulo)
 * `cn-north` (`cn-north-1`) for China (Beijing)
+* `ca-central-1` (`ca-central-1`) for Canada (Central)
 
 [[repository-s3-usage-signer]]
 ===== S3 Signer API

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2ServiceImpl.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2ServiceImpl.java
@@ -193,6 +193,7 @@ public class AwsEc2ServiceImpl extends AbstractComponent implements AwsEc2Servic
                 case "cn-north-1":
                     endpoint = "ec2.cn-north-1.amazonaws.com.cn";
                     break;
+                case "ca-central":
                 case "ca-central-1":
                     endpoint = "ec2.ca-central-1.amazonaws.com";
                     break;

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2ServiceImpl.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2ServiceImpl.java
@@ -193,6 +193,9 @@ public class AwsEc2ServiceImpl extends AbstractComponent implements AwsEc2Servic
                 case "cn-north-1":
                     endpoint = "ec2.cn-north-1.amazonaws.com.cn";
                     break;
+                case "ca-central-1":
+                    endpoint = "ec2.ca-central-1.amazonaws.com";
+                    break;
                 default:
                     throw new IllegalArgumentException("No automatic endpoint could be derived from region [" + region + "]");
             }

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -221,6 +221,7 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent implements 
             case "us-gov-west-1":
                 endpoint = "s3-us-gov-west-1.amazonaws.com";
                 break;
+            case "ca-central":
             case "ca-central-1":
                 endpoint = "s3.ca-central-1.amazonaws.com";
                 break;

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -221,6 +221,9 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent implements 
             case "us-gov-west-1":
                 endpoint = "s3-us-gov-west-1.amazonaws.com";
                 break;
+            case "ca-central-1":
+                endpoint = "s3.ca-central-1.amazonaws.com";
+                break;
             default:
                 throw new IllegalArgumentException("No automatic endpoint could be derived from region [" + region + "]");
         }


### PR DESCRIPTION
Someone else also submitted a merge/pull request (https://github.com/elastic/elasticsearch/pull/22457), please consider this one since I filed the request. Thank you.

Closes #22454.