### PR TITLE
Add parsing method to BytesRestResponse's error

### DIFF
--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -565,7 +565,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
      * Parses the output of {@link #generateFailureXContent(XContentBuilder, Params, Exception, boolean)}
      */
     public static ElasticsearchException failureFromXContent(XContentParser parser) throws IOException {
-        XContentParser.Token token = parser.nextToken();
+        XContentParser.Token token = parser.currentToken();
         ensureFieldName(parser, token, ERROR);
 
         token = parser.nextToken();

--- a/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
+++ b/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
@@ -139,8 +139,8 @@ public class BytesRestResponse extends RestResponse {
         }
 
         XContentBuilder builder = channel.newErrorBuilder().startObject();
-        builder.field(STATUS, status.getStatus());
         ElasticsearchException.generateFailureXContent(builder, params, e, channel.detailedErrorsEnabled());
+        builder.field(STATUS, status.getStatus());
         builder.endObject();
         return builder;
     }
@@ -151,12 +151,8 @@ public class BytesRestResponse extends RestResponse {
 
         ElasticsearchException exception = null;
 
-        String currentFieldName = parser.currentName();
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.FIELD_NAME) {
-                currentFieldName = parser.currentName();
-            }
-            if (STATUS.equals(currentFieldName) == false) {
+            if ((token == XContentParser.Token.FIELD_NAME) && (STATUS.equals(parser.currentName()) == false)) {
                 exception = ElasticsearchException.failureFromXContent(parser);
             }
         }

--- a/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
+++ b/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
@@ -153,13 +153,14 @@ public class BytesRestResponse extends RestResponse {
         ElasticsearchException exception = null;
         RestStatus status = null;
 
-        String currentFieldName = parser.currentName();
+        String currentFieldName = null;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             }
             if (STATUS.equals(currentFieldName)) {
-                if (token.isValue()) {
+                if (token != XContentParser.Token.FIELD_NAME) {
+                    ensureExpectedToken(XContentParser.Token.VALUE_NUMBER, token, parser::getTokenLocation);
                     status = RestStatus.fromCode(parser.intValue());
                 }
             } else {

--- a/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -604,6 +604,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
         ElasticsearchException parsedFailure;
         try (XContentParser parser = createParser(xContent, failureBytes)) {
             assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
             parsedFailure = ElasticsearchException.failureFromXContent(parser);
             assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
             assertNull(parser.nextToken());
@@ -629,6 +630,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
         ElasticsearchException parsedFailure;
         try (XContentParser parser = createParser(xContent, failureBytes)) {
             assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
             parsedFailure = ElasticsearchException.failureFromXContent(parser);
             assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
             assertNull(parser.nextToken());

--- a/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -672,14 +672,14 @@ public class ElasticsearchExceptionTests extends ESTestCase {
         }, expectedJson);
     }
 
-    private static void assertDeepEquals(ElasticsearchException expected, ElasticsearchException actual) {
-        if (expected == null) {
-            assertNull(actual);
-        } else {
-            assertNotNull(actual);
-        }
-
+    public static void assertDeepEquals(ElasticsearchException expected, ElasticsearchException actual) {
         do {
+            if (expected == null) {
+                assertNull(actual);
+            } else {
+                assertNotNull(actual);
+            }
+
             assertEquals(expected.getMessage(), actual.getMessage());
             assertEquals(expected.getHeaders(), actual.getHeaders());
             assertEquals(expected.getMetadata(), actual.getMetadata());

--- a/core/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
@@ -20,12 +20,17 @@
 package org.elasticsearch.rest;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.Index;
@@ -39,6 +44,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.elasticsearch.ElasticsearchExceptionTests.assertDeepEquals;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
@@ -213,16 +219,90 @@ public class BytesRestResponseTests extends ESTestCase {
     }
 
     public void testErrorToAndFromXContent() throws IOException {
+        final boolean detailed = randomBoolean();
+
+        Exception original;
+        ElasticsearchException cause = null;
+        String reason;
+        String type = "exception";
+        RestStatus status = RestStatus.INTERNAL_SERVER_ERROR;
+
+        switch (randomIntBetween(0, 5)) {
+            case 0:
+                original = new ElasticsearchException("ElasticsearchException without cause");
+                if (detailed) {
+                    reason = "ElasticsearchException without cause";
+                } else {
+                    reason = "ElasticsearchException[ElasticsearchException without cause]";
+                }
+                break;
+            case 1:
+                original = new ElasticsearchException("ElasticsearchException with a cause", new FileNotFoundException("missing"));
+                if (detailed) {
+                    type = "exception";
+                    reason = "ElasticsearchException with a cause";
+                    cause = new ElasticsearchException("Elasticsearch exception [type=file_not_found_exception, reason=missing]");
+                } else {
+                    reason = "ElasticsearchException[ElasticsearchException with a cause]";
+                }
+                break;
+            case 2:
+                original = new ResourceNotFoundException("ElasticsearchException with custom status");
+                status = RestStatus.NOT_FOUND;
+                if (detailed) {
+                    type = "resource_not_found_exception";
+                    reason = "ElasticsearchException with custom status";
+                } else {
+                    reason = "ResourceNotFoundException[ElasticsearchException with custom status]";
+                }
+                break;
+            case 3:
+                TransportAddress address = buildNewFakeTransportAddress();
+                original = new RemoteTransportException("remote", address, "action",
+                        new ResourceAlreadyExistsException("ElasticsearchWrapperException with a cause that has a custom status"));
+                status = RestStatus.BAD_REQUEST;
+                if (detailed) {
+                    type = "resource_already_exists_exception";
+                    reason = "ElasticsearchWrapperException with a cause that has a custom status";
+                } else {
+                    reason = "RemoteTransportException[[remote][" + address.toString() + "][action]]";
+                }
+                break;
+            case 4:
+                original = new RemoteTransportException("ElasticsearchWrapperException with a cause that has a special treatment",
+                        new IllegalArgumentException("wrong"));
+                status = RestStatus.BAD_REQUEST;
+                if (detailed) {
+                    type = "illegal_argument_exception";
+                    reason = "wrong";
+                } else {
+                    reason = "RemoteTransportException[[ElasticsearchWrapperException with a cause that has a special treatment]]";
+                }
+                break;
+            case 5:
+                status = randomFrom(RestStatus.values());
+                original = new ElasticsearchStatusException("ElasticsearchStatusException with random status", status);
+                if (detailed) {
+                    type = "status_exception";
+                    reason = "ElasticsearchStatusException with random status";
+                } else {
+                    reason = "ElasticsearchStatusException[ElasticsearchStatusException with random status]";
+                }
+                break;
+            default:
+                throw new UnsupportedOperationException("Failed to generate random exception");
+        }
+
+        String message = "Elasticsearch exception [type=" + type + ", reason=" + reason + "]";
+        ElasticsearchStatusException expected = new ElasticsearchStatusException(message, status, cause);
+
         final XContentType xContentType = randomFrom(XContentType.values());
 
         Map<String, String> params = Collections.singletonMap("format", xContentType.mediaType());
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withParams(params).build();
-
-        final boolean detailed = randomBoolean();
         RestChannel channel = detailed ? new DetailedExceptionRestChannel(request) : new SimpleExceptionRestChannel(request);
 
-        Exception exception = new ElasticsearchException("Something wrong happened", new IllegalArgumentException("Bad"));
-        BytesRestResponse response = new BytesRestResponse(channel, exception);
+        BytesRestResponse response = new BytesRestResponse(channel, original);
 
         ElasticsearchException parsedError;
         try (XContentParser parser = createParser(xContentType.xContent(), response.content())) {
@@ -230,15 +310,23 @@ public class BytesRestResponseTests extends ESTestCase {
             assertNull(parser.nextToken());
         }
 
-        if (detailed) {
-            assertEquals("Elasticsearch exception [type=exception, reason=Something wrong happened]",
-                    parsedError.getMessage());
-            assertEquals("Elasticsearch exception [type=illegal_argument_exception, reason=Bad]",
-                    parsedError.getCause().getMessage());
-        } else {
-            assertEquals("Elasticsearch exception [type=exception, reason=ElasticsearchException[Something wrong happened]]",
-                    parsedError.getMessage());
-        }
+        assertEquals(expected.status(), parsedError.status());
+        assertDeepEquals(expected, parsedError);
+    }
+
+    public void testNoErrorFromXContent() throws IOException {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
+            try (XContentBuilder builder = XContentBuilder.builder(randomFrom(XContentType.values()).xContent())) {
+                builder.startObject();
+                builder.field("status", randomFrom(RestStatus.values()));
+                builder.endObject();
+
+                try (XContentParser parser = createParser(builder.contentType().xContent(), builder.bytes())) {
+                    BytesRestResponse.errorFromXContent(parser);
+                }
+            }
+        });
+        assertEquals("Unable to parse elasticsearch status exception", e.getMessage());
     }
 
     public static class WithHeadersException extends ElasticsearchException {


### PR DESCRIPTION
This commit adds a BytesRestResponse.errorFromXContent() method to parse the error returned by BytesRestResponse.