### PR TITLE
Clarify aggregations size attribute

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -1002,13 +1002,13 @@ In addition to the `match_all`, `match`, `bool`, and `range` queries, there are 
 
 Aggregations provide the ability to group and extract statistics from your data. The easiest way to think about aggregations is by roughly equating it to the SQL GROUP BY and the SQL aggregate functions. In Elasticsearch, you have the ability to execute searches returning hits and at the same time return aggregated results separate from the hits all in one response. This is very powerful and efficient in the sense that you can run queries and multiple aggregations and get the results back of both (or either) operations in one shot avoiding network roundtrips using a concise and simplified API.
 
-To start with, this example groups all the accounts by state, and then returns the top 10 (default) states sorted by count descending (also default):
+To start with, this example groups all the accounts by state, and then returns the top 10 states sorted by count descending (default):
 
 [source,js]
 --------------------------------------------------
 GET /bank/_search
 {
-  "size": 0,
+  "size": 10,
   "aggs": {
     "group_by_state": {
       "terms": {
@@ -1020,6 +1020,8 @@ GET /bank/_search
 --------------------------------------------------
 // CONSOLE
 // TEST[continued]
+
+Note that if `size` is not specified, it defaults to 10.
 
 In SQL, the above aggregation is similar in concept to:
 


### PR DESCRIPTION
Based on a short discussion with @clintongormley, size: 0 is not allowed any longer.

I believe my proposed changes clarify the default aspect as it pertains to the size attribute.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
