### PR TITLE
Log deleting indices at info level

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataDeleteIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataDeleteIndexService.java
@@ -97,7 +97,7 @@ public class MetaDataDeleteIndexService extends AbstractComponent {
         final int previousGraveyardSize = graveyardBuilder.tombstones().size();
         for (final Index index : indices) {
             String indexName = index.getName();
-            logger.debug("[{}] deleting index", index);
+            logger.info("{} deleting index", index);
             routingTableBuilder.remove(indexName);
             clusterBlocksBuilder.removeIndexBlocks(indexName);
             metaDataBuilder.remove(indexName);


### PR DESCRIPTION
Deleting indices is an important event in a cluster and as such should be logged at the info level. This commit changes the logging level on index deletion to the info level.

Closes #22605
