### PR TITLE
Remove optional dependency flag for log4j-api

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -81,10 +81,10 @@ dependencies {
   compile "com.vividsolutions:jts:${versions.jts}", optional
 
   // logging
-  compile "org.apache.logging.log4j:log4j-api:${versions.log4j}", optional
+  compile "org.apache.logging.log4j:log4j-api:${versions.log4j}"
   compile "org.apache.logging.log4j:log4j-core:${versions.log4j}", optional
   // to bridge dependencies that are still on Log4j 1 to Log4j 2
-  compile "org.apache.logging.log4j:log4j-1.2-api:${versions.log4j}", optional
+  compile "org.apache.logging.log4j:log4j-1.2-api:${versions.log4j}"
 
   compile "net.java.dev.jna:jna:${versions.jna}"
 


### PR DESCRIPTION
Embedded version of elasticsearch and transport client can't work without
dependency on log4j-api, because they fail during initialize logging.

```
Caused by: java.lang.NoClassDefFoundError: org/apache/logging/log4j/Logger
	at org.elasticsearch.common.logging.Loggers.getLogger(Loggers.java:105)
	at org.elasticsearch.common.logging.Loggers.getLogger(Loggers.java:72)
	at org.elasticsearch.common.component.AbstractComponent.<init>(AbstractComponent.java:37)
	at org.elasticsearch.plugins.PluginsService.<init>(PluginsService.java:98)
	at org.elasticsearch.client.transport.TransportClient.newPluginService(TransportClient.java:94)
	at org.elasticsearch.client.transport.TransportClient.buildTemplate(TransportClient.java:119)
	at org.elasticsearch.client.transport.TransportClient.<init>(TransportClient.java:247)
	at org.elasticsearch.transport.client.PreBuiltTransportClient.<init>(PreBuiltTransportClient.java:125)
	at org.elasticsearch.transport.client.PreBuiltTransportClient.<init>(PreBuiltTransportClient.java:111)
	at org.elasticsearch.transport.client.PreBuiltTransportClient.<init>(PreBuiltTransportClient.java:101)
	... 99 common frames omitted
Caused by: java.lang.ClassNotFoundException: org.apache.logging.log4j.Logger
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 120 common frames omitted
```

Now for start use Transport client or embedded version of elasticsearch
need add only one dependency

Closes #22671
