### PR TITLE
Allow token-count type to calculate sum of integer strings

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldsIntegrationIT.java
@@ -138,6 +138,7 @@ public class MultiFieldsIntegrationIT extends ESIntegTestCase {
                                 .startObject("a")
                                 .field("type", "token_count")
                                 .field("analyzer", "simple")
+                                .field("is_number", false)
                                 .startObject("fields")
                                 .startObject("b")
                                 .field("type", "keyword")
@@ -153,7 +154,7 @@ public class MultiFieldsIntegrationIT extends ESIntegTestCase {
         assertThat(mappingMetaData, not(nullValue()));
         Map<String, Object> mappingSource = mappingMetaData.sourceAsMap();
         Map aField = ((Map) XContentMapValues.extractValue("properties.a", mappingSource));
-        assertThat(aField.size(), equalTo(3));
+        assertThat(aField.size(), equalTo(4));
         assertThat(aField.get("type").toString(), equalTo("token_count"));
         assertThat(aField.get("fields"), notNullValue());
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/TokenCountFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/TokenCountFieldMapperTests.java
@@ -102,6 +102,39 @@ public class TokenCountFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(TokenCountFieldMapper.countPositions(analyzer, "", ""), equalTo(7));
     }
 
+
+    public void testCountSum() throws IOException {
+        Token t1 = new Token("100", 0, 3);
+        Token t2 = new Token("200", 0, 3);
+        Token t3 = new Token("300", 0, 3);
+        Token[] tokens = new Token[] {t1, t2, t3};
+        Collections.shuffle(Arrays.asList(tokens), random());
+        final TokenStream tokenStream = new CannedTokenStream(0, 0, tokens);
+        Analyzer analyzer = new Analyzer() {
+            @Override
+            public TokenStreamComponents createComponents(String fieldName) {
+                return new TokenStreamComponents(new MockTokenizer(), tokenStream);
+            }
+        };
+        assertThat(TokenCountFieldMapper.countSum(analyzer, "", ""), equalTo(600));
+    }
+
+    public void testCountSumWithNotANumber() throws IOException {
+        Token t1 = new Token("100", 0, 3);
+        Token t2 = new Token("NaN", 0, 3);
+        Token t3 = new Token("300", 0, 3);
+        Token[] tokens = new Token[] {t1, t2, t3};
+        Collections.shuffle(Arrays.asList(tokens), random());
+        final TokenStream tokenStream = new CannedTokenStream(0, 0, tokens);
+        Analyzer analyzer = new Analyzer() {
+            @Override
+            public TokenStreamComponents createComponents(String fieldName) {
+                return new TokenStreamComponents(new MockTokenizer(), tokenStream);
+            }
+        };
+        assertThat(TokenCountFieldMapper.countSum(analyzer, "", ""), equalTo(-1));
+    }
+
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
         return pluginList(InternalSettingsPlugin.class);

--- a/docs/reference/mapping/types/token-count.asciidoc
+++ b/docs/reference/mapping/types/token-count.asciidoc
@@ -55,6 +55,53 @@ counting tokens. This means that even if the analyzer filters out stop
 words they are included in the count.
 ===================================================================
 
+==== Calculate sum of tokens
+
+With `is_number` option to true, the `token_count` field would convert tokens
+provided by analyzer into integers, calculate sum, then indexes with this sum
+value.
+
+For instance:
+
+[source,js]
+--------------------------------------------------
+PUT my_index
+{
+  "mappings": {
+    "my_type": {
+      "properties": {
+        "rainfall": {
+          "type": "text",
+          "fields": {
+            "amount": {
+              "type":     "token_count",
+              "is_number": true,
+              "analyzer": "standard"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+PUT my_index/my_type/1
+{ "rainfall": "10 20 50" }
+
+PUT my_index/my_type/2
+{ "rainfall": "10 20 30 20 10 10" }
+
+GET my_index/_search
+{
+  "query": {
+    "term": {
+      "rainfall.amount": 100
+    }
+  }
+}
+--------------------------------------------------
+// CONSOLE
+
 [[token-count-params]]
 ==== Parameters for `token_count` fields
 
@@ -67,6 +114,12 @@ The following parameters are accepted by `token_count` fields:
     The <<analysis,analyzer>> which should be used to analyze the string
     value. Required. For best performance, use an analyzer without token
     filters.
+
+<<is_number,`is_number`>>::
+
+    Whether or not the tokens provided by the analyzer are integer numbers.
+    If `true`, the sum of all token is calculated for indexing. Accepts
+    `true` or `false` (default).
 
 <<mapping-boost,`boost`>>::
 


### PR DESCRIPTION
We need this feature for adding customized dictionary information on fields. We are developing project related to Chinese text analysis, and the Chinese text's analysis accuracy is highly depends on content of dictionary, and it is everyday updated, and documents needed re-index periodically.

With dictionary information in field as a integer, we can apply our re-index stragey on per document basics.
