### PR TITLE
Include human readable responses in response parsing tests

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action.delete;
 
 import org.elasticsearch.action.DocWriteResponse;
-import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
@@ -85,7 +84,7 @@ public class DeleteResponse extends DocWriteResponse {
         PARSER.declareBoolean(constructorArg(), new ParseField(FOUND));
     }
 
-    public static DeleteResponse fromXContent(XContentParser parser) throws IOException {
+    public static DeleteResponse fromXContent(XContentParser parser) {
         return PARSER.apply(parser, null);
     }
 

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -376,10 +376,6 @@ public class XContentHelper {
         }
     }
 
-    public static BytesReference toXContent(ToXContent toXContent, XContentType xContentType) throws IOException {
-        return toXContent(toXContent, xContentType, false);
-    }
-
     /**
      * Returns the bytes that represent the XContent output of the provided {@link ToXContent} object, using the provided
      * {@link XContentType}. Wraps the output into a new anonymous object.

--- a/core/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.seqno.SequenceNumbersService;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.RandomObjects;
@@ -93,7 +94,7 @@ public class DeleteResponseTests extends ESTestCase {
         ShardId shardId = new ShardId(randomAsciiOfLength(5), randomAsciiOfLength(5), randomIntBetween(0, 5));
         String type = randomAsciiOfLength(5);
         String id = randomAsciiOfLength(5);
-        long seqNo = randomBoolean() ? randomNonNegativeLong() : randomIntBetween(0, 10000);
+        long seqNo = randomFrom(SequenceNumbersService.UNASSIGNED_SEQ_NO, randomNonNegativeLong(), (long) randomIntBetween(0, 10000));
         long version = randomBoolean() ? randomNonNegativeLong() : randomIntBetween(0, 10000);
         boolean found = randomBoolean();
 

--- a/core/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 
 public class DeleteResponseTests extends ESTestCase {
 
-    public void testToXContent() throws IOException {
+    public void testToXContent() {
         {
             DeleteResponse response = new DeleteResponse(new ShardId("index", "index_uuid", 0), "type", "id", 3, 5, true);
             String output = Strings.toString(response);
@@ -59,7 +59,8 @@ public class DeleteResponseTests extends ESTestCase {
 
         // Create a random DeleteResponse and converts it to XContent in bytes
         DeleteResponse deleteResponse = randomDeleteResponse();
-        BytesReference deleteResponseBytes = toXContent(deleteResponse, xContentType);
+        boolean humanReadable = randomBoolean();
+        BytesReference deleteResponseBytes = toXContent(deleteResponse, xContentType, humanReadable);
 
         // Parse the XContent bytes to obtain a parsed
         DeleteResponse parsedDeleteResponse;
@@ -73,7 +74,7 @@ public class DeleteResponseTests extends ESTestCase {
         // and those exceptions are not parsed back with the same types.
 
         // Print the parsed object out and test that the output is the same as the original output
-        BytesReference parsedDeleteResponseBytes = toXContent(parsedDeleteResponse, xContentType);
+        BytesReference parsedDeleteResponseBytes = toXContent(parsedDeleteResponse, xContentType, humanReadable);
         try (XContentParser parser = createParser(xContentType.xContent(), parsedDeleteResponseBytes)) {
             assertDeleteResponse(deleteResponse, parser.map());
         }
@@ -92,8 +93,8 @@ public class DeleteResponseTests extends ESTestCase {
         ShardId shardId = new ShardId(randomAsciiOfLength(5), randomAsciiOfLength(5), randomIntBetween(0, 5));
         String type = randomAsciiOfLength(5);
         String id = randomAsciiOfLength(5);
-        long seqNo = randomIntBetween(-2, 5);
-        long version = (long) randomIntBetween(0, 5);
+        long seqNo = randomBoolean() ? randomNonNegativeLong() : randomIntBetween(0, 10000);
+        long version = randomBoolean() ? randomNonNegativeLong() : randomIntBetween(0, 10000);
         boolean found = randomBoolean();
 
         DeleteResponse response = new DeleteResponse(shardId, type, id, seqNo, version, found);

--- a/core/src/test/java/org/elasticsearch/action/get/GetResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/get/GetResponseTests.java
@@ -46,7 +46,8 @@ public class GetResponseTests extends ESTestCase {
         Tuple<GetResult, GetResult> tuple = randomGetResult(xContentType);
         GetResponse getResponse = new GetResponse(tuple.v1());
         GetResponse expectedGetResponse = new GetResponse(tuple.v2());
-        BytesReference originalBytes = toXContent(getResponse, xContentType);
+        boolean humanReadable = randomBoolean();
+        BytesReference originalBytes = toXContent(getResponse, xContentType, humanReadable);
         //test that we can parse what we print out
         GetResponse parsedGetResponse;
         try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
@@ -55,7 +56,7 @@ public class GetResponseTests extends ESTestCase {
         }
         assertEquals(expectedGetResponse, parsedGetResponse);
         //print the parsed object out and test that the output is the same as the original output
-        BytesReference finalBytes = toXContent(parsedGetResponse, xContentType);
+        BytesReference finalBytes = toXContent(parsedGetResponse, xContentType, humanReadable);
         assertToXContentEquivalent(originalBytes, finalBytes, xContentType);
         //check that the source stays unchanged, no shuffling of keys nor anything like that
         assertEquals(expectedGetResponse.getSourceAsString(), parsedGetResponse.getSourceAsString());

--- a/core/src/test/java/org/elasticsearch/action/index/IndexResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/index/IndexResponseTests.java
@@ -40,7 +40,7 @@ import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 
 public class IndexResponseTests extends ESTestCase {
 
-    public void testToXContent() throws IOException {
+    public void testToXContent() {
         {
             IndexResponse indexResponse = new IndexResponse(new ShardId("index", "index_uuid", 0), "type", "id", 3, 5, true);
             String output = Strings.toString(indexResponse);
@@ -62,7 +62,8 @@ public class IndexResponseTests extends ESTestCase {
 
         // Create a random IndexResponse and converts it to XContent in bytes
         IndexResponse indexResponse = randomIndexResponse();
-        BytesReference indexResponseBytes = toXContent(indexResponse, xContentType);
+        boolean humanReadable = randomBoolean();
+        BytesReference indexResponseBytes = toXContent(indexResponse, xContentType, humanReadable);
 
         // Parse the XContent bytes to obtain a parsed
         IndexResponse parsedIndexResponse;
@@ -76,12 +77,13 @@ public class IndexResponseTests extends ESTestCase {
         // and those exceptions are not parsed back with the same types.
 
         // Print the parsed object out and test that the output is the same as the original output
-        BytesReference parsedIndexResponseBytes = toXContent(parsedIndexResponse, xContentType);
+        BytesReference parsedIndexResponseBytes = toXContent(parsedIndexResponse, xContentType, humanReadable);
         try (XContentParser parser = createParser(xContentType.xContent(), parsedIndexResponseBytes)) {
             assertIndexResponse(indexResponse, parser.map());
         }
     }
 
+    @SuppressWarnings("unchecked")
     public static void assertDocWriteResponse(DocWriteResponse expected, Map<String, Object> actual) {
         assertEquals(expected.getIndex(), actual.get("_index"));
         assertEquals(expected.getType(), actual.get("_type"));
@@ -165,8 +167,8 @@ public class IndexResponseTests extends ESTestCase {
         ShardId shardId = new ShardId(randomAsciiOfLength(5), randomAsciiOfLength(5), randomIntBetween(0, 5));
         String type = randomAsciiOfLength(5);
         String id = randomAsciiOfLength(5);
-        long seqNo = randomIntBetween(-2, 5);
-        long version = (long) randomIntBetween(0, 5);
+        long seqNo = randomBoolean() ? randomNonNegativeLong() : randomIntBetween(0, 10000);
+        long version = randomBoolean() ? randomNonNegativeLong() : randomIntBetween(0, 10000);
         boolean created = randomBoolean();
 
         IndexResponse indexResponse = new IndexResponse(shardId, type, id, seqNo, version, created);

--- a/core/src/test/java/org/elasticsearch/action/index/IndexResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/index/IndexResponseTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.seqno.SequenceNumbersService;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
@@ -167,7 +168,7 @@ public class IndexResponseTests extends ESTestCase {
         ShardId shardId = new ShardId(randomAsciiOfLength(5), randomAsciiOfLength(5), randomIntBetween(0, 5));
         String type = randomAsciiOfLength(5);
         String id = randomAsciiOfLength(5);
-        long seqNo = randomBoolean() ? randomNonNegativeLong() : randomIntBetween(0, 10000);
+        long seqNo = randomFrom(SequenceNumbersService.UNASSIGNED_SEQ_NO, randomNonNegativeLong(), (long) randomIntBetween(0, 10000));
         long version = randomBoolean() ? randomNonNegativeLong() : randomIntBetween(0, 10000);
         boolean created = randomBoolean();
 

--- a/core/src/test/java/org/elasticsearch/action/search/ShardSearchFailureTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/ShardSearchFailureTests.java
@@ -74,7 +74,7 @@ public class ShardSearchFailureTests extends ESTestCase {
     public void testToXContent() throws IOException {
         ShardSearchFailure failure = new ShardSearchFailure(new ParsingException(0, 0, "some message", null),
                 new SearchShardTarget("nodeId", new ShardId(new Index("indexName", "indexUuid"), 123)));
-        BytesReference xContent = toXContent(failure, XContentType.JSON);
+        BytesReference xContent = toXContent(failure, XContentType.JSON, randomBoolean());
         assertEquals(
                 "{\"shard\":123,"
                         + "\"index\":\"indexName\","

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationResponseTests.java
@@ -136,7 +136,7 @@ public class ReplicationResponseTests extends ESTestCase {
         final XContentType xContentType = randomFrom(XContentType.values());
 
         final ReplicationResponse.ShardInfo shardInfo = new ReplicationResponse.ShardInfo(5, 3);
-        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfo, xContentType);
+        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfo, xContentType, randomBoolean());
 
         // Expected JSON is {"total":5,"successful":3,"failed":0}
         assertThat(shardInfo, instanceOf(ToXContentObject.class));
@@ -163,7 +163,8 @@ public class ReplicationResponseTests extends ESTestCase {
         final XContentType xContentType = randomFrom(XContentType.values());
 
         final ReplicationResponse.ShardInfo shardInfo = new ReplicationResponse.ShardInfo(randomIntBetween(1, 5), randomIntBetween(1, 5));
-        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfo, xContentType);
+        boolean humanReadable = randomBoolean();
+        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfo, xContentType, humanReadable);
 
         ReplicationResponse.ShardInfo parsedShardInfo;
         try (XContentParser parser = createParser(xContentType.xContent(), shardInfoBytes)) {
@@ -175,7 +176,7 @@ public class ReplicationResponseTests extends ESTestCase {
         // We can use assertEquals because the shardInfo doesn't have a failure (and exceptions)
         assertEquals(shardInfo, parsedShardInfo);
 
-        BytesReference parsedShardInfoBytes = XContentHelper.toXContent(parsedShardInfo, xContentType);
+        BytesReference parsedShardInfoBytes = XContentHelper.toXContent(parsedShardInfo, xContentType, humanReadable);
         assertEquals(shardInfoBytes, parsedShardInfoBytes);
     }
 
@@ -183,7 +184,7 @@ public class ReplicationResponseTests extends ESTestCase {
         final XContentType xContentType = randomFrom(XContentType.values());
 
         final ReplicationResponse.ShardInfo shardInfo = RandomObjects.randomShardInfo(random(), true);
-        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfo, xContentType);
+        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfo, xContentType, randomBoolean());
 
         try (XContentParser parser = createParser(xContentType.xContent(), shardInfoBytes)) {
             assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
@@ -220,7 +221,7 @@ public class ReplicationResponseTests extends ESTestCase {
         final XContentType xContentType = randomFrom(XContentType.values());
 
         final ReplicationResponse.ShardInfo shardInfo = RandomObjects.randomShardInfo(random(), randomBoolean());
-        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfo, xContentType);
+        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfo, xContentType, randomBoolean());
 
         ReplicationResponse.ShardInfo parsedShardInfo;
         try (XContentParser parser = createParser(xContentType.xContent(), shardInfoBytes)) {
@@ -260,7 +261,7 @@ public class ReplicationResponseTests extends ESTestCase {
         final XContentType xContentType = randomFrom(XContentType.values());
 
         final ReplicationResponse.ShardInfo.Failure shardInfoFailure = RandomObjects.randomShardInfoFailure(random());
-        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfoFailure, xContentType);
+        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfoFailure, xContentType, randomBoolean());
 
         try (XContentParser parser = createParser(xContentType.xContent(), shardInfoBytes)) {
             assertFailure(parser, shardInfoFailure);
@@ -271,7 +272,7 @@ public class ReplicationResponseTests extends ESTestCase {
         final XContentType xContentType = randomFrom(XContentType.values());
 
         final ReplicationResponse.ShardInfo.Failure shardInfoFailure = RandomObjects.randomShardInfoFailure(random());;
-        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfoFailure, xContentType);
+        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfoFailure, xContentType, randomBoolean());
 
         ReplicationResponse.ShardInfo.Failure parsedFailure;
         try (XContentParser parser = createParser(xContentType.xContent(), shardInfoBytes)) {

--- a/core/src/test/java/org/elasticsearch/action/update/UpdateResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/update/UpdateResponseTests.java
@@ -82,16 +82,17 @@ public class UpdateResponseTests extends ESTestCase {
     public void testToAndFromXContent() throws IOException {
         final XContentType xContentType = randomFrom(XContentType.values());
         final Tuple<UpdateResponse, UpdateResponse> tuple = randomUpdateResponse(xContentType);
+        boolean humanReadable = randomBoolean();
 
         // Parse the XContent bytes to obtain a parsed UpdateResponse
         UpdateResponse parsedUpdateResponse;
-        try (XContentParser parser = createParser(xContentType.xContent(), toXContent(tuple.v1(), xContentType))) {
+        try (XContentParser parser = createParser(xContentType.xContent(), toXContent(tuple.v1(), xContentType, humanReadable))) {
             parsedUpdateResponse = UpdateResponse.fromXContent(parser);
             assertNull(parser.nextToken());
         }
 
         final UpdateResponse expectedUpdateResponse = tuple.v2();
-        try (XContentParser parser = createParser(xContentType.xContent(), toXContent(parsedUpdateResponse, xContentType))) {
+        try (XContentParser parser = createParser(xContentType.xContent(), toXContent(parsedUpdateResponse, xContentType, humanReadable))) {
             IndexResponseTests.assertDocWriteResponse(expectedUpdateResponse, parser.map());
         }
         assertEquals(expectedUpdateResponse.getGetResult(), parsedUpdateResponse.getGetResult());

--- a/core/src/test/java/org/elasticsearch/common/xcontent/support/XContentHelperTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/support/XContentHelperTests.java
@@ -90,9 +90,9 @@ public class XContentHelperTests extends ESTestCase {
             }
         }
         if (error) {
-            expectThrows(IOException.class, () -> XContentHelper.toXContent(toXContent, xContentType));
+            expectThrows(IOException.class, () -> XContentHelper.toXContent(toXContent, xContentType, randomBoolean()));
         } else {
-            BytesReference bytes = XContentHelper.toXContent(toXContent, xContentType);
+            BytesReference bytes = XContentHelper.toXContent(toXContent, xContentType, randomBoolean());
             try (XContentParser parser = xContentType.xContent().createParser(NamedXContentRegistry.EMPTY, bytes)) {
                 assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
                 assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());

--- a/core/src/test/java/org/elasticsearch/index/get/GetFieldTests.java
+++ b/core/src/test/java/org/elasticsearch/index/get/GetFieldTests.java
@@ -57,7 +57,8 @@ public class GetFieldTests extends ESTestCase {
         Tuple<GetField, GetField> tuple = randomGetField(xContentType);
         GetField getField = tuple.v1();
         GetField expectedGetField = tuple.v2();
-        BytesReference originalBytes = toXContent(getField, xContentType);
+        boolean humanReadable = randomBoolean();
+        BytesReference originalBytes = toXContent(getField, xContentType, humanReadable);
         //test that we can parse what we print out
         GetField parsedGetField;
         try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
@@ -70,7 +71,7 @@ public class GetFieldTests extends ESTestCase {
             assertNull(parser.nextToken());
         }
         assertEquals(expectedGetField, parsedGetField);
-        BytesReference finalBytes = toXContent(parsedGetField, xContentType);
+        BytesReference finalBytes = toXContent(parsedGetField, xContentType, humanReadable);
         assertToXContentEquivalent(originalBytes, finalBytes, xContentType);
     }
 

--- a/core/src/test/java/org/elasticsearch/index/get/GetResultTests.java
+++ b/core/src/test/java/org/elasticsearch/index/get/GetResultTests.java
@@ -52,7 +52,8 @@ public class GetResultTests extends ESTestCase {
         Tuple<GetResult, GetResult> tuple = randomGetResult(xContentType);
         GetResult getResult = tuple.v1();
         GetResult expectedGetResult = tuple.v2();
-        BytesReference originalBytes = toXContent(getResult, xContentType);
+        boolean humanReadable = randomBoolean();
+        BytesReference originalBytes = toXContent(getResult, xContentType, humanReadable);
         //test that we can parse what we print out
         GetResult parsedGetResult;
         try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
@@ -61,7 +62,7 @@ public class GetResultTests extends ESTestCase {
         }
         assertEquals(expectedGetResult, parsedGetResult);
         //print the parsed object out and test that the output is the same as the original output
-        BytesReference finalBytes = toXContent(parsedGetResult, xContentType);
+        BytesReference finalBytes = toXContent(parsedGetResult, xContentType, humanReadable);
         assertToXContentEquivalent(originalBytes, finalBytes, xContentType);
         //check that the source stays unchanged, no shuffling of keys nor anything like that
         assertEquals(expectedGetResult.sourceAsString(), parsedGetResult.sourceAsString());
@@ -93,7 +94,8 @@ public class GetResultTests extends ESTestCase {
         GetResult expectedGetResult = new GetResult(null, null, null, -1,
                 tuple.v2().isExists(), tuple.v2().sourceRef(), tuple.v2().getFields());
 
-        BytesReference originalBytes = toXContentEmbedded(getResult, xContentType);
+        boolean humanReadable = randomBoolean();
+        BytesReference originalBytes = toXContentEmbedded(getResult, xContentType, humanReadable);
 
         // Test that we can parse the result of toXContentEmbedded()
         GetResult parsedEmbeddedGetResult;
@@ -105,7 +107,7 @@ public class GetResultTests extends ESTestCase {
 
         assertEquals(expectedGetResult, parsedEmbeddedGetResult);
         //print the parsed object out and test that the output is the same as the original output
-        BytesReference finalBytes = toXContentEmbedded(parsedEmbeddedGetResult, xContentType);
+        BytesReference finalBytes = toXContentEmbedded(parsedEmbeddedGetResult, xContentType, humanReadable);
         assertToXContentEquivalent(originalBytes, finalBytes, xContentType);
         //check that the source stays unchanged, no shuffling of keys nor anything like that
         assertEquals(expectedGetResult.sourceAsString(), parsedEmbeddedGetResult.sourceAsString());
@@ -119,7 +121,7 @@ public class GetResultTests extends ESTestCase {
         GetResult getResult = new GetResult("index", "type", "id", 2, true,
                 new BytesArray("{\"foo\":\"bar\",\"baz\":[\"baz_0\",\"baz_1\"]}"), fields);
 
-        BytesReference originalBytes = toXContentEmbedded(getResult, XContentType.JSON);
+        BytesReference originalBytes = toXContentEmbedded(getResult, XContentType.JSON, false);
         assertEquals("{\"found\":true,\"_source\":{\"foo\":\"bar\",\"baz\":[\"baz_0\",\"baz_1\"]}," +
                 "\"fields\":{\"foo\":[\"bar\"],\"baz\":[\"baz_0\",\"baz_1\"]}}", originalBytes.utf8ToString());
     }
@@ -127,7 +129,7 @@ public class GetResultTests extends ESTestCase {
     public void testToXContentEmbeddedNotFound() throws IOException {
         GetResult getResult = new GetResult("index", "type", "id", 1, false, null, null);
 
-        BytesReference originalBytes = toXContentEmbedded(getResult, XContentType.JSON);
+        BytesReference originalBytes = toXContentEmbedded(getResult, XContentType.JSON, false);
         assertEquals("{\"found\":false}", originalBytes.utf8ToString());
     }
 
@@ -213,7 +215,8 @@ public class GetResultTests extends ESTestCase {
         return Tuple.tuple(fields, expectedFields);
     }
 
-    private static BytesReference toXContentEmbedded(GetResult getResult, XContentType xContentType) throws IOException {
-        return XContentHelper.toXContent(getResult::toXContentEmbedded, xContentType);
+    private static BytesReference toXContentEmbedded(GetResult getResult, XContentType xContentType, boolean humanReadable)
+            throws IOException {
+        return XContentHelper.toXContent(getResult::toXContentEmbedded, xContentType, humanReadable);
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/profile/SearchProfileShardResultsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/SearchProfileShardResultsTests.java
@@ -59,16 +59,18 @@ public class SearchProfileShardResultsTests  extends ESTestCase {
     public void testFromXContent() throws IOException {
         SearchProfileShardResults shardResult = createTestItem();
         XContentType xContentType = randomFrom(XContentType.values());
-        BytesReference originalBytes = toXContent(shardResult, xContentType);
+        boolean humanReadable = randomBoolean();
+        BytesReference originalBytes = toXContent(shardResult, xContentType, humanReadable);
+        SearchProfileShardResults parsed = null;
         try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
             ensureExpectedToken(parser.nextToken(), XContentParser.Token.START_OBJECT, parser::getTokenLocation);
             ensureFieldName(parser, parser.nextToken(), SearchProfileShardResults.PROFILE_FIELD);
             ensureExpectedToken(parser.nextToken(), XContentParser.Token.START_OBJECT, parser::getTokenLocation);
-            SearchProfileShardResults parsed = SearchProfileShardResults.fromXContent(parser);
-            assertToXContentEquivalent(originalBytes, toXContent(parsed, xContentType), xContentType);
+            parsed = SearchProfileShardResults.fromXContent(parser);
             assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
             assertNull(parser.nextToken());
         }
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, xContentType, humanReadable), xContentType);
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/search/profile/aggregation/AggregationProfileShardResultTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/aggregation/AggregationProfileShardResultTests.java
@@ -74,10 +74,20 @@ public class AggregationProfileShardResultTests extends ESTestCase {
         ProfileResult profileResult = new ProfileResult("someType", "someDescription", timings, Collections.emptyList());
         profileResults.add(profileResult);
         AggregationProfileShardResult aggProfileResults = new AggregationProfileShardResult(profileResults);
-        BytesReference xContent = toXContent(aggProfileResults, XContentType.JSON);
+        BytesReference xContent = toXContent(aggProfileResults, XContentType.JSON, false);
         assertEquals("{\"aggregations\":["
                         + "{\"type\":\"someType\","
                             + "\"description\":\"someDescription\","
+                            + "\"time_in_nanos\":6000,"
+                            + "\"breakdown\":{\"timing1\":2000,\"timing2\":4000}"
+                        + "}"
+                   + "]}", xContent.utf8ToString());
+
+        xContent = toXContent(aggProfileResults, XContentType.JSON, true);
+        assertEquals("{\"aggregations\":["
+                        + "{\"type\":\"someType\","
+                            + "\"description\":\"someDescription\","
+                            + "\"time\":\"6micros\","
                             + "\"time_in_nanos\":6000,"
                             + "\"breakdown\":{\"timing1\":2000,\"timing2\":4000}"
                         + "}"

--- a/core/src/test/java/org/elasticsearch/search/profile/query/QueryProfileShardResultTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/query/QueryProfileShardResultTests.java
@@ -53,7 +53,8 @@ public class QueryProfileShardResultTests extends ESTestCase {
     public void testFromXContent() throws IOException {
         QueryProfileShardResult profileResult = createTestItem();
         XContentType xContentType = randomFrom(XContentType.values());
-        BytesReference originalBytes = toXContent(profileResult, xContentType);
+        boolean humanReadable = randomBoolean();
+        BytesReference originalBytes = toXContent(profileResult, xContentType, humanReadable);
 
         QueryProfileShardResult parsed;
         try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
@@ -62,7 +63,7 @@ public class QueryProfileShardResultTests extends ESTestCase {
             assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
             assertNull(parser.nextToken());
         }
-        assertToXContentEquivalent(originalBytes, toXContent(parsed, xContentType), xContentType);
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, xContentType, humanReadable), xContentType);
     }
 
 }


### PR DESCRIPTION
As a follow up to #22649, this changes the resent tests for parsing parts of search responses to randomly set the humanReadable() flag of
the XContentBuilder that is used to render the responses. This should help to test that we can parse back thoses classes if the user specifies `?human=true` in the request url.