### PR TITLE
Harden close and remove reference concurrency in MockTcpTransport

### DIFF
--- a/core/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/core/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -439,9 +439,6 @@ public abstract class TcpTransport<Channel> extends AbstractLifecycleComponent i
         try {
             ensureOpen();
             try (Releasable ignored = connectionLock.acquire(node.getId())) {
-                if (!lifecycle.started()) {
-                    throw new IllegalStateException("can't add nodes to a stopped transport");
-                }
                 NodeChannels nodeChannels = connectedNodes.get(node);
                 if (nodeChannels != null) {
                     return;
@@ -867,7 +864,7 @@ public abstract class TcpTransport<Channel> extends AbstractLifecycleComponent i
                     }
                 }
 
-                for (Iterator<NodeChannels> it = connectedNodes.values().iterator(); it.hasNext(); ) {
+                for (Iterator<NodeChannels> it = connectedNodes.values().iterator(); it.hasNext();) {
                     NodeChannels nodeChannels = it.next();
                     it.remove();
                     IOUtils.closeWhileHandlingException(nodeChannels);
@@ -889,7 +886,8 @@ public abstract class TcpTransport<Channel> extends AbstractLifecycleComponent i
 
     protected void onException(Channel channel, Exception e) throws IOException {
         if (!lifecycle.started()) {
-            // ignore
+            // just close and ignore - we are already stopped and just need to make sure we release all resources
+            disconnectFromNodeChannel(channel, e);
             return;
         }
         if (isCloseConnectionException(e)) {


### PR DESCRIPTION
There was still small race in MockTcpTransport where channesl that are concurrently
closing are not yet removed from the reference tracking causing tests to fail. Compared to
the other races before this is a rather small windown and requires very very short test durations.

an example failure is here: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+multijob-unix-compatibility/os=ubuntu/510/console

```
  2> java.lang.AssertionError: there are still open channels: [MockChannel{profile='none', isOpen=false, localAddress=/127.0.0.1:9301, isServerSocket=false}]
```

where the channel is already marked as closed but not yet removed from the open channels.
