### PR TITLE
First step towards separating individual search phases

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -487,9 +487,10 @@ abstract class AbstractSearchAsyncAction<FirstResult extends SearchPhaseResult> 
             }
         }
 
-        private void executeFetch(final int shardIndex, final SearchShardTarget shardTarget, final  CountedCollector<FetchSearchResult> counter,
-                          final ShardFetchSearchRequest fetchSearchRequest, final QuerySearchResult querySearchResult,
-                          Transport.Connection connection) {
+        private void executeFetch(final int shardIndex, final SearchShardTarget shardTarget,
+                                    final CountedCollector<FetchSearchResult> counter,
+                                    final ShardFetchSearchRequest fetchSearchRequest, final QuerySearchResult querySearchResult,
+                                    final Transport.Connection connection) {
             searchTransportService.sendExecuteFetch(connection, fetchSearchRequest, task, new ActionListener<FetchSearchResult>() {
                 @Override
                 public void onResponse(FetchSearchResult result) {
@@ -530,7 +531,6 @@ abstract class AbstractSearchAsyncAction<FirstResult extends SearchPhaseResult> 
                 }
             }
         }
-
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
@@ -39,9 +39,7 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 
-class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<DfsSearchResult> {
-
-    protected final SearchPhaseController searchPhaseController;
+final class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<DfsSearchResult> {
 
     SearchDfsQueryThenFetchAsyncAction(Logger logger, SearchTransportService searchTransportService,
                                        Function<String, Transport.Connection> nodeIdToConnection,
@@ -49,9 +47,8 @@ class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<DfsSe
                                        SearchPhaseController searchPhaseController, Executor executor, SearchRequest request,
                                        ActionListener<SearchResponse> listener, GroupShardsIterator shardsIts, long startTime,
                                        long clusterStateVersion, SearchTask task) {
-        super(logger, searchTransportService, nodeIdToConnection, aliasFilter, concreteIndexBoosts, executor,
+        super(logger, searchTransportService, nodeIdToConnection, aliasFilter, concreteIndexBoosts, searchPhaseController, executor,
                 request, listener, shardsIts, startTime, clusterStateVersion, task);
-        this.searchPhaseController = searchPhaseController;
     }
 
     @Override
@@ -71,7 +68,7 @@ class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<DfsSe
             (queryResults) -> new FetchPhase(queryResults, searchPhaseController));
     }
 
-    private class DfsQueryPhase implements CheckedRunnable<Exception> {
+    private final class DfsQueryPhase implements CheckedRunnable<Exception> {
         private final AtomicArray<QuerySearchResultProvider> queryResult;
         private final SearchPhaseController searchPhaseController;
         private final AtomicArray<DfsSearchResult> firstResults;

--- a/core/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
@@ -19,40 +19,28 @@
 
 package org.elasticsearch.action.search;
 
-import com.carrotsearch.hppc.IntArrayList;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
-import org.apache.lucene.search.ScoreDoc;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRunnable;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
-import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.dfs.AggregatedDfs;
 import org.elasticsearch.search.dfs.DfsSearchResult;
-import org.elasticsearch.search.fetch.FetchSearchResult;
-import org.elasticsearch.search.fetch.ShardFetchSearchRequest;
 import org.elasticsearch.search.internal.AliasFilter;
-import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 import org.elasticsearch.search.query.QuerySearchRequest;
 import org.elasticsearch.search.query.QuerySearchResult;
+import org.elasticsearch.search.query.QuerySearchResultProvider;
 import org.elasticsearch.transport.Transport;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<DfsSearchResult> {
 
-    final AtomicArray<QuerySearchResult> queryResults;
-    final AtomicArray<FetchSearchResult> fetchResults;
-    final AtomicArray<IntArrayList> docIdsToLoad;
-    private final SearchPhaseController searchPhaseController;
+    protected final SearchPhaseController searchPhaseController;
 
     SearchDfsQueryThenFetchAsyncAction(Logger logger, SearchTransportService searchTransportService,
                                        Function<String, Transport.Connection> nodeIdToConnection,
@@ -63,13 +51,10 @@ class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<DfsSe
         super(logger, searchTransportService, nodeIdToConnection, aliasFilter, concreteIndexBoosts, executor,
                 request, listener, shardsIts, startTime, clusterStateVersion, task);
         this.searchPhaseController = searchPhaseController;
-        queryResults = new AtomicArray<>(firstResults.length());
-        fetchResults = new AtomicArray<>(firstResults.length());
-        docIdsToLoad = new AtomicArray<>(firstResults.length());
     }
 
     @Override
-    protected String firstPhaseName() {
+    protected String initialPhaseName() {
         return "dfs";
     }
 
@@ -80,149 +65,71 @@ class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<DfsSe
     }
 
     @Override
-    protected void moveToSecondPhase() {
-        final AggregatedDfs dfs = searchPhaseController.aggregateDfs(firstResults);
-        final AtomicInteger counter = new AtomicInteger(firstResults.asList().size());
-        for (final AtomicArray.Entry<DfsSearchResult> entry : firstResults.asList()) {
-            DfsSearchResult dfsResult = entry.value;
-            Transport.Connection connection = nodeIdToConnection.apply(dfsResult.shardTarget().getNodeId());
-            QuerySearchRequest querySearchRequest = new QuerySearchRequest(request, dfsResult.id(), dfs);
-            executeQuery(entry.index, dfsResult, counter, querySearchRequest, connection);
-        }
+    protected void executeNextPhase(AtomicArray<DfsSearchResult> initialResults) {
+        DfsQueryPhase queryPhase = new DfsQueryPhase(initialResults, searchPhaseController,
+            (queryResults) -> new FetchPhase(queryResults, searchPhaseController));
+        queryPhase.execute();
     }
 
-    void executeQuery(final int shardIndex, final DfsSearchResult dfsResult, final AtomicInteger counter,
-                      final QuerySearchRequest querySearchRequest, final Transport.Connection connection) {
-        searchTransportService.sendExecuteQuery(connection, querySearchRequest, task, new ActionListener<QuerySearchResult>() {
-            @Override
-            public void onResponse(QuerySearchResult result) {
-                result.shardTarget(dfsResult.shardTarget());
-                queryResults.set(shardIndex, result);
-                if (counter.decrementAndGet() == 0) {
-                    executeFetchPhase();
-                }
-            }
+    private class DfsQueryPhase {
+        private final AtomicArray<QuerySearchResultProvider> queryResult;
+        private final SearchPhaseController searchPhaseController;
+        private final AtomicArray<DfsSearchResult> firstResults;
+        private final Function<AtomicArray<QuerySearchResultProvider>, Runnable> nextPhaseFactory;
 
-            @Override
-            public void onFailure(Exception t) {
-                try {
-                    onQueryFailure(t, querySearchRequest, shardIndex, dfsResult, counter);
-                } finally {
-                    // the query might not have been executed at all (for example because thread pool rejected
-                    // execution) and the search context that was created in dfs phase might not be released.
-                    // release it again to be in the safe side
-                    sendReleaseSearchContext(querySearchRequest.id(), connection);
-                }
-            }
-        });
-    }
-
-    void onQueryFailure(Exception e, QuerySearchRequest querySearchRequest, int shardIndex, DfsSearchResult dfsResult,
-                        AtomicInteger counter) {
-        if (logger.isDebugEnabled()) {
-            logger.debug((Supplier<?>) () -> new ParameterizedMessage("[{}] Failed to execute query phase", querySearchRequest.id()), e);
-        }
-        this.addShardFailure(shardIndex, dfsResult.shardTarget(), e);
-        successfulOps.decrementAndGet();
-        if (counter.decrementAndGet() == 0) {
-            if (successfulOps.get() == 0) {
-                listener.onFailure(new SearchPhaseExecutionException("query", "all shards failed", buildShardFailures()));
-            } else {
-                executeFetchPhase();
-            }
-        }
-    }
-
-    void executeFetchPhase() {
-        try {
-            innerExecuteFetchPhase();
-        } catch (Exception e) {
-            listener.onFailure(new ReduceSearchPhaseException("query", "", e, buildShardFailures()));
-        }
-    }
-
-    void innerExecuteFetchPhase() throws Exception {
-        final boolean isScrollRequest = request.scroll() != null;
-        sortedShardDocs = searchPhaseController.sortDocs(isScrollRequest, queryResults);
-        searchPhaseController.fillDocIdsToLoad(docIdsToLoad, sortedShardDocs);
-
-        if (docIdsToLoad.asList().isEmpty()) {
-            finishHim();
-            return;
+        public DfsQueryPhase(AtomicArray<DfsSearchResult> firstResults,
+                             SearchPhaseController searchPhaseController,
+                             Function<AtomicArray<QuerySearchResultProvider>, Runnable> nextPhaseFactory) {
+            this.queryResult = new AtomicArray<>(firstResults.length());
+            this.searchPhaseController = searchPhaseController;
+            this.firstResults = firstResults;
+            this.nextPhaseFactory = nextPhaseFactory;
         }
 
-        final ScoreDoc[] lastEmittedDocPerShard = (request.scroll() != null) ?
-            searchPhaseController.getLastEmittedDocPerShard(queryResults.asList(), sortedShardDocs, firstResults.length()) : null;
-        final AtomicInteger counter = new AtomicInteger(docIdsToLoad.asList().size());
-        for (final AtomicArray.Entry<IntArrayList> entry : docIdsToLoad.asList()) {
-            QuerySearchResult queryResult = queryResults.get(entry.index);
-            Transport.Connection connection = nodeIdToConnection.apply(queryResult.shardTarget().getNodeId());
-            ShardFetchSearchRequest fetchSearchRequest = createFetchRequest(queryResult, entry, lastEmittedDocPerShard);
-            executeFetch(entry.index, queryResult.shardTarget(), counter, fetchSearchRequest, connection);
-        }
-    }
-
-    void executeFetch(final int shardIndex, final SearchShardTarget shardTarget, final AtomicInteger counter,
-                      final ShardFetchSearchRequest fetchSearchRequest, Transport.Connection connection) {
-        searchTransportService.sendExecuteFetch(connection, fetchSearchRequest, task, new ActionListener<FetchSearchResult>() {
-            @Override
-            public void onResponse(FetchSearchResult result) {
-                result.shardTarget(shardTarget);
-                fetchResults.set(shardIndex, result);
-                if (counter.decrementAndGet() == 0) {
-                    finishHim();
-                }
-            }
-
-            @Override
-            public void onFailure(Exception t) {
-                // the search context might not be cleared on the node where the fetch was executed for example
-                // because the action was rejected by the thread pool. in this case we need to send a dedicated
-                // request to clear the search context. by setting docIdsToLoad to null, the context will be cleared
-                // in TransportSearchTypeAction.releaseIrrelevantSearchContexts() after the search request is done.
-                docIdsToLoad.set(shardIndex, null);
-                onFetchFailure(t, fetchSearchRequest, shardIndex, shardTarget, counter);
-            }
-        });
-    }
-
-    void onFetchFailure(Exception e, ShardFetchSearchRequest fetchSearchRequest, int shardIndex,
-                        SearchShardTarget shardTarget, AtomicInteger counter) {
-        if (logger.isDebugEnabled()) {
-            logger.debug((Supplier<?>) () -> new ParameterizedMessage("[{}] Failed to execute fetch phase", fetchSearchRequest.id()), e);
-        }
-        this.addShardFailure(shardIndex, shardTarget, e);
-        successfulOps.decrementAndGet();
-        if (counter.decrementAndGet() == 0) {
-            finishHim();
-        }
-    }
-
-    private void finishHim() {
-        getExecutor().execute(new ActionRunnable<SearchResponse>(listener) {
-            @Override
-            public void doRun() throws IOException {
-                final boolean isScrollRequest = request.scroll() != null;
-                final InternalSearchResponse internalResponse = searchPhaseController.merge(isScrollRequest, sortedShardDocs, queryResults,
-                    fetchResults);
-                String scrollId = isScrollRequest ? TransportSearchHelper.buildScrollId(request.searchType(), firstResults) : null;
-                listener.onResponse(new SearchResponse(internalResponse, scrollId, expectedSuccessfulOps, successfulOps.get(),
-                    buildTookInMillis(), buildShardFailures()));
-                releaseIrrelevantSearchContexts(queryResults, docIdsToLoad);
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                try {
-                    ReduceSearchPhaseException failure = new ReduceSearchPhaseException("merge", "", e, buildShardFailures());
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("failed to reduce search", failure);
+        public void execute() {
+            final AggregatedDfs dfs = searchPhaseController.aggregateDfs(firstResults);
+            final CountedCollector<QuerySearchResultProvider> counter = new CountedCollector<>(queryResult, (successfulOps) -> {
+                    if (successfulOps == 0) {
+                        listener.onFailure(new SearchPhaseExecutionException("query", "all shards failed", buildShardFailures()));
+                    } else {
+                        Runnable nextPhase = this.nextPhaseFactory.apply(queryResult);
+                        nextPhase.run();
                     }
-                    super.onFailure(failure);
-                } finally {
-                    releaseIrrelevantSearchContexts(queryResults, docIdsToLoad);
-                }
+                });
+            for (final AtomicArray.Entry<DfsSearchResult> entry : firstResults.asList()) {
+                DfsSearchResult dfsResult = entry.value;
+                final int shardIndex = entry.index;
+                Transport.Connection connection = nodeIdToConnection.apply(dfsResult.shardTarget().getNodeId());
+                QuerySearchRequest querySearchRequest = new QuerySearchRequest(request, dfsResult.id(), dfs);
+                executeQuery(querySearchRequest, connection, new ActionListener<QuerySearchResult>() {
+                    @Override
+                    public void onResponse(QuerySearchResult result) {
+                        counter.onResult(shardIndex, result, dfsResult.shardTarget());
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        try {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug((Supplier<?>) () -> new ParameterizedMessage("[{}] Failed to execute query phase",
+                                    querySearchRequest.id()), e);
+                            }
+                            counter.onFailure(shardIndex, dfsResult.shardTarget(), e);
+                        } finally {
+                            // the query might not have been executed at all (for example because thread pool rejected
+                            // execution) and the search context that was created in dfs phase might not be released.
+                            // release it again to be in the safe side
+                            sendReleaseSearchContext(querySearchRequest.id(), connection);
+                        }
+                    }
+                });
             }
-        });
+
+        }
+
+        protected void executeQuery(final QuerySearchRequest querySearchRequest, final Transport.Connection connection,
+                                    ActionListener<QuerySearchResult> queryListener) {
+            searchTransportService.sendExecuteQuery(connection, querySearchRequest, task, queryListener);
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
@@ -31,11 +31,15 @@ import org.apache.lucene.search.TermStatistics;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopFieldDocs;
 import org.apache.lucene.search.grouping.CollapseTopFieldDocs;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.IntsRef;
 import org.elasticsearch.common.collect.HppcMaps;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.ArrayUtils;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -64,6 +68,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -365,15 +370,16 @@ public class SearchPhaseController extends AbstractComponent {
     /**
      * Builds an array, with potential null elements, with docs to load.
      */
-    public void fillDocIdsToLoad(AtomicArray<IntArrayList> docIdsToLoad, ScoreDoc[] shardDocs) {
+    public IntArrayList[] fillDocIdsToLoad(int numShards, ScoreDoc[] shardDocs) {
+        IntArrayList[] docIdsToLoad = new IntArrayList[numShards];
         for (ScoreDoc shardDoc : shardDocs) {
-            IntArrayList shardDocIdsToLoad = docIdsToLoad.get(shardDoc.shardIndex);
+            IntArrayList shardDocIdsToLoad = docIdsToLoad[shardDoc.shardIndex];
             if (shardDocIdsToLoad == null) {
-                shardDocIdsToLoad = new IntArrayList(); // can't be shared!, uses unsafe on it later on
-                docIdsToLoad.set(shardDoc.shardIndex, shardDocIdsToLoad);
+                shardDocIdsToLoad = docIdsToLoad[shardDoc.shardIndex] = new IntArrayList();
             }
             shardDocIdsToLoad.add(shardDoc.doc);
         }
+        return docIdsToLoad;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/search/SearchQueryAndFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchQueryAndFetchAsyncAction.java
@@ -21,25 +21,19 @@ package org.elasticsearch.action.search;
 
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRunnable;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.search.fetch.QueryFetchSearchResult;
 import org.elasticsearch.search.internal.AliasFilter;
-import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 import org.elasticsearch.transport.Transport;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 
-class SearchQueryAndFetchAsyncAction extends AbstractSearchAsyncAction<QueryFetchSearchResult> {
-
-    private final SearchPhaseController searchPhaseController;
+final class SearchQueryAndFetchAsyncAction extends AbstractSearchAsyncAction<QueryFetchSearchResult> {
 
     SearchQueryAndFetchAsyncAction(Logger logger, SearchTransportService searchTransportService,
                                    Function<String, Transport.Connection> nodeIdToConnection,
@@ -48,9 +42,8 @@ class SearchQueryAndFetchAsyncAction extends AbstractSearchAsyncAction<QueryFetc
                                    SearchRequest request, ActionListener<SearchResponse> listener,
                                    GroupShardsIterator shardsIts, long startTime, long clusterStateVersion,
                                    SearchTask task) {
-        super(logger, searchTransportService, nodeIdToConnection, aliasFilter, concreteIndexBoosts, executor,
+        super(logger, searchTransportService, nodeIdToConnection, aliasFilter, concreteIndexBoosts, searchPhaseController, executor,
                 request, listener, shardsIts, startTime, clusterStateVersion, task);
-        this.searchPhaseController = searchPhaseController;
     }
 
     @Override
@@ -66,6 +59,6 @@ class SearchQueryAndFetchAsyncAction extends AbstractSearchAsyncAction<QueryFetc
 
     @Override
     protected CheckedRunnable<Exception> getNextPhase(AtomicArray<QueryFetchSearchResult> initialResults) {
-        return () -> sendResponseAsync(searchPhaseController, null, initialResults, initialResults);
+        return () -> sendResponseAsync("fetch", searchPhaseController, null, initialResults, initialResults);
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/search/SearchQueryAndFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchQueryAndFetchAsyncAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
+import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.search.fetch.QueryFetchSearchResult;
 import org.elasticsearch.search.internal.AliasFilter;
@@ -64,7 +65,7 @@ class SearchQueryAndFetchAsyncAction extends AbstractSearchAsyncAction<QueryFetc
     }
 
     @Override
-    protected void executeNextPhase(AtomicArray<QueryFetchSearchResult> initialResults) throws Exception {
-        sendResponseAsync(searchPhaseController, null, initialResults, initialResults);
+    protected CheckedRunnable<Exception> getNextPhase(AtomicArray<QueryFetchSearchResult> initialResults) {
+        return () -> sendResponseAsync(searchPhaseController, null, initialResults, initialResults);
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -42,8 +42,8 @@ final class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<Qu
                                     SearchRequest request, ActionListener<SearchResponse> listener,
                                     GroupShardsIterator shardsIts, long startTime, long clusterStateVersion,
                                     SearchTask task) {
-        super(logger, searchTransportService, nodeIdToConnection, aliasFilter, concreteIndexBoosts, searchPhaseController, executor, request, listener,
-            shardsIts, startTime, clusterStateVersion, task);
+        super(logger, searchTransportService, nodeIdToConnection, aliasFilter, concreteIndexBoosts, searchPhaseController, executor,
+            request, listener, shardsIts, startTime, clusterStateVersion, task);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -19,35 +19,20 @@
 
 package org.elasticsearch.action.search;
 
-import com.carrotsearch.hppc.IntArrayList;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.apache.logging.log4j.util.Supplier;
-import org.apache.lucene.search.ScoreDoc;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRunnable;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
-import org.elasticsearch.search.SearchShardTarget;
-import org.elasticsearch.search.fetch.FetchSearchResult;
-import org.elasticsearch.search.fetch.ShardFetchSearchRequest;
 import org.elasticsearch.search.internal.AliasFilter;
-import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 import org.elasticsearch.search.query.QuerySearchResultProvider;
 import org.elasticsearch.transport.Transport;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<QuerySearchResultProvider> {
-
-    final AtomicArray<FetchSearchResult> fetchResults;
-    final AtomicArray<IntArrayList> docIdsToLoad;
     private final SearchPhaseController searchPhaseController;
 
     SearchQueryThenFetchAsyncAction(Logger logger, SearchTransportService searchTransportService,
@@ -60,12 +45,10 @@ class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<QuerySea
         super(logger, searchTransportService, nodeIdToConnection, aliasFilter, concreteIndexBoosts, executor, request, listener,
             shardsIts, startTime, clusterStateVersion, task);
         this.searchPhaseController = searchPhaseController;
-        fetchResults = new AtomicArray<>(firstResults.length());
-        docIdsToLoad = new AtomicArray<>(firstResults.length());
     }
 
     @Override
-    protected String firstPhaseName() {
+    protected String initialPhaseName() {
         return "query";
     }
 
@@ -76,88 +59,8 @@ class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<QuerySea
     }
 
     @Override
-    protected void moveToSecondPhase() throws Exception {
-        final boolean isScrollRequest = request.scroll() != null;
-        sortedShardDocs = searchPhaseController.sortDocs(isScrollRequest, firstResults);
-        searchPhaseController.fillDocIdsToLoad(docIdsToLoad, sortedShardDocs);
-
-        if (docIdsToLoad.asList().isEmpty()) {
-            finishHim();
-            return;
-        }
-
-        final ScoreDoc[] lastEmittedDocPerShard = isScrollRequest ?
-            searchPhaseController.getLastEmittedDocPerShard(firstResults.asList(), sortedShardDocs, firstResults.length()) : null;
-        final AtomicInteger counter = new AtomicInteger(docIdsToLoad.asList().size());
-        for (AtomicArray.Entry<IntArrayList> entry : docIdsToLoad.asList()) {
-            QuerySearchResultProvider queryResult = firstResults.get(entry.index);
-            Transport.Connection connection = nodeIdToConnection.apply(queryResult.shardTarget().getNodeId());
-            ShardFetchSearchRequest fetchSearchRequest = createFetchRequest(queryResult.queryResult(), entry, lastEmittedDocPerShard);
-            executeFetch(entry.index, queryResult.shardTarget(), counter, fetchSearchRequest, connection);
-        }
-    }
-
-    void executeFetch(final int shardIndex, final SearchShardTarget shardTarget, final AtomicInteger counter,
-                      final ShardFetchSearchRequest fetchSearchRequest, Transport.Connection connection) {
-        searchTransportService.sendExecuteFetch(connection, fetchSearchRequest, task, new ActionListener<FetchSearchResult>() {
-            @Override
-            public void onResponse(FetchSearchResult result) {
-                result.shardTarget(shardTarget);
-                fetchResults.set(shardIndex, result);
-                if (counter.decrementAndGet() == 0) {
-                    finishHim();
-                }
-            }
-
-            @Override
-            public void onFailure(Exception t) {
-                // the search context might not be cleared on the node where the fetch was executed for example
-                // because the action was rejected by the thread pool. in this case we need to send a dedicated
-                // request to clear the search context. by setting docIdsToLoad to null, the context will be cleared
-                // in TransportSearchTypeAction.releaseIrrelevantSearchContexts() after the search request is done.
-                docIdsToLoad.set(shardIndex, null);
-                onFetchFailure(t, fetchSearchRequest, shardIndex, shardTarget, counter);
-            }
-        });
-    }
-
-    void onFetchFailure(Exception e, ShardFetchSearchRequest fetchSearchRequest, int shardIndex, SearchShardTarget shardTarget,
-                        AtomicInteger counter) {
-        if (logger.isDebugEnabled()) {
-            logger.debug((Supplier<?>) () -> new ParameterizedMessage("[{}] Failed to execute fetch phase", fetchSearchRequest.id()), e);
-        }
-        this.addShardFailure(shardIndex, shardTarget, e);
-        successfulOps.decrementAndGet();
-        if (counter.decrementAndGet() == 0) {
-            finishHim();
-        }
-    }
-
-    private void finishHim() {
-        getExecutor().execute(new ActionRunnable<SearchResponse>(listener) {
-            @Override
-            public void doRun() throws IOException {
-                final boolean isScrollRequest = request.scroll() != null;
-                final InternalSearchResponse internalResponse = searchPhaseController.merge(isScrollRequest, sortedShardDocs, firstResults,
-                    fetchResults);
-                String scrollId = isScrollRequest ? TransportSearchHelper.buildScrollId(request.searchType(), firstResults) : null;
-                listener.onResponse(new SearchResponse(internalResponse, scrollId, expectedSuccessfulOps,
-                    successfulOps.get(), buildTookInMillis(), buildShardFailures()));
-                releaseIrrelevantSearchContexts(firstResults, docIdsToLoad);
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                try {
-                    ReduceSearchPhaseException failure = new ReduceSearchPhaseException("fetch", "", e, buildShardFailures());
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("failed to reduce search", failure);
-                    }
-                    super.onFailure(failure);
-                } finally {
-                    releaseIrrelevantSearchContexts(firstResults, docIdsToLoad);
-                }
-            }
-        });
+    protected void executeNextPhase(AtomicArray<QuerySearchResultProvider> initialResults) throws Exception {
+        final FetchPhase fetchPhase = new FetchPhase(initialResults, searchPhaseController);
+        fetchPhase.run();
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.search;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
+import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.search.internal.ShardSearchTransportRequest;
@@ -59,8 +60,7 @@ class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<QuerySea
     }
 
     @Override
-    protected void executeNextPhase(AtomicArray<QuerySearchResultProvider> initialResults) throws Exception {
-        final FetchPhase fetchPhase = new FetchPhase(initialResults, searchPhaseController);
-        fetchPhase.run();
+    protected CheckedRunnable<Exception> getNextPhase(AtomicArray<QuerySearchResultProvider> initialResults) {
+        return new FetchPhase(initialResults, searchPhaseController);
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -33,8 +33,7 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 
-class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<QuerySearchResultProvider> {
-    private final SearchPhaseController searchPhaseController;
+final class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<QuerySearchResultProvider> {
 
     SearchQueryThenFetchAsyncAction(Logger logger, SearchTransportService searchTransportService,
                                     Function<String, Transport.Connection> nodeIdToConnection,
@@ -43,9 +42,8 @@ class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<QuerySea
                                     SearchRequest request, ActionListener<SearchResponse> listener,
                                     GroupShardsIterator shardsIts, long startTime, long clusterStateVersion,
                                     SearchTask task) {
-        super(logger, searchTransportService, nodeIdToConnection, aliasFilter, concreteIndexBoosts, executor, request, listener,
+        super(logger, searchTransportService, nodeIdToConnection, aliasFilter, concreteIndexBoosts, searchPhaseController, executor, request, listener,
             shardsIts, startTime, clusterStateVersion, task);
-        this.searchPhaseController = searchPhaseController;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/search/SearchScrollQueryThenFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchScrollQueryThenFetchAsyncAction.java
@@ -169,12 +169,12 @@ class SearchScrollQueryThenFetchAsyncAction extends AbstractAsyncAction {
 
     private void executeFetchPhase() throws Exception {
         sortedShardDocs = searchPhaseController.sortDocs(true, queryResults);
-        final IntArrayList[] docIdsToLoad = searchPhaseController.fillDocIdsToLoad(queryResults.length(), sortedShardDocs);
         if (sortedShardDocs.length == 0) {
             finishHim();
             return;
         }
 
+        final IntArrayList[] docIdsToLoad = searchPhaseController.fillDocIdsToLoad(queryResults.length(), sortedShardDocs);
         final ScoreDoc[] lastEmittedDocPerShard = searchPhaseController.getLastEmittedDocPerShard(queryResults.asList(),
             sortedShardDocs, queryResults.length());
         final AtomicInteger counter = new AtomicInteger(docIdsToLoad.length);
@@ -207,6 +207,11 @@ class SearchScrollQueryThenFetchAsyncAction extends AbstractAsyncAction {
                         }
                     }
                 });
+            } else {
+                // the counter is set to the total size of docIdsToLoad which can have null values so we have to count them down too
+                if (counter.decrementAndGet() == 0) {
+                    finishHim();
+                }
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/search/SearchScrollQueryThenFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchScrollQueryThenFetchAsyncAction.java
@@ -36,6 +36,7 @@ import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.search.query.ScrollQuerySearchResult;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -168,45 +169,45 @@ class SearchScrollQueryThenFetchAsyncAction extends AbstractAsyncAction {
 
     private void executeFetchPhase() throws Exception {
         sortedShardDocs = searchPhaseController.sortDocs(true, queryResults);
-        AtomicArray<IntArrayList> docIdsToLoad = new AtomicArray<>(queryResults.length());
-        searchPhaseController.fillDocIdsToLoad(docIdsToLoad, sortedShardDocs);
-
-        if (docIdsToLoad.asList().isEmpty()) {
+        final IntArrayList[] docIdsToLoad = searchPhaseController.fillDocIdsToLoad(queryResults.length(), sortedShardDocs);
+        if (sortedShardDocs.length == 0) {
             finishHim();
             return;
         }
 
-
         final ScoreDoc[] lastEmittedDocPerShard = searchPhaseController.getLastEmittedDocPerShard(queryResults.asList(),
             sortedShardDocs, queryResults.length());
-        final AtomicInteger counter = new AtomicInteger(docIdsToLoad.asList().size());
-        for (final AtomicArray.Entry<IntArrayList> entry : docIdsToLoad.asList()) {
-            IntArrayList docIds = entry.value;
-            final QuerySearchResult querySearchResult = queryResults.get(entry.index);
-            ScoreDoc lastEmittedDoc = lastEmittedDocPerShard[entry.index];
-            ShardFetchRequest shardFetchRequest = new ShardFetchRequest(querySearchResult.id(), docIds, lastEmittedDoc);
-            DiscoveryNode node = nodes.get(querySearchResult.shardTarget().getNodeId());
-            searchTransportService.sendExecuteFetchScroll(node, shardFetchRequest, task, new ActionListener<FetchSearchResult>() {
-                @Override
-                public void onResponse(FetchSearchResult result) {
-                    result.shardTarget(querySearchResult.shardTarget());
-                    fetchResults.set(entry.index, result);
-                    if (counter.decrementAndGet() == 0) {
-                        finishHim();
+        final AtomicInteger counter = new AtomicInteger(docIdsToLoad.length);
+        for (int i = 0; i < docIdsToLoad.length; i++) {
+            final int index = i;
+            final IntArrayList docIds = docIdsToLoad[index];
+            if (docIds != null) {
+                final QuerySearchResult querySearchResult = queryResults.get(index);
+                ScoreDoc lastEmittedDoc = lastEmittedDocPerShard[index];
+                ShardFetchRequest shardFetchRequest = new ShardFetchRequest(querySearchResult.id(), docIds, lastEmittedDoc);
+                DiscoveryNode node = nodes.get(querySearchResult.shardTarget().getNodeId());
+                searchTransportService.sendExecuteFetchScroll(node, shardFetchRequest, task, new ActionListener<FetchSearchResult>() {
+                    @Override
+                    public void onResponse(FetchSearchResult result) {
+                        result.shardTarget(querySearchResult.shardTarget());
+                        fetchResults.set(index, result);
+                        if (counter.decrementAndGet() == 0) {
+                            finishHim();
+                        }
                     }
-                }
 
-                @Override
-                public void onFailure(Exception t) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Failed to execute fetch phase", t);
+                    @Override
+                    public void onFailure(Exception t) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Failed to execute fetch phase", t);
+                        }
+                        successfulOps.decrementAndGet();
+                        if (counter.decrementAndGet() == 0) {
+                            finishHim();
+                        }
                     }
-                    successfulOps.decrementAndGet();
-                    if (counter.decrementAndGet() == 0) {
-                        finishHim();
-                    }
-                }
-            });
+                });
+            }
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -71,7 +71,6 @@ public class SearchTransportService extends AbstractLifecycleComponent {
     public static final String QUERY_ID_ACTION_NAME = "indices:data/read/search[phase/query/id]";
     public static final String QUERY_SCROLL_ACTION_NAME = "indices:data/read/search[phase/query/scroll]";
     public static final String QUERY_FETCH_ACTION_NAME = "indices:data/read/search[phase/query+fetch]";
-    public static final String QUERY_QUERY_FETCH_ACTION_NAME = "indices:data/read/search[phase/query/query+fetch]";
     public static final String QUERY_FETCH_SCROLL_ACTION_NAME = "indices:data/read/search[phase/query+fetch/scroll]";
     public static final String FETCH_ID_SCROLL_ACTION_NAME = "indices:data/read/search[phase/fetch/id/scroll]";
     public static final String FETCH_ID_ACTION_NAME = "indices:data/read/search[phase/fetch/id]";
@@ -139,12 +138,6 @@ public class SearchTransportService extends AbstractLifecycleComponent {
     public void sendExecuteFetch(Transport.Connection connection, final ShardSearchTransportRequest request, SearchTask task,
                                  final ActionListener<QueryFetchSearchResult> listener) {
         transportService.sendChildRequest(connection, QUERY_FETCH_ACTION_NAME, request, task,
-            new ActionListenerResponseHandler<>(listener, QueryFetchSearchResult::new));
-    }
-
-    public void sendExecuteFetch(Transport.Connection connection, final QuerySearchRequest request, SearchTask task,
-                                 final ActionListener<QueryFetchSearchResult> listener) {
-        transportService.sendChildRequest(connection, QUERY_QUERY_FETCH_ACTION_NAME, request, task,
             new ActionListenerResponseHandler<>(listener, QueryFetchSearchResult::new));
     }
 
@@ -350,16 +343,6 @@ public class SearchTransportService extends AbstractLifecycleComponent {
                 }
             });
         TransportActionProxy.registerProxyAction(transportService, QUERY_FETCH_ACTION_NAME, QueryFetchSearchResult::new);
-
-        transportService.registerRequestHandler(QUERY_QUERY_FETCH_ACTION_NAME, QuerySearchRequest::new, ThreadPool.Names.SEARCH,
-            new TaskAwareTransportRequestHandler<QuerySearchRequest>() {
-                @Override
-                public void messageReceived(QuerySearchRequest request, TransportChannel channel, Task task) throws Exception {
-                    QueryFetchSearchResult result = searchService.executeFetchPhase(request, (SearchTask)task);
-                    channel.sendResponse(result);
-                }
-            });
-        TransportActionProxy.registerProxyAction(transportService, QUERY_QUERY_FETCH_ACTION_NAME, QueryFetchSearchResult::new);
 
         transportService.registerRequestHandler(QUERY_FETCH_SCROLL_ACTION_NAME, InternalScrollSearchRequest::new, ThreadPool.Names.SEARCH,
             new TaskAwareTransportRequestHandler<InternalScrollSearchRequest>() {

--- a/core/src/test/java/org/elasticsearch/action/RejectionActionIT.java
+++ b/core/src/test/java/org/elasticsearch/action/RejectionActionIT.java
@@ -80,7 +80,7 @@ public class RejectionActionIT extends ESIntegTestCase {
                     });
         }
         latch.await();
-        assertThat(responses.size(), equalTo(numberOfAsyncOps));
+
 
         // validate all responses
         for (Object response : responses) {
@@ -102,5 +102,6 @@ public class RejectionActionIT extends ESIntegTestCase {
                 }
             }
         }
+        assertThat(responses.size(), equalTo(numberOfAsyncOps));
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchPhaseResult;
@@ -114,9 +115,9 @@ public class SearchAsyncActionTests extends ESTestCase {
             }
 
             @Override
-            protected void moveToSecondPhase() throws Exception {
-                for (int i = 0; i < firstResults.length(); i++) {
-                    TestSearchPhaseResult result = firstResults.get(i);
+            protected void executeNextPhase(AtomicArray<TestSearchPhaseResult> initialResults) throws Exception {
+                for (int i = 0; i < initialResults.length(); i++) {
+                    TestSearchPhaseResult result = initialResults.get(i);
                     assertEquals(result.node.getId(), result.shardTarget().getNodeId());
                     sendReleaseSearchContext(result.id(), new MockConnection(result.node));
                 }
@@ -125,7 +126,7 @@ public class SearchAsyncActionTests extends ESTestCase {
             }
 
             @Override
-            protected String firstPhaseName() {
+            protected String initialPhaseName() {
                 return "test";
             }
 

--- a/core/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
@@ -97,7 +97,7 @@ public class SearchAsyncActionTests extends ESTestCase {
         lookup.put(replicaNode.getId(), new MockConnection(replicaNode));
         Map<String, AliasFilter> aliasFilters = Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY));
         AbstractSearchAsyncAction asyncAction = new AbstractSearchAsyncAction<TestSearchPhaseResult>(logger, transportService, lookup::get,
-            aliasFilters, Collections.emptyMap(), null, request, responseListener, shardsIter, 0, 0, null) {
+            aliasFilters, Collections.emptyMap(), null, null, request, responseListener, shardsIter, 0, 0, null) {
             TestSearchResponse response = new TestSearchResponse();
 
             @Override


### PR DESCRIPTION
At this point AbstractSearchAsyncAction is just a base-class for the first phase of a search where we have multiple replicas
for each shardID. If one of them is not available we move to the next one. Yet, once we passed that first stage we have to work with
the shards we succeeded on the initial phase.
Unfortunately, subsequent phases are not fully detached from the initial phase since they are all non-static inner classes.
In future changes this will be changed to detach the inner classes to test them in isolation and to simplify their creation.
The AbstractSearchAsyncAction should be final and it should just get a factory for the next phase instead of requiring subclasses
etc.