### PR TITLE
S3 Repository: Remove client region

### DIFF
--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -228,8 +228,8 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent implements 
      * Return the region configured, or empty string.
      * TODO: remove after https://github.com/elastic/elasticsearch/issues/22761 */
     public static String getRegion(Settings repositorySettings, Settings settings) {
-        return getConfigValue(repositorySettings, settings, CLIENT_NAME.get(repositorySettings), S3Repository.REGION_SETTING,
-                              S3Repository.Repository.REGION_SETTING, S3Repository.Repositories.REGION_SETTING);
+        return S3Repository.getValue(repositorySettings, settings,
+            S3Repository.Repository.REGION_SETTING, S3Repository.Repositories.REGION_SETTING);
     }
 
     private static String getEndpoint(String region) {

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -75,10 +75,6 @@ public class S3Repository extends BlobStoreRepository {
     public static final AffixSetting<SecureString> SECRET_KEY_SETTING = Setting.affixKeySetting(PREFIX, "secret_key",
         key -> SecureSetting.secureString(key, Repositories.SECRET_SETTING, false));
 
-    /** The region the s3 repository bucket should exist in. */
-    public static final AffixSetting<String> REGION_SETTING = Setting.affixKeySetting(PREFIX, "region",
-        key -> new Setting<>(key, "", s -> s.toLowerCase(Locale.ROOT), Property.NodeScope));
-
     /** An override for the s3 endpoint to connect to. */
     public static final AffixSetting<String> ENDPOINT_SETTING = Setting.affixKeySetting(PREFIX, "endpoint",
         key -> new Setting<>(key, Repositories.ENDPOINT_SETTING, s -> s.toLowerCase(Locale.ROOT), Property.NodeScope));


### PR DESCRIPTION
The region setting was added for named clients before the decision was
made to remove region altogether. This change removes the setting,
before it has been released, so as not to introduce an already
deprecated setting.
