### PR TITLE
Add example configuration for rotating GC log

### DIFF
--- a/distribution/src/main/resources/config/jvm.options
+++ b/distribution/src/main/resources/config/jvm.options
@@ -98,7 +98,7 @@
 # ensure the directory exists
 #-Xloggc:${loggc}
 
-# By default, the JVM log file will not rotate.
+# By default, the GC log file will not rotate.
 # By uncommenting the lines below, the GC log file
 # will be rotated every 128MB at most 32 times.
 #-XX:+UseGCLogFileRotation

--- a/distribution/src/main/resources/config/jvm.options
+++ b/distribution/src/main/resources/config/jvm.options
@@ -97,3 +97,10 @@
 # log GC status to a file with time stamps
 # ensure the directory exists
 #-Xloggc:${loggc}
+
+# By default, the JVM log file will not rotate.
+# By uncommenting the lines below, the GC log file
+# will be rotated every 128MB at most 32 times.
+#-XX:+UseGCLogFileRotation
+#-XX:NumberOfGCLogFiles=32
+#-XX:GCLogFileSize=128M


### PR DESCRIPTION
By default, the JVM GC log file grows without
limitation. This is inconvenient for a long running
process like Elasticsearch.

With this commit we add an example configuration
for a rotating GC log in `conig/jvm.options`.