### PR TITLE
Increase maxwait for reading transport port from seed node

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
@@ -88,7 +88,7 @@ class ClusterConfiguration {
         if (seedNode == node) {
             return null
         }
-        ant.waitfor(maxwait: '20', maxwaitunit: 'second', checkevery: '500', checkeveryunit: 'millisecond') {
+        ant.waitfor(maxwait: '30', maxwaitunit: 'second', checkevery: '500', checkeveryunit: 'millisecond') {
             resourceexists {
                 file(file: seedNode.transportPortsFile.toString())
             }


### PR DESCRIPTION
On slower machines `20s` isn't enough for the seed node to write the `transport.ports` file into the log directory.

The test cluster formation constantly fails with:

```
Execution failed for task ':qa:rolling-upgrade:oldClusterTest#node1.configure'.
> /Users/mvg/dev/projects/elasticsearch/qa/rolling-upgrade/build/cluster/oldClusterTest node0/elasticsearch-5.2.0-SNAPSHOT/logs/transport.ports (No such file or directory)
```
