### PR TITLE
Update Painless Loop Counter to be Higher

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/CompilerSettings.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/CompilerSettings.java
@@ -41,7 +41,7 @@ public final class CompilerSettings {
      * Constant to be used for enabling additional internal compilation checks (slower).
      */
     public static final String PICKY = "picky";
-    
+
     /**
      * For testing: do not use.
      */
@@ -49,15 +49,17 @@ public final class CompilerSettings {
 
     /**
      * The maximum number of statements allowed to be run in a loop.
+     * For now the number is set fairly high to accommodate users
+     * doing large update queries.
      */
-    private int maxLoopCounter = 10000;
+    private int maxLoopCounter = 1000000;
 
     /**
      * Whether to throw exception on ambiguity or other internal parsing issues. This option
      * makes things slower too, it is only for debugging.
      */
     private boolean picky = false;
-    
+
     /**
      * For testing. Do not use.
      */
@@ -102,7 +104,7 @@ public final class CompilerSettings {
     public void setPicky(boolean picky) {
       this.picky = picky;
     }
-    
+
     /**
      * Returns initial call site depth. This means we pretend we've already seen N different types,
      * to better exercise fallback code in tests.
@@ -110,7 +112,7 @@ public final class CompilerSettings {
     public int getInitialCallSiteDepth() {
         return initialCallSiteDepth;
     }
-    
+
     /**
      * For testing megamorphic fallbacks. Do not use.
      * @see #getInitialCallSiteDepth()

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
@@ -148,10 +148,10 @@ public class WhenThingsGoWrongTests extends ScriptTestCase {
 
     public void testLoopLimits() {
         // right below limit: ok
-        exec("for (int x = 0; x < 9999; ++x) {}");
+        exec("for (int x = 0; x < 999999; ++x) {}");
 
         PainlessError expected = expectScriptThrows(PainlessError.class, () -> {
-            exec("for (int x = 0; x < 10000; ++x) {}");
+            exec("for (int x = 0; x < 1000000; ++x) {}");
         });
         assertTrue(expected.getMessage().contains(
                    "The maximum number of statements that can be executed in a loop has been reached."));


### PR DESCRIPTION
Considering this a bug as it probably should have been higher to support updates in the first place, but still provides some infinite loop protection.  Updated to 1000000 from 10000.

This counter applies on a loose basis to statements (not operations) within a loop in Painless.  It is cumulative on a per function basis including the main function.  Calls external to Painless functions count as one statement.  This will hopefully become smarter in the future.

Relates: (#22508)