### PR TITLE
[Doc]Not support "M" time unit in offset param

### DIFF
--- a/docs/reference/aggregations/bucket/datehistogram-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/datehistogram-aggregation.asciidoc
@@ -238,7 +238,7 @@ happens.
 
 The `offset` parameter is used to change the start value of each bucket by the
 specified positive (`+`) or negative offset (`-`) duration, such as `1h` for
-an hour, or `1M` for a month. See <<time-units>> for more possible time
+an hour, or `1d` for a day. See <<time-units>> for more possible time
 duration options.
 
 For instance, when using an interval of `day`, each bucket runs from midnight


### PR DESCRIPTION
Removed by https://github.com/elastic/elasticsearch/pull/19649