### PR TITLE
Improve error message when reindex-from-remote gets bad json

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
@@ -463,6 +463,17 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
         assertThat(e.getCause().getCause().getMessage(), containsString("Response didn't include Content-Type: body={"));
     }
 
+    public void testInvalidJsonThinksRemoveIsNotES() throws IOException {
+        Exception e = expectThrows(RuntimeException.class, () -> sourceWithMockedRemoteCall("some_text.txt").doStart(null));
+        assertEquals("Error parsing the response, remote is likely not an Elasticsearch instance", e.getCause().getCause().getMessage());
+    }
+
+    public void testUnexpectedJsonThinksRemoveIsNotES() throws IOException {
+        // Use the response from a main action instead of a proper start response to generate a parse error
+        Exception e = expectThrows(RuntimeException.class, () -> sourceWithMockedRemoteCall("main/2_3_3.json").doStart(null));
+        assertEquals("Error parsing the response, remote is likely not an Elasticsearch instance", e.getCause().getCause().getMessage());
+    }
+
     private RemoteScrollableHitSource sourceWithMockedRemoteCall(String... paths) throws Exception {
         return sourceWithMockedRemoteCall(true, ContentType.APPLICATION_JSON, paths);
     }

--- a/modules/reindex/src/test/resources/responses/some_text.txt
+++ b/modules/reindex/src/test/resources/responses/some_text.txt
@@ -1,0 +1,1 @@
+I'm just text!


### PR DESCRIPTION
Adds a message about how the remote is unlikely to be Elasticsearch.
This isn't as good as including the whole message from the remote but
we can't do that because we are stream parsing it and we don't want
to mark the whole request.

Closes #22330
