### PR TITLE
Add the ability to define search response listeners in search plugin

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
@@ -65,6 +65,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -82,11 +83,25 @@ public class SearchPhaseController extends AbstractComponent {
 
     private final BigArrays bigArrays;
     private final ScriptService scriptService;
+    private final List<BiConsumer<SearchRequest, SearchResponse> > searchResponseListener;
 
     public SearchPhaseController(Settings settings, BigArrays bigArrays, ScriptService scriptService) {
+        this(settings, bigArrays, scriptService, Collections.emptyList());
+    }
+
+    public SearchPhaseController(Settings settings, BigArrays bigArrays, ScriptService scriptService,
+                                 List<BiConsumer<SearchRequest, SearchResponse> > searchResponseListener) {
         super(settings);
         this.bigArrays = bigArrays;
         this.scriptService = scriptService;
+        this.searchResponseListener = searchResponseListener;
+    }
+
+    /**
+     * Returns the search response listeners registry
+     */
+    public List<BiConsumer<SearchRequest, SearchResponse> > getSearchResponseListener() {
+        return searchResponseListener;
     }
 
     public AggregatedDfs aggregateDfs(AtomicArray<DfsSearchResult> results) {

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -451,7 +451,7 @@ public class Node implements Closeable {
                     b.bind(SearchTransportService.class).toInstance(new SearchTransportService(settings,
                             settingsModule.getClusterSettings(), transportService));
                     b.bind(SearchPhaseController.class).toInstance(new SearchPhaseController(settings, bigArrays,
-                            scriptModule.getScriptService()));
+                            scriptModule.getScriptService(), searchModule.getSearchResponseListeners()));
                     b.bind(Transport.class).toInstance(transport);
                     b.bind(TransportService.class).toInstance(transportService);
                     b.bind(NetworkService.class).toInstance(networkService);

--- a/core/src/main/java/org/elasticsearch/plugins/SearchPlugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/SearchPlugin.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.plugins;
 
 import org.apache.lucene.search.Query;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -51,6 +53,7 @@ import org.elasticsearch.search.suggest.SuggestionBuilder;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.BiConsumer;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -119,6 +122,15 @@ public interface SearchPlugin {
      * The new {@link PipelineAggregator}s added by this plugin.
      */
     default List<PipelineAggregationSpec> getPipelineAggregations() {
+        return emptyList();
+    }
+    /**
+     * The new search response listeners in the form of {@link BiConsumer}s added by this plugin.
+     * The listeners are invoked on the coordinating node, at the very end of the search request.
+     * This provides a convenient location if you wish to inspect/modify the final response (took time, etc).
+     * The BiConsumers are passed the original {@link SearchRequest} and the final {@link SearchResponse}
+     */
+    default List<BiConsumer<SearchRequest, SearchResponse>> getSearchResponseListeners() {
         return emptyList();
     }
 

--- a/core/src/test/java/org/elasticsearch/search/ResponseListenerPluginIT.java
+++ b/core/src/test/java/org/elasticsearch/search/ResponseListenerPluginIT.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search;
+
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SearchPlugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Before;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+
+import static java.util.Collections.singletonList;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.greaterThan;
+
+public class ResponseListenerPluginIT extends ESIntegTestCase {
+
+    static AtomicBoolean hookWasFired = new AtomicBoolean(false);
+
+    public static class FooResponseListenerPlugin extends Plugin implements SearchPlugin {
+        @Override
+        public List<BiConsumer<SearchRequest, SearchResponse>> getSearchResponseListeners() {
+            return singletonList((searchRequest, response) -> {
+                assertThat(response.getTookInMillis(), greaterThan(0L));
+                boolean alreadyFired = hookWasFired.getAndSet(true);
+                assertFalse(alreadyFired);
+            });
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(FooResponseListenerPlugin.class);
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        createIndex("test");
+        ensureGreen();
+        client().prepareIndex("index", "type", "1").setSource("field", "value").get();
+        refresh();
+    }
+
+    public void testSearchResponseHook() {
+        assertHitCount(client().prepareSearch("index").setQuery(QueryBuilders.matchAllQuery()).get(), 1L);
+        boolean alreadyFired = hookWasFired.get();
+        assertTrue(alreadyFired);
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -18,6 +18,8 @@
  */
 package org.elasticsearch.search;
 
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.inject.ModuleTestCase;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -69,6 +71,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -254,6 +257,18 @@ public class SearchModuleTests extends ModuleTestCase {
                     .filter(entry -> entry.categoryClass.equals(BaseAggregationBuilder.class) && entry.name.match("test"))
                     .collect(toList()),
                 hasSize(1));
+    }
+
+    public void testRegisterSearchResponseListener() {
+        BiConsumer<SearchRequest, SearchResponse> listener = (s, r) -> {};
+        SearchModule module = new SearchModule(Settings.EMPTY, false, singletonList(new SearchPlugin() {
+            public List<BiConsumer<SearchRequest, SearchResponse>> getSearchResponseListeners() {
+                return singletonList(listener);
+            }
+        }));
+        List<BiConsumer<SearchRequest, SearchResponse>> listeners = module.getSearchResponseListeners();
+        assertEquals(listeners.size(), 1);
+        assertEquals(listeners.get(0), listener);
     }
 
     private static final String[] NON_DEPRECATED_QUERIES = new String[] {


### PR DESCRIPTION
This change is a simple adaptation of https://github.com/elastic/elasticsearch/pull/19587 for the current state of master.
It allows to define search response listener in the form of `BiConsumer<SearchRequest, SearchResponse>`s in a search plugin.
I plan to use this feature to cleanup the current PR for field collapsing:
https://github.com/elastic/elasticsearch/pull/22337