### PR TITLE
Add string field to store tokens' integer sum

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/TokenSumFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TokenSumFieldMapper.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeIntegerValue;
+import static org.elasticsearch.index.mapper.TypeParsers.parseField;
+
+/**
+ * A {@link FieldMapper} that takes a string and writes the integer of the token values
+ * for indexing.  In most ways the mapper acts just like an {@link NumberFieldMapper}.
+ */
+public class TokenSumFieldMapper extends FieldMapper {
+    public static final String CONTENT_TYPE = "token_sum";
+
+    public static class Defaults {
+        public static final MappedFieldType FIELD_TYPE = new NumberFieldMapper.NumberFieldType(NumberFieldMapper.NumberType.INTEGER);
+    }
+
+    public static class Builder extends FieldMapper.Builder<Builder, TokenSumFieldMapper> {
+        private NamedAnalyzer analyzer;
+
+        public Builder(String name) {
+            super(name, Defaults.FIELD_TYPE, Defaults.FIELD_TYPE);
+            builder = this;
+        }
+
+        public Builder analyzer(NamedAnalyzer analyzer) {
+            this.analyzer = analyzer;
+            return this;
+        }
+
+        public NamedAnalyzer analyzer() {
+            return analyzer;
+        }
+
+        @Override
+        public TokenSumFieldMapper build(BuilderContext context) {
+            setupFieldType(context);
+            return new TokenSumFieldMapper(name, fieldType, defaultFieldType,
+                    context.indexSettings(), analyzer, multiFieldsBuilder.build(this, context), copyTo);
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        @SuppressWarnings("unchecked")
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            TokenSumFieldMapper.Builder builder = new TokenSumFieldMapper.Builder(name);
+            for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
+                Map.Entry<String, Object> entry = iterator.next();
+                String propName = entry.getKey();
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    builder.nullValue(nodeIntegerValue(propNode));
+                    iterator.remove();
+                } else if (propName.equals("analyzer")) {
+                    NamedAnalyzer analyzer = parserContext.getIndexAnalyzers().get(propNode.toString());
+                    if (analyzer == null) {
+                        throw new MapperParsingException("Analyzer [" + propNode.toString() + "] not found for field [" + name + "]");
+                    }
+                    builder.analyzer(analyzer);
+                    iterator.remove();
+                }
+            }
+            parseField(builder, name, node, parserContext);
+            if (builder.analyzer() == null) {
+                throw new MapperParsingException("Analyzer must be set for field [" + name + "] but wasn't.");
+            }
+            return builder;
+        }
+    }
+
+    private NamedAnalyzer analyzer;
+    protected TokenSumFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
+                                  Settings indexSettings, NamedAnalyzer analyzer, MultiFields multiFields, CopyTo copyTo) {
+        super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        this.analyzer = analyzer;
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context, List<IndexableField> fields) throws IOException {
+        final String value;
+        if (context.externalValueSet()) {
+            value = context.externalValue().toString();
+        } else {
+            value = context.parser().textOrNull();
+        }
+
+        final int tokenSum;
+
+        if (value == null) {
+            tokenSum = (Integer) fieldType().nullValue();
+        } else {
+            tokenSum = calculateSum(analyzer, name(), value);
+        }
+
+        boolean indexed = fieldType().indexOptions() != IndexOptions.NONE;
+        boolean docValued = fieldType().hasDocValues();
+        boolean stored = fieldType().stored();
+        fields.addAll(NumberFieldMapper.NumberType.INTEGER.createFields(fieldType().name(), tokenSum, indexed, docValued, stored));
+    }
+
+    /**
+     * Calculate sum of integer tokens from token stream.
+     * @param analyzer analyzer to create token stream
+     * @param fieldName field name to pass to analyzer
+     * @param fieldValue field value to pass to analyzer
+     * @return integer sum of token stream, or -1 if format error
+     * @throws IOException if tokenStream throws it
+     */
+    static int calculateSum(Analyzer analyzer, String fieldName, String fieldValue) throws IOException {
+        try (TokenStream tokenStream = analyzer.tokenStream(fieldName, fieldValue)) {
+            int sum = 0;
+            CharTermAttribute terms = tokenStream.getAttribute(CharTermAttribute.class);
+            tokenStream.reset();
+            while (tokenStream.incrementToken()) {
+                sum += Integer.parseInt(terms.toString());
+            }
+            tokenStream.end();
+            return sum;
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    /**
+     * Name of analyzer.
+     * @return name of analyzer
+     */
+    public String analyzer() {
+        return analyzer.name();
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+        super.doMerge(mergeWith, updateAllTypes);
+        this.analyzer = ((TokenSumFieldMapper) mergeWith).analyzer;
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        super.doXContentBody(builder, includeDefaults, params);
+        builder.field("analyzer", analyzer());
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -49,6 +49,7 @@ import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.mapper.TokenCountFieldMapper;
+import org.elasticsearch.index.mapper.TokenSumFieldMapper;
 import org.elasticsearch.index.mapper.TypeFieldMapper;
 import org.elasticsearch.index.mapper.UidFieldMapper;
 import org.elasticsearch.index.mapper.VersionFieldMapper;
@@ -108,6 +109,7 @@ public class IndicesModule extends AbstractModule {
         mappers.put(TextFieldMapper.CONTENT_TYPE, new TextFieldMapper.TypeParser());
         mappers.put(KeywordFieldMapper.CONTENT_TYPE, new KeywordFieldMapper.TypeParser());
         mappers.put(TokenCountFieldMapper.CONTENT_TYPE, new TokenCountFieldMapper.TypeParser());
+        mappers.put(TokenSumFieldMapper.CONTENT_TYPE, new TokenSumFieldMapper.TypeParser());
         mappers.put(ObjectMapper.CONTENT_TYPE, new ObjectMapper.TypeParser());
         mappers.put(ObjectMapper.NESTED_CONTENT_TYPE, new ObjectMapper.TypeParser());
         mappers.put(CompletionFieldMapper.CONTENT_TYPE, new CompletionFieldMapper.TypeParser());

--- a/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldsIntegrationIT.java
@@ -166,6 +166,42 @@ public class MultiFieldsIntegrationIT extends ESIntegTestCase {
         assertThat(countResponse.getHits().totalHits(), equalTo(1L));
     }
 
+    public void testTokenSumMultiField() throws Exception {
+        assertAcked(
+            client().admin().indices().prepareCreate("my-index")
+                .addMapping("my-type", XContentFactory.jsonBuilder().startObject().startObject("my-type")
+                    .startObject("properties")
+                    .startObject("a")
+                    .field("type", "token_sum")
+                    .field("analyzer", "simple")
+                    .startObject("fields")
+                    .startObject("b")
+                    .field("type", "keyword")
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject().endObject())
+        );
+
+        GetMappingsResponse getMappingsResponse = client().admin().indices().prepareGetMappings("my-index").get();
+        MappingMetaData mappingMetaData = getMappingsResponse.mappings().get("my-index").get("my-type");
+        assertThat(mappingMetaData, not(nullValue()));
+        Map<String, Object> mappingSource = mappingMetaData.sourceAsMap();
+        Map aField = ((Map) XContentMapValues.extractValue("properties.a", mappingSource));
+        assertThat(aField.size(), equalTo(3));
+        assertThat(aField.get("type").toString(), equalTo("token_sum"));
+        assertThat(aField.get("fields"), notNullValue());
+
+        Map bField = ((Map) XContentMapValues.extractValue("properties.a.fields.b", mappingSource));
+        assertThat(bField.size(), equalTo(1));
+        assertThat(bField.get("type").toString(), equalTo("keyword"));
+
+        client().prepareIndex("my-index", "my-type", "1").setSource("a", "my tokens").setRefreshPolicy(IMMEDIATE).get();
+        SearchResponse countResponse = client().prepareSearch("my-index").setSize(0).setQuery(matchQuery("a.b", "my tokens")).get();
+        assertThat(countResponse.getHits().totalHits(), equalTo(1L));
+    }
+
     public void testCompletionMultiField() throws Exception {
         assertAcked(
                 client().admin().indices().prepareCreate("my-index")

--- a/core/src/test/java/org/elasticsearch/index/mapper/TokenSumFieldMapperIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/TokenSumFieldMapperIntegrationIT.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+public class TokenSumFieldMapperIntegrationIT extends ESIntegTestCase {
+    @ParametersFactory
+    public static Iterable<Object[]> buildParameters() {
+        List<Object[]> parameters = new ArrayList<>();
+        for (boolean storeCountedFields : new boolean[] { true, false }) {
+            for (boolean loadCountedFields : new boolean[] { true, false }) {
+                parameters.add(new Object[] { storeCountedFields, loadCountedFields });
+            }
+        }
+        return parameters;
+    }
+
+    private final boolean storeCountedFields;
+    private final boolean loadCountedFields;
+
+    public TokenSumFieldMapperIntegrationIT(@Name("storeCountedFields") boolean storeCountedFields,
+                                            @Name("loadCountedFields") boolean loadCountedFields) {
+        this.storeCountedFields = storeCountedFields;
+        this.loadCountedFields = loadCountedFields;
+    }
+
+    /**
+     * It is possible to get the token sum in a search response.
+     */
+    public void testSearchReturnsTokenSum() throws IOException {
+        init();
+
+        assertSearchReturns(searchById("single"), "single");
+        assertSearchReturns(searchById("numbers1"), "numbers1");
+        assertSearchReturns(searchById("numbers2"), "numbers2");
+        assertSearchReturns(searchById("nan1"), "nan1");
+        assertSearchReturns(searchById("nan2"), "nan2");
+        assertSearchReturns(searchById("nan3"), "nan3");
+        assertSearchReturns(searchById("multi"), "multi");
+        assertSearchReturns(searchById("multinumbers1"), "multinumbers1");
+        assertSearchReturns(searchById("multinumbers2"), "multinumbers2");
+    }
+
+    /**
+     * It is possible to search by sum of token.
+     */
+    public void testSearchByTokenSum() throws IOException {
+        init();
+
+        assertSearchReturns(searchByNumericRange(1, 1).get(), "single");
+        assertSearchReturns(searchByNumericRange(6, 6).get(), "numbers1");
+        assertSearchReturns(searchByNumericRange(21, 21).get(), "numbers2");
+        assertSearchReturns(searchByNumericRange(6, 21).get(), "numbers1", "numbers2");
+        assertSearchReturns(searchByNumericRange(-1, -1).get(), "nan1", "nan2", "nan3");
+        assertSearchReturns(searchByNumericRange(25, 25).get(), "multi");
+        assertSearchReturns(searchByNumericRange(30, 35).get(), "multinumbers1", "multinumbers2");
+        assertSearchReturns(searchByNumericRange(1000, 1000).get(), "multinumbers2");
+        assertSearchReturns(searchByNumericRange(1, 21).get(), "single", "numbers1", "numbers2", "multi", "multinumbers1", "multinumbers2");
+    }
+
+    /**
+     * It is possible to search by token sum.
+     */
+    public void testFacetByTokenSum() throws IOException {
+        init();
+
+        String facetField = "foo.token_sum";
+        SearchResponse result = searchByNumericRange(6, 21)
+            .addAggregation(AggregationBuilders.terms("facet").field(facetField)).get();
+        assertSearchReturns(result, "numbers1", "numbers2");
+        assertThat(result.getAggregations().asList().size(), equalTo(1));
+        Terms terms = (Terms) result.getAggregations().asList().get(0);
+        assertThat(terms.getBuckets().size(), equalTo(2));
+    }
+
+    private void init() throws IOException {
+        prepareCreate("test").addMapping("test", jsonBuilder().startObject()
+                .startObject("test")
+                    .startObject("properties")
+                        .startObject("foo")
+                            .field("type", "text")
+                            .field("store", storeCountedFields)
+                            .field("analyzer", "simple")
+                            .startObject("fields")
+                                .startObject("token_sum")
+                                    .field("type", "token_sum")
+                                    .field("analyzer", "standard")
+                                    .field("store", true)
+                                .endObject()
+                                .startObject("token_sum_unstored")
+                                    .field("type", "token_sum")
+                                    .field("analyzer", "standard")
+                                .endObject()
+                                .startObject("token_sum_with_doc_values")
+                                    .field("type", "token_sum")
+                                    .field("analyzer", "standard")
+                                    .field("doc_values", true)
+                                .endObject()
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endObject().endObject()).get();
+        ensureGreen();
+
+        assertEquals(DocWriteResponse.Result.CREATED, prepareIndex("single", "1").get().getResult());
+        BulkResponse bulk = client().prepareBulk()
+                .add(prepareIndex("numbers1", "1 2 3"))
+                .add(prepareIndex("numbers2", "1 2 3 4 5 6"))
+                .add(prepareIndex("nan1", "nan 2 3"))
+                .add(prepareIndex("nan2", "1 nan 3"))
+                .add(prepareIndex("nan3", "1 2 nan")).get();
+        assertFalse(bulk.buildFailureMessage(), bulk.hasFailures());
+        assertEquals(DocWriteResponse.Result.CREATED,
+                     prepareIndex("multi", "1 2", "3 4 5 6 7").get().getResult());
+        bulk = client().prepareBulk()
+                .add(prepareIndex("multinumbers1", "1 2", "3 4 5 6 7 8"))
+            .add(prepareIndex("multinumbers2", "1 2", "3 4 5 6 7 8", "1000"))
+            .get();
+        assertFalse(bulk.buildFailureMessage(), bulk.hasFailures());
+
+        assertThat(refresh().getFailedShards(), equalTo(0));
+    }
+
+    private IndexRequestBuilder prepareIndex(String id, String... texts) throws IOException {
+        return client().prepareIndex("test", "test", id).setSource("foo", texts);
+    }
+
+    private SearchResponse searchById(String id) {
+        return prepareSearch().setQuery(QueryBuilders.termQuery("_id", id)).get();
+    }
+
+    private SearchRequestBuilder searchByNumericRange(int low, int high) {
+        return prepareSearch().setQuery(QueryBuilders.rangeQuery(randomFrom(
+                Arrays.asList("foo.token_sum", "foo.token_sum_unstored", "foo.token_sum_with_doc_values")
+        )).gte(low).lte(high));
+    }
+
+
+    private SearchRequestBuilder prepareSearch() {
+        SearchRequestBuilder request = client().prepareSearch("test").setTypes("test");
+        request.addStoredField("foo.token_sum");
+        if (loadCountedFields) {
+            request.addStoredField("foo");
+        }
+        return request;
+    }
+
+    private void assertSearchReturns(SearchResponse result, String... ids) {
+        assertThat(result.getHits().getTotalHits(), equalTo((long) ids.length));
+        assertThat(result.getHits().hits().length, equalTo(ids.length));
+        List<String> foundIds = new ArrayList<>();
+        for (SearchHit hit : result.getHits()) {
+            foundIds.add(hit.id());
+        }
+        assertThat(foundIds, containsInAnyOrder(ids));
+        for (SearchHit hit : result.getHits()) {
+            String id = hit.id();
+            if (id.equals("single")) {
+                assertSearchHit(hit, 1);
+            } else if (id.equals("numbers1")) {
+                assertSearchHit(hit, 6);
+            } else if (id.equals("numbers2")) {
+                assertSearchHit(hit, 21);
+            } else if (id.equals("nan1")) {
+                assertSearchHit(hit, -1);
+            } else if (id.equals("nan2")) {
+                assertSearchHit(hit, -1);
+            } else if (id.equals("nan3")) {
+                assertSearchHit(hit, -1);
+            } else if (id.equals("multi")) {
+                assertSearchHit(hit, 3, 25);
+            } else if (id.equals("multinumbers1")) {
+                assertSearchHit(hit, 3, 33);
+            } else if (id.equals("multinumbers2")) {
+                assertSearchHit(hit, 3, 33, 1000);
+            } else {
+                throw new ElasticsearchException("Unexpected response!");
+            }
+        }
+    }
+
+
+    private void assertSearchHit(SearchHit hit, int... termCounts) {
+        assertThat(hit.field("foo.token_sum"), not(nullValue()));
+        assertThat(hit.field("foo.token_sum").values().size(), equalTo(termCounts.length));
+        for (int i = 0; i < termCounts.length; i++) {
+            assertThat((Integer) hit.field("foo.token_sum").values().get(i), equalTo(termCounts[i]));
+        }
+
+        if (loadCountedFields && storeCountedFields) {
+            assertThat(hit.field("foo").values().size(), equalTo(termCounts.length));
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/mapper/TokenSumFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/TokenSumFieldMapperTests.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.CannedTokenStream;
+import org.apache.lucene.analysis.MockTokenizer;
+import org.apache.lucene.analysis.Token;
+import org.apache.lucene.analysis.TokenStream;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Test for {@link TokenSumFieldMapper}.
+ */
+public class TokenSumFieldMapperTests extends ESSingleNodeTestCase {
+    public void testMerge() throws IOException {
+        String stage1Mapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("person")
+                    .startObject("properties")
+                        .startObject("ts")
+                            .field("type", "token_sum")
+                            .field("analyzer", "keyword")
+                        .endObject()
+                    .endObject()
+                .endObject().endObject().string();
+        MapperService mapperService = createIndex("test").mapperService();
+        DocumentMapper stage1 = mapperService.merge("person",
+                new CompressedXContent(stage1Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+
+        String stage2Mapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("person")
+                    .startObject("properties")
+                        .startObject("ts")
+                            .field("type", "token_sum")
+                            .field("analyzer", "standard")
+                        .endObject()
+                    .endObject()
+                .endObject().endObject().string();
+        DocumentMapper stage2 = mapperService.merge("person",
+                new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+
+        // previous mapper has not been modified
+        assertThat(((TokenSumFieldMapper) stage1.mappers().smartNameFieldMapper("ts")).analyzer(), equalTo("keyword"));
+        // but the new one has the change
+        assertThat(((TokenSumFieldMapper) stage2.mappers().smartNameFieldMapper("ts")).analyzer(), equalTo("standard"));
+    }
+
+    public void testCalculateSum() throws IOException {
+        Token t1 = new Token("100", 0, 3);
+        Token t2 = new Token("200", 0, 3);
+        Token t3 = new Token("300", 0, 3);
+        Token[] tokens = new Token[] {t1, t2, t3};
+        Collections.shuffle(Arrays.asList(tokens), random());
+        final TokenStream tokenStream = new CannedTokenStream(0, 0, tokens);
+        Analyzer analyzer = new Analyzer() {
+            @Override
+            public TokenStreamComponents createComponents(String fieldName) {
+                return new TokenStreamComponents(new MockTokenizer(), tokenStream);
+            }
+        };
+        assertThat(TokenSumFieldMapper.calculateSum(analyzer, "", ""), equalTo(600));
+    }
+
+    public void testCalculateSumWithNotANumber() throws IOException {
+        Token t1 = new Token("100", 0, 3);
+        Token t2 = new Token("NaN", 0, 3);
+        Token t3 = new Token("300", 0, 3);
+        Token[] tokens = new Token[] {t1, t2, t3};
+        Collections.shuffle(Arrays.asList(tokens), random());
+        final TokenStream tokenStream = new CannedTokenStream(0, 0, tokens);
+        Analyzer analyzer = new Analyzer() {
+            @Override
+            public TokenStreamComponents createComponents(String fieldName) {
+                return new TokenStreamComponents(new MockTokenizer(), tokenStream);
+            }
+        };
+        assertThat(TokenSumFieldMapper.calculateSum(analyzer, "", ""), equalTo(-1));
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(InternalSettingsPlugin.class);
+    }
+
+    public void testEmptyName() throws IOException {
+        IndexService indexService = createIndex("test");
+        DocumentMapperParser parser = indexService.mapperService().documentMapperParser();
+        String mapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("type")
+                    .startObject("properties")
+                        .startObject("")
+                            .field("type", "token_sum")
+                            .field("analyzer", "standard")
+                        .endObject()
+                    .endObject()
+                .endObject().endObject().string();
+
+        // Empty name not allowed in index created after 5.0
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> parser.parse("type", new CompressedXContent(mapping))
+        );
+        assertThat(e.getMessage(), containsString("name cannot be empty string"));
+    }
+}

--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -34,6 +34,7 @@ string::        <<text,`text`>> and <<keyword,`keyword`>>
 <<search-suggesters-completion,Completion datatype>>::
                     `completion` to provide auto-complete suggestions
 <<token-count>>::   `token_count` to count the number of tokens in a string
+<<token-sum>>::   `token_sum` to calculate the sum of integer values stored in tokens
 {plugins}/mapper-size.html[`mapper-murmur3`]:: `murmur3` to compute hashes of values at index-time and store them in the index
 
 <<percolator>>::    Accepts queries from the query-dsl
@@ -81,6 +82,8 @@ include::types/string.asciidoc[]
 include::types/text.asciidoc[]
 
 include::types/token-count.asciidoc[]
+
+include::types/token-sum.asciidoc[]
 
 include::types/percolator.asciidoc[]
 

--- a/docs/reference/mapping/types/token-sum.asciidoc
+++ b/docs/reference/mapping/types/token-sum.asciidoc
@@ -1,0 +1,92 @@
+[[token-sum]]
+=== Token sum datatype
+
+A field of type `token_sum` is really an <<number,`integer`>> field which
+accepts string tokens with integer values from analyzer, then calculate the integer sum of the tokens to indexed.
+
+For instance:
+
+[source,js]
+--------------------------------------------------
+PUT my_index
+{
+  "mappings": {
+    "my_type": {
+      "properties": {
+        "rainfall": {
+          "type": "text",
+          "fields": {
+            "amount": {
+              "type":     "token_sum",
+              "analyzer": "standard"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+PUT my_index/my_type/1
+{ "rainfall": "10 20 50" }
+
+PUT my_index/my_type/2
+{ "rainfall": "10 20 30 20 10 10" }
+
+GET my_index/_search
+{
+  "query": {
+    "term": {
+      "rainfall.amount": 100
+    }
+  }
+}
+--------------------------------------------------
+// CONSOLE
+
+[[token-sum-params]]
+==== Parameters for `token_sum` fields
+
+The following parameters are accepted by `token_sum` fields:
+
+[horizontal]
+
+<<analyzer,`analyzer`>>::
+
+    The <<analysis,analyzer>> which should be used to analyze the string
+    value. Required. For best performance, use an analyzer without token
+    filters.
+
+<<mapping-boost,`boost`>>::
+
+    Mapping field-level query time boosting. Accepts a floating point number, defaults
+    to `1.0`.
+
+<<doc-values,`doc_values`>>::
+
+    Should the field be stored on disk in a column-stride fashion, so that it
+    can later be used for sorting, aggregations, or scripting? Accepts `true`
+    (default) or `false`.
+
+<<mapping-index,`index`>>::
+
+    Should the field be searchable? Accepts `not_analyzed` (default) and `no`.
+
+<<include-in-all,`include_in_all`>>::
+
+    Whether or not the field value should be included in the
+    <<mapping-all-field,`_all`>> field? Accepts `true` or `false`.  Defaults
+    to `false`. Note: if `true`, it is the string value that is added to `_all`,
+    not the calculated token sum.
+
+<<null-value,`null_value`>>::
+
+    Accepts a numeric value of the same `type` as the field which is
+    substituted for any explicit `null` values.  Defaults to `null`, which
+    means the field is treated as missing.
+
+<<mapping-store,`store`>>::
+
+    Whether the field value should be stored and retrievable separately from
+    the <<mapping-source-field,`_source`>> field. Accepts `true` or `false`
+    (default).


### PR DESCRIPTION
This commit add a `toke-sum` field type, that accepts string tokens with integer values from analyzer, then calculate the integer sum of the tokens to indexed.
