### PR TITLE
Fix NPE on FieldStats with mixed cluster on version pre/post 5.2

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
@@ -329,10 +329,8 @@ public abstract class FieldStats<T> implements Writeable, ToXContent {
                 writeMinMax(out);
             }
         } else {
-            if (hasMinMax == false) {
-                throw new IllegalArgumentException("cannot serialize null min/max fieldstats in a mixed-cluster " +
-                    "with pre-" + Version.V_5_2_0_UNRELEASED + " nodes, node version [" + out.getVersion() + "]");
-            }
+            assert hasMinMax : "cannot serialize null min/max fieldstats in a mixed-cluster " +
+                    "with pre-" + Version.V_5_2_0_UNRELEASED + " nodes, remote version [" + out.getVersion() + "]";
             writeMinMax(out);
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
@@ -329,6 +329,10 @@ public abstract class FieldStats<T> implements Writeable, ToXContent {
                 writeMinMax(out);
             }
         } else {
+            if (hasMinMax == false) {
+                throw new IllegalArgumentException("cannot serialize null min/max fieldstats in a mixed-cluster " +
+                    "with pre-" + Version.V_5_2_0_UNRELEASED + " nodes, node version [" + out.getVersion() + "]");
+            }
             writeMinMax(out);
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsShardResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsShardResponse.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.fieldstats;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -27,6 +28,7 @@ import org.elasticsearch.index.shard.ShardId;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class FieldStatsShardResponse extends BroadcastShardResponse {
 
@@ -44,6 +46,12 @@ public class FieldStatsShardResponse extends BroadcastShardResponse {
         return fieldStats;
     }
 
+    Map<String, FieldStats<?> > filterNullMinMax() {
+        return fieldStats.entrySet().stream()
+            .filter((e) -> e.getValue().hasMinMax())
+            .collect(Collectors.toMap(p -> p.getKey(), p -> p.getValue()));
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -59,8 +67,17 @@ public class FieldStatsShardResponse extends BroadcastShardResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeVInt(fieldStats.size());
-        for (Map.Entry<String, FieldStats<?>> entry : fieldStats.entrySet()) {
+        final Map<String, FieldStats<?> > stats;
+        if (out.getVersion().before(Version.V_5_2_0_UNRELEASED)) {
+            /**
+             * FieldStats with null min/max are not (de)serializable in versions prior to {@link Version.V_5_2_0_UNRELEASED}
+             */
+            stats = filterNullMinMax();
+        } else {
+            stats = getFieldStats();
+        }
+        out.writeVInt(stats.size());
+        for (Map.Entry<String, FieldStats<?>> entry : stats.entrySet()) {
             out.writeString(entry.getKey());
             entry.getValue().writeTo(out);
         }

--- a/core/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsAction.java
@@ -36,8 +36,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;

--- a/core/src/test/java/org/elasticsearch/action/fieldstats/FieldStatsRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/fieldstats/FieldStatsRequestTests.java
@@ -19,10 +19,19 @@
 
 package org.elasticsearch.action.fieldstats;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.fieldstats.FieldStatsTests;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.StreamsUtils;
+import org.elasticsearch.test.VersionUtils;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.elasticsearch.action.fieldstats.IndexConstraint.Comparison.GT;
 import static org.elasticsearch.action.fieldstats.IndexConstraint.Comparison.GTE;
@@ -83,6 +92,35 @@ public class FieldStatsRequestTests extends ESTestCase {
         assertThat(request.getIndexConstraints()[7].getProperty(), equalTo(MAX));
         assertThat(request.getIndexConstraints()[7].getComparison(), equalTo(LT));
         assertThat(request.getIndexConstraints()[7].getOptionalFormat(), equalTo("date_optional_time"));
+    }
+
+    public void testFieldStatsBWC() throws Exception {
+        int size = randomIntBetween(5, 20);
+        Map<String, FieldStats<?> > stats = new HashMap<> ();
+        for (int i = 0; i < size; i++) {
+            stats.put(Integer.toString(i), FieldStatsTests.randomFieldStats(true));
+        }
+
+        FieldStatsShardResponse response = new FieldStatsShardResponse(new ShardId("test", "test", 0), stats);
+        for (int i = 0; i < 10; i++) {
+            Version version = VersionUtils.randomVersionBetween(random(), Version.V_5_0_0, Version.CURRENT);
+            BytesStreamOutput output = new BytesStreamOutput();
+            output.setVersion(version);
+            response.writeTo(output);
+            output.flush();
+            StreamInput input = output.bytes().streamInput();
+            input.setVersion(version);
+            FieldStatsShardResponse deserialized = new FieldStatsShardResponse();
+            deserialized.readFrom(input);
+            final Map<String, FieldStats<?>> expected;
+            if (version.before(Version.V_5_2_0_UNRELEASED)) {
+                expected = deserialized.filterNullMinMax();
+            } else {
+                expected = deserialized.getFieldStats();
+            }
+            assertEquals(expected.size(), deserialized.getFieldStats().size());
+            assertThat(expected, equalTo(deserialized.getFieldStats()));
+        }
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
@@ -609,10 +609,6 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                 assertSerialization(randomFieldStats(version.onOrAfter(Version.V_5_2_0_UNRELEASED)), version);
             }
         }
-        FieldStats.Long stats = new FieldStats.Long(0, -1, -1,-1, false, true);
-        IllegalArgumentException exc =
-            expectThrows(IllegalArgumentException.class, () -> assertSerialization(stats, Version.V_5_0_1));
-        assertThat(exc.getMessage(), containsString("cannot serialize null min/max fieldstats"));
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
@@ -609,12 +609,16 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                 assertSerialization(randomFieldStats(version.onOrAfter(Version.V_5_2_0_UNRELEASED)), version);
             }
         }
+        FieldStats.Long stats = new FieldStats.Long(0, -1, -1,-1, false, true);
+        IllegalArgumentException exc =
+            expectThrows(IllegalArgumentException.class, () -> assertSerialization(stats, Version.V_5_0_1));
+        assertThat(exc.getMessage(), containsString("cannot serialize null min/max fieldstats"));
     }
 
     /**
      * creates a random field stats which does not guarantee that {@link FieldStats#maxValue} is greater than {@link FieldStats#minValue}
      **/
-    private FieldStats randomFieldStats(boolean withNullMinMax) throws UnknownHostException {
+    public static FieldStats randomFieldStats(boolean withNullMinMax) throws UnknownHostException {
         int type = randomInt(5);
         switch (type) {
             case 0:


### PR DESCRIPTION
In 5.2 the FieldStats API can return null min/max values.
These values cannot be deserialized by a node with version pre 5.2 so if this node
is pick to coordinate a FieldStats request in a mixed cluster an NPE can be thrown.
This change prevents the NPE by removing the non serializable FieldStats object directly in the field stats shard request.
The filtered fields will not be present in the response when a node pre 5.2 acts as a coordinating node.