### PR TITLE
Adds removed inQuery method alternative

### DIFF
--- a/docs/reference/migration/migrate_2_0/java.asciidoc
+++ b/docs/reference/migration/migrate_2_0/java.asciidoc
@@ -73,7 +73,7 @@ In addition some query builders have been removed or renamed:
 * `textPhrasePrefix(...)` removed
 * `textPhrasePrefixQuery(...)` removed
 * `filtered(...)` removed. Use `filteredQuery(...)` instead.
-* `inQuery(...)` removed.
+* `inQuery(...)` removed. Use `termsQuery(...)` instead.
 
 ==== GetIndexRequest
 


### PR DESCRIPTION
When I migrated from ES 1.7 to 5.1, I have found that there is no described alternative to `inQuery` function in the docs. After some investigation i found #13145, where someone wrote that `termsQuery` should  be used instead.