### PR TITLE
Geo distance range deprecation

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryBuilder.java
@@ -32,6 +32,8 @@ import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -50,6 +52,8 @@ import java.util.Optional;
 
 public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistanceRangeQueryBuilder> {
     public static final String NAME = "geo_distance_range";
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(Loggers.getLogger(GeoDistanceRangeQueryBuilder.class));
 
     public static final boolean DEFAULT_INCLUDE_LOWER = true;
     public static final boolean DEFAULT_INCLUDE_UPPER = true;
@@ -351,7 +355,11 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
         if (indexVersionCreated.onOrAfter(LatLonPointFieldMapper.LAT_LON_FIELD_VERSION)) {
             throw new QueryShardException(context, "[{}] queries are no longer supported for geo_point field types. "
                 + "Use geo_distance sort or aggregations", NAME);
-        } else if (indexVersionCreated.before(Version.V_2_2_0)) {
+        }
+
+        deprecationLogger.deprecated("geo_distance_range search is deprecated. Use geo_distance aggregation or sort instead.");
+
+        if (indexVersionCreated.before(Version.V_2_2_0)) {
             LegacyGeoPointFieldType geoFieldType = (LegacyGeoPointFieldType) fieldType;
             IndexGeoPointFieldData indexFieldData = context.getForField(fieldType);
             String bboxOptimization = Strings.isEmpty(optimizeBbox) ? DEFAULT_OPTIMIZE_BBOX : optimizeBbox;

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceRangeQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceRangeQueryTests.java
@@ -208,6 +208,7 @@ public class GeoDistanceRangeQueryTests extends AbstractQueryTestCase<GeoDistanc
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         if (createShardContext().indexVersionCreated().before(LatLonPointFieldMapper.LAT_LON_FIELD_VERSION)) {
             super.testToQuery();
+            assertWarnings("geo_distance_range search is deprecated. Use geo_distance aggregation or sort instead.");
         }
     }
 
@@ -290,6 +291,7 @@ public class GeoDistanceRangeQueryTests extends AbstractQueryTestCase<GeoDistanc
         NestedQueryBuilder builder = (NestedQueryBuilder) parseQuery(queryJson);
         QueryShardContext context = createShardContext();
         builder.toQuery(context);
+        assertWarnings("geo_distance_range search is deprecated. Use geo_distance aggregation or sort instead.");
     }
 
     public void testFromJson() throws IOException {
@@ -379,6 +381,7 @@ public class GeoDistanceRangeQueryTests extends AbstractQueryTestCase<GeoDistanc
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         if (createShardContext().indexVersionCreated().before(LatLonPointFieldMapper.LAT_LON_FIELD_VERSION)) {
             super.testMustRewrite();
+            assertWarnings("geo_distance_range search is deprecated. Use geo_distance aggregation or sort instead.");
         }
     }
 

--- a/docs/reference/migration/migrate_5_0/search.asciidoc
+++ b/docs/reference/migration/migrate_5_0/search.asciidoc
@@ -160,7 +160,7 @@ This parameter was undocumented and silently ignored before for these types of `
 
 * Deprecated support for the coerce, normalize, ignore_malformed parameters in GeoBoundingBoxQuery. Use parameter validation_method instead.
 
-* The `geo_distance_range` query is no longer supported and should be replaced by the `geo_distance` bucket aggregation.
+* The `geo_distance_range` query is deprecated and should be replaced by either the `geo_distance` bucket aggregation, or geo_distance sort.
 
 ==== Top level `filter` parameter
 

--- a/docs/reference/query-dsl/geo-distance-range-query.asciidoc
+++ b/docs/reference/query-dsl/geo-distance-range-query.asciidoc
@@ -1,6 +1,10 @@
 [[query-dsl-geo-distance-range-query]]
 === Geo Distance Range Query
 
+deprecated[5.0.0,Elasticsearch will continue to support geo_distance_range queries on indexes created
+prior to 5.0.0. Range searches on indexes created in 5.0.0 and later will no longer be supported.
+Distance aggregations or sorting should be used instead.]
+
 Filters documents that exists within a range from a specific point:
 
 [source,js]


### PR DESCRIPTION
This PR adds deprecation logging to `GeoDistanceRangeQueryBuilder` for 5.x and a deprecation note in the reference documentation.
