### PR TITLE
Use generic interfaces for checking socket access

### DIFF
--- a/plugins/discovery-gce/src/main/java/org/elasticsearch/cloud/gce/util/Access.java
+++ b/plugins/discovery-gce/src/main/java/org/elasticsearch/cloud/gce/util/Access.java
@@ -42,10 +42,10 @@ public final class Access {
         return AccessController.doPrivileged(operation);
     }
 
-    public static void doPrivilegedVoid(DiscoveryRunnable action) {
+    public static void doPrivilegedVoid(Runnable action) {
         SpecialPermission.check();
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            action.execute();
+            action.run();
             return null;
         });
     }
@@ -57,10 +57,5 @@ public final class Access {
         } catch (PrivilegedActionException e) {
             throw (IOException) e.getCause();
         }
-    }
-
-    @FunctionalInterface
-    public interface DiscoveryRunnable {
-        void execute();
     }
 }

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/common/blobstore/gcs/util/SocketAccess.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/common/blobstore/gcs/util/SocketAccess.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.common.blobstore.gcs.util;
 
 import org.elasticsearch.SpecialPermission;
+import org.elasticsearch.common.CheckedRunnable;
 
 import java.io.IOException;
 import java.net.SocketPermission;
@@ -46,20 +47,15 @@ public final class SocketAccess {
         }
     }
 
-    public static void doPrivilegedVoidIOException(StorageRunnable action) throws IOException {
+    public static void doPrivilegedVoidIOException(CheckedRunnable<IOException> action) throws IOException {
         SpecialPermission.check();
         try {
             AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
-                action.executeCouldThrow();
+                action.run();
                 return null;
             });
         } catch (PrivilegedActionException e) {
             throw (IOException) e.getCause();
         }
-    }
-
-    @FunctionalInterface
-    public interface StorageRunnable {
-        void executeCouldThrow() throws IOException;
     }
 }

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/util/SocketAccess.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/util/SocketAccess.java
@@ -38,12 +38,12 @@ public final class SocketAccess {
     private SocketAccess() {}
 
     public static <T> T doPrivileged(PrivilegedAction<T> operation) {
-        checkSpecialPermission();
+        SpecialPermission.check();
         return AccessController.doPrivileged(operation);
     }
 
     public static <T> T doPrivilegedIOException(PrivilegedExceptionAction<T> operation) throws IOException {
-        checkSpecialPermission();
+        SpecialPermission.check();
         try {
             return AccessController.doPrivileged(operation);
         } catch (PrivilegedActionException e) {
@@ -51,21 +51,12 @@ public final class SocketAccess {
         }
     }
 
-    public static void doPrivilegedVoid(StorageRunnable action) {
-        checkSpecialPermission();
+    public static void doPrivilegedVoid(Runnable action) {
+        SpecialPermission.check();
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            action.execute();
+            action.run();
             return null;
         });
-    }
-
-    private static void checkSpecialPermission() {
-        SpecialPermission.check();
-    }
-
-    @FunctionalInterface
-    public interface StorageRunnable {
-        void execute();
     }
 
 }


### PR DESCRIPTION
This commit replaces specialized functional interfaces in various
plugins with generic options. Instead of creating `StorageRunnable`
interfaces in every plugin we can just use `Runnable` or `CheckedRunnable`.
