### PR TITLE
S3 repository: Add named configurations

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -338,12 +338,13 @@ final class Bootstrap {
 
             INSTANCE.setup(true, environment);
 
+            /* TODO: close this once s3 repository doesn't try to read during repository construction
             try {
                 // any secure settings must be read during node construction
                 IOUtils.close(keystore);
             } catch (IOException e) {
                 throw new BootstrapException(e);
-            }
+            }*/
 
             INSTANCE.start();
 

--- a/core/src/main/java/org/elasticsearch/common/settings/SecureSetting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/SecureSetting.java
@@ -109,8 +109,8 @@ public abstract class SecureSetting<T> extends Setting<T> {
      *
      * This may be any sensitive string, e.g. a username, a password, an auth token, etc.
      */
-    public static SecureSetting<SecureString> secureString(String name, SecureSetting<SecureString> fallback,
-                                                           boolean allowLegacy, Property... properties) {
+    public static Setting<SecureString> secureString(String name, Setting<SecureString> fallback,
+                                                     boolean allowLegacy, Property... properties) {
         final Setting<String> legacy;
         if (allowLegacy) {
             Property[] legacyProperties = ArrayUtils.concat(properties, LEGACY_PROPERTIES, Property.class);

--- a/core/src/main/java/org/elasticsearch/common/settings/SecureString.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/SecureString.java
@@ -39,6 +39,16 @@ public final class SecureString implements CharSequence, Closeable {
         this.chars = Objects.requireNonNull(chars);
     }
 
+    /**
+     * Constructs a new SecureString from an existing String.
+     *
+     * NOTE: This is not actually secure, since the provided String cannot be deallocated, but
+     * this constructor allows for easy compatibility between new and old apis.
+     */
+    public SecureString(String s) {
+        this(s.toCharArray());
+    }
+
     /** Constant time equality to avoid potential timing attacks. */
     @Override
     public synchronized boolean equals(Object o) {

--- a/core/src/main/java/org/elasticsearch/common/settings/SecureString.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/SecureString.java
@@ -44,7 +44,10 @@ public final class SecureString implements CharSequence, Closeable {
      *
      * NOTE: This is not actually secure, since the provided String cannot be deallocated, but
      * this constructor allows for easy compatibility between new and old apis.
+     *
+     * @deprecated Only use for compatibility between deprecated string settings and new secure strings
      */
+    @Deprecated
     public SecureString(String s) {
         this(s.toCharArray());
     }

--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -123,7 +123,7 @@ public class Setting<T> extends ToXContentToBytes {
 
     private Setting(Key key, @Nullable Setting<T> fallbackSetting, Function<Settings, String> defaultValue, Function<String, T> parser,
             Property... properties) {
-        assert this instanceof SecureSetting || parser.apply(defaultValue.apply(Settings.EMPTY)) != null || this.isGroupSetting()
+        assert this instanceof SecureSetting || this.isGroupSetting() || parser.apply(defaultValue.apply(Settings.EMPTY)) != null
                : "parser returned null";
         this.key = key;
         this.fallbackSetting = fallbackSetting;
@@ -525,6 +525,14 @@ public class Setting<T> extends ToXContentToBytes {
             } else {
                 throw new IllegalArgumentException("key [" + key + "] must match [" + getKey() + "] but didn't.");
             }
+        }
+
+        /**
+         * Get a setting with the given namespace filled in for prefix and suffix.
+         */
+        public Setting<T> getConcreteSettingForNamespace(String namespace) {
+            String fullKey = key.toConcreteKey(namespace).toString();
+            return getConcreteSetting(fullKey);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -897,6 +897,9 @@ public final class Settings implements ToXContent {
         public Builder put(Settings settings) {
             removeNonArraysFieldsIfNewSettingsContainsFieldAsArray(settings.getAsMap());
             map.putAll(settings.getAsMap());
+            if (settings.getSecureSettings() != null) {
+                setSecureSettings(settings.getSecureSettings());
+            }
             return this;
         }
 

--- a/core/src/main/java/org/elasticsearch/node/InternalSettingsPreparer.java
+++ b/core/src/main/java/org/elasticsearch/node/InternalSettingsPreparer.java
@@ -89,6 +89,7 @@ public class InternalSettingsPreparer {
         initializeSettings(output, input, true, properties);
         Environment environment = new Environment(output.build());
 
+        output = Settings.builder(); // start with a fresh output
         boolean settingsFileFound = false;
         Set<String> foundSuffixes = new HashSet<>();
         for (String allowedSuffix : ALLOWED_SUFFIXES) {

--- a/core/src/test/java/org/elasticsearch/node/internal/InternalSettingsPreparerTests.java
+++ b/core/src/test/java/org/elasticsearch/node/internal/InternalSettingsPreparerTests.java
@@ -21,6 +21,10 @@ package org.elasticsearch.node.internal;
 
 import org.elasticsearch.cli.MockTerminal;
 import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.settings.MockSecureSettings;
+import org.elasticsearch.common.settings.SecureSetting;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.env.Environment;
@@ -160,5 +164,14 @@ public class InternalSettingsPreparerTests extends ESTestCase {
             assertTrue(e.getMessage(), e.getMessage().contains(".yaml"));
             assertTrue(e.getMessage(), e.getMessage().contains(".properties"));
         }
+    }
+
+    public void testSecureSettings() {
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString("foo", "secret");
+        Settings input = Settings.builder().put(baseEnvSettings).setSecureSettings(secureSettings).build();
+        Environment env = InternalSettingsPreparer.prepareEnvironment(input, null);
+        Setting<SecureString> fakeSetting = SecureSetting.secureString("foo", null, false);
+        assertEquals("secret", fakeSetting.get(env.settings()).toString());
     }
 }

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
@@ -40,123 +40,124 @@ public interface AwsS3Service extends LifecycleComponent {
     /**
      * cloud.aws.access_key: AWS Access key. Shared with discovery-ec2 plugin
      */
-    Setting<SecureString> LEGACY_KEY_SETTING = new Setting<>("cloud.aws.access_key", "", SecureString::new,
+    Setting<SecureString> KEY_SETTING = new Setting<>("cloud.aws.access_key", "", SecureString::new,
         Property.NodeScope, Property.Filtered, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.secret_key: AWS Secret key. Shared with discovery-ec2 plugin
      */
-    Setting<SecureString> LEGACY_SECRET_SETTING = new Setting<>("cloud.aws.secret_key", "", SecureString::new,
+    Setting<SecureString> SECRET_SETTING = new Setting<>("cloud.aws.secret_key", "", SecureString::new,
         Property.NodeScope, Property.Filtered, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.protocol: Protocol for AWS API: http or https. Defaults to https. Shared with discovery-ec2 plugin
      */
-    Setting<Protocol> LEGACY_PROTOCOL_SETTING = new Setting<>("cloud.aws.protocol", "https",
+    Setting<Protocol> PROTOCOL_SETTING = new Setting<>("cloud.aws.protocol", "https",
         s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)), Property.NodeScope, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.proxy.host: In case of proxy, define its hostname/IP. Shared with discovery-ec2 plugin
      */
-    Setting<String> LEGACY_PROXY_HOST_SETTING = Setting.simpleString("cloud.aws.proxy.host",
+    Setting<String> PROXY_HOST_SETTING = Setting.simpleString("cloud.aws.proxy.host",
         Property.NodeScope, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.proxy.port: In case of proxy, define its port. Defaults to 80. Shared with discovery-ec2 plugin
      */
-    Setting<Integer> LEGACY_PROXY_PORT_SETTING = Setting.intSetting("cloud.aws.proxy.port", 80, 0, 1<<16,
+    Setting<Integer> PROXY_PORT_SETTING = Setting.intSetting("cloud.aws.proxy.port", 80, 0, 1<<16,
         Property.NodeScope, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.proxy.username: In case of proxy with auth, define the username. Shared with discovery-ec2 plugin
      */
-    Setting<SecureString> LEGACY_PROXY_USERNAME_SETTING = new Setting<>("cloud.aws.proxy.username", "", SecureString::new,
+    Setting<SecureString> PROXY_USERNAME_SETTING = new Setting<>("cloud.aws.proxy.username", "", SecureString::new,
         Property.NodeScope, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.proxy.password: In case of proxy with auth, define the password. Shared with discovery-ec2 plugin
      */
-    Setting<SecureString> LEGACY_PROXY_PASSWORD_SETTING = new Setting<>("cloud.aws.proxy.password", "", SecureString::new,
+    Setting<SecureString> PROXY_PASSWORD_SETTING = new Setting<>("cloud.aws.proxy.password", "", SecureString::new,
         Property.NodeScope, Property.Filtered, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.signer: If you are using an old AWS API version, you can define a Signer. Shared with discovery-ec2 plugin
      */
-    Setting<String> LEGACY_SIGNER_SETTING = Setting.simpleString("cloud.aws.signer",
+    Setting<String> SIGNER_SETTING = Setting.simpleString("cloud.aws.signer",
         Property.NodeScope, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.region: Region. Shared with discovery-ec2 plugin
      */
-    Setting<String> LEGACY_REGION_SETTING = new Setting<>("cloud.aws.region", "", s -> s.toLowerCase(Locale.ROOT),
+    Setting<String> REGION_SETTING = new Setting<>("cloud.aws.region", "", s -> s.toLowerCase(Locale.ROOT),
         Property.NodeScope, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.read_timeout: Socket read timeout. Shared with discovery-ec2 plugin
      */
-    Setting<TimeValue> LEGACY_READ_TIMEOUT = Setting.timeSetting("cloud.aws.read_timeout",
+    Setting<TimeValue> READ_TIMEOUT = Setting.timeSetting("cloud.aws.read_timeout",
         TimeValue.timeValueMillis(ClientConfiguration.DEFAULT_SOCKET_TIMEOUT), Property.NodeScope, Property.Deprecated, Property.Shared);
 
     /**
      * Defines specific s3 settings starting with cloud.aws.s3.
+     * NOTE: These are legacy settings. Use the named client configs in {@link org.elasticsearch.repositories.s3.S3Repository}.
      */
     interface CLOUD_S3 {
         /**
          * cloud.aws.s3.access_key: AWS Access key specific for S3 API calls. Defaults to cloud.aws.access_key.
-         * @see AwsS3Service#LEGACY_KEY_SETTING
+         * @see AwsS3Service#KEY_SETTING
          */
         Setting<SecureString> KEY_SETTING =
-            new Setting<>("cloud.aws.s3.access_key", AwsS3Service.LEGACY_KEY_SETTING, SecureString::new,
+            new Setting<>("cloud.aws.s3.access_key", AwsS3Service.KEY_SETTING, SecureString::new,
                 Property.NodeScope, Property.Filtered, Property.Deprecated);
         /**
          * cloud.aws.s3.secret_key: AWS Secret key specific for S3 API calls. Defaults to cloud.aws.secret_key.
-         * @see AwsS3Service#LEGACY_SECRET_SETTING
+         * @see AwsS3Service#SECRET_SETTING
          */
         Setting<SecureString> SECRET_SETTING =
-            new Setting<>("cloud.aws.s3.secret_key", AwsS3Service.LEGACY_SECRET_SETTING, SecureString::new,
+            new Setting<>("cloud.aws.s3.secret_key", AwsS3Service.SECRET_SETTING, SecureString::new,
                 Property.NodeScope, Property.Filtered, Property.Deprecated);
         /**
          * cloud.aws.s3.protocol: Protocol for AWS API specific for S3 API calls: http or https. Defaults to cloud.aws.protocol.
-         * @see AwsS3Service#LEGACY_PROTOCOL_SETTING
+         * @see AwsS3Service#PROTOCOL_SETTING
          */
         Setting<Protocol> PROTOCOL_SETTING =
-            new Setting<>("cloud.aws.s3.protocol", AwsS3Service.LEGACY_PROTOCOL_SETTING, s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)),
+            new Setting<>("cloud.aws.s3.protocol", AwsS3Service.PROTOCOL_SETTING, s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)),
                 Property.NodeScope, Property.Deprecated);
         /**
          * cloud.aws.s3.proxy.host: In case of proxy, define its hostname/IP specific for S3 API calls. Defaults to cloud.aws.proxy.host.
-         * @see AwsS3Service#LEGACY_PROXY_HOST_SETTING
+         * @see AwsS3Service#PROXY_HOST_SETTING
          */
         Setting<String> PROXY_HOST_SETTING =
-            new Setting<>("cloud.aws.s3.proxy.host", AwsS3Service.LEGACY_PROXY_HOST_SETTING, Function.identity(),
+            new Setting<>("cloud.aws.s3.proxy.host", AwsS3Service.PROXY_HOST_SETTING, Function.identity(),
                 Property.NodeScope, Property.Deprecated);
         /**
          * cloud.aws.s3.proxy.port: In case of proxy, define its port specific for S3 API calls.  Defaults to cloud.aws.proxy.port.
-         * @see AwsS3Service#LEGACY_PROXY_PORT_SETTING
+         * @see AwsS3Service#PROXY_PORT_SETTING
          */
         Setting<Integer> PROXY_PORT_SETTING =
-            new Setting<>("cloud.aws.s3.proxy.port", AwsS3Service.LEGACY_PROXY_PORT_SETTING,
+            new Setting<>("cloud.aws.s3.proxy.port", AwsS3Service.PROXY_PORT_SETTING,
                 s -> Setting.parseInt(s, 0, 1<<16, "cloud.aws.s3.proxy.port"), Property.NodeScope, Property.Deprecated);
         /**
          * cloud.aws.s3.proxy.username: In case of proxy with auth, define the username specific for S3 API calls.
          * Defaults to cloud.aws.proxy.username.
-         * @see AwsS3Service#LEGACY_PROXY_USERNAME_SETTING
+         * @see AwsS3Service#PROXY_USERNAME_SETTING
          */
         Setting<SecureString> PROXY_USERNAME_SETTING =
-            new Setting<>("cloud.aws.s3.proxy.username", AwsS3Service.LEGACY_PROXY_USERNAME_SETTING, SecureString::new,
+            new Setting<>("cloud.aws.s3.proxy.username", AwsS3Service.PROXY_USERNAME_SETTING, SecureString::new,
                 Property.NodeScope, Property.Deprecated);
         /**
          * cloud.aws.s3.proxy.password: In case of proxy with auth, define the password specific for S3 API calls.
          * Defaults to cloud.aws.proxy.password.
-         * @see AwsS3Service#LEGACY_PROXY_PASSWORD_SETTING
+         * @see AwsS3Service#PROXY_PASSWORD_SETTING
          */
         Setting<SecureString> PROXY_PASSWORD_SETTING =
-            new Setting<>("cloud.aws.s3.proxy.password", AwsS3Service.LEGACY_PROXY_PASSWORD_SETTING, SecureString::new,
+            new Setting<>("cloud.aws.s3.proxy.password", AwsS3Service.PROXY_PASSWORD_SETTING, SecureString::new,
                 Property.NodeScope, Property.Filtered, Property.Deprecated);
         /**
          * cloud.aws.s3.signer: If you are using an old AWS API version, you can define a Signer. Specific for S3 API calls.
          * Defaults to cloud.aws.signer.
-         * @see AwsS3Service#LEGACY_SIGNER_SETTING
+         * @see AwsS3Service#SIGNER_SETTING
          */
         Setting<String> SIGNER_SETTING =
-            new Setting<>("cloud.aws.s3.signer", AwsS3Service.LEGACY_SIGNER_SETTING, Function.identity(),
+            new Setting<>("cloud.aws.s3.signer", AwsS3Service.SIGNER_SETTING, Function.identity(),
                 Property.NodeScope, Property.Deprecated);
         /**
          * cloud.aws.s3.region: Region specific for S3 API calls. Defaults to cloud.aws.region.
-         * @see AwsS3Service#LEGACY_REGION_SETTING
+         * @see AwsS3Service#REGION_SETTING
          */
         Setting<String> REGION_SETTING =
-            new Setting<>("cloud.aws.s3.region", AwsS3Service.LEGACY_REGION_SETTING, s -> s.toLowerCase(Locale.ROOT),
+            new Setting<>("cloud.aws.s3.region", AwsS3Service.REGION_SETTING, s -> s.toLowerCase(Locale.ROOT),
                 Property.NodeScope, Property.Deprecated);
         /**
          * cloud.aws.s3.endpoint: Endpoint. If not set, endpoint will be guessed based on region setting.
@@ -164,10 +165,10 @@ public interface AwsS3Service extends LifecycleComponent {
         Setting<String> ENDPOINT_SETTING = Setting.simpleString("cloud.aws.s3.endpoint", Property.NodeScope);
         /**
          * cloud.aws.s3.read_timeout: Socket read timeout. Defaults to cloud.aws.read_timeout
-         * @see AwsS3Service#LEGACY_READ_TIMEOUT
+         * @see AwsS3Service#READ_TIMEOUT
          */
         Setting<TimeValue> READ_TIMEOUT =
-            Setting.timeSetting("cloud.aws.s3.read_timeout", AwsS3Service.LEGACY_READ_TIMEOUT, Property.NodeScope, Property.Deprecated);
+            Setting.timeSetting("cloud.aws.s3.read_timeout", AwsS3Service.READ_TIMEOUT, Property.NodeScope, Property.Deprecated);
     }
 
     AmazonS3 client(Settings repositorySettings, Integer maxRetries, boolean useThrottleRetries, Boolean pathStyleAccess);

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
@@ -19,73 +19,74 @@
 
 package org.elasticsearch.cloud.aws;
 
+import java.util.Locale;
+import java.util.function.Function;
+
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
 import com.amazonaws.services.s3.AmazonS3;
 import org.elasticsearch.common.component.LifecycleComponent;
-import org.elasticsearch.common.settings.SecureSetting;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 
-import java.util.Locale;
-import java.util.function.Function;
-
 public interface AwsS3Service extends LifecycleComponent {
 
-    // Global AWS settings (shared between discovery-ec2 and repository-s3)
+    // Legacy global AWS settings (shared between discovery-ec2 and repository-s3)
     // Each setting starting with `cloud.aws` also exists in discovery-ec2 project. Don't forget to update
     // the code there if you change anything here.
     /**
      * cloud.aws.access_key: AWS Access key. Shared with discovery-ec2 plugin
      */
-    SecureSetting<SecureString> KEY_SETTING = SecureSetting.secureString("cloud.aws.access_key", null, true, Property.Shared);
-
+    Setting<SecureString> LEGACY_KEY_SETTING = new Setting<>("cloud.aws.access_key", "", SecureString::new,
+        Property.NodeScope, Property.Filtered, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.secret_key: AWS Secret key. Shared with discovery-ec2 plugin
      */
-    SecureSetting<SecureString> SECRET_SETTING = SecureSetting.secureString("cloud.aws.secret_key", null, true, Property.Shared);
+    Setting<SecureString> LEGACY_SECRET_SETTING = new Setting<>("cloud.aws.secret_key", "", SecureString::new,
+        Property.NodeScope, Property.Filtered, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.protocol: Protocol for AWS API: http or https. Defaults to https. Shared with discovery-ec2 plugin
      */
-    Setting<Protocol> PROTOCOL_SETTING = new Setting<>("cloud.aws.protocol", "https", s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)),
-        Property.NodeScope, Property.Shared);
+    Setting<Protocol> LEGACY_PROTOCOL_SETTING = new Setting<>("cloud.aws.protocol", "https",
+        s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)), Property.NodeScope, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.proxy.host: In case of proxy, define its hostname/IP. Shared with discovery-ec2 plugin
      */
-    Setting<String> PROXY_HOST_SETTING = Setting.simpleString("cloud.aws.proxy.host", Property.NodeScope, Property.Shared);
+    Setting<String> LEGACY_PROXY_HOST_SETTING = Setting.simpleString("cloud.aws.proxy.host",
+        Property.NodeScope, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.proxy.port: In case of proxy, define its port. Defaults to 80. Shared with discovery-ec2 plugin
      */
-    Setting<Integer> PROXY_PORT_SETTING = Setting.intSetting("cloud.aws.proxy.port", 80, 0, 1<<16, Property.NodeScope,
-        Property.Shared);
+    Setting<Integer> LEGACY_PROXY_PORT_SETTING = Setting.intSetting("cloud.aws.proxy.port", 80, 0, 1<<16,
+        Property.NodeScope, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.proxy.username: In case of proxy with auth, define the username. Shared with discovery-ec2 plugin
      */
-    SecureSetting<SecureString> PROXY_USERNAME_SETTING =
-        SecureSetting.secureString("cloud.aws.proxy.username", null, true, Property.Shared);
-
+    Setting<SecureString> LEGACY_PROXY_USERNAME_SETTING = new Setting<>("cloud.aws.proxy.username", "", SecureString::new,
+        Property.NodeScope, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.proxy.password: In case of proxy with auth, define the password. Shared with discovery-ec2 plugin
      */
-    SecureSetting<SecureString> PROXY_PASSWORD_SETTING =
-        SecureSetting.secureString("cloud.aws.proxy.password", null, true, Property.Shared);
+    Setting<SecureString> LEGACY_PROXY_PASSWORD_SETTING = new Setting<>("cloud.aws.proxy.password", "", SecureString::new,
+        Property.NodeScope, Property.Filtered, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.signer: If you are using an old AWS API version, you can define a Signer. Shared with discovery-ec2 plugin
      */
-    Setting<String> SIGNER_SETTING = Setting.simpleString("cloud.aws.signer", Property.NodeScope, Property.Shared);
+    Setting<String> LEGACY_SIGNER_SETTING = Setting.simpleString("cloud.aws.signer",
+        Property.NodeScope, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.region: Region. Shared with discovery-ec2 plugin
      */
-    Setting<String> REGION_SETTING =
-        new Setting<>("cloud.aws.region", "", s -> s.toLowerCase(Locale.ROOT), Property.NodeScope, Property.Shared);
+    Setting<String> LEGACY_REGION_SETTING = new Setting<>("cloud.aws.region", "", s -> s.toLowerCase(Locale.ROOT),
+        Property.NodeScope, Property.Deprecated, Property.Shared);
     /**
      * cloud.aws.read_timeout: Socket read timeout. Shared with discovery-ec2 plugin
      */
-    Setting<TimeValue> READ_TIMEOUT = Setting.timeSetting("cloud.aws.read_timeout",
-        TimeValue.timeValueMillis(ClientConfiguration.DEFAULT_SOCKET_TIMEOUT), Property.NodeScope, Property.Shared);
+    Setting<TimeValue> LEGACY_READ_TIMEOUT = Setting.timeSetting("cloud.aws.read_timeout",
+        TimeValue.timeValueMillis(ClientConfiguration.DEFAULT_SOCKET_TIMEOUT), Property.NodeScope, Property.Deprecated, Property.Shared);
 
     /**
      * Defines specific s3 settings starting with cloud.aws.s3.
@@ -93,77 +94,81 @@ public interface AwsS3Service extends LifecycleComponent {
     interface CLOUD_S3 {
         /**
          * cloud.aws.s3.access_key: AWS Access key specific for S3 API calls. Defaults to cloud.aws.access_key.
-         * @see AwsS3Service#KEY_SETTING
+         * @see AwsS3Service#LEGACY_KEY_SETTING
          */
-        SecureSetting<SecureString> KEY_SETTING = SecureSetting.secureString("cloud.aws.s3.access_key", AwsS3Service.KEY_SETTING, true);
+        Setting<SecureString> KEY_SETTING =
+            new Setting<>("cloud.aws.s3.access_key", AwsS3Service.LEGACY_KEY_SETTING, SecureString::new,
+                Property.NodeScope, Property.Filtered, Property.Deprecated);
         /**
          * cloud.aws.s3.secret_key: AWS Secret key specific for S3 API calls. Defaults to cloud.aws.secret_key.
-         * @see AwsS3Service#SECRET_SETTING
+         * @see AwsS3Service#LEGACY_SECRET_SETTING
          */
-        SecureSetting<SecureString> SECRET_SETTING = SecureSetting.secureString("cloud.aws.s3.secret_key",
-            AwsS3Service.SECRET_SETTING, true);
+        Setting<SecureString> SECRET_SETTING =
+            new Setting<>("cloud.aws.s3.secret_key", AwsS3Service.LEGACY_SECRET_SETTING, SecureString::new,
+                Property.NodeScope, Property.Filtered, Property.Deprecated);
         /**
          * cloud.aws.s3.protocol: Protocol for AWS API specific for S3 API calls: http or https. Defaults to cloud.aws.protocol.
-         * @see AwsS3Service#PROTOCOL_SETTING
+         * @see AwsS3Service#LEGACY_PROTOCOL_SETTING
          */
         Setting<Protocol> PROTOCOL_SETTING =
-            new Setting<>("cloud.aws.s3.protocol", AwsS3Service.PROTOCOL_SETTING, s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)),
-                Property.NodeScope);
+            new Setting<>("cloud.aws.s3.protocol", AwsS3Service.LEGACY_PROTOCOL_SETTING, s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)),
+                Property.NodeScope, Property.Deprecated);
         /**
          * cloud.aws.s3.proxy.host: In case of proxy, define its hostname/IP specific for S3 API calls. Defaults to cloud.aws.proxy.host.
-         * @see AwsS3Service#PROXY_HOST_SETTING
+         * @see AwsS3Service#LEGACY_PROXY_HOST_SETTING
          */
         Setting<String> PROXY_HOST_SETTING =
-            new Setting<>("cloud.aws.s3.proxy.host", AwsS3Service.PROXY_HOST_SETTING, Function.identity(),
-                Property.NodeScope);
+            new Setting<>("cloud.aws.s3.proxy.host", AwsS3Service.LEGACY_PROXY_HOST_SETTING, Function.identity(),
+                Property.NodeScope, Property.Deprecated);
         /**
          * cloud.aws.s3.proxy.port: In case of proxy, define its port specific for S3 API calls.  Defaults to cloud.aws.proxy.port.
-         * @see AwsS3Service#PROXY_PORT_SETTING
+         * @see AwsS3Service#LEGACY_PROXY_PORT_SETTING
          */
         Setting<Integer> PROXY_PORT_SETTING =
-            new Setting<>("cloud.aws.s3.proxy.port", AwsS3Service.PROXY_PORT_SETTING,
-                s -> Setting.parseInt(s, 0, 1<<16, "cloud.aws.s3.proxy.port"), Property.NodeScope);
+            new Setting<>("cloud.aws.s3.proxy.port", AwsS3Service.LEGACY_PROXY_PORT_SETTING,
+                s -> Setting.parseInt(s, 0, 1<<16, "cloud.aws.s3.proxy.port"), Property.NodeScope, Property.Deprecated);
         /**
          * cloud.aws.s3.proxy.username: In case of proxy with auth, define the username specific for S3 API calls.
          * Defaults to cloud.aws.proxy.username.
-         * @see AwsS3Service#PROXY_USERNAME_SETTING
+         * @see AwsS3Service#LEGACY_PROXY_USERNAME_SETTING
          */
-        SecureSetting<SecureString> PROXY_USERNAME_SETTING =
-            SecureSetting.secureString("cloud.aws.s3.proxy.username", AwsS3Service.PROXY_USERNAME_SETTING, true);
+        Setting<SecureString> PROXY_USERNAME_SETTING =
+            new Setting<>("cloud.aws.s3.proxy.username", AwsS3Service.LEGACY_PROXY_USERNAME_SETTING, SecureString::new,
+                Property.NodeScope, Property.Deprecated);
         /**
          * cloud.aws.s3.proxy.password: In case of proxy with auth, define the password specific for S3 API calls.
          * Defaults to cloud.aws.proxy.password.
-         * @see AwsS3Service#PROXY_PASSWORD_SETTING
+         * @see AwsS3Service#LEGACY_PROXY_PASSWORD_SETTING
          */
-        SecureSetting<SecureString> PROXY_PASSWORD_SETTING =
-            SecureSetting.secureString("cloud.aws.s3.proxy.password", AwsS3Service.PROXY_PASSWORD_SETTING, true);
-
+        Setting<SecureString> PROXY_PASSWORD_SETTING =
+            new Setting<>("cloud.aws.s3.proxy.password", AwsS3Service.LEGACY_PROXY_PASSWORD_SETTING, SecureString::new,
+                Property.NodeScope, Property.Filtered, Property.Deprecated);
         /**
          * cloud.aws.s3.signer: If you are using an old AWS API version, you can define a Signer. Specific for S3 API calls.
          * Defaults to cloud.aws.signer.
-         * @see AwsS3Service#SIGNER_SETTING
+         * @see AwsS3Service#LEGACY_SIGNER_SETTING
          */
         Setting<String> SIGNER_SETTING =
-            new Setting<>("cloud.aws.s3.signer", AwsS3Service.SIGNER_SETTING, Function.identity(), Property.NodeScope);
+            new Setting<>("cloud.aws.s3.signer", AwsS3Service.LEGACY_SIGNER_SETTING, Function.identity(),
+                Property.NodeScope, Property.Deprecated);
         /**
          * cloud.aws.s3.region: Region specific for S3 API calls. Defaults to cloud.aws.region.
-         * @see AwsS3Service#REGION_SETTING
+         * @see AwsS3Service#LEGACY_REGION_SETTING
          */
         Setting<String> REGION_SETTING =
-            new Setting<>("cloud.aws.s3.region", AwsS3Service.REGION_SETTING, s -> s.toLowerCase(Locale.ROOT),
-                Property.NodeScope);
+            new Setting<>("cloud.aws.s3.region", AwsS3Service.LEGACY_REGION_SETTING, s -> s.toLowerCase(Locale.ROOT),
+                Property.NodeScope, Property.Deprecated);
         /**
          * cloud.aws.s3.endpoint: Endpoint. If not set, endpoint will be guessed based on region setting.
          */
         Setting<String> ENDPOINT_SETTING = Setting.simpleString("cloud.aws.s3.endpoint", Property.NodeScope);
         /**
          * cloud.aws.s3.read_timeout: Socket read timeout. Defaults to cloud.aws.read_timeout
-         * @see AwsS3Service#READ_TIMEOUT
+         * @see AwsS3Service#LEGACY_READ_TIMEOUT
          */
         Setting<TimeValue> READ_TIMEOUT =
-            Setting.timeSetting("cloud.aws.s3.read_timeout", AwsS3Service.READ_TIMEOUT, Property.NodeScope);
+            Setting.timeSetting("cloud.aws.s3.read_timeout", AwsS3Service.LEGACY_READ_TIMEOUT, Property.NodeScope, Property.Deprecated);
     }
 
-    AmazonS3 client(Settings repositorySettings, String endpoint, Protocol protocol, String region, Integer maxRetries,
-                    boolean useThrottleRetries, Boolean pathStyleAccess);
+    AmazonS3 client(Settings repositorySettings, Integer maxRetries, boolean useThrottleRetries, Boolean pathStyleAccess);
 }

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/plugin/repository/s3/S3RepositoryPlugin.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/plugin/repository/s3/S3RepositoryPlugin.java
@@ -82,16 +82,16 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin {
     public List<Setting<?>> getSettings() {
         return Arrays.asList(
         // Register global cloud aws settings: cloud.aws (might have been registered in ec2 plugin)
-        AwsS3Service.LEGACY_KEY_SETTING,
-        AwsS3Service.LEGACY_SECRET_SETTING,
-        AwsS3Service.LEGACY_PROTOCOL_SETTING,
-        AwsS3Service.LEGACY_PROXY_HOST_SETTING,
-        AwsS3Service.LEGACY_PROXY_PORT_SETTING,
-        AwsS3Service.LEGACY_PROXY_USERNAME_SETTING,
-        AwsS3Service.LEGACY_PROXY_PASSWORD_SETTING,
-        AwsS3Service.LEGACY_SIGNER_SETTING,
-        AwsS3Service.LEGACY_REGION_SETTING,
-        AwsS3Service.LEGACY_READ_TIMEOUT,
+        AwsS3Service.KEY_SETTING,
+        AwsS3Service.SECRET_SETTING,
+        AwsS3Service.PROTOCOL_SETTING,
+        AwsS3Service.PROXY_HOST_SETTING,
+        AwsS3Service.PROXY_PORT_SETTING,
+        AwsS3Service.PROXY_USERNAME_SETTING,
+        AwsS3Service.PROXY_PASSWORD_SETTING,
+        AwsS3Service.SIGNER_SETTING,
+        AwsS3Service.REGION_SETTING,
+        AwsS3Service.READ_TIMEOUT,
 
         // Register S3 specific settings: cloud.aws.s3
         AwsS3Service.CLOUD_S3.KEY_SETTING,

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/plugin/repository/s3/S3RepositoryPlugin.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/plugin/repository/s3/S3RepositoryPlugin.java
@@ -82,16 +82,16 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin {
     public List<Setting<?>> getSettings() {
         return Arrays.asList(
         // Register global cloud aws settings: cloud.aws (might have been registered in ec2 plugin)
-        AwsS3Service.KEY_SETTING,
-        AwsS3Service.SECRET_SETTING,
-        AwsS3Service.PROTOCOL_SETTING,
-        AwsS3Service.PROXY_HOST_SETTING,
-        AwsS3Service.PROXY_PORT_SETTING,
-        AwsS3Service.PROXY_USERNAME_SETTING,
-        AwsS3Service.PROXY_PASSWORD_SETTING,
-        AwsS3Service.SIGNER_SETTING,
-        AwsS3Service.REGION_SETTING,
-        AwsS3Service.READ_TIMEOUT,
+        AwsS3Service.LEGACY_KEY_SETTING,
+        AwsS3Service.LEGACY_SECRET_SETTING,
+        AwsS3Service.LEGACY_PROTOCOL_SETTING,
+        AwsS3Service.LEGACY_PROXY_HOST_SETTING,
+        AwsS3Service.LEGACY_PROXY_PORT_SETTING,
+        AwsS3Service.LEGACY_PROXY_USERNAME_SETTING,
+        AwsS3Service.LEGACY_PROXY_PASSWORD_SETTING,
+        AwsS3Service.LEGACY_SIGNER_SETTING,
+        AwsS3Service.LEGACY_REGION_SETTING,
+        AwsS3Service.LEGACY_READ_TIMEOUT,
 
         // Register S3 specific settings: cloud.aws.s3
         AwsS3Service.CLOUD_S3.KEY_SETTING,

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -21,8 +21,11 @@ package org.elasticsearch.repositories.s3;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
 import org.elasticsearch.cloud.aws.AwsS3Service;
 import org.elasticsearch.cloud.aws.AwsS3Service.CLOUD_S3;
+import org.elasticsearch.cloud.aws.InternalAwsS3Service;
 import org.elasticsearch.cloud.aws.blobstore.S3BlobStore;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.common.Strings;
@@ -31,10 +34,12 @@ import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.settings.SecureSetting;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.AffixSetting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.repositories.RepositoryException;
@@ -42,7 +47,6 @@ import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 
 import java.io.IOException;
 import java.util.Locale;
-import java.util.function.Function;
 
 /**
  * Shared file system implementation of the BlobStoreRepository
@@ -61,6 +65,49 @@ public class S3Repository extends BlobStoreRepository {
 
     public static final String TYPE = "s3";
 
+    // prefix for aws client settings
+    private static final String PREFIX = "aws.config.";
+
+    /** The access key (ie login id) for connecting to s3. */
+    public static final AffixSetting<SecureString> ACCESS_KEY_SETTING = Setting.affixKeySetting(PREFIX, "access_key",
+        key -> SecureSetting.secureString(key, Repositories.KEY_SETTING, false));
+
+    /** The secret key (ie password) for connecting to s3. */
+    public static final AffixSetting<SecureString> SECRET_KEY_SETTING = Setting.affixKeySetting(PREFIX, "secret_key",
+        key -> SecureSetting.secureString(key, Repositories.SECRET_SETTING, false));
+
+    /** The region the s3 repository bucket should exist in. */
+    public static final AffixSetting<String> REGION_SETTING = Setting.affixKeySetting(PREFIX, "region",
+        key -> new Setting<>(key, "", s -> s.toLowerCase(Locale.ROOT), Property.NodeScope));
+
+    /** An override for the s3 endpoint to connect to. */
+    public static final AffixSetting<String> ENDPOINT_SETTING = Setting.affixKeySetting(PREFIX, "endpoint",
+        key -> new Setting<>(key, Repositories.ENDPOINT_SETTING, s -> s.toLowerCase(Locale.ROOT), Property.NodeScope));
+
+    /** The protocol to use to connec to to s3. */
+    public static final AffixSetting<Protocol> PROTOCOL_SETTING = Setting.affixKeySetting(PREFIX, "protocol",
+        key -> new Setting<>(key, "https", s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)), Property.NodeScope));
+
+    /** The host name of a proxy to connect to s3 through. */
+    public static final AffixSetting<String> PROXY_HOST_SETTING = Setting.affixKeySetting(PREFIX, "proxy.host",
+        key -> Setting.simpleString(key, Property.NodeScope));
+
+    /** The port of a proxy to connect to s3 through. */
+    public static final AffixSetting<Integer> PROXY_PORT_SETTING = Setting.affixKeySetting(PREFIX, "proxy.port",
+        key -> Setting.intSetting(key, 80, 0, 1<<16, Property.NodeScope));
+
+    /** The username of a proxy to connect to s3 through. */
+    public static final AffixSetting<SecureString> PROXY_USERNAME_SETTING = Setting.affixKeySetting(PREFIX, "proxy.username",
+        key -> SecureSetting.secureString(key, AwsS3Service.LEGACY_PROXY_USERNAME_SETTING, false));
+
+    /** The password of a proxy to connect to s3 through. */
+    public static final AffixSetting<SecureString> PROXY_PASSWORD_SETTING = Setting.affixKeySetting(PREFIX, "proxy.password",
+        key -> SecureSetting.secureString(key, AwsS3Service.LEGACY_PROXY_PASSWORD_SETTING, false));
+
+    /** The socket timeout for connecting to s3. */
+    public static final AffixSetting<TimeValue> READ_TIMEOUT_SETTING = Setting.affixKeySetting(PREFIX, "read_timeout",
+        key -> Setting.timeSetting(key, TimeValue.timeValueMillis(ClientConfiguration.DEFAULT_SOCKET_TIMEOUT), Property.NodeScope));
+
     /**
      * Global S3 repositories settings. Starting with: repositories.s3
      */
@@ -69,32 +116,34 @@ public class S3Repository extends BlobStoreRepository {
          * repositories.s3.access_key: AWS Access key specific for all S3 Repositories API calls. Defaults to cloud.aws.s3.access_key.
          * @see CLOUD_S3#KEY_SETTING
          */
-        SecureSetting<SecureString> KEY_SETTING = SecureSetting.secureString("repositories.s3.access_key", CLOUD_S3.KEY_SETTING, true);
+        Setting<SecureString> KEY_SETTING = new Setting<>("repositories.s3.access_key", CLOUD_S3.KEY_SETTING, SecureString::new,
+            Property.NodeScope, Property.Filtered, Property.Deprecated);
 
         /**
          * repositories.s3.secret_key: AWS Secret key specific for all S3 Repositories API calls. Defaults to cloud.aws.s3.secret_key.
          * @see CLOUD_S3#SECRET_SETTING
          */
-        SecureSetting<SecureString> SECRET_SETTING = SecureSetting.secureString("repositories.s3.secret_key", CLOUD_S3.SECRET_SETTING, true);
+        Setting<SecureString> SECRET_SETTING = new Setting<>("repositories.s3.secret_key", CLOUD_S3.SECRET_SETTING, SecureString::new,
+            Property.NodeScope, Property.Filtered, Property.Deprecated);
 
         /**
          * repositories.s3.region: Region specific for all S3 Repositories API calls. Defaults to cloud.aws.s3.region.
          * @see CLOUD_S3#REGION_SETTING
          */
-        Setting<String> REGION_SETTING =
-            new Setting<>("repositories.s3.region", CLOUD_S3.REGION_SETTING, s -> s.toLowerCase(Locale.ROOT), Property.NodeScope);
+        Setting<String> REGION_SETTING = new Setting<>("repositories.s3.region", CLOUD_S3.REGION_SETTING,
+            s -> s.toLowerCase(Locale.ROOT), Property.NodeScope, Property.Deprecated);
         /**
          * repositories.s3.endpoint: Endpoint specific for all S3 Repositories API calls. Defaults to cloud.aws.s3.endpoint.
          * @see CLOUD_S3#ENDPOINT_SETTING
          */
-        Setting<String> ENDPOINT_SETTING =
-            new Setting<>("repositories.s3.endpoint", CLOUD_S3.ENDPOINT_SETTING, s -> s.toLowerCase(Locale.ROOT), Property.NodeScope);
+        Setting<String> ENDPOINT_SETTING = new Setting<>("repositories.s3.endpoint", CLOUD_S3.ENDPOINT_SETTING,
+            s -> s.toLowerCase(Locale.ROOT), Property.NodeScope, Property.Deprecated);
         /**
          * repositories.s3.protocol: Protocol specific for all S3 Repositories API calls. Defaults to cloud.aws.s3.protocol.
          * @see CLOUD_S3#PROTOCOL_SETTING
          */
-        Setting<Protocol> PROTOCOL_SETTING =
-            new Setting<>("repositories.s3.protocol", CLOUD_S3.PROTOCOL_SETTING, s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)), Property.NodeScope);
+        Setting<Protocol> PROTOCOL_SETTING = new Setting<>("repositories.s3.protocol", CLOUD_S3.PROTOCOL_SETTING,
+            s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)), Property.NodeScope, Property.Deprecated);
         /**
          * repositories.s3.bucket: The name of the bucket to be used for snapshots.
          */
@@ -177,37 +226,30 @@ public class S3Repository extends BlobStoreRepository {
      * If undefined, they use the repositories.s3.xxx equivalent setting.
      */
     public interface Repository {
-        /**
-         * access_key
-         * @see  Repositories#KEY_SETTING
-         */
-        SecureSetting<SecureString> KEY_SETTING = SecureSetting.secureString("access_key", null, true);
+        Setting<SecureString> KEY_SETTING = new Setting<>("access_key", "", SecureString::new,
+            Property.Filtered, Property.Deprecated);
 
-        /**
-         * secret_key
-         * @see  Repositories#SECRET_SETTING
-         */
-        SecureSetting<SecureString> SECRET_SETTING = SecureSetting.secureString("secret_key", null, true);
-        /**
-         * bucket
-         * @see  Repositories#BUCKET_SETTING
-         */
+
+        Setting<SecureString> SECRET_SETTING = new Setting<>("secret_key", "", SecureString::new,
+            Property.Filtered, Property.Deprecated);
+
         Setting<String> BUCKET_SETTING = Setting.simpleString("bucket");
         /**
          * endpoint
          * @see  Repositories#ENDPOINT_SETTING
          */
-        Setting<String> ENDPOINT_SETTING = Setting.simpleString("endpoint");
+        Setting<String> ENDPOINT_SETTING = Setting.simpleString("endpoint", Property.Deprecated);
         /**
          * protocol
          * @see  Repositories#PROTOCOL_SETTING
          */
-        Setting<Protocol> PROTOCOL_SETTING = new Setting<>("protocol", "https", s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)));
+        Setting<Protocol> PROTOCOL_SETTING = new Setting<>("protocol", "https", s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)),
+            Property.Deprecated);
         /**
          * region
          * @see  Repositories#REGION_SETTING
          */
-        Setting<String> REGION_SETTING = new Setting<>("region", "", s -> s.toLowerCase(Locale.ROOT));
+        Setting<String> REGION_SETTING = new Setting<>("region", "", s -> s.toLowerCase(Locale.ROOT), Property.Deprecated);
         /**
          * server_side_encryption
          * @see  Repositories#SERVER_SIDE_ENCRYPTION_SETTING
@@ -286,10 +328,6 @@ public class S3Repository extends BlobStoreRepository {
             throw new RepositoryException(metadata.name(), "No bucket defined for s3 gateway");
         }
 
-        String endpoint = getValue(metadata.settings(), settings, Repository.ENDPOINT_SETTING, Repositories.ENDPOINT_SETTING);
-        Protocol protocol = getValue(metadata.settings(), settings, Repository.PROTOCOL_SETTING, Repositories.PROTOCOL_SETTING);
-        String region = getValue(metadata.settings(), settings, Repository.REGION_SETTING, Repositories.REGION_SETTING);
-
         boolean serverSideEncryption = getValue(metadata.settings(), settings, Repository.SERVER_SIDE_ENCRYPTION_SETTING, Repositories.SERVER_SIDE_ENCRYPTION_SETTING);
         ByteSizeValue bufferSize = getValue(metadata.settings(), settings, Repository.BUFFER_SIZE_SETTING, Repositories.BUFFER_SIZE_SETTING);
         Integer maxRetries = getValue(metadata.settings(), settings, Repository.MAX_RETRIES_SETTING, Repositories.MAX_RETRIES_SETTING);
@@ -315,13 +353,14 @@ public class S3Repository extends BlobStoreRepository {
             pathStyleAccess = getValue(metadata.settings(), settings, Repository.PATH_STYLE_ACCESS_SETTING, Repositories.PATH_STYLE_ACCESS_SETTING);
         }
 
-        logger.debug("using bucket [{}], region [{}], endpoint [{}], protocol [{}], chunk_size [{}], server_side_encryption [{}], " +
+        logger.debug("using bucket [{}], chunk_size [{}], server_side_encryption [{}], " +
             "buffer_size [{}], max_retries [{}], use_throttle_retries [{}], cannedACL [{}], storageClass [{}], path_style_access [{}]",
-            bucket, region, endpoint, protocol, chunkSize, serverSideEncryption, bufferSize, maxRetries, useThrottleRetries, cannedACL,
+            bucket, chunkSize, serverSideEncryption, bufferSize, maxRetries, useThrottleRetries, cannedACL,
             storageClass, pathStyleAccess);
 
-        blobStore = new S3BlobStore(settings,
-            s3Service.client(metadata.settings(), endpoint, protocol, region, maxRetries, useThrottleRetries, pathStyleAccess),
+        AmazonS3 client = s3Service.client(metadata.settings(), maxRetries, useThrottleRetries, pathStyleAccess);
+        String region = InternalAwsS3Service.getRegion(metadata.settings(), settings);
+        blobStore = new S3BlobStore(settings, client,
                 bucket, region, serverSideEncryption, bufferSize, maxRetries, cannedACL, storageClass);
 
         String basePath = getValue(metadata.settings(), settings, Repository.BASE_PATH_SETTING, Repositories.BASE_PATH_SETTING);

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -22,7 +22,6 @@ package org.elasticsearch.repositories.s3;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
 import org.elasticsearch.cloud.aws.AwsS3Service;
 import org.elasticsearch.cloud.aws.AwsS3Service.CLOUD_S3;
 import org.elasticsearch.cloud.aws.InternalAwsS3Service;
@@ -65,8 +64,8 @@ public class S3Repository extends BlobStoreRepository {
 
     public static final String TYPE = "s3";
 
-    // prefix for aws client settings
-    private static final String PREFIX = "aws.config.";
+    // prefix for s3 client settings
+    private static final String PREFIX = "s3.client.";
 
     /** The access key (ie login id) for connecting to s3. */
     public static final AffixSetting<SecureString> ACCESS_KEY_SETTING = Setting.affixKeySetting(PREFIX, "access_key",
@@ -98,11 +97,11 @@ public class S3Repository extends BlobStoreRepository {
 
     /** The username of a proxy to connect to s3 through. */
     public static final AffixSetting<SecureString> PROXY_USERNAME_SETTING = Setting.affixKeySetting(PREFIX, "proxy.username",
-        key -> SecureSetting.secureString(key, AwsS3Service.LEGACY_PROXY_USERNAME_SETTING, false));
+        key -> SecureSetting.secureString(key, AwsS3Service.PROXY_USERNAME_SETTING, false));
 
     /** The password of a proxy to connect to s3 through. */
     public static final AffixSetting<SecureString> PROXY_PASSWORD_SETTING = Setting.affixKeySetting(PREFIX, "proxy.password",
-        key -> SecureSetting.secureString(key, AwsS3Service.LEGACY_PROXY_PASSWORD_SETTING, false));
+        key -> SecureSetting.secureString(key, AwsS3Service.PROXY_PASSWORD_SETTING, false));
 
     /** The socket timeout for connecting to s3. */
     public static final AffixSetting<TimeValue> READ_TIMEOUT_SETTING = Setting.affixKeySetting(PREFIX, "read_timeout",
@@ -110,6 +109,7 @@ public class S3Repository extends BlobStoreRepository {
 
     /**
      * Global S3 repositories settings. Starting with: repositories.s3
+     * NOTE: These are legacy settings. Use the named client config settings above.
      */
     public interface Repositories {
         /**

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/AwsS3ServiceImplTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/AwsS3ServiceImplTests.java
@@ -23,7 +23,6 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -38,115 +37,41 @@ public class AwsS3ServiceImplTests extends ESTestCase {
 
     public void testAWSCredentialsWithSystemProviders() {
         AWSCredentialsProvider credentialsProvider =
-            InternalAwsS3Service.buildCredentials(logger, deprecationLogger, Settings.EMPTY, Settings.EMPTY);
+            InternalAwsS3Service.buildCredentials(logger, deprecationLogger, Settings.EMPTY, Settings.EMPTY, "default");
         assertThat(credentialsProvider, instanceOf(InstanceProfileCredentialsProvider.class));
     }
 
-    public void testAWSCredentialsWithElasticsearchAwsSettings() {
+    public void testAwsCredsDefaultSettings() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(AwsS3Service.KEY_SETTING.getKey(), "aws_key");
-        secureSettings.setString(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret");
+        secureSettings.setString("aws.config.default.access_key", "aws_key");
+        secureSettings.setString("aws.config.default.secret_key", "aws_secret");
         Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
         launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "aws_key", "aws_secret");
     }
 
-    public void testAWSCredentialsWithElasticsearchS3Settings() {
+    public void testAwsCredsExplicitConfigSettings() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
+        repositorySettings = Settings.builder().put(repositorySettings)
+            .put(InternalAwsS3Service.CONFIG_NAME.getKey(), "myconfig").build();
         MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(AwsS3Service.CLOUD_S3.KEY_SETTING.getKey(), "s3_key");
-        secureSettings.setString(AwsS3Service.CLOUD_S3.SECRET_SETTING.getKey(), "s3_secret");
+        secureSettings.setString("aws.config.myconfig.access_key", "aws_key");
+        secureSettings.setString("aws.config.myconfig.secret_key", "aws_secret");
+        secureSettings.setString("aws.config.default.access_key", "wrong_key");
+        secureSettings.setString("aws.config.default.secret_key", "wrong_secret");
         Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
-        launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "s3_key", "s3_secret");
-    }
-
-    public void testAWSCredentialsWithElasticsearchAwsAndS3Settings() {
-        Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
-        MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(AwsS3Service.KEY_SETTING.getKey(), "aws_key");
-        secureSettings.setString(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret");
-        secureSettings.setString(AwsS3Service.CLOUD_S3.KEY_SETTING.getKey(), "s3_key");
-        secureSettings.setString(AwsS3Service.CLOUD_S3.SECRET_SETTING.getKey(), "s3_secret");
-        Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
-        launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "s3_key", "s3_secret");
-    }
-
-    public void testAWSCredentialsWithElasticsearchRepositoriesSettings() {
-        Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
-        MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(S3Repository.Repositories.KEY_SETTING.getKey(), "repositories_key");
-        secureSettings.setString(S3Repository.Repositories.SECRET_SETTING.getKey(), "repositories_secret");
-        Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
-        launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "repositories_key", "repositories_secret");
-    }
-
-
-    public void testAWSCredentialsWithElasticsearchAwsAndRepositoriesSettings() {
-        Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
-        MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(AwsS3Service.KEY_SETTING.getKey(), "aws_key");
-        secureSettings.setString(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret");
-        secureSettings.setString(S3Repository.Repositories.KEY_SETTING.getKey(), "repositories_key");
-        secureSettings.setString(S3Repository.Repositories.SECRET_SETTING.getKey(), "repositories_secret");
-        Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
-        launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "repositories_key", "repositories_secret");
-    }
-
-    public void testAWSCredentialsWithElasticsearchAwsAndS3AndRepositoriesSettings() {
-        Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
-        MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(AwsS3Service.KEY_SETTING.getKey(), "aws_key");
-        secureSettings.setString(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret");
-        secureSettings.setString(AwsS3Service.CLOUD_S3.KEY_SETTING.getKey(), "s3_key");
-        secureSettings.setString(AwsS3Service.CLOUD_S3.SECRET_SETTING.getKey(), "s3_secret");
-        secureSettings.setString(S3Repository.Repositories.KEY_SETTING.getKey(), "repositories_key");
-        secureSettings.setString(S3Repository.Repositories.SECRET_SETTING.getKey(), "repositories_secret");
-        Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
-        launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "repositories_key", "repositories_secret");
-    }
-
-    public void testAWSCredentialsWithElasticsearchRepositoriesSettingsAndRepositorySettings() {
-        Settings repositorySettings = generateSecureRepositorySettings("repository_key", "repository_secret", "eu-central", null, null);
-        MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(S3Repository.Repositories.KEY_SETTING.getKey(), "repositories_key");
-        secureSettings.setString(S3Repository.Repositories.SECRET_SETTING.getKey(), "repositories_secret");
-        Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
-        launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "repository_key", "repository_secret");
-    }
-
-    public void testAWSCredentialsWithElasticsearchAwsAndRepositoriesSettingsAndRepositorySettings() {
-        Settings repositorySettings = generateSecureRepositorySettings("repository_key", "repository_secret", "eu-central", null, null);
-        MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(AwsS3Service.KEY_SETTING.getKey(), "aws_key");
-        secureSettings.setString(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret");
-        secureSettings.setString(S3Repository.Repositories.KEY_SETTING.getKey(), "repositories_key");
-        secureSettings.setString(S3Repository.Repositories.SECRET_SETTING.getKey(), "repositories_secret");
-        Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
-        launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "repository_key", "repository_secret");
-    }
-
-    public void testAWSCredentialsWithElasticsearchAwsAndS3AndRepositoriesSettingsAndRepositorySettings() {
-        Settings repositorySettings = generateSecureRepositorySettings("repository_key", "repository_secret", "eu-central", null, null);
-        MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(AwsS3Service.KEY_SETTING.getKey(), "aws_key");
-        secureSettings.setString(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret");
-        secureSettings.setString(AwsS3Service.CLOUD_S3.KEY_SETTING.getKey(), "s3_key");
-        secureSettings.setString(AwsS3Service.CLOUD_S3.SECRET_SETTING.getKey(), "s3_secret");
-        secureSettings.setString(S3Repository.Repositories.KEY_SETTING.getKey(), "repositories_key");
-        secureSettings.setString(S3Repository.Repositories.SECRET_SETTING.getKey(), "repositories_secret");
-        Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
-        launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "repository_key", "repository_secret");
+        launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "aws_key", "aws_secret");
     }
 
     public void testAWSCredentialsWithElasticsearchAwsSettingsBackcompat() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         Settings settings = Settings.builder()
-            .put(AwsS3Service.KEY_SETTING.getKey(), "aws_key")
-            .put(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret")
+            .put(AwsS3Service.LEGACY_KEY_SETTING.getKey(), "aws_key")
+            .put(AwsS3Service.LEGACY_SECRET_SETTING.getKey(), "aws_secret")
             .build();
         launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "aws_key", "aws_secret");
-        assertWarnings("[" + AwsS3Service.KEY_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.SECRET_SETTING.getKey() + "] setting was deprecated");
+        assertWarnings("[" + AwsS3Service.LEGACY_KEY_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.LEGACY_SECRET_SETTING.getKey() + "] setting was deprecated");
     }
 
     public void testAWSCredentialsWithElasticsearchS3SettingsBackcompat() {
@@ -163,13 +88,15 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     public void testAWSCredentialsWithElasticsearchAwsAndS3SettingsBackcompat() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         Settings settings = Settings.builder()
-            .put(AwsS3Service.KEY_SETTING.getKey(), "aws_key")
-            .put(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret")
+            .put(AwsS3Service.LEGACY_KEY_SETTING.getKey(), "aws_key")
+            .put(AwsS3Service.LEGACY_SECRET_SETTING.getKey(), "aws_secret")
             .put(AwsS3Service.CLOUD_S3.KEY_SETTING.getKey(), "s3_key")
             .put(AwsS3Service.CLOUD_S3.SECRET_SETTING.getKey(), "s3_secret")
             .build();
         launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "s3_key", "s3_secret");
-        assertWarnings("[" + AwsS3Service.CLOUD_S3.KEY_SETTING.getKey() + "] setting was deprecated",
+        assertWarnings("[" + AwsS3Service.LEGACY_KEY_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.LEGACY_SECRET_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.CLOUD_S3.KEY_SETTING.getKey() + "] setting was deprecated",
                        "[" + AwsS3Service.CLOUD_S3.SECRET_SETTING.getKey() + "] setting was deprecated");
     }
 
@@ -187,28 +114,34 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     public void testAWSCredentialsWithElasticsearchAwsAndRepositoriesSettingsBackcompat() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         Settings settings = Settings.builder()
-            .put(AwsS3Service.KEY_SETTING.getKey(), "aws_key")
-            .put(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret")
+            .put(AwsS3Service.LEGACY_KEY_SETTING.getKey(), "aws_key")
+            .put(AwsS3Service.LEGACY_SECRET_SETTING.getKey(), "aws_secret")
             .put(S3Repository.Repositories.KEY_SETTING.getKey(), "repositories_key")
             .put(S3Repository.Repositories.SECRET_SETTING.getKey(), "repositories_secret")
             .build();
         launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "repositories_key", "repositories_secret");
-        assertWarnings("[" + S3Repository.Repositories.KEY_SETTING.getKey() + "] setting was deprecated",
+        assertWarnings("[" + AwsS3Service.LEGACY_KEY_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.LEGACY_SECRET_SETTING.getKey() + "] setting was deprecated",
+                       "[" + S3Repository.Repositories.KEY_SETTING.getKey() + "] setting was deprecated",
                        "[" + S3Repository.Repositories.SECRET_SETTING.getKey() + "] setting was deprecated");
     }
 
     public void testAWSCredentialsWithElasticsearchAwsAndS3AndRepositoriesSettingsBackcompat() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         Settings settings = Settings.builder()
-            .put(AwsS3Service.KEY_SETTING.getKey(), "aws_key")
-            .put(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret")
+            .put(AwsS3Service.LEGACY_KEY_SETTING.getKey(), "aws_key")
+            .put(AwsS3Service.LEGACY_SECRET_SETTING.getKey(), "aws_secret")
             .put(AwsS3Service.CLOUD_S3.KEY_SETTING.getKey(), "s3_key")
             .put(AwsS3Service.CLOUD_S3.SECRET_SETTING.getKey(), "s3_secret")
             .put(S3Repository.Repositories.KEY_SETTING.getKey(), "repositories_key")
             .put(S3Repository.Repositories.SECRET_SETTING.getKey(), "repositories_secret")
             .build();
         launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "repositories_key", "repositories_secret");
-        assertWarnings("[" + S3Repository.Repositories.KEY_SETTING.getKey() + "] setting was deprecated",
+        assertWarnings("[" + AwsS3Service.LEGACY_KEY_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.LEGACY_SECRET_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.CLOUD_S3.KEY_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.CLOUD_S3.SECRET_SETTING.getKey() + "] setting was deprecated",
+                       "[" + S3Repository.Repositories.KEY_SETTING.getKey() + "] setting was deprecated",
                        "[" + S3Repository.Repositories.SECRET_SETTING.getKey() + "] setting was deprecated");
     }
 
@@ -226,8 +159,8 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     public void testAWSCredentialsWithElasticsearchAwsAndRepositoriesSettingsAndRepositorySettingsBackcompat() {
         Settings repositorySettings = generateRepositorySettings("repository_key", "repository_secret", "eu-central", null, null);
         Settings settings = Settings.builder()
-            .put(AwsS3Service.KEY_SETTING.getKey(), "aws_key")
-            .put(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret")
+            .put(AwsS3Service.LEGACY_KEY_SETTING.getKey(), "aws_key")
+            .put(AwsS3Service.LEGACY_SECRET_SETTING.getKey(), "aws_secret")
             .put(S3Repository.Repositories.KEY_SETTING.getKey(), "repositories_key")
             .put(S3Repository.Repositories.SECRET_SETTING.getKey(), "repositories_secret")
             .build();
@@ -239,8 +172,8 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     public void testAWSCredentialsWithElasticsearchAwsAndS3AndRepositoriesSettingsAndRepositorySettingsBackcompat() {
         Settings repositorySettings = generateRepositorySettings("repository_key", "repository_secret", "eu-central", null, null);
         Settings settings = Settings.builder()
-            .put(AwsS3Service.KEY_SETTING.getKey(), "aws_key")
-            .put(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret")
+            .put(AwsS3Service.LEGACY_KEY_SETTING.getKey(), "aws_key")
+            .put(AwsS3Service.LEGACY_SECRET_SETTING.getKey(), "aws_secret")
             .put(AwsS3Service.CLOUD_S3.KEY_SETTING.getKey(), "s3_key")
             .put(AwsS3Service.CLOUD_S3.SECRET_SETTING.getKey(), "s3_secret")
             .put(S3Repository.Repositories.KEY_SETTING.getKey(), "repositories_key")
@@ -253,8 +186,9 @@ public class AwsS3ServiceImplTests extends ESTestCase {
 
     protected void launchAWSCredentialsWithElasticsearchSettingsTest(Settings singleRepositorySettings, Settings settings,
                                                                      String expectedKey, String expectedSecret) {
-        AWSCredentials credentials =
-            InternalAwsS3Service.buildCredentials(logger, deprecationLogger, settings, singleRepositorySettings).getCredentials();
+        String configName = InternalAwsS3Service.CONFIG_NAME.get(singleRepositorySettings);
+        AWSCredentials credentials = InternalAwsS3Service.buildCredentials(logger, deprecationLogger, settings,
+            singleRepositorySettings, configName).getCredentials();
         assertThat(credentials.getAWSAccessKeyId(), is(expectedKey));
         assertThat(credentials.getAWSSecretKey(), is(expectedSecret));
     }
@@ -268,69 +202,51 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     public void testAWSConfigurationWithAwsSettings() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(AwsS3Service.PROXY_USERNAME_SETTING.getKey(), "aws_proxy_username");
-        secureSettings.setString(AwsS3Service.PROXY_PASSWORD_SETTING.getKey(), "aws_proxy_password");
+        secureSettings.setString("aws.config.default.proxy.username", "aws_proxy_username");
+        secureSettings.setString("aws.config.default.proxy.password", "aws_proxy_password");
         Settings settings = Settings.builder()
             .setSecureSettings(secureSettings)
-            .put(AwsS3Service.PROTOCOL_SETTING.getKey(), "http")
-            .put(AwsS3Service.PROXY_HOST_SETTING.getKey(), "aws_proxy_host")
-            .put(AwsS3Service.PROXY_PORT_SETTING.getKey(), 8080)
-            .put(AwsS3Service.SIGNER_SETTING.getKey(), "AWS3SignerType")
-            .put(AwsS3Service.READ_TIMEOUT.getKey(), "10s")
+            .put("aws.config.default.protocol", "http")
+            .put("aws.config.default.proxy.host", "aws_proxy_host")
+            .put("aws.config.default.proxy.port", 8080)
+            .put("aws.config.default.read_timeout", "10s")
             .build();
         launchAWSConfigurationTest(settings, repositorySettings, Protocol.HTTP, "aws_proxy_host", 8080, "aws_proxy_username",
-            "aws_proxy_password", "AWS3SignerType", 3, false, 10000);
-    }
-
-    public void testAWSConfigurationWithAwsAndS3Settings() {
-        Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
-        MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(AwsS3Service.PROXY_USERNAME_SETTING.getKey(), "aws_proxy_username");
-        secureSettings.setString(AwsS3Service.PROXY_PASSWORD_SETTING.getKey(), "aws_proxy_password");
-        secureSettings.setString(AwsS3Service.CLOUD_S3.PROXY_USERNAME_SETTING.getKey(), "s3_proxy_username");
-        secureSettings.setString(AwsS3Service.CLOUD_S3.PROXY_PASSWORD_SETTING.getKey(), "s3_proxy_password");
-        Settings settings = Settings.builder()
-            .setSecureSettings(secureSettings)
-            .put(AwsS3Service.PROTOCOL_SETTING.getKey(), "http")
-            .put(AwsS3Service.PROXY_HOST_SETTING.getKey(), "aws_proxy_host")
-            .put(AwsS3Service.PROXY_PORT_SETTING.getKey(), 8080)
-            .put(AwsS3Service.SIGNER_SETTING.getKey(), "AWS3SignerType")
-            .put(AwsS3Service.CLOUD_S3.PROTOCOL_SETTING.getKey(), "https")
-            .put(AwsS3Service.CLOUD_S3.PROXY_HOST_SETTING.getKey(), "s3_proxy_host")
-            .put(AwsS3Service.CLOUD_S3.PROXY_PORT_SETTING.getKey(), 8081)
-            .put(AwsS3Service.CLOUD_S3.SIGNER_SETTING.getKey(), "NoOpSignerType")
-            .put(AwsS3Service.CLOUD_S3.READ_TIMEOUT.getKey(), "10s")
-            .build();
-        launchAWSConfigurationTest(settings, repositorySettings, Protocol.HTTPS, "s3_proxy_host", 8081, "s3_proxy_username",
-            "s3_proxy_password", "NoOpSignerType", 3, false, 10000);
+            "aws_proxy_password", null, 3, false, 10000);
     }
 
     public void testAWSConfigurationWithAwsSettingsBackcompat() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         Settings settings = Settings.builder()
-            .put(AwsS3Service.PROTOCOL_SETTING.getKey(), "http")
-            .put(AwsS3Service.PROXY_HOST_SETTING.getKey(), "aws_proxy_host")
-            .put(AwsS3Service.PROXY_PORT_SETTING.getKey(), 8080)
-            .put(AwsS3Service.PROXY_USERNAME_SETTING.getKey(), "aws_proxy_username")
-            .put(AwsS3Service.PROXY_PASSWORD_SETTING.getKey(), "aws_proxy_password")
-            .put(AwsS3Service.SIGNER_SETTING.getKey(), "AWS3SignerType")
-            .put(AwsS3Service.READ_TIMEOUT.getKey(), "10s")
+            .put(AwsS3Service.LEGACY_PROTOCOL_SETTING.getKey(), "http")
+            .put(AwsS3Service.LEGACY_PROXY_HOST_SETTING.getKey(), "aws_proxy_host")
+            .put(AwsS3Service.LEGACY_PROXY_PORT_SETTING.getKey(), 8080)
+            .put(AwsS3Service.LEGACY_PROXY_USERNAME_SETTING.getKey(), "aws_proxy_username")
+            .put(AwsS3Service.LEGACY_PROXY_PASSWORD_SETTING.getKey(), "aws_proxy_password")
+            .put(AwsS3Service.LEGACY_SIGNER_SETTING.getKey(), "AWS3SignerType")
+            .put(AwsS3Service.LEGACY_READ_TIMEOUT.getKey(), "10s")
             .build();
         launchAWSConfigurationTest(settings, repositorySettings, Protocol.HTTP, "aws_proxy_host", 8080, "aws_proxy_username",
             "aws_proxy_password", "AWS3SignerType", 3, false, 10000);
-        assertWarnings("[" + AwsS3Service.PROXY_USERNAME_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.PROXY_PASSWORD_SETTING.getKey() + "] setting was deprecated");
+        assertWarnings("[" + AwsS3Service.LEGACY_PROXY_USERNAME_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.LEGACY_PROXY_PASSWORD_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.LEGACY_PROTOCOL_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.LEGACY_PROXY_HOST_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.LEGACY_PROXY_PORT_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.LEGACY_SIGNER_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.LEGACY_READ_TIMEOUT.getKey() + "] setting was deprecated");
     }
 
     public void testAWSConfigurationWithAwsAndS3SettingsBackcompat() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         Settings settings = Settings.builder()
-            .put(AwsS3Service.PROTOCOL_SETTING.getKey(), "http")
-            .put(AwsS3Service.PROXY_HOST_SETTING.getKey(), "aws_proxy_host")
-            .put(AwsS3Service.PROXY_PORT_SETTING.getKey(), 8080)
-            .put(AwsS3Service.PROXY_USERNAME_SETTING.getKey(), "aws_proxy_username")
-            .put(AwsS3Service.PROXY_PASSWORD_SETTING.getKey(), "aws_proxy_password")
-            .put(AwsS3Service.SIGNER_SETTING.getKey(), "AWS3SignerType")
+            .put(AwsS3Service.LEGACY_PROTOCOL_SETTING.getKey(), "http")
+            .put(AwsS3Service.LEGACY_PROXY_HOST_SETTING.getKey(), "aws_proxy_host")
+            .put(AwsS3Service.LEGACY_PROXY_PORT_SETTING.getKey(), 8080)
+            .put(AwsS3Service.LEGACY_PROXY_USERNAME_SETTING.getKey(), "aws_proxy_username")
+            .put(AwsS3Service.LEGACY_PROXY_PASSWORD_SETTING.getKey(), "aws_proxy_password")
+            .put(AwsS3Service.LEGACY_SIGNER_SETTING.getKey(), "AWS3SignerType")
+            .put(AwsS3Service.LEGACY_READ_TIMEOUT.getKey(), "5s")
             .put(AwsS3Service.CLOUD_S3.PROTOCOL_SETTING.getKey(), "https")
             .put(AwsS3Service.CLOUD_S3.PROXY_HOST_SETTING.getKey(), "s3_proxy_host")
             .put(AwsS3Service.CLOUD_S3.PROXY_PORT_SETTING.getKey(), 8081)
@@ -341,8 +257,20 @@ public class AwsS3ServiceImplTests extends ESTestCase {
             .build();
         launchAWSConfigurationTest(settings, repositorySettings, Protocol.HTTPS, "s3_proxy_host", 8081, "s3_proxy_username",
             "s3_proxy_password", "NoOpSignerType", 3, false, 10000);
-        assertWarnings("[" + AwsS3Service.CLOUD_S3.PROXY_USERNAME_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.CLOUD_S3.PROXY_PASSWORD_SETTING.getKey() + "] setting was deprecated");
+        assertWarnings("[" + AwsS3Service.LEGACY_PROXY_USERNAME_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.LEGACY_PROXY_PASSWORD_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.LEGACY_PROTOCOL_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.LEGACY_PROXY_HOST_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.LEGACY_PROXY_PORT_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.LEGACY_SIGNER_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.LEGACY_READ_TIMEOUT.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.CLOUD_S3.PROXY_USERNAME_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.CLOUD_S3.PROXY_PASSWORD_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.CLOUD_S3.PROTOCOL_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.CLOUD_S3.PROXY_HOST_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.CLOUD_S3.PROXY_PORT_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.CLOUD_S3.SIGNER_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.CLOUD_S3.READ_TIMEOUT.getKey() + "] setting was deprecated");
     }
 
     protected void launchAWSConfigurationTest(Settings settings,
@@ -356,15 +284,13 @@ public class AwsS3ServiceImplTests extends ESTestCase {
                                               Integer expectedMaxRetries,
                                               boolean expectedUseThrottleRetries,
                                               int expectedReadTimeout) {
-        Protocol protocol = S3Repository.getValue(singleRepositorySettings, settings,
-            S3Repository.Repository.PROTOCOL_SETTING, S3Repository.Repositories.PROTOCOL_SETTING);
         Integer maxRetries = S3Repository.getValue(singleRepositorySettings, settings,
             S3Repository.Repository.MAX_RETRIES_SETTING, S3Repository.Repositories.MAX_RETRIES_SETTING);
         Boolean useThrottleRetries = S3Repository.getValue(singleRepositorySettings, settings,
             S3Repository.Repository.USE_THROTTLE_RETRIES_SETTING, S3Repository.Repositories.USE_THROTTLE_RETRIES_SETTING);
 
-        ClientConfiguration configuration = InternalAwsS3Service.buildConfiguration(logger, settings, protocol, maxRetries, null,
-            useThrottleRetries);
+        ClientConfiguration configuration = InternalAwsS3Service.buildConfiguration(logger, singleRepositorySettings, settings,
+            "default", maxRetries, null, useThrottleRetries);
 
         assertThat(configuration.getResponseMetadataCacheSize(), is(0));
         assertThat(configuration.getProtocol(), is(expectedProtocol));
@@ -398,84 +324,84 @@ public class AwsS3ServiceImplTests extends ESTestCase {
         return builder.build();
     }
 
-    private static Settings generateSecureRepositorySettings(String key, String secret, String region, String endpoint,
-                                                             Integer maxRetries) {
-        Settings settings = generateRepositorySettings(null, null, region, endpoint, maxRetries);
-        MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(S3Repository.Repository.KEY_SETTING.getKey(), key);
-        secureSettings.setString(S3Repository.Repository.SECRET_SETTING.getKey(), secret);
-        return Settings.builder().put(settings).setSecureSettings(secureSettings).build();
-    }
-
     public void testDefaultEndpoint() {
-        launchAWSEndpointTest(generateRepositorySettings("repository_key", "repository_secret", null, null, null), Settings.EMPTY, "");
-        launchAWSEndpointTest(generateRepositorySettings("repository_key", "repository_secret", "eu-central", null, null), Settings.EMPTY,
-            "s3.eu-central-1.amazonaws.com");
-        launchAWSEndpointTest(generateRepositorySettings("repository_key", "repository_secret", null, "repository.endpoint", null),
+        assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, null, null), Settings.EMPTY, "");
+    }
+
+    public void testEndpointSetting() {
+        Settings settings = Settings.builder()
+            .put("aws.config.default.endpoint", "ec2.endpoint")
+            .build();
+        assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, null, null), settings,
+            "ec2.endpoint");
+    }
+
+    public void testEndpointSettingBackcompat() {
+        assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, "repository.endpoint", null),
             Settings.EMPTY, "repository.endpoint");
+        assertWarnings("[" + S3Repository.Repository.ENDPOINT_SETTING.getKey() + "] setting was deprecated");
+        Settings settings = Settings.builder()
+            .put(S3Repository.Repositories.ENDPOINT_SETTING.getKey(), "repositories.endpoint")
+            .build();
+        assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, null, null), settings,
+            "repositories.endpoint");
+        assertWarnings("[" + S3Repository.Repositories.ENDPOINT_SETTING.getKey() + "] setting was deprecated");
     }
 
-    public void testSpecificEndpoint() {
+    public void testRegionSetting() {
         Settings settings = Settings.builder()
-            .put(InternalAwsS3Service.CLOUD_S3.ENDPOINT_SETTING.getKey(), "ec2.endpoint")
+            .put("aws.config.default.region", randomFrom("eu-west", "eu-west-1"))
             .build();
-        launchAWSEndpointTest(generateRepositorySettings("repository_key", "repository_secret", null, null, null), settings,
-            "ec2.endpoint");
-        // Endpoint has precedence on region. Whatever region we set, we won't use it
-        launchAWSEndpointTest(generateRepositorySettings("repository_key", "repository_secret", "eu-central", null, null), settings,
-            "ec2.endpoint");
-        launchAWSEndpointTest(generateRepositorySettings("repository_key", "repository_secret", null, "repository.endpoint", null),
-            settings, "repository.endpoint");
-    }
-
-    public void testRegionWithAwsSettings() {
-        Settings settings = Settings.builder()
-            .put(InternalAwsS3Service.REGION_SETTING.getKey(), randomFrom("eu-west", "eu-west-1"))
-            .build();
-        launchAWSEndpointTest(generateRepositorySettings("repository_key", "repository_secret", null, null, null), settings,
+        assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, null, null), settings,
             "s3-eu-west-1.amazonaws.com");
-        launchAWSEndpointTest(generateRepositorySettings("repository_key", "repository_secret", "eu-central", null, null), settings,
-            "s3.eu-central-1.amazonaws.com");
-        launchAWSEndpointTest(generateRepositorySettings("repository_key", "repository_secret", null, "repository.endpoint", null),
-            settings, "repository.endpoint");
     }
 
-    public void testRegionWithAwsAndS3Settings() {
+    public void testRegionSettingBackcompat() {
         Settings settings = Settings.builder()
-            .put(InternalAwsS3Service.REGION_SETTING.getKey(), randomFrom("eu-west", "eu-west-1"))
+            .put(InternalAwsS3Service.LEGACY_REGION_SETTING.getKey(), randomFrom("eu-west", "eu-west-1"))
+            .build();
+        assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, null, null), settings,
+            "s3-eu-west-1.amazonaws.com");
+        assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", "eu-central", null, null), settings,
+            "s3.eu-central-1.amazonaws.com");
+        assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, "repository.endpoint", null),
+            settings, "repository.endpoint");
+        assertWarnings("[" + InternalAwsS3Service.LEGACY_REGION_SETTING.getKey() + "] setting was deprecated",
+                       "[" + S3Repository.Repository.REGION_SETTING.getKey() + "] setting was deprecated",
+                       "[" + S3Repository.Repository.ENDPOINT_SETTING.getKey() + "] setting was deprecated");
+    }
+
+    public void testRegionAndEndpointSettingBackcompatPrecedence() {
+        Settings settings = Settings.builder()
+            .put(InternalAwsS3Service.LEGACY_REGION_SETTING.getKey(), randomFrom("eu-west", "eu-west-1"))
             .put(InternalAwsS3Service.CLOUD_S3.REGION_SETTING.getKey(), randomFrom("us-west", "us-west-1"))
             .build();
-        launchAWSEndpointTest(generateRepositorySettings("repository_key", "repository_secret", null, null, null), settings,
+        assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, null, null), settings,
             "s3-us-west-1.amazonaws.com");
-        launchAWSEndpointTest(generateRepositorySettings("repository_key", "repository_secret", "eu-central", null, null), settings,
+        assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", "eu-central", null, null), settings,
             "s3.eu-central-1.amazonaws.com");
-        launchAWSEndpointTest(generateRepositorySettings("repository_key", "repository_secret", null, "repository.endpoint", null),
+        assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, "repository.endpoint", null),
             settings, "repository.endpoint");
+        assertWarnings("[" + InternalAwsS3Service.LEGACY_REGION_SETTING.getKey() + "] setting was deprecated",
+                       "[" + S3Repository.Repository.REGION_SETTING.getKey() + "] setting was deprecated",
+                       "[" + InternalAwsS3Service.CLOUD_S3.REGION_SETTING.getKey() + "] setting was deprecated",
+                       "[" + S3Repository.Repository.ENDPOINT_SETTING.getKey() + "] setting was deprecated");
     }
 
     public void testInvalidRegion() {
         Settings settings = Settings.builder()
-            .put(InternalAwsS3Service.REGION_SETTING.getKey(), "does-not-exist")
+            .put("aws.config.default.region", "does-not-exist")
             .build();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
-            launchAWSEndpointTest(generateRepositorySettings("repository_key", "repository_secret", null, null, null), settings, null);
+            assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, null, null), settings, null);
         });
         assertThat(e.getMessage(), containsString("No automatic endpoint could be derived from region"));
-
-        launchAWSEndpointTest(generateRepositorySettings("repository_key", "repository_secret", "eu-central", null, null), settings,
-            "s3.eu-central-1.amazonaws.com");
-        launchAWSEndpointTest(generateRepositorySettings("repository_key", "repository_secret", null, "repository.endpoint", null),
-            settings, "repository.endpoint");
     }
 
-    protected void launchAWSEndpointTest(Settings singleRepositorySettings, Settings settings,
-                                         String expectedEndpoint) {
-        String region = S3Repository.getValue(singleRepositorySettings, settings,
-            S3Repository.Repository.REGION_SETTING, S3Repository.Repositories.REGION_SETTING);
-        String endpoint = S3Repository.getValue(singleRepositorySettings, settings,
-            S3Repository.Repository.ENDPOINT_SETTING, S3Repository.Repositories.ENDPOINT_SETTING);
-
-        String foundEndpoint = InternalAwsS3Service.findEndpoint(logger, settings, endpoint, region);
+    private void assertEndpoint(Settings repositorySettings, Settings settings,
+                                  String expectedEndpoint) {
+        String configName = InternalAwsS3Service.CONFIG_NAME.get(repositorySettings);
+        String foundEndpoint = InternalAwsS3Service.findEndpoint(logger, repositorySettings, settings, configName);
         assertThat(foundEndpoint, is(expectedEndpoint));
     }
 

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/AwsS3ServiceImplTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/AwsS3ServiceImplTests.java
@@ -44,8 +44,8 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     public void testAwsCredsDefaultSettings() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString("aws.config.default.access_key", "aws_key");
-        secureSettings.setString("aws.config.default.secret_key", "aws_secret");
+        secureSettings.setString("s3.client.default.access_key", "aws_key");
+        secureSettings.setString("s3.client.default.secret_key", "aws_secret");
         Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
         launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "aws_key", "aws_secret");
     }
@@ -53,12 +53,12 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     public void testAwsCredsExplicitConfigSettings() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         repositorySettings = Settings.builder().put(repositorySettings)
-            .put(InternalAwsS3Service.CONFIG_NAME.getKey(), "myconfig").build();
+            .put(InternalAwsS3Service.CLIENT_NAME.getKey(), "myconfig").build();
         MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString("aws.config.myconfig.access_key", "aws_key");
-        secureSettings.setString("aws.config.myconfig.secret_key", "aws_secret");
-        secureSettings.setString("aws.config.default.access_key", "wrong_key");
-        secureSettings.setString("aws.config.default.secret_key", "wrong_secret");
+        secureSettings.setString("s3.client.myconfig.access_key", "aws_key");
+        secureSettings.setString("s3.client.myconfig.secret_key", "aws_secret");
+        secureSettings.setString("s3.client.default.access_key", "wrong_key");
+        secureSettings.setString("s3.client.default.secret_key", "wrong_secret");
         Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
         launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "aws_key", "aws_secret");
     }
@@ -66,12 +66,12 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     public void testAWSCredentialsWithElasticsearchAwsSettingsBackcompat() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         Settings settings = Settings.builder()
-            .put(AwsS3Service.LEGACY_KEY_SETTING.getKey(), "aws_key")
-            .put(AwsS3Service.LEGACY_SECRET_SETTING.getKey(), "aws_secret")
+            .put(AwsS3Service.KEY_SETTING.getKey(), "aws_key")
+            .put(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret")
             .build();
         launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "aws_key", "aws_secret");
-        assertWarnings("[" + AwsS3Service.LEGACY_KEY_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.LEGACY_SECRET_SETTING.getKey() + "] setting was deprecated");
+        assertWarnings("[" + AwsS3Service.KEY_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.SECRET_SETTING.getKey() + "] setting was deprecated");
     }
 
     public void testAWSCredentialsWithElasticsearchS3SettingsBackcompat() {
@@ -88,14 +88,14 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     public void testAWSCredentialsWithElasticsearchAwsAndS3SettingsBackcompat() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         Settings settings = Settings.builder()
-            .put(AwsS3Service.LEGACY_KEY_SETTING.getKey(), "aws_key")
-            .put(AwsS3Service.LEGACY_SECRET_SETTING.getKey(), "aws_secret")
+            .put(AwsS3Service.KEY_SETTING.getKey(), "aws_key")
+            .put(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret")
             .put(AwsS3Service.CLOUD_S3.KEY_SETTING.getKey(), "s3_key")
             .put(AwsS3Service.CLOUD_S3.SECRET_SETTING.getKey(), "s3_secret")
             .build();
         launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "s3_key", "s3_secret");
-        assertWarnings("[" + AwsS3Service.LEGACY_KEY_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.LEGACY_SECRET_SETTING.getKey() + "] setting was deprecated",
+        assertWarnings("[" + AwsS3Service.KEY_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.SECRET_SETTING.getKey() + "] setting was deprecated",
                        "[" + AwsS3Service.CLOUD_S3.KEY_SETTING.getKey() + "] setting was deprecated",
                        "[" + AwsS3Service.CLOUD_S3.SECRET_SETTING.getKey() + "] setting was deprecated");
     }
@@ -114,14 +114,14 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     public void testAWSCredentialsWithElasticsearchAwsAndRepositoriesSettingsBackcompat() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         Settings settings = Settings.builder()
-            .put(AwsS3Service.LEGACY_KEY_SETTING.getKey(), "aws_key")
-            .put(AwsS3Service.LEGACY_SECRET_SETTING.getKey(), "aws_secret")
+            .put(AwsS3Service.KEY_SETTING.getKey(), "aws_key")
+            .put(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret")
             .put(S3Repository.Repositories.KEY_SETTING.getKey(), "repositories_key")
             .put(S3Repository.Repositories.SECRET_SETTING.getKey(), "repositories_secret")
             .build();
         launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "repositories_key", "repositories_secret");
-        assertWarnings("[" + AwsS3Service.LEGACY_KEY_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.LEGACY_SECRET_SETTING.getKey() + "] setting was deprecated",
+        assertWarnings("[" + AwsS3Service.KEY_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.SECRET_SETTING.getKey() + "] setting was deprecated",
                        "[" + S3Repository.Repositories.KEY_SETTING.getKey() + "] setting was deprecated",
                        "[" + S3Repository.Repositories.SECRET_SETTING.getKey() + "] setting was deprecated");
     }
@@ -129,16 +129,16 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     public void testAWSCredentialsWithElasticsearchAwsAndS3AndRepositoriesSettingsBackcompat() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         Settings settings = Settings.builder()
-            .put(AwsS3Service.LEGACY_KEY_SETTING.getKey(), "aws_key")
-            .put(AwsS3Service.LEGACY_SECRET_SETTING.getKey(), "aws_secret")
+            .put(AwsS3Service.KEY_SETTING.getKey(), "aws_key")
+            .put(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret")
             .put(AwsS3Service.CLOUD_S3.KEY_SETTING.getKey(), "s3_key")
             .put(AwsS3Service.CLOUD_S3.SECRET_SETTING.getKey(), "s3_secret")
             .put(S3Repository.Repositories.KEY_SETTING.getKey(), "repositories_key")
             .put(S3Repository.Repositories.SECRET_SETTING.getKey(), "repositories_secret")
             .build();
         launchAWSCredentialsWithElasticsearchSettingsTest(repositorySettings, settings, "repositories_key", "repositories_secret");
-        assertWarnings("[" + AwsS3Service.LEGACY_KEY_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.LEGACY_SECRET_SETTING.getKey() + "] setting was deprecated",
+        assertWarnings("[" + AwsS3Service.KEY_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.SECRET_SETTING.getKey() + "] setting was deprecated",
                        "[" + AwsS3Service.CLOUD_S3.KEY_SETTING.getKey() + "] setting was deprecated",
                        "[" + AwsS3Service.CLOUD_S3.SECRET_SETTING.getKey() + "] setting was deprecated",
                        "[" + S3Repository.Repositories.KEY_SETTING.getKey() + "] setting was deprecated",
@@ -159,8 +159,8 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     public void testAWSCredentialsWithElasticsearchAwsAndRepositoriesSettingsAndRepositorySettingsBackcompat() {
         Settings repositorySettings = generateRepositorySettings("repository_key", "repository_secret", "eu-central", null, null);
         Settings settings = Settings.builder()
-            .put(AwsS3Service.LEGACY_KEY_SETTING.getKey(), "aws_key")
-            .put(AwsS3Service.LEGACY_SECRET_SETTING.getKey(), "aws_secret")
+            .put(AwsS3Service.KEY_SETTING.getKey(), "aws_key")
+            .put(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret")
             .put(S3Repository.Repositories.KEY_SETTING.getKey(), "repositories_key")
             .put(S3Repository.Repositories.SECRET_SETTING.getKey(), "repositories_secret")
             .build();
@@ -172,8 +172,8 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     public void testAWSCredentialsWithElasticsearchAwsAndS3AndRepositoriesSettingsAndRepositorySettingsBackcompat() {
         Settings repositorySettings = generateRepositorySettings("repository_key", "repository_secret", "eu-central", null, null);
         Settings settings = Settings.builder()
-            .put(AwsS3Service.LEGACY_KEY_SETTING.getKey(), "aws_key")
-            .put(AwsS3Service.LEGACY_SECRET_SETTING.getKey(), "aws_secret")
+            .put(AwsS3Service.KEY_SETTING.getKey(), "aws_key")
+            .put(AwsS3Service.SECRET_SETTING.getKey(), "aws_secret")
             .put(AwsS3Service.CLOUD_S3.KEY_SETTING.getKey(), "s3_key")
             .put(AwsS3Service.CLOUD_S3.SECRET_SETTING.getKey(), "s3_secret")
             .put(S3Repository.Repositories.KEY_SETTING.getKey(), "repositories_key")
@@ -186,7 +186,7 @@ public class AwsS3ServiceImplTests extends ESTestCase {
 
     protected void launchAWSCredentialsWithElasticsearchSettingsTest(Settings singleRepositorySettings, Settings settings,
                                                                      String expectedKey, String expectedSecret) {
-        String configName = InternalAwsS3Service.CONFIG_NAME.get(singleRepositorySettings);
+        String configName = InternalAwsS3Service.CLIENT_NAME.get(singleRepositorySettings);
         AWSCredentials credentials = InternalAwsS3Service.buildCredentials(logger, deprecationLogger, settings,
             singleRepositorySettings, configName).getCredentials();
         assertThat(credentials.getAWSAccessKeyId(), is(expectedKey));
@@ -202,14 +202,14 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     public void testAWSConfigurationWithAwsSettings() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString("aws.config.default.proxy.username", "aws_proxy_username");
-        secureSettings.setString("aws.config.default.proxy.password", "aws_proxy_password");
+        secureSettings.setString("s3.client.default.proxy.username", "aws_proxy_username");
+        secureSettings.setString("s3.client.default.proxy.password", "aws_proxy_password");
         Settings settings = Settings.builder()
             .setSecureSettings(secureSettings)
-            .put("aws.config.default.protocol", "http")
-            .put("aws.config.default.proxy.host", "aws_proxy_host")
-            .put("aws.config.default.proxy.port", 8080)
-            .put("aws.config.default.read_timeout", "10s")
+            .put("s3.client.default.protocol", "http")
+            .put("s3.client.default.proxy.host", "aws_proxy_host")
+            .put("s3.client.default.proxy.port", 8080)
+            .put("s3.client.default.read_timeout", "10s")
             .build();
         launchAWSConfigurationTest(settings, repositorySettings, Protocol.HTTP, "aws_proxy_host", 8080, "aws_proxy_username",
             "aws_proxy_password", null, 3, false, 10000);
@@ -218,35 +218,35 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     public void testAWSConfigurationWithAwsSettingsBackcompat() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         Settings settings = Settings.builder()
-            .put(AwsS3Service.LEGACY_PROTOCOL_SETTING.getKey(), "http")
-            .put(AwsS3Service.LEGACY_PROXY_HOST_SETTING.getKey(), "aws_proxy_host")
-            .put(AwsS3Service.LEGACY_PROXY_PORT_SETTING.getKey(), 8080)
-            .put(AwsS3Service.LEGACY_PROXY_USERNAME_SETTING.getKey(), "aws_proxy_username")
-            .put(AwsS3Service.LEGACY_PROXY_PASSWORD_SETTING.getKey(), "aws_proxy_password")
-            .put(AwsS3Service.LEGACY_SIGNER_SETTING.getKey(), "AWS3SignerType")
-            .put(AwsS3Service.LEGACY_READ_TIMEOUT.getKey(), "10s")
+            .put(AwsS3Service.PROTOCOL_SETTING.getKey(), "http")
+            .put(AwsS3Service.PROXY_HOST_SETTING.getKey(), "aws_proxy_host")
+            .put(AwsS3Service.PROXY_PORT_SETTING.getKey(), 8080)
+            .put(AwsS3Service.PROXY_USERNAME_SETTING.getKey(), "aws_proxy_username")
+            .put(AwsS3Service.PROXY_PASSWORD_SETTING.getKey(), "aws_proxy_password")
+            .put(AwsS3Service.SIGNER_SETTING.getKey(), "AWS3SignerType")
+            .put(AwsS3Service.READ_TIMEOUT.getKey(), "10s")
             .build();
         launchAWSConfigurationTest(settings, repositorySettings, Protocol.HTTP, "aws_proxy_host", 8080, "aws_proxy_username",
             "aws_proxy_password", "AWS3SignerType", 3, false, 10000);
-        assertWarnings("[" + AwsS3Service.LEGACY_PROXY_USERNAME_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.LEGACY_PROXY_PASSWORD_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.LEGACY_PROTOCOL_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.LEGACY_PROXY_HOST_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.LEGACY_PROXY_PORT_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.LEGACY_SIGNER_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.LEGACY_READ_TIMEOUT.getKey() + "] setting was deprecated");
+        assertWarnings("[" + AwsS3Service.PROXY_USERNAME_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.PROXY_PASSWORD_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.PROTOCOL_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.PROXY_HOST_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.PROXY_PORT_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.SIGNER_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.READ_TIMEOUT.getKey() + "] setting was deprecated");
     }
 
     public void testAWSConfigurationWithAwsAndS3SettingsBackcompat() {
         Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
         Settings settings = Settings.builder()
-            .put(AwsS3Service.LEGACY_PROTOCOL_SETTING.getKey(), "http")
-            .put(AwsS3Service.LEGACY_PROXY_HOST_SETTING.getKey(), "aws_proxy_host")
-            .put(AwsS3Service.LEGACY_PROXY_PORT_SETTING.getKey(), 8080)
-            .put(AwsS3Service.LEGACY_PROXY_USERNAME_SETTING.getKey(), "aws_proxy_username")
-            .put(AwsS3Service.LEGACY_PROXY_PASSWORD_SETTING.getKey(), "aws_proxy_password")
-            .put(AwsS3Service.LEGACY_SIGNER_SETTING.getKey(), "AWS3SignerType")
-            .put(AwsS3Service.LEGACY_READ_TIMEOUT.getKey(), "5s")
+            .put(AwsS3Service.PROTOCOL_SETTING.getKey(), "http")
+            .put(AwsS3Service.PROXY_HOST_SETTING.getKey(), "aws_proxy_host")
+            .put(AwsS3Service.PROXY_PORT_SETTING.getKey(), 8080)
+            .put(AwsS3Service.PROXY_USERNAME_SETTING.getKey(), "aws_proxy_username")
+            .put(AwsS3Service.PROXY_PASSWORD_SETTING.getKey(), "aws_proxy_password")
+            .put(AwsS3Service.SIGNER_SETTING.getKey(), "AWS3SignerType")
+            .put(AwsS3Service.READ_TIMEOUT.getKey(), "5s")
             .put(AwsS3Service.CLOUD_S3.PROTOCOL_SETTING.getKey(), "https")
             .put(AwsS3Service.CLOUD_S3.PROXY_HOST_SETTING.getKey(), "s3_proxy_host")
             .put(AwsS3Service.CLOUD_S3.PROXY_PORT_SETTING.getKey(), 8081)
@@ -257,13 +257,13 @@ public class AwsS3ServiceImplTests extends ESTestCase {
             .build();
         launchAWSConfigurationTest(settings, repositorySettings, Protocol.HTTPS, "s3_proxy_host", 8081, "s3_proxy_username",
             "s3_proxy_password", "NoOpSignerType", 3, false, 10000);
-        assertWarnings("[" + AwsS3Service.LEGACY_PROXY_USERNAME_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.LEGACY_PROXY_PASSWORD_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.LEGACY_PROTOCOL_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.LEGACY_PROXY_HOST_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.LEGACY_PROXY_PORT_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.LEGACY_SIGNER_SETTING.getKey() + "] setting was deprecated",
-                       "[" + AwsS3Service.LEGACY_READ_TIMEOUT.getKey() + "] setting was deprecated",
+        assertWarnings("[" + AwsS3Service.PROXY_USERNAME_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.PROXY_PASSWORD_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.PROTOCOL_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.PROXY_HOST_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.PROXY_PORT_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.SIGNER_SETTING.getKey() + "] setting was deprecated",
+                       "[" + AwsS3Service.READ_TIMEOUT.getKey() + "] setting was deprecated",
                        "[" + AwsS3Service.CLOUD_S3.PROXY_USERNAME_SETTING.getKey() + "] setting was deprecated",
                        "[" + AwsS3Service.CLOUD_S3.PROXY_PASSWORD_SETTING.getKey() + "] setting was deprecated",
                        "[" + AwsS3Service.CLOUD_S3.PROTOCOL_SETTING.getKey() + "] setting was deprecated",
@@ -271,6 +271,24 @@ public class AwsS3ServiceImplTests extends ESTestCase {
                        "[" + AwsS3Service.CLOUD_S3.PROXY_PORT_SETTING.getKey() + "] setting was deprecated",
                        "[" + AwsS3Service.CLOUD_S3.SIGNER_SETTING.getKey() + "] setting was deprecated",
                        "[" + AwsS3Service.CLOUD_S3.READ_TIMEOUT.getKey() + "] setting was deprecated");
+    }
+
+    public void testGlobalMaxRetries() {
+        Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, null);
+        Settings settings = Settings.builder()
+            .put(S3Repository.Repositories.MAX_RETRIES_SETTING.getKey(), 10)
+            .build();
+        launchAWSConfigurationTest(settings, repositorySettings, Protocol.HTTPS, null, -1, null,
+            null, null, 10, false, 50000);
+    }
+
+    public void testRepositoryMaxRetries() {
+        Settings repositorySettings = generateRepositorySettings(null, null, "eu-central", null, 20);
+        Settings settings = Settings.builder()
+            .put(S3Repository.Repositories.MAX_RETRIES_SETTING.getKey(), 10)
+            .build();
+        launchAWSConfigurationTest(settings, repositorySettings, Protocol.HTTPS, null, -1, null,
+            null, null, 20, false, 50000);
     }
 
     protected void launchAWSConfigurationTest(Settings settings,
@@ -330,10 +348,9 @@ public class AwsS3ServiceImplTests extends ESTestCase {
 
     public void testEndpointSetting() {
         Settings settings = Settings.builder()
-            .put("aws.config.default.endpoint", "ec2.endpoint")
+            .put("s3.client.default.endpoint", "s3.endpoint")
             .build();
-        assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, null, null), settings,
-            "ec2.endpoint");
+        assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, null, null), settings, "s3.endpoint");
     }
 
     public void testEndpointSettingBackcompat() {
@@ -350,7 +367,7 @@ public class AwsS3ServiceImplTests extends ESTestCase {
 
     public void testRegionSetting() {
         Settings settings = Settings.builder()
-            .put("aws.config.default.region", randomFrom("eu-west", "eu-west-1"))
+            .put("s3.client.default.region", randomFrom("eu-west", "eu-west-1"))
             .build();
         assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, null, null), settings,
             "s3-eu-west-1.amazonaws.com");
@@ -358,7 +375,7 @@ public class AwsS3ServiceImplTests extends ESTestCase {
 
     public void testRegionSettingBackcompat() {
         Settings settings = Settings.builder()
-            .put(InternalAwsS3Service.LEGACY_REGION_SETTING.getKey(), randomFrom("eu-west", "eu-west-1"))
+            .put(InternalAwsS3Service.REGION_SETTING.getKey(), randomFrom("eu-west", "eu-west-1"))
             .build();
         assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, null, null), settings,
             "s3-eu-west-1.amazonaws.com");
@@ -366,14 +383,14 @@ public class AwsS3ServiceImplTests extends ESTestCase {
             "s3.eu-central-1.amazonaws.com");
         assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, "repository.endpoint", null),
             settings, "repository.endpoint");
-        assertWarnings("[" + InternalAwsS3Service.LEGACY_REGION_SETTING.getKey() + "] setting was deprecated",
+        assertWarnings("[" + InternalAwsS3Service.REGION_SETTING.getKey() + "] setting was deprecated",
                        "[" + S3Repository.Repository.REGION_SETTING.getKey() + "] setting was deprecated",
                        "[" + S3Repository.Repository.ENDPOINT_SETTING.getKey() + "] setting was deprecated");
     }
 
     public void testRegionAndEndpointSettingBackcompatPrecedence() {
         Settings settings = Settings.builder()
-            .put(InternalAwsS3Service.LEGACY_REGION_SETTING.getKey(), randomFrom("eu-west", "eu-west-1"))
+            .put(InternalAwsS3Service.REGION_SETTING.getKey(), randomFrom("eu-west", "eu-west-1"))
             .put(InternalAwsS3Service.CLOUD_S3.REGION_SETTING.getKey(), randomFrom("us-west", "us-west-1"))
             .build();
         assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, null, null), settings,
@@ -382,7 +399,7 @@ public class AwsS3ServiceImplTests extends ESTestCase {
             "s3.eu-central-1.amazonaws.com");
         assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, "repository.endpoint", null),
             settings, "repository.endpoint");
-        assertWarnings("[" + InternalAwsS3Service.LEGACY_REGION_SETTING.getKey() + "] setting was deprecated",
+        assertWarnings("[" + InternalAwsS3Service.REGION_SETTING.getKey() + "] setting was deprecated",
                        "[" + S3Repository.Repository.REGION_SETTING.getKey() + "] setting was deprecated",
                        "[" + InternalAwsS3Service.CLOUD_S3.REGION_SETTING.getKey() + "] setting was deprecated",
                        "[" + S3Repository.Repository.ENDPOINT_SETTING.getKey() + "] setting was deprecated");
@@ -390,7 +407,7 @@ public class AwsS3ServiceImplTests extends ESTestCase {
 
     public void testInvalidRegion() {
         Settings settings = Settings.builder()
-            .put("aws.config.default.region", "does-not-exist")
+            .put("s3.client.default.region", "does-not-exist")
             .build();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
             assertEndpoint(generateRepositorySettings("repository_key", "repository_secret", null, null, null), settings, null);
@@ -400,7 +417,7 @@ public class AwsS3ServiceImplTests extends ESTestCase {
 
     private void assertEndpoint(Settings repositorySettings, Settings settings,
                                   String expectedEndpoint) {
-        String configName = InternalAwsS3Service.CONFIG_NAME.get(repositorySettings);
+        String configName = InternalAwsS3Service.CLIENT_NAME.get(repositorySettings);
         String foundEndpoint = InternalAwsS3Service.findEndpoint(logger, repositorySettings, settings, configName);
         assertThat(foundEndpoint, is(expectedEndpoint));
     }

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/EnvironmentCredentialsTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/EnvironmentCredentialsTests.java
@@ -27,7 +27,7 @@ public class EnvironmentCredentialsTests extends ESTestCase {
 
     public void test() {
         AWSCredentialsProvider provider =
-            InternalAwsS3Service.buildCredentials(logger, deprecationLogger, Settings.EMPTY, Settings.EMPTY);
+            InternalAwsS3Service.buildCredentials(logger, deprecationLogger, Settings.EMPTY, Settings.EMPTY, "default");
         // NOTE: env vars are setup by the test runner in gradle
         assertEquals("env_access", provider.getCredentials().getAWSAccessKeyId());
         assertEquals("env_secret", provider.getCredentials().getAWSSecretKey());

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/SyspropCredentialsTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/SyspropCredentialsTests.java
@@ -26,7 +26,7 @@ import org.elasticsearch.test.ESTestCase;
 public class SyspropCredentialsTests extends ESTestCase {
     public void test() {
         AWSCredentialsProvider provider =
-            InternalAwsS3Service.buildCredentials(logger, deprecationLogger, Settings.EMPTY, Settings.EMPTY);
+            InternalAwsS3Service.buildCredentials(logger, deprecationLogger, Settings.EMPTY, Settings.EMPTY, "default");
         // NOTE: sys props are setup by the test runner in gradle
         assertEquals("sysprop_access", provider.getCredentials().getAWSAccessKeyId());
         assertEquals("sysprop_secret", provider.getCredentials().getAWSSecretKey());

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/TestAwsS3Service.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/TestAwsS3Service.java
@@ -18,13 +18,13 @@
  */
 package org.elasticsearch.cloud.aws;
 
-import com.amazonaws.Protocol;
+import java.util.IdentityHashMap;
+
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugin.repository.s3.S3RepositoryPlugin;
-
-import java.util.IdentityHashMap;
 
 public class TestAwsS3Service extends InternalAwsS3Service {
     public static class TestPlugin extends S3RepositoryPlugin {
@@ -42,9 +42,9 @@ public class TestAwsS3Service extends InternalAwsS3Service {
 
 
     @Override
-    public synchronized AmazonS3 client(Settings repositorySettings, String endpoint, Protocol protocol, String region, Integer maxRetries,
-                                        boolean useThrottleRetries, Boolean pathStyleAccess) {
-        return cachedWrapper(super.client(repositorySettings, endpoint, protocol, region, maxRetries, useThrottleRetries, pathStyleAccess));
+    public synchronized AmazonS3 client(Settings repositorySettings, Integer maxRetries,
+                                              boolean useThrottleRetries, Boolean pathStyleAccess) {
+        return cachedWrapper(super.client(repositorySettings, maxRetries, useThrottleRetries, pathStyleAccess));
     }
 
     private AmazonS3 cachedWrapper(AmazonS3 client) {

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AbstractS3SnapshotRestoreTest.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AbstractS3SnapshotRestoreTest.java
@@ -197,12 +197,7 @@ public abstract class AbstractS3SnapshotRestoreTest extends AbstractAwsTestCase 
 
         Settings settings = internalCluster().getInstance(Settings.class);
         Settings bucket = settings.getByPrefix("repositories.s3.");
-        AmazonS3 s3Client = internalCluster().getInstance(AwsS3Service.class).client(
-            repositorySettings,
-            null,
-            S3Repository.Repositories.PROTOCOL_SETTING.get(settings),
-            S3Repository.Repositories.REGION_SETTING.get(settings),
-            null, randomBoolean(), null);
+        AmazonS3 s3Client = internalCluster().getInstance(AwsS3Service.class).client(repositorySettings, null, randomBoolean(), null);
 
         String bucketName = bucket.get("bucket");
         logger.info("--> verify encryption for bucket [{}], prefix [{}]", bucketName, basePath);
@@ -467,16 +462,12 @@ public abstract class AbstractS3SnapshotRestoreTest extends AbstractAwsTestCase 
                 settings.getByPrefix("repositories.s3.external-bucket.")
         };
         for (Settings bucket : buckets) {
-            String endpoint = bucket.get("endpoint", S3Repository.Repositories.ENDPOINT_SETTING.get(settings));
-            Protocol protocol = S3Repository.Repositories.PROTOCOL_SETTING.get(settings);
-            String region = bucket.get("region", S3Repository.Repositories.REGION_SETTING.get(settings));
             String bucketName = bucket.get("bucket");
 
             // We check that settings has been set in elasticsearch.yml integration test file
             // as described in README
             assertThat("Your settings in elasticsearch.yml are incorrects. Check README file.", bucketName, notNullValue());
-            AmazonS3 client = internalCluster().getInstance(AwsS3Service.class).client(Settings.EMPTY, endpoint, protocol, region, null,
-                randomBoolean(), null);
+            AmazonS3 client = internalCluster().getInstance(AwsS3Service.class).client(Settings.EMPTY, null, randomBoolean(), null);
             try {
                 ObjectListing prevListing = null;
                 //From http://docs.amazonwebservices.com/AmazonS3/latest/dev/DeletingMultipleObjectsUsingJava.html
@@ -513,7 +504,7 @@ public abstract class AbstractS3SnapshotRestoreTest extends AbstractAwsTestCase 
                     client.deleteObjects(multiObjectDeleteRequest);
                 }
             } catch (Exception ex) {
-                logger.warn((Supplier<?>) () -> new ParameterizedMessage("Failed to delete S3 repository [{}] in [{}]", bucketName, region), ex);
+                logger.warn((Supplier<?>) () -> new ParameterizedMessage("Failed to delete S3 repository [{}]", bucketName), ex);
             }
         }
     }

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.repositories.s3;
 
-import com.amazonaws.Protocol;
+import java.io.IOException;
+
 import com.amazonaws.services.s3.AbstractAmazonS3;
 import com.amazonaws.services.s3.AmazonS3;
 import org.elasticsearch.cloud.aws.AwsS3Service;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
-import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
@@ -34,8 +34,6 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
-
-import java.io.IOException;
 
 import static org.elasticsearch.repositories.s3.S3Repository.Repositories;
 import static org.elasticsearch.repositories.s3.S3Repository.Repository;
@@ -62,19 +60,15 @@ public class S3RepositoryTests extends ESTestCase {
         @Override
         protected void doClose() {}
         @Override
-        public AmazonS3 client(Settings repositorySettings, String endpoint, Protocol protocol, String region, Integer maxRetries,
+        public AmazonS3 client(Settings repositorySettings, Integer maxRetries,
                                boolean useThrottleRetries, Boolean pathStyleAccess) {
             return new DummyS3Client();
         }
     }
 
     public void testSettingsResolution() throws Exception {
-        MockSecureSettings secureSettings1 = new MockSecureSettings();
-        secureSettings1.setString(Repository.KEY_SETTING.getKey(), "key1");
-        Settings localSettings = Settings.builder().setSecureSettings(secureSettings1).build();
-        MockSecureSettings secureSettings2 = new MockSecureSettings();
-        secureSettings2.setString(Repositories.KEY_SETTING.getKey(), "key2");
-        Settings globalSettings = Settings.builder().setSecureSettings(secureSettings2).build();
+        Settings localSettings = Settings.builder().put(Repository.KEY_SETTING.getKey(), "key1").build();
+        Settings globalSettings = Settings.builder().put(Repositories.KEY_SETTING.getKey(), "key2").build();
 
         assertEquals(new SecureString("key1".toCharArray()),
                      getValue(localSettings, globalSettings, Repository.KEY_SETTING, Repositories.KEY_SETTING));
@@ -84,6 +78,8 @@ public class S3RepositoryTests extends ESTestCase {
                      getValue(Settings.EMPTY, globalSettings, Repository.KEY_SETTING, Repositories.KEY_SETTING));
         assertEquals(new SecureString("".toCharArray()),
                      getValue(Settings.EMPTY, Settings.EMPTY, Repository.KEY_SETTING, Repositories.KEY_SETTING));
+        assertWarnings("[" + Repository.KEY_SETTING.getKey() + "] setting was deprecated",
+                       "[" + Repositories.KEY_SETTING.getKey() + "] setting was deprecated");
     }
 
     public void testInvalidChunkBufferSizeSettings() throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -306,12 +306,12 @@ public abstract class ESTestCase extends LuceneTestCase {
         }
         try {
             final List<String> actualWarnings = threadContext.getResponseHeaders().get(DeprecationLogger.WARNING_HEADER);
-            assertEquals("Expected " + expectedWarnings.length + " warnings but found " + actualWarnings.size() + "\nExpected: "
-                    + Arrays.asList(expectedWarnings) + "\nActual: " + actualWarnings,
-                    expectedWarnings.length, actualWarnings.size());
             for (String msg : expectedWarnings) {
                 assertThat(actualWarnings, hasItem(containsString(msg)));
             }
+            assertEquals("Expected " + expectedWarnings.length + " warnings but found " + actualWarnings.size() + "\nExpected: "
+                    + Arrays.asList(expectedWarnings) + "\nActual: " + actualWarnings,
+                expectedWarnings.length, actualWarnings.size());
         } finally {
             resetDeprecationLogger();
         }


### PR DESCRIPTION
This change implements named configurations for s3 repository as
proposed in #22520. The access/secret key secure settings which were
added in #22479 are reverted, and the only secure settings are those
with the new named configs. All other previously used settings for the
connection are deprecated.

closes #22520
