### PR TITLE
Limit IndexRequest toString() length

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -616,7 +616,8 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
         String sSource = "_na_";
         try {
             if (source.length() > MAX_SOURCE_LENGTH_IN_TOSTRING) {
-                sSource = "too big: " + ByteSizeValue.formatBytesSizeValue(source.length());
+                sSource = "n/a, actual length: [" + new ByteSizeValue(source.length()).toString() + "], max length: " +
+                    new ByteSizeValue(MAX_SOURCE_LENGTH_IN_TOSTRING).toString();
             } else {
                 sSource = XContentHelper.convertToJson(source, false);
             }

--- a/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.CompositeIndicesRequest;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.support.replication.ReplicatedWriteRequest;
+import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -36,6 +37,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -69,6 +71,13 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * @see org.elasticsearch.client.Client#index(IndexRequest)
  */
 public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implements DocWriteRequest<IndexRequest>, CompositeIndicesRequest {
+
+    /**
+     * Max length of the source document to include into toString()
+     *
+     * @see ReplicationRequest#createTask(long, java.lang.String, java.lang.String, org.elasticsearch.tasks.TaskId)
+     */
+    static final int MAX_SOURCE_LENGTH_IN_TOSTRING = 2048;
 
     private String type;
     private String id;
@@ -606,8 +615,17 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
     public String toString() {
         String sSource = "_na_";
         try {
-            sSource = XContentHelper.convertToJson(source, false);
-        } catch (Exception e) {
+            if (source.length() > MAX_SOURCE_LENGTH_IN_TOSTRING) {
+                // We might slice in the middle of a UTF-8 character here, but BytesRef.utf8ToString() will read more bytes if needed.
+                // There is no risk of ArrayIndexOutOfBoundsException either as source is assumed to be properly UTF-8 encoded.
+                sSource = source.slice(0, MAX_SOURCE_LENGTH_IN_TOSTRING).utf8ToString() + "..." +
+                    new ByteSizeValue(source.length()).toString();
+            }
+            else {
+                sSource = XContentHelper.convertToJson(source, false);
+            }
+        }
+        catch (Exception e) {
             // ignore
         }
         return "index {[" + index + "][" + type + "][" + id + "], source[" + sSource + "]}";

--- a/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -616,16 +616,11 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
         String sSource = "_na_";
         try {
             if (source.length() > MAX_SOURCE_LENGTH_IN_TOSTRING) {
-                // We might slice in the middle of a UTF-8 character here, but BytesRef.utf8ToString() will read more bytes if needed.
-                // There is no risk of ArrayIndexOutOfBoundsException either as source is assumed to be properly UTF-8 encoded.
-                sSource = source.slice(0, MAX_SOURCE_LENGTH_IN_TOSTRING).utf8ToString() + "..." +
-                    new ByteSizeValue(source.length()).toString();
-            }
-            else {
+                sSource = "too big: " + ByteSizeValue.formatBytesSizeValue(source.length());
+            } else {
                 sSource = XContentHelper.convertToJson(source, false);
             }
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             // ignore
         }
         return "index {[" + index + "][" + type + "][" + id + "], source[" + sSource + "]}";

--- a/core/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -107,26 +107,23 @@ public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue> {
 
     @Override
     public String toString() {
-        return formatBytesSizeValue(getBytes());
-    }
-
-    public static String formatBytesSizeValue(long bytes) {
+        long bytes = getBytes();
         double value = bytes;
         String suffix = "b";
         if (bytes >= ByteSizeUnit.C5) {
-            value = value / ByteSizeUnit.C5;
+            value = getPbFrac();
             suffix = "pb";
         } else if (bytes >= ByteSizeUnit.C4) {
-            value = value / ByteSizeUnit.C4;
+            value = getTbFrac();
             suffix = "tb";
         } else if (bytes >= ByteSizeUnit.C3) {
-            value = value / ByteSizeUnit.C3;
+            value = getGbFrac();
             suffix = "gb";
         } else if (bytes >= ByteSizeUnit.C2) {
-            value = value / ByteSizeUnit.C2;
+            value = getMbFrac();
             suffix = "mb";
         } else if (bytes >= ByteSizeUnit.C1) {
-            value = value / ByteSizeUnit.C1;
+            value = getKbFrac();
             suffix = "kb";
         }
         return Strings.format1Decimals(value, suffix);

--- a/core/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -107,23 +107,26 @@ public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue> {
 
     @Override
     public String toString() {
-        long bytes = getBytes();
+        return formatBytesSizeValue(getBytes());
+    }
+
+    public static String formatBytesSizeValue(long bytes) {
         double value = bytes;
         String suffix = "b";
         if (bytes >= ByteSizeUnit.C5) {
-            value = getPbFrac();
+            value = value / ByteSizeUnit.C5;
             suffix = "pb";
         } else if (bytes >= ByteSizeUnit.C4) {
-            value = getTbFrac();
+            value = value / ByteSizeUnit.C4;
             suffix = "tb";
         } else if (bytes >= ByteSizeUnit.C3) {
-            value = getGbFrac();
+            value = value / ByteSizeUnit.C3;
             suffix = "gb";
         } else if (bytes >= ByteSizeUnit.C2) {
-            value = getMbFrac();
+            value = value / ByteSizeUnit.C2;
             suffix = "mb";
         } else if (bytes >= ByteSizeUnit.C1) {
-            value = getKbFrac();
+            value = value / ByteSizeUnit.C1;
             suffix = "kb";
         }
         return Strings.format1Decimals(value, suffix);

--- a/core/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
@@ -202,4 +202,17 @@ public class IndexRequestTests extends ESTestCase {
             }
         }
     }
+
+    public void testToStringSizeLimit() {
+        IndexRequest request = new IndexRequest("index", "type");
+
+        String source = "{\"name\":\"value\"}";
+        request.source(source);
+        assertEquals("index {[index][type][null], source[" + source + "]}", request.toString());
+
+        source = "{\"name\":\"" + randomAsciiOfLength(IndexRequest.MAX_SOURCE_LENGTH_IN_TOSTRING) + "\"}";
+        request.source(source);
+        assertEquals("index {[index][type][null], source[" + source.substring(0, IndexRequest.MAX_SOURCE_LENGTH_IN_TOSTRING) + "...2kb]}",
+            request.toString());
+    }
 }

--- a/core/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.seqno.SequenceNumbersService;
 import org.elasticsearch.index.shard.ShardId;
@@ -34,6 +35,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashSet;
@@ -203,16 +205,16 @@ public class IndexRequestTests extends ESTestCase {
         }
     }
 
-    public void testToStringSizeLimit() {
+    public void testToStringSizeLimit() throws UnsupportedEncodingException {
         IndexRequest request = new IndexRequest("index", "type");
 
         String source = "{\"name\":\"value\"}";
         request.source(source);
         assertEquals("index {[index][type][null], source[" + source + "]}", request.toString());
 
-        source = "{\"name\":\"" + randomAsciiOfLength(IndexRequest.MAX_SOURCE_LENGTH_IN_TOSTRING) + "\"}";
+        source = "{\"name\":\"" + randomUnicodeOfLength(IndexRequest.MAX_SOURCE_LENGTH_IN_TOSTRING) + "\"}";
         request.source(source);
-        assertEquals("index {[index][type][null], source[" + source.substring(0, IndexRequest.MAX_SOURCE_LENGTH_IN_TOSTRING) + "...2kb]}",
-            request.toString());
+        assertEquals("index {[index][type][null], source[too big: " + ByteSizeValue.formatBytesSizeValue(source.getBytes("UTF-8").length) +
+                "]}", request.toString());
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
@@ -214,7 +214,8 @@ public class IndexRequestTests extends ESTestCase {
 
         source = "{\"name\":\"" + randomUnicodeOfLength(IndexRequest.MAX_SOURCE_LENGTH_IN_TOSTRING) + "\"}";
         request.source(source);
-        assertEquals("index {[index][type][null], source[too big: " + ByteSizeValue.formatBytesSizeValue(source.getBytes("UTF-8").length) +
-                "]}", request.toString());
+        int actualBytes = source.getBytes("UTF-8").length;
+        assertEquals("index {[index][type][null], source[n/a, actual length: [" + new ByteSizeValue(actualBytes).toString() +
+                "], max length: " + new ByteSizeValue(IndexRequest.MAX_SOURCE_LENGTH_IN_TOSTRING).toString() + "]}", request.toString());
     }
 }


### PR DESCRIPTION
This patch significantly reduces memory usage when indexing large documents.

Apparently the whole input document (`source`) is rendered into `IndexRequest` `toString()` result.
And two distinct copies of such `String`s are then used as `ReplicationTask` descriptions.
(in `TransportReplicationAction.PrimaryPhase` and `TransportReplicationAction.ReroutePhase`)

Thus, for 10 MB input in UTF-8 there would be about 40 MB of 'excessively allocated' memory.

The patch changes `IndexRequest.toString()` implementation so that only piece of large `source` is used.

