### PR TITLE
Add parsing methods to BulkItemResponse

### DIFF
--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -586,7 +586,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             return new ElasticsearchException(buildMessage("exception", parser.text(), null));
         }
 
-        ensureExpectedToken(token, XContentParser.Token.START_OBJECT, parser::getTokenLocation);
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser::getTokenLocation);
         token = parser.nextToken();
 
         // Root causes are parsed in the innerFromXContent() and are added as suppressed exceptions.

--- a/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -291,7 +291,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
      * {@link DocWriteResponse} objects. It always parses the current token, updates the given parsing context accordingly
      * if needed and then immediately returns.
      */
-    public static void parseInnerToXContent(XContentParser parser, ParsingContext context) throws IOException {
+    protected static void parseInnerToXContent(XContentParser parser, DocWriteResponseBuilder context) throws IOException {
         XContentParser.Token token = parser.currentToken();
         ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
 
@@ -335,21 +335,18 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
     }
 
     /**
-     * {@link ParsingContext} holds information about {@link DocWriteResponse} objects during XContent parsing.
+     * {@link DocWriteResponseBuilder} is used to build {@link DocWriteResponse} objects during XContent parsing.
      */
-    public static class ParsingContext {
+    public static abstract class DocWriteResponseBuilder {
 
-        private ShardId shardId = null;
-        private String type = null;
-        private String id = null;
-        private Long version = null;
-        private Result result = null;
-        private boolean forcedRefresh;
-        private ShardInfo shardInfo = null;
-        private Long seqNo = SequenceNumbersService.UNASSIGNED_SEQ_NO;
-
-        public ParsingContext(){
-        }
+        protected ShardId shardId = null;
+        protected String type = null;
+        protected String id = null;
+        protected Long version = null;
+        protected Result result = null;
+        protected boolean forcedRefresh;
+        protected ShardInfo shardInfo = null;
+        protected Long seqNo = SequenceNumbersService.UNASSIGNED_SEQ_NO;
 
         public ShardId getShardId() {
             return shardId;
@@ -375,44 +372,26 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
             this.id = id;
         }
 
-        public Long getVersion() {
-            return version;
-        }
-
         public void setVersion(Long version) {
             this.version = version;
-        }
-
-        public Result getResult() {
-            return result;
         }
 
         public void setResult(Result result) {
             this.result = result;
         }
 
-        public boolean isForcedRefresh() {
-            return forcedRefresh;
-        }
-
         public void setForcedRefresh(boolean forcedRefresh) {
             this.forcedRefresh = forcedRefresh;
-        }
-
-        public ShardInfo getShardInfo() {
-            return shardInfo;
         }
 
         public void setShardInfo(ShardInfo shardInfo) {
             this.shardInfo = shardInfo;
         }
 
-        public Long getSeqNo() {
-            return seqNo;
-        }
-
         public void setSeqNo(Long seqNo) {
             this.seqNo = seqNo;
         }
+
+        public abstract DocWriteResponse build();
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -23,15 +23,15 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.action.support.WriteResponse;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
-import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.StatusToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.seqno.SequenceNumbersService;
 import org.elasticsearch.index.shard.ShardId;
@@ -42,8 +42,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Locale;
 
-import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
-import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknownField;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknownToken;
 
 /**
  * A base class for the response of a write operation that involves a single doc
@@ -284,16 +285,134 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
     }
 
     /**
-     * Declare the {@link ObjectParser} fields to use when parsing a {@link DocWriteResponse}
+     * Parse the output of the {@link #innerToXContent(XContentBuilder, Params)} method.
+     *
+     * This method is intended to be called by subclasses and must be called multiple times to parse all the information concerning
+     * {@link DocWriteResponse} objects. It always parses the current token, updates the given parsing context accordingly
+     * if needed and then immediately returns.
      */
-    protected static void declareParserFields(ConstructingObjectParser<? extends DocWriteResponse, Void> objParser) {
-        objParser.declareString(constructorArg(), new ParseField(_INDEX));
-        objParser.declareString(constructorArg(), new ParseField(_TYPE));
-        objParser.declareString(constructorArg(), new ParseField(_ID));
-        objParser.declareLong(constructorArg(), new ParseField(_VERSION));
-        objParser.declareString(constructorArg(), new ParseField(RESULT));
-        objParser.declareObject(optionalConstructorArg(), (p, c) -> ShardInfo.fromXContent(p), new ParseField(_SHARDS));
-        objParser.declareLong(optionalConstructorArg(), new ParseField(_SEQ_NO));
-        objParser.declareBoolean(DocWriteResponse::setForcedRefresh, new ParseField(FORCED_REFRESH));
+    public static void parseInnerToXContent(XContentParser parser, ParsingContext context) throws IOException {
+        XContentParser.Token token = parser.currentToken();
+        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
+
+        String currentFieldName = parser.currentName();
+        token = parser.nextToken();
+
+        if (token.isValue()) {
+            if (_INDEX.equals(currentFieldName)) {
+                // index uuid and shard id are unknown and can't be parsed back for now.
+                context.setShardId(new ShardId(new Index(parser.text(), IndexMetaData.INDEX_UUID_NA_VALUE), -1));
+            } else if (_TYPE.equals(currentFieldName)) {
+                context.setType(parser.text());
+            } else if (_ID.equals(currentFieldName)) {
+                context.setId(parser.text());
+            } else if (_VERSION.equals(currentFieldName)) {
+                context.setVersion(parser.longValue());
+            } else if (RESULT.equals(currentFieldName)) {
+                String result = parser.text();
+                for (Result r :  Result.values()) {
+                    if (r.getLowercase().equals(result)) {
+                        context.setResult(r);
+                        break;
+                    }
+                }
+            } else if (FORCED_REFRESH.equals(currentFieldName)) {
+                context.setForcedRefresh(parser.booleanValue());
+            } else if (_SEQ_NO.equals(currentFieldName)) {
+                context.setSeqNo(parser.longValue());
+            } else {
+                throwUnknownField(currentFieldName, parser.getTokenLocation());
+            }
+        } else if (token == XContentParser.Token.START_OBJECT) {
+            if (_SHARDS.equals(currentFieldName)) {
+                context.setShardInfo(ShardInfo.fromXContent(parser));
+            } else {
+                throwUnknownField(currentFieldName, parser.getTokenLocation());
+            }
+        } else {
+            throwUnknownToken(token, parser.getTokenLocation());
+        }
+    }
+
+    /**
+     * {@link ParsingContext} holds information about {@link DocWriteResponse} objects during XContent parsing.
+     */
+    public static class ParsingContext {
+
+        private ShardId shardId = null;
+        private String type = null;
+        private String id = null;
+        private Long version = null;
+        private Result result = null;
+        private boolean forcedRefresh;
+        private ShardInfo shardInfo = null;
+        private Long seqNo = SequenceNumbersService.UNASSIGNED_SEQ_NO;
+
+        public ParsingContext(){
+        }
+
+        public ShardId getShardId() {
+            return shardId;
+        }
+
+        public void setShardId(ShardId shardId) {
+            this.shardId = shardId;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Long getVersion() {
+            return version;
+        }
+
+        public void setVersion(Long version) {
+            this.version = version;
+        }
+
+        public Result getResult() {
+            return result;
+        }
+
+        public void setResult(Result result) {
+            this.result = result;
+        }
+
+        public boolean isForcedRefresh() {
+            return forcedRefresh;
+        }
+
+        public void setForcedRefresh(boolean forcedRefresh) {
+            this.forcedRefresh = forcedRefresh;
+        }
+
+        public ShardInfo getShardInfo() {
+            return shardInfo;
+        }
+
+        public void setShardInfo(ShardInfo shardInfo) {
+            this.shardInfo = shardInfo;
+        }
+
+        public Long getSeqNo() {
+            return seqNo;
+        }
+
+        public void setSeqNo(Long seqNo) {
+            this.seqNo = seqNo;
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
@@ -130,17 +130,16 @@ public class BulkItemResponse implements Streamable, StatusToXContentObject {
             if (STATUS.equals(currentFieldName)) {
                 // ignoring status field
                 continue;
-            } else {
-                itemParser.accept(parser);
             }
 
-            if (token == XContentParser.Token.START_OBJECT) {
-                if (ERROR.equals(currentFieldName)) {
+            if (ERROR.equals(currentFieldName)) {
+                if (token == XContentParser.Token.START_OBJECT) {
                     exception = ElasticsearchException.fromXContent(parser);
-                } else {
-                    itemParser.accept(parser);
                 }
+                continue;
             }
+
+            itemParser.accept(parser);
         }
 
         ensureExpectedToken(XContentParser.Token.END_OBJECT, token, parser::getTokenLocation);

--- a/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
@@ -74,17 +74,17 @@ public class DeleteResponse extends DocWriteResponse {
     public static DeleteResponse fromXContent(XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
 
-        ParsingContext context = new ParsingContext();
+        DeleteResponseBuilder context = new DeleteResponseBuilder();
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
             parseXContentFields(parser, context);
         }
-        return fromParsingContext(context);
+        return context.build();
     }
 
     /**
      * Parse the current token and update the parsing context appropriately.
      */
-    public static void parseXContentFields(XContentParser parser, ParsingContext context) throws IOException {
+    public static void parseXContentFields(XContentParser parser, DeleteResponseBuilder context) throws IOException {
         XContentParser.Token token = parser.currentToken();
         String currentFieldName = parser.currentName();
 
@@ -97,29 +97,22 @@ public class DeleteResponse extends DocWriteResponse {
         }
     }
 
-    /**
-     * Create a {@link DeleteResponse} from a parsing context.
-     */
-    public static DeleteResponse fromParsingContext(ParsingContext context) {
-        DeleteResponse deleteResponse = new DeleteResponse(context.getShardId(), context.getType(), context.getId(),
-                context.getSeqNo(), context.getVersion(), context.isFound());
-        deleteResponse.setForcedRefresh(context.isForcedRefresh());
-        if (context.getShardInfo() != null) {
-            deleteResponse.setShardInfo(context.getShardInfo());
-        }
-        return deleteResponse;
-    }
-
-    public static class ParsingContext extends DocWriteResponse.ParsingContext {
+    public static class DeleteResponseBuilder extends DocWriteResponse.DocWriteResponseBuilder {
 
         private boolean found = false;
 
-        public boolean isFound() {
-            return found;
-        }
-
         public void setFound(boolean found) {
             this.found = found;
+        }
+
+        @Override
+        public DeleteResponse build() {
+            DeleteResponse deleteResponse = new DeleteResponse(shardId, type, id, seqNo, version, found);
+            deleteResponse.setForcedRefresh(forcedRefresh);
+            if (shardInfo != null) {
+                deleteResponse.setShardInfo(shardInfo);
+            }
+            return deleteResponse;
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
@@ -76,17 +76,17 @@ public class IndexResponse extends DocWriteResponse {
     public static IndexResponse fromXContent(XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
 
-        ParsingContext context = new ParsingContext();
+        IndexResponseBuilder context = new IndexResponseBuilder();
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
             parseXContentFields(parser, context);
         }
-        return fromParsingContext(context);
+        return context.build();
     }
 
     /**
      * Parse the current token and update the parsing context appropriately.
      */
-    public static void parseXContentFields(XContentParser parser, ParsingContext context) throws IOException {
+    public static void parseXContentFields(XContentParser parser, IndexResponseBuilder context) throws IOException {
         XContentParser.Token token = parser.currentToken();
         String currentFieldName = parser.currentName();
 
@@ -99,29 +99,22 @@ public class IndexResponse extends DocWriteResponse {
         }
     }
 
-    /**
-     * Create a {@link IndexResponse} from a parsing context.
-     */
-    public static IndexResponse fromParsingContext(ParsingContext context) {
-        IndexResponse indexResponse = new IndexResponse(context.getShardId(), context.getType(), context.getId(),
-                context.getSeqNo(), context.getVersion(), context.isCreated());
-        indexResponse.setForcedRefresh(context.isForcedRefresh());
-        if (context.getShardInfo() != null) {
-            indexResponse.setShardInfo(context.getShardInfo());
-        }
-        return indexResponse;
-    }
-
-    public static class ParsingContext extends DocWriteResponse.ParsingContext {
+    public static class IndexResponseBuilder extends DocWriteResponse.DocWriteResponseBuilder {
 
         private boolean created = false;
 
-        public boolean isCreated() {
-            return created;
-        }
-
         public void setCreated(boolean created) {
             this.created = created;
+        }
+
+        @Override
+        public IndexResponse build() {
+            IndexResponse indexResponse = new IndexResponse(shardId, type, id, seqNo, version, created);
+            indexResponse.setForcedRefresh(forcedRefresh);
+            if (shardInfo != null) {
+                indexResponse.setShardInfo(shardInfo);
+            }
+            return indexResponse;
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -859,7 +859,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
         } while (expected != null);
     }
 
-    private static Tuple<Throwable, ElasticsearchException> randomExceptions() {
+    public static Tuple<Throwable, ElasticsearchException> randomExceptions() {
         Throwable actual;
         ElasticsearchException expected;
 

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
@@ -19,17 +19,101 @@
 
 package org.elasticsearch.action.bulk;
 
+import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse.Failure;
+import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.IOException;
+import java.util.Map;
+
+import static org.elasticsearch.action.delete.DeleteResponseTests.assertDeleteResponse;
+import static org.elasticsearch.action.delete.DeleteResponseTests.randomDeleteResponse;
+import static org.elasticsearch.action.index.IndexResponseTests.assertIndexResponse;
+import static org.elasticsearch.action.index.IndexResponseTests.randomIndexResponse;
+import static org.elasticsearch.action.update.UpdateResponseTests.assertUpdateResponse;
+import static org.elasticsearch.action.update.UpdateResponseTests.randomUpdateResponse;
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.hamcrest.Matchers.containsString;
 
 public class BulkItemResponseTests extends ESTestCase {
+
     public void testFailureToString() {
         Failure failure = new Failure("index", "type", "id", new RuntimeException("test"));
         String toString = failure.toString();
         assertThat(toString, containsString("\"type\":\"runtime_exception\""));
         assertThat(toString, containsString("\"reason\":\"test\""));
         assertThat(toString, containsString("\"status\":500"));
+    }
+
+    public void testToAndFromXContent() throws IOException {
+        final XContentType xContentType = randomFrom(XContentType.values());
+
+        for (DocWriteRequest.OpType opType : DocWriteRequest.OpType.values()) {
+            int id = randomIntBetween(0, 100);
+            boolean humanReadable = randomBoolean();
+            BytesReference originalBytes = null;
+            BulkItemResponse expectedBulkItemResponse = null;
+
+            if (opType == DocWriteRequest.OpType.INDEX || opType == DocWriteRequest.OpType.CREATE) {
+                expectedBulkItemResponse = new BulkItemResponse(id, opType, randomIndexResponse());
+                originalBytes = toXContent(expectedBulkItemResponse, xContentType, humanReadable);
+
+            } else if (opType == DocWriteRequest.OpType.DELETE) {
+                expectedBulkItemResponse = new BulkItemResponse(id, opType, randomDeleteResponse());
+                originalBytes = toXContent(expectedBulkItemResponse, xContentType, humanReadable);
+
+            } else if (opType == DocWriteRequest.OpType.UPDATE) {
+                Tuple<UpdateResponse, UpdateResponse> updates = randomUpdateResponse(xContentType);
+                expectedBulkItemResponse = new BulkItemResponse(id, opType, updates.v2());
+                originalBytes = toXContent(new BulkItemResponse(id, opType, updates.v1()), xContentType, humanReadable);
+
+            } else {
+                fail("Test does not support opType [" + opType + "]");
+            }
+
+            // Shuffle the XContent fields
+            if (randomBoolean()) {
+                try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+                    originalBytes = shuffleXContent(parser, randomBoolean()).bytes();
+                }
+            }
+
+            BulkItemResponse parsedBulkItemResponse;
+            try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+                parsedBulkItemResponse = BulkItemResponse.fromXContent(parser);
+                assertNull(parser.nextToken());
+            }
+
+            assertEquals(expectedBulkItemResponse.getIndex(), parsedBulkItemResponse.getIndex());
+            assertEquals(expectedBulkItemResponse.getType(), parsedBulkItemResponse.getType());
+            assertEquals(expectedBulkItemResponse.getId(), parsedBulkItemResponse.getId());
+            assertEquals(expectedBulkItemResponse.getOpType(), parsedBulkItemResponse.getOpType());
+            assertEquals(expectedBulkItemResponse.getVersion(), parsedBulkItemResponse.getVersion());
+
+            BytesReference finalBytes = toXContent(parsedBulkItemResponse, xContentType, humanReadable);
+            try (XContentParser parser = createParser(xContentType.xContent(), finalBytes)) {
+                assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+                assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+                assertEquals(opType.getLowercase(), parser.currentName());
+                assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+
+                Map<String, Object> map = parser.map();
+
+                if (opType == DocWriteRequest.OpType.INDEX || opType == DocWriteRequest.OpType.CREATE) {
+                    assertIndexResponse(expectedBulkItemResponse.getResponse(), map);
+                } else if (opType == DocWriteRequest.OpType.DELETE) {
+                    assertDeleteResponse(expectedBulkItemResponse.getResponse(), map);
+                } else if (opType == DocWriteRequest.OpType.UPDATE) {
+                    assertUpdateResponse(expectedBulkItemResponse.getResponse(), parsedBulkItemResponse.getResponse(), map);
+                } else {
+                    fail("Test does not support opType [" + opType + "]");
+                }
+            }
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
@@ -74,9 +74,6 @@ public class BulkItemResponseTests extends ESTestCase {
                 Tuple<UpdateResponse, UpdateResponse> updates = randomUpdateResponse(xContentType);
                 expectedBulkItemResponse = new BulkItemResponse(bulkItemId, opType, updates.v2());
                 originalBytes = toXContent(new BulkItemResponse(bulkItemId, opType, updates.v1()), xContentType, humanReadable);
-
-            } else {
-                fail("Test does not support opType [" + opType + "]");
             }
 
             // Shuffle the XContent fields
@@ -88,6 +85,7 @@ public class BulkItemResponseTests extends ESTestCase {
 
             BulkItemResponse parsedBulkItemResponse;
             try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+                assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
                 parsedBulkItemResponse = BulkItemResponse.fromXContent(parser, bulkItemId);
                 assertNull(parser.nextToken());
             }
@@ -146,6 +144,7 @@ public class BulkItemResponseTests extends ESTestCase {
 
         BulkItemResponse parsedBulkItemResponse;
         try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
             parsedBulkItemResponse = BulkItemResponse.fromXContent(parser, bulkItemId);
             assertNull(parser.nextToken());
         }

--- a/core/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
@@ -63,6 +63,13 @@ public class DeleteResponseTests extends ESTestCase {
         boolean humanReadable = randomBoolean();
         BytesReference deleteResponseBytes = toXContent(deleteResponse, xContentType, humanReadable);
 
+        // Shuffle the XContent fields
+        if (randomBoolean()) {
+            try (XContentParser parser = createParser(xContentType.xContent(), deleteResponseBytes)) {
+                deleteResponseBytes = shuffleXContent(parser, randomBoolean()).bytes();
+            }
+        }
+
         // Parse the XContent bytes to obtain a parsed
         DeleteResponse parsedDeleteResponse;
         try (XContentParser parser = createParser(xContentType.xContent(), deleteResponseBytes)) {
@@ -81,7 +88,7 @@ public class DeleteResponseTests extends ESTestCase {
         }
     }
 
-    private static void assertDeleteResponse(DeleteResponse expected, Map<String, Object> actual) {
+    public static void assertDeleteResponse(DeleteResponse expected, Map<String, Object> actual) {
         assertDocWriteResponse(expected, actual);
         if (expected.getResult() == DocWriteResponse.Result.DELETED) {
             assertTrue((boolean) actual.get("found"));
@@ -90,7 +97,7 @@ public class DeleteResponseTests extends ESTestCase {
         }
     }
 
-    private static DeleteResponse randomDeleteResponse() {
+    public static DeleteResponse randomDeleteResponse() {
         ShardId shardId = new ShardId(randomAsciiOfLength(5), randomAsciiOfLength(5), randomIntBetween(0, 5));
         String type = randomAsciiOfLength(5);
         String id = randomAsciiOfLength(5);

--- a/core/src/test/java/org/elasticsearch/action/index/IndexResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/index/IndexResponseTests.java
@@ -59,12 +59,19 @@ public class IndexResponseTests extends ESTestCase {
     }
 
     public void testToAndFromXContent() throws IOException {
-        final XContentType xContentType = randomFrom(XContentType.values());
+        final XContentType xContentType = XContentType.JSON;//randomFrom(XContentType.values());
 
         // Create a random IndexResponse and converts it to XContent in bytes
         IndexResponse indexResponse = randomIndexResponse();
         boolean humanReadable = randomBoolean();
         BytesReference indexResponseBytes = toXContent(indexResponse, xContentType, humanReadable);
+
+        // Shuffle the XContent fields
+        if (randomBoolean()) {
+            try (XContentParser parser = createParser(xContentType.xContent(), indexResponseBytes)) {
+                indexResponseBytes = shuffleXContent(parser, randomBoolean()).bytes();
+            }
+        }
 
         // Parse the XContent bytes to obtain a parsed
         IndexResponse parsedIndexResponse;
@@ -155,7 +162,7 @@ public class IndexResponseTests extends ESTestCase {
         }
     }
 
-    private static void assertIndexResponse(IndexResponse expected, Map<String, Object> actual) {
+    public static void assertIndexResponse(IndexResponse expected, Map<String, Object> actual) {
         assertDocWriteResponse(expected, actual);
         if (expected.getResult() == DocWriteResponse.Result.CREATED) {
             assertTrue((boolean) actual.get("created"));
@@ -164,7 +171,7 @@ public class IndexResponseTests extends ESTestCase {
         }
     }
 
-    private static IndexResponse randomIndexResponse() {
+    public static IndexResponse randomIndexResponse() {
         ShardId shardId = new ShardId(randomAsciiOfLength(5), randomAsciiOfLength(5), randomIntBetween(0, 5));
         String type = randomAsciiOfLength(5);
         String id = randomAsciiOfLength(5);


### PR DESCRIPTION
This commit adds a parsing method to the `BulkItemResponse` class. In order to do that, the way `DocWriteResponse`s are parsed has to be changed: `ConstructingObjectParser`/`ObjectParser` is removed in favor of a simpler (and more readable, I think) way to parse these objects.

`DocWriteResponse` now provides the `parseInnerToXContent(`) method that can be used by subclasses (`IndexResponse`, `UpdateReponse` and `DeleteResponse`) to parse the current token/field and potentially update a `ParsingContext`. 

The `ParsingContext` is a simple POJO used to contain parsed values. It can be passed around from one parsing method to another parsing method. This is what is done in IndexResponse: a `ParsingContext` is created in `IndexResponse.fromXContent()`, and the parsing context is passed to `IndexResponse.parseXContentFields()` that parses fields specific to `IndexResponse` (like "created") and updates the context, delegating to `DocWriteResponse.parseInnerToXContent()`
the parsing of any other field. Once all XContent is parsed, `IndexResponse.fromXContent(`) uses the method `IndexResponse.fromParsingContext()` to create the new instance of `IndexResponse`.

This behavior allow to reuse parsing code among the class hierarchy while keeping the current behavior. It also allows other objects like `BulkItemResponse` to reuse the same parsing code to parse `DocWriteResponse`s.

Finally, IndexResponseTests, UpdateResponseTests and DeleteResponseTests have been updated to introduce some random shuffling of fields before the XContent is parsed in order to ensure that the parsing code does not rely on field order.