### PR TITLE
repositories.hdfs.path can not be set

### DIFF
--- a/docs/plugins/repository-hdfs.asciidoc
+++ b/docs/plugins/repository-hdfs.asciidoc
@@ -95,16 +95,3 @@ The following settings are supported:
 
     Override the chunk size. (Disabled by default)
 
-
-Alternatively, you can define the `hdfs` repository and its settings in your `elasticsearch.yml`:
-[source,yaml]
-----
-repositories:
-  hdfs:
-    uri: "hdfs://<host>:<port>/"    \# required - HDFS address only
-    path: "some/path"               \# required - path within the file-system where data is stored/loaded
-    load_defaults: "true"           \# optional - whether to load the default Hadoop configuration (default) or not
-    conf.<key> : "<value>"          \# optional - 'inlined' key=value added to the Hadoop configuration
-    compress: "false"               \# optional - whether to compress the metadata or not (default)
-    chunk_size: "10mb"              \# optional - chunk size (disabled by default)
-----


### PR DESCRIPTION
Reported at: https://discuss.elastic.co/t/combine-elasticsearch-5-1-1-and-repository-hdfs/69659

If you define as described [in our docs](https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-hdfs-config.html) the following `elasticsearch.yml` settings:

```yml
repositories:
  hdfs:
    uri: "hdfs://es-master:9000/" # optional - Hadoop file-system URI
    path: "some/path" # required - path with the file-system where data is stored/loaded
```

It fails at startup because we don't register the global setting `repositories.hdfs.path` in `HdfsPlugin`.

This PR removes that from our docs so people must provide those settings only when registering the repository with:

```
PUT _snapshot/my_hdfs_repository
{
  "type": "hdfs",
  "settings": {
    "uri": "hdfs://namenode:8020/",
    "path": "elasticsearch/respositories/my_hdfs_repository",
    "conf.dfs.client.read.shortcircuit": "true"
  }
}
```

Based on issue #22800.

Closes #22301