### PR TITLE
gradle run --debug-jvm is explained twice

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -485,20 +485,14 @@ gradle run --debug-jvm
 
 == Debugging remotely from an IDE
 
-If you want to run elasticsearch and be able to remotely attach the process
-for debugging purposes from your IDE, you need to add the following line in
-`config/jvm.options`:
+If you want to run Elasticsearch and be able to remotely attach the process
+for debugging purposes from your IDE, can start Elasticsearch using `ES_JAVA_OPTS`:
 
 ---------------------------------------------------------------------------
--Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=4000,suspend=n
+ES_JAVA_OPTS="-Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=4000,suspend=y" ./bin/elasticsearch
 ---------------------------------------------------------------------------
 
-Then start elasticsearch with `bin/elasticsearch` as usual.
-
-If you are using IntelliJ, create a new Run/Debug configuration, choose `Remote`
-and define the same port you defined in `config/jvm.options`. Then start the
-remote debug session from IntelliJ.
-
+Read your IDE documentation for how to attach a debugger to a JVM process.
 
 == Building with extra plugins
 Additional plugins may be built alongside elasticsearch, where their

--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -25,12 +25,6 @@ run it using Gradle:
 gradle run
 -------------------------------------
 
-or to attach a remote debugger, run it as:
-
--------------------------------------
-gradle run --debug-jvm
--------------------------------------
-
 === Test case filtering.
 
 - `tests.class` is a class-filtering shell-like glob pattern,

--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -474,7 +474,7 @@ Combined (Unit+Integration) coverage:
 mvn -Dtests.coverage verify jacoco:report
 ---------------------------------------------------------------------------
 
-== Debugging from an IDE
+== Launching and debugging from an IDE
 
 If you want to run elasticsearch from your IDE, the `gradle run` task
 supports a remote debugging option:
@@ -482,6 +482,23 @@ supports a remote debugging option:
 ---------------------------------------------------------------------------
 gradle run --debug-jvm
 ---------------------------------------------------------------------------
+
+== Debugging remotely from an IDE
+
+If you want to run elasticsearch and be able to remotely attach the process
+for debugging purposes from your IDE, you need to add the following line in
+`config/jvm.options`:
+
+---------------------------------------------------------------------------
+-Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=4000,suspend=n
+---------------------------------------------------------------------------
+
+Then start elasticsearch with `bin/elasticsearch` as usual.
+
+If you are using IntelliJ, create a new Run/Debug configuration, choose `Remote`
+and define the same port you defined in `config/jvm.options`. Then start the
+remote debug session from IntelliJ.
+
 
 == Building with extra plugins
 Additional plugins may be built alongside elasticsearch, where their


### PR DESCRIPTION
We are already explaining how to debug remotely in `Debugging from an IDE` section.
We can remove one.
