### PR TITLE
Remove content type detection from reindex-from-remote

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSource.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSource.java
@@ -42,14 +42,12 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.reindex.ScrollableHitSource;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
@@ -165,16 +163,9 @@ public class RemoteScrollableHitSource extends ScrollableHitSource {
                                  xContentType = XContentType.fromMediaTypeOrFormat(responseEntity.getContentType().getValue());
                             }
                             if (xContentType == null) {
-                                //auto-detect as a fallback
-                                if (false == content.markSupported()) {
-                                    content = new BufferedInputStream(content);
-                                }
-                                xContentType = XContentFactory.xContentType(content);
-                            }
-                            if (xContentType == null) {
                                 try {
                                     throw new ElasticsearchException(
-                                            "Can't detect content type for response: " + bodyMessage(response.getEntity()));
+                                            "Response didn't include Content-Type: " + bodyMessage(response.getEntity()));
                                 } catch (IOException e) {
                                     ElasticsearchException ee = new ElasticsearchException("Error extracting body from response");
                                     ee.addSuppressed(e);

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSource.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSource.java
@@ -49,6 +49,7 @@ import org.elasticsearch.index.reindex.ScrollableHitSource;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
@@ -165,6 +166,9 @@ public class RemoteScrollableHitSource extends ScrollableHitSource {
                             }
                             if (xContentType == null) {
                                 //auto-detect as a fallback
+                                if (false == content.markSupported()) {
+                                    content = new BufferedInputStream(content);
+                                }
                                 xContentType = XContentFactory.xContentType(content);
                             }
                             if (xContentType == null) {

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
@@ -61,9 +61,7 @@ import org.junit.Before;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -75,6 +73,7 @@ import java.util.function.Consumer;
 
 import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
 import static org.elasticsearch.common.unit.TimeValue.timeValueMinutes;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -122,37 +121,37 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
 
     public void testLookupRemoteVersion() throws Exception {
         AtomicBoolean called = new AtomicBoolean();
-        sourceWithMockedRemoteCall(false, "main/0_20_5.json").lookupRemoteVersion(v -> {
+        sourceWithMockedRemoteCall(false, ContentType.APPLICATION_JSON, "main/0_20_5.json").lookupRemoteVersion(v -> {
             assertEquals(Version.fromString("0.20.5"), v);
             called.set(true);
         });
         assertTrue(called.get());
         called.set(false);
-        sourceWithMockedRemoteCall(false, "main/0_90_13.json").lookupRemoteVersion(v -> {
+        sourceWithMockedRemoteCall(false, ContentType.APPLICATION_JSON, "main/0_90_13.json").lookupRemoteVersion(v -> {
             assertEquals(Version.fromString("0.90.13"), v);
             called.set(true);
         });
         assertTrue(called.get());
         called.set(false);
-        sourceWithMockedRemoteCall(false, "main/1_7_5.json").lookupRemoteVersion(v -> {
+        sourceWithMockedRemoteCall(false, ContentType.APPLICATION_JSON, "main/1_7_5.json").lookupRemoteVersion(v -> {
             assertEquals(Version.fromString("1.7.5"), v);
             called.set(true);
         });
         assertTrue(called.get());
         called.set(false);
-        sourceWithMockedRemoteCall(false, "main/2_3_3.json").lookupRemoteVersion(v -> {
+        sourceWithMockedRemoteCall(false, ContentType.APPLICATION_JSON, "main/2_3_3.json").lookupRemoteVersion(v -> {
             assertEquals(Version.V_2_3_3, v);
             called.set(true);
         });
         assertTrue(called.get());
         called.set(false);
-        sourceWithMockedRemoteCall(false, "main/5_0_0_alpha_3.json").lookupRemoteVersion(v -> {
+        sourceWithMockedRemoteCall(false, ContentType.APPLICATION_JSON, "main/5_0_0_alpha_3.json").lookupRemoteVersion(v -> {
             assertEquals(Version.V_5_0_0_alpha3, v);
             called.set(true);
         });
         assertTrue(called.get());
         called.set(false);
-        sourceWithMockedRemoteCall(false, "main/with_unknown_fields.json").lookupRemoteVersion(v -> {
+        sourceWithMockedRemoteCall(false, ContentType.APPLICATION_JSON, "main/with_unknown_fields.json").lookupRemoteVersion(v -> {
             assertEquals(Version.V_5_0_0_alpha3, v);
             called.set(true);
         });
@@ -224,7 +223,6 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
         });
         assertTrue(called.get());
     }
-
 
     /**
      * Versions of Elasticsearch before 2.1.0 don't support sort:_doc and instead need to use search_type=scan. Scan doesn't return
@@ -459,8 +457,14 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
         assertFalse(called.get());
     }
 
+    public void testNoContentTypeIsError() throws Exception {
+        Exception e = expectThrows(RuntimeException.class, () ->
+                sourceWithMockedRemoteCall(false, null, "main/0_20_5.json").lookupRemoteVersion(null));
+        assertThat(e.getCause().getCause().getMessage(), containsString("Response didn't include Content-Type: body={\n  \"ok\""));
+    }
+
     private RemoteScrollableHitSource sourceWithMockedRemoteCall(String... paths) throws Exception {
-        return sourceWithMockedRemoteCall(true, paths);
+        return sourceWithMockedRemoteCall(true, ContentType.APPLICATION_JSON, paths);
     }
 
     /**
@@ -468,7 +472,8 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
      * synchronously rather than asynchronously.
      */
     @SuppressWarnings("unchecked")
-    private RemoteScrollableHitSource sourceWithMockedRemoteCall(boolean mockRemoteVersion, String... paths) throws Exception {
+    private RemoteScrollableHitSource sourceWithMockedRemoteCall(boolean mockRemoteVersion, ContentType contentType, String... paths)
+            throws Exception {
         URL[] resources = new URL[paths.length];
         for (int i = 0; i < paths.length; i++) {
             resources[i] = Thread.currentThread().getContextClassLoader().getResource("responses/" + paths[i].replace("fail:", ""));
@@ -505,27 +510,7 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
                 } else {
                     StatusLine statusLine = new BasicStatusLine(protocolVersion, 200, "");
                     HttpResponse httpResponse = new BasicHttpResponse(statusLine);
-                    final InputStream originalStream = resource.openStream();
-                    /* Randomly return a stream that doesn't support mark because the client sometimes returns one that supports it and
-                     * sometimes doesn't. */
-                    boolean supportsMark = randomBoolean();
-                    InputStream stream;
-                    if (supportsMark) {
-                        stream = new InputStream() {
-                            public boolean markSupported() {
-                                return false;
-                            }
-
-                            @Override
-                            public int read() throws IOException {
-                                return originalStream.read();
-                            }
-                        };
-                    } else {
-                        // originalStream is almost certainly a BufferedInputStream already but let's be paranoid
-                        stream = new BufferedInputStream(originalStream);
-                    }
-                    httpResponse.setEntity(new InputStreamEntity(stream, randomBoolean() ? ContentType.APPLICATION_JSON : null));
+                    httpResponse.setEntity(new InputStreamEntity(resource.openStream(), contentType));
                     futureCallback.completed(httpResponse);
                 }
                 return null;


### PR DESCRIPTION
If the remote doesn't return a content type then reindex
tried to guess the content-type. This didn't work most
of the time and produced a rather useless error message.
Given that Elasticsearch always returns the content-type
we are dropping content-type detection in favor of just
failing the request if the remote didn't return a content-type.

Closes #22329

