### PR TITLE
Increase visibility of doExecute so it can be used directly

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportDeleteByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportDeleteByQueryAction.java
@@ -52,7 +52,7 @@ public class TransportDeleteByQueryAction extends HandledTransportAction<DeleteB
     }
 
     @Override
-    protected void doExecute(Task task, DeleteByQueryRequest request, ActionListener<BulkIndexByScrollResponse> listener) {
+    public void doExecute(Task task, DeleteByQueryRequest request, ActionListener<BulkIndexByScrollResponse> listener) {
         if (request.getSlices() > 1) {
             ReindexParallelizationHelper.startSlices(client, taskManager, DeleteByQueryAction.INSTANCE, clusterService.localNode().getId(),
                     (ParentBulkByScrollTask) task, request, listener);


### PR DESCRIPTION
Minor tweak to raise the visibility of `doExecute()`, so that other modules/plugins/libraries depending on Reindex can use it.  The alternative is to make `AsyncDeleteBySearchAction` and `ParentBulkByScrollTask` public so they can be used directly, but it seemed cleaner to just elevate `doExecute()` instead so the user doesn't need to fiddle with the internal bits.

/cc @nik9000 