### PR TITLE
Fix name of `enabled_position_increments`

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -97,7 +97,8 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
     private static final ParseField MAX_DETERMINIZED_STATES_FIELD = new ParseField("max_determinized_states", "max_determined_states");
     private static final ParseField LOWERCASE_EXPANDED_TERMS_FIELD = new ParseField("lowercase_expanded_terms")
             .withAllDeprecated("Decision is now made by the analyzer");
-    private static final ParseField ENABLE_POSITION_INCREMENTS_FIELD = new ParseField("enable_position_increment");
+    private static final ParseField ENABLE_POSITION_INCREMENTS_FIELD = new ParseField("enable_position_increments",
+            "enable_position_increment");
     private static final ParseField ESCAPE_FIELD = new ParseField("escape");
     private static final ParseField USE_DIS_MAX_FIELD = new ParseField("use_dis_max");
     private static final ParseField FUZZY_PREFIX_LENGTH_FIELD = new ParseField("fuzzy_prefix_length");

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -562,6 +562,31 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         assertWarnings("Deprecated field [max_determined_states] used, expected [max_determinized_states] instead");
     }
 
+    /**
+     * Validates that {@code max_determinized_states} can be parsed and lowers the allowed number of determinized states.
+     */
+    public void testEnabledPositionIncrements() throws Exception {
+        assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
+
+        boolean useDeprecatedName = randomBoolean();
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        builder.startObject(); {
+            builder.startObject("query_string"); {
+                builder.field("query", "text");
+                builder.field("default_field", STRING_FIELD_NAME);
+                builder.field(useDeprecatedName ? "enable_position_increment" : "enable_position_increments", false);
+            }
+            builder.endObject();
+        }
+        builder.endObject();
+
+        QueryStringQueryBuilder queryBuilder = (QueryStringQueryBuilder) new QueryParseContext(createParser(builder))
+                .parseInnerQueryBuilder().get();
+        assertFalse(queryBuilder.enablePositionIncrements());
+        if (useDeprecatedName) {
+            assertWarnings("Deprecated field [enable_position_increment] used, expected [enable_position_increments] instead");
+        }
+    }
 
     public void testToQueryFuzzyQueryAutoFuziness() throws Exception {
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
@@ -837,7 +862,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                 "    \"default_operator\" : \"or\",\n" +
                 "    \"auto_generate_phrase_queries\" : false,\n" +
                 "    \"max_determinized_states\" : 10000,\n" +
-                "    \"enable_position_increment\" : true,\n" +
+                "    \"enable_position_increments\" : true,\n" +
                 "    \"fuzziness\" : \"AUTO\",\n" +
                 "    \"fuzzy_prefix_length\" : 0,\n" +
                 "    \"fuzzy_max_expansions\" : 50,\n" +


### PR DESCRIPTION
It was accidentally renamed `enable_position_increment` in the cleanups
for 5.0. This adds `enable_position_increment` as a deprecated alias
so it will continue to work.
