### PR TITLE
Remove "term" from list of valid span multi-term subqueries

### DIFF
--- a/docs/reference/query-dsl/span-multi-term-query.asciidoc
+++ b/docs/reference/query-dsl/span-multi-term-query.asciidoc
@@ -2,7 +2,7 @@
 === Span Multi Term Query
 
 The `span_multi` query allows you to wrap a `multi term query` (one of wildcard,
-fuzzy, prefix, term, range or regexp query) as a `span query`, so
+fuzzy, prefix, range or regexp query) as a `span query`, so
 it can be nested. Example:
 
 [source,js]


### PR DESCRIPTION
"term" is not actually a multi-term query (perhaps confusion with "term range")
