### PR TITLE
[TEST] Fixed the incorrect indentation for the `skip` clauses in the REST tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yaml
@@ -61,8 +61,8 @@
 ---
 "Test cat nodes output with full_id set":
   - skip:
-    version: " - 5.0.0"
-    reason:  The full_id setting was rejected in 5.0.0 see #21266
+      version: " - 5.0.0"
+      reason:  The full_id setting was rejected in 5.0.0 see #21266
 
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/field_stats/10_basics.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/field_stats/10_basics.yaml
@@ -164,8 +164,8 @@ setup:
 ---
 "Geopoint field stats with level set to indices":
   - skip:
-    version: " - 5.2.0"
-    reason:  geo_point fields don't return min/max for versions greater than 5.2.0
+      version: " - 5.2.0"
+      reason:  geo_point fields don't return min/max for versions greater than 5.2.0
 
   - do:
       field_stats:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_template/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_template/10_basic.yaml
@@ -12,8 +12,8 @@ setup:
 "Get template":
 
   - skip:
-    version: " - 5.99.99"
-    reason:  this uses a new API that has been added in 6.0
+      version: " - 5.99.99"
+      reason:  this uses a new API that has been added in 6.0
 
   - do:
       indices.get_template:
@@ -26,8 +26,8 @@ setup:
 "Get all templates":
 
   - skip:
-    version: " - 5.99.99"
-    reason:  this uses a new API that has been added in 6.0
+      version: " - 5.99.99"
+      reason:  this uses a new API that has been added in 6.0
 
   - do:
       indices.put_template:
@@ -47,8 +47,8 @@ setup:
 "Get template with local flag":
 
   - skip:
-    version: " - 5.99.99"
-    reason:  this uses a new API that has been added in 6.0
+      version: " - 5.99.99"
+      reason:  this uses a new API that has been added in 6.0
 
   - do:
       indices.get_template:
@@ -61,8 +61,8 @@ setup:
 "Get template with flat settings and master timeout":
 
   - skip:
-    version: " - 5.99.99"
-    reason:  this uses a new API that has been added in 6.0
+      version: " - 5.99.99"
+      reason:  this uses a new API that has been added in 6.0
 
   - do:
       indices.get_template:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_template/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_template/10_basic.yaml
@@ -2,8 +2,8 @@
 "Put template":
 
   - skip:
-    version: " - 5.99.99"
-    reason:  this uses a new API that has been added in 6.0
+      version: " - 5.99.99"
+      reason:  this uses a new API that has been added in 6.0
 
   - do:
       indices.put_template:
@@ -26,8 +26,8 @@
 "Put multiple template":
 
   - skip:
-    version: " - 5.99.99"
-    reason:  this uses a new API that has been added in 6.0
+      version: " - 5.99.99"
+      reason:  this uses a new API that has been added in 6.0
 
   - do:
       indices.put_template:
@@ -50,8 +50,8 @@
 "Put template with aliases":
 
   - skip:
-    version: " - 5.99.99"
-    reason:  this uses a new API that has been added in 6.0
+      version: " - 5.99.99"
+      reason:  this uses a new API that has been added in 6.0
 
   - do:
       indices.put_template:
@@ -78,8 +78,8 @@
 "Put template create":
 
   - skip:
-    version: " - 5.99.99"
-    reason:  this uses a new API that has been added in 6.0
+      version: " - 5.99.99"
+      reason:  this uses a new API that has been added in 6.0
 
   - do:
       indices.put_template:
@@ -114,8 +114,8 @@
 "Test Put Versioned Template":
 
   - skip:
-    version: " - 5.99.99"
-    reason:  this uses a new API that has been added in 6.0
+      version: " - 5.99.99"
+      reason:  this uses a new API that has been added in 6.0
 
   - do:
       indices.put_template:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.upgrade/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.upgrade/10_basic.yaml
@@ -19,8 +19,8 @@
 ---
 "Upgrade indices ignore unavailable":
   - skip:
-    version: " - 5.0.0"
-    reason: ignore_unavailable was added as a bugfix in 5.0.1 see #21281
+      version: " - 5.0.0"
+      reason: ignore_unavailable was added as a bugfix in 5.0.1 see #21281
 
   - do:
       indices.create:
@@ -44,8 +44,8 @@
 "Upgrade indices allow no indices":
 
   - skip:
-    version: " - 5.0.0"
-    reason: ignore_unavailable was added as a bugfix in 5.0.1 see #21281
+      version: " - 5.0.0"
+      reason: ignore_unavailable was added as a bugfix in 5.0.1 see #21281
 
   - do:
       indices.upgrade:
@@ -59,8 +59,8 @@
 "Upgrade indices disallow no indices":
 
   - skip:
-    version: " - 5.0.0"
-    reason: ignore_unavailable was added as a bugfix in 5.0.1 see #21281
+      version: " - 5.0.0"
+      reason: ignore_unavailable was added as a bugfix in 5.0.1 see #21281
 
   - do:
       catch: missing
@@ -73,8 +73,8 @@
 "Upgrade indices disallow unavailable":
 
   - skip:
-    version: " - 5.0.0"
-    reason: ignore_unavailable was added as a bugfix in 5.0.1 see #21281
+      version: " - 5.0.0"
+      reason: ignore_unavailable was added as a bugfix in 5.0.1 see #21281
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yaml
@@ -288,8 +288,8 @@ setup:
 ---
 "Scaled float test":
   - skip:
-    version: " - 5.2.0"
-    reason:  scaled_float were considered as longs in aggregations, this was fixed in 5.2.0
+      version: " - 5.2.0"
+      reason:  scaled_float were considered as longs in aggregations, this was fixed in 5.2.0
 
   - do:
       index:
@@ -409,9 +409,9 @@ setup:
 "Partitioned string test":
 
   - skip:
-    version: " - 5.1.99"
-    reason:  Partitioning is a 5.2.0 feature
-    
+      version: " - 5.1.99"
+      reason:  Partitioning is a 5.2.0 feature
+
   - do:
       index:
         index: test_1
@@ -468,8 +468,8 @@ setup:
 "Partitioned integer test":
 
   - skip:
-    version: " - 5.1.99"
-    reason:  Partitioning is a 5.2.0 feature
+      version: " - 5.1.99"
+      reason:  Partitioning is a 5.2.0 feature
 
   - do:
       index:
@@ -650,7 +650,7 @@ setup:
       index:
         index: test_1
         type: test
-        id: 1 
+        id: 1
         body: {}
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/50_filter.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/50_filter.yaml
@@ -36,8 +36,8 @@ setup:
 ---
 "Filter aggs with terms lookup ensure not cached":
   - skip:
-    version: " - 5.0.0"
-    reason:  This using filter aggs that needs rewriting, this was fixed in 5.0.1
+      version: " - 5.0.0"
+      reason:  This using filter aggs that needs rewriting, this was fixed in 5.0.1
 
   - do:
       search:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/60_filters.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/60_filters.yaml
@@ -39,8 +39,8 @@ setup:
 ---
 "Filters aggs with wrapper query":
   - skip:
-    version: " - 5.1.1"
-    reason:  Using filters aggs that needs rewriting, this was fixed in 5.1.2
+      version: " - 5.1.1"
+      reason:  Using filters aggs that needs rewriting, this was fixed in 5.1.2
 
   - do:
       search:


### PR DESCRIPTION
This patch fixes the incorrect indentation in the REST tests, which makes tests in language runners (eg. Ruby, Python) to fail, since the skip clause is parsed as an empty value. Tha Java YAML parser is smarter/lenient about whitespace, so it doesn't catch this.
