### PR TITLE
Include stale replica shard info when explaining an unassigned primary

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocateUnassignedDecision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocateUnassignedDecision.java
@@ -35,7 +35,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Represents the allocation decision by an allocator for an unassigned shard.
@@ -270,13 +269,10 @@ public class AllocateUnassignedDecision extends AbstractAllocationDecision {
     }
 
     private boolean hasNodeWithStaleOrCorruptShard() {
-        if (getNodeDecisions() != null && getNodeDecisions().isEmpty() == false) {
-            return getNodeDecisions().stream().anyMatch(result ->
+        return getNodeDecisions() != null && getNodeDecisions().stream().anyMatch(result ->
                 result.getShardStoreInfo() != null
                     && (result.getShardStoreInfo().getAllocationId() != null
                             || result.getShardStoreInfo().getStoreException() != null));
-        }
-        return false;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocateUnassignedDecision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocateUnassignedDecision.java
@@ -271,12 +271,10 @@ public class AllocateUnassignedDecision extends AbstractAllocationDecision {
 
     private boolean hasNodeWithStaleOrCorruptShard() {
         if (getNodeDecisions() != null && getNodeDecisions().isEmpty() == false) {
-            return getNodeDecisions().stream()
-                       .filter(result -> result.getShardStoreInfo() != null
-                                             && (result.getShardStoreInfo().getAllocationId() != null
-                                                     || result.getShardStoreInfo().getStoreException() != null))
-                       .collect(Collectors.toList())
-                       .isEmpty() == false;
+            return getNodeDecisions().stream().anyMatch(result ->
+                result.getShardStoreInfo() != null
+                    && (result.getShardStoreInfo().getAllocationId() != null
+                            || result.getShardStoreInfo().getStoreException() != null));
         }
         return false;
     }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java
@@ -153,7 +153,14 @@ public class NodeAllocationResult implements ToXContent, Writeable, Comparable<N
             if (isWeightRanked()) {
                 builder.field("weight_ranking", getWeightRanking());
             }
-            if (canAllocateDecision.getDecisions().isEmpty() == false) {
+            boolean hasDecisions = false;
+            for (Decision d : canAllocateDecision.getDecisions()) {
+                if (d != canAllocateDecision) {
+                    hasDecisions = true;
+                    break;
+                }
+            }
+            if (hasDecisions) {
                 builder.startArray("deciders");
                 canAllocateDecision.toXContent(builder, params);
                 builder.endArray();

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cluster.routing.allocation;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.common.Nullable;
@@ -48,14 +49,15 @@ public class NodeAllocationResult implements ToXContent, Writeable, Comparable<N
     @Nullable
     private final ShardStoreInfo shardStoreInfo;
     private final AllocationDecision nodeDecision;
+    @Nullable
     private final Decision canAllocateDecision;
     private final int weightRanking;
 
-    public NodeAllocationResult(DiscoveryNode node, ShardStoreInfo shardStoreInfo, Decision decision) {
+    public NodeAllocationResult(DiscoveryNode node, ShardStoreInfo shardStoreInfo, @Nullable Decision decision) {
         this.node = node;
         this.shardStoreInfo = shardStoreInfo;
         this.canAllocateDecision = decision;
-        this.nodeDecision = AllocationDecision.fromDecisionType(canAllocateDecision.type());
+        this.nodeDecision = decision != null ? AllocationDecision.fromDecisionType(canAllocateDecision.type()) : AllocationDecision.NO;
         this.weightRanking = 0;
     }
 
@@ -78,7 +80,11 @@ public class NodeAllocationResult implements ToXContent, Writeable, Comparable<N
     public NodeAllocationResult(StreamInput in) throws IOException {
         node = new DiscoveryNode(in);
         shardStoreInfo = in.readOptionalWriteable(ShardStoreInfo::new);
-        canAllocateDecision = Decision.readFrom(in);
+        if (in.getVersion().before(Version.V_5_3_0_UNRELEASED)) {
+            canAllocateDecision = Decision.readFrom(in);
+        } else {
+            canAllocateDecision = Decision.readOptional(in);
+        }
         nodeDecision = AllocationDecision.readFrom(in);
         weightRanking = in.readVInt();
     }
@@ -87,7 +93,15 @@ public class NodeAllocationResult implements ToXContent, Writeable, Comparable<N
     public void writeTo(StreamOutput out) throws IOException {
         node.writeTo(out);
         out.writeOptionalWriteable(shardStoreInfo);
-        canAllocateDecision.writeTo(out);
+        if (out.getVersion().before(Version.V_5_3_0_UNRELEASED)) {
+            if (canAllocateDecision == null) {
+                Decision.NO.writeTo(out);
+            } else {
+                canAllocateDecision.writeTo(out);
+            }
+        } else {
+            out.writeOptionalWriteable(canAllocateDecision);
+        }
         nodeDecision.writeTo(out);
         out.writeVInt(weightRanking);
     }
@@ -108,8 +122,11 @@ public class NodeAllocationResult implements ToXContent, Writeable, Comparable<N
     }
 
     /**
-     * The decision details for allocating to this node.
+     * The decision details for allocating to this node.  Returns {@code null} if
+     * no allocation decision was taken on the node; in this case, {@link #getNodeDecision()}
+     * will return {@link AllocationDecision#NO}.
      */
+    @Nullable
     public Decision getCanAllocateDecision() {
         return canAllocateDecision;
     }
@@ -153,14 +170,7 @@ public class NodeAllocationResult implements ToXContent, Writeable, Comparable<N
             if (isWeightRanked()) {
                 builder.field("weight_ranking", getWeightRanking());
             }
-            boolean hasDecisions = false;
-            for (Decision d : canAllocateDecision.getDecisions()) {
-                if (d != canAllocateDecision) {
-                    hasDecisions = true;
-                    break;
-                }
-            }
-            if (hasDecisions) {
+            if (canAllocateDecision != null && canAllocateDecision.getDecisions().isEmpty() == false) {
                 builder.startArray("deciders");
                 canAllocateDecision.toXContent(builder, params);
                 builder.endArray();
@@ -241,6 +251,15 @@ public class NodeAllocationResult implements ToXContent, Writeable, Comparable<N
             return matchingBytes;
         }
 
+        /**
+         * Gets the store exception when trying to read the store, if there was an error.  If
+         * there was no error, returns {@code null}.
+         */
+        @Nullable
+        public Exception getStoreException() {
+            return storeException;
+        }
+
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeBoolean(inSync);
@@ -255,7 +274,12 @@ public class NodeAllocationResult implements ToXContent, Writeable, Comparable<N
             {
                 if (matchingBytes < 0) {
                     // dealing with a primary shard
-                    builder.field("in_sync", inSync);
+                    if (allocationId == null && storeException == null) {
+                        // there was no information we could obtain of any shard data on the node
+                        builder.field("found", false);
+                    } else {
+                        builder.field("in_sync", inSync);
+                    }
                 }
                 if (allocationId != null) {
                     builder.field("allocation_id", allocationId);

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java
@@ -80,7 +80,7 @@ public class NodeAllocationResult implements ToXContent, Writeable, Comparable<N
     public NodeAllocationResult(StreamInput in) throws IOException {
         node = new DiscoveryNode(in);
         shardStoreInfo = in.readOptionalWriteable(ShardStoreInfo::new);
-        if (in.getVersion().before(Version.V_5_3_0_UNRELEASED)) {
+        if (in.getVersion().before(Version.V_5_2_1_UNRELEASED)) {
             canAllocateDecision = Decision.readFrom(in);
         } else {
             canAllocateDecision = in.readOptionalWriteable(Decision::readFrom);
@@ -93,7 +93,7 @@ public class NodeAllocationResult implements ToXContent, Writeable, Comparable<N
     public void writeTo(StreamOutput out) throws IOException {
         node.writeTo(out);
         out.writeOptionalWriteable(shardStoreInfo);
-        if (out.getVersion().before(Version.V_5_3_0_UNRELEASED)) {
+        if (out.getVersion().before(Version.V_5_2_1_UNRELEASED)) {
             if (canAllocateDecision == null) {
                 Decision.NO.writeTo(out);
             } else {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java
@@ -83,7 +83,7 @@ public class NodeAllocationResult implements ToXContent, Writeable, Comparable<N
         if (in.getVersion().before(Version.V_5_3_0_UNRELEASED)) {
             canAllocateDecision = Decision.readFrom(in);
         } else {
-            canAllocateDecision = Decision.readOptional(in);
+            canAllocateDecision = in.readOptionalWriteable(Decision::readFrom);
         }
         nodeDecision = AllocationDecision.readFrom(in);
         weightRanking = in.readVInt();

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
@@ -58,6 +58,13 @@ public abstract class Decision implements ToXContent, Writeable {
         return new Single(type, label, explanation, explanationParams);
     }
 
+    public static Decision readOptional(StreamInput in) throws IOException {
+        if (in.readBoolean()) {
+            return readFrom(in);
+        }
+        return null;
+    }
+
     public static Decision readFrom(StreamInput in) throws IOException {
         // Determine whether to read a Single or Multi Decision
         if (in.readBoolean()) {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
@@ -58,13 +58,6 @@ public abstract class Decision implements ToXContent, Writeable {
         return new Single(type, label, explanation, explanationParams);
     }
 
-    public static Decision readOptional(StreamInput in) throws IOException {
-        if (in.readBoolean()) {
-            return readFrom(in);
-        }
-        return null;
-    }
-
     public static Decision readFrom(StreamInput in) throws IOException {
         // Determine whether to read a Single or Multi Decision
         if (in.readBoolean()) {

--- a/core/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
@@ -40,7 +40,6 @@ import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.env.ShardLockObtainFailedException;
 import org.elasticsearch.gateway.AsyncShardFetch.FetchResult;
 import org.elasticsearch.gateway.TransportNodesListGatewayStartedShards.NodeGatewayStartedShards;

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
@@ -124,7 +124,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
         assertEquals(0L, allocateDecision.getRemainingDelayInMillis());
 
         if (allocateDecision.getAllocationDecision() == AllocationDecision.NO_VALID_SHARD_COPY) {
-            assertEquals(0, allocateDecision.getNodeDecisions().size());
+            assertEquals(1, allocateDecision.getNodeDecisions().size());
 
             // verify JSON output
             try (XContentParser parser = getParser(explanation)) {
@@ -138,7 +138,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
                 parser.nextToken();
                 assertEquals("cannot allocate because a previous copy of the primary shard existed but can no longer be found " +
                                  "on the nodes in the cluster", parser.text());
-                assertEquals(Token.END_OBJECT, parser.nextToken());
+                verifyStaleShardCopyNodeDecisions(parser, 1, Collections.emptySet());
             }
         }
     }
@@ -1011,11 +1011,13 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
 
     public void testCannotAllocateStaleReplicaExplanation() throws Exception {
         logger.info("--> starting 3 nodes");
-        internalCluster().startMasterOnlyNode();
-        internalCluster().startNodes(2);
+        String masterNode = internalCluster().startNode();
+        internalCluster().startDataOnlyNodes(2);
 
         logger.info("--> creating an index with 1 primary and 1 replica");
-        createIndexAndIndexData(1, 1);
+        createIndexAndIndexData(1, 1,
+            Settings.builder().put("index.routing.allocation.exclude._name", masterNode).build(),
+            ActiveShardCount.ALL);
 
         logger.info("--> stop node with the replica shard");
         String stoppedNode = replicaNode().getName();
@@ -1028,6 +1030,8 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNodeName()));
 
         logger.info("--> restart the node with the stale replica");
+        client().admin().indices().prepareUpdateSettings("idx").setSettings(
+            Settings.builder().put("index.routing.allocation.include._name", (String) null)).get();
         String restartedNode = internalCluster().startNode(Settings.builder().put("node.name", stoppedNode).build());
 
         // wait until the system has fetched shard data and we know there is no valid shard copy
@@ -1064,11 +1068,33 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
         assertTrue(allocateDecision.isDecisionTaken());
         assertFalse(moveDecision.isDecisionTaken());
         assertEquals(AllocationDecision.NO_VALID_SHARD_COPY, allocateDecision.getAllocationDecision());
-        assertEquals(1, allocateDecision.getNodeDecisions().size());
+        assertEquals(2, allocateDecision.getNodeDecisions().size());
         NodeAllocationResult nodeAllocationResult = allocateDecision.getNodeDecisions().get(0);
         assertEquals(restartedNode, nodeAllocationResult.getNode().getName());
         assertNotNull(nodeAllocationResult.getShardStoreInfo());
+        assertNotNull(nodeAllocationResult.getShardStoreInfo().getAllocationId());
         assertFalse(nodeAllocationResult.getShardStoreInfo().isInSync());
+        assertNull(nodeAllocationResult.getShardStoreInfo().getStoreException());
+        nodeAllocationResult = allocateDecision.getNodeDecisions().get(1);
+        assertEquals(masterNode, nodeAllocationResult.getNode().getName());
+        assertNotNull(nodeAllocationResult.getShardStoreInfo());
+        assertNull(nodeAllocationResult.getShardStoreInfo().getAllocationId());
+        assertFalse(nodeAllocationResult.getShardStoreInfo().isInSync());
+        assertNull(nodeAllocationResult.getShardStoreInfo().getStoreException());
+
+        // verify JSON output
+        try (XContentParser parser = getParser(explanation)) {
+            verifyShardInfo(parser, true, includeDiskInfo, ShardRoutingState.UNASSIGNED);
+            parser.nextToken();
+            assertEquals("can_allocate", parser.currentName());
+            parser.nextToken();
+            assertEquals(AllocationDecision.NO_VALID_SHARD_COPY.toString(), parser.text());
+            parser.nextToken();
+            assertEquals("allocate_explanation", parser.currentName());
+            parser.nextToken();
+            assertEquals("cannot allocate because all found copies of the shard are either stale or corrupt", parser.text());
+            verifyStaleShardCopyNodeDecisions(parser, 2, Collections.singleton(restartedNode));
+        }
     }
 
     private void verifyClusterInfo(ClusterInfo clusterInfo, boolean includeDiskInfo, int numNodes) {
@@ -1220,6 +1246,39 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
         }
     }
 
+    private void verifyStaleShardCopyNodeDecisions(XContentParser parser, int numNodes, Set<String> foundStores) throws IOException {
+        parser.nextToken();
+        assertEquals("node_allocation_decisions", parser.currentName());
+        assertEquals(Token.START_ARRAY, parser.nextToken());
+        for (int i = 0; i < numNodes; i++) {
+            String nodeName = verifyNodeDecisionPrologue(parser);
+            assertEquals(AllocationDecision.NO.toString(), parser.text());
+            parser.nextToken();
+            assertEquals("store", parser.currentName());
+            assertEquals(Token.START_OBJECT, parser.nextToken());
+            parser.nextToken();
+            if (foundStores.contains(nodeName)) {
+                // shard data was found on the node, but it is stale
+                assertEquals("in_sync", parser.currentName());
+                parser.nextToken();
+                assertFalse(parser.booleanValue());
+                parser.nextToken();
+                assertEquals("allocation_id", parser.currentName());
+                parser.nextToken();
+                assertNotNull(parser.text());
+            } else {
+                // no shard data was found on the node
+                assertEquals("found", parser.currentName());
+                parser.nextToken();
+                assertFalse(parser.booleanValue());
+            }
+            assertEquals(Token.END_OBJECT, parser.nextToken());
+            parser.nextToken();
+            assertEquals(Token.END_OBJECT, parser.currentToken());
+        }
+        assertEquals(Token.END_ARRAY, parser.nextToken());
+    }
+
     private void verifyNodeDecisions(XContentParser parser, Map<String, AllocationDecision> expectedNodeDecisions,
                                      boolean includeYesDecisions, boolean reuseStore) throws IOException {
         parser.nextToken();
@@ -1228,24 +1287,8 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
         boolean encounteredNo = false;
         final int numNodes = expectedNodeDecisions.size();
         for (int i = 0; i < numNodes; i++) {
-            assertEquals(Token.START_OBJECT, parser.nextToken());
-            parser.nextToken();
-            assertEquals("node_id", parser.currentName());
-            parser.nextToken();
-            assertNotNull(parser.text());
-            parser.nextToken();
-            assertEquals("node_name", parser.currentName());
-            parser.nextToken();
-            String nodeName = parser.text();
+            String nodeName = verifyNodeDecisionPrologue(parser);
             AllocationDecision allocationDecision = expectedNodeDecisions.get(nodeName);
-            assertNotNull(nodeName);
-            parser.nextToken();
-            assertEquals("transport_address", parser.currentName());
-            parser.nextToken();
-            assertNotNull(parser.text());
-            parser.nextToken();
-            assertEquals("node_decision", parser.currentName());
-            parser.nextToken();
             assertEquals(allocationDecision.toString(), parser.text());
             if (allocationDecision != AllocationDecision.YES) {
                 encounteredNo = true;
@@ -1281,6 +1324,27 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
             assertEquals(Token.END_OBJECT, parser.currentToken());
         }
         assertEquals(Token.END_ARRAY, parser.nextToken());
+    }
+
+    private String verifyNodeDecisionPrologue(XContentParser parser) throws IOException {
+        assertEquals(Token.START_OBJECT, parser.nextToken());
+        parser.nextToken();
+        assertEquals("node_id", parser.currentName());
+        parser.nextToken();
+        assertNotNull(parser.text());
+        parser.nextToken();
+        assertEquals("node_name", parser.currentName());
+        parser.nextToken();
+        String nodeName = parser.text();
+        assertNotNull(nodeName);
+        parser.nextToken();
+        assertEquals("transport_address", parser.currentName());
+        parser.nextToken();
+        assertNotNull(parser.text());
+        parser.nextToken();
+        assertEquals("node_decision", parser.currentName());
+        parser.nextToken();
+        return nodeName;
     }
 
     private boolean verifyDeciders(XContentParser parser, AllocationDecision allocationDecision) throws IOException {


### PR DESCRIPTION
Currently, if a previously allocated shard has no in-sync copy in the
cluster, but there is a stale replica copy, the explain API does not
include information about the stale replica copies in its output.  This
commit includes shard copy information available (even for stale
copies or corrupt copies) for all nodes in the cluster, when explaining 
an unassigned primary shard that was previously allocated in the cluster.

This situation can arise as follows: imagine an index with 1 primary and
1 replica and a cluster with 2 nodes.  If the node holding the replica
is shut down, and data continues to be indexed, only the primary will
have the latest data and the replica that has gone offline will be
marked as stale.  Now, suppose the node holding the primary is shut
down.  There are no copies of the shard data in the cluster.  Now, start
the first stopped node (holding the stale replica) back up.  The cluster
is red because there is no in-sync copy available.  Running the explain
API before would inform the user that there is no valid shard copy in
the cluster for that shard, but it would not provide any information
about the existence of the stale replica that exists on the restarted
node.  With this commit, the explain API provides information about all
the shard copy information when explaining the unassigned primary.