### PR TITLE
Build: Improve detection of older java versions

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -27,6 +27,10 @@ if (GradleVersion.current() < GradleVersion.version('2.13')) {
   throw new GradleException('Gradle 2.13+ is required to build elasticsearch')
 }
 
+if (JavaVersion.current() < JavaVersion.VERSION_1_8) {
+  throw new GradleException('Java 1.8 is required to build elasticsearch gradle tools')
+}
+
 if (project == rootProject) {
   // change the build dir used during build init, so that doing a clean
   // won't wipe out the buildscript jar

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -202,22 +202,13 @@ class BuildPlugin implements Plugin<Project> {
 
     /** Runs the given javascript using jjs from the jdk, and returns the output */
     private static String runJavascript(Project project, String javaHome, String script) {
-        File jjs = new File(javaHome, 'bin/jjs')
-        if (jjs.exists() == false) {
-            throw new GradleException("Cannot find jjs binary in java installation at ${javaHome}. At least java 1.8 is required.")
-        }
-        File tmpScript = File.createTempFile('es-gradle-tmp', '.js')
-        tmpScript.setText(script, 'UTF-8')
         ByteArrayOutputStream output = new ByteArrayOutputStream()
-        ExecResult result = project.exec {
-            executable = jjs
-            args tmpScript.toString()
+        project.exec {
+            executable = new File(javaHome, 'bin/jrunscript')
+            args '-e', script
             standardOutput = output
             errorOutput = new ByteArrayOutputStream()
-            ignoreExitValue = true // we do not fail so we can first cleanup the tmp file
         }
-        java.nio.file.Files.delete(tmpScript.toPath())
-        result.assertNormalExitValue()
         return output.toString('UTF-8').trim()
     }
 


### PR DESCRIPTION
This change switches to using jrunscript, instead of jjs, for detecting
version properties of java, which is available on java versions prior to 8.

closes #22898