### PR TITLE
Add parsing method for ElasticsearchException.generateThrowableXContent()

### DIFF
--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -436,17 +436,17 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                             currentFieldName = parser.currentName();
                         } else {
                             List<String> values = headers.getOrDefault(currentFieldName, new ArrayList<>());
-                            if (token.isValue() || token == XContentParser.Token.VALUE_NULL) {
-                                values.add(parser.textOrNull());
+                            if (token == XContentParser.Token.VALUE_STRING) {
+                                values.add(parser.text());
                             } else if (token == XContentParser.Token.START_ARRAY) {
                                 while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                                    if (token.isValue() || token == XContentParser.Token.VALUE_NULL) {
-                                        values.add(parser.textOrNull());
+                                    if (token == XContentParser.Token.VALUE_STRING) {
+                                        values.add(parser.text());
                                     } else {
                                         parser.skipChildren();
                                     }
                                 }
-                            } else if (token == XContentParser.Token.START_ARRAY) {
+                            } else if (token == XContentParser.Token.START_OBJECT) {
                                 parser.skipChildren();
                             }
                             headers.put(currentFieldName, values);
@@ -463,8 +463,8 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                 // Arrays of objects are not supported yet and just ignored and skipped.
                 List<String> values = new ArrayList<>();
                 while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                    if (token.isValue() || token == XContentParser.Token.VALUE_NULL) {
-                        values.add(parser.textOrNull());
+                    if (token == XContentParser.Token.VALUE_STRING) {
+                        values.add(parser.text());
                     } else {
                         parser.skipChildren();
                     }

--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -424,7 +424,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                     reason = parser.text();
                 } else if (STACK_TRACE.equals(currentFieldName)) {
                     stack = parser.text();
-                } else {
+                } else if (token == XContentParser.Token.VALUE_STRING) {
                     metadata.put(currentFieldName, Collections.singletonList(parser.text()));
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {

--- a/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -543,7 +543,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
         assertNotNull(parsedException);
 
         ElasticsearchException expected = exceptions.v2();
-        while (expected != null) {
+        do {
             assertEquals(expected.getMessage(), parsedException.getMessage());
             assertEquals(expected.getHeaders(), parsedException.getHeaders());
             assertEquals(expected.getMetadata(), parsedException.getMetadata());
@@ -555,7 +555,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
             if (expected == null) {
                 assertNull(parsedException);
             }
-        }
+        } while (expected != null);
     }
 
     /**
@@ -633,10 +633,11 @@ public class ElasticsearchExceptionTests extends ESTestCase {
         }
 
         if (actual instanceof ElasticsearchException) {
+            ElasticsearchException actualException = (ElasticsearchException) actual;
             if (randomBoolean()) {
-                Map<String, List<String>> randomHeaders = new HashMap<>();
-
                 int nbHeaders = randomIntBetween(1, 5);
+                Map<String, List<String>> randomHeaders = new HashMap<>(nbHeaders);
+
                 for (int i = 0; i < nbHeaders; i++) {
                     List<String> values = new ArrayList<>();
 
@@ -648,15 +649,15 @@ public class ElasticsearchExceptionTests extends ESTestCase {
                 }
 
                 for (Map.Entry<String, List<String>> entry : randomHeaders.entrySet()) {
-                    ((ElasticsearchException) actual).addHeader(entry.getKey(), entry.getValue());
+                    actualException.addHeader(entry.getKey(), entry.getValue());
                     expected.addHeader(entry.getKey(), entry.getValue());
                 }
             }
 
             if (randomBoolean()) {
-                Map<String, List<String>> randomMetadata = new HashMap<>();
-
                 int nbMetadata = randomIntBetween(1, 5);
+                Map<String, List<String>> randomMetadata = new HashMap<>(nbMetadata);
+
                 for (int i = 0; i < nbMetadata; i++) {
                     List<String> values = new ArrayList<>();
 
@@ -668,7 +669,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
                 }
 
                 for (Map.Entry<String, List<String>> entry : randomMetadata.entrySet()) {
-                    ((ElasticsearchException) actual).addMetadata(entry.getKey(), entry.getValue());
+                    actualException.addMetadata(entry.getKey(), entry.getValue());
                     expected.addMetadata(entry.getKey(), entry.getValue());
                 }
             }
@@ -679,13 +680,12 @@ public class ElasticsearchExceptionTests extends ESTestCase {
                     String resourceType = "type_" + i;
                     String[] resourceIds = null;
                     if (frequently()) {
-                        resourceIds = new String[randomIntBetween(0, 3)];
+                        resourceIds = new String[randomIntBetween(1, 3)];
                         for (int j = 0; j < resourceIds.length; j++) {
                             resourceIds[j] = frequently() ? randomAsciiOfLength(5) : null;
                         }
                     }
-
-                    ((ElasticsearchException) actual).setResources(resourceType, resourceIds);
+                    actualException.setResources(resourceType, resourceIds);
                     expected.setResources(resourceType, resourceIds);
                 }
             }

--- a/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -643,7 +643,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
 
                     int nbValues = randomIntBetween(1, 3);
                     for (int j = 0; j < nbValues; j++) {
-                        values.add(frequently() ? randomAsciiOfLength(5) : null);
+                        values.add(frequently() ? randomAsciiOfLength(5) : "");
                     }
                     randomHeaders.put("header_" + i, values);
                 }
@@ -663,7 +663,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
 
                     int nbValues = randomIntBetween(1, 3);
                     for (int j = 0; j < nbValues; j++) {
-                        values.add(frequently() ? randomAsciiOfLength(5) : null);
+                        values.add(frequently() ? randomAsciiOfLength(5) : "");
                     }
                     randomMetadata.put("es.metadata_" + i, values);
                 }
@@ -682,7 +682,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
                     if (frequently()) {
                         resourceIds = new String[randomIntBetween(1, 3)];
                         for (int j = 0; j < resourceIds.length; j++) {
-                            resourceIds[j] = frequently() ? randomAsciiOfLength(5) : null;
+                            resourceIds[j] = frequently() ? randomAsciiOfLength(5) : "";
                         }
                     }
                     actualException.setResources(resourceType, resourceIds);

--- a/core/src/test/java/org/elasticsearch/action/search/SearchPhaseExecutionExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/SearchPhaseExecutionExceptionTests.java
@@ -169,9 +169,8 @@ public class SearchPhaseExecutionExceptionTests extends ESTestCase {
 
         assertNotNull(parsedException);
         assertThat(parsedException.getHeaderKeys(), hasSize(0));
-        assertThat(parsedException.getMetadataKeys(), hasSize(2));
+        assertThat(parsedException.getMetadataKeys(), hasSize(1));
         assertThat(parsedException.getMetadata("es.phase"), hasItem(phase));
-        assertThat(parsedException.getMetadata("es.grouped"), hasItem("true"));
         // SearchPhaseExecutionException has no cause field
         assertNull(parsedException.getCause());
     }

--- a/core/src/test/java/org/elasticsearch/action/search/SearchPhaseExecutionExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/SearchPhaseExecutionExceptionTests.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.search;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.TimestampParsingException;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.shard.IndexShardClosedException;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.InvalidIndexTemplateException;
+import org.elasticsearch.search.SearchShardTarget;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+import static java.util.Collections.singletonMap;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+
+public class SearchPhaseExecutionExceptionTests extends ESTestCase {
+
+    public void testToXContent() throws IOException {
+        SearchPhaseExecutionException exception = new SearchPhaseExecutionException("test", "all shards failed",
+                new ShardSearchFailure[]{
+                        new ShardSearchFailure(new ParsingException(1, 2, "foobar", null),
+                                new SearchShardTarget("node_1", new Index("foo", "_na_"), 0)),
+                        new ShardSearchFailure(new IndexShardClosedException(new ShardId(new Index("foo", "_na_"), 1)),
+                                new SearchShardTarget("node_2", new Index("foo", "_na_"), 1)),
+                        new ShardSearchFailure(new ParsingException(5, 7, "foobar", null),
+                                new SearchShardTarget("node_3", new Index("foo", "_na_"), 2)),
+                });
+
+        // Failures are grouped (by default)
+        assertEquals("{" +
+                "\"type\":\"search_phase_execution_exception\"," +
+                "\"reason\":\"all shards failed\"," +
+                "\"phase\":\"test\"," +
+                "\"grouped\":true," +
+                "\"failed_shards\":[" +
+                        "{" +
+                            "\"shard\":0," +
+                            "\"index\":\"foo\"," +
+                            "\"node\":\"node_1\"," +
+                            "\"reason\":{" +
+                                        "\"type\":\"parsing_exception\"," +
+                                        "\"reason\":\"foobar\"," +
+                                        "\"line\":1," +
+                                        "\"col\":2" +
+                            "}" +
+                        "}," +
+                        "{" +
+                            "\"shard\":1," +
+                            "\"index\":\"foo\"," +
+                            "\"node\":\"node_2\"," +
+                            "\"reason\":{" +
+                                        "\"type\":\"index_shard_closed_exception\"," +
+                                        "\"reason\":\"CurrentState[CLOSED] Closed\"," +
+                                        "\"index_uuid\":\"_na_\"," +
+                                        "\"shard\":\"1\"," +
+                                        "\"index\":\"foo\"" +
+                            "}" +
+                        "}" +
+                "]}", Strings.toString(exception));
+
+        // Failures are NOT grouped
+        ToXContent.MapParams params = new ToXContent.MapParams(singletonMap("group_shard_failures", "false"));
+        try (XContentBuilder builder = jsonBuilder()) {
+            builder.startObject();
+            exception.toXContent(builder, params);
+            builder.endObject();
+
+            assertEquals("{" +
+                    "\"type\":\"search_phase_execution_exception\"," +
+                    "\"reason\":\"all shards failed\"," +
+                    "\"phase\":\"test\"," +
+                    "\"grouped\":false," +
+                    "\"failed_shards\":[" +
+                            "{" +
+                                "\"shard\":0," +
+                                "\"index\":\"foo\"," +
+                                "\"node\":\"node_1\"," +
+                                "\"reason\":{" +
+                                            "\"type\":\"parsing_exception\"," +
+                                            "\"reason\":\"foobar\"," +
+                                            "\"line\":1," +
+                                            "\"col\":2" +
+                                "}" +
+                            "}," +
+                            "{" +
+                                "\"shard\":1," +
+                                "\"index\":\"foo\"," +
+                                "\"node\":\"node_2\"," +
+                                "\"reason\":{" +
+                                            "\"type\":\"index_shard_closed_exception\"," +
+                                            "\"reason\":\"CurrentState[CLOSED] Closed\"," +
+                                            "\"index_uuid\":\"_na_\"," +
+                                            "\"shard\":\"1\"," +
+                                            "\"index\":\"foo\"" +
+                                "}" +
+                            "}," +
+                            "{" +
+                                "\"shard\":2," +
+                                "\"index\":\"foo\"," +
+                                "\"node\":\"node_3\"," +
+                                "\"reason\":{" +
+                                            "\"type\":\"parsing_exception\"," +
+                                            "\"reason\":\"foobar\"," +
+                                            "\"line\":5," +
+                                            "\"col\":7" +
+                                "}" +
+                            "}" +
+                    "]}", builder.string());
+        }
+    }
+
+    public void testToAndFromXContent() throws IOException {
+        final XContent xContent = randomFrom(XContentType.values()).xContent();
+
+        ShardSearchFailure[] shardSearchFailures = new ShardSearchFailure[randomIntBetween(1, 5)];
+        for (int i = 0; i < shardSearchFailures.length; i++) {
+            Exception cause = randomFrom(
+                    new ParsingException(1, 2, "foobar", null),
+                    new InvalidIndexTemplateException("foo", "bar"),
+                    new TimestampParsingException("foo", null),
+                    new NullPointerException()
+            );
+            shardSearchFailures[i] = new  ShardSearchFailure(cause, new SearchShardTarget("node_" + i, new Index("test", "_na_"), i));
+        }
+
+        final String phase = randomFrom("query", "search", "other");
+        SearchPhaseExecutionException actual = new SearchPhaseExecutionException(phase, "unexpected failures", shardSearchFailures);
+
+        BytesReference exceptionBytes = XContentHelper.toXContent(actual, xContent.type(), randomBoolean());
+
+        ElasticsearchException parsedException;
+        try (XContentParser parser = createParser(xContent, exceptionBytes)) {
+            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+            parsedException = ElasticsearchException.fromXContent(parser);
+            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+            assertNull(parser.nextToken());
+        }
+
+        assertNotNull(parsedException);
+        assertThat(parsedException.getHeaderKeys(), hasSize(0));
+        assertThat(parsedException.getMetadataKeys(), hasSize(2));
+        assertThat(parsedException.getMetadata("es.phase"), hasItem(phase));
+        assertThat(parsedException.getMetadata("es.grouped"), hasItem("true"));
+        // SearchPhaseExecutionException has no cause field
+        assertNull(parsedException.getCause());
+    }
+}


### PR DESCRIPTION
The output of the `ElasticsearchException.generateThrowableXContent()` method can be parsed back by the `ElasticsearchException.fromXContent()` method.

This commit adds unit tests in the style of the `to-and-from-xcontent` tests we already have for other parsing methods. It also relax the strict parsing of the `ElasticsearchException.fromXContent()` so that it does not throw an exception when custom metadata of type array & objects are parsed.