### PR TITLE
[TESTS] Create vagrant up task for all boxes

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -430,14 +430,32 @@ cd $BATS_ARCHIVES
 sudo -E bats $BATS_TESTS/*.bats
 -------------------------------------------------
 
-Note: Starting vagrant VM outside of the elasticsearch folder requires to
-indicates the folder that contains the Vagrantfile using the VAGRANT_CWD
-environment variable:
+You can also use Gradle to prepare the test environment and then starts a single VM:
 
 -------------------------------------------------
-gradle vagrantSetUp
-VAGRANT_CWD=/path/to/elasticsearch vagrant up centos-7 --provider virtualbox
+gradle vagrantFedora24#up
 -------------------------------------------------
+
+Or any of vagrantCentos6#up, vagrantDebian8#up, vagrantFedora24#up, vagrantOel6#up,
+vagrantOel7#up, vagrantOpensuse13#up, vagrantSles12#up, vagrantUbuntu1204#up,
+vagrantUbuntu1604#up.
+
+Once up, you can then connect to the VM using SSH from the elasticsearch directory:
+
+-------------------------------------------------
+vagrant ssh fedora-24
+-------------------------------------------------
+
+Or from another directory:
+
+-------------------------------------------------
+VAGRANT_CWD=/path/to/elasticsearch vagrant ssh fedora-24
+-------------------------------------------------
+
+Note: Starting vagrant VM outside of the elasticsearch folder requires to
+indicates the folder that contains the Vagrantfile using the VAGRANT_CWD
+environment variable.
+
 
 == Coverage analysis
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -404,10 +404,6 @@ class VagrantTestPlugin implements Plugin<Project> {
                 args 'halt', box
             }
             stop.dependsOn(halt)
-            if (project.extensions.esvagrant.boxes.contains(box) == false) {
-                // we only need a halt task if this box was not specified
-                continue;
-            }
 
             Task update = project.tasks.create("vagrant${boxTask}#update", VagrantCommandTask) {
                 boxName box
@@ -433,6 +429,11 @@ class VagrantTestPlugin implements Plugin<Project> {
                 /* It'd be possible to check if the box is already up here and output
                   SKIPPED but that would require running vagrant status which is slow! */
                 dependsOn update
+            }
+
+            if (project.extensions.esvagrant.boxes.contains(box) == false) {
+                // we d'ont need tests tasks if this box was not specified
+                continue;
             }
 
             Task smoke = project.tasks.create("vagrant${boxTask}#smoketest", Exec) {


### PR DESCRIPTION
Currently, such tasks are only created for default boxes (`centos-7`, `ubuntu-1404`) and not for all boxes. This can be misleading for developers who want to debug testing scripts on non-default boxes like Fedora 24.