### PR TITLE
Fix default port for unicast zen ping hosts

### DIFF
--- a/docs/reference/modules/discovery/zen.asciidoc
+++ b/docs/reference/modules/discovery/zen.asciidoc
@@ -39,8 +39,8 @@ Unicast discovery provides the following settings with the `discovery.zen.ping.u
 |=======================================================================
 |Setting |Description
 |`hosts` |Either an array setting or a comma delimited setting. Each
-value should be in the form of `host:port` or `host` (where `port` defaults to `9300`). Note that IPv6 hosts must be
-bracketed. Defaults to `127.0.0.1, [::1]`
+          value should be in the form of `host:port` or `host` (where `port` defaults to the setting `transport.profiles.default.port`
+          falling back to `transport.tcp.port` if not set). Note that IPv6 hosts must be bracketed. Defaults to `127.0.0.1, [::1]`
 |`hosts.resolve_timeout` |The amount of time to wait for DNS lookups on each round of pinging. Specified as
 <<time-units, time units>>. Defaults to 5s.
 |=======================================================================

--- a/docs/reference/setup/important-settings.asciidoc
+++ b/docs/reference/setup/important-settings.asciidoc
@@ -150,7 +150,7 @@ discovery.zen.ping.unicast.hosts:
    - 192.168.1.11 <1>
    - seeds.mydomain.com <2>
 --------------------------------------------------
-<1> The port will default to 9300 if not specified.
+<1> The port will default to `transport.profiles.default.port` and fallback to `transport.tcp.port` if not specified.
 <2> A hostname that resolves to multiple IP addresses will try all resolved addresses.
 
 [float]


### PR DESCRIPTION
Today when you do not specify a port for an entry in
discovery.zen.ping.unicast.hosts, the default port is the value of the
setting transport.profiles.default.port and falls back to the value of
transport.tcp.port if this is not set. For a node that is explicitly
bound to a different port than the default port, this means that the
default port will be equal to this explicitly bound port. Yet, the docs
say that we fall back to 9300 here. This commit corrects the docs.

