### PR TITLE
NPE when no setting name passed to elasticsearch-keystore

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/AddStringKeyStoreCommand.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/AddStringKeyStoreCommand.java
@@ -64,6 +64,9 @@ class AddStringKeyStoreCommand extends EnvironmentAwareCommand {
         keystore.decrypt(new char[0] /* TODO: prompt for password when they are supported */);
 
         String setting = arguments.value(options);
+        if (setting == null) {
+            throw new UserException(ExitCodes.DATA_ERROR, "the setting name can not be null.");
+        }
         if (keystore.getSettings().contains(setting) && options.has(forceOption) == false) {
             if (terminal.promptYesNo("Setting " + setting + " already exists. Overwrite?", false) == false) {
                 terminal.println("Exiting without modifying keystore.");

--- a/core/src/main/java/org/elasticsearch/common/settings/AddStringKeyStoreCommand.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/AddStringKeyStoreCommand.java
@@ -65,7 +65,7 @@ class AddStringKeyStoreCommand extends EnvironmentAwareCommand {
 
         String setting = arguments.value(options);
         if (setting == null) {
-            throw new UserException(ExitCodes.DATA_ERROR, "the setting name can not be null.");
+            throw new UserException(ExitCodes.USAGE, "The setting name can not be null");
         }
         if (keystore.getSettings().contains(setting) && options.has(forceOption) == false) {
             if (terminal.promptYesNo("Setting " + setting + " already exists. Overwrite?", false) == false) {

--- a/core/src/test/java/org/elasticsearch/common/settings/AddStringKeyStoreCommandTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/AddStringKeyStoreCommandTests.java
@@ -127,6 +127,14 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
         assertEquals("String value must contain only ASCII", e.getMessage());
     }
 
+    public void testNpe() throws Exception {
+        createKeystore("");
+        terminal.addTextInput("");
+        UserException e = expectThrows(UserException.class, this::execute);
+        assertEquals(ExitCodes.USAGE, e.exitCode);
+        assertThat(e.getMessage(), containsString("The setting name can not be null"));
+    }
+
     void setInput(String inputStr) {
         input = new ByteArrayInputStream(inputStr.getBytes(StandardCharsets.UTF_8));
     }


### PR DESCRIPTION
```sh
$ bin/elasticsearch-keystore create
Created elasticsearch keystore in /Users/dpilato/Documents/Elasticsearch/apps/elasticsearch/elasticsearch-6.0.0-alpha1/config
$ bin/elasticsearch-keystore add
Enter value for null: xyz
Exception in thread "main" java.lang.NullPointerException: invalid null input
	at java.security.KeyStore.setEntry(KeyStore.java:1552)
	at org.elasticsearch.common.settings.KeyStoreWrapper.setString(KeyStoreWrapper.java:264)
	at org.elasticsearch.common.settings.AddStringKeyStoreCommand.execute(AddStringKeyStoreCommand.java:83)
	at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:58)
	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:122)
	at org.elasticsearch.cli.MultiCommand.execute(MultiCommand.java:69)
	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:122)
	at org.elasticsearch.cli.Command.main(Command.java:88)
	at org.elasticsearch.common.settings.KeyStoreCli.main(KeyStoreCli.java:39)
```
