### PR TITLE
Indentation error on example of dist_max

### DIFF
--- a/docs/reference/query-dsl/dis-max-query.asciidoc
+++ b/docs/reference/query-dsl/dis-max-query.asciidoc
@@ -32,15 +32,15 @@ GET /_search
     "query": {
         "dis_max" : {
             "tie_breaker" : 0.7,
-                "boost" : 1.2,
-                "queries" : [
+            "boost" : 1.2,
+            "queries" : [
                 {
                     "term" : { "age" : 34 }
                 },
                 {
                     "term" : { "age" : 35 }
                 }
-                ]
+            ]
         }
     }
 }    


### PR DESCRIPTION
There was a problem with the indentation on the example of the `dist_max` query.
