### PR TITLE
Add single static instance of SpecialPermission

### DIFF
--- a/core/src/main/java/org/elasticsearch/SpecialPermission.java
+++ b/core/src/main/java/org/elasticsearch/SpecialPermission.java
@@ -79,4 +79,14 @@ public final class SpecialPermission extends BasicPermission {
     public SpecialPermission(String name, String actions) {
         this();
     }
+
+    /**
+     * Check that the current stack has {@link SpecialPermission} access according to the {@link SecurityManager}.
+     */
+    public static void checkSpecialPermission() {
+        SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPermission(INSTANCE);
+        }
+    }
 }

--- a/core/src/main/java/org/elasticsearch/SpecialPermission.java
+++ b/core/src/main/java/org/elasticsearch/SpecialPermission.java
@@ -57,6 +57,9 @@ import java.security.BasicPermission;
  * </code></pre>
  */
 public final class SpecialPermission extends BasicPermission {
+
+    public static final SpecialPermission INSTANCE = new SpecialPermission();
+
     /**
      * Creates a new SpecialPermision object.
      */

--- a/core/src/main/java/org/elasticsearch/SpecialPermission.java
+++ b/core/src/main/java/org/elasticsearch/SpecialPermission.java
@@ -83,7 +83,7 @@ public final class SpecialPermission extends BasicPermission {
     /**
      * Check that the current stack has {@link SpecialPermission} access according to the {@link SecurityManager}.
      */
-    public static void checkSpecialPermission() {
+    public static void check() {
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             sm.checkPermission(INSTANCE);

--- a/core/src/test/java/org/elasticsearch/SpecialPermissionTests.java
+++ b/core/src/test/java/org/elasticsearch/SpecialPermissionTests.java
@@ -25,14 +25,18 @@ import java.security.AllPermission;
 
 /** Very simple sanity checks for {@link SpecialPermission} */
 public class SpecialPermissionTests extends ESTestCase {
-    
+
     public void testEquals() {
         assertEquals(new SpecialPermission(), new SpecialPermission());
+        assertEquals(SpecialPermission.INSTANCE, new SpecialPermission());
         assertFalse(new SpecialPermission().equals(new AllPermission()));
+        assertFalse(SpecialPermission.INSTANCE.equals(new AllPermission()));
     }
-    
+
     public void testImplies() {
-        assertTrue(new SpecialPermission().implies(new SpecialPermission()));
+        assertTrue(SpecialPermission.INSTANCE.implies(new SpecialPermission()));
+        assertTrue(SpecialPermission.INSTANCE.implies(SpecialPermission.INSTANCE));
         assertFalse(new SpecialPermission().implies(new AllPermission()));
+        assertFalse(SpecialPermission.INSTANCE.implies(new AllPermission()));
     }
 }

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
@@ -78,9 +78,7 @@ public class ExpressionScriptEngineService extends AbstractComponent implements 
     public Object compile(String scriptName, String scriptSource, Map<String, String> params) {
         // classloader created here
         final SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
-        }
+        SpecialPermission.checkSpecialPermission();
         return AccessController.doPrivileged(new PrivilegedAction<Expression>() {
             @Override
             public Expression run() {

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
@@ -79,7 +79,7 @@ public class ExpressionScriptEngineService extends AbstractComponent implements 
         // classloader created here
         final SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            sm.checkPermission(new SpecialPermission());
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
         return AccessController.doPrivileged(new PrivilegedAction<Expression>() {
             @Override

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
@@ -78,7 +78,7 @@ public class ExpressionScriptEngineService extends AbstractComponent implements 
     public Object compile(String scriptName, String scriptSource, Map<String, String> params) {
         // classloader created here
         final SecurityManager sm = System.getSecurityManager();
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         return AccessController.doPrivileged(new PrivilegedAction<Expression>() {
             @Override
             public Expression run() {

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
@@ -127,9 +127,6 @@ public final class MustacheScriptEngineService extends AbstractComponent impleme
         // Nothing to do here
     }
 
-    // permission checked before doing crazy reflection
-    static final SpecialPermission SPECIAL_PERMISSION = new SpecialPermission();
-
     /**
      * Used at query execution time by script service in order to execute a query template.
      * */
@@ -160,7 +157,7 @@ public final class MustacheScriptEngineService extends AbstractComponent impleme
                 // crazy reflection here
                 SecurityManager sm = System.getSecurityManager();
                 if (sm != null) {
-                    sm.checkPermission(SPECIAL_PERMISSION);
+                    sm.checkPermission(SpecialPermission.INSTANCE);
                 }
                 AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
                     ((Mustache) template.compiled()).execute(writer, vars);

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
@@ -155,10 +155,7 @@ public final class MustacheScriptEngineService extends AbstractComponent impleme
             final BytesStreamOutput result = new BytesStreamOutput();
             try (UTF8StreamWriter writer = utf8StreamWriter().setOutput(result)) {
                 // crazy reflection here
-                SecurityManager sm = System.getSecurityManager();
-                if (sm != null) {
-                    sm.checkPermission(SpecialPermission.INSTANCE);
-                }
+                SpecialPermission.checkSpecialPermission();
                 AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
                     ((Mustache) template.compiled()).execute(writer, vars);
                     return null;

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
@@ -155,7 +155,7 @@ public final class MustacheScriptEngineService extends AbstractComponent impleme
             final BytesStreamOutput result = new BytesStreamOutput();
             try (UTF8StreamWriter writer = utf8StreamWriter().setOutput(result)) {
                 // crazy reflection here
-                SpecialPermission.checkSpecialPermission();
+                SpecialPermission.check();
                 AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
                     ((Mustache) template.compiled()).execute(writer, vars);
                     return null;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngineService.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngineService.java
@@ -149,7 +149,7 @@ public final class PainlessScriptEngineService extends AbstractComponent impleme
         }
 
         // Check we ourselves are not being called by unprivileged code.
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
 
         // Create our loader (which loads compiled code with no permissions).
         final Loader loader = AccessController.doPrivileged(new PrivilegedAction<Loader>() {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngineService.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngineService.java
@@ -152,7 +152,7 @@ public final class PainlessScriptEngineService extends AbstractComponent impleme
         final SecurityManager sm = System.getSecurityManager();
 
         if (sm != null) {
-            sm.checkPermission(new SpecialPermission());
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
 
         // Create our loader (which loads compiled code with no permissions).

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngineService.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngineService.java
@@ -149,11 +149,7 @@ public final class PainlessScriptEngineService extends AbstractComponent impleme
         }
 
         // Check we ourselves are not being called by unprivileged code.
-        final SecurityManager sm = System.getSecurityManager();
-
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
-        }
+        SpecialPermission.checkSpecialPermission();
 
         // Create our loader (which loads compiled code with no permissions).
         final Loader loader = AccessController.doPrivileged(new PrivilegedAction<Loader>() {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/channel/PrivilegedNioServerSocketChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/channel/PrivilegedNioServerSocketChannel.java
@@ -39,7 +39,7 @@ public class PrivilegedNioServerSocketChannel extends NioServerSocketChannel {
     protected int doReadMessages(List<Object> buf) throws Exception {
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            sm.checkPermission(new SpecialPermission());
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
         try {
             return AccessController.doPrivileged((PrivilegedExceptionAction<Integer>) () -> super.doReadMessages(buf));

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/channel/PrivilegedNioServerSocketChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/channel/PrivilegedNioServerSocketChannel.java
@@ -37,7 +37,7 @@ public class PrivilegedNioServerSocketChannel extends NioServerSocketChannel {
 
     @Override
     protected int doReadMessages(List<Object> buf) throws Exception {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         try {
             return AccessController.doPrivileged((PrivilegedExceptionAction<Integer>) () -> super.doReadMessages(buf));
         } catch (PrivilegedActionException e) {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/channel/PrivilegedNioServerSocketChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/channel/PrivilegedNioServerSocketChannel.java
@@ -37,10 +37,7 @@ public class PrivilegedNioServerSocketChannel extends NioServerSocketChannel {
 
     @Override
     protected int doReadMessages(List<Object> buf) throws Exception {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
-        }
+        SpecialPermission.checkSpecialPermission();
         try {
             return AccessController.doPrivileged((PrivilegedExceptionAction<Integer>) () -> super.doReadMessages(buf));
         } catch (PrivilegedActionException e) {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/channel/PrivilegedNioSocketChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/channel/PrivilegedNioSocketChannel.java
@@ -37,10 +37,7 @@ public class PrivilegedNioSocketChannel extends NioSocketChannel {
 
     @Override
     protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
-        }
+        SpecialPermission.checkSpecialPermission();
         try {
             return AccessController.doPrivileged((PrivilegedExceptionAction<Boolean>) () -> super.doConnect(remoteAddress, localAddress));
         } catch (PrivilegedActionException e) {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/channel/PrivilegedNioSocketChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/channel/PrivilegedNioSocketChannel.java
@@ -37,7 +37,7 @@ public class PrivilegedNioSocketChannel extends NioSocketChannel {
 
     @Override
     protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         try {
             return AccessController.doPrivileged((PrivilegedExceptionAction<Boolean>) () -> super.doConnect(remoteAddress, localAddress));
         } catch (PrivilegedActionException e) {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/channel/PrivilegedNioSocketChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/channel/PrivilegedNioSocketChannel.java
@@ -39,7 +39,7 @@ public class PrivilegedNioSocketChannel extends NioSocketChannel {
     protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            sm.checkPermission(new SpecialPermission());
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
         try {
             return AccessController.doPrivileged((PrivilegedExceptionAction<Boolean>) () -> super.doConnect(remoteAddress, localAddress));

--- a/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/cloud/azure/classic/management/AzureComputeServiceImpl.java
+++ b/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/cloud/azure/classic/management/AzureComputeServiceImpl.java
@@ -20,9 +20,7 @@
 package org.elasticsearch.cloud.azure.classic.management;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ServiceLoader;
@@ -31,7 +29,6 @@ import com.microsoft.windowsazure.Configuration;
 import com.microsoft.windowsazure.core.Builder;
 import com.microsoft.windowsazure.core.DefaultBuilder;
 import com.microsoft.windowsazure.core.utils.KeyStoreType;
-import com.microsoft.windowsazure.exception.ServiceException;
 import com.microsoft.windowsazure.management.compute.ComputeManagementClient;
 import com.microsoft.windowsazure.management.compute.ComputeManagementService;
 import com.microsoft.windowsazure.management.compute.models.HostedServiceGetDetailedResponse;
@@ -43,9 +40,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.xml.sax.SAXException;
-
-import javax.xml.parsers.ParserConfigurationException;
 
 public class AzureComputeServiceImpl extends AbstractLifecycleComponent
     implements AzureComputeService {
@@ -99,7 +93,7 @@ public class AzureComputeServiceImpl extends AbstractLifecycleComponent
 
     @Override
     public HostedServiceGetDetailedResponse getServiceDetails() {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         try {
             return AccessController.doPrivileged((PrivilegedExceptionAction<HostedServiceGetDetailedResponse>)
                 () -> client.getHostedServicesOperations().getDetailed(serviceName));

--- a/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/cloud/azure/classic/management/AzureComputeServiceImpl.java
+++ b/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/cloud/azure/classic/management/AzureComputeServiceImpl.java
@@ -99,10 +99,7 @@ public class AzureComputeServiceImpl extends AbstractLifecycleComponent
 
     @Override
     public HostedServiceGetDetailedResponse getServiceDetails() {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
-        }
+        SpecialPermission.checkSpecialPermission();
         try {
             return AccessController.doPrivileged((PrivilegedExceptionAction<HostedServiceGetDetailedResponse>)
                 () -> client.getHostedServicesOperations().getDetailed(serviceName));

--- a/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/cloud/azure/classic/management/AzureComputeServiceImpl.java
+++ b/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/cloud/azure/classic/management/AzureComputeServiceImpl.java
@@ -101,7 +101,7 @@ public class AzureComputeServiceImpl extends AbstractLifecycleComponent
     public HostedServiceGetDetailedResponse getServiceDetails() {
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            sm.checkPermission(new SpecialPermission());
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
         try {
             return AccessController.doPrivileged((PrivilegedExceptionAction<HostedServiceGetDetailedResponse>)

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/util/SocketAccess.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/util/SocketAccess.java
@@ -38,12 +38,12 @@ public final class SocketAccess {
     private SocketAccess() {}
 
     public static <T> T doPrivileged(PrivilegedAction<T> operation) {
-        checkSpecialPermission();
+        SpecialPermission.checkSpecialPermission();
         return AccessController.doPrivileged(operation);
     }
 
     public static <T> T doPrivilegedIOException(PrivilegedExceptionAction<T> operation) throws IOException {
-        checkSpecialPermission();
+        SpecialPermission.checkSpecialPermission();
         try {
             return AccessController.doPrivileged(operation);
         } catch (PrivilegedActionException e) {
@@ -51,10 +51,4 @@ public final class SocketAccess {
         }
     }
 
-    private static void checkSpecialPermission() {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
-        }
-    }
 }

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/util/SocketAccess.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/util/SocketAccess.java
@@ -38,12 +38,12 @@ public final class SocketAccess {
     private SocketAccess() {}
 
     public static <T> T doPrivileged(PrivilegedAction<T> operation) {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         return AccessController.doPrivileged(operation);
     }
 
     public static <T> T doPrivilegedIOException(PrivilegedExceptionAction<T> operation) throws IOException {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         try {
             return AccessController.doPrivileged(operation);
         } catch (PrivilegedActionException e) {

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/util/SocketAccess.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/util/SocketAccess.java
@@ -35,8 +35,6 @@ import java.security.PrivilegedExceptionAction;
  */
 public final class SocketAccess {
 
-    private static final SpecialPermission SPECIAL_PERMISSION = new SpecialPermission();
-
     private SocketAccess() {}
 
     public static <T> T doPrivileged(PrivilegedAction<T> operation) {
@@ -56,7 +54,7 @@ public final class SocketAccess {
     private static void checkSpecialPermission() {
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            sm.checkPermission(SPECIAL_PERMISSION);
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
     }
 }

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/plugin/discovery/ec2/Ec2DiscoveryPlugin.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/plugin/discovery/ec2/Ec2DiscoveryPlugin.java
@@ -71,10 +71,7 @@ public class Ec2DiscoveryPlugin extends Plugin implements DiscoveryPlugin, Close
     public static final String EC2 = "ec2";
 
     static {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
-        }
+        SpecialPermission.checkSpecialPermission();
         // Initializing Jackson requires RuntimePermission accessDeclaredMembers
         // The ClientConfiguration class requires RuntimePermission getClassLoader
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/plugin/discovery/ec2/Ec2DiscoveryPlugin.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/plugin/discovery/ec2/Ec2DiscoveryPlugin.java
@@ -73,7 +73,7 @@ public class Ec2DiscoveryPlugin extends Plugin implements DiscoveryPlugin, Close
     static {
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            sm.checkPermission(new SpecialPermission());
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
         // Initializing Jackson requires RuntimePermission accessDeclaredMembers
         // The ClientConfiguration class requires RuntimePermission getClassLoader

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/plugin/discovery/ec2/Ec2DiscoveryPlugin.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/plugin/discovery/ec2/Ec2DiscoveryPlugin.java
@@ -71,7 +71,7 @@ public class Ec2DiscoveryPlugin extends Plugin implements DiscoveryPlugin, Close
     public static final String EC2 = "ec2";
 
     static {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         // Initializing Jackson requires RuntimePermission accessDeclaredMembers
         // The ClientConfiguration class requires RuntimePermission getClassLoader
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {

--- a/plugins/discovery-gce/src/main/java/org/elasticsearch/cloud/gce/util/Access.java
+++ b/plugins/discovery-gce/src/main/java/org/elasticsearch/cloud/gce/util/Access.java
@@ -35,8 +35,6 @@ import java.security.PrivilegedExceptionAction;
  */
 public final class Access {
 
-    private static final SpecialPermission SPECIAL_PERMISSION = new SpecialPermission();
-
     private Access() {}
 
     public static <T> T doPrivileged(PrivilegedAction<T> operation) {
@@ -64,7 +62,7 @@ public final class Access {
     private static void checkSpecialPermission() {
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            sm.checkPermission(SPECIAL_PERMISSION);
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
     }
 

--- a/plugins/discovery-gce/src/main/java/org/elasticsearch/cloud/gce/util/Access.java
+++ b/plugins/discovery-gce/src/main/java/org/elasticsearch/cloud/gce/util/Access.java
@@ -38,12 +38,12 @@ public final class Access {
     private Access() {}
 
     public static <T> T doPrivileged(PrivilegedAction<T> operation) {
-        checkSpecialPermission();
+        SpecialPermission.checkSpecialPermission();
         return AccessController.doPrivileged(operation);
     }
 
     public static void doPrivilegedVoid(DiscoveryRunnable action) {
-        checkSpecialPermission();
+        SpecialPermission.checkSpecialPermission();
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             action.execute();
             return null;
@@ -51,18 +51,11 @@ public final class Access {
     }
 
     public static <T> T doPrivilegedIOException(PrivilegedExceptionAction<T> operation) throws IOException {
-        checkSpecialPermission();
+        SpecialPermission.checkSpecialPermission();
         try {
             return AccessController.doPrivileged(operation);
         } catch (PrivilegedActionException e) {
             throw (IOException) e.getCause();
-        }
-    }
-
-    private static void checkSpecialPermission() {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
         }
     }
 

--- a/plugins/discovery-gce/src/main/java/org/elasticsearch/cloud/gce/util/Access.java
+++ b/plugins/discovery-gce/src/main/java/org/elasticsearch/cloud/gce/util/Access.java
@@ -38,12 +38,12 @@ public final class Access {
     private Access() {}
 
     public static <T> T doPrivileged(PrivilegedAction<T> operation) {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         return AccessController.doPrivileged(operation);
     }
 
     public static void doPrivilegedVoid(DiscoveryRunnable action) {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             action.execute();
             return null;
@@ -51,7 +51,7 @@ public final class Access {
     }
 
     public static <T> T doPrivilegedIOException(PrivilegedExceptionAction<T> operation) throws IOException {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         try {
             return AccessController.doPrivileged(operation);
         } catch (PrivilegedActionException e) {

--- a/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/TikaImpl.java
+++ b/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/TikaImpl.java
@@ -84,16 +84,12 @@ final class TikaImpl {
         // check that its not unprivileged code like a script
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            sm.checkPermission(new SpecialPermission());
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
 
         try {
-            return AccessController.doPrivileged(new PrivilegedExceptionAction<String>() {
-                @Override
-                public String run() throws TikaException, IOException {
-                    return TIKA_INSTANCE.parseToString(new ByteArrayInputStream(content), metadata, limit);
-                }
-            }, RESTRICTED_CONTEXT);
+            return AccessController.doPrivileged((PrivilegedExceptionAction<String>)
+                () -> TIKA_INSTANCE.parseToString(new ByteArrayInputStream(content), metadata, limit), RESTRICTED_CONTEXT);
         } catch (PrivilegedActionException e) {
             // checked exception from tika: unbox it
             Throwable cause = e.getCause();

--- a/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/TikaImpl.java
+++ b/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/TikaImpl.java
@@ -82,7 +82,7 @@ final class TikaImpl {
     // only package private for testing!
     static String parse(final byte content[], final Metadata metadata, final int limit) throws TikaException, IOException {
         // check that its not unprivileged code like a script
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
 
         try {
             return AccessController.doPrivileged((PrivilegedExceptionAction<String>)

--- a/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/TikaImpl.java
+++ b/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/TikaImpl.java
@@ -82,10 +82,7 @@ final class TikaImpl {
     // only package private for testing!
     static String parse(final byte content[], final Metadata metadata, final int limit) throws TikaException, IOException {
         // check that its not unprivileged code like a script
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
-        }
+        SpecialPermission.checkSpecialPermission();
 
         try {
             return AccessController.doPrivileged((PrivilegedExceptionAction<String>)

--- a/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -139,7 +139,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
     }
 
     private Map<String, Object> retrieveCityGeoData(InetAddress ipAddress) {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         CityResponse response = AccessController.doPrivileged((PrivilegedAction<CityResponse>) () -> {
             try {
                 return dbReader.city(ipAddress);
@@ -214,7 +214,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
     }
 
     private Map<String, Object> retrieveCountryGeoData(InetAddress ipAddress) {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         CountryResponse response = AccessController.doPrivileged((PrivilegedAction<CountryResponse>) () -> {
             try {
                 return dbReader.country(ipAddress);

--- a/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -139,10 +139,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
     }
 
     private Map<String, Object> retrieveCityGeoData(InetAddress ipAddress) {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
-        }
+        SpecialPermission.checkSpecialPermission();
         CityResponse response = AccessController.doPrivileged((PrivilegedAction<CityResponse>) () -> {
             try {
                 return dbReader.city(ipAddress);
@@ -217,10 +214,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
     }
 
     private Map<String, Object> retrieveCountryGeoData(InetAddress ipAddress) {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
-        }
+        SpecialPermission.checkSpecialPermission();
         CountryResponse response = AccessController.doPrivileged((PrivilegedAction<CountryResponse>) () -> {
             try {
                 return dbReader.country(ipAddress);

--- a/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -141,7 +141,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
     private Map<String, Object> retrieveCityGeoData(InetAddress ipAddress) {
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            sm.checkPermission(new SpecialPermission());
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
         CityResponse response = AccessController.doPrivileged((PrivilegedAction<CityResponse>) () -> {
             try {
@@ -219,7 +219,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
     private Map<String, Object> retrieveCountryGeoData(InetAddress ipAddress) {
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            sm.checkPermission(new SpecialPermission());
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
         CountryResponse response = AccessController.doPrivileged((PrivilegedAction<CountryResponse>) () -> {
             try {

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/util/SocketAccess.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/util/SocketAccess.java
@@ -39,7 +39,7 @@ public final class SocketAccess {
     private SocketAccess() {}
 
     public static <T> T doPrivilegedException(PrivilegedExceptionAction<T> operation) throws StorageException, URISyntaxException {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         try {
             return AccessController.doPrivileged(operation);
         } catch (PrivilegedActionException e) {
@@ -48,7 +48,7 @@ public final class SocketAccess {
     }
 
     public static void doPrivilegedVoidException(StorageRunnable action) throws StorageException, URISyntaxException {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         try {
             AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
                 action.executeCouldThrow();

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/util/SocketAccess.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/util/SocketAccess.java
@@ -36,8 +36,6 @@ import java.security.PrivilegedExceptionAction;
  */
 public final class SocketAccess {
 
-    private static final SpecialPermission SPECIAL_PERMISSION = new SpecialPermission();
-
     private SocketAccess() {}
 
     public static <T> T doPrivilegedException(PrivilegedExceptionAction<T> operation) throws StorageException, URISyntaxException {
@@ -69,7 +67,7 @@ public final class SocketAccess {
     private static void checkSpecialPermission() {
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            sm.checkPermission(SPECIAL_PERMISSION);
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
     }
 

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/util/SocketAccess.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/util/SocketAccess.java
@@ -39,7 +39,7 @@ public final class SocketAccess {
     private SocketAccess() {}
 
     public static <T> T doPrivilegedException(PrivilegedExceptionAction<T> operation) throws StorageException, URISyntaxException {
-        checkSpecialPermission();
+        SpecialPermission.checkSpecialPermission();
         try {
             return AccessController.doPrivileged(operation);
         } catch (PrivilegedActionException e) {
@@ -48,7 +48,7 @@ public final class SocketAccess {
     }
 
     public static void doPrivilegedVoidException(StorageRunnable action) throws StorageException, URISyntaxException {
-        checkSpecialPermission();
+        SpecialPermission.checkSpecialPermission();
         try {
             AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
                 action.executeCouldThrow();
@@ -61,13 +61,6 @@ public final class SocketAccess {
             } else {
                 throw (URISyntaxException) cause;
             }
-        }
-    }
-
-    private static void checkSpecialPermission() {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
         }
     }
 

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/common/blobstore/gcs/util/SocketAccess.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/common/blobstore/gcs/util/SocketAccess.java
@@ -38,7 +38,7 @@ public final class SocketAccess {
     private SocketAccess() {}
 
     public static <T> T doPrivilegedIOException(PrivilegedExceptionAction<T> operation) throws IOException {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         try {
             return AccessController.doPrivileged(operation);
         } catch (PrivilegedActionException e) {
@@ -47,7 +47,7 @@ public final class SocketAccess {
     }
 
     public static void doPrivilegedVoidIOException(StorageRunnable action) throws IOException {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         try {
             AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
                 action.executeCouldThrow();

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/common/blobstore/gcs/util/SocketAccess.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/common/blobstore/gcs/util/SocketAccess.java
@@ -38,7 +38,7 @@ public final class SocketAccess {
     private SocketAccess() {}
 
     public static <T> T doPrivilegedIOException(PrivilegedExceptionAction<T> operation) throws IOException {
-        checkSpecialPermission();
+        SpecialPermission.checkSpecialPermission();
         try {
             return AccessController.doPrivileged(operation);
         } catch (PrivilegedActionException e) {
@@ -47,7 +47,7 @@ public final class SocketAccess {
     }
 
     public static void doPrivilegedVoidIOException(StorageRunnable action) throws IOException {
-        checkSpecialPermission();
+        SpecialPermission.checkSpecialPermission();
         try {
             AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
                 action.executeCouldThrow();
@@ -55,13 +55,6 @@ public final class SocketAccess {
             });
         } catch (PrivilegedActionException e) {
             throw (IOException) e.getCause();
-        }
-    }
-
-    private static void checkSpecialPermission() {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
         }
     }
 

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/common/blobstore/gcs/util/SocketAccess.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/common/blobstore/gcs/util/SocketAccess.java
@@ -35,8 +35,6 @@ import java.security.PrivilegedExceptionAction;
  */
 public final class SocketAccess {
 
-    private static final SpecialPermission SPECIAL_PERMISSION = new SpecialPermission();
-
     private SocketAccess() {}
 
     public static <T> T doPrivilegedIOException(PrivilegedExceptionAction<T> operation) throws IOException {
@@ -63,7 +61,7 @@ public final class SocketAccess {
     private static void checkSpecialPermission() {
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            sm.checkPermission(SPECIAL_PERMISSION);
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
     }
 

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/plugin/repository/gcs/GoogleCloudStoragePlugin.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/plugin/repository/gcs/GoogleCloudStoragePlugin.java
@@ -21,7 +21,6 @@ package org.elasticsearch.plugin.repository.gcs;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
@@ -40,13 +39,10 @@ import com.google.api.services.storage.model.Bucket;
 import com.google.api.services.storage.model.Objects;
 import com.google.api.services.storage.model.StorageObject;
 import org.elasticsearch.SpecialPermission;
-import org.elasticsearch.common.inject.Module;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.RepositoryPlugin;
-import org.elasticsearch.repositories.RepositoriesModule;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.gcs.GoogleCloudStorageRepository;
 import org.elasticsearch.repositories.gcs.GoogleCloudStorageService;
@@ -64,7 +60,7 @@ public class GoogleCloudStoragePlugin extends Plugin implements RepositoryPlugin
          * our plugin permissions don't allow core to "reach through" plugins to
          * change the permission. Because that'd be silly.
          */
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             // ClassInfo put in cache all the fields of a given class
             // that are annoted with @Key; at the same time it changes

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/plugin/repository/gcs/GoogleCloudStoragePlugin.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/plugin/repository/gcs/GoogleCloudStoragePlugin.java
@@ -64,10 +64,7 @@ public class GoogleCloudStoragePlugin extends Plugin implements RepositoryPlugin
          * our plugin permissions don't allow core to "reach through" plugins to
          * change the permission. Because that'd be silly.
          */
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
-        }
+        SpecialPermission.checkSpecialPermission();
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             // ClassInfo put in cache all the fields of a given class
             // that are annoted with @Key; at the same time it changes

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/plugin/repository/gcs/GoogleCloudStoragePlugin.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/plugin/repository/gcs/GoogleCloudStoragePlugin.java
@@ -66,7 +66,7 @@ public class GoogleCloudStoragePlugin extends Plugin implements RepositoryPlugin
          */
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            sm.checkPermission(new SpecialPermission());
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             // ClassInfo put in cache all the fields of a given class

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobStore.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobStore.java
@@ -109,7 +109,7 @@ final class HdfsBlobStore implements BlobStore {
         }
         return path;
     }
-    
+
     interface Operation<V> {
         V run(FileContext fileContext) throws IOException;
     }
@@ -124,18 +124,14 @@ final class HdfsBlobStore implements BlobStore {
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             // unprivileged code such as scripts do not have SpecialPermission
-            sm.checkPermission(new SpecialPermission());
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
         if (closed) {
             throw new AlreadyClosedException("HdfsBlobStore is closed: " + this);
         }
         try {
-            return AccessController.doPrivileged(new PrivilegedExceptionAction<V>() {
-                @Override
-                public V run() throws IOException {
-                    return operation.run(fileContext);
-                }
-            }, null, new ReflectPermission("suppressAccessChecks"),
+            return AccessController.doPrivileged((PrivilegedExceptionAction<V>)
+                    () -> operation.run(fileContext), null, new ReflectPermission("suppressAccessChecks"),
                      new AuthPermission("modifyPrivateCredentials"));
         } catch (PrivilegedActionException pae) {
             throw (IOException) pae.getException();

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobStore.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobStore.java
@@ -121,11 +121,7 @@ final class HdfsBlobStore implements BlobStore {
     // 1) hadoop dynamic proxy is messy with access rules
     // 2) allow hadoop to add credentials to our Subject
     <V> V execute(Operation<V> operation) throws IOException {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            // unprivileged code such as scripts do not have SpecialPermission
-            sm.checkPermission(SpecialPermission.INSTANCE);
-        }
+        SpecialPermission.checkSpecialPermission();
         if (closed) {
             throw new AlreadyClosedException("HdfsBlobStore is closed: " + this);
         }

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobStore.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobStore.java
@@ -121,7 +121,7 @@ final class HdfsBlobStore implements BlobStore {
     // 1) hadoop dynamic proxy is messy with access rules
     // 2) allow hadoop to add credentials to our Subject
     <V> V execute(Operation<V> operation) throws IOException {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         if (closed) {
             throw new AlreadyClosedException("HdfsBlobStore is closed: " + this);
         }

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsPlugin.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsPlugin.java
@@ -41,14 +41,9 @@ public final class HdfsPlugin extends Plugin implements RepositoryPlugin {
     static {
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            sm.checkPermission(new SpecialPermission());
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            @Override
-            public Void run() {
-                return evilHadoopInit();
-            }
-        });
+        AccessController.doPrivileged((PrivilegedAction<Void>) HdfsPlugin::evilHadoopInit);
     }
 
     @SuppressForbidden(reason = "Needs a security hack for hadoop on windows, until HADOOP-XXXX is fixed")

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsPlugin.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsPlugin.java
@@ -39,10 +39,7 @@ public final class HdfsPlugin extends Plugin implements RepositoryPlugin {
 
     // initialize some problematic classes with elevated privileges
     static {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
-        }
+        SpecialPermission.checkSpecialPermission();
         AccessController.doPrivileged((PrivilegedAction<Void>) HdfsPlugin::evilHadoopInit);
     }
 

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsPlugin.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsPlugin.java
@@ -32,14 +32,13 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.RepositoryPlugin;
-import org.elasticsearch.repositories.RepositoriesModule;
 import org.elasticsearch.repositories.Repository;
 
 public final class HdfsPlugin extends Plugin implements RepositoryPlugin {
 
     // initialize some problematic classes with elevated privileges
     static {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         AccessController.doPrivileged((PrivilegedAction<Void>) HdfsPlugin::evilHadoopInit);
     }
 

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
@@ -95,7 +95,7 @@ public final class HdfsRepository extends BlobStoreRepository {
 
         try {
             // initialize our filecontext
-            SpecialPermission.checkSpecialPermission();
+            SpecialPermission.check();
             FileContext fileContext = AccessController.doPrivileged((PrivilegedAction<FileContext>)
                 () -> createContext(uri, getMetadata().settings()));
             blobStore = new HdfsBlobStore(fileContext, pathSetting, bufferSize);

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
@@ -97,14 +97,10 @@ public final class HdfsRepository extends BlobStoreRepository {
             // initialize our filecontext
             SecurityManager sm = System.getSecurityManager();
             if (sm != null) {
-                sm.checkPermission(new SpecialPermission());
+                sm.checkPermission(SpecialPermission.INSTANCE);
             }
-            FileContext fileContext = AccessController.doPrivileged(new PrivilegedAction<FileContext>() {
-                @Override
-                public FileContext run() {
-                    return createContext(uri, getMetadata().settings());
-                }
-            });
+            FileContext fileContext = AccessController.doPrivileged((PrivilegedAction<FileContext>)
+                () -> createContext(uri, getMetadata().settings()));
             blobStore = new HdfsBlobStore(fileContext, pathSetting, bufferSize);
             logger.debug("Using file-system [{}] for URI [{}], path [{}]", fileContext.getDefaultFileSystem(), fileContext.getDefaultFileSystem().getUri(), pathSetting);
         } catch (IOException e) {

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
@@ -95,10 +95,7 @@ public final class HdfsRepository extends BlobStoreRepository {
 
         try {
             // initialize our filecontext
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                sm.checkPermission(SpecialPermission.INSTANCE);
-            }
+            SpecialPermission.checkSpecialPermission();
             FileContext fileContext = AccessController.doPrivileged((PrivilegedAction<FileContext>)
                 () -> createContext(uri, getMetadata().settings()));
             blobStore = new HdfsBlobStore(fileContext, pathSetting, bufferSize);

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/util/SocketAccess.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/util/SocketAccess.java
@@ -60,7 +60,7 @@ public final class SocketAccess {
     }
 
     private static void checkSpecialPermission() {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
     }
 
     @FunctionalInterface

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/util/SocketAccess.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/util/SocketAccess.java
@@ -35,8 +35,6 @@ import java.security.PrivilegedExceptionAction;
  */
 public final class SocketAccess {
 
-    private static final SpecialPermission SPECIAL_PERMISSION = new SpecialPermission();
-
     private SocketAccess() {}
 
     public static <T> T doPrivileged(PrivilegedAction<T> operation) {
@@ -64,7 +62,7 @@ public final class SocketAccess {
     private static void checkSpecialPermission() {
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            sm.checkPermission(SPECIAL_PERMISSION);
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
     }
 

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/util/SocketAccess.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/util/SocketAccess.java
@@ -60,10 +60,7 @@ public final class SocketAccess {
     }
 
     private static void checkSpecialPermission() {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
-        }
+        SpecialPermission.checkSpecialPermission();
     }
 
     @FunctionalInterface

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/plugin/repository/s3/S3RepositoryPlugin.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/plugin/repository/s3/S3RepositoryPlugin.java
@@ -45,10 +45,7 @@ import org.elasticsearch.repositories.s3.S3Repository;
 public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin {
 
     static {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SpecialPermission.INSTANCE);
-        }
+        SpecialPermission.checkSpecialPermission();
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             try {
                 // kick jackson to do some static caching of declared members info

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/plugin/repository/s3/S3RepositoryPlugin.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/plugin/repository/s3/S3RepositoryPlugin.java
@@ -45,7 +45,7 @@ import org.elasticsearch.repositories.s3.S3Repository;
 public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin {
 
     static {
-        SpecialPermission.checkSpecialPermission();
+        SpecialPermission.check();
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             try {
                 // kick jackson to do some static caching of declared members info

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/plugin/repository/s3/S3RepositoryPlugin.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/plugin/repository/s3/S3RepositoryPlugin.java
@@ -47,22 +47,19 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin {
     static {
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            sm.checkPermission(new SpecialPermission());
+            sm.checkPermission(SpecialPermission.INSTANCE);
         }
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            @Override
-            public Void run() {
-                try {
-                    // kick jackson to do some static caching of declared members info
-                    Jackson.jsonNodeOf("{}");
-                    // ClientConfiguration clinit has some classloader problems
-                    // TODO: fix that
-                    Class.forName("com.amazonaws.ClientConfiguration");
-                } catch (ClassNotFoundException e) {
-                    throw new RuntimeException(e);
-                }
-                return null;
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            try {
+                // kick jackson to do some static caching of declared members info
+                Jackson.jsonNodeOf("{}");
+                // ClientConfiguration clinit has some classloader problems
+                // TODO: fix that
+                Class.forName("com.amazonaws.ClientConfiguration");
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
             }
+            return null;
         });
     }
 


### PR DESCRIPTION
This commit adds a SpecialPermission constant and uses that constant
opposed to introducing new instances everywhere.

Additionally, this commit introduces a single static method to check that
the current code has permission. This avoids all the duplicated access
blocks that exist currently.