### PR TITLE
Enable Azure snapshot plugin to support taking snapshot into multiple storage accounts.

### DIFF
--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageService.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageService.java
@@ -84,6 +84,6 @@ public interface AzureStorageService {
     Map<String,BlobMetaData> listBlobsByPrefix(String account, LocationMode mode, String container, String keyPath, String prefix)
         throws URISyntaxException, StorageException;
 
-    void moveBlob(String account, LocationMode mode, String container, String sourceBlob, String targetBlob)
+    void moveBlob(String account, String targetAccount, LocationMode mode, String container, String sourceBlob, String targetBlob)
         throws URISyntaxException, StorageException;
 }

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cloud.azure.storage;
 
 import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.LocationMode;
+import com.microsoft.azure.storage.RetryExponentialRetry;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.BlobProperties;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
@@ -145,6 +146,7 @@ public class AzureStorageServiceImpl extends AbstractComponent implements AzureS
             try {
                 int timeout = (int) azureStorageSettings.getTimeout().getMillis();
                 client.getDefaultRequestOptions().setTimeoutIntervalInMs(timeout);
+                client.getDefaultRequestOptions().setRetryPolicyFactory(new RetryExponentialRetry(1000 * 30, 7));
             } catch (ClassCastException e) {
                 throw new IllegalArgumentException("Can not convert [" + azureStorageSettings.getTimeout() +
                     "]. It can not be longer than 2,147,483,647ms.");

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
@@ -47,7 +47,7 @@ import java.util.Map;
 
 public class AzureStorageServiceImpl extends AbstractComponent implements AzureStorageService {
 
-    final AzureStorageSettings primaryStorageSettings;
+    final Map<String, AzureStorageSettings> primariesStorageSettings;
     final Map<String, AzureStorageSettings> secondariesStorageSettings;
 
     final Map<String, CloudBlobClient> clients;
@@ -55,18 +55,18 @@ public class AzureStorageServiceImpl extends AbstractComponent implements AzureS
     public AzureStorageServiceImpl(Settings settings) {
         super(settings);
 
-        Tuple<AzureStorageSettings, Map<String, AzureStorageSettings>> storageSettings = AzureStorageSettings.parse(settings);
-        this.primaryStorageSettings = storageSettings.v1();
+        Tuple<Map<String, AzureStorageSettings>, Map<String, AzureStorageSettings>> storageSettings = AzureStorageSettings.parse(settings);
+        this.primariesStorageSettings = storageSettings.v1();
         this.secondariesStorageSettings = storageSettings.v2();
 
         this.clients = new HashMap<>();
 
         logger.debug("starting azure storage client instance");
 
-        // We register the primary client if any
-        if (primaryStorageSettings != null) {
-            logger.debug("registering primary client for account [{}]", primaryStorageSettings.getAccount());
-            createClient(primaryStorageSettings);
+        // We register all primary clients
+        for (Map.Entry<String, AzureStorageSettings> azureStorageSettingsEntry : primariesStorageSettings.entrySet()) {
+            logger.debug("registering primary client for account [{}]", azureStorageSettingsEntry.getKey());
+            createClient(azureStorageSettingsEntry.getValue());
         }
 
         // We register all secondary clients
@@ -80,6 +80,13 @@ public class AzureStorageServiceImpl extends AbstractComponent implements AzureS
         try {
             logger.trace("creating new Azure storage client using account [{}], key [{}]",
                     azureStorageSettings.getAccount(), azureStorageSettings.getKey());
+
+            if (this.clients.containsKey(azureStorageSettings.getAccount()))
+            {
+                logger.trace("Azure storage client using account [{}], key [{}] exists.",
+                    azureStorageSettings.getAccount(), azureStorageSettings.getKey());
+                return;
+            }
 
             String storageConnectionString =
                     "DefaultEndpointsProtocol=https;"
@@ -103,7 +110,7 @@ public class AzureStorageServiceImpl extends AbstractComponent implements AzureS
         logger.trace("selecting a client for account [{}], mode [{}]", account, mode.name());
         AzureStorageSettings azureStorageSettings = null;
 
-        if (this.primaryStorageSettings == null) {
+        if (this.primariesStorageSettings == null) {
             throw new IllegalArgumentException("No primary azure storage can be found. Check your elasticsearch.yml.");
         }
 
@@ -113,8 +120,8 @@ public class AzureStorageServiceImpl extends AbstractComponent implements AzureS
 
         // if account is not secondary, it's the primary
         if (azureStorageSettings == null) {
-            if (Strings.hasLength(account) == false || primaryStorageSettings.getName() == null || account.equals(primaryStorageSettings.getName())) {
-                azureStorageSettings = primaryStorageSettings;
+            if (Strings.hasLength(account)) {
+                azureStorageSettings = this.primariesStorageSettings.get(account);
             }
         }
 
@@ -294,14 +301,19 @@ public class AzureStorageServiceImpl extends AbstractComponent implements AzureS
     }
 
     @Override
-    public void moveBlob(String account, LocationMode mode, String container, String sourceBlob, String targetBlob) throws URISyntaxException, StorageException {
+    public void moveBlob(String account, String targetAccount, LocationMode mode, String container, String sourceBlob, String targetBlob) throws URISyntaxException, StorageException {
         logger.debug("moveBlob container [{}], sourceBlob [{}], targetBlob [{}]", container, sourceBlob, targetBlob);
 
         CloudBlobClient client = this.getSelectedClient(account, mode);
         CloudBlobContainer blobContainer = client.getContainerReference(container);
         CloudBlockBlob blobSource = blobContainer.getBlockBlobReference(sourceBlob);
+
+        CloudBlobClient targetClient = this.getSelectedClient(targetAccount, mode);
+        CloudBlobContainer targetBlobContainer = targetClient.getContainerReference(container);
+        targetBlobContainer.createIfNotExists();
+
         if (blobSource.exists()) {
-            CloudBlockBlob blobTarget = blobContainer.getBlockBlobReference(targetBlob);
+            CloudBlockBlob blobTarget = targetBlobContainer.getBlockBlobReference(targetBlob);
             blobTarget.startCopy(blobSource);
             blobSource.delete();
             logger.debug("moveBlob container [{}], sourceBlob [{}], targetBlob [{}] -> done", container, sourceBlob, targetBlob);


### PR DESCRIPTION
The default Elasticsearch Azure snapshot plugin write the whole snapshot data into a single Azure storage account. For big Elasticsearch cluster with multiple TB data in size, the snapshot could fail because of the storage account throttling limit. Here is an example of the snapshot failure error:  
 
        {
          "node_id": "cR_OjhxaRvW0ZmR14w8c6g",
          "index": "rawevents_v3.2016_06_29",
          "reason": "IndexShardSnapshotFailedException[[rawevents_v3.2016_06_29][1] Failed to perform snapshot (index files)]; nested: IOException; nested: StorageException[The server encountered an unknown failure: ]; nested: IOException[Error writing to server]; ",
          "shard_id": 1,
          "status": "INTERNAL_SERVER_ERROR"
        }

To address this problem, we extend Elasticsearch Azure plugin by adding the feature to support taking snapshot into and restore from multiple storage accounts to avoid overload a single storage account. That said, Elasticsearch can write their snapshot data into multiple storage accounts evenly and in parallel. 

Here are the configuration as well as the commands to take snapshot and restore snapshot: 

Elasticsearch.yml
cloud.azure.storage.my_account1.account: storageaccount1
cloud.azure.storage.my_account1.key: key1
cloud.azure.storage.my_account1.default: true
cloud.azure.storage.my_account2.account: storageaccount2
cloud.azure.storage.my_account2.key: key2
cloud.azure.storage.my_account2.default: true
cloud.azure.storage.my_account3.account: storageaccount3
cloud.azure.storage.my_account3.key: key3
cloud.azure.storage.my_account3.default: true
 
Commands
#1: define repository
PUT _snapshot/plugintest160921
{
  "type": "azure",
   "settings": {
      "account": "my_account1,my_account2,my_account3",
      "container": "plugintest160921"
   }
}
 
#2: take snapshot
PUT _snapshot/plugintest160921/backup0921?wait_for_completion=true
{
}
 
#3: restore
POST _snapshot/plugintest160921/backup0921/_restore?wait_for_completion=true
{
    "ignore_unavailable": "true",
    "include_global_state": false
}
 
#4: define repository for secondary 
PUT _snapshot/plugintest160921
{
  "type": "azure",
   "settings": {
      "account": "my_account1,my_account2,my_account3",
      "container": "plugintest160921",
            "location_mode": "secondary_only"
   }
}


