### PR TITLE
Read ec2 discovery address from aws instance tags

### DIFF
--- a/docs/plugins/discovery-ec2.asciidoc
+++ b/docs/plugins/discovery-ec2.asciidoc
@@ -172,9 +172,20 @@ The following are a list of settings (prefixed with `discovery.ec2`) that can fu
 
 `host_type`::
 
-    The type of host type to use to communicate with other instances. Can be
-    one of `private_ip`, `public_ip`, `private_dns`, `public_dns`. Defaults to
-    `private_ip`.
++
+--
+The type of host type to use to communicate with other instances. Can be
+one of `private_ip`, `public_ip`, `private_dns`, `public_dns` or `tag:TAGNAME` where
+`TAGNAME` refers to a name of a tag configured for all EC2 instances. Instances which don't
+have this tag set will be ignored by the discovery process.
+
+For example if you defined a tag `my-elasticsearch-host` in ec2 and set it to `myhostname1.mydomain.com`, then
+setting `host_type: tag:my-elasticsearch-host` will tell Discovery Ec2 plugin to read the host name from the
+`my-elasticsearch-host` tag. In this case, it will be resolved to `myhostname1.mydomain.com`.
+http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html[Read more about EC2 Tags].
+
+Defaults to `private_ip`.
+--
 
 `availability_zones`::
 

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
@@ -164,20 +164,22 @@ public interface AwsEc2Service {
      * Defines discovery settings for ec2. Starting with discovery.ec2.
      */
     interface DISCOVERY_EC2 {
-        enum HostType {
-            PRIVATE_IP,
-            PUBLIC_IP,
-            PRIVATE_DNS,
-            PUBLIC_DNS
+        class HostType {
+            public static final String PRIVATE_IP = "private_ip";
+            public static final String PUBLIC_IP = "public_ip";
+            public static final String PRIVATE_DNS = "private_dns";
+            public static final String PUBLIC_DNS = "public_dns";
+            public static final String TAG_PREFIX = "tag:";
         }
 
         /**
          * discovery.ec2.host_type: The type of host type to use to communicate with other instances.
-         * Can be one of private_ip, public_ip, private_dns, public_dns. Defaults to private_ip.
+         * Can be one of private_ip, public_ip, private_dns, public_dns or tag:XXXX where
+         * XXXX refers to a name of a tag configured for all EC2 instances. Instances which don't
+         * have this tag set will be ignored by the discovery process. Defaults to private_ip.
          */
-        Setting<HostType> HOST_TYPE_SETTING =
-            new Setting<>("discovery.ec2.host_type", HostType.PRIVATE_IP.name(), s -> HostType.valueOf(s.toUpperCase(Locale.ROOT)),
-                Property.NodeScope);
+        Setting<String> HOST_TYPE_SETTING =
+            new Setting<>("discovery.ec2.host_type", HostType.PRIVATE_IP, Function.identity(), Property.NodeScope);
         /**
          * discovery.ec2.any_group: If set to false, will require all security groups to be present for the instance to be used for the
          * discovery. Defaults to true.

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryTests.java
@@ -133,8 +133,8 @@ public class Ec2DiscoveryTests extends ESTestCase {
 
     public void testPrivateIp() throws InterruptedException {
         int nodes = randomInt(10);
-        for (int i = 0; i < nodes; i++) {
-            poorMansDNS.put(AmazonEC2Mock.PREFIX_PRIVATE_IP + (i+1), buildNewFakeTransportAddress());
+        for (int node = 1; node < nodes + 1; node++) {
+            poorMansDNS.put(AmazonEC2Mock.PREFIX_PRIVATE_IP + node, buildNewFakeTransportAddress());
         }
         Settings nodeSettings = Settings.builder()
             .put(DISCOVERY_EC2.HOST_TYPE_SETTING.getKey(), "private_ip")
@@ -152,8 +152,8 @@ public class Ec2DiscoveryTests extends ESTestCase {
 
     public void testPublicIp() throws InterruptedException {
         int nodes = randomInt(10);
-        for (int i = 0; i < nodes; i++) {
-            poorMansDNS.put(AmazonEC2Mock.PREFIX_PUBLIC_IP + (i+1), buildNewFakeTransportAddress());
+        for (int node = 1; node < nodes + 1; node++) {
+            poorMansDNS.put(AmazonEC2Mock.PREFIX_PUBLIC_IP + node, buildNewFakeTransportAddress());
         }
         Settings nodeSettings = Settings.builder()
             .put(DISCOVERY_EC2.HOST_TYPE_SETTING.getKey(), "public_ip")
@@ -171,9 +171,8 @@ public class Ec2DiscoveryTests extends ESTestCase {
 
     public void testPrivateDns() throws InterruptedException {
         int nodes = randomInt(10);
-        for (int i = 0; i < nodes; i++) {
-            String instanceId = "node" + (i+1);
-            poorMansDNS.put(AmazonEC2Mock.PREFIX_PRIVATE_DNS + instanceId +
+        for (int node = 1; node < nodes + 1; node++) {
+            poorMansDNS.put(AmazonEC2Mock.PREFIX_PRIVATE_DNS + "node" + node +
                 AmazonEC2Mock.SUFFIX_PRIVATE_DNS, buildNewFakeTransportAddress());
         }
         Settings nodeSettings = Settings.builder()
@@ -194,9 +193,8 @@ public class Ec2DiscoveryTests extends ESTestCase {
 
     public void testPublicDns() throws InterruptedException {
         int nodes = randomInt(10);
-        for (int i = 0; i < nodes; i++) {
-            String instanceId = "node" + (i+1);
-            poorMansDNS.put(AmazonEC2Mock.PREFIX_PUBLIC_DNS + instanceId
+        for (int node = 1; node < nodes + 1; node++) {
+            poorMansDNS.put(AmazonEC2Mock.PREFIX_PUBLIC_DNS + "node" + node
                 + AmazonEC2Mock.SUFFIX_PUBLIC_DNS, buildNewFakeTransportAddress());
         }
         Settings nodeSettings = Settings.builder()
@@ -283,13 +281,10 @@ public class Ec2DiscoveryTests extends ESTestCase {
     }
 
     public void testReadHostFromTag() throws InterruptedException, UnknownHostException {
-        int nodes = 2;//randomIntBetween(5, 10);
+        int nodes = randomIntBetween(5, 10);
 
-        String[] addresses = new String[nodes];
-
-        for (int node = 0; node < nodes; node++) {
-            addresses[node] = "192.168.0." + (node + 1);
-            poorMansDNS.put("node" + (node + 1), new InetSocketTransportAddress(InetAddress.getByName(addresses[node]), 9300));
+        for (int node = 1; node < nodes + 1; node++) {
+            poorMansDNS.put("node" + node, new InetSocketTransportAddress(InetAddress.getByName("192.168.0." + node), 9300));
         }
 
         Settings nodeSettings = Settings.builder()
@@ -298,9 +293,9 @@ public class Ec2DiscoveryTests extends ESTestCase {
 
         List<List<Tag>> tagsList = new ArrayList<>();
 
-        for (int node = 0; node < nodes; node++) {
+        for (int node = 1; node < nodes + 1; node++) {
             List<Tag> tags = new ArrayList<>();
-            tags.add(new Tag("foo", "node" + (node + 1)));
+            tags.add(new Tag("foo", "node" + node));
             tagsList.add(tags);
         }
 


### PR DESCRIPTION
This PR adds a new option for `host_type`: `tag:TAGNAME` where `TAGNAME` is the tag field you defined for your ec2 instance.

For example if you defined a tag `my-elasticsearch-host` in ec2 and set it to `myhostname1.mydomain.com`, then
setting `host_type: tag:my-elasticsearch-host` will tell Discovery Ec2 plugin to read the host name from the
`my-elasticsearch-host` tag. In this case, it will be resolved to `myhostname1.mydomain.com`.

Relates to #22566.
Backport of #22743 for 5.x branch (5.3)
