### PR TITLE
Update Line 775 default size

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -772,7 +772,7 @@ GET /bank/_search
 // CONSOLE
 // TEST[continued]
 
-Note that if `size` is not specified, it defaults to 10.
+Note that if `size` is not specified or if `size` is set to 0 , it defaults to 10.
 
 This example does a `match_all` and returns documents 11 through 20:
 


### PR DESCRIPTION
New to Elasticsearch so this is my first reading of any material and noticed this as I was reading your document.

On line 1011 in the section 'Executing Aggregation'
It states that "...returns the top 10 (default)..."
But the code in place states "size": 0". So being that "size" is defined, either
a: This statement on line 775 needs to be reworded to include if set to 0, or 
b: Line 1011 is a typo where size: 0 and should be size: 10 or should not be included at all.

Am I correct?

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
