### PR TITLE
Make build Gradle 2.14 / 3.x compatible

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -23,14 +23,8 @@ apply plugin: 'groovy'
 
 group = 'org.elasticsearch.gradle'
 
-// TODO: remove this when upgrading to a version that supports ProgressLogger
-// gradle 2.14 made internal apis unavailable to plugins, and gradle considered
-// ProgressLogger to be an internal api. Until this is made available again,
-// we can't upgrade without losing our nice progress logging
-// NOTE that this check duplicates that in BuildPlugin, but we need to check
-// early here before trying to compile the broken classes in buildSrc
-if (GradleVersion.current() != GradleVersion.version('2.13')) {
-  throw new GradleException('Gradle 2.13 is required to build elasticsearch')
+if (GradleVersion.current() < GradleVersion.version('2.13')) {
+  throw new GradleException('Gradle 2.13+ is required to build elasticsearch')
 }
 
 if (project == rootProject) {
@@ -96,9 +90,25 @@ dependencies {
   compile 'com.perforce:p4java:2012.3.551082' // THIS IS SUPPOSED TO BE OPTIONAL IN THE FUTURE....
   compile 'de.thetaphi:forbiddenapis:2.2'
   compile 'org.apache.rat:apache-rat:0.11'
-  compile 'ru.vyarus:gradle-animalsniffer-plugin:1.0.1'
 }
 
+// Gradle version-specific options (allows build to run with Gradle 2.13 as well as 2.14+/3.+)
+if (GradleVersion.current() == GradleVersion.version("2.13")) {
+  // ProgressLogger(-Factory) classes are part of the public Gradle API
+  // Add default imports for (org.gradle.logging)
+  compileGroovy.groovyOptions.configurationScript = file('src/compile/groovy/gradle-2.13-loggers.groovy')
+  dependencies {
+    compile 'ru.vyarus:gradle-animalsniffer-plugin:1.0.1' // last version compatible with Gradle 2.13
+  }
+} else {
+  // Gradle 2.14+ removed ProgressLogger(-Factory) classes from the public APIs
+  // Use logging dependency and add default imports for "org.gradle.internal.logging.progress"
+  compileGroovy.groovyOptions.configurationScript = file('src/compile/groovy/gradle-2.14-loggers.groovy')
+  dependencies {
+    compile "org.gradle:gradle-logging:3.3" // any version >= 2.14 is ok, take a recent one
+    compile 'ru.vyarus:gradle-animalsniffer-plugin:1.2.0' // Gradle 2.14 requires a version > 1.0.1
+  }
+}
 
 /*****************************************************************************
  *                         Bootstrap repositories                            *

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -105,7 +105,7 @@ if (GradleVersion.current() == GradleVersion.version("2.13")) {
   // Use logging dependency and add default imports for "org.gradle.internal.logging.progress"
   compileGroovy.groovyOptions.configurationScript = file('src/compile/groovy/gradle-2.14-loggers.groovy')
   dependencies {
-    compile "org.gradle:gradle-logging:3.3" // any version >= 2.14 is ok, take a recent one
+    compileOnly "org.gradle:gradle-logging:${GradleVersion.current().getVersion()}"
     compile 'ru.vyarus:gradle-animalsniffer-plugin:1.2.0' // Gradle 2.14 requires a version > 1.0.1
   }
 }

--- a/buildSrc/src/compile/groovy/gradle-2.13-loggers.groovy
+++ b/buildSrc/src/compile/groovy/gradle-2.13-loggers.groovy
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.codehaus.groovy.control.customizers.ImportCustomizer
+
+def imports = new ImportCustomizer()
+imports.addImports(
+   'org.gradle.logging.ProgressLogger',
+   'org.gradle.logging.ProgressLoggerFactory')
+configuration.addCompilationCustomizers(imports)

--- a/buildSrc/src/compile/groovy/gradle-2.14-loggers.groovy
+++ b/buildSrc/src/compile/groovy/gradle-2.14-loggers.groovy
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.codehaus.groovy.control.customizers.ImportCustomizer
+
+def imports = new ImportCustomizer()
+imports.addImports(
+        'org.gradle.internal.logging.progress.ProgressLogger',
+        'org.gradle.internal.logging.progress.ProgressLoggerFactory')
+configuration.addCompilationCustomizers(imports)

--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingTask.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingTask.groovy
@@ -19,7 +19,6 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.api.tasks.util.PatternSet
-import org.gradle.logging.ProgressLoggerFactory
 import org.gradle.util.ConfigureUtil
 
 import javax.inject.Inject

--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/TestProgressLogger.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/TestProgressLogger.groovy
@@ -25,8 +25,6 @@ import com.carrotsearch.ant.tasks.junit4.events.aggregated.AggregatedStartEvent
 import com.carrotsearch.ant.tasks.junit4.events.aggregated.AggregatedSuiteResultEvent
 import com.carrotsearch.ant.tasks.junit4.events.aggregated.AggregatedTestResultEvent
 import com.carrotsearch.ant.tasks.junit4.listeners.AggregatedEventListener
-import org.gradle.logging.ProgressLogger
-import org.gradle.logging.ProgressLoggerFactory
 
 import static com.carrotsearch.ant.tasks.junit4.FormattingUtils.formatDurationInSeconds
 import static com.carrotsearch.ant.tasks.junit4.events.aggregated.TestStatus.ERROR

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -418,8 +418,10 @@ class BuildPlugin implements Plugin<Project> {
                     // hack until gradle supports java 9's new "--release" arg
                     assert minimumJava == JavaVersion.VERSION_1_8
                     options.compilerArgs << '--release' << '8'
-                    project.sourceCompatibility = null
-                    project.targetCompatibility = null
+                    doFirst{
+                        sourceCompatibility = null
+                        targetCompatibility = null
+                    }
                 }
             }
         }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/TapLoggerOutputStream.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/TapLoggerOutputStream.groovy
@@ -22,8 +22,6 @@ import com.carrotsearch.gradle.junit4.LoggingOutputStream
 import groovy.transform.PackageScope
 import org.gradle.api.GradleScriptException
 import org.gradle.api.logging.Logger
-import org.gradle.logging.ProgressLogger
-import org.gradle.logging.ProgressLoggerFactory
 
 import java.util.regex.Matcher
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantCommandTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantCommandTask.groovy
@@ -21,7 +21,6 @@ package org.elasticsearch.gradle.vagrant
 import org.apache.commons.io.output.TeeOutputStream
 import org.elasticsearch.gradle.LoggedExec
 import org.gradle.api.tasks.Input
-import org.gradle.logging.ProgressLoggerFactory
 
 import javax.inject.Inject
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantLoggerOutputStream.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantLoggerOutputStream.groovy
@@ -20,8 +20,6 @@ package org.elasticsearch.gradle.vagrant
 
 import com.carrotsearch.gradle.junit4.LoggingOutputStream
 import org.gradle.api.logging.Logger
-import org.gradle.logging.ProgressLogger
-import org.gradle.logging.ProgressLoggerFactory
 
 /**
  * Adapts an OutputStream being written to by vagrant into a ProcessLogger. It

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -368,3 +368,9 @@ thirdPartyAudit.excludes = [
   'org.apache.log4j.helpers.ISO8601DateFormat',
   'org.apache.log4j.spi.ThrowableInformation'
 ]
+
+// Gradle 2.13 bundles org.slf4j.impl.StaticLoggerBinder in its core.jar which leaks into the forbidden APIs ant task
+// Gradle 2.14+ does not bundle this class anymore so we need to properly exclude it here.
+if (GradleVersion.current() > GradleVersion.version("2.13")) {
+  thirdPartyAudit.excludes += ['org.slf4j.impl.StaticLoggerBinder']
+}


### PR DESCRIPTION
This changes build files so that building Elasticsearch works with both Gradle 2.13 as well as higher versions of Gradle (tested 2.14 and 3.3), enabling a smooth transition from Gradle 2.13 to 3.x.