### PR TITLE
Deprecate auto creation of container for azure repository

### DIFF
--- a/docs/plugins/repository-azure.asciidoc
+++ b/docs/plugins/repository-azure.asciidoc
@@ -102,7 +102,8 @@ The Azure repository supports following settings:
 
 `container`::
 
-    Container name. Defaults to `elasticsearch-snapshots`
+    Container name. You must create the azure container before creating the repository.
+    Defaults to `elasticsearch-snapshots`.
 
 `base_path`::
 

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
@@ -157,6 +157,8 @@ public class AzureRepository extends BlobStoreRepository {
         try {
             if (!blobStore.doesContainerExist(blobStore.container())) {
                 logger.debug("container [{}] does not exist. Creating...", blobStore.container());
+                deprecationLogger.deprecated("Auto creation of the container for an azure backed repository is deprecated" +
+                    " and will be removed in 6.0.");
                 blobStore.createContainer(blobStore.container());
             }
             super.initializeSnapshot(snapshotId, indices, clusterMetadata);
@@ -172,6 +174,8 @@ public class AzureRepository extends BlobStoreRepository {
             try {
                 if (!blobStore.doesContainerExist(blobStore.container())) {
                     logger.debug("container [{}] does not exist. Creating...", blobStore.container());
+                    deprecationLogger.deprecated("Auto creation of the container for an azure backed repository is deprecated" +
+                        " and will be removed in 6.0.");
                     blobStore.createContainer(blobStore.container());
                 }
             } catch (StorageException | URISyntaxException e) {


### PR DESCRIPTION
Similar to #22843 but for azure

Note that we need to add also this information to the deprecation documentation once it will be available (see #22856).
