### PR TITLE
Fix status logger message at startup

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -430,7 +430,7 @@ You can also use Gradle to prepare the test environment and then starts a single
 gradle vagrantFedora24#up
 -------------------------------------------------
 
-Or any of vagrantCentos6#up, vagrantDebian8#up, vagrantFedora24#up, vagrantOel6#up,
+Or any of vagrantCentos6#up, vagrantDebian8#up, vagrantCentos7#up, vagrantOel6#up,
 vagrantOel7#up, vagrantOpensuse13#up, vagrantSles12#up, vagrantUbuntu1204#up,
 vagrantUbuntu1604#up.
 

--- a/core/src/main/java/org/elasticsearch/cli/Command.java
+++ b/core/src/main/java/org/elasticsearch/cli/Command.java
@@ -81,8 +81,7 @@ public abstract class Command implements Closeable {
 
         // initialize default for es.logger.level because we will not read the log4j2.properties
         final String loggerLevel = System.getProperty("es.logger.level", Level.INFO.name());
-        final Settings settings = Settings.builder().put("logger.level", loggerLevel).build();
-        LogConfigurator.configureWithoutConfig(settings);
+        LogConfigurator.configureWithoutConfig(loggerLevel);
 
         try {
             mainWithoutErrorHandling(args, terminal);

--- a/core/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -58,12 +58,14 @@ public class LogConfigurator {
      * Configure logging without reading a log4j2.properties file, effectively configuring the
      * status logger and all loggers to the console.
      *
-     * @param settings for configuring logger.level and individual loggers
+     * @param loggerLevel for configuring logger.level
      */
-    public static void configureWithoutConfig(final Settings settings) {
-        Objects.requireNonNull(settings);
+    public static void configureWithoutConfig(final String loggerLevel) {
+        Objects.requireNonNull(loggerLevel);
         // we initialize the status logger immediately otherwise Log4j will complain when we try to get the context
         configureStatusLogger();
+
+        Settings settings = Settings.builder().put("logger.level", loggerLevel).build();
         configureLoggerLevels(settings);
     }
 


### PR DESCRIPTION
Since #22200 the `Settings` class now uses a static `DeprecationLogger`. This makes Log4j2 status logger yells when Elasticsearch starts with the message `ERROR StatusLogger No log4j2 configuration file found. Using default configuration` because this deprecation logger is instantiated before the status logger has been configured.

This commit changes the `LogConfigurator.configureWithoutConfig()` method so that the status logger is initialized without using any `Settings`, making the message disappear.