### PR TITLE
ClusterState: Fix ClusterChangedEvent.indexRoutingTableChanged equality check

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterChangedEvent.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterChangedEvent.java
@@ -21,8 +21,8 @@ package org.elasticsearch.cluster;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexGraveyard;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -100,7 +100,7 @@ public class ClusterChangedEvent {
             return false;
         }
         if (state.routingTable().hasIndex(index) && previousState.routingTable().hasIndex(index)) {
-            return state.routingTable().index(index) != previousState.routingTable().index(index);
+            return state.routingTable().index(index).equals(previousState.routingTable().index(index)) == false;
         }
         return true;
     }


### PR DESCRIPTION
The equality check in `ClusterChangedEvent.indexRoutingTableChanged()` is not based on object equality, but only does reference equality. This can lead to cases where `ClusterChangedEvent.indexRoutingTableChange(String index)` returns true, even though the index did not change - this leads to confusion and unwanted trigger actions when using this API in a `ClusterStateListener`.

The same is true for `ClusterChangedEvent.routingTableChanged()` - suppose this is a leftover when there were no cluster state diffs, but maybe I am missing things and context here.