### PR TITLE
[DOCS] Low Level REST Client should emphasize ContentType

### DIFF
--- a/docs/java-rest/usage.asciidoc
+++ b/docs/java-rest/usage.asciidoc
@@ -233,14 +233,18 @@ HttpEntity entity = new NStringEntity(
         "    \"post_date\" : \"2009-11-15T14:12:12\",\n" +
         "    \"message\" : \"trying out Elasticsearch\"\n" +
         "}", ContentType.APPLICATION_JSON);
+
 Response indexResponse = restClient.performRequest(
         "PUT",
         "/twitter/tweet/1",
         Collections.<String, String>emptyMap(),
         entity);
-
-
 --------------------------------------------------
+
+IMPORTANT: The `ContentType` that you specify for the `HttpEntity` is important
+because it will be used to set the `Content-Type` header so that Elasticsearch
+can properly parse the content. Future releases of Elasticsearch will require this
+to be set properly.
 
 Note that the low-level client doesn't expose any helper for json marshalling
 and un-marshalling. Users are free to use the library that they prefer for that
@@ -262,6 +266,7 @@ The following is a basic example of how async requests can be sent:
 --------------------------------------------------
 int numRequests = 10;
 final CountDownLatch latch = new CountDownLatch(numRequests);
+
 for (int i = 0; i < numRequests; i++) {
     restClient.performRequestAsync(
         "PUT",
@@ -283,6 +288,7 @@ for (int i = 0; i < numRequests; i++) {
         }
     );
 }
+
 //wait for all requests to be completed
 latch.await();
 


### PR DESCRIPTION
This adds a callout to note that the Low Level REST Client example sets the `ContentType` explicitly and that users should do the same (`ContentType` is required by all of the `HttpEntity`'s that I am aware of, but it's not required to be set properly).

I will drop the `Future releases of Elasticsearch will require this to be set properly.` sentence from the master branch in a follow-up commit.

Relates to #19388