### PR TITLE
[TESTS] Fix GetResultTests.testGetSourceAsBytes()

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/get/GetResultTests.java
+++ b/core/src/test/java/org/elasticsearch/index/get/GetResultTests.java
@@ -83,7 +83,7 @@ public class GetResultTests extends ESTestCase {
         XContentType xContentType = randomFrom(XContentType.values());
         Tuple<GetResult, GetResult> tuple = randomGetResult(xContentType);
         GetResult getResult = tuple.v1();
-        if (getResult.isExists()) {
+        if (getResult.isExists() && getResult.isSourceEmpty() == false) {
             assertNotNull(getResult.sourceRef());
         } else {
             assertNull(getResult.sourceRef());


### PR DESCRIPTION
The document in the randomized `GetResult` can exist with no source (like if the `_source` was disabled in mappings) but the test should not always expect a non null source when the doc exists.

Related to #22386.

It can be reproduced with: 
<details>

>  gradle :core:test -Dtests.seed=9F97D124A3385FBB -Dtests.class=org.elasticsearch.index.get.GetResultTests -Dtests.method="testGetSourceAsBytes" -Dtests.security.manager=true -Dtests.locale=fr-BE -Dtests.timezone=Africa/Porto-Novo
</details>

