### PR TITLE
Add hack for Docker cgroups

### DIFF
--- a/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -21,7 +21,6 @@ package org.elasticsearch.monitor.os;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.Constants;
-import org.elasticsearch.bootstrap.BootstrapInfo;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.logging.ESLoggerFactory;
@@ -191,10 +190,9 @@ public class OsProbe {
     // pattern for lines in /proc/self/cgroup
     private static final Pattern CONTROL_GROUP_PATTERN = Pattern.compile("\\d+:([^:,]+(?:,[^:,]+)?):(/.*)");
 
-    // this property is to support a hack to workaround an issue with Docker containers not mounting the cgroups hierarchy inconsistently
-    // with respect to /proc/self/cgroup; for Docker containers this should be set to "/"
-    private static final String CONTROL_GROUPS_PATH_OVERRIDE =
-        (String) BootstrapInfo.getSystemProperties().get("es.cgroups.path.override");
+    // this property is to support a hack to workaround an issue with Docker containers mounting the cgroups hierarchy inconsistently with
+    // respect to /proc/self/cgroup; for Docker containers this should be set to "/"
+    private static final String CONTROL_GROUPS_HIERARCHY_OVERRIDE = System.getProperty("es.cgroups.hierarchy.override");
 
     /**
      * A map of the control groups to which the Elasticsearch process belongs. Note that this is a map because the control groups can vary
@@ -214,13 +212,13 @@ public class OsProbe {
             // at this point we have captured the subsystems and the control group
             final String[] controllers = matcher.group(1).split(",");
             for (final String controller : controllers) {
-                if (CONTROL_GROUPS_PATH_OVERRIDE != null) {
+                if (CONTROL_GROUPS_HIERARCHY_OVERRIDE != null) {
                     /*
                      * Docker violates the relationship between /proc/self/cgroups and the /sys/fs/cgroup hierarchy. It's possible that this
                      * will be fixed in future versions of Docker with cgroup namespaces, but this requires modern kernels. Thus, we provide
                      * an undocumented hack for overriding the control group path. Do not rely on this hack, it will be removed.
                      */
-                    controllerMap.put(controller, CONTROL_GROUPS_PATH_OVERRIDE);
+                    controllerMap.put(controller, CONTROL_GROUPS_HIERARCHY_OVERRIDE);
                 } else {
                     controllerMap.put(controller, matcher.group(2));
                 }

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -21,6 +21,7 @@ package org.elasticsearch.monitor.os;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.Constants;
+import org.elasticsearch.bootstrap.BootstrapInfo;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.logging.ESLoggerFactory;
@@ -35,7 +36,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -191,6 +191,11 @@ public class OsProbe {
     // pattern for lines in /proc/self/cgroup
     private static final Pattern CONTROL_GROUP_PATTERN = Pattern.compile("\\d+:([^:,]+(?:,[^:,]+)?):(/.*)");
 
+    // this property is to support a hack to workaround an issue with Docker containers not mounting the cgroups hierarchy inconsistently
+    // with respect to /proc/self/cgroup; for Docker containers this should be set to "/"
+    private static final String CONTROL_GROUPS_PATH_OVERRIDE =
+        (String) BootstrapInfo.getSystemProperties().get("es.cgroups.path.override");
+
     /**
      * A map of the control groups to which the Elasticsearch process belongs. Note that this is a map because the control groups can vary
      * from subsystem to subsystem. Additionally, this map can not be cached because a running process can be reclassified.
@@ -209,7 +214,16 @@ public class OsProbe {
             // at this point we have captured the subsystems and the control group
             final String[] controllers = matcher.group(1).split(",");
             for (final String controller : controllers) {
-                controllerMap.put(controller, matcher.group(2));
+                if (CONTROL_GROUPS_PATH_OVERRIDE != null) {
+                    /*
+                     * Docker violates the relationship between /proc/self/cgroups and the /sys/fs/cgroup hierarchy. It's possible that this
+                     * will be fixed in future versions of Docker with cgroup namespaces, but this requires modern kernels. Thus, we provide
+                     * an undocumented hack for overriding the control group path. Do not rely on this hack, it will be removed.
+                     */
+                    controllerMap.put(controller, CONTROL_GROUPS_PATH_OVERRIDE);
+                } else {
+                    controllerMap.put(controller, matcher.group(2));
+                }
             }
         }
         return controllerMap;


### PR DESCRIPTION
Docker cgroups are mounted in the wrong place (i.e., inconsistently with /proc/self/cgroup). This commit adds an undocumented hack for working around, for now.

Relates #21029