### PR TITLE
Human flag to be moved under always accepted query_string params

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.stats.json
@@ -16,11 +16,6 @@
           "type": "boolean",
           "description": "Return settings in flat format (default: false)"
         },
-        "human": {
-            "type": "boolean",
-            "description": "Whether to return time and byte values in human-readable format.",
-            "default": false
-        },
         "timeout": {
           "type" : "time",
           "description" : "Explicit operation timeout"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
@@ -40,11 +40,6 @@
           "type": "boolean",
           "description": "Return settings in flat format (default: false)"
         },
-        "human": {
-          "type": "boolean",
-          "description": "Whether to return version and creation date values in human-readable format.",
-          "default": false
-        },
         "include_defaults": {
           "type": "boolean",
           "description": "Whether to return all default setting for each of the indices.",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
@@ -38,11 +38,6 @@
           "type": "boolean",
           "description": "Return local information, do not retrieve the state from master node (default: false)"
         },
-        "human": {
-          "type": "boolean",
-          "description": "Whether to return version and creation date values in human-readable format.",
-          "default": false
-        },
         "include_defaults": {
           "type": "boolean",
           "description": "Whether to return all default setting for each of the indices.",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_upgrade.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_upgrade.json
@@ -25,11 +25,6 @@
             "options" : ["open","closed","none","all"],
             "default" : "open",
             "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
-        },
-        "human": {
-            "type": "boolean",
-            "description": "Whether to return time and byte values in human-readable format.",
-            "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.recovery.json
@@ -21,11 +21,6 @@
                     "type": "boolean",
                     "description": "Display only those recoveries that are currently on-going",
                     "default": false
-                },
-                "human": {
-                    "type": "boolean",
-                    "description": "Whether to return time and byte values in human-readable format.",
-                    "default": false
                 }
             }
         },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
@@ -26,11 +26,6 @@
             "default" : "open",
             "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
         },
-        "human": {
-            "type": "boolean",
-            "description": "Whether to return time and byte values in human-readable format.",
-            "default": false
-        },
         "operation_threading": {
           "description" : "TODO: ?"
         },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
@@ -38,11 +38,6 @@
           "type" : "list",
           "description" : "A comma-separated list of search groups for `search` index metric"
         },
-        "human": {
-            "type": "boolean",
-            "description": "Whether to return time and byte values in human-readable format.",
-            "default": false
-        },
         "level": {
           "type" : "enum",
           "description": "Return stats aggregated at cluster, index or shard level",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.info.json
@@ -21,11 +21,6 @@
           "type": "boolean",
           "description": "Return settings in flat format (default: false)"
         },
-        "human": {
-            "type": "boolean",
-            "description": "Whether to return time and byte values in human-readable format.",
-            "default": false
-        },
         "timeout": {
           "type" : "time",
           "description" : "Explicit operation timeout"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
@@ -45,11 +45,6 @@
           "type" : "boolean",
           "description" : "A comma-separated list of search groups for `search` index metric"
         },
-        "human": {
-            "type": "boolean",
-            "description": "Whether to return time and byte values in human-readable format.",
-            "default": false
-        },
         "level": {
           "type" : "enum",
           "description": "Return indices stats aggregated at index, node or shard level",

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
@@ -59,7 +59,7 @@ public class ClientYamlTestClient {
      * Query params that don't need to be declared in the spec, they are supported by default.
      */
     private static final Set<String> ALWAYS_ACCEPTED_QUERY_STRING_PARAMS = Sets.newHashSet(
-            "error_trace", "filter_path", "pretty", "source");
+            "error_trace", "filter_path", "human", "pretty", "source");
 
     private final ClientYamlSuiteRestSpec restSpec;
     private final RestClient restClient;


### PR DESCRIPTION
There are some parameters that are accepted by each and every api we expose. Those (pretty, source, error_trace and filter_path)  are not explicitly listed in the spec of every api, rather whitelisted in clients test runners so that they are always accepted. The `human` flag has been treated up until now as a parameter that's accepted by only some stats and info api, but that doesn't reflect reality as es core treats it exactly like `pretty` (relevant especially now that we validate params and throw exception when we find one that is not supported). Furthermore, the human flag has effect on every api that outputs a date, time, percentage or byte size field. For instance the tasks api outputs a date field although they don't have the human flag explicitly listed in their spec. There are other similar cases. This commit removes the human flag from the rest spec and makes it an always accepted query_string param.