### PR TITLE
Add CheckedSupplier and CheckedRunnable to core

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/CheckedRunnable.java
+++ b/core/src/main/java/org/elasticsearch/common/CheckedRunnable.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+import java.lang.Runnable;
+
+/**
+ * A {@link Runnable}-like interface which allows throwing checked exceptions.
+ */
+@FunctionalInterface
+public interface CheckedRunnable<E extends Exception> {
+    void run() throws E;
+}

--- a/core/src/main/java/org/elasticsearch/common/CheckedSupplier.java
+++ b/core/src/main/java/org/elasticsearch/common/CheckedSupplier.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+import java.util.function.Supplier;
+
+/**
+ * A {@link Supplier}-like interface which allows throwing checked exceptions.
+ */
+@FunctionalInterface
+public interface CheckedSupplier<R, E extends Exception> {
+    R get() throws E;
+}


### PR DESCRIPTION
Introduce CheckedSupplier and CheckedRunnable functional interfaces 
into core. These offer a checked version of the Supplier and Runnable
interfaces for use with lambda apis.