### PR TITLE
Apply cluster state on active master using standard publishing mechanism

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
@@ -38,6 +38,10 @@ public interface ClusterStateTaskExecutor<T> {
         return true;
     }
 
+    default boolean isPublishingTask() {
+        return true;
+    }
+
     /**
      * Callback invoked after new cluster state is published. Note that
      * this method is not invoked if the cluster state was not updated.

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
@@ -84,4 +84,9 @@ public abstract class ClusterStateUpdateTask implements ClusterStateTaskConfig, 
     public final boolean runOnlyOnMaster() {
         return true;
     }
+
+    @Override
+    public final boolean isPublishingTask() {
+        return true;
+    }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/LocalClusterUpdateTask.java
+++ b/core/src/main/java/org/elasticsearch/cluster/LocalClusterUpdateTask.java
@@ -90,4 +90,9 @@ public abstract class LocalClusterUpdateTask implements ClusterStateTaskConfig, 
     public final boolean runOnlyOnMaster() {
         return false;
     }
+
+    @Override
+    public final boolean isPublishingTask() {
+        return false;
+    }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
@@ -179,7 +179,7 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
      * Figure out if an existing scheduled reroute is good enough or whether we need to cancel and reschedule.
      */
     private void scheduleIfNeeded(long currentNanoTime, ClusterState state) {
-        assertClusterStateThread();
+        assertClusterOrMasterStateThread();
         long nextDelayNanos = UnassignedInfo.findNextDelayedAllocation(currentNanoTime, state);
         if (nextDelayNanos < 0) {
             logger.trace("no need to schedule reroute - no delayed unassigned shards");
@@ -214,7 +214,7 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
     }
 
     // protected so that it can be overridden (and disabled) by unit tests
-    protected void assertClusterStateThread() {
-        ClusterService.assertClusterStateThread();
+    protected void assertClusterOrMasterStateThread() {
+        ClusterService.assertClusterOrMasterStateThread();
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/BaseFuture.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/BaseFuture.java
@@ -63,7 +63,8 @@ public abstract class BaseFuture<V> implements Future<V> {
         assert timeout <= 0 ||
             (Transports.assertNotTransportThread(BLOCKING_OP_REASON) &&
                 ThreadPool.assertNotScheduleThread(BLOCKING_OP_REASON) &&
-                ClusterService.assertNotClusterStateUpdateThread(BLOCKING_OP_REASON));
+                ClusterService.assertNotClusterUpdateThread(BLOCKING_OP_REASON) &&
+                ClusterService.assertNotMasterUpdateThread(BLOCKING_OP_REASON));
         return sync.get(unit.toNanos(timeout));
     }
 
@@ -87,7 +88,8 @@ public abstract class BaseFuture<V> implements Future<V> {
     public V get() throws InterruptedException, ExecutionException {
         assert Transports.assertNotTransportThread(BLOCKING_OP_REASON) &&
             ThreadPool.assertNotScheduleThread(BLOCKING_OP_REASON) &&
-            ClusterService.assertNotClusterStateUpdateThread(BLOCKING_OP_REASON);
+            ClusterService.assertNotClusterUpdateThread(BLOCKING_OP_REASON) &&
+            ClusterService.assertNotMasterUpdateThread(BLOCKING_OP_REASON);
         return sync.get();
     }
 

--- a/core/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
@@ -307,7 +307,7 @@ public class NodeJoinController extends AbstractComponent {
         }
 
         private void onElectedAsMaster(ClusterState state) {
-            ClusterService.assertClusterStateThread();
+            ClusterService.assertMasterStateThread();
             assert state.nodes().isLocalNodeElectedMaster() : "onElectedAsMaster called but local node is not master";
             ElectionCallback callback = getCallback(); // get under lock
             if (callback != null) {
@@ -316,7 +316,7 @@ public class NodeJoinController extends AbstractComponent {
         }
 
         private void onFailure(Throwable t) {
-            ClusterService.assertClusterStateThread();
+            ClusterService.assertMasterStateThread();
             ElectionCallback callback = getCallback(); // get under lock
             if (callback != null) {
                 callback.onFailure(t);

--- a/core/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
@@ -133,12 +133,9 @@ public class PublishClusterStateAction extends AbstractComponent {
         try {
             nodes = clusterChangedEvent.state().nodes();
             nodesToPublishTo = new HashSet<>(nodes.getSize());
-            DiscoveryNode localNode = nodes.getLocalNode();
             final int totalMasterNodes = nodes.getMasterNodes().size();
             for (final DiscoveryNode node : nodes) {
-                if (node.equals(localNode) == false) {
-                    nodesToPublishTo.add(node);
-                }
+                nodesToPublishTo.add(node);
             }
             sendFullVersion = !discoverySettings.getPublishDiff() || clusterChangedEvent.previousState() == null;
             serializedStates = new HashMap<>();
@@ -541,8 +538,8 @@ public class PublishClusterStateAction extends AbstractComponent {
                                   BlockingClusterStatePublishResponseHandler publishResponseHandler) {
             this.clusterState = clusterState;
             this.publishResponseHandler = publishResponseHandler;
-            this.neededMastersToCommit = Math.max(0, minMasterNodes - 1); // we are one of the master nodes
-            this.pendingMasterNodes = totalMasterNodes - 1;
+            this.neededMastersToCommit = Math.max(1, minMasterNodes);
+            this.pendingMasterNodes = totalMasterNodes;
             if (this.neededMastersToCommit > this.pendingMasterNodes) {
                 throw new Discovery.FailedToCommitClusterStateException("not enough masters to ack sent cluster state." +
                     "[{}] needed , have [{}]", neededMastersToCommit, pendingMasterNodes);

--- a/core/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/core/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -148,7 +148,8 @@ public class RepositoriesService extends AbstractComponent implements ClusterSta
 
             @Override
             public boolean mustAck(DiscoveryNode discoveryNode) {
-                return discoveryNode.isMasterNode();
+                // repository verification is only possible after the repo has been created on both master and data nodes
+                return discoveryNode.isMasterNode() || discoveryNode.isDataNode();
             }
         });
     }

--- a/core/src/main/java/org/elasticsearch/tribe/TribeService.java
+++ b/core/src/main/java/org/elasticsearch/tribe/TribeService.java
@@ -378,6 +378,11 @@ public class TribeService extends AbstractLifecycleComponent {
         }
 
         @Override
+        public boolean isPublishingTask() {
+            return false;
+        }
+
+        @Override
         public ClusterTasksResult<ClusterChangedEvent> execute(ClusterState currentState, List<ClusterChangedEvent> tasks) throws Exception {
             ClusterTasksResult.Builder<ClusterChangedEvent> builder = ClusterTasksResult.builder();
             ClusterState.Builder newState = ClusterState.builder(currentState).incrementVersion();

--- a/core/src/test/java/org/elasticsearch/cluster/routing/DelayedAllocationServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/DelayedAllocationServiceTests.java
@@ -470,7 +470,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
         }
 
         @Override
-        protected void assertClusterStateThread() {
+        protected void assertClusterOrMasterStateThread() {
             // do not check this in the unit tests
         }
 

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardStateIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardStateIT.java
@@ -50,8 +50,11 @@ public class ShardStateIT extends ESIntegTestCase {
         logger.info("--> waiting for a yellow index");
         // JDK 9 type inference gets confused, so we have to help the
         // type inference
-        assertBusy(((Runnable) () -> assertThat(client().admin().cluster().prepareHealth().get().getStatus(),
+        for (String nodeName : internalCluster().getNodeNames()) {
+            // wait for cluster state with YELLOW health to be applied on all nodes
+            assertBusy(((Runnable) () -> assertThat(client(nodeName).admin().cluster().prepareHealth().setLocal(true).get().getStatus(),
                 equalTo(ClusterHealthStatus.YELLOW))));
+        }
 
         final long term0 = shard == 0 ? 2 : 1;
         final long term1 = shard == 1 ? 2 : 1;

--- a/core/src/test/java/org/elasticsearch/cluster/service/ClusterServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/service/ClusterServiceTests.java
@@ -48,6 +48,7 @@ import org.elasticsearch.common.util.concurrent.BaseFuture;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoverySettings;
+import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.junit.annotations.TestLogging;
@@ -137,8 +138,7 @@ public class ClusterServiceTests extends ESTestCase {
                 // skip
             }
         });
-        timedClusterService.setClusterStatePublisher((event, ackListener) -> {
-        });
+        timedClusterService.setClusterStatePublisher(ClusterServiceUtils.createClusterStatePublisher(timedClusterService));
         timedClusterService.setDiscoverySettings(new DiscoverySettings(Settings.EMPTY,
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)));
         timedClusterService.start();
@@ -392,7 +392,7 @@ public class ClusterServiceTests extends ESTestCase {
 
         latch.await();
         assertNotNull(assertionRef.get());
-        assertThat(assertionRef.get().getMessage(), containsString("not be the cluster state update thread. Reason: [Blocking operation]"));
+        assertThat(assertionRef.get().getMessage(), containsString("not be the master state update thread. Reason: [Blocking operation]"));
     }
 
     public void testOneExecutorDontStarveAnother() throws InterruptedException {
@@ -837,7 +837,7 @@ public class ClusterServiceTests extends ESTestCase {
                         "test3",
                         "org.elasticsearch.cluster.service.ClusterServiceTests$TimedClusterService",
                         Level.DEBUG,
-                        "*processing [test3]: took [3s] done applying updated cluster_state (version: *, uuid: *)"));
+                        "*processing [test3]: took [3s] done publishing updated cluster_state (version: *, uuid: *)"));
 
         Logger clusterLogger = Loggers.getLogger("org.elasticsearch.cluster.service");
         Loggers.addAppender(clusterLogger, mockAppender);

--- a/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
@@ -446,29 +446,30 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
         ensureGreen("test");
 
         // verify all cluster states are the same
-        ClusterState state = null;
-        for (String node : nodes) {
-            ClusterState nodeState = getNodeClusterState(node);
-            if (state == null) {
-                state = nodeState;
-                continue;
-            }
-            // assert nodes are identical
-            try {
-                assertEquals("unequal versions", state.version(), nodeState.version());
-                assertEquals("unequal node count", state.nodes().getSize(), nodeState.nodes().getSize());
-                assertEquals("different masters ", state.nodes().getMasterNodeId(), nodeState.nodes().getMasterNodeId());
-                assertEquals("different meta data version", state.metaData().version(), nodeState.metaData().version());
-                if (!state.routingTable().toString().equals(nodeState.routingTable().toString())) {
-                    fail("different routing");
+        // use assert busy to wait for cluster states to be applied (as publish_timeout has low value)
+        assertBusy(() -> {
+            ClusterState state = null;
+            for (String node : nodes) {
+                ClusterState nodeState = getNodeClusterState(node);
+                if (state == null) {
+                    state = nodeState;
+                    continue;
                 }
-            } catch (AssertionError t) {
-                fail("failed comparing cluster state: " + t.getMessage() + "\n" +
-                    "--- cluster state of node [" + nodes.get(0) + "]: ---\n" + state +
-                    "\n--- cluster state [" + node + "]: ---\n" + nodeState);
-            }
+                // assert nodes are identical
+                try {
+                    assertEquals("unequal versions", state.version(), nodeState.version());
+                    assertEquals("unequal node count", state.nodes().getSize(), nodeState.nodes().getSize());
+                    assertEquals("different masters ", state.nodes().getMasterNodeId(), nodeState.nodes().getMasterNodeId());
+                    assertEquals("different meta data version", state.metaData().version(), nodeState.metaData().version());
+                    assertEquals("different routing", state.routingTable().toString(), nodeState.routingTable().toString());
+                } catch (AssertionError t) {
+                    fail("failed comparing cluster state: " + t.getMessage() + "\n" +
+                        "--- cluster state of node [" + nodes.get(0) + "]: ---\n" + state +
+                        "\n--- cluster state [" + node + "]: ---\n" + nodeState);
+                }
 
-        }
+            }
+        });
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/discovery/zen/PublishClusterStateActionTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/PublishClusterStateActionTests.java
@@ -343,10 +343,7 @@ public class PublishClusterStateActionTests extends ESTestCase {
     }
 
     public void testUnexpectedDiffPublishing() throws Exception {
-        MockNode nodeA = createMockNode("nodeA", Settings.EMPTY, event -> {
-            fail("Shouldn't send cluster state to myself");
-        }).setAsMaster();
-
+        MockNode nodeA = createMockNode("nodeA").setAsMaster();
         MockNode nodeB = createMockNode("nodeB");
 
         // Initial cluster state with both states - the second node still shouldn't
@@ -368,19 +365,8 @@ public class PublishClusterStateActionTests extends ESTestCase {
     public void testDisablingDiffPublishing() throws Exception {
         Settings noDiffPublishingSettings = Settings.builder().put(DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING.getKey(), false).build();
 
-        MockNode nodeA = createMockNode("nodeA", noDiffPublishingSettings, new ClusterStateListener() {
-            @Override
-            public void clusterChanged(ClusterChangedEvent event) {
-                fail("Shouldn't send cluster state to myself");
-            }
-        });
-
-        MockNode nodeB = createMockNode("nodeB", noDiffPublishingSettings, new ClusterStateListener() {
-            @Override
-            public void clusterChanged(ClusterChangedEvent event) {
-                assertFalse(event.state().wasReadFromDiff());
-            }
-        });
+        MockNode nodeA = createMockNode("nodeA", noDiffPublishingSettings, event -> assertFalse(event.state().wasReadFromDiff()));
+        MockNode nodeB = createMockNode("nodeB", noDiffPublishingSettings, event -> assertFalse(event.state().wasReadFromDiff()));
 
         // Initial cluster state
         DiscoveryNodes discoveryNodes = DiscoveryNodes.builder()
@@ -452,13 +438,7 @@ public class PublishClusterStateActionTests extends ESTestCase {
     }
 
     public void testSerializationFailureDuringDiffPublishing() throws Exception {
-        MockNode nodeA = createMockNode("nodeA", Settings.EMPTY, new ClusterStateListener() {
-            @Override
-            public void clusterChanged(ClusterChangedEvent event) {
-                fail("Shouldn't send cluster state to myself");
-            }
-        }).setAsMaster();
-
+        MockNode nodeA = createMockNode("nodeA").setAsMaster();
         MockNode nodeB = createMockNode("nodeB");
 
         // Initial cluster state with both states - the second node still shouldn't get


### PR DESCRIPTION
Cluster state publishing has special handling to apply the cluster state on the active master: The master publishes the new cluster state to all nodes except itself, waits for up to 30 seconds for the nodes to apply the cluster state, and then applies the cluster state to itself.
This PR changes ClusterService so that the master publishes cluster state changes to itself in the same way as it publishes changes to other nodes. This is achieved by adding a second thread pool executor to ClusterService so that there is a dedicated thread for publishing and one for applying cluster states. A future step will be to separate the publishing aspects out of the ClusterService class into a dedicated component.