### PR TITLE
Prepare Vagrantfile tests for SLES12-SP2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -176,10 +176,8 @@ end
 
 def sles_common(config)
   extra = <<-SHELL
-    zypper rr systemsmanagement_puppet
+    zypper rr systemsmanagement_puppet puppetlabs-pc1
     zypper addrepo -t yast2 http://demeter.uni-regensburg.de/SLES12-x64/DVD1/ dvd1 || true
-    zypper addrepo -t yast2 http://demeter.uni-regensburg.de/SLES12-x64/DVD2/ dvd2 || true
-    zypper addrepo http://download.opensuse.org/repositories/Java:Factory/SLE_12/Java:Factory.repo || true
     zypper --no-gpg-checks --non-interactive refresh
     zypper --non-interactive install git-core
 SHELL

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -248,7 +248,7 @@ In some environments, it may make more sense to prepare a custom image containin
 FROM docker.elastic.co/elasticsearch/elasticsearch:{version}
 ADD elasticsearch.yml /usr/share/elasticsearch/config/
 USER root
-chown elasticsearch:elasticsearch config/elasticsearch.yml
+RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
 USER elasticsearch
 --------------------------------------------
 


### PR DESCRIPTION
This PR prepares us for changes coming in a new build of `elastic/sles-12-x86_64` Vagrant box, mostly related to upgrading to SLES-12-SP2.

With SLES-12 SP2, there is a system package available for `java-1_8_0-openjdk` and thus we can deprecate the OpenSUSE external repo.

We also remove the `puppetlabs-pc1` repo from Puppetlabs. With the existing SLES-12 vagrant boxes Puppet+facter get installed from source but going forward the official Puppetlabs repo is pre-installed.

Also we remove the `src rpm` repo which is not needed as we don't build packages from source and leads to errors about missing `media.2` directory with `zypper addrepo`.