### PR TITLE
Include global query string parameters in the REST spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_common.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_common.json
@@ -1,0 +1,29 @@
+{
+  "description": "Parameters that are accepted by all API endpoints.",
+  "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html",
+  "params": {
+    "pretty": {
+      "type": "boolean",
+      "description": "Pretty format the returned JSON response.",
+      "default": false
+    },
+    "human": {
+      "type": "boolean",
+      "description": "Return human readable values for statistics.",
+      "default": true
+    },
+    "error_trace": {
+      "type": "boolean",
+      "description": "Include the stack trace of returned errors.",
+      "default": false
+    },
+    "source": {
+      "type": "string",
+      "description": "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."
+    },
+    "filter_path": {
+      "type": "string",
+      "description": "A comma-separated list of filters used to reduce the respone."
+    }
+  }
+}


### PR DESCRIPTION
Closes #11638
