### PR TITLE
 Add parsing from xContent to Suggest

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/internal/InternalSearchHit.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/InternalSearchHit.java
@@ -400,22 +400,22 @@ public class InternalSearchHit implements SearchHit {
     }
 
     public static class Fields {
-        static final String _INDEX = "_index";
-        static final String _TYPE = "_type";
-        static final String _ID = "_id";
-        static final String _VERSION = "_version";
-        static final String _SCORE = "_score";
-        static final String FIELDS = "fields";
-        static final String HIGHLIGHT = "highlight";
-        static final String SORT = "sort";
-        static final String MATCHED_QUERIES = "matched_queries";
-        static final String _EXPLANATION = "_explanation";
-        static final String VALUE = "value";
-        static final String DESCRIPTION = "description";
-        static final String DETAILS = "details";
-        static final String INNER_HITS = "inner_hits";
-        static final String _SHARD = "_shard";
-        static final String _NODE = "_node";
+        public static final String _INDEX = "_index";
+        public static final String _TYPE = "_type";
+        public static final String _ID = "_id";
+        public static final String _VERSION = "_version";
+        public static final String _SCORE = "_score";
+        public static final String FIELDS = "fields";
+        public static final String HIGHLIGHT = "highlight";
+        public static final String SORT = "sort";
+        public static final String MATCHED_QUERIES = "matched_queries";
+        public static final String _EXPLANATION = "_explanation";
+        public static final String VALUE = "value";
+        public static final String DESCRIPTION = "description";
+        public static final String DETAILS = "details";
+        public static final String INNER_HITS = "inner_hits";
+        public static final String _SHARD = "_shard";
+        public static final String _NODE = "_node";
     }
 
     // public because we render hit as part of completion suggestion option
@@ -512,7 +512,8 @@ public class InternalSearchHit implements SearchHit {
     }
 
     private static ObjectParser<Map<String, Object>, Void> PARSER = new ObjectParser<>("innerHitsParser", HashMap<String, Object>::new);
-    {
+
+    static {
         declareInnerHitsParseFields(PARSER);
     }
 
@@ -581,7 +582,10 @@ public class InternalSearchHit implements SearchHit {
     }
 
     public static InternalSearchHit fromXContent(XContentParser parser) {
-        Map<String, Object> values = PARSER.apply(parser, null);
+        return createFromMap(PARSER.apply(parser, null));
+    }
+
+    public static InternalSearchHit createFromMap(Map<String, Object> values) {
         String type = get(Fields._TYPE, values, null);
         String id = get(Fields._ID, values, null);
         String index = get(Fields._INDEX, values, null);
@@ -964,9 +968,9 @@ public class InternalSearchHit implements SearchHit {
         }
 
         public static class Fields {
-            static final String _NESTED = "_nested";
-            static final String _NESTED_FIELD = "field";
-            static final String _NESTED_OFFSET = "offset";
+            public static final String _NESTED = "_nested";
+            public static final String _NESTED_FIELD = "field";
+            public static final String _NESTED_OFFSET = "offset";
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestion.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestion.java
@@ -20,26 +20,28 @@ package org.elasticsearch.search.suggest.completion;
 
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.suggest.Lookup;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.internal.InternalSearchHit;
-import org.elasticsearch.search.internal.InternalSearchHits;
 import org.elasticsearch.search.suggest.Suggest;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.elasticsearch.search.suggest.Suggest.COMPARATOR;
+import static org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option.Fields.SCORE;
+import static org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option.Fields.TEXT;
 
 /**
  * Suggestion response for {@link CompletionSuggester} results
@@ -192,14 +194,18 @@ public final class CompletionSuggestion extends Suggest.Suggestion<CompletionSug
         }
 
         public static class Option extends Suggest.Suggestion.Entry.Option {
-            private Map<String, Set<CharSequence>> contexts;
+            private Map<String, Set<CharSequence>> contexts = Collections.emptyMap();
             private ScoreDoc doc;
             private InternalSearchHit hit;
+
+            public static class Fields {
+                public static final ParseField CONTEXT = new ParseField("contexts");
+            }
 
             public Option(int docID, Text text, float score, Map<String, Set<CharSequence>> contexts) {
                 super(text, score);
                 this.doc = new ScoreDoc(docID, score);
-                this.contexts = contexts;
+                this.contexts = Objects.requireNonNull(contexts, "context map cannot be null");
             }
 
             protected Option() {
@@ -235,14 +241,14 @@ public final class CompletionSuggestion extends Suggest.Suggestion<CompletionSug
 
             @Override
             protected XContentBuilder innerToXContent(XContentBuilder builder, Params params) throws IOException {
-                builder.field("text", getText());
+                builder.field(TEXT.getPreferredName(), getText());
                 if (hit != null) {
                     hit.toInnerXContent(builder, params);
                 } else {
-                    builder.field("score", getScore());
+                    builder.field(SCORE.getPreferredName(), getScore());
                 }
                 if (contexts.size() > 0) {
-                    builder.startObject("contexts");
+                    builder.startObject(Fields.CONTEXT.getPreferredName());
                     for (Map.Entry<String, Set<CharSequence>> entry : contexts.entrySet()) {
                         builder.startArray(entry.getKey());
                         for (CharSequence context : entry.getValue()) {

--- a/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestion.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestion.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.suggest.term;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.text.Text;
@@ -127,10 +128,9 @@ public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
     /**
      * Represents a part from the suggest text with suggested options.
      */
-    public static class Entry extends
-            org.elasticsearch.search.suggest.Suggest.Suggestion.Entry<TermSuggestion.Entry.Option> {
+    public static class Entry extends Suggestion.Entry<TermSuggestion.Entry.Option> {
 
-        Entry(Text text, int offset, int length) {
+        public Entry(Text text, int offset, int length) {
             super(text, offset, length);
         }
 
@@ -147,13 +147,13 @@ public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
          */
         public static class Option extends org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option {
 
-            static class Fields {
-                static final String FREQ = "freq";
+            public static class Fields {
+                public static final ParseField FREQ = new ParseField("freq");
             }
 
             private int freq;
 
-            protected Option(Text text, int freq, float score) {
+            public Option(Text text, int freq, float score) {
                 super(text, score);
                 this.freq = freq;
             }
@@ -194,7 +194,7 @@ public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
             @Override
             protected XContentBuilder innerToXContent(XContentBuilder builder, Params params) throws IOException {
                 builder = super.innerToXContent(builder, params);
-                builder.field(Fields.FREQ, freq);
+                builder.field(Fields.FREQ.getPreferredName(), freq);
                 return builder;
             }
         }

--- a/core/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestionOptionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestionOptionTests.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.suggest;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.search.internal.InternalSearchHit;
+import org.elasticsearch.search.internal.InternalSearchHitTests;
+import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option;
+import org.elasticsearch.search.suggest.completion.CompletionSuggestion;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+public class CompletionSuggestionOptionTests extends ESTestCase {
+
+    public static CompletionSuggestion.Entry.Option createTestItem() {
+        Text text = new Text(randomAsciiOfLengthBetween(5, 10));
+        int docId = randomInt(1000);
+        int numberOfContexts = randomIntBetween(0, 5);
+        Map<String, Set<CharSequence>> contexts = new HashMap<>();
+        for (int i = 0; i < numberOfContexts; i++) {
+            int numberOfValues = randomIntBetween(0, 5);
+            Set<CharSequence> values = new HashSet<>();
+            for (int v = 0; v < numberOfValues; v++) {
+                values.add(randomAsciiOfLengthBetween(4, 10));
+            }
+            contexts.put(randomAsciiOfLength(5), values);
+        }
+        // TODO re-check with Areek, we should always have a hit set to the CompletionSuggestion.Entry.Option
+        InternalSearchHit hit = InternalSearchHitTests.createTestItem(false);
+        // we use the hit.score() here because it should always be the same
+        CompletionSuggestion.Entry.Option option = new CompletionSuggestion.Entry.Option(docId, text, hit.score(), contexts);
+        option.setHit(hit);
+        return option;
+    }
+
+    public void testFromXContent() throws IOException {
+        CompletionSuggestion.Entry.Option option = createTestItem();
+        XContentType xContentType = XContentType.JSON; //randomFrom(XContentType.values());
+        boolean humanReadable = randomBoolean();
+        BytesReference originalBytes = toXContent(option, xContentType, humanReadable);
+        Option parsed;
+        try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+            parsed = Option.fromXContent(parser);
+            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+            assertNull(parser.nextToken());
+        }
+        assertThat(parsed, instanceOf(CompletionSuggestion.Entry.Option.class));
+        CompletionSuggestion.Entry.Option parsedOption = (CompletionSuggestion.Entry.Option) parsed;
+        assertEquals(option.getText(), parsedOption.getText());
+        assertEquals(option.getHighlighted(), parsedOption.getHighlighted());
+        assertEquals(option.getScore(), parsedOption.getScore(), Float.MIN_VALUE);
+        assertEquals(option.collateMatch(), parsedOption.collateMatch());
+        assertEquals(option.getContexts(), parsedOption.getContexts());
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, xContentType, humanReadable), xContentType);
+    }
+
+    public void testToXContent() throws IOException {
+        Map<String, Set<CharSequence>> contexts = Collections.singletonMap("key", Collections.singleton("value"));
+        CompletionSuggestion.Entry.Option option = new CompletionSuggestion.Entry.Option(1, new Text("someText"), 1.3f, contexts);
+        BytesReference xContent = toXContent(option, XContentType.JSON, randomBoolean());
+        assertEquals("{\"text\":\"someText\",\"score\":1.3,\"contexts\":{\"key\":[\"value\"]}}"
+                   , xContent.utf8ToString());
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestTests.java
@@ -19,19 +19,83 @@
 
 package org.elasticsearch.search.suggest;
 
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.search.suggest.Suggest.Suggestion;
+import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry;
+import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option;
 import org.elasticsearch.search.suggest.completion.CompletionSuggestion;
 import org.elasticsearch.search.suggest.phrase.PhraseSuggestion;
 import org.elasticsearch.search.suggest.term.TermSuggestion;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureFieldName;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.hamcrest.Matchers.equalTo;
 
 public class SuggestTests extends ESTestCase {
+
+    public static Suggest createTestItem() {
+        int numEntries = randomIntBetween(0, 5);
+        List<Suggestion<? extends Entry<? extends Option>>> suggestions = new ArrayList<>();
+        for (int i = 0; i < numEntries; i++) {
+            suggestions.add(SuggestionTests.createTestItem());
+        }
+        return new Suggest(suggestions);
+    }
+
+    public void testFromXContent() throws IOException {
+        Suggest suggest = createTestItem();
+        XContentType xContentType = randomFrom(XContentType.values());
+        boolean humanReadable = randomBoolean();
+        BytesReference originalBytes = toXContent(suggest, xContentType, humanReadable);
+        Suggest parsed;
+        try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+            ensureFieldName(parser, parser.nextToken(), "suggest");
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+            parsed = Suggest.fromXContent(parser);
+            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+            assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
+            assertNull(parser.nextToken());
+        }
+        assertEquals(suggest.size(), parsed.size());
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, xContentType, humanReadable), xContentType);
+    }
+
+    public void testToXContent() throws IOException {
+        Option option = new Option(new Text("someText"), new Text("somethingHighlighted"), 1.3f, true);
+        Entry<Option> entry = new Entry<>(new Text("entryText"), 42, 313);
+        entry.addOption(option);
+        Suggestion<Entry<Option>> suggestion = new Suggestion<>("suggestionName", 5);
+        suggestion.addTerm(entry);
+        Suggest suggest = new Suggest(Collections.singletonList(suggestion));
+        BytesReference xContent = toXContent(suggest, XContentType.JSON, randomBoolean());
+        assertEquals(
+                "{\"suggest\":"
+                        + "{\"suggestionName\":"
+                            + "[{\"text\":\"entryText\","
+                            + "\"offset\":42,"
+                            + "\"length\":313,"
+                            + "\"options\":[{\"text\":\"someText\","
+                                        + "\"highlighted\":\"somethingHighlighted\","
+                                        + "\"score\":1.3,"
+                                        + "\"collate_match\":true}]"
+                            + "}]"
+                        + "}"
+                +"}",
+                xContent.utf8ToString());
+    }
 
     public void testFilter() throws Exception {
         List<Suggest.Suggestion<? extends Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>>> suggestions;

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestionEntryTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestionEntryTests.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.suggest;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry;
+import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option;
+import org.elasticsearch.search.suggest.completion.CompletionSuggestion;
+import org.elasticsearch.search.suggest.phrase.PhraseSuggestion;
+import org.elasticsearch.search.suggest.term.TermSuggestion;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.function.Supplier;
+
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+
+public class SuggestionEntryTests extends ESTestCase {
+
+    /**
+     * Create a randomized Suggestion.Entry, determined by the type argument.
+     * @param type determines the entry type. Valid arguments are 0 for {@link TermSuggestion.Entry},
+     * 1 for {@link PhraseSuggestion.Entry} and 2 for {@link CompletionSuggestion.Entry}
+     */
+    public static <O extends Option> Entry<O> createTestItem(int type) {
+        Text entryText = new Text(randomAsciiOfLengthBetween(5, 15));
+
+        int offset = randomInt();
+        int length = randomInt();
+        Entry<O> entry;
+        Supplier<Entry.Option> supplier;
+        switch (type) {
+            case 0:
+                entry = (Entry<O>) new TermSuggestion.Entry(entryText, offset, length);
+                supplier = TermSuggestionOptionTests::createTestItem;
+                break;
+            case 1:
+                entry = (Entry<O>) new PhraseSuggestion.Entry(entryText, offset, length, randomDouble());
+                supplier = SuggestionOptionTests::createTestItem;
+                break;
+            case 2:
+            default:
+                entry = (Entry<O>) new CompletionSuggestion.Entry(entryText, offset, length);
+                supplier = CompletionSuggestionOptionTests::createTestItem;
+                break;
+        }
+        int numOptions = randomIntBetween(0, 5);
+        for (int i = 0; i < numOptions; i++) {
+            entry.addOption((O) supplier.get());
+        }
+        return entry;
+    }
+
+    public void testFromXContent() throws IOException {
+        Entry<Option> entry = createTestItem(randomIntBetween(0, 2));
+        XContentType xContentType = randomFrom(XContentType.values());
+        boolean humanReadable = randomBoolean();
+        BytesReference originalBytes = toXContent(entry, xContentType, humanReadable);
+        Entry<Option> parsed;
+        try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+            parsed = Entry.fromXContent(parser);
+            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+            assertNull(parser.nextToken());
+        }
+        if (entry.options.size() > 0) {
+            // without options we cannot determine the suggestion type of the entry
+            assertEquals(entry.getClass(), parsed.getClass());
+        }
+        assertEquals(entry.getText(), parsed.getText());
+        assertEquals(entry.getLength(), parsed.getLength());
+        assertEquals(entry.getOffset(), parsed.getOffset());
+        assertEquals(entry.getOptions().size(), parsed.getOptions().size());
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, xContentType, humanReadable), xContentType);
+    }
+
+    public void testToXContent() throws IOException {
+        Option option = new Option(new Text("someText"), new Text("somethingHighlighted"), 1.3f, true);
+        Entry<Option> entry = new Entry<>(new Text("entryText"), 42, 313);
+        entry.addOption(option);
+        BytesReference xContent = toXContent(entry, XContentType.JSON, randomBoolean());
+        assertEquals(
+                "{\"text\":\"entryText\","
+                + "\"offset\":42,"
+                + "\"length\":313,"
+                + "\"options\":["
+                    + "{\"text\":\"someText\","
+                    + "\"highlighted\":\"somethingHighlighted\","
+                    + "\"score\":1.3,"
+                    + "\"collate_match\":true}"
+                + "]}", xContent.utf8ToString());
+
+        org.elasticsearch.search.suggest.term.TermSuggestion.Entry.Option termOption =
+                new org.elasticsearch.search.suggest.term.TermSuggestion.Entry.Option(new Text("termSuggestOption"), 42, 3.13f);
+        entry = new Entry<>(new Text("entryText"), 42, 313);
+        entry.addOption(termOption);
+        xContent = toXContent(entry, XContentType.JSON, randomBoolean());
+        assertEquals(
+                "{\"text\":\"entryText\","
+                + "\"offset\":42,"
+                + "\"length\":313,"
+                + "\"options\":["
+                    + "{\"text\":\"termSuggestOption\","
+                    + "\"score\":3.13,"
+                    + "\"freq\":42}"
+                + "]}", xContent.utf8ToString());
+
+        org.elasticsearch.search.suggest.completion.CompletionSuggestion.Entry.Option completionOption =
+                new org.elasticsearch.search.suggest.completion.CompletionSuggestion.Entry.Option(-1, new Text("completionOption"),
+                        3.13f, Collections.singletonMap("key", Collections.singleton("value")));
+        entry = new Entry<>(new Text("entryText"), 42, 313);
+        entry.addOption(completionOption);
+        xContent = toXContent(entry, XContentType.JSON, randomBoolean());
+        assertEquals(
+                "{\"text\":\"entryText\","
+                + "\"offset\":42,"
+                + "\"length\":313,"
+                + "\"options\":["
+                    + "{\"text\":\"completionOption\","
+                    + "\"score\":3.13,"
+                    + "\"contexts\":{\"key\":[\"value\"]}"
+                    + "}"
+                + "]}", xContent.utf8ToString());
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestionOptionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestionOptionTests.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.suggest;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+
+public class SuggestionOptionTests extends ESTestCase {
+
+    public static Option createTestItem() {
+        Text text = new Text(randomAsciiOfLengthBetween(5, 10));
+        float score = randomFloat();
+        Text highlighted = randomFrom((Text) null, new Text(randomAsciiOfLengthBetween(5, 10)));
+        Boolean collateMatch = randomFrom((Boolean) null, randomBoolean());
+        return new Option(text, highlighted, score, collateMatch);
+    }
+
+    public void testFromXContent() throws IOException {
+        Option option = createTestItem();
+        XContentType xContentType = randomFrom(XContentType.values());
+        boolean humanReadable = randomBoolean();
+        BytesReference originalBytes = toXContent(option, xContentType, humanReadable);
+        Option parsed;
+        try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+            parsed = Option.fromXContent(parser);
+            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+            assertNull(parser.nextToken());
+        }
+        assertEquals(option.getText(), parsed.getText());
+        assertEquals(option.getHighlighted(), parsed.getHighlighted());
+        assertEquals(option.getScore(), parsed.getScore(), Float.MIN_VALUE);
+        assertEquals(option.collateMatch(), parsed.collateMatch());
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, xContentType, humanReadable), xContentType);
+    }
+
+    public void testToXContent() throws IOException {
+        Option option = new Option(new Text("someText"), new Text("somethingHighlighted"), 1.3f, true);
+        BytesReference xContent = toXContent(option, XContentType.JSON, randomBoolean());
+        assertEquals("{\"text\":\"someText\","
+                      + "\"highlighted\":\"somethingHighlighted\","
+                      + "\"score\":1.3,"
+                      + "\"collate_match\":true"
+                   + "}"
+                   , xContent.utf8ToString());
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.suggest;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.search.suggest.Suggest.Suggestion;
+import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry;
+import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option;
+import org.elasticsearch.search.suggest.completion.CompletionSuggestion;
+import org.elasticsearch.search.suggest.phrase.PhraseSuggestion;
+import org.elasticsearch.search.suggest.term.TermSuggestion;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+
+public class SuggestionTests extends ESTestCase {
+
+    public static Suggestion<Entry<Option>> createTestItem() {
+        String name = randomAsciiOfLengthBetween(5, 10);
+        // note: size will not be rendered via "toXContent", only passed on internally on transport layer
+        int size = randomInt();
+        @SuppressWarnings("unchecked")
+        Suggestion[] suggestions = new Suggestion[] { new TermSuggestion(name, size, randomFrom(SortBy.values())),
+                new PhraseSuggestion(name, size), new CompletionSuggestion(name, size) };
+        int type = randomIntBetween(0, 2);
+        Suggestion suggestion = suggestions[type];
+        int numEntries = randomIntBetween(0, 5);
+        if (type == 2) {
+            numEntries = randomIntBetween(0, 1); // CompletionSuggestion must have only one entry
+        }
+        for (int i = 0; i < numEntries; i++) {
+            suggestion.addTerm(SuggestionEntryTests.createTestItem(type));
+        }
+        return suggestion;
+    }
+
+    public void testFromXContent() throws IOException {
+        Suggestion<Entry<Option>> suggestion = createTestItem();
+        XContentType xContentType = XContentType.JSON; //randomFrom(XContentType.values());
+        boolean humanReadable = randomBoolean();
+        BytesReference originalBytes = toXContent(suggestion, xContentType, humanReadable);
+        Suggestion<Entry<Option>> parsed;
+        try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+            ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
+            parsed = Suggestion.fromXContent(parser);
+            assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
+            assertNull(parser.nextToken());
+        }
+        assertEquals(suggestion.getName(), parsed.getName());
+        assertEquals(suggestion.getEntries().size(), parsed.getEntries().size());
+        // TODO re-check whats a good default value for size here. We don't send it via xContent, so we need to pick something
+        assertEquals(-1, parsed.getSize());
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, xContentType, humanReadable), xContentType);
+    }
+
+    public void testToXContent() throws IOException {
+        Option option = new Option(new Text("someText"), new Text("somethingHighlighted"), 1.3f, true);
+        Entry<Option> entry = new Entry<>(new Text("entryText"), 42, 313);
+        entry.addOption(option);
+        BytesReference xContent = toXContent(entry, XContentType.JSON, randomBoolean());
+        assertEquals(
+                "{\"text\":\"entryText\","
+                + "\"offset\":42,"
+                + "\"length\":313,"
+                + "\"options\":["
+                    + "{\"text\":\"someText\","
+                    + "\"highlighted\":\"somethingHighlighted\","
+                    + "\"score\":1.3,"
+                    + "\"collate_match\":true}"
+                + "]}", xContent.utf8ToString());
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/suggest/TermSuggestionOptionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/TermSuggestionOptionTests.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.suggest;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.search.suggest.term.TermSuggestion;
+import org.elasticsearch.search.suggest.term.TermSuggestion.Entry.Option;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+public class TermSuggestionOptionTests extends ESTestCase {
+
+    public static TermSuggestion.Entry.Option createTestItem() {
+        Text text = new Text(randomAsciiOfLengthBetween(5, 10));
+        float score = randomFloat();
+        int freq = randomInt(1000);
+        return new TermSuggestion.Entry.Option(text, freq, score);
+    }
+
+    public void testFromXContent() throws IOException {
+        TermSuggestion.Entry.Option option = createTestItem();
+        XContentType xContentType = randomFrom(XContentType.values());
+        boolean humanReadable = randomBoolean();
+        BytesReference originalBytes = toXContent(option, xContentType, humanReadable);
+        org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option parsed;
+        try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+            parsed = org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option.fromXContent(parser);
+            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+            assertNull(parser.nextToken());
+        }
+        assertThat(parsed, instanceOf(TermSuggestion.Entry.Option.class));
+        TermSuggestion.Entry.Option parsedTermSuggestionOption = (TermSuggestion.Entry.Option) parsed;
+        assertEquals(option.getText(), parsedTermSuggestionOption.getText());
+        assertEquals(option.getHighlighted(), parsedTermSuggestionOption.getHighlighted());
+        assertEquals(option.getScore(), parsedTermSuggestionOption.getScore(), Float.MIN_VALUE);
+        assertEquals(option.collateMatch(), parsedTermSuggestionOption.collateMatch());
+        assertEquals(option.getFreq(), parsedTermSuggestionOption.getFreq());
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, xContentType, humanReadable), xContentType);
+    }
+
+    public void testToXContent() throws IOException {
+        Option option = new Option(new Text("someText"), 100, 1.3f);
+        BytesReference xContent = toXContent(option, XContentType.JSON, randomBoolean());
+        assertEquals("{\"text\":\"someText\",\"score\":1.3,\"freq\":100}"
+                   , xContent.utf8ToString());
+
+
+    }
+
+}


### PR DESCRIPTION
In preparation for being able to parse SearchResponse from its rest
representation, this adds fromXContent to Suggest and nested Suggestion
classes and its child objects.

This is still WIP since we might get a better way to determine the parsed suggestion type with another PR.