### PR TITLE
Fix duplicates from search.query

### DIFF
--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -164,11 +164,11 @@ phase |37ms
 operations |7
 |`search.open_contexts` |`so`, `searchOpenContexts` |No |Open search
 contexts |0
-|`search.query_current` |`sqc`, `searchFetchCurrent` |No |Current query
+|`search.query_current` |`sqc`, `searchQueryCurrent` |No |Current query
 phase operations |0
-|`search.query_time` |`sqti`, `searchFetchTime` |No |Time spent in query
+|`search.query_time` |`sqti`, `searchQueryTime` |No |Time spent in query
 phase |43ms
-|`search.query_total` |`sqto`, `searchFetchTotal` |No |Number of query
+|`search.query_total` |`sqto`, `searchQueryTotal` |No |Number of query
 operations |9
 |`search.scroll_current` |`scc`, `searchScrollCurrent` |No |Open scroll contexts |2
 |`search.scroll_time` |`scti`, `searchScrollTime` |No |Time scroll contexts held open|2m


### PR DESCRIPTION
search.query_current, search.query_time and search.query_total have wrong aliases.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
