### PR TITLE
Add replica ops with version conflict to translog

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -202,7 +202,7 @@ public class ReplicationOperation<
                         shard,
                         replicaRequest),
                     replicaException);
-                if (ignoreReplicaException(replicaException)) {
+                if (TransportActions.isShardNotAvailableException(replicaException)) {
                     decPendingAndFinishIfNeeded();
                 } else {
                     RestStatus restStatus = ExceptionsHelper.status(replicaException);
@@ -313,30 +313,6 @@ public class ReplicationOperation<
             resultListener.onFailure(exception);
         }
     }
-
-
-    /**
-     * Should an exception be ignored when the operation is performed on the replica.
-     */
-    public static boolean ignoreReplicaException(Exception e) {
-        if (TransportActions.isShardNotAvailableException(e)) {
-            return true;
-        }
-        // on version conflict or document missing, it means
-        // that a new change has crept into the replica, and it's fine
-        if (isConflictException(e)) {
-            return true;
-        }
-        return false;
-    }
-
-    public static boolean isConflictException(Throwable t) {
-        final Throwable cause = ExceptionsHelper.unwrapCause(t);
-        // on version conflict or document missing, it means
-        // that a new change has crept into the replica, and it's fine
-        return cause instanceof VersionConflictEngineException;
-    }
-
 
     public interface Primary<
                 Request extends ReplicationRequest<Request>,

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -487,6 +487,10 @@ public class InternalEngine extends Engine {
                         op.versionType().explainConflictForWrites(currentVersion, expectedVersion, deleted));
                 result = onFailure.apply(e);
             } else {
+                /*
+                 * Version conflicts during recovery and on replicas are normal due to asynchronous execution; as such, we should return a
+                 * successful result.
+                 */
                 result = onSuccess.get();
             }
             return Optional.of(result);

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -674,7 +674,7 @@ public class InternalEngine extends Engine {
                 }
             }
             final long expectedVersion = index.version();
-            final Optional<IndexResult> checkVersionConflictResult =
+            final Optional<IndexResult> resultOnVersionConflict =
                 checkVersionConflict(
                     index,
                     currentVersion,
@@ -684,8 +684,8 @@ public class InternalEngine extends Engine {
                     e -> new IndexResult(e, currentVersion, index.seqNo()));
 
             final IndexResult indexResult;
-            if (checkVersionConflictResult.isPresent()) {
-                indexResult = checkVersionConflictResult.get();
+            if (resultOnVersionConflict.isPresent()) {
+                indexResult = resultOnVersionConflict.get();
             } else {
                 // no version conflict
                 if (index.origin() == Operation.Origin.PRIMARY) {
@@ -808,7 +808,7 @@ public class InternalEngine extends Engine {
 
             final long expectedVersion = delete.version();
 
-            final Optional<DeleteResult> checkVersionConflictResult =
+            final Optional<DeleteResult> resultOnVersionConflict =
                 checkVersionConflict(
                     delete,
                     currentVersion,
@@ -817,8 +817,8 @@ public class InternalEngine extends Engine {
                     () -> new DeleteResult(expectedVersion, delete.seqNo(), true),
                     e -> new DeleteResult(e, expectedVersion, delete.seqNo()));
             final DeleteResult deleteResult;
-            if (checkVersionConflictResult.isPresent()) {
-                deleteResult = checkVersionConflictResult.get();
+            if (resultOnVersionConflict.isPresent()) {
+                deleteResult = resultOnVersionConflict.get();
             } else {
                 if (delete.origin() == Operation.Origin.PRIMARY) {
                     seqNo = seqNoService().generateSeqNo();

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -1478,76 +1478,121 @@ public class InternalEngineTests extends ESTestCase {
     }
 
     public void testVersioningReplicaConflict1() {
-        ParsedDocument doc = testParsedDocument("1", "1", "test", null, testDocument(), B_1, null);
-        Engine.Index index = new Engine.Index(newUid("1"), doc);
-        Engine.IndexResult indexResult = engine.index(index);
-        assertThat(indexResult.getVersion(), equalTo(1L));
+        final ParsedDocument doc = testParsedDocument("1", "1", "test", null, testDocument(), B_1, null);
+        final Engine.Index v1Index = new Engine.Index(newUid("1"), doc);
+        final Engine.IndexResult v1Result = engine.index(v1Index);
+        assertThat(v1Result.getVersion(), equalTo(1L));
 
-        index = new Engine.Index(newUid("1"), doc);
-        indexResult = engine.index(index);
-        assertThat(indexResult.getVersion(), equalTo(2L));
+        final Engine.Index v2Index = new Engine.Index(newUid("1"), doc);
+        final Engine.IndexResult v2Result = engine.index(v2Index);
+        assertThat(v2Result.getVersion(), equalTo(2L));
 
         // apply the second index to the replica, should work fine
-        index = new Engine.Index(newUid("1"), doc, indexResult.getSeqNo(), index.primaryTerm(), indexResult.getVersion(), VersionType.INTERNAL.versionTypeForReplicationAndRecovery(), REPLICA,  0, -1, false);
-        indexResult = replicaEngine.index(index);
-        assertThat(indexResult.getVersion(), equalTo(2L));
+        final Engine.Index replicaV2Index = new Engine.Index(
+            newUid("1"),
+            doc,
+            v2Result.getSeqNo(),
+            v2Index.primaryTerm(),
+            v2Result.getVersion(),
+            VersionType.INTERNAL.versionTypeForReplicationAndRecovery(),
+            REPLICA,
+            0,
+            -1,
+            false);
+        final Engine.IndexResult replicaV2Result = replicaEngine.index(replicaV2Index);
+        assertThat(replicaV2Result.getVersion(), equalTo(2L));
 
-        long seqNo = indexResult.getSeqNo();
-        long primaryTerm = index.primaryTerm();
-        // now, the old one should not work
-        index = new Engine.Index(newUid("1"), doc, seqNo, primaryTerm, 1L, VersionType.INTERNAL.versionTypeForReplicationAndRecovery(), REPLICA, 0, -1, false);
-        indexResult = replicaEngine.index(index);
-        assertTrue(indexResult.hasFailure());
-        assertThat(indexResult.getFailure(), instanceOf(VersionConflictEngineException.class));
+        // now, the old one should produce an indexing result
+        final Engine.Index replicaV1Index = new Engine.Index(
+            newUid("1"),
+            doc,
+            v1Result.getSeqNo(),
+            v1Index.primaryTerm(),
+            v1Result.getVersion(),
+            VersionType.INTERNAL.versionTypeForReplicationAndRecovery(),
+            REPLICA,
+            0,
+            -1,
+            false);
+        final Engine.IndexResult replicaV1Result = replicaEngine.index(replicaV1Index);
+        assertFalse(replicaV1Result.hasFailure());
+        assertFalse(replicaV1Result.isCreated());
+        assertThat(replicaV1Result.getVersion(), equalTo(2L));
 
         // second version on replica should fail as well
-        index = new Engine.Index(newUid("1"), doc, seqNo, primaryTerm, 2L
-                , VersionType.INTERNAL.versionTypeForReplicationAndRecovery(), REPLICA, 0, -1, false);
-        indexResult = replicaEngine.index(index);
-        assertThat(indexResult.getVersion(), equalTo(2L));
-        assertThat(indexResult.getFailure(), instanceOf(VersionConflictEngineException.class));
+        final Engine.IndexResult replicaV2ReplayResult = replicaEngine.index(replicaV2Index);
+        assertFalse(replicaV2Result.hasFailure());
+        assertFalse(replicaV1Result.isCreated());
+        assertThat(replicaV2ReplayResult.getVersion(), equalTo(2L));
     }
 
     public void testVersioningReplicaConflict2() {
-        ParsedDocument doc = testParsedDocument("1", "1", "test", null, testDocument(), B_1, null);
-        Engine.Index index = new Engine.Index(newUid("1"), doc);
-        Engine.IndexResult indexResult = engine.index(index);
-        assertThat(indexResult.getVersion(), equalTo(1L));
+        final ParsedDocument doc = testParsedDocument("1", "1", "test", null, testDocument(), B_1, null);
+        final Engine.Index v1Index = new Engine.Index(newUid("1"), doc);
+        final Engine.IndexResult v1Result = engine.index(v1Index);
+        assertThat(v1Result.getVersion(), equalTo(1L));
 
         // apply the first index to the replica, should work fine
-        index = new Engine.Index(newUid("1"), doc, indexResult.getSeqNo(), index.primaryTerm(), 1L,
-                VersionType.INTERNAL.versionTypeForReplicationAndRecovery(), REPLICA, 0, -1, false);
-        indexResult = replicaEngine.index(index);
-        assertThat(indexResult.getVersion(), equalTo(1L));
+        final Engine.Index replicaV1Index = new Engine.Index(
+            newUid("1"),
+            doc,
+            v1Result.getSeqNo(),
+            v1Index.primaryTerm(),
+            v1Result.getVersion(),
+            VersionType.INTERNAL.versionTypeForReplicationAndRecovery(),
+            REPLICA,
+            0,
+            -1,
+            false);
+        Engine.IndexResult replicaV1Result = replicaEngine.index(replicaV1Index);
+        assertThat(replicaV1Result.getVersion(), equalTo(1L));
 
         // index it again
-        index = new Engine.Index(newUid("1"), doc);
-        indexResult = engine.index(index);
-        assertThat(indexResult.getVersion(), equalTo(2L));
+        final Engine.Index v2Index = new Engine.Index(newUid("1"), doc);
+        final Engine.IndexResult v2Result = engine.index(v2Index);
+        assertThat(v2Result.getVersion(), equalTo(2L));
 
         // now delete it
-        Engine.Delete delete = new Engine.Delete("test", "1", newUid("1"));
-        Engine.DeleteResult deleteResult = engine.delete(delete);
+        final Engine.Delete delete = new Engine.Delete("test", "1", newUid("1"));
+        final Engine.DeleteResult deleteResult = engine.delete(delete);
         assertThat(deleteResult.getVersion(), equalTo(3L));
 
         // apply the delete on the replica (skipping the second index)
-        delete = new Engine.Delete("test", "1", newUid("1"), deleteResult.getSeqNo(), delete.primaryTerm(), 3L
-                , VersionType.INTERNAL.versionTypeForReplicationAndRecovery(), REPLICA, 0);
-        deleteResult = replicaEngine.delete(delete);
-        assertThat(deleteResult.getVersion(), equalTo(3L));
+        final Engine.Delete replicaDelete = new Engine.Delete(
+            "test",
+            "1",
+            newUid("1"),
+            deleteResult.getSeqNo(),
+            delete.primaryTerm(),
+            deleteResult.getVersion(),
+            VersionType.INTERNAL.versionTypeForReplicationAndRecovery(),
+            REPLICA,
+            0);
+        final Engine.DeleteResult replicaDeleteResult = replicaEngine.delete(replicaDelete);
+        assertThat(replicaDeleteResult.getVersion(), equalTo(3L));
 
-        // second time delete with same version should fail
-        delete = new Engine.Delete("test", "1", newUid("1"), deleteResult.getSeqNo(), delete.primaryTerm(), 3L
-                , VersionType.INTERNAL.versionTypeForReplicationAndRecovery(), REPLICA, 0);
-        deleteResult = replicaEngine.delete(delete);
-        assertTrue(deleteResult.hasFailure());
-        assertThat(deleteResult.getFailure(), instanceOf(VersionConflictEngineException.class));
+        // second time delete with same version should just produce the same version
+        final Engine.DeleteResult deleteReplayResult = replicaEngine.delete(replicaDelete);
+        assertFalse(deleteReplayResult.hasFailure());
+        assertTrue(deleteReplayResult.isFound());
+        assertThat(deleteReplayResult.getVersion(), equalTo(3L));
 
-        // now do the second index on the replica, it should fail
-        index = new Engine.Index(newUid("1"), doc, deleteResult.getSeqNo(), delete.primaryTerm(), 2L, VersionType.INTERNAL.versionTypeForReplicationAndRecovery(), REPLICA, 0, -1, false);
-        indexResult = replicaEngine.index(index);
-        assertTrue(indexResult.hasFailure());
-        assertThat(indexResult.getFailure(), instanceOf(VersionConflictEngineException.class));
+        // now do the second index on the replica, it should result in the current version
+        final Engine.Index replicaV2Index = new Engine.Index(
+            newUid("1"),
+            doc,
+            v2Result.getSeqNo(),
+            v2Index.primaryTerm(),
+            v2Result.getVersion(),
+            VersionType.INTERNAL.versionTypeForReplicationAndRecovery(),
+            REPLICA,
+            0,
+            -1,
+            false);
+        final Engine.IndexResult replicaV2Result = replicaEngine.index(replicaV2Index);
+        assertFalse(replicaV2Result.hasFailure());
+        assertFalse(replicaV2Result.isCreated());
+        assertThat(replicaV2Result.getVersion(), equalTo(3L));
     }
 
     public void testBasicCreatedFlag() {


### PR DESCRIPTION
An operation that completed successfully on a primary can result in a version conflict on a replica due to the asynchronous nature of operations. When a replica operation results in a version conflict, the operation is not added to the translog. This leads to gaps in the translog which is problematic as it can lead to situations where a replica shard can never advance its local checkpoint. As such operations are just normal course of business for a replica shard, these operations should be treated as if they completed successfully. This commit adds these operations to the translog. 