### PR TITLE
[WIP] Add headers parsing to ElasticsearchException

### DIFF
--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -36,6 +36,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.transport.TcpTransport;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -49,7 +50,6 @@ import static java.util.Collections.singletonMap;
 import static java.util.Collections.unmodifiableMap;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_UUID_NA_VALUE;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknownField;
 
 /**
  * A base class for all elasticsearch exceptions.
@@ -329,7 +329,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     private static ElasticsearchException innerFromXContent(XContentParser parser) throws IOException {
         String type = null, reason = null, stack = null;
         ElasticsearchException cause = null;
-        Map<String, Object> headers = new HashMap<>();
+        Map<String, List<String>> headers = new HashMap<>();
 
         XContentParser.Token token = parser.currentToken();
         String currentFieldName = parser.currentName();
@@ -348,16 +348,25 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                     stack = parser.text();
                 } else {
                     // Everything else is considered as a header
-                    headers.put(currentFieldName, parser.text());
+                    headerFromXContent(headers, currentFieldName, parser.text());
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (CAUSED_BY.equals(currentFieldName)) {
                     cause = fromXContent(parser);
                 } else if (HEADER.equals(currentFieldName)) {
-                    headers.putAll(parser.map());
+                    // Add everything under "header" field as header fields.
+                    // Objects will be added with flattened key names, like
+                    // "header: {"foo": "bar"} will be added as header.foo=bar
+                    headerFromXContent(headers, currentFieldName, parser.map());
                 } else {
-                    throwUnknownField(currentFieldName, parser.getTokenLocation());
+                    // Everything else is considered as a header too since we don't
+                    // know is this object has been added by an exception or not.
+                    headerFromXContent(headers, currentFieldName, parser.map());
                 }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                // Everything else is considered as a header too since we don't
+                // know is this array has been added by an exception or not.
+                headerFromXContent(headers, currentFieldName, parser.list());
             }
         } while ((token = parser.nextToken()) == XContentParser.Token.FIELD_NAME);
 
@@ -370,8 +379,8 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         message.append(']');
 
         ElasticsearchException e = new ElasticsearchException(message.toString(), cause);
-        for (Map.Entry<String, Object> header : headers.entrySet()) {
-            e.addHeader(header.getKey(), String.valueOf(header.getValue()));
+        for (Map.Entry<String, List<String>> header : headers.entrySet()) {
+            e.addHeader(header.getKey(), header.getValue());
         }
         return e;
     }
@@ -387,6 +396,34 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                 }
                 builder.endArray();
             }
+        }
+    }
+
+    /**
+     * This method adds the current object value to the list of the headers, converting the value to String
+     * and flattening the name for objects and arrays.
+     */
+    @SuppressWarnings("unchecked")
+    private static void headerFromXContent(Map<String, List<String>> headers, String current, Object value) {
+        if (value instanceof Map) {
+            Map<String, ?> map = (Map) value;
+            for (Map.Entry<String, ?> entry : map.entrySet()) {
+                headerFromXContent(headers, current + "." + entry.getKey(), entry.getValue());
+            }
+        } else if (value instanceof List) {
+            List<?> list = (List) value;
+            for (int i = 0; i < list.size(); i++) {
+                Object item = list.get(i);
+                if (item instanceof String || item instanceof Number || item instanceof Boolean) {
+                    headerFromXContent(headers, current, item);
+                } else {
+                    headerFromXContent(headers, current + "." + i, item);
+                }
+            }
+        } else {
+            List<String> values = headers.getOrDefault(current, new ArrayList<>());
+            values.add(String.valueOf(value));
+            headers.put(current, values);
         }
     }
 


### PR DESCRIPTION
**This is work in progress**

When rendered to XContent, ElasticsearchException's headers and other metadata are added to the XContent as new fields/objects.
    
For example, a `new CircuitBreakingException("Excessive stuff", 30L, 20L)` is rendered as the following JSON:
```
    {
        "type": "circuit_breaking_exception",
        "reason": "Excessive stuff",
        "bytes_wanted": 30,
        "bytes_limit": 20
    }
```
    
The same exception with an internal header "es.uuid"="foo" and a custom header "bar"="baz" would be rendered as:
```
    {
        "type": "circuit_breaking_exception",
        "reason": "Excessive stuff",
        "uuid": "foo"
        "bytes_wanted": 30,
        "bytes_limit": 20,
        "header": {
            "bar": "baz"
        }
    }
```
    
When this JSON is parsed back, there is no way to know if `bytes_wanted` is an internal header or a metadata because only custom headers (ie, which does not start with "es.") are added as sub fields of a parent `header` field. The internal headers are just added in the stream. In the best world, headers and metadata would have their own namespaces to avoid name conflicts but for now we can just assume that everything is a header.
    
This commit changes the ElasticsearchException so that:
- innerFromXContent() method is added and is in charge of parsing what is produced by innerToXContent()
- every field/object is considered as a header
- header objects/arrays  names are flattened
- header values are converted to String (because headers only accept strings)
