### PR TITLE
Lucene with Java 1.9 doesn't support unmap in MMapDirectory until Lucene 6.4.0

### DIFF
--- a/core/src/test/java/org/elasticsearch/common/lucene/LuceneTests.java
+++ b/core/src/test/java/org/elasticsearch/common/lucene/LuceneTests.java
@@ -406,7 +406,7 @@ public class LuceneTests extends ESTestCase {
      */
     public void testMMapHackSupported() throws Exception {
         // add assume's here if needed for certain platforms, but we should know if it does not work.
-        assumeTrue("Lucene 6.3.0 doesn't support unmap with Java 9", Constants.JVM_SPEC_VERSION.startsWith("1.9") == false);
+        assumeTrue("Lucene 6.3.0 doesn't support unmap with Java 9", Constants.JRE_IS_MINIMUM_JAVA9 == false);
         assertTrue("MMapDirectory does not support unmapping: " + MMapDirectory.UNMAP_NOT_SUPPORTED_REASON, MMapDirectory.UNMAP_SUPPORTED);
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/lucene/LuceneTests.java
+++ b/core/src/test/java/org/elasticsearch/common/lucene/LuceneTests.java
@@ -43,6 +43,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.store.MockDirectoryWrapper;
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -405,6 +406,7 @@ public class LuceneTests extends ESTestCase {
      */
     public void testMMapHackSupported() throws Exception {
         // add assume's here if needed for certain platforms, but we should know if it does not work.
+        assumeTrue("Lucene 6.3.0 doesn't support unmap with Java 9", Constants.JVM_SPEC_VERSION.startsWith("1.9") == false);
         assertTrue("MMapDirectory does not support unmapping: " + MMapDirectory.UNMAP_NOT_SUPPORTED_REASON, MMapDirectory.UNMAP_SUPPORTED);
     }
 }


### PR DESCRIPTION
The Java APIs for unmapping are changing, and Lucene 6.4.0 will support it correctly, so until then we need an assume in this test case.

See https://issues.apache.org/jira/browse/LUCENE-6989 for details.

Closes #22495
