### PR TITLE
Add parsing from xContent to SearchProfileShardResults and nested classes

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -376,12 +376,17 @@ public class XContentHelper {
         }
     }
 
+    public static BytesReference toXContent(ToXContent toXContent, XContentType xContentType) throws IOException {
+        return toXContent(toXContent, xContentType, false);
+    }
+
     /**
      * Returns the bytes that represent the XContent output of the provided {@link ToXContent} object, using the provided
      * {@link XContentType}. Wraps the output into a new anonymous object.
      */
-    public static BytesReference toXContent(ToXContent toXContent, XContentType xContentType) throws IOException {
+    public static BytesReference toXContent(ToXContent toXContent, XContentType xContentType, boolean humanReadable) throws IOException {
         try (XContentBuilder builder = XContentBuilder.builder(xContentType.xContent())) {
+            builder.humanReadable(humanReadable);
             if (toXContent.isFragment()) {
                 builder.startObject();
             }

--- a/core/src/main/java/org/elasticsearch/search/profile/AbstractInternalProfileTree.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/AbstractInternalProfileTree.java
@@ -162,10 +162,9 @@ public abstract class AbstractInternalProfileTree<PB extends AbstractProfileBrea
 
         // TODO this would be better done bottom-up instead of top-down to avoid
         // calculating the same times over and over...but worth the effort?
-        long nodeTime = getNodeTime(timings);
         String type = getTypeFromElement(element);
         String description = getDescriptionFromElement(element);
-        return new ProfileResult(type, description, timings, childrenProfileResults, nodeTime);
+        return new ProfileResult(type, description, timings, childrenProfileResults);
     }
 
     protected abstract String getTypeFromElement(E element);
@@ -182,21 +181,6 @@ public abstract class AbstractInternalProfileTree<PB extends AbstractProfileBrea
         ArrayList<Integer> parentNode = tree.get(parent);
         parentNode.add(childToken);
         tree.set(parent, parentNode);
-    }
-
-    /**
-     * Internal helper to calculate the time of a node, inclusive of children
-     *
-     * @param timings
-     *            A map of breakdown timing for the node
-     * @return The total time at this node, inclusive of children
-     */
-    private static long getNodeTime(Map<String, Long> timings) {
-        long nodeTime = 0;
-        for (long time : timings.values()) {
-            nodeTime += time;
-        }
-        return nodeTime;
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
@@ -68,7 +68,7 @@ public final class ProfileResult implements Writeable, ToXContentObject {
         this.description = description;
         this.timings = Objects.requireNonNull(timings, "required timings argument missing");
         this.children = children;
-        this.nodeTime = getNodeTime(timings);
+        this.nodeTime = getTotalTime(timings);
     }
 
     /**
@@ -182,10 +182,10 @@ public final class ProfileResult implements Writeable, ToXContentObject {
                 } else if (DESCRIPTION.match(currentFieldName)) {
                     description = parser.text();
                 } else if (NODE_TIME.match(currentFieldName)) {
-                    // we need to consume this value, but we use the raw nanosecond value
+                    // skip, total time is calculate by adding up 'timings' values in ProfileResult ctor
                     parser.text();
                 } else if (NODE_TIME_RAW.match(currentFieldName)) {
-                    // the total time is calculate by adding up all timings internally, so we skip it
+                    // skip, total time is calculate by adding up 'timings' values in ProfileResult ctor
                     parser.longValue();
                 } else {
                     throwUnknownField(currentFieldName, parser.getTokenLocation());
@@ -216,13 +216,10 @@ public final class ProfileResult implements Writeable, ToXContentObject {
     }
 
     /**
-     * Internal helper to calculate the time of a node, inclusive of children
-     *
-     * @param timings
-     *            A map of breakdown timing for the node
-     * @return The total time at this node, inclusive of children
+     * @param timings a map of breakdown timing for the node
+     * @return The total time at this node
      */
-    private static long getNodeTime(Map<String, Long> timings) {
+    private static long getTotalTime(Map<String, Long> timings) {
         long nodeTime = 0;
         for (long time : timings.values()) {
             nodeTime += time;

--- a/core/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
@@ -23,8 +23,9 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,7 +33,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknownField;
 
 /**
  * This class is the internal representation of a profiled Query, corresponding
@@ -43,7 +48,7 @@ import java.util.concurrent.TimeUnit;
  * Each InternalProfileResult has a List of InternalProfileResults, which will contain
  * "children" queries if applicable
  */
-public final class ProfileResult implements Writeable, ToXContent {
+public final class ProfileResult implements Writeable, ToXContentObject {
 
     private static final ParseField TYPE = new ParseField("type");
     private static final ParseField DESCRIPTION = new ParseField("description");
@@ -58,13 +63,12 @@ public final class ProfileResult implements Writeable, ToXContent {
     private final long nodeTime;
     private final List<ProfileResult> children;
 
-    public ProfileResult(String type, String description, Map<String, Long> timings, List<ProfileResult> children,
-            long nodeTime) {
+    public ProfileResult(String type, String description, Map<String, Long> timings, List<ProfileResult> children) {
         this.type = type;
         this.description = description;
         this.timings = timings;
         this.children = children;
-        this.nodeTime = nodeTime;
+        this.nodeTime = getNodeTime(timings);
     }
 
     /**
@@ -160,6 +164,68 @@ public final class ProfileResult implements Writeable, ToXContent {
 
         builder = builder.endObject();
         return builder;
+    }
+
+    public static ProfileResult fromXContent(XContentParser parser) throws IOException {
+        XContentParser.Token token = parser.currentToken();
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser::getTokenLocation);
+        String currentFieldName = null;
+        String type = null, description = null;
+        Map<String, Object> parsedTimings =  null;
+        List<ProfileResult> children = new ArrayList<>();
+        while((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token.isValue()) {
+                if (TYPE.match(currentFieldName)) {
+                    type = parser.text();
+                } else if (DESCRIPTION.match(currentFieldName)) {
+                    description = parser.text();
+                } else if (NODE_TIME.match(currentFieldName)) {
+                    // we need to consume this value, but we use the raw nanosecond value
+                    parser.text();
+                } else if (NODE_TIME_RAW.match(currentFieldName)) {
+                    // the total time is calculate by adding up all timings internally, so we skip it
+                    parser.longValue();
+                } else {
+                    throwUnknownField(currentFieldName, parser.getTokenLocation());
+                }
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                if (BREAKDOWN.match(currentFieldName)) {
+                    parsedTimings = parser.map();
+                } else {
+                    throwUnknownField(currentFieldName, parser.getTokenLocation());
+                }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                if (CHILDREN.match(currentFieldName)) {
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        children.add(ProfileResult.fromXContent(parser));
+                    }
+                } else {
+                    throwUnknownField(currentFieldName, parser.getTokenLocation());
+                }
+            }
+        }
+        Map<String, Long> timings = new HashMap<>(parsedTimings.size());
+        for (Entry<String, Object> entry : parsedTimings.entrySet()) {
+            timings.put(entry.getKey(), (Long) entry.getValue());
+        }
+        return new ProfileResult(type, description, timings, children);
+    }
+
+    /**
+     * Internal helper to calculate the time of a node, inclusive of children
+     *
+     * @param timings
+     *            A map of breakdown timing for the node
+     * @return The total time at this node, inclusive of children
+     */
+    private static long getNodeTime(Map<String, Long> timings) {
+        long nodeTime = 0;
+        for (long time : timings.values()) {
+            nodeTime += time;
+        }
+        return nodeTime;
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
@@ -208,7 +208,12 @@ public final class ProfileResult implements Writeable, ToXContentObject {
         }
         Map<String, Long> timings = new HashMap<>(parsedTimings.size());
         for (Entry<String, Object> entry : parsedTimings.entrySet()) {
-            timings.put(entry.getKey(), (Long) entry.getValue());
+            Object value = entry.getValue();
+            if (value instanceof Integer) {
+                timings.put(entry.getKey(), ((Integer)value).longValue());
+            } else {
+                timings.put(entry.getKey(), (Long) value);
+            }
         }
         return new ProfileResult(type, description, timings, children);
     }

--- a/core/src/main/java/org/elasticsearch/search/profile/SearchProfileShardResults.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/SearchProfileShardResults.java
@@ -88,6 +88,8 @@ public final class SearchProfileShardResults implements Writeable, ToXContent{
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(PROFILE_FIELD).startArray(SHARDS_FIELD);
+        // shardResults is a map, but we print entries in a json array, which is ordered.
+        // we sort the keys of the map, so that toXContent always prints out the same array order
         TreeSet<String> sortedKeys = new TreeSet<>(shardResults.keySet());
         for (String key : sortedKeys) {
             builder.startObject();

--- a/core/src/main/java/org/elasticsearch/search/profile/SearchProfileShardResults.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/SearchProfileShardResults.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.profile.aggregation.AggregationProfileShardResult;
 import org.elasticsearch.search.profile.aggregation.AggregationProfiler;
 import org.elasticsearch.search.profile.query.QueryProfileShardResult;
@@ -36,11 +37,20 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureFieldName;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknownField;
+
 /**
  * A container class to hold all the profile results across all shards.  Internally
  * holds a map of shard ID -&gt; Profiled results
  */
 public final class SearchProfileShardResults implements Writeable, ToXContent{
+
+    private static final String SEARCHES_FIELD = "searches";
+    private static final String ID_FIELD = "id";
+    private static final String SHARDS_FIELD = "shards";
+    public static final String PROFILE_FIELD = "profile";
 
     private Map<String, ProfileShardResult> shardResults;
 
@@ -75,16 +85,14 @@ public final class SearchProfileShardResults implements Writeable, ToXContent{
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject("profile").startArray("shards");
+        builder.startObject(PROFILE_FIELD).startArray(SHARDS_FIELD);
 
         for (Map.Entry<String, ProfileShardResult> entry : shardResults.entrySet()) {
             builder.startObject();
-            builder.field("id", entry.getKey());
-            builder.startArray("searches");
+            builder.field(ID_FIELD, entry.getKey());
+            builder.startArray(SEARCHES_FIELD);
             for (QueryProfileShardResult result : entry.getValue().getQueryProfileResults()) {
-                builder.startObject();
                 result.toXContent(builder, params);
-                builder.endObject();
             }
             builder.endArray();
             entry.getValue().getAggregationProfileResults().toXContent(builder, params);
@@ -93,6 +101,51 @@ public final class SearchProfileShardResults implements Writeable, ToXContent{
 
         builder.endArray().endObject();
         return builder;
+    }
+
+    public static SearchProfileShardResults fromXContent(XContentParser parser) throws IOException {
+        XContentParser.Token token = parser.currentToken();
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser::getTokenLocation);
+        Map<String, ProfileShardResult> searchProfileResults = new HashMap<>();
+        ensureFieldName(parser, parser.nextToken(), SHARDS_FIELD);
+        ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser::getTokenLocation);
+        while((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+            parseSearchProfileResultsEntry(parser, searchProfileResults);
+        }
+        ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser::getTokenLocation);
+        return new SearchProfileShardResults(searchProfileResults);
+    }
+
+    private static void parseSearchProfileResultsEntry(XContentParser parser,
+            Map<String, ProfileShardResult> searchProfileResults) throws IOException {
+        XContentParser.Token token = parser.currentToken();
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser::getTokenLocation);
+        List<QueryProfileShardResult> queryProfileResults = new ArrayList<>();
+        AggregationProfileShardResult aggProfileShardResult = null;
+        String name = null;
+        String currentFieldName = null;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token.isValue()) {
+                if (ID_FIELD.equals(currentFieldName)) {
+                    name = parser.text();
+                } else {
+                    throwUnknownField(currentFieldName, parser.getTokenLocation());
+                }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                if (SEARCHES_FIELD.equals(currentFieldName)) {
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        queryProfileResults.add(QueryProfileShardResult.fromXContent(parser));
+                    }
+                } else if (AggregationProfileShardResult.AGGREGATIONS.equals(currentFieldName)) {
+                    aggProfileShardResult = AggregationProfileShardResult.fromXContent(parser);
+                } else {
+                    throwUnknownField(currentFieldName, parser.getTokenLocation());
+                }
+            }
+        }
+        searchProfileResults.put(name, new ProfileShardResult(queryProfileResults, aggProfileShardResult));
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/search/profile/query/CollectorResult.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/query/CollectorResult.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknownField;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknownToken;
 
 /**
  * Public interface and serialization container for profiled timings of the
@@ -175,7 +176,7 @@ public class CollectorResult implements ToXContentObject, Writeable {
                 } else if (REASON.match(currentFieldName)) {
                     reason = parser.text();
                 } else if (TIME.match(currentFieldName)) {
-                    // we can skip this, it only for human readability
+                    // we need to consume this value, but we use the raw nanosecond value
                     parser.text();
                 } else if (TIME_NANOS.match(currentFieldName)) {
                     time = parser.longValue();
@@ -190,6 +191,8 @@ public class CollectorResult implements ToXContentObject, Writeable {
                 } else {
                     throwUnknownField(currentFieldName, parser.getTokenLocation());
                 }
+            } else {
+                throwUnknownToken(token, parser.getTokenLocation());
             }
         }
         return new CollectorResult(name, reason, time, children);

--- a/core/src/main/java/org/elasticsearch/search/profile/query/CollectorResult.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/query/CollectorResult.java
@@ -163,7 +163,8 @@ public class CollectorResult implements ToXContentObject, Writeable {
         XContentParser.Token token = parser.currentToken();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser::getTokenLocation);
         String currentFieldName = null;
-        String name = null, reason = null, timeString = null;
+        String name = null, reason = null;
+        long time = -1;
         List<CollectorResult> children = new ArrayList<>();
         while((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
@@ -174,7 +175,10 @@ public class CollectorResult implements ToXContentObject, Writeable {
                 } else if (REASON.match(currentFieldName)) {
                     reason = parser.text();
                 } else if (TIME.match(currentFieldName)) {
-                    timeString = parser.text();
+                    // we can skip this, it only for human readability
+                    parser.text();
+                } else if (TIME_NANOS.match(currentFieldName)) {
+                    time = parser.longValue();
                 } else {
                     throwUnknownField(currentFieldName, parser.getTokenLocation());
                 }
@@ -188,7 +192,6 @@ public class CollectorResult implements ToXContentObject, Writeable {
                 }
             }
         }
-        long time = (long) (Double.parseDouble(timeString.substring(0, timeString.length() - 2)) * 1000000.0);
         return new CollectorResult(name, reason, time, children);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/profile/query/QueryProfileShardResult.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/query/QueryProfileShardResult.java
@@ -22,7 +22,7 @@ package org.elasticsearch.search.profile.query;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.profile.ProfileResult;
@@ -39,7 +39,7 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknown
  * A container class to hold the profile results for a single shard in the request.
  * Contains a list of query profiles, a collector tree and a total rewrite tree.
  */
-public final class QueryProfileShardResult implements Writeable, ToXContent {
+public final class QueryProfileShardResult implements Writeable, ToXContentObject {
 
     public static final String COLLECTOR = "collector";
     public static final String REWRITE_TIME = "rewrite_time";
@@ -98,6 +98,7 @@ public final class QueryProfileShardResult implements Writeable, ToXContent {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
         builder.startArray(QUERY_ARRAY);
         for (ProfileResult p : queryProfileResults) {
             p.toXContent(builder, params);
@@ -107,6 +108,7 @@ public final class QueryProfileShardResult implements Writeable, ToXContent {
         builder.startArray(COLLECTOR);
         profileCollector.toXContent(builder, params);
         builder.endArray();
+        builder.endObject();
         return builder;
     }
 

--- a/core/src/main/java/org/elasticsearch/search/profile/query/QueryProfileShardResult.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/query/QueryProfileShardResult.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.profile.ProfileResult;
 
 import java.io.IOException;
@@ -31,11 +32,18 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknownField;
+
 /**
  * A container class to hold the profile results for a single shard in the request.
  * Contains a list of query profiles, a collector tree and a total rewrite tree.
  */
 public final class QueryProfileShardResult implements Writeable, ToXContent {
+
+    public static final String COLLECTOR = "collector";
+    public static final String REWRITE_TIME = "rewrite_time";
+    public static final String QUERY_ARRAY = "query";
 
     private final List<ProfileResult> queryProfileResults;
 
@@ -90,15 +98,48 @@ public final class QueryProfileShardResult implements Writeable, ToXContent {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startArray("query");
+        builder.startArray(QUERY_ARRAY);
         for (ProfileResult p : queryProfileResults) {
             p.toXContent(builder, params);
         }
         builder.endArray();
-        builder.field("rewrite_time", rewriteTime);
-        builder.startArray("collector");
+        builder.field(REWRITE_TIME, rewriteTime);
+        builder.startArray(COLLECTOR);
         profileCollector.toXContent(builder, params);
         builder.endArray();
         return builder;
+    }
+
+    public static QueryProfileShardResult fromXContent(XContentParser parser) throws IOException {
+        XContentParser.Token token = parser.currentToken();
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser::getTokenLocation);
+        String currentFieldName = null;
+        List<ProfileResult> queryProfileResults = new ArrayList<>();
+        long rewriteTime = 0;
+        CollectorResult profileCollector = null;
+        while((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token.isValue()) {
+                if (REWRITE_TIME.equals(currentFieldName)) {
+                    rewriteTime = parser.longValue();
+                } else {
+                    throwUnknownField(currentFieldName, parser.getTokenLocation());
+                }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                if (QUERY_ARRAY.equals(currentFieldName)) {
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        queryProfileResults.add(ProfileResult.fromXContent(parser));
+                    }
+                } else if (COLLECTOR.equals(currentFieldName)) {
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        profileCollector = CollectorResult.fromXContent(parser);
+                    }
+                } else {
+                    throwUnknownField(currentFieldName, parser.getTokenLocation());
+                }
+            }
+        }
+        return new QueryProfileShardResult(queryProfileResults, rewriteTime, profileCollector);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/profile/query/QueryProfileShardResult.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/query/QueryProfileShardResult.java
@@ -119,7 +119,7 @@ public final class QueryProfileShardResult implements Writeable, ToXContentObjec
         String currentFieldName = null;
         List<ProfileResult> queryProfileResults = new ArrayList<>();
         long rewriteTime = 0;
-        CollectorResult profileCollector = null;
+        CollectorResult collector = null;
         while((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
@@ -136,7 +136,7 @@ public final class QueryProfileShardResult implements Writeable, ToXContentObjec
                     }
                 } else if (COLLECTOR.equals(currentFieldName)) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                        profileCollector = CollectorResult.fromXContent(parser);
+                        collector = CollectorResult.fromXContent(parser);
                     }
                 } else {
                     throwUnknownField(currentFieldName, parser.getTokenLocation());
@@ -145,6 +145,6 @@ public final class QueryProfileShardResult implements Writeable, ToXContentObjec
                 throwUnknownToken(token, parser.getTokenLocation());
             }
         }
-        return new QueryProfileShardResult(queryProfileResults, rewriteTime, profileCollector);
+        return new QueryProfileShardResult(queryProfileResults, rewriteTime, collector);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/profile/query/QueryProfileShardResult.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/query/QueryProfileShardResult.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknownField;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknownToken;
 
 /**
  * A container class to hold the profile results for a single shard in the request.
@@ -140,6 +141,8 @@ public final class QueryProfileShardResult implements Writeable, ToXContentObjec
                 } else {
                     throwUnknownField(currentFieldName, parser.getTokenLocation());
                 }
+            } else {
+                throwUnknownToken(token, parser.getTokenLocation());
             }
         }
         return new QueryProfileShardResult(queryProfileResults, rewriteTime, profileCollector);

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -162,7 +162,6 @@ public class TransportReplicationActionTests extends ESTestCase {
         action = new Action(Settings.EMPTY, "testAction", transportService, clusterService, shardStateAction, threadPool);
     }
 
-    @Override
     @After
     public void tearDown() throws Exception {
         super.tearDown();
@@ -499,7 +498,6 @@ public class TransportReplicationActionTests extends ESTestCase {
                                       TransportReplicationAction<Request, Request, Response>.PrimaryShardReference primaryShardReference,
                                       boolean executeOnReplicas) {
                 return new NoopReplicationOperation(request, actionListener) {
-                    @Override
                     public void execute() throws Exception {
                         assertPhase(task, "primary");
                         assertFalse(executed.getAndSet(true));
@@ -552,7 +550,6 @@ public class TransportReplicationActionTests extends ESTestCase {
                                       TransportReplicationAction<Request, Request, Response>.PrimaryShardReference primaryShardReference,
                                       boolean executeOnReplicas) {
                 return new NoopReplicationOperation(request, actionListener) {
-                    @Override
                     public void execute() throws Exception {
                         assertPhase(task, "primary");
                         assertFalse(executed.getAndSet(true));
@@ -1166,8 +1163,7 @@ public class TransportReplicationActionTests extends ESTestCase {
 
         @Override
         public void execute() throws Exception {
-            // Using the diamond operator (<>) prevents Eclipse from being able to compile this code
-            this.resultListener.onResponse(new TransportReplicationAction.PrimaryResult<Request, Response>(null, new Response()));
+            this.resultListener.onResponse(new TransportReplicationAction.PrimaryResult<>(null, new Response()));
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -162,6 +162,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         action = new Action(Settings.EMPTY, "testAction", transportService, clusterService, shardStateAction, threadPool);
     }
 
+    @Override
     @After
     public void tearDown() throws Exception {
         super.tearDown();
@@ -498,6 +499,7 @@ public class TransportReplicationActionTests extends ESTestCase {
                                       TransportReplicationAction<Request, Request, Response>.PrimaryShardReference primaryShardReference,
                                       boolean executeOnReplicas) {
                 return new NoopReplicationOperation(request, actionListener) {
+                    @Override
                     public void execute() throws Exception {
                         assertPhase(task, "primary");
                         assertFalse(executed.getAndSet(true));
@@ -550,6 +552,7 @@ public class TransportReplicationActionTests extends ESTestCase {
                                       TransportReplicationAction<Request, Request, Response>.PrimaryShardReference primaryShardReference,
                                       boolean executeOnReplicas) {
                 return new NoopReplicationOperation(request, actionListener) {
+                    @Override
                     public void execute() throws Exception {
                         assertPhase(task, "primary");
                         assertFalse(executed.getAndSet(true));
@@ -1163,7 +1166,8 @@ public class TransportReplicationActionTests extends ESTestCase {
 
         @Override
         public void execute() throws Exception {
-            this.resultListener.onResponse(new TransportReplicationAction.PrimaryResult<>(null, new Response()));
+            // Using the diamond operator (<>) prevents Eclipse from being able to compile this code
+            this.resultListener.onResponse(new TransportReplicationAction.PrimaryResult<Request, Response>(null, new Response()));
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/search/profile/ProfileResultTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/ProfileResultTests.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 
 public class ProfileResultTests extends ESTestCase {
@@ -60,12 +61,12 @@ public class ProfileResultTests extends ESTestCase {
 
     public void testFromXContent() throws IOException {
         ProfileResult profileResult = createTestItem(2);
-        XContentType xcontentType = XContentType.JSON; // randomFrom(XContentType.values());
+        XContentType xcontentType = randomFrom(XContentType.values());
         XContentBuilder builder = XContentFactory.contentBuilder(xcontentType);
         builder = profileResult.toXContent(builder, ToXContent.EMPTY_PARAMS);
 
         XContentParser parser = createParser(builder);
-        parser.nextToken(); // move to START_OBJECT
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
         ProfileResult parsed = ProfileResult.fromXContent(parser);
         assertToXContentEquivalent(builder.bytes(), toXContent(parsed, xcontentType), xcontentType);
         assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());

--- a/core/src/test/java/org/elasticsearch/search/profile/ProfileResultTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/ProfileResultTests.java
@@ -3,7 +3,11 @@
  * license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright
  * ownership. Elasticsearch licenses this file to you under
+<<<<<<< eea4db5512fb616608e283d295d583e62d4607c6
  * the Apache License, Version 2.0 (the "License"); you may
+=======
+ * the Apache License, Version 2.0 (the \"License\"); you may
+>>>>>>> Adding parsing to ProfileResult
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -22,6 +26,8 @@ package org.elasticsearch.search.profile;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -31,38 +37,79 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+
 public class ProfileResultTests extends ESTestCase {
 
+    public static ProfileResult createTestItem(int depth) {
+        String type = randomAsciiOfLengthBetween(5, 10);
+        String description = randomAsciiOfLengthBetween(5, 10);
+        int timingsSize = randomIntBetween(0, 5);
+        Map<String, Long> timings = new HashMap<>(timingsSize);
+        for (int i = 0; i < timingsSize; i++) {
+            timings.put(randomAsciiOfLengthBetween(5, 10), randomNonNegativeLong() / timingsSize); // don't overflow Long.MAX_VALUE;
+        }
+        int childrenSize = depth > 0 ? randomIntBetween(0, 1) : 0;
+        List<ProfileResult> children = new ArrayList<>(childrenSize);
+        for (int i = 0; i < childrenSize; i++) {
+            children.add(createTestItem(depth - 1));
+        }
+        return new ProfileResult(type, description, timings, children);
+    }
+
+    public void testFromXContent() throws IOException {
+        ProfileResult profileResult = createTestItem(2);
+        XContentType xcontentType = XContentType.JSON; // randomFrom(XContentType.values());
+        XContentBuilder builder = XContentFactory.contentBuilder(xcontentType);
+        builder = profileResult.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        XContentParser parser = createParser(builder);
+        parser.nextToken(); // move to START_OBJECT
+        ProfileResult parsed = ProfileResult.fromXContent(parser);
+        assertToXContentEquivalent(builder.bytes(), toXContent(parsed, xcontentType), xcontentType);
+        assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+        assertNull(parser.nextToken());
+    }
+
     public void testToXContent() throws IOException {
+        Map<String, Long> timings1 = new HashMap<>();
+        timings1.put("key1", 100L);
+        Map<String, Long> timings2 = new HashMap<>();
+        timings2.put("key1", 123356L);
         List<ProfileResult> children = new ArrayList<>();
-        children.add(new ProfileResult("child1", "desc1", Collections.emptyMap(), Collections.emptyList(), 100L));
-        children.add(new ProfileResult("child2", "desc2", Collections.emptyMap(), Collections.emptyList(), 123356L));
-        Map<String, Long> timings = new HashMap<>();
-        timings.put("key1", 12345L);
-        timings.put("key2", 6789L);
-        ProfileResult result = new ProfileResult("someType", "some description", timings, children, 123456L);
+        children.add(new ProfileResult("child1", "desc1", timings1, Collections.emptyList()));
+        children.add(new ProfileResult("child2", "desc2", timings2, Collections.emptyList()));
+        Map<String, Long> timings3 = new HashMap<>();
+        timings3.put("key1", 123456L);
+        timings3.put("key2", 100000L);
+        ProfileResult result = new ProfileResult("someType", "some description", timings3, children);
         XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
         result.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertEquals("{\n" +
                 "  \"type\" : \"someType\",\n" +
                 "  \"description\" : \"some description\",\n" +
-                "  \"time_in_nanos\" : 123456,\n" +
+                "  \"time_in_nanos\" : 223456,\n" +
                 "  \"breakdown\" : {\n" +
-                "    \"key1\" : 12345,\n" +
-                "    \"key2\" : 6789\n" +
+                "    \"key1\" : 123456,\n" +
+                "    \"key2\" : 100000\n" +
                 "  },\n" +
                 "  \"children\" : [\n" +
                 "    {\n" +
                 "      \"type\" : \"child1\",\n" +
                 "      \"description\" : \"desc1\",\n" +
                 "      \"time_in_nanos\" : 100,\n" +
-                "      \"breakdown\" : { }\n" +
+                "      \"breakdown\" : {\n" +
+                "        \"key1\" : 100\n" +
+                "      }\n" +
                 "    },\n" +
                 "    {\n" +
                 "      \"type\" : \"child2\",\n" +
                 "      \"description\" : \"desc2\",\n" +
                 "      \"time_in_nanos\" : 123356,\n" +
-                "      \"breakdown\" : { }\n" +
+                "      \"breakdown\" : {\n" +
+                "        \"key1\" : 123356\n" +
+                "      }\n" +
                 "    }\n" +
                 "  ]\n" +
           "}", builder.string());
@@ -96,7 +143,7 @@ public class ProfileResultTests extends ESTestCase {
                 "  ]\n" +
           "}", builder.string());
 
-        result = new ProfileResult("profileName", "some description", Collections.emptyMap(), Collections.emptyList(), 12345678L);
+        result = new ProfileResult("profileName", "some description", Collections.emptyMap(), Collections.emptyList());
         builder = XContentFactory.jsonBuilder().prettyPrint().humanReadable(true);
         result.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertEquals("{\n" +
@@ -107,7 +154,7 @@ public class ProfileResultTests extends ESTestCase {
                 "  \"breakdown\" : { }\n" +
               "}", builder.string());
 
-        result = new ProfileResult("profileName", "some description", Collections.emptyMap(), Collections.emptyList(), 1234567890L);
+        result = new ProfileResult("profileName", "some description", Collections.emptyMap(), Collections.emptyList());
         builder = XContentFactory.jsonBuilder().prettyPrint().humanReadable(true);
         result.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertEquals("{\n" +

--- a/core/src/test/java/org/elasticsearch/search/profile/ProfileResultTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/ProfileResultTests.java
@@ -66,24 +66,21 @@ public class ProfileResultTests extends ESTestCase {
         XContentType xContentType = randomFrom(XContentType.values());
         boolean humanReadable = randomBoolean();
         BytesReference originalBytes = toXContent(profileResult, xContentType, humanReadable);
+        ProfileResult parsed;
         try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
-            ProfileResult parsed = ProfileResult.fromXContent(parser);
-            assertEquals(profileResult.getTime(), parsed.getTime());
-            assertToXContentEquivalent(originalBytes, toXContent(parsed, xContentType, humanReadable), xContentType);
+            parsed = ProfileResult.fromXContent(parser);
             assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
             assertNull(parser.nextToken());
         }
+        assertEquals(profileResult.getTime(), parsed.getTime());
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, xContentType, humanReadable), xContentType);
     }
 
     public void testToXContent() throws IOException {
-        Map<String, Long> timings1 = new HashMap<>();
-        timings1.put("key1", 100L);
-        Map<String, Long> timings2 = new HashMap<>();
-        timings2.put("key1", 123356L);
         List<ProfileResult> children = new ArrayList<>();
-        children.add(new ProfileResult("child1", "desc1", timings1, Collections.emptyList()));
-        children.add(new ProfileResult("child2", "desc2", timings2, Collections.emptyList()));
+        children.add(new ProfileResult("child1", "desc1", Collections.singletonMap("key1", 100L), Collections.emptyList()));
+        children.add(new ProfileResult("child2", "desc2", Collections.singletonMap("key1", 123356L), Collections.emptyList()));
         Map<String, Long> timings3 = new HashMap<>();
         timings3.put("key1", 123456L);
         timings3.put("key2", 100000L);
@@ -151,9 +148,7 @@ public class ProfileResultTests extends ESTestCase {
                 "  ]\n" +
           "}", builder.string());
 
-        timings1 = new HashMap<>();
-        timings1.put("key1", 12345678L);
-        result = new ProfileResult("profileName", "some description", timings1, Collections.emptyList());
+        result = new ProfileResult("profileName", "some description", Collections.singletonMap("key1", 12345678L), Collections.emptyList());
         builder = XContentFactory.jsonBuilder().prettyPrint().humanReadable(true);
         result.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertEquals("{\n" +
@@ -166,9 +161,8 @@ public class ProfileResultTests extends ESTestCase {
                 "  }\n" +
               "}", builder.string());
 
-        timings1 = new HashMap<>();
-        timings1.put("key1", 1234567890L);
-        result = new ProfileResult("profileName", "some description", timings1, Collections.emptyList());
+        result = new ProfileResult("profileName", "some description", Collections.singletonMap("key1", 1234567890L),
+                Collections.emptyList());
         builder = XContentFactory.jsonBuilder().prettyPrint().humanReadable(true);
         result.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertEquals("{\n" +

--- a/core/src/test/java/org/elasticsearch/search/profile/ProfileResultTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/ProfileResultTests.java
@@ -49,7 +49,12 @@ public class ProfileResultTests extends ESTestCase {
         int timingsSize = randomIntBetween(0, 5);
         Map<String, Long> timings = new HashMap<>(timingsSize);
         for (int i = 0; i < timingsSize; i++) {
-            timings.put(randomAsciiOfLengthBetween(5, 10), randomNonNegativeLong() / timingsSize); // don't overflow Long.MAX_VALUE;
+            long time = randomNonNegativeLong() / timingsSize;
+            if (randomBoolean()) {
+                // also often use "small" values in tests
+                time = randomNonNegativeLong() % 10000;
+            }
+            timings.put(randomAsciiOfLengthBetween(5, 10), time); // don't overflow Long.MAX_VALUE;
         }
         int childrenSize = depth > 0 ? randomIntBetween(0, 1) : 0;
         List<ProfileResult> children = new ArrayList<>(childrenSize);
@@ -68,6 +73,7 @@ public class ProfileResultTests extends ESTestCase {
         XContentParser parser = createParser(builder);
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
         ProfileResult parsed = ProfileResult.fromXContent(parser);
+        assertEquals(profileResult.getTime(), parsed.getTime());
         assertToXContentEquivalent(builder.bytes(), toXContent(parsed, xcontentType), xcontentType);
         assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
         assertNull(parser.nextToken());

--- a/core/src/test/java/org/elasticsearch/search/profile/SearchProfileShardResultsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/SearchProfileShardResultsTests.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.profile;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.search.profile.aggregation.AggregationProfileShardResult;
+import org.elasticsearch.search.profile.aggregation.AggregationProfileShardResultTests;
+import org.elasticsearch.search.profile.query.QueryProfileShardResult;
+import org.elasticsearch.search.profile.query.QueryProfileShardResultTests;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureFieldName;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;;
+
+public class SearchProfileShardResultsTests  extends ESTestCase {
+
+    public static SearchProfileShardResults createTestItem() {
+        int size = rarely() ? 0 : randomIntBetween(1, 2);
+        Map<String, ProfileShardResult> searchProfileResults = new HashMap<>(size);
+        for (int i = 0; i < size; i++) {
+            List<QueryProfileShardResult> queryProfileResults = new ArrayList<>();
+            int queryItems = rarely() ? 0 : randomIntBetween(0, 2);
+            for (int q = 0; q < queryItems; q++) {
+                queryProfileResults.add(QueryProfileShardResultTests.createTestItem());
+            }
+            AggregationProfileShardResult aggProfileShardResult = AggregationProfileShardResultTests.createTestItem(1);
+            searchProfileResults.put(randomAsciiOfLengthBetween(5, 10), new ProfileShardResult(queryProfileResults, aggProfileShardResult));
+        }
+        return new SearchProfileShardResults(searchProfileResults);
+    }
+
+    public void testFromXContent() throws IOException {
+        SearchProfileShardResults shardResult = createTestItem();
+        XContentType xcontentType = randomFrom(XContentType.values());
+        XContentBuilder builder = XContentFactory.contentBuilder(xcontentType);
+        builder.startObject();
+        builder = shardResult.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        System.out.println(builder.string());
+
+        XContentParser parser = createParser(builder);
+        ensureExpectedToken(parser.nextToken(), XContentParser.Token.START_OBJECT, parser::getTokenLocation);
+        ensureFieldName(parser, parser.nextToken(), SearchProfileShardResults.PROFILE_FIELD);
+        ensureExpectedToken(parser.nextToken(), XContentParser.Token.START_OBJECT, parser::getTokenLocation);
+        SearchProfileShardResults parsed = SearchProfileShardResults.fromXContent(parser);
+        assertToXContentEquivalent(builder.bytes(), toXContent(parsed, xcontentType), xcontentType);
+        assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
+        assertNull(parser.nextToken());
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/search/profile/SearchProfileShardResultsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/SearchProfileShardResultsTests.java
@@ -65,7 +65,6 @@ public class SearchProfileShardResultsTests  extends ESTestCase {
         builder.startObject();
         builder = shardResult.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
-        System.out.println(builder.string());
 
         XContentParser parser = createParser(builder);
         ensureExpectedToken(parser.nextToken(), XContentParser.Token.START_OBJECT, parser::getTokenLocation);

--- a/core/src/test/java/org/elasticsearch/search/profile/SearchProfileShardResultsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/SearchProfileShardResultsTests.java
@@ -46,7 +46,7 @@ public class SearchProfileShardResultsTests  extends ESTestCase {
         Map<String, ProfileShardResult> searchProfileResults = new HashMap<>(size);
         for (int i = 0; i < size; i++) {
             List<QueryProfileShardResult> queryProfileResults = new ArrayList<>();
-            int queryItems = rarely() ? 0 : randomIntBetween(0, 2);
+            int queryItems = rarely() ? 0 : randomIntBetween(1, 2);
             for (int q = 0; q < queryItems; q++) {
                 queryProfileResults.add(QueryProfileShardResultTests.createTestItem());
             }

--- a/core/src/test/java/org/elasticsearch/search/profile/aggregation/AggregationProfileShardResultTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/aggregation/AggregationProfileShardResultTests.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the \"License\"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.profile.aggregation;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParserUtils;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.search.profile.ProfileResult;
+import org.elasticsearch.search.profile.ProfileResultTests;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+
+public class AggregationProfileShardResultTests extends ESTestCase {
+
+    public static AggregationProfileShardResult createTestItem(int depth) {
+        int size = randomIntBetween(0, 5);
+        List<ProfileResult> aggProfileResults = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            aggProfileResults.add(ProfileResultTests.createTestItem(1));
+        }
+        return new AggregationProfileShardResult(aggProfileResults);
+    }
+
+    public void testFromXContent() throws IOException {
+        AggregationProfileShardResult profileResult = createTestItem(2);
+        XContentType xcontentType = XContentType.JSON; // randomFrom(XContentType.values());
+        XContentBuilder builder = XContentFactory.contentBuilder(xcontentType);
+        builder.startObject();
+        builder = profileResult.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        XContentParser parser = createParser(builder);
+        XContentParserUtils.ensureExpectedToken(parser.nextToken(), XContentParser.Token.START_OBJECT, parser::getTokenLocation);
+        XContentParserUtils.ensureFieldName(parser, parser.nextToken(), AggregationProfileShardResult.AGGREGATIONS);
+        XContentParserUtils.ensureExpectedToken(parser.nextToken(), XContentParser.Token.START_ARRAY, parser::getTokenLocation);
+        AggregationProfileShardResult parsed = AggregationProfileShardResult.fromXContent(parser);
+        assertToXContentEquivalent(builder.bytes(), toXContent(parsed, xcontentType), xcontentType);
+        assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
+        assertNull(parser.nextToken());
+    }
+
+    public void testToXContent() throws IOException {
+        List<ProfileResult> profileResults = new ArrayList<>();
+        Map<String, Long> timings = new HashMap<>();
+        timings.put("timing1", 2000L);
+        timings.put("timing2", 4000L);
+        ProfileResult profileResult = new ProfileResult("someType", "someDescription", timings, Collections.emptyList());
+        profileResults.add(profileResult);
+        AggregationProfileShardResult aggProfileResults = new AggregationProfileShardResult(profileResults);
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        builder.startObject();
+        aggProfileResults.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        assertEquals("{\"aggregations\":["
+                        + "{\"type\":\"someType\","
+                            + "\"description\":\"someDescription\","
+                            + "\"time\":\"0.006000000000ms\","
+                            + "\"breakdown\":{\"timing1\":2000,\"timing2\":4000}"
+                        + "}"
+                   + "]}", builder.string());
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/search/profile/aggregation/AggregationProfileShardResultTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/aggregation/AggregationProfileShardResultTests.java
@@ -84,7 +84,7 @@ public class AggregationProfileShardResultTests extends ESTestCase {
         assertEquals("{\"aggregations\":["
                         + "{\"type\":\"someType\","
                             + "\"description\":\"someDescription\","
-                            + "\"time\":\"0.006000000000ms\","
+                            + "\"time_in_nanos\":6000,"
                             + "\"breakdown\":{\"timing1\":2000,\"timing2\":4000}"
                         + "}"
                    + "]}", builder.string());

--- a/core/src/test/java/org/elasticsearch/search/profile/query/CollectorResultTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/query/CollectorResultTests.java
@@ -41,6 +41,10 @@ public class CollectorResultTests extends ESTestCase {
         String name = randomAsciiOfLengthBetween(5, 10);
         String reason = randomAsciiOfLengthBetween(5, 10);
         long time = randomNonNegativeLong();
+        if (randomBoolean()) {
+            // also often use relatively "small" values, otherwise we will mostly test huge longs
+            time = time % 100000;
+        }
         int size = randomIntBetween(0, 5);
         List<CollectorResult> children = new ArrayList<>(size);
         if (depth > 0) {
@@ -50,6 +54,7 @@ public class CollectorResultTests extends ESTestCase {
         }
         return new CollectorResult(name, reason, time, children);
     }
+
 
     public void testFromXContent() throws IOException {
         CollectorResult collectorResult = createTestItem(1);

--- a/core/src/test/java/org/elasticsearch/search/profile/query/CollectorResultTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/query/CollectorResultTests.java
@@ -60,12 +60,14 @@ public class CollectorResultTests extends ESTestCase {
         CollectorResult collectorResult = createTestItem(1);
         XContentType xcontentType = randomFrom(XContentType.values());
         XContentBuilder builder = XContentFactory.contentBuilder(xcontentType);
+        boolean humanReadable = randomBoolean();
+        builder.humanReadable(humanReadable);
         builder = collectorResult.toXContent(builder, ToXContent.EMPTY_PARAMS);
 
         XContentParser parser = createParser(builder);
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
         CollectorResult parsed = CollectorResult.fromXContent(parser);
-        assertToXContentEquivalent(builder.bytes(), toXContent(parsed, xcontentType), xcontentType);
+        assertToXContentEquivalent(builder.bytes(), toXContent(parsed, xcontentType, humanReadable), xcontentType);
         assertNull(parser.nextToken());
     }
 

--- a/core/src/test/java/org/elasticsearch/search/profile/query/QueryProfileShardResultTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/query/QueryProfileShardResultTests.java
@@ -53,9 +53,7 @@ public class QueryProfileShardResultTests extends ESTestCase {
         QueryProfileShardResult profileResult = createTestItem();
         XContentType xcontentType = randomFrom(XContentType.values());
         XContentBuilder builder = XContentFactory.contentBuilder(xcontentType);
-        builder.startObject();
         builder = profileResult.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        builder.endObject();
 
         XContentParser parser = createParser(builder);
         XContentParserUtils.ensureExpectedToken(parser.nextToken(), XContentParser.Token.START_OBJECT, parser::getTokenLocation);


### PR DESCRIPTION
In preparation for being able to parse SearchResponse from its rest representation
for the java rest client, this adds fromXContent to SearchProfileShardResults and its
nested classes. 