### PR TITLE
Do not configure a logger named level

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -122,19 +122,26 @@ public class LogConfigurator {
         Configurator.initialize(builder.build());
     }
 
-    private static void configureLoggerLevels(Settings settings) {
+    /**
+     * Configures the logging levels for loggers configured in the specified settings.
+     *
+     * @param settings the settings from which logger levels will be extracted
+     */
+    private static void configureLoggerLevels(final Settings settings) {
         if (ESLoggerFactory.LOG_DEFAULT_LEVEL_SETTING.exists(settings)) {
             final Level level = ESLoggerFactory.LOG_DEFAULT_LEVEL_SETTING.get(settings);
             Loggers.setLevel(ESLoggerFactory.getRootLogger(), level);
         }
 
         final Map<String, String> levels = settings.filter(ESLoggerFactory.LOG_LEVEL_SETTING::match).getAsMap();
-        for (String key : levels.keySet()) {
-            final Level level = ESLoggerFactory.LOG_LEVEL_SETTING.getConcreteSetting(key).get(settings);
-            Loggers.setLevel(ESLoggerFactory.getLogger(key.substring("logger.".length())), level);
+        for (final String key : levels.keySet()) {
+            // do not set a log level for a logger named level (from the default log setting)
+            if (!key.equals(ESLoggerFactory.LOG_DEFAULT_LEVEL_SETTING.getKey())) {
+                final Level level = ESLoggerFactory.LOG_LEVEL_SETTING.getConcreteSetting(key).get(settings);
+                Loggers.setLevel(ESLoggerFactory.getLogger(key.substring("logger.".length())), level);
+            }
         }
     }
-
 
     @SuppressForbidden(reason = "sets system property for logging configuration")
     private static void setLogConfigurationSystemProperty(final Path logsPath, final Settings settings) {

--- a/qa/evil-tests/src/test/resources/org/elasticsearch/common/logging/minimal/log4j2.properties
+++ b/qa/evil-tests/src/test/resources/org/elasticsearch/common/logging/minimal/log4j2.properties
@@ -1,0 +1,7 @@
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console


### PR DESCRIPTION
When logger.level is set, we end up configuring a logger named "level" because we look for all settings of the form "logger\..+" as configuring a logger. Yet, logger.level is special and is meant to only configure the default logging level. This commit causes is to avoid not configuring a logger named level. 