### PR TITLE
Simplify ElasticsearchException rendering as a XContent

### DIFF
--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -69,13 +69,12 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
      */
     public static final String REST_EXCEPTION_SKIP_STACK_TRACE = "rest.exception.stacktrace.skip";
     public static final boolean REST_EXCEPTION_SKIP_STACK_TRACE_DEFAULT = true;
-    private static final boolean REST_EXCEPTION_SKIP_CAUSE_DEFAULT = false;
-    private static final String ES_HEADER_PREFIX = "es.";
-    private static final String INDEX_HEADER_KEY = ES_HEADER_PREFIX + "index";
-    private static final String INDEX_HEADER_KEY_UUID = ES_HEADER_PREFIX + "index_uuid";
-    private static final String SHARD_HEADER_KEY = ES_HEADER_PREFIX + "shard";
-    private static final String RESOURCE_HEADER_TYPE_KEY = ES_HEADER_PREFIX + "resource.type";
-    private static final String RESOURCE_HEADER_ID_KEY = ES_HEADER_PREFIX + "resource.id";
+    public static final boolean REST_EXCEPTION_SKIP_CAUSE_DEFAULT = false;
+    private static final String INDEX_HEADER_KEY = "es.index";
+    private static final String INDEX_HEADER_KEY_UUID = "es.index_uuid";
+    private static final String SHARD_HEADER_KEY = "es.shard";
+    private static final String RESOURCE_HEADER_TYPE_KEY = "es.resource.type";
+    private static final String RESOURCE_HEADER_ID_KEY = "es.resource.id";
 
     private static final String TYPE = "type";
     private static final String REASON = "reason";
@@ -266,8 +265,8 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
 
             Set<String> customHeaders = null;
             for (String header : headers.keySet()) {
-                if (header.startsWith(ES_HEADER_PREFIX)) {
-                    headerToXContent(builder, header.substring(ES_HEADER_PREFIX.length()), headers.get(header));
+                if (header.startsWith("es.")) {
+                    headerToXContent(builder, header.substring("es.".length()), headers.get(header));
                 } else {
                     if (customHeaders == null) {
                         customHeaders = new HashSet<>();
@@ -364,7 +363,8 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
      * exception is rendered. When it equals to true, all detail are provided including guesses root causes, cause and potentially stack
      * trace.
      */
-    public static void toXContentError(XContentBuilder builder, Params params, @Nullable Exception e, boolean detailed) throws IOException {
+    public static void generateFailureXContent(XContentBuilder builder, Params params, @Nullable Exception e, boolean detailed)
+            throws IOException {
         // No exception to render as an error
         if (e == null) {
             builder.field(ERROR, "unknown");
@@ -403,10 +403,10 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     }
 
     /**
-     * Same as {@link ElasticsearchException#toXContentError(XContentBuilder, Params, Exception, boolean)} with all details.
+     * Same as {@link ElasticsearchException#generateFailureXContent(XContentBuilder, Params, Exception, boolean)} with all details.
      */
-    public static void toXContentError(XContentBuilder builder, Params params, @Nullable Exception e) throws IOException {
-        toXContentError(builder, params, e, true);
+    public static void generateFailureXContent(XContentBuilder builder, Params params, @Nullable Exception e) throws IOException {
+        generateFailureXContent(builder, params, e, true);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -58,13 +58,13 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     static final Version UNKNOWN_VERSION_ADDED = Version.fromId(0);
 
     /**
-     * Passed in the {@link Params} of {@link #generateThrowableXContent(XContentBuilder, org.elasticsearch.common.xcontent.ToXContent.Params, Throwable)}
+     * Passed in the {@link Params} of {@link #generateThrowableXContent(XContentBuilder, Params, Throwable)}
      * to control if the {@code caused_by} element should render. Unlike most parameters to {@code toXContent} methods this parameter is
      * internal only and not available as a URL parameter.
      */
     public static final String REST_EXCEPTION_SKIP_CAUSE = "rest.exception.cause.skip";
     /**
-     * Passed in the {@link Params} of {@link #generateThrowableXContent(XContentBuilder, org.elasticsearch.common.xcontent.ToXContent.Params, Throwable)}
+     * Passed in the {@link Params} of {@link #generateThrowableXContent(XContentBuilder, Params, Throwable)}
      * to control if the {@code stack_trace} element should render. Unlike most parameters to {@code toXContent} methods this parameter is
      * internal only and not available as a URL parameter. Use the {@code error_trace} parameter instead.
      */
@@ -382,7 +382,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             builder.startArray(ROOT_CAUSE);
             for (ElasticsearchException rootCause : rootCauses) {
                 builder.startObject();
-                rootCause.toXContent(builder, new ToXContent.DelegatingMapParams(singletonMap(REST_EXCEPTION_SKIP_CAUSE, "true"), params));
+                rootCause.toXContent(builder, new DelegatingMapParams(singletonMap(REST_EXCEPTION_SKIP_CAUSE, "true"), params));
                 builder.endObject();
             }
             builder.endArray();

--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -57,13 +57,13 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     static final Version UNKNOWN_VERSION_ADDED = Version.fromId(0);
 
     /**
-     * Passed in the {@link Params} of {@link #toXContent(XContentBuilder, org.elasticsearch.common.xcontent.ToXContent.Params, Throwable)}
+     * Passed in the {@link Params} of {@link #generateThrowableXContent(XContentBuilder, org.elasticsearch.common.xcontent.ToXContent.Params, Throwable)}
      * to control if the {@code caused_by} element should render. Unlike most parameters to {@code toXContent} methods this parameter is
      * internal only and not available as a URL parameter.
      */
     public static final String REST_EXCEPTION_SKIP_CAUSE = "rest.exception.cause.skip";
     /**
-     * Passed in the {@link Params} of {@link #toXContent(XContentBuilder, org.elasticsearch.common.xcontent.ToXContent.Params, Throwable)}
+     * Passed in the {@link Params} of {@link #generateThrowableXContent(XContentBuilder, org.elasticsearch.common.xcontent.ToXContent.Params, Throwable)}
      * to control if the {@code stack_trace} element should render. Unlike most parameters to {@code toXContent} methods this parameter is
      * internal only and not available as a URL parameter. Use the {@code error_trace} parameter instead.
      */
@@ -258,7 +258,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         Throwable ex = ExceptionsHelper.unwrapCause(this);
         if (ex != this) {
-            toXContent(builder, params, this);
+            generateThrowableXContent(builder, params, this);
         } else {
             builder.field(TYPE, getExceptionName());
             builder.field(REASON, getMessage());
@@ -283,7 +283,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                 if (cause != null) {
                     builder.field(CAUSED_BY);
                     builder.startObject();
-                    toXContent(builder, params, cause);
+                    generateThrowableXContent(builder, params, cause);
                     builder.endObject();
                 }
             }
@@ -338,7 +338,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
      * Static toXContent helper method that also renders non {@link org.elasticsearch.ElasticsearchException} instances as XContent,
      * delegating the rendering to {@link ElasticsearchException#toXContent(XContentBuilder, Params)}.
      */
-    public static void toXContent(XContentBuilder builder, Params params, Throwable t) throws IOException {
+    public static void generateThrowableXContent(XContentBuilder builder, Params params, Throwable t) throws IOException {
         t = ExceptionsHelper.unwrapCause(t);
 
         ElasticsearchException exception;
@@ -398,7 +398,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             }
             builder.endArray();
         }
-        toXContent(builder, params, e);
+        generateThrowableXContent(builder, params, e);
         builder.endObject();
     }
 

--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -275,7 +275,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                 }
             }
 
-            innerToXContent(builder, params);
+            metadataToXContent(builder, params);
 
             boolean skipCause = skipCauseInXContent(params);
             if (skipCause == false) {
@@ -320,7 +320,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     /**
      * Renders additional per exception information into the XContent
      */
-    protected void innerToXContent(XContentBuilder builder, Params params) throws IOException {
+    protected void metadataToXContent(XContentBuilder builder, Params params) throws IOException {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -266,8 +266,8 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
 
             Set<String> customHeaders = null;
             for (String key : headers.keySet()) {
-                if (key.startsWith(ES_HEADER_PREFIX)) {
-                    headerToXContent(builder, key.substring(ES_HEADER_PREFIX.length()), headers.get(key));
+                if (key.startsWith("es.")) {
+                    headerToXContent(builder, key.substring("es.".length()), headers.get(key));
                 } else {
                     if (customHeaders == null) {
                         customHeaders = new HashSet<>();
@@ -364,7 +364,8 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
      * exception is rendered. When it equals to true, all detail are provided including guesses root causes, cause and potentially stack
      * trace.
      */
-    public static void toXContentError(XContentBuilder builder, Params params, @Nullable Exception e, boolean detailed) throws IOException {
+    public static void generateFailureXContent(XContentBuilder builder, Params params, @Nullable Exception e, boolean detailed)
+            throws IOException {
         // No exception to render as an error
         if (e == null) {
             builder.field(ERROR, "unknown");
@@ -403,10 +404,10 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     }
 
     /**
-     * Same as {@link ElasticsearchException#toXContentError(XContentBuilder, Params, Exception, boolean)} with all details.
+     * Same as {@link ElasticsearchException#generateFailureXContent(XContentBuilder, Params, Exception, boolean)} with all details.
      */
-    public static void toXContentError(XContentBuilder builder, Params params, @Nullable Exception e) throws IOException {
-        toXContentError(builder, params, e, true);
+    public static void generateFailureXContent(XContentBuilder builder, Params params, @Nullable Exception e) throws IOException {
+        generateFailureXContent(builder, params, e, true);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -333,8 +333,11 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     }
 
     /**
-     * Static toXContent helper method that also renders non {@link org.elasticsearch.ElasticsearchException} instances as XContent,
-     * delegating the rendering to {@link ElasticsearchException#toXContent(XContentBuilder, Params)}.
+     * Static toXContent helper method that renders {@link org.elasticsearch.ElasticsearchException} or {@link Throwable} instances
+     * as XContent, delegating the rendering to {@link #toXContent(XContentBuilder, Params)}
+     * or {@link #innerToXContent(XContentBuilder, Params, Throwable, String, String, Map, Throwable)}.
+     *
+     * This method is usually used when the {@link Throwable} is rendered as a part of another XContent object.
      */
     public static void generateThrowableXContent(XContentBuilder builder, Params params, Throwable t) throws IOException {
         t = ExceptionsHelper.unwrapCause(t);
@@ -348,9 +351,11 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
 
     /**
      * Render any exception as a xcontent, encapsulated within a field or object named "error". The level of details that are rendered
-     * depends on the value of the "detailed" parameter: when it equals to false, only a simple message based on the type and message of the
-     * exception is rendered. When it equals to true, all detail are provided including guesses root causes, cause and potentially stack
+     * depends on the value of the "detailed" parameter: when it's false only a simple message based on the type and message of the
+     * exception is rendered. When it's true all detail are provided including guesses root causes, cause and potentially stack
      * trace.
+     *
+     * This method is usually used when the {@link Exception} is rendered as a full XContent object.
      */
     public static void generateFailureXContent(XContentBuilder builder, Params params, @Nullable Exception e, boolean detailed)
             throws IOException {
@@ -389,13 +394,6 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         }
         generateThrowableXContent(builder, params, e);
         builder.endObject();
-    }
-
-    /**
-     * Same as {@link ElasticsearchException#generateFailureXContent(XContentBuilder, Params, Exception, boolean)} with all details.
-     */
-    public static void generateFailureXContent(XContentBuilder builder, Params params, @Nullable Exception e) throws IOException {
-        generateFailureXContent(builder, params, e, true);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -69,12 +69,13 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
      */
     public static final String REST_EXCEPTION_SKIP_STACK_TRACE = "rest.exception.stacktrace.skip";
     public static final boolean REST_EXCEPTION_SKIP_STACK_TRACE_DEFAULT = true;
-    public static final boolean REST_EXCEPTION_SKIP_CAUSE_DEFAULT = false;
-    private static final String INDEX_HEADER_KEY = "es.index";
-    private static final String INDEX_HEADER_KEY_UUID = "es.index_uuid";
-    private static final String SHARD_HEADER_KEY = "es.shard";
-    private static final String RESOURCE_HEADER_TYPE_KEY = "es.resource.type";
-    private static final String RESOURCE_HEADER_ID_KEY = "es.resource.id";
+    private static final boolean REST_EXCEPTION_SKIP_CAUSE_DEFAULT = false;
+    private static final String ES_HEADER_PREFIX = "es.";
+    private static final String INDEX_HEADER_KEY = ES_HEADER_PREFIX + "index";
+    private static final String INDEX_HEADER_KEY_UUID = ES_HEADER_PREFIX + "index_uuid";
+    private static final String SHARD_HEADER_KEY = ES_HEADER_PREFIX + "shard";
+    private static final String RESOURCE_HEADER_TYPE_KEY = ES_HEADER_PREFIX + "resource.type";
+    private static final String RESOURCE_HEADER_ID_KEY = ES_HEADER_PREFIX + "resource.id";
 
     private static final String TYPE = "type";
     private static final String REASON = "reason";
@@ -265,8 +266,8 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
 
             Set<String> customHeaders = null;
             for (String header : headers.keySet()) {
-                if (header.startsWith("es.")) {
-                    headerToXContent(builder, header.substring("es.".length()), headers.get(header));
+                if (header.startsWith(ES_HEADER_PREFIX)) {
+                    headerToXContent(builder, header.substring(ES_HEADER_PREFIX.length()), headers.get(header));
                 } else {
                     if (customHeaders == null) {
                         customHeaders = new HashSet<>();
@@ -363,8 +364,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
      * exception is rendered. When it equals to true, all detail are provided including guesses root causes, cause and potentially stack
      * trace.
      */
-    public static void generateFailureXContent(XContentBuilder builder, Params params, @Nullable Exception e, boolean detailed)
-            throws IOException {
+    public static void toXContentError(XContentBuilder builder, Params params, @Nullable Exception e, boolean detailed) throws IOException {
         // No exception to render as an error
         if (e == null) {
             builder.field(ERROR, "unknown");
@@ -403,10 +403,10 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     }
 
     /**
-     * Same as {@link ElasticsearchException#generateFailureXContent(XContentBuilder, Params, Exception, boolean)} with all details.
+     * Same as {@link ElasticsearchException#toXContentError(XContentBuilder, Params, Exception, boolean)} with all details.
      */
-    public static void generateFailureXContent(XContentBuilder builder, Params params, @Nullable Exception e) throws IOException {
-        generateFailureXContent(builder, params, e, true);
+    public static void toXContentError(XContentBuilder builder, Params params, @Nullable Exception e) throws IOException {
+        toXContentError(builder, params, e, true);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -265,14 +265,14 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             builder.field(REASON, getMessage());
 
             Set<String> customHeaders = null;
-            for (String header : headers.keySet()) {
-                if (header.startsWith(ES_HEADER_PREFIX)) {
-                    headerToXContent(builder, header.substring(ES_HEADER_PREFIX.length()), headers.get(header));
+            for (String key : headers.keySet()) {
+                if (key.startsWith(ES_HEADER_PREFIX)) {
+                    headerToXContent(builder, key.substring(ES_HEADER_PREFIX.length()), headers.get(key));
                 } else {
                     if (customHeaders == null) {
                         customHeaders = new HashSet<>();
                     }
-                    customHeaders.add(header);
+                    customHeaders.add(key);
                 }
             }
 

--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -22,6 +22,7 @@ package org.elasticsearch;
 import org.elasticsearch.action.support.replication.ReplicationOperation;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;

--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -70,12 +70,11 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     public static final String REST_EXCEPTION_SKIP_STACK_TRACE = "rest.exception.stacktrace.skip";
     public static final boolean REST_EXCEPTION_SKIP_STACK_TRACE_DEFAULT = true;
     private static final boolean REST_EXCEPTION_SKIP_CAUSE_DEFAULT = false;
-    private static final String ES_HEADER_PREFIX = "es.";
-    private static final String INDEX_HEADER_KEY = ES_HEADER_PREFIX + "index";
-    private static final String INDEX_HEADER_KEY_UUID = ES_HEADER_PREFIX + "index_uuid";
-    private static final String SHARD_HEADER_KEY = ES_HEADER_PREFIX + "shard";
-    private static final String RESOURCE_HEADER_TYPE_KEY = ES_HEADER_PREFIX + "resource.type";
-    private static final String RESOURCE_HEADER_ID_KEY = ES_HEADER_PREFIX + "resource.id";
+    private static final String INDEX_HEADER_KEY = "es.index";
+    private static final String INDEX_HEADER_KEY_UUID = "es.index_uuid";
+    private static final String SHARD_HEADER_KEY = "es.shard";
+    private static final String RESOURCE_HEADER_TYPE_KEY = "es.resource.type";
+    private static final String RESOURCE_HEADER_ID_KEY = "es.resource.id";
 
     private static final String TYPE = "type";
     private static final String REASON = "reason";

--- a/core/src/main/java/org/elasticsearch/action/TaskOperationFailure.java
+++ b/core/src/main/java/org/elasticsearch/action/TaskOperationFailure.java
@@ -105,7 +105,7 @@ public final class TaskOperationFailure implements Writeable, ToXContent {
         if (reason != null) {
             builder.field("reason");
             builder.startObject();
-            ElasticsearchException.toXContent(builder, params, reason);
+            ElasticsearchException.generateThrowableXContent(builder, params, reason);
             builder.endObject();
         }
         return builder;

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
@@ -207,7 +207,7 @@ public class IndicesShardStoresResponse extends ActionResponse implements ToXCon
             builder.field(Fields.ALLOCATED, allocationStatus.value());
             if (storeException != null) {
                 builder.startObject(Fields.STORE_EXCEPTION);
-                ElasticsearchException.toXContent(builder, params, storeException);
+                ElasticsearchException.generateThrowableXContent(builder, params, storeException);
                 builder.endObject();
             }
             return builder;

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
@@ -63,7 +63,7 @@ public class BulkItemResponse implements Streamable, StatusToXContentObject {
             builder.field(Fields._ID, failure.getId());
             builder.field(Fields.STATUS, failure.getStatus().getStatus());
             builder.startObject(Fields.ERROR);
-            ElasticsearchException.toXContent(builder, params, failure.getCause());
+            ElasticsearchException.generateThrowableXContent(builder, params, failure.getCause());
             builder.endObject();
         }
         builder.endObject();
@@ -173,7 +173,7 @@ public class BulkItemResponse implements Streamable, StatusToXContentObject {
                 builder.field(ID_FIELD, id);
             }
             builder.startObject(CAUSE_FIELD);
-            ElasticsearchException.toXContent(builder, params, cause);
+            ElasticsearchException.generateThrowableXContent(builder, params, cause);
             builder.endObject();
             builder.field(STATUS_FIELD, status.getStatus());
             return builder;

--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetResponse.java
@@ -137,7 +137,7 @@ public class MultiGetResponse extends ActionResponse implements Iterable<MultiGe
                 builder.field(Fields._INDEX, failure.getIndex());
                 builder.field(Fields._TYPE, failure.getType());
                 builder.field(Fields._ID, failure.getId());
-                ElasticsearchException.toXContentError(builder, params, failure.getFailure());
+                ElasticsearchException.generateFailureXContent(builder, params, failure.getFailure());
                 builder.endObject();
             } else {
                 GetResponse getResponse = response.getResponse();

--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetResponse.java
@@ -137,7 +137,7 @@ public class MultiGetResponse extends ActionResponse implements Iterable<MultiGe
                 builder.field(Fields._INDEX, failure.getIndex());
                 builder.field(Fields._TYPE, failure.getType());
                 builder.field(Fields._ID, failure.getId());
-                ElasticsearchException.renderException(builder, params, failure.getFailure());
+                ElasticsearchException.toXContentError(builder, params, failure.getFailure());
                 builder.endObject();
             } else {
                 GetResponse getResponse = response.getResponse();

--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetResponse.java
@@ -137,7 +137,7 @@ public class MultiGetResponse extends ActionResponse implements Iterable<MultiGe
                 builder.field(Fields._INDEX, failure.getIndex());
                 builder.field(Fields._TYPE, failure.getType());
                 builder.field(Fields._ID, failure.getId());
-                ElasticsearchException.generateFailureXContent(builder, params, failure.getFailure());
+                ElasticsearchException.toXContentError(builder, params, failure.getFailure());
                 builder.endObject();
             } else {
                 GetResponse getResponse = response.getResponse();

--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetResponse.java
@@ -137,7 +137,7 @@ public class MultiGetResponse extends ActionResponse implements Iterable<MultiGe
                 builder.field(Fields._INDEX, failure.getIndex());
                 builder.field(Fields._TYPE, failure.getType());
                 builder.field(Fields._ID, failure.getId());
-                ElasticsearchException.generateFailureXContent(builder, params, failure.getFailure());
+                ElasticsearchException.generateFailureXContent(builder, params, failure.getFailure(), true);
                 builder.endObject();
             } else {
                 GetResponse getResponse = response.getResponse();

--- a/core/src/main/java/org/elasticsearch/action/ingest/SimulateDocumentBaseResult.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/SimulateDocumentBaseResult.java
@@ -84,7 +84,7 @@ public final class SimulateDocumentBaseResult implements SimulateDocumentResult 
         if (failure == null) {
             ingestDocument.toXContent(builder, params);
         } else {
-            ElasticsearchException.toXContentError(builder, params, failure);
+            ElasticsearchException.generateFailureXContent(builder, params, failure);
         }
         builder.endObject();
         return builder;

--- a/core/src/main/java/org/elasticsearch/action/ingest/SimulateDocumentBaseResult.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/SimulateDocumentBaseResult.java
@@ -84,7 +84,7 @@ public final class SimulateDocumentBaseResult implements SimulateDocumentResult 
         if (failure == null) {
             ingestDocument.toXContent(builder, params);
         } else {
-            ElasticsearchException.renderException(builder, params, failure);
+            ElasticsearchException.toXContentError(builder, params, failure);
         }
         builder.endObject();
         return builder;

--- a/core/src/main/java/org/elasticsearch/action/ingest/SimulateDocumentBaseResult.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/SimulateDocumentBaseResult.java
@@ -84,7 +84,7 @@ public final class SimulateDocumentBaseResult implements SimulateDocumentResult 
         if (failure == null) {
             ingestDocument.toXContent(builder, params);
         } else {
-            ElasticsearchException.generateFailureXContent(builder, params, failure);
+            ElasticsearchException.generateFailureXContent(builder, params, failure, true);
         }
         builder.endObject();
         return builder;

--- a/core/src/main/java/org/elasticsearch/action/ingest/SimulateDocumentBaseResult.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/SimulateDocumentBaseResult.java
@@ -84,7 +84,7 @@ public final class SimulateDocumentBaseResult implements SimulateDocumentResult 
         if (failure == null) {
             ingestDocument.toXContent(builder, params);
         } else {
-            ElasticsearchException.generateFailureXContent(builder, params, failure);
+            ElasticsearchException.toXContentError(builder, params, failure);
         }
         builder.endObject();
         return builder;

--- a/core/src/main/java/org/elasticsearch/action/ingest/SimulateProcessorResult.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/SimulateProcessorResult.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.action.ingest;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -98,10 +99,10 @@ class SimulateProcessorResult implements Writeable, ToXContent {
 
         if (failure != null && ingestDocument != null) {
             builder.startObject("ignored_error");
-            ElasticsearchException.generateFailureXContent(builder, params, failure);
+            ElasticsearchException.toXContentError(builder, params, failure);
             builder.endObject();
         } else if (failure != null) {
-            ElasticsearchException.generateFailureXContent(builder, params, failure);
+            ElasticsearchException.toXContentError(builder, params, failure);
         }
 
         if (ingestDocument != null) {

--- a/core/src/main/java/org/elasticsearch/action/ingest/SimulateProcessorResult.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/SimulateProcessorResult.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.action.ingest;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -99,10 +98,10 @@ class SimulateProcessorResult implements Writeable, ToXContent {
 
         if (failure != null && ingestDocument != null) {
             builder.startObject("ignored_error");
-            ElasticsearchException.toXContentError(builder, params, failure);
+            ElasticsearchException.generateFailureXContent(builder, params, failure);
             builder.endObject();
         } else if (failure != null) {
-            ElasticsearchException.toXContentError(builder, params, failure);
+            ElasticsearchException.generateFailureXContent(builder, params, failure);
         }
 
         if (ingestDocument != null) {

--- a/core/src/main/java/org/elasticsearch/action/ingest/SimulateProcessorResult.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/SimulateProcessorResult.java
@@ -98,10 +98,10 @@ class SimulateProcessorResult implements Writeable, ToXContent {
 
         if (failure != null && ingestDocument != null) {
             builder.startObject("ignored_error");
-            ElasticsearchException.generateFailureXContent(builder, params, failure);
+            ElasticsearchException.generateFailureXContent(builder, params, failure, true);
             builder.endObject();
         } else if (failure != null) {
-            ElasticsearchException.generateFailureXContent(builder, params, failure);
+            ElasticsearchException.generateFailureXContent(builder, params, failure, true);
         }
 
         if (ingestDocument != null) {

--- a/core/src/main/java/org/elasticsearch/action/ingest/SimulateProcessorResult.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/SimulateProcessorResult.java
@@ -99,10 +99,10 @@ class SimulateProcessorResult implements Writeable, ToXContent {
 
         if (failure != null && ingestDocument != null) {
             builder.startObject("ignored_error");
-            ElasticsearchException.renderException(builder, params, failure);
+            ElasticsearchException.toXContentError(builder, params, failure);
             builder.endObject();
         } else if (failure != null) {
-            ElasticsearchException.renderException(builder, params, failure);
+            ElasticsearchException.toXContentError(builder, params, failure);
         }
 
         if (ingestDocument != null) {

--- a/core/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
@@ -156,7 +156,7 @@ public class MultiSearchResponse extends ActionResponse implements Iterable<Mult
         for (Item item : items) {
             builder.startObject();
             if (item.isFailure()) {
-                ElasticsearchException.generateFailureXContent(builder, params, item.getFailure());
+                ElasticsearchException.toXContentError(builder, params, item.getFailure());
                 builder.field(Fields.STATUS, ExceptionsHelper.status(item.getFailure()).getStatus());
             } else {
                 item.getResponse().innerToXContent(builder, params);

--- a/core/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
@@ -156,7 +156,7 @@ public class MultiSearchResponse extends ActionResponse implements Iterable<Mult
         for (Item item : items) {
             builder.startObject();
             if (item.isFailure()) {
-                ElasticsearchException.generateFailureXContent(builder, params, item.getFailure());
+                ElasticsearchException.generateFailureXContent(builder, params, item.getFailure(), true);
                 builder.field(Fields.STATUS, ExceptionsHelper.status(item.getFailure()).getStatus());
             } else {
                 item.getResponse().innerToXContent(builder, params);

--- a/core/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
@@ -156,7 +156,7 @@ public class MultiSearchResponse extends ActionResponse implements Iterable<Mult
         for (Item item : items) {
             builder.startObject();
             if (item.isFailure()) {
-                ElasticsearchException.renderException(builder, params, item.getFailure());
+                ElasticsearchException.toXContentError(builder, params, item.getFailure());
                 builder.field(Fields.STATUS, ExceptionsHelper.status(item.getFailure()).getStatus());
             } else {
                 item.getResponse().innerToXContent(builder, params);

--- a/core/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
@@ -156,7 +156,7 @@ public class MultiSearchResponse extends ActionResponse implements Iterable<Mult
         for (Item item : items) {
             builder.startObject();
             if (item.isFailure()) {
-                ElasticsearchException.toXContentError(builder, params, item.getFailure());
+                ElasticsearchException.generateFailureXContent(builder, params, item.getFailure());
                 builder.field(Fields.STATUS, ExceptionsHelper.status(item.getFailure()).getStatus());
             } else {
                 item.getResponse().innerToXContent(builder, params);

--- a/core/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
@@ -147,12 +147,17 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
     }
 
     @Override
-    protected boolean skipCauseInXContent(Params params) {
-        if (super.skipCauseInXContent(params)) {
-            return true;
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        Throwable ex = ExceptionsHelper.unwrapCause(this);
+        if (ex != this) {
+            generateThrowableXContent(builder, params, this);
+        } else {
+            // We don't have a cause when all shards failed, but we do have shards failures so we can "guess" a cause.
+            // Here, we use super.getCause() because we don't want the guessed exception to be rendered twice (one in
+            // the "cause" field, one in "failed_shards")
+            innerToXContent(builder, params, this, getExceptionName(), getMessage(), getHeaders(), super.getCause());
         }
-        // if the cause is null we inject a guessed root cause that will then be rendered twice so we disable it manually
-        return super.getCause() == null;
+        return builder;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
@@ -144,15 +144,15 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
             builder.endObject();
         }
         builder.endArray();
-        super.innerToXContent(builder, params);
     }
 
     @Override
-    protected void causeToXContent(XContentBuilder builder, Params params) throws IOException {
-        if (super.getCause() != null) {
-            // if the cause is null we inject a guessed root cause that will then be rendered twice so wi disable it manually
-            super.causeToXContent(builder, params);
+    protected boolean skipCauseInXContent(Params params) {
+        if (super.skipCauseInXContent(params)) {
+            return true;
         }
+        // if the cause is null we inject a guessed root cause that will then be rendered twice so we disable it manually
+        return super.getCause() == null;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
@@ -131,7 +131,7 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
     }
 
     @Override
-    protected void innerToXContent(XContentBuilder builder, Params params) throws IOException {
+    protected void metadataToXContent(XContentBuilder builder, Params params) throws IOException {
         builder.field("phase", phaseName);
         final boolean group = params.paramAsBoolean("group_shard_failures", true); // we group by default
         builder.field("grouped", group); // notify that it's grouped

--- a/core/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
@@ -103,6 +103,7 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
         return shardFailures;
     }
 
+    @Override
     public Throwable getCause() {
         Throwable cause = super.getCause();
         if (cause == null) {
@@ -152,9 +153,9 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
         if (ex != this) {
             generateThrowableXContent(builder, params, this);
         } else {
-            // We don't have a cause when all shards failed, but we do have shards failures so we can "guess" a cause.
-            // Here, we use super.getCause() because we don't want the guessed exception to be rendered twice (one in
-            // the "cause" field, one in "failed_shards")
+            // We don't have a cause when all shards failed, but we do have shards failures so we can "guess" a cause
+            // (see {@link #getCause()}). Here, we use super.getCause() because we don't want the guessed exception to
+            // be rendered twice (one in the "cause" field, one in "failed_shards")
             innerToXContent(builder, params, this, getExceptionName(), getMessage(), getHeaders(), super.getCause());
         }
         return builder;

--- a/core/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
+++ b/core/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
@@ -161,7 +161,7 @@ public class ShardSearchFailure implements ShardOperationFailedException {
         if (cause != null) {
             builder.field("reason");
             builder.startObject();
-            ElasticsearchException.toXContent(builder, params, cause);
+            ElasticsearchException.generateThrowableXContent(builder, params, cause);
             builder.endObject();
         }
         return builder;

--- a/core/src/main/java/org/elasticsearch/action/support/DefaultShardOperationFailedException.java
+++ b/core/src/main/java/org/elasticsearch/action/support/DefaultShardOperationFailedException.java
@@ -125,7 +125,7 @@ public class DefaultShardOperationFailedException implements ShardOperationFaile
         if (reason != null) {
             builder.field("reason");
             builder.startObject();
-            ElasticsearchException.toXContent(builder, params, reason);
+            ElasticsearchException.generateThrowableXContent(builder, params, reason);
             builder.endObject();
         }
         return builder;

--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -375,7 +374,7 @@ public class ReplicationResponse extends ActionResponse {
                 builder.field(_NODE, nodeId);
                 builder.field(REASON);
                 builder.startObject();
-                ElasticsearchException.toXContent(builder, params, cause);
+                ElasticsearchException.generateThrowableXContent(builder, params, cause);
                 builder.endObject();
                 builder.field(STATUS, status);
                 builder.field(PRIMARY, primary);

--- a/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsResponse.java
@@ -133,7 +133,7 @@ public class MultiTermVectorsResponse extends ActionResponse implements Iterable
                 builder.field(Fields._INDEX, failure.getIndex());
                 builder.field(Fields._TYPE, failure.getType());
                 builder.field(Fields._ID, failure.getId());
-                ElasticsearchException.renderException(builder, params, failure.getCause());
+                ElasticsearchException.toXContentError(builder, params, failure.getCause());
                 builder.endObject();
             } else {
                 TermVectorsResponse getResponse = response.getResponse();

--- a/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsResponse.java
@@ -133,7 +133,7 @@ public class MultiTermVectorsResponse extends ActionResponse implements Iterable
                 builder.field(Fields._INDEX, failure.getIndex());
                 builder.field(Fields._TYPE, failure.getType());
                 builder.field(Fields._ID, failure.getId());
-                ElasticsearchException.generateFailureXContent(builder, params, failure.getCause());
+                ElasticsearchException.toXContentError(builder, params, failure.getCause());
                 builder.endObject();
             } else {
                 TermVectorsResponse getResponse = response.getResponse();

--- a/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsResponse.java
@@ -133,7 +133,7 @@ public class MultiTermVectorsResponse extends ActionResponse implements Iterable
                 builder.field(Fields._INDEX, failure.getIndex());
                 builder.field(Fields._TYPE, failure.getType());
                 builder.field(Fields._ID, failure.getId());
-                ElasticsearchException.generateFailureXContent(builder, params, failure.getCause());
+                ElasticsearchException.generateFailureXContent(builder, params, failure.getCause(), true);
                 builder.endObject();
             } else {
                 TermVectorsResponse getResponse = response.getResponse();

--- a/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsResponse.java
@@ -133,7 +133,7 @@ public class MultiTermVectorsResponse extends ActionResponse implements Iterable
                 builder.field(Fields._INDEX, failure.getIndex());
                 builder.field(Fields._TYPE, failure.getType());
                 builder.field(Fields._ID, failure.getId());
-                ElasticsearchException.toXContentError(builder, params, failure.getCause());
+                ElasticsearchException.generateFailureXContent(builder, params, failure.getCause());
                 builder.endObject();
             } else {
                 TermVectorsResponse getResponse = response.getResponse();

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java
@@ -262,7 +262,7 @@ public class NodeAllocationResult implements ToXContent, Writeable, Comparable<N
                 }
                 if (storeException != null) {
                     builder.startObject("store_exception");
-                    ElasticsearchException.toXContent(builder, params, storeException);
+                    ElasticsearchException.generateThrowableXContent(builder, params, storeException);
                     builder.endObject();
                 }
             }

--- a/core/src/main/java/org/elasticsearch/common/ParsingException.java
+++ b/core/src/main/java/org/elasticsearch/common/ParsingException.java
@@ -95,7 +95,7 @@ public class ParsingException extends ElasticsearchException {
     }
 
     @Override
-    protected void innerToXContent(XContentBuilder builder, Params params) throws IOException {
+    protected void metadataToXContent(XContentBuilder builder, Params params) throws IOException {
         if (lineNumber != UNKNOWN_POSITION) {
             builder.field("line", lineNumber);
             builder.field("col", columnNumber);

--- a/core/src/main/java/org/elasticsearch/common/ParsingException.java
+++ b/core/src/main/java/org/elasticsearch/common/ParsingException.java
@@ -100,7 +100,6 @@ public class ParsingException extends ElasticsearchException {
             builder.field("line", lineNumber);
             builder.field("col", columnNumber);
         }
-        super.innerToXContent(builder, params);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/breaker/CircuitBreakingException.java
+++ b/core/src/main/java/org/elasticsearch/common/breaker/CircuitBreakingException.java
@@ -76,6 +76,5 @@ public class CircuitBreakingException extends ElasticsearchException {
     protected void innerToXContent(XContentBuilder builder, Params params) throws IOException {
         builder.field("bytes_wanted", bytesWanted);
         builder.field("bytes_limit", byteLimit);
-        super.innerToXContent(builder, params);
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/breaker/CircuitBreakingException.java
+++ b/core/src/main/java/org/elasticsearch/common/breaker/CircuitBreakingException.java
@@ -73,7 +73,7 @@ public class CircuitBreakingException extends ElasticsearchException {
     }
 
     @Override
-    protected void innerToXContent(XContentBuilder builder, Params params) throws IOException {
+    protected void metadataToXContent(XContentBuilder builder, Params params) throws IOException {
         builder.field("bytes_wanted", bytesWanted);
         builder.field("bytes_limit", byteLimit);
     }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryShardException.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryShardException.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.query;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.rest.RestStatus;
 
@@ -58,11 +57,6 @@ public class QueryShardException extends ElasticsearchException {
     @Override
     public RestStatus status() {
         return RestStatus.BAD_REQUEST;
-    }
-
-    @Override
-    protected void innerToXContent(XContentBuilder builder, Params params) throws IOException {
-        super.innerToXContent(builder, params);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
+++ b/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Collections;
 
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.ElasticsearchException.REST_EXCEPTION_SKIP_STACK_TRACE;
@@ -136,7 +135,7 @@ public class BytesRestResponse extends RestResponse {
         }
 
         XContentBuilder builder = channel.newErrorBuilder().startObject();
-        ElasticsearchException.toXContentError(builder, params, e, channel.detailedErrorsEnabled());
+        ElasticsearchException.generateFailureXContent(builder, params, e, channel.detailedErrorsEnabled());
         builder.field("status", status.getStatus());
         builder.endObject();
         return builder;

--- a/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
+++ b/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.ElasticsearchException.REST_EXCEPTION_SKIP_STACK_TRACE;
@@ -135,7 +136,7 @@ public class BytesRestResponse extends RestResponse {
         }
 
         XContentBuilder builder = channel.newErrorBuilder().startObject();
-        ElasticsearchException.generateFailureXContent(builder, params, e, channel.detailedErrorsEnabled());
+        ElasticsearchException.toXContentError(builder, params, e, channel.detailedErrorsEnabled());
         builder.field("status", status.getStatus());
         builder.endObject();
         return builder;

--- a/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
+++ b/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
@@ -140,20 +140,4 @@ public class BytesRestResponse extends RestResponse {
         builder.endObject();
         return builder;
     }
-
-    /*
-     * Builds a simple error string from the message of the first ElasticsearchException
-     */
-    private static String simpleMessage(Throwable t) throws IOException {
-        int counter = 0;
-        Throwable next = t;
-        while (next != null && counter++ < 10) {
-            if (t instanceof ElasticsearchException) {
-                return next.getClass().getSimpleName() + "[" + next.getMessage() + "]";
-            }
-            next = next.getCause();
-        }
-
-        return "No ElasticsearchException found";
-    }
 }

--- a/core/src/main/java/org/elasticsearch/script/ScriptException.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptException.java
@@ -87,7 +87,7 @@ public class ScriptException extends ElasticsearchException {
     }
     
     @Override
-    protected void innerToXContent(XContentBuilder builder, Params params) throws IOException {
+    protected void metadataToXContent(XContentBuilder builder, Params params) throws IOException {
         builder.field("script_stack", scriptStack);
         builder.field("script", script);
         builder.field("lang", lang);

--- a/core/src/main/java/org/elasticsearch/script/ScriptException.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptException.java
@@ -88,7 +88,6 @@ public class ScriptException extends ElasticsearchException {
     
     @Override
     protected void innerToXContent(XContentBuilder builder, Params params) throws IOException {
-        super.innerToXContent(builder, params);
         builder.field("script_stack", scriptStack);
         builder.field("script", script);
         builder.field("lang", lang);

--- a/core/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -607,7 +607,7 @@ public class ScriptService extends AbstractComponent implements Closeable, Clust
                     try (XContentBuilder builder = JsonXContent.contentBuilder()) {
                         builder.prettyPrint();
                         builder.startObject();
-                        ElasticsearchException.toXContent(builder, ToXContent.EMPTY_PARAMS, e);
+                        ElasticsearchException.generateThrowableXContent(builder, ToXContent.EMPTY_PARAMS, e);
                         builder.endObject();
                         logger.warn("failed to load/compile script [{}]: {}", scriptNameExt.v1(), builder.string());
                     } catch (IOException ioe) {

--- a/core/src/main/java/org/elasticsearch/search/SearchParseException.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchParseException.java
@@ -77,7 +77,6 @@ public class SearchParseException extends SearchContextException {
             builder.field("line", lineNumber);
             builder.field("col", columnNumber);
         }
-        super.innerToXContent(builder, params);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/search/SearchParseException.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchParseException.java
@@ -72,7 +72,7 @@ public class SearchParseException extends SearchContextException {
     }
 
     @Override
-    protected void innerToXContent(XContentBuilder builder, Params params) throws IOException {
+    protected void metadataToXContent(XContentBuilder builder, Params params) throws IOException {
         if (lineNumber != UNKNOWN_POSITION) {
             builder.field("line", lineNumber);
             builder.field("col", columnNumber);

--- a/core/src/main/java/org/elasticsearch/tasks/TaskResult.java
+++ b/core/src/main/java/org/elasticsearch/tasks/TaskResult.java
@@ -230,7 +230,7 @@ public final class TaskResult implements Writeable, ToXContent {
     private static BytesReference toXContent(Exception error) throws IOException {
         try (XContentBuilder builder = XContentFactory.contentBuilder(Requests.INDEX_CONTENT_TYPE)) {
             builder.startObject();
-            ElasticsearchException.toXContent(builder, ToXContent.EMPTY_PARAMS, error);
+            ElasticsearchException.generateThrowableXContent(builder, ToXContent.EMPTY_PARAMS, error);
             builder.endObject();
             return builder.bytes();
         }

--- a/core/src/test/java/org/elasticsearch/ESExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/ESExceptionTests.java
@@ -253,7 +253,7 @@ public class ESExceptionTests extends ESTestCase {
             }
             XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.startObject();
-            ElasticsearchException.toXContent(builder, PARAMS, ex);
+            ElasticsearchException.generateThrowableXContent(builder, PARAMS, ex);
             builder.endObject();
 
             String expected = "{\"type\":\"file_not_found_exception\",\"reason\":\"foo not found\"}";
@@ -264,7 +264,7 @@ public class ESExceptionTests extends ESTestCase {
             ParsingException ex = new ParsingException(1, 2, "foobar", null);
             XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.startObject();
-            ElasticsearchException.toXContent(builder, PARAMS, ex);
+            ElasticsearchException.generateThrowableXContent(builder, PARAMS, ex);
             builder.endObject();
             String expected = "{\"type\":\"parsing_exception\",\"reason\":\"foobar\",\"line\":1,\"col\":2}";
             assertEquals(expected, builder.string());
@@ -274,7 +274,7 @@ public class ESExceptionTests extends ESTestCase {
             ElasticsearchException ex =  new RemoteTransportException("foobar", new FileNotFoundException("foo not found"));
             XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.startObject();
-            ElasticsearchException.toXContent(builder, PARAMS, ex);
+            ElasticsearchException.generateThrowableXContent(builder, PARAMS, ex);
             builder.endObject();
 
             XContentBuilder otherBuilder = XContentFactory.jsonBuilder();
@@ -292,7 +292,7 @@ public class ESExceptionTests extends ESTestCase {
             ex.addHeader("test_multi", "some value", "another value");
             XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.startObject();
-            ElasticsearchException.toXContent(builder, PARAMS, ex);
+            ElasticsearchException.generateThrowableXContent(builder, PARAMS, ex);
             builder.endObject();
             assertThat(builder.string(), Matchers.anyOf( // iteration order depends on platform
                             equalTo("{\"type\":\"parsing_exception\",\"reason\":\"foobar\",\"line\":1,\"col\":2,\"header\":{\"test_multi\":[\"some value\",\"another value\"],\"test\":\"some value\"}}"),

--- a/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -67,7 +67,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
         // in the JSON. Since the stack can be large, it only checks the beginning of the JSON.
         assertExceptionAsJson(e, true, startsWith("{\"type\":\"exception\",\"reason\":\"foo\"," +
                 "\"caused_by\":{\"type\":\"illegal_state_exception\",\"reason\":\"bar\"," +
-                "\"stack_trace\":\"java.lang.IllegalStateException: bar"));
+                "\"stack_trace\":\"[bar]\\n\\tat org.elasticsearch."));
     }
 
     public void testToXContentWithHeaders() throws IOException {

--- a/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -67,7 +68,9 @@ public class ElasticsearchExceptionTests extends ESTestCase {
         // in the JSON. Since the stack can be large, it only checks the beginning of the JSON.
         assertExceptionAsJson(e, true, startsWith("{\"type\":\"exception\",\"reason\":\"foo\"," +
                 "\"caused_by\":{\"type\":\"illegal_state_exception\",\"reason\":\"bar\"," +
-                "\"stack_trace\":\"java.lang.IllegalStateException: bar\\n\\tat org.elasticsearch."));
+                "\"stack_trace\":\"java.lang.IllegalStateException: bar" +
+                (Constants.WINDOWS ? "\\r\\n" : "\\n") +
+                "\\tat org.elasticsearch."));
     }
 
     public void testToXContentWithHeaders() throws IOException {

--- a/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -67,7 +67,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
         // in the JSON. Since the stack can be large, it only checks the beginning of the JSON.
         assertExceptionAsJson(e, true, startsWith("{\"type\":\"exception\",\"reason\":\"foo\"," +
                 "\"caused_by\":{\"type\":\"illegal_state_exception\",\"reason\":\"bar\"," +
-                "\"stack_trace\":\"[bar]\\n\\tat org.elasticsearch."));
+                "\"stack_trace\":\"java.lang.IllegalStateException: bar\\n\\tat org.elasticsearch."));
     }
 
     public void testToXContentWithHeaders() throws IOException {

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponse.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponse.java
@@ -152,7 +152,7 @@ public class MultiSearchTemplateResponse extends ActionResponse implements Itera
         for (Item item : items) {
             if (item.isFailure()) {
                 builder.startObject();
-                ElasticsearchException.generateFailureXContent(builder, params, item.getFailure());
+                ElasticsearchException.generateFailureXContent(builder, params, item.getFailure(), true);
                 builder.endObject();
             } else {
                 item.getResponse().toXContent(builder, params);

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponse.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponse.java
@@ -152,7 +152,7 @@ public class MultiSearchTemplateResponse extends ActionResponse implements Itera
         for (Item item : items) {
             if (item.isFailure()) {
                 builder.startObject();
-                ElasticsearchException.toXContentError(builder, params, item.getFailure());
+                ElasticsearchException.generateFailureXContent(builder, params, item.getFailure());
                 builder.endObject();
             } else {
                 item.getResponse().toXContent(builder, params);

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponse.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponse.java
@@ -152,7 +152,7 @@ public class MultiSearchTemplateResponse extends ActionResponse implements Itera
         for (Item item : items) {
             if (item.isFailure()) {
                 builder.startObject();
-                ElasticsearchException.renderException(builder, params, item.getFailure());
+                ElasticsearchException.toXContentError(builder, params, item.getFailure());
                 builder.endObject();
             } else {
                 item.getResponse().toXContent(builder, params);

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
@@ -486,7 +486,7 @@ public abstract class BulkByScrollTask extends CancellableTask {
                 status.toXContent(builder, params);
             } else {
                 builder.startObject();
-                ElasticsearchException.toXContent(builder, params, exception);
+                ElasticsearchException.generateThrowableXContent(builder, params, exception);
                 builder.endObject();
             }
             return builder;

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ScrollableHitSource.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ScrollableHitSource.java
@@ -348,7 +348,7 @@ public abstract class ScrollableHitSource implements Closeable {
             builder.field("reason");
             {
                 builder.startObject();
-                ElasticsearchException.toXContent(builder, params, reason);
+                ElasticsearchException.generateThrowableXContent(builder, params, reason);
                 builder.endObject();
             }
             builder.endObject();


### PR DESCRIPTION
This pull request tries to simplify the way `ElasticsearchException` are rendered to xcontent. It adds some documentation and renames and merges some methods. Current behavior is preserved, the goal is to be more readable and centralize everything in the `ElasticsearchException` class.