### PR TITLE
Collate all NOTICE and LICENSE files into NOTICES.txt

### DIFF
--- a/dev-tools/collate-NOTICE.sh
+++ b/dev-tools/collate-NOTICE.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+cd `dirname $0`/..
+
+exec > NOTICE.txt
+
+year=$(date +"%Y")
+echo "Elasticsearch"
+echo "Copyright 2009-$year Elasticsearch"
+echo
+echo "This product includes software developed by The Apache Software Foundation"
+echo "(http://www.apache.org/)."
+echo
+echo
+
+for file in $(find core/licenses/ -name '*LICENSE*' -or -name '*NOTICE*' | sort) ; do
+  if [ -s $file ]
+    then
+      filename=`basename $file`
+      filename=${filename//.txt/}
+      echo "================================================================================"
+      echo $filename;
+      echo "================================================================================"
+      cat $file
+      echo;
+      echo;
+  fi;
+done
+


### PR DESCRIPTION
We need to adjust our NOTICE.txt file to include:

* if apache license, and if NOTICE file is present, include that text in our own NOTICE file.
* if MIT, ISC or BSD license, we need to include the whole copyright block in NOTICE (meaning copyright + license)

I've added a bash script which collates all the non-empty license and notice files from `core/licenses/` into our NOTICE.txt file, with the standard header that we had in NOTICE.txt previously.

I'm not sure where we should call this script from, should it be manual or part of the build process?
