### PR TITLE
Add note regarding custom jvm.options

### DIFF
--- a/docs/reference/setup/rolling_upgrade.asciidoc
+++ b/docs/reference/setup/rolling_upgrade.asciidoc
@@ -69,7 +69,8 @@ default.
 It is a good idea to place these directories in a different location so that
 there is no chance of deleting them when upgrading Elasticsearch.  These
 custom paths can be <<path-settings,configured>> with the `path.conf`,
-`path.logs`, and `path.data` settings.
+`path.logs`, and `path.data` settings, and using `ES_JVM_OPTIONS` to specify
+the location of the `jvm.options` file.
 
 The <<deb,Debian>> and <<rpm,RPM>> packages place these directories in the
 appropriate place for each operating system.
@@ -88,8 +89,9 @@ To upgrade using a zip or compressed tarball:
     overwrite the `config` or `data` directories.
 
 *   Either copy the files in the `config` directory from your old installation
-    to your new installation, or use the `-E path.conf=` option on the command
-    line to point to an external config directory.
+    to your new installation, or set the environment variable `ES_JVM_OPTIONS`
+    to the location of the `jvm.options` file and use the `-E path.conf=`
+    option on the command line to point to an external config directory.
 
 *   Either copy the files in the `data` directory from your old installation
     to your new installation, or configure the location of the data directory


### PR DESCRIPTION
When users need to specify a custom location for configuration files, they also need to specify a custom location for the jvm.options file yet our docs are absent in this regard. This commit adds a note to the rolling upgrade docs explaining this situation.

Closes #22744
