### PR TITLE
Ensure fixed serialization order of InnerHitBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -266,8 +267,10 @@ public final class InnerHitBuilder extends ToXContentToBytes implements Writeabl
         out.writeBoolean(hasScriptFields);
         if (hasScriptFields) {
             out.writeVInt(scriptFields.size());
-            for (ScriptField scriptField : scriptFields) {
-                scriptField.writeTo(out);
+            Iterator<ScriptField> iterator = scriptFields.stream()
+                    .sorted((a, b) -> a.fieldName().compareTo(b.fieldName())).iterator();
+            while (iterator.hasNext()) {
+                iterator.next().writeTo(out);
             }
         }
         out.writeOptionalWriteable(fetchSourceContext);
@@ -285,7 +288,10 @@ public final class InnerHitBuilder extends ToXContentToBytes implements Writeabl
         out.writeBoolean(hasChildInnerHits);
         if (hasChildInnerHits) {
             out.writeVInt(childInnerHits.size());
-            for (Map.Entry<String, InnerHitBuilder> entry : childInnerHits.entrySet()) {
+            Iterator<Map.Entry<String, InnerHitBuilder>> iterator = childInnerHits.entrySet().stream()
+                    .sorted((a, b) -> a.getKey().compareTo(b.getKey())).iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<String, InnerHitBuilder> entry = iterator.next();
                 out.writeString(entry.getKey());
                 entry.getValue().writeTo(out);
             }


### PR DESCRIPTION
Usually the order in which we serialize sets and maps of things doesn't matter,
but since InnerHitBuilder is part of SearchSourceBuilder, which is in turn used
as a cache key in its (serialized bytes form), we need to ensure the order of all
these fields when writing them to an output stream.

This adds tests and makes sure we iterate over the scriptField set and the
childInnerHits map in a fixed order.

Closes #22808
