### PR TITLE
Minor doc changes to clarify mapping index param for string type

### DIFF
--- a/docs/reference/analysis/tokenfilters/truncate-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/truncate-tokenfilter.asciidoc
@@ -2,9 +2,7 @@
 === Truncate Token Filter
 
 The `truncate` token filter can be used to truncate tokens into a
-specific length. This can come in handy with keyword (single token)
-based mapped fields that are used for sorting in order to reduce memory
-usage.
+specific length.
 
 It accepts a `length` parameter which control the number of characters
 to truncate to, defaults to `10`.

--- a/docs/reference/mapping/params/index.asciidoc
+++ b/docs/reference/mapping/params/index.asciidoc
@@ -4,3 +4,4 @@
 The `index` option controls whether field values are indexed. It accepts `true`
 or `false`. Fields that are not indexed are not queryable.
 
+NOTE: For the legacy mapping type <<string,`string`>> the `index` option only accepts legacy values `analyzed` (default, treat as full-text field), `not_analyzed` (treat as keyword field) and `no`.

--- a/docs/reference/mapping/types/string.asciidoc
+++ b/docs/reference/mapping/types/string.asciidoc
@@ -12,7 +12,7 @@ to use `text` or `keyword`.
 
 Indexes imported from 2.x *only* support `string` and not `text` or `keyword`.
 To ease the migration from 2.x Elasticsearch will downgrade `text` and `keyword`
-mappings applied to indexes imported to 2.x into `string`. While long lived
+mappings applied to indexes imported from 2.x into `string`. While long lived
 indexes will eventually need to be recreated against 5.x before eventually
 upgrading to 6.x, this downgrading smooths the process before you find time for
 it.


### PR DESCRIPTION
The docs are not entirely clear about the possible options for the legacy string mapping type.  This PR aims to make it easier for users moving from 2.x to 5.x by clarifying the options for the string mapping type as a legacy mapping type on 5.x

While it is still possilble to specifiy a string mapping type in 5.x, and this is automatically converted to either a text or keyword mapping type, the index option must be specified using the legacy values ("no" / "analyzed" / "not_analyzed") and not the values currently documented (true / false).