### PR TITLE
Add parsing from xContent to MainResponse

### DIFF
--- a/core/src/main/java/org/elasticsearch/Build.java
+++ b/core/src/main/java/org/elasticsearch/Build.java
@@ -79,10 +79,10 @@ public class Build {
         return Build.class.getProtectionDomain().getCodeSource().getLocation();
     }
 
-    private String shortHash;
-    private String date;
+    private final String shortHash;
+    private final String date;
 
-    Build(String shortHash, String date, boolean isSnapshot) {
+    public Build(String shortHash, String date, boolean isSnapshot) {
         this.shortHash = shortHash;
         this.date = date;
         this.isSnapshot = isSnapshot;

--- a/core/src/main/java/org/elasticsearch/action/main/MainResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/main/MainResponse.java
@@ -118,7 +118,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         return builder;
     }
 
-    private final static ObjectParser<MainResponse, Void> PARSER = new ObjectParser<>(MainResponse.class.getName(),
+    private static final ObjectParser<MainResponse, Void> PARSER = new ObjectParser<>(MainResponse.class.getName(), true,
             () -> new MainResponse());
 
     static {

--- a/core/src/main/java/org/elasticsearch/action/main/MainResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/main/MainResponse.java
@@ -23,14 +23,17 @@ import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 
-public class MainResponse extends ActionResponse implements ToXContent {
+public class MainResponse extends ActionResponse implements ToXContentObject {
 
     private String nodeName;
     private Version version;
@@ -113,5 +116,25 @@ public class MainResponse extends ActionResponse implements ToXContent {
         builder.field("tagline", "You Know, for Search");
         builder.endObject();
         return builder;
+    }
+
+    private final static ObjectParser<MainResponse, Void> PARSER = new ObjectParser<>(MainResponse.class.getName(),
+            () -> new MainResponse());
+
+    static {
+        PARSER.declareString((response, value) -> response.nodeName = value, new ParseField("name"));
+        PARSER.declareString((response, value) -> response.clusterName = new ClusterName(value), new ParseField("cluster_name"));
+        PARSER.declareString((response, value) -> response.clusterUuid = value, new ParseField("cluster_uuid"));
+        PARSER.declareString((response, value) -> {}, new ParseField("tagline"));
+        PARSER.declareObject((response, value) -> {
+            response.build = new Build((String) value.get("build_hash"), (String) value.get("build_date"),
+                    (boolean) value.get("build_snapshot"));
+            response.version = Version.fromString((String) value.get("number"));
+            response.available = true;
+        }, (parser, context) -> parser.map(), new ParseField("version"));
+    }
+
+    public static MainResponse fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
@@ -32,7 +32,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 
 import java.io.IOException;
-import java.sql.Date;
+import java.util.Date;
 
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;

--- a/core/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.main;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.VersionUtils;
+
+import java.io.IOException;
+import java.sql.Date;
+
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+
+public class MainResponseTests extends ESTestCase {
+
+    public static MainResponse createTestItem() {
+        String clusterUuid = randomAsciiOfLength(10);
+        ClusterName clusterName = new ClusterName(randomAsciiOfLength(10));
+        String nodeName = randomAsciiOfLength(10);
+        Build build = new Build(randomAsciiOfLength(8), new Date(randomNonNegativeLong()).toString(), randomBoolean());
+        Version version = VersionUtils.randomVersion(random());
+        boolean available = randomBoolean();
+        return new MainResponse(nodeName, version, clusterName, clusterUuid , build, available);
+    }
+
+    public void testFromXContent() throws IOException {
+        MainResponse mainResponse = createTestItem();
+        XContentType xContentType = randomFrom(XContentType.values());
+        boolean humanReadable = randomBoolean();
+        BytesReference originalBytes = toXContent(mainResponse, xContentType, humanReadable);
+        MainResponse parsed;
+        try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+            parsed = MainResponse.fromXContent(parser);
+            assertNull(parser.nextToken());
+        }
+        assertEquals(mainResponse.getClusterUuid(), parsed.getClusterUuid());
+        assertEquals(mainResponse.getClusterName(), parsed.getClusterName());
+        assertEquals(mainResponse.getNodeName(), parsed.getNodeName());
+        assertEquals(mainResponse.getBuild(), parsed.getBuild());
+        assertEquals(mainResponse.getVersion(), parsed.getVersion());
+        // we cannot recreate the "available" flag from xContent, but should be "true" if request came through
+        assertEquals(true, parsed.isAvailable());
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, xContentType, humanReadable), xContentType);
+    }
+
+    public void testToXContent() throws IOException {
+        Build build = new Build("buildHash", "2016-11-15".toString(), true);
+        Version version = Version.V_2_4_5;
+        MainResponse response = new MainResponse("nodeName", version, new ClusterName("clusterName"), "clusterUuid", build, true);
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertEquals("{"
+                + "\"name\":\"nodeName\","
+                + "\"cluster_name\":\"clusterName\","
+                + "\"cluster_uuid\":\"clusterUuid\","
+                + "\"version\":{"
+                    + "\"number\":\"2.4.5\","
+                    + "\"build_hash\":\"buildHash\","
+                    + "\"build_date\":\"2016-11-15\","
+                    + "\"build_snapshot\":true,"
+                    + "\"lucene_version\":\"5.5.2\"},"
+                + "\"tagline\":\"You Know, for Search\""
+          + "}", builder.string());
+    }
+
+}


### PR DESCRIPTION
This adds fromXContent to MainResponse so we can use it in the java rest client.
