### PR TITLE
Add setting to FsRepository to disable O_EXCL file creation flag

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobStore.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobStore.java
@@ -39,11 +39,14 @@ public class FsBlobStore extends AbstractComponent implements BlobStore {
 
     private final int bufferSizeInBytes;
 
-    public FsBlobStore(Settings settings, Path path) throws IOException {
+    private final boolean writeOnce;
+
+    public FsBlobStore(Settings settings, Path path, boolean writeOnce) throws IOException {
         super(settings);
         this.path = path;
         Files.createDirectories(path);
         this.bufferSizeInBytes = (int) settings.getAsBytesSize("repositories.fs.buffer_size", new ByteSizeValue(100, ByteSizeUnit.KB)).getBytes();
+        this.writeOnce = writeOnce;
     }
 
     @Override
@@ -57,6 +60,10 @@ public class FsBlobStore extends AbstractComponent implements BlobStore {
 
     public int bufferSizeInBytes() {
         return this.bufferSizeInBytes;
+    }
+
+    public boolean writeOnce() {
+        return writeOnce;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -180,6 +180,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     FsRepository.REPOSITORIES_CHUNK_SIZE_SETTING,
                     FsRepository.REPOSITORIES_COMPRESS_SETTING,
                     FsRepository.REPOSITORIES_LOCATION_SETTING,
+                    FsRepository.REPOSITORIES_ENFORCE_WRITE_ONCE_SETTING,
                     IndicesQueryCache.INDICES_CACHE_QUERY_SIZE_SETTING,
                     IndicesQueryCache.INDICES_CACHE_QUERY_COUNT_SETTING,
                     IndicesQueryCache.INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING,

--- a/core/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
@@ -61,6 +61,8 @@ public class FsRepository extends BlobStoreRepository {
     public static final Setting<Boolean> COMPRESS_SETTING = Setting.boolSetting("compress", false, Property.NodeScope);
     public static final Setting<Boolean> REPOSITORIES_COMPRESS_SETTING =
         Setting.boolSetting("repositories.fs.compress", false, Property.NodeScope);
+    public static final Setting<Boolean> REPOSITORIES_ENFORCE_WRITE_ONCE_SETTING =
+        Setting.boolSetting("repositories.fs.enforce_write_once", true, Property.NodeScope);
 
     private final FsBlobStore blobStore;
 
@@ -92,7 +94,7 @@ public class FsRepository extends BlobStoreRepository {
             }
         }
 
-        blobStore = new FsBlobStore(settings, locationFile);
+        blobStore = new FsBlobStore(settings, locationFile, REPOSITORIES_ENFORCE_WRITE_ONCE_SETTING.get(metadata.settings()));
         if (CHUNK_SIZE_SETTING.exists(metadata.settings())) {
             this.chunkSize = CHUNK_SIZE_SETTING.get(metadata.settings());
         } else if (REPOSITORIES_CHUNK_SIZE_SETTING.exists(settings)) {

--- a/core/src/test/java/org/elasticsearch/common/blobstore/FsBlobStoreContainerTests.java
+++ b/core/src/test/java/org/elasticsearch/common/blobstore/FsBlobStoreContainerTests.java
@@ -33,6 +33,6 @@ public class FsBlobStoreContainerTests extends ESBlobStoreContainerTestCase {
     protected BlobStore newBlobStore() throws IOException {
         Path tempDir = createTempDir();
         Settings settings = randomBoolean() ? Settings.EMPTY : Settings.builder().put("buffer_size", new ByteSizeValue(randomIntBetween(1, 100), ByteSizeUnit.KB)).build();
-        return new FsBlobStore(settings, tempDir);
+        return new FsBlobStore(settings, tempDir, randomBoolean());
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/blobstore/FsBlobStoreTests.java
+++ b/core/src/test/java/org/elasticsearch/common/blobstore/FsBlobStoreTests.java
@@ -33,6 +33,6 @@ public class FsBlobStoreTests extends ESBlobStoreTestCase {
     protected BlobStore newBlobStore() throws IOException {
         Path tempDir = createTempDir();
         Settings settings = randomBoolean() ? Settings.EMPTY : Settings.builder().put("buffer_size", new ByteSizeValue(randomIntBetween(1, 100), ByteSizeUnit.KB)).build();
-        return new FsBlobStore(settings, tempDir);
+        return new FsBlobStore(settings, tempDir, randomBoolean());
     }
 }

--- a/core/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatIT.java
@@ -211,7 +211,7 @@ public class BlobStoreFormatIT extends AbstractSnapshotIntegTestCase {
 
     protected BlobStore createTestBlobStore() throws IOException {
         Settings settings = Settings.builder().build();
-        return new FsBlobStore(settings, randomRepoPath());
+        return new FsBlobStore(settings, randomRepoPath(), randomBoolean());
     }
 
     protected void randomCorruption(BlobContainer blobContainer, String blobName) throws IOException {

--- a/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -138,6 +138,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 .setType("fs").setSettings(Settings.builder()
                         .put("location", randomRepoPath())
                         .put("compress", randomBoolean())
+                        .put("enforce_write_once", randomBoolean())
                         .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)));
 
         createIndex("test-idx-1", "test-idx-2", "test-idx-3");


### PR DESCRIPTION
ES v5.0.0+ uses the `O_EXCL | O_CREAT` file creation flags when writing snapshot blobs to ensure that existing files in the repository are not mistakenly overridden. Some NFS implementations have issues with the `O_EXCL` file creation flag though. This commit adds a FS-repository setting `enforce_write_once` (default `true`) that provides the possibility to revert to the pre-v5.0.0 file creation flags.