### PR TITLE
Document `must_not` context and scoring

### DIFF
--- a/docs/reference/query-dsl/bool-query.asciidoc
+++ b/docs/reference/query-dsl/bool-query.asciidoc
@@ -25,7 +25,9 @@ be set using the
 parameter.
 
 |`must_not` |The clause (query) must not appear in the matching
-documents.
+documents.  Clauses are executed in <<query-filter-context,filter context>> meaning
+that scoring is ignored and clauses are considered for caching. Because scoring is
+ignored, a score of `0` for all documents is returned.
 |=======================================================================
 
 [IMPORTANT]


### PR DESCRIPTION
Document that `must_not` uses filter context and returns a score of `0`.

Fixes #22518