### PR TITLE
Upgrade checkstyle to version 7.5

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
@@ -139,6 +139,7 @@ class PrecommitTasks {
             configProperties = [
                 suppressions: checkstyleSuppressions
             ]
+            toolVersion = 7.5
         }
         for (String taskName : ['checkstyleMain', 'checkstyleTest']) {
             Task task = project.tasks.findByName(taskName)

--- a/client/benchmark/src/main/java/org/elasticsearch/client/benchmark/ops/bulk/BulkBenchmarkTask.java
+++ b/client/benchmark/src/main/java/org/elasticsearch/client/benchmark/ops/bulk/BulkBenchmarkTask.java
@@ -95,7 +95,7 @@ public class BulkBenchmarkTask implements BenchmarkTask {
         private final BlockingQueue<List<String>> bulkQueue;
         private final int bulkSize;
 
-        public LoadGenerator(Path bulkDataFile, BlockingQueue<List<String>> bulkQueue, int bulkSize) {
+        LoadGenerator(Path bulkDataFile, BlockingQueue<List<String>> bulkQueue, int bulkSize) {
             this.bulkDataFile = bulkDataFile;
             this.bulkQueue = bulkQueue;
             this.bulkSize = bulkSize;
@@ -143,7 +143,7 @@ public class BulkBenchmarkTask implements BenchmarkTask {
         private final BulkRequestExecutor bulkRequestExecutor;
         private final SampleRecorder sampleRecorder;
 
-        public BulkIndexer(BlockingQueue<List<String>> bulkData, int warmupIterations, int measurementIterations,
+        BulkIndexer(BlockingQueue<List<String>> bulkData, int warmupIterations, int measurementIterations,
                            SampleRecorder sampleRecorder, BulkRequestExecutor bulkRequestExecutor) {
             this.bulkData = bulkData;
             this.warmupIterations = warmupIterations;

--- a/client/benchmark/src/main/java/org/elasticsearch/client/benchmark/rest/RestClientBenchmark.java
+++ b/client/benchmark/src/main/java/org/elasticsearch/client/benchmark/rest/RestClientBenchmark.java
@@ -73,7 +73,7 @@ public final class RestClientBenchmark extends AbstractBenchmark<RestClient> {
         private final RestClient client;
         private final String actionMetaData;
 
-        public RestBulkRequestExecutor(RestClient client, String index, String type) {
+        RestBulkRequestExecutor(RestClient client, String index, String type) {
             this.client = client;
             this.actionMetaData = String.format(Locale.ROOT, "{ \"index\" : { \"_index\" : \"%s\", \"_type\" : \"%s\" } }%n", index, type);
         }

--- a/client/benchmark/src/main/java/org/elasticsearch/client/benchmark/transport/TransportClientBenchmark.java
+++ b/client/benchmark/src/main/java/org/elasticsearch/client/benchmark/transport/TransportClientBenchmark.java
@@ -71,7 +71,7 @@ public final class TransportClientBenchmark extends AbstractBenchmark<TransportC
         private final String indexName;
         private final String typeName;
 
-        public TransportBulkRequestExecutor(TransportClient client, String indexName, String typeName) {
+        TransportBulkRequestExecutor(TransportClient client, String indexName, String typeName) {
             this.client = client;
             this.indexName = indexName;
             this.typeName = typeName;

--- a/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/RestNoopBulkAction.java
+++ b/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/RestNoopBulkAction.java
@@ -90,7 +90,7 @@ public class RestNoopBulkAction extends BaseRestHandler {
         private final RestRequest request;
 
 
-        public BulkRestBuilderListener(RestChannel channel, RestRequest request) {
+        BulkRestBuilderListener(RestChannel channel, RestRequest request) {
             super(channel);
             this.request = request;
         }

--- a/client/rest/src/main/java/org/elasticsearch/client/HttpAsyncResponseConsumerFactory.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/HttpAsyncResponseConsumerFactory.java
@@ -53,7 +53,7 @@ interface HttpAsyncResponseConsumerFactory {
 
         private final int bufferLimit;
 
-        public HeapBufferedResponseConsumerFactory(int bufferLimitBytes) {
+        HeapBufferedResponseConsumerFactory(int bufferLimitBytes) {
             this.bufferLimit = bufferLimitBytes;
         }
 

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -705,7 +705,7 @@ public class RestClient implements Closeable {
         public final T hosts;
         public final AuthCache authCache;
 
-        public HostTuple(final T hosts, final AuthCache authCache) {
+        HostTuple(final T hosts, final AuthCache authCache) {
             this.hosts = hosts;
             this.authCache = authCache;
         }

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
@@ -219,7 +219,7 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
     public void testPreemptiveAuthEnabled() throws IOException  {
         final String[] methods = { "POST", "PUT", "GET", "DELETE" };
 
-        try (final RestClient restClient = createRestClient(true, true)) {
+        try (RestClient restClient = createRestClient(true, true)) {
             for (final String method : methods) {
                 final Response response = bodyTest(restClient, method);
 
@@ -234,7 +234,7 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
     public void testPreemptiveAuthDisabled() throws IOException  {
         final String[] methods = { "POST", "PUT", "GET", "DELETE" };
 
-        try (final RestClient restClient = createRestClient(true, false)) {
+        try (RestClient restClient = createRestClient(true, false)) {
             for (final String method : methods) {
                 final Response response = bodyTest(restClient, method);
 

--- a/core/src/main/java/org/apache/lucene/search/grouping/CollapseTopFieldDocs.java
+++ b/core/src/main/java/org/apache/lucene/search/grouping/CollapseTopFieldDocs.java
@@ -56,7 +56,7 @@ public class CollapseTopFieldDocs extends TopFieldDocs {
         // Which hit within the shard:
         int hitIndex;
 
-        public ShardRef(int shardIndex) {
+        ShardRef(int shardIndex) {
             this.shardIndex = shardIndex;
         }
 
@@ -72,7 +72,7 @@ public class CollapseTopFieldDocs extends TopFieldDocs {
         final FieldComparator<?>[] comparators;
         final int[] reverseMul;
 
-        public MergeSortQueue(Sort sort, CollapseTopFieldDocs[] shardHits) throws IOException {
+        MergeSortQueue(Sort sort, CollapseTopFieldDocs[] shardHits) throws IOException {
             super(shardHits.length);
             this.shardHits = new ScoreDoc[shardHits.length][];
             for (int shardIDX = 0; shardIDX < shardHits.length; shardIDX++) {

--- a/core/src/main/java/org/apache/lucene/search/grouping/CollapsingDocValuesSource.java
+++ b/core/src/main/java/org/apache/lucene/search/grouping/CollapsingDocValuesSource.java
@@ -56,7 +56,7 @@ abstract class CollapsingDocValuesSource<T> {
         private NumericDocValues values;
         private Bits docsWithField;
 
-        public Numeric(String field) throws IOException {
+        Numeric(String field) throws IOException {
             super(field);
         }
 
@@ -122,7 +122,7 @@ abstract class CollapsingDocValuesSource<T> {
         private Bits docsWithField;
         private SortedDocValues values;
 
-        public Keyword(String field) throws IOException {
+        Keyword(String field) throws IOException {
             super(field);
         }
 

--- a/core/src/main/java/org/apache/lucene/search/suggest/analyzing/XAnalyzingSuggester.java
+++ b/core/src/main/java/org/apache/lucene/search/suggest/analyzing/XAnalyzingSuggester.java
@@ -392,7 +392,7 @@ public long ramBytesUsed() {
     final BytesRefBuilder spare = new BytesRefBuilder();
     private char sepLabel;
 
-    public EscapingTokenStreamToAutomaton(char sepLabel) {
+    EscapingTokenStreamToAutomaton(char sepLabel) {
       this.sepLabel = sepLabel;
     }
 
@@ -432,7 +432,7 @@ public long ramBytesUsed() {
 
     private final boolean hasPayloads;
 
-    public AnalyzingComparator(boolean hasPayloads) {
+    AnalyzingComparator(boolean hasPayloads) {
       this.hasPayloads = hasPayloads;
     }
 
@@ -1114,7 +1114,7 @@ public long ramBytesUsed() {
             BytesRef payload;
             long weight;
 
-            public SurfaceFormAndPayload(BytesRef payload, long cost) {
+            SurfaceFormAndPayload(BytesRef payload, long cost) {
                 super();
                 this.payload = payload;
                 this.weight = cost;

--- a/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -214,7 +214,7 @@ public final class ExceptionsHelper {
         final String index;
         final Class<? extends Throwable> causeType;
 
-        public GroupBy(Throwable t) {
+        GroupBy(Throwable t) {
             if (t instanceof ElasticsearchException) {
                 final Index index = ((ElasticsearchException) t).getIndex();
                 if (index != null) {

--- a/core/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -382,7 +382,7 @@ public class ActionModule extends AbstractModule {
     static Map<String, ActionHandler<?, ?>> setupActions(List<ActionPlugin> actionPlugins) {
         // Subclass NamedRegistry for easy registration
         class ActionRegistry extends NamedRegistry<ActionHandler<?, ?>> {
-            public ActionRegistry() {
+            ActionRegistry() {
                 super("action");
             }
 

--- a/core/src/main/java/org/elasticsearch/action/ListenableActionFuture.java
+++ b/core/src/main/java/org/elasticsearch/action/ListenableActionFuture.java
@@ -29,5 +29,5 @@ public interface ListenableActionFuture<T> extends ActionFuture<T> {
     /**
      * Add an action listener to be invoked when a response has received.
      */
-    void addListener(final ActionListener<T> listener);
+    void addListener(ActionListener<T> listener);
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/TransportCancelTasksAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/TransportCancelTasksAction.java
@@ -217,7 +217,7 @@ public class TransportCancelTasksAction extends TransportTasksAction<Cancellable
         private final AtomicInteger counter;
         private final int nodesSize;
 
-        public BanLock(int nodesSize, Runnable finish) {
+        BanLock(int nodesSize, Runnable finish) {
             counter = new AtomicInteger(0);
             this.finish = finish;
             this.nodesSize = nodesSize;
@@ -268,7 +268,7 @@ public class TransportCancelTasksAction extends TransportTasksAction<Cancellable
             this.ban = false;
         }
 
-        public BanParentTaskRequest() {
+        BanParentTaskRequest() {
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStage.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStage.java
@@ -47,7 +47,7 @@ public enum SnapshotIndexShardStage {
 
     private boolean completed;
 
-    private SnapshotIndexShardStage(byte value, boolean completed) {
+    SnapshotIndexShardStage(byte value, boolean completed) {
         this.value = value;
         this.completed = completed;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
@@ -34,7 +34,7 @@ import java.util.List;
  */
 public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
 
-    public static enum Feature {
+    public enum Feature {
         ALIASES((byte) 0, "_aliases", "_alias"),
         MAPPINGS((byte) 1, "_mappings", "_mapping"),
         SETTINGS((byte) 2, "_settings");
@@ -52,7 +52,7 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
         private final String preferredName;
         private final byte id;
 
-        private Feature(byte id, String... validNames) {
+        Feature(byte id, String... validNames) {
             assert validNames != null && validNames.length > 0;
             this.id = id;
             this.validNames = Arrays.asList(validNames);

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
@@ -47,7 +47,7 @@ public abstract class Condition<T> implements NamedWriteable {
         this.name = name;
     }
 
-    public abstract Result evaluate(final Stats stats);
+    public abstract Result evaluate(Stats stats);
 
     @Override
     public final String toString() {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
@@ -226,7 +226,7 @@ public class TransportIndicesShardStoresAction extends TransportMasterNodeReadAc
                 private final List<NodeGatewayStartedShards> responses;
                 private final List<FailedNodeException> failures;
 
-                public Response(ShardId shardId, List<NodeGatewayStartedShards> responses, List<FailedNodeException> failures) {
+                Response(ShardId shardId, List<NodeGatewayStartedShards> responses, List<FailedNodeException> failures) {
                     this.shardId = shardId;
                     this.responses = responses;
                     this.failures = failures;

--- a/core/src/main/java/org/elasticsearch/action/bulk/BackoffPolicy.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BackoffPolicy.java
@@ -171,7 +171,7 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
 
         private final int numberOfElements;
 
-        public ConstantBackoff(TimeValue delay, int numberOfElements) {
+        ConstantBackoff(TimeValue delay, int numberOfElements) {
             assert numberOfElements >= 0;
             this.delay = delay;
             this.numberOfElements = numberOfElements;
@@ -188,7 +188,7 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
         private final int numberOfElements;
         private int curr;
 
-        public ConstantBackoffIterator(TimeValue delay, int numberOfElements) {
+        ConstantBackoffIterator(TimeValue delay, int numberOfElements) {
             this.delay = delay;
             this.numberOfElements = numberOfElements;
         }
@@ -212,7 +212,7 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
         private final BackoffPolicy delegate;
         private final Runnable onBackoff;
 
-        public WrappedBackoffPolicy(BackoffPolicy delegate, Runnable onBackoff) {
+        WrappedBackoffPolicy(BackoffPolicy delegate, Runnable onBackoff) {
             this.delegate = delegate;
             this.onBackoff = onBackoff;
         }
@@ -227,7 +227,7 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
         private final Iterator<TimeValue> delegate;
         private final Runnable onBackoff;
 
-        public WrappedBackoffIterator(Iterator<TimeValue> delegate, Runnable onBackoff) {
+        WrappedBackoffIterator(Iterator<TimeValue> delegate, Runnable onBackoff) {
             this.delegate = delegate;
             this.onBackoff = onBackoff;
         }

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkRequestHandler.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkRequestHandler.java
@@ -59,7 +59,7 @@ abstract class BulkRequestHandler {
         private final BulkProcessor.Listener listener;
         private final BackoffPolicy backoffPolicy;
 
-        public SyncBulkRequestHandler(Client client, BackoffPolicy backoffPolicy, BulkProcessor.Listener listener) {
+        SyncBulkRequestHandler(Client client, BackoffPolicy backoffPolicy, BulkProcessor.Listener listener) {
             super(client);
             this.backoffPolicy = backoffPolicy;
             this.listener = listener;

--- a/core/src/main/java/org/elasticsearch/action/bulk/Retry.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/Retry.java
@@ -102,7 +102,7 @@ public class Retry {
         private volatile BulkRequest currentBulkRequest;
         private volatile ScheduledFuture<?> scheduledRequestFuture;
 
-        public AbstractRetryHandler(Class<? extends Throwable> retryOnThrowable, BackoffPolicy backoffPolicy, Client client, ActionListener<BulkResponse> listener) {
+        AbstractRetryHandler(Class<? extends Throwable> retryOnThrowable, BackoffPolicy backoffPolicy, Client client, ActionListener<BulkResponse> listener) {
             this.retryOnThrowable = retryOnThrowable;
             this.backoff = backoffPolicy.iterator();
             this.client = client;
@@ -213,7 +213,7 @@ public class Retry {
     }
 
     static class AsyncRetryHandler extends AbstractRetryHandler {
-        public AsyncRetryHandler(Class<? extends Throwable> retryOnThrowable, BackoffPolicy backoffPolicy, Client client, ActionListener<BulkResponse> listener) {
+        AsyncRetryHandler(Class<? extends Throwable> retryOnThrowable, BackoffPolicy backoffPolicy, Client client, ActionListener<BulkResponse> listener) {
             super(retryOnThrowable, backoffPolicy, client, listener);
         }
     }
@@ -226,7 +226,7 @@ public class Retry {
             return new SyncRetryHandler(retryOnThrowable, backoffPolicy, client, actionFuture);
         }
 
-        public SyncRetryHandler(Class<? extends Throwable> retryOnThrowable, BackoffPolicy backoffPolicy, Client client, PlainActionFuture<BulkResponse> actionFuture) {
+        SyncRetryHandler(Class<? extends Throwable> retryOnThrowable, BackoffPolicy backoffPolicy, Client client, PlainActionFuture<BulkResponse> actionFuture) {
             super(retryOnThrowable, backoffPolicy, client, actionFuture);
             this.actionFuture = actionFuture;
         }

--- a/core/src/main/java/org/elasticsearch/action/bulk/byscroll/WorkingBulkByScrollTask.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/byscroll/WorkingBulkByScrollTask.java
@@ -306,7 +306,7 @@ public class WorkingBulkByScrollTask extends BulkByScrollTask implements Success
         private final AtomicBoolean hasRun = new AtomicBoolean(false);
         private final AbstractRunnable delegate;
 
-        public RunOnce(AbstractRunnable delegate) {
+        RunOnce(AbstractRunnable delegate) {
             this.delegate = delegate;
         }
 

--- a/core/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -429,7 +429,7 @@ abstract class AbstractSearchAsyncAction<FirstResult extends SearchPhaseResult> 
         private final SearchPhaseController searchPhaseController;
         private final AtomicArray<QuerySearchResultProvider> queryResults;
 
-        public FetchPhase(AtomicArray<QuerySearchResultProvider> queryResults,
+        FetchPhase(AtomicArray<QuerySearchResultProvider> queryResults,
                            SearchPhaseController searchPhaseController) {
             this.fetchResults = new AtomicArray<>(queryResults.length());
             this.searchPhaseController = searchPhaseController;

--- a/core/src/main/java/org/elasticsearch/action/search/ParsedScrollId.java
+++ b/core/src/main/java/org/elasticsearch/action/search/ParsedScrollId.java
@@ -31,7 +31,7 @@ class ParsedScrollId {
 
     private final ScrollIdForNode[] context;
 
-    public ParsedScrollId(String source, String type, ScrollIdForNode[] context) {
+    ParsedScrollId(String source, String type, ScrollIdForNode[] context) {
         this.source = source;
         this.type = type;
         this.context = context;

--- a/core/src/main/java/org/elasticsearch/action/search/ScrollIdForNode.java
+++ b/core/src/main/java/org/elasticsearch/action/search/ScrollIdForNode.java
@@ -23,7 +23,7 @@ class ScrollIdForNode {
     private final String node;
     private final long scrollId;
 
-    public ScrollIdForNode(String node, long scrollId) {
+    ScrollIdForNode(String node, long scrollId) {
         this.node = node;
         this.scrollId = scrollId;
     }

--- a/core/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
@@ -74,7 +74,7 @@ final class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction
         private final AtomicArray<DfsSearchResult> firstResults;
         private final Function<AtomicArray<QuerySearchResultProvider>, CheckedRunnable<Exception>> nextPhaseFactory;
 
-        public DfsQueryPhase(AtomicArray<DfsSearchResult> firstResults,
+        DfsQueryPhase(AtomicArray<DfsSearchResult> firstResults,
                              SearchPhaseController searchPhaseController,
                              Function<AtomicArray<QuerySearchResultProvider>, CheckedRunnable<Exception>> nextPhaseFactory) {
             this.queryResult = new AtomicArray<>(firstResults.length());

--- a/core/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -197,7 +197,7 @@ public class SearchTransportService extends AbstractLifecycleComponent {
     static class SearchFreeContextRequest extends ScrollFreeContextRequest implements IndicesRequest {
         private OriginalIndices originalIndices;
 
-        public SearchFreeContextRequest() {
+        SearchFreeContextRequest() {
         }
 
         SearchFreeContextRequest(SearchRequest request, long id) {

--- a/core/src/main/java/org/elasticsearch/action/support/ActionFilter.java
+++ b/core/src/main/java/org/elasticsearch/action/support/ActionFilter.java
@@ -47,7 +47,7 @@ public interface ActionFilter {
      * filter chain. This base class should serve any action filter implementations that doesn't require
      * to apply async filtering logic.
      */
-    public abstract static class Simple extends AbstractComponent implements ActionFilter {
+    abstract class Simple extends AbstractComponent implements ActionFilter {
 
         protected Simple(Settings settings) {
             super(settings);

--- a/core/src/main/java/org/elasticsearch/action/support/ActionFilterChain.java
+++ b/core/src/main/java/org/elasticsearch/action/support/ActionFilterChain.java
@@ -33,5 +33,5 @@ public interface ActionFilterChain<Request extends ActionRequest, Response exten
      * Continue processing the request. Should only be called if a response has not been sent through
      * the given {@link ActionListener listener}
      */
-    void proceed(Task task, final String action, final Request request, final ActionListener<Response> listener);
+    void proceed(Task task, String action, Request request, ActionListener<Response> listener);
 }

--- a/core/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -522,10 +522,10 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
         protected List<BroadcastShardOperationFailedException> exceptions;
         protected List<ShardOperationResult> results;
 
-        public NodeResponse() {
+        NodeResponse() {
         }
 
-        public NodeResponse(String nodeId,
+        NodeResponse(String nodeId,
                             int totalShards,
                             List<ShardOperationResult> results,
                             List<BroadcastShardOperationFailedException> exceptions) {

--- a/core/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
@@ -52,5 +52,5 @@ public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequ
         doMasterOperation(request, concreteIndices, state, listener);
     }
 
-    protected abstract void doMasterOperation(Request request, String[] concreteIndices, ClusterState state, final ActionListener<Response> listener);
+    protected abstract void doMasterOperation(Request request, String[] concreteIndices, ClusterState state, ActionListener<Response> listener);
 }

--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -575,7 +575,7 @@ public abstract class TransportReplicationAction<
         private class ResponseListener implements ActionListener<TransportResponse.Empty> {
             private final ReplicaResponse replicaResponse;
 
-            public ResponseListener(ReplicaResponse replicaResponse) {
+            ResponseListener(ReplicaResponse replicaResponse) {
                 this.replicaResponse = replicaResponse;
             }
 

--- a/core/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
@@ -402,10 +402,10 @@ public abstract class TransportTasksAction<
         protected List<TaskOperationFailure> exceptions;
         protected List<TaskResponse> results;
 
-        public NodeTasksResponse() {
+        NodeTasksResponse() {
         }
 
-        public NodeTasksResponse(String nodeId,
+        NodeTasksResponse(String nodeId,
                                  List<TaskResponse> results,
                                  List<TaskOperationFailure> exceptions) {
             this.nodeId = nodeId;

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsFields.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsFields.java
@@ -200,7 +200,7 @@ public final class TermVectorsFields extends Fields {
         private long sumDocFreq;
         private int docCount;
 
-        public TermVector(BytesReference termVectors, long readOffset) throws IOException {
+        TermVector(BytesReference termVectors, long readOffset) throws IOException {
             this.perFieldTermVectorInput = termVectors.streamInput();
             this.readOffset = readOffset;
             reset();

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
@@ -577,7 +577,7 @@ public class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> i
         out.writeLong(version);
     }
 
-    public static enum Flag {
+    public enum Flag {
         // Do not change the order of these flags we use
         // the ordinal for encoding! Only append to the end!
         Positions, Offsets, Payloads, FieldStatistics, TermStatistics

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -207,7 +207,7 @@ final class BootstrapChecks {
 
     static class OsXFileDescriptorCheck extends FileDescriptorCheck {
 
-        public OsXFileDescriptorCheck() {
+        OsXFileDescriptorCheck() {
             // see constant OPEN_MAX defined in
             // /usr/include/sys/syslimits.h on OS X and its use in JVM
             // initialization in int os:init_2(void) defined in the JVM
@@ -258,7 +258,7 @@ final class BootstrapChecks {
 
         private final boolean mlockallSet;
 
-        public MlockallCheck(final boolean mlockAllSet) {
+        MlockallCheck(final boolean mlockAllSet) {
             this.mlockallSet = mlockAllSet;
         }
 
@@ -360,7 +360,7 @@ final class BootstrapChecks {
         // visible for testing
         long getMaxMapCount(Logger logger) {
             final Path path = getProcSysVmMaxMapCountPath();
-            try (final BufferedReader bufferedReader = getBufferedReader(path)) {
+            try (BufferedReader bufferedReader = getBufferedReader(path)) {
                 final String rawProcSysVmMaxMapCount = readProcSysVmMaxMapCount(bufferedReader);
                 if (rawProcSysVmMaxMapCount != null) {
                     try {

--- a/core/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java
@@ -48,7 +48,7 @@ final class ESPolicy extends Policy {
     final PermissionCollection dynamic;
     final Map<String,Policy> plugins;
 
-    public ESPolicy(PermissionCollection dynamic, Map<String,Policy> plugins, boolean filterBadDefaults) {
+    ESPolicy(PermissionCollection dynamic, Map<String,Policy> plugins, boolean filterBadDefaults) {
         this.template = Security.readPolicy(getClass().getResource(POLICY_RESOURCE), JarHell.parseClassPath());
         this.untrusted = Security.readPolicy(getClass().getResource(UNTRUSTED_RESOURCE), new URL[0]);
         if (filterBadDefaults) {
@@ -150,7 +150,7 @@ final class ESPolicy extends Policy {
          * @param preImplies           a test that is applied to a desired permission before checking if the bad default permission that
          *                             this instance wraps implies the desired permission
          */
-        public BadDefaultPermission(final Permission badDefaultPermission, final Predicate<Permission> preImplies) {
+        BadDefaultPermission(final Permission badDefaultPermission, final Predicate<Permission> preImplies) {
             super(badDefaultPermission.getName());
             this.badDefaultPermission = badDefaultPermission;
             this.preImplies = preImplies;

--- a/core/src/main/java/org/elasticsearch/bootstrap/JNAKernel32Library.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/JNAKernel32Library.java
@@ -109,7 +109,7 @@ final class JNAKernel32Library {
 
         private final ConsoleCtrlHandler handler;
 
-        public NativeHandlerCallback(ConsoleCtrlHandler handler) {
+        NativeHandlerCallback(ConsoleCtrlHandler handler) {
             this.handler = handler;
         }
 
@@ -155,11 +155,11 @@ final class JNAKernel32Library {
 
     public static class SizeT extends IntegerType {
 
-        public SizeT() {
+        SizeT() {
             this(0);
         }
 
-        public SizeT(long value) {
+        SizeT(long value) {
             super(Native.SIZE_T_SIZE, value);
         }
 

--- a/core/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
@@ -154,7 +154,7 @@ final class SystemCallFilter {
         public short   len;           // number of filters
         public Pointer filter;        // filters
 
-        public SockFProg(SockFilter filters[]) {
+        SockFProg(SockFilter filters[]) {
             len = (short) filters.length;
             // serialize struct sock_filter * explicitly, its less confusing than the JNA magic we would need
             Memory filter = new Memory(len * 8);

--- a/core/src/main/java/org/elasticsearch/cli/Command.java
+++ b/core/src/main/java/org/elasticsearch/cli/Command.java
@@ -65,8 +65,8 @@ public abstract class Command implements Closeable {
                     this.close();
                 } catch (final IOException e) {
                     try (
-                        final StringWriter sw = new StringWriter();
-                        final PrintWriter pw = new PrintWriter(sw)) {
+                        StringWriter sw = new StringWriter();
+                        PrintWriter pw = new PrintWriter(sw)) {
                         e.printStackTrace(pw);
                         terminal.println(sw.toString());
                     } catch (final IOException impossible) {

--- a/core/src/main/java/org/elasticsearch/client/ElasticsearchClient.java
+++ b/core/src/main/java/org/elasticsearch/client/ElasticsearchClient.java
@@ -41,7 +41,7 @@ public interface ElasticsearchClient {
      * @return A future allowing to get back the response.
      */
     <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder>> ActionFuture<Response> execute(
-            final Action<Request, Response, RequestBuilder> action, final Request request);
+            Action<Request, Response, RequestBuilder> action, Request request);
 
     /**
      * Executes a generic action, denoted by an {@link Action}.
@@ -54,7 +54,7 @@ public interface ElasticsearchClient {
      * @param <RequestBuilder> The request builder type.
      */
     <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder>> void execute(
-            final Action<Request, Response, RequestBuilder> action, final Request request, ActionListener<Response> listener);
+            Action<Request, Response, RequestBuilder> action, Request request, ActionListener<Response> listener);
 
     /**
      * Prepares a request builder to execute, specified by {@link Action}.
@@ -66,7 +66,7 @@ public interface ElasticsearchClient {
      * @return The request builder, that can, at a later stage, execute the request.
      */
     <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder>> RequestBuilder prepareExecute(
-            final Action<Request, Response, RequestBuilder> action);
+            Action<Request, Response, RequestBuilder> action);
 
     /**
      * Returns the threadpool used to execute requests on this client

--- a/core/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/core/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -401,7 +401,7 @@ public abstract class AbstractClient extends AbstractComponent implements Client
         doExecute(action, request, listener);
     }
 
-    protected abstract <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder>> void doExecute(final Action<Request, Response, RequestBuilder> action, final Request request, ActionListener<Response> listener);
+    protected abstract <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder>> void doExecute(Action<Request, Response, RequestBuilder> action, Request request, ActionListener<Response> listener);
 
     @Override
     public ActionFuture<IndexResponse> index(final IndexRequest request) {
@@ -672,7 +672,7 @@ public abstract class AbstractClient extends AbstractComponent implements Client
         private final ClusterAdmin clusterAdmin;
         private final IndicesAdmin indicesAdmin;
 
-        public Admin(ElasticsearchClient client) {
+        Admin(ElasticsearchClient client) {
             this.clusterAdmin = new ClusterAdmin(client);
             this.indicesAdmin = new IndicesAdmin(client);
         }
@@ -692,7 +692,7 @@ public abstract class AbstractClient extends AbstractComponent implements Client
 
         private final ElasticsearchClient client;
 
-        public ClusterAdmin(ElasticsearchClient client) {
+        ClusterAdmin(ElasticsearchClient client) {
             this.client = client;
         }
 
@@ -1218,7 +1218,7 @@ public abstract class AbstractClient extends AbstractComponent implements Client
 
         private final ElasticsearchClient client;
 
-        public IndicesAdmin(ElasticsearchClient client) {
+        IndicesAdmin(ElasticsearchClient client) {
             this.client = client;
         }
 

--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -264,7 +264,7 @@ final class TransportClientNodesService extends AbstractComponent implements Clo
 
         private volatile int i;
 
-        public RetryListener(NodeListenerCallback<Response> callback, ActionListener<Response> listener,
+        RetryListener(NodeListenerCallback<Response> callback, ActionListener<Response> listener,
                              List<DiscoveryNode> nodes, int index, TransportClient.HostFailureListener hostFailureListener) {
             this.callback = callback;
             this.listener = listener;

--- a/core/src/main/java/org/elasticsearch/cluster/AbstractDiffable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/AbstractDiffable.java
@@ -52,21 +52,21 @@ public abstract class AbstractDiffable<T extends Diffable<T>> implements Diffabl
         /**
          * Creates simple diff with changes
          */
-        public CompleteDiff(T part) {
+        CompleteDiff(T part) {
             this.part = part;
         }
 
         /**
          * Creates simple diff without changes
          */
-        public CompleteDiff() {
+        CompleteDiff() {
             this.part = null;
         }
 
         /**
          * Read simple diff from the stream
          */
-        public CompleteDiff(Reader<T> reader, StreamInput in) throws IOException {
+        CompleteDiff(Reader<T> reader, StreamInput in) throws IOException {
             if (in.readBoolean()) {
                 this.part = reader.read(in);
             } else {

--- a/core/src/main/java/org/elasticsearch/cluster/AbstractNamedDiffable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/AbstractNamedDiffable.java
@@ -64,7 +64,7 @@ public abstract class AbstractNamedDiffable<T extends NamedDiffable<T>> implemen
         /**
          * Creates simple diff with changes
          */
-        public CompleteNamedDiff(T part) {
+        CompleteNamedDiff(T part) {
             this.part = part;
             this.name = part.getWriteableName();
             this.minimalSupportedVersion = part.getMinimalSupportedVersion();
@@ -73,7 +73,7 @@ public abstract class AbstractNamedDiffable<T extends NamedDiffable<T>> implemen
         /**
          * Creates simple diff without changes
          */
-        public CompleteNamedDiff(String name, Version minimalSupportedVersion) {
+        CompleteNamedDiff(String name, Version minimalSupportedVersion) {
             this.part = null;
             this.name = name;
             this.minimalSupportedVersion = minimalSupportedVersion;
@@ -82,7 +82,7 @@ public abstract class AbstractNamedDiffable<T extends NamedDiffable<T>> implemen
         /**
          * Read simple diff from the stream
          */
-        public CompleteNamedDiff(Class<? extends T> tClass, String name, StreamInput in) throws IOException {
+        CompleteNamedDiff(Class<? extends T> tClass, String name, StreamInput in) throws IOException {
             if (in.readBoolean()) {
                 this.part = in.readNamedWriteable(tClass, name);
                 this.minimalSupportedVersion = part.getMinimalSupportedVersion();

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -713,7 +713,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
 
         private final Diff<ImmutableOpenMap<String, Custom>> customs;
 
-        public ClusterStateDiff(ClusterState before, ClusterState after) {
+        ClusterStateDiff(ClusterState before, ClusterState after) {
             fromUuid = before.stateUUID;
             toUuid = after.stateUUID;
             toVersion = after.version;
@@ -725,7 +725,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
             customs = DiffableUtils.diff(before.customs, after.customs, DiffableUtils.getStringKeySerializer(), CUSTOM_VALUE_SERIALIZER);
         }
 
-        public ClusterStateDiff(StreamInput in, DiscoveryNode localNode) throws IOException {
+        ClusterStateDiff(StreamInput in, DiscoveryNode localNode) throws IOException {
             clusterName = new ClusterName(in);
             fromUuid = in.readString();
             toUuid = in.readString();

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterStateObserver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterStateObserver.java
@@ -246,7 +246,7 @@ public class ClusterStateObserver {
         private final String masterNodeId;
         private final long version;
 
-        public StoredState(ClusterState clusterState) {
+        StoredState(ClusterState clusterState) {
             this.masterNodeId = clusterState.nodes().getMasterNodeId();
             this.version = clusterState.version();
         }
@@ -271,7 +271,7 @@ public class ClusterStateObserver {
         public final Listener listener;
         public final Predicate<ClusterState> statePredicate;
 
-        public ObservingContext(Listener listener, Predicate<ClusterState> statePredicate) {
+        ObservingContext(Listener listener, Predicate<ClusterState> statePredicate) {
             this.listener = listener;
             this.statePredicate = statePredicate;
         }

--- a/core/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
+++ b/core/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
@@ -166,7 +166,7 @@ public final class DiffableUtils {
             super(in, keySerializer, valueSerializer);
         }
 
-        public JdkMapDiff(Map<K, T> before, Map<K, T> after,
+        JdkMapDiff(Map<K, T> before, Map<K, T> after,
                           KeySerializer<K> keySerializer, ValueSerializer<K, T> valueSerializer) {
             super(keySerializer, valueSerializer);
             assert after != null && before != null;
@@ -298,7 +298,7 @@ public final class DiffableUtils {
             super(in, keySerializer, valueSerializer);
         }
 
-        public ImmutableOpenIntMapDiff(ImmutableOpenIntMap<T> before, ImmutableOpenIntMap<T> after,
+        ImmutableOpenIntMapDiff(ImmutableOpenIntMap<T> before, ImmutableOpenIntMap<T> after,
                                        KeySerializer<Integer> keySerializer, ValueSerializer<Integer, T> valueSerializer) {
             super(keySerializer, valueSerializer);
             assert after != null && before != null;

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -199,7 +199,7 @@ public class ShardStateAction extends AbstractComponent {
         private final ShardFailedClusterStateTaskExecutor shardFailedClusterStateTaskExecutor;
         private final Logger logger;
 
-        public ShardFailedTransportHandler(ClusterService clusterService, ShardFailedClusterStateTaskExecutor shardFailedClusterStateTaskExecutor, Logger logger) {
+        ShardFailedTransportHandler(ClusterService clusterService, ShardFailedClusterStateTaskExecutor shardFailedClusterStateTaskExecutor, Logger logger) {
             this.clusterService = clusterService;
             this.shardFailedClusterStateTaskExecutor = shardFailedClusterStateTaskExecutor;
             this.logger = logger;
@@ -365,7 +365,7 @@ public class ShardStateAction extends AbstractComponent {
         private final ShardStartedClusterStateTaskExecutor shardStartedClusterStateTaskExecutor;
         private final Logger logger;
 
-        public ShardStartedTransportHandler(ClusterService clusterService, ShardStartedClusterStateTaskExecutor shardStartedClusterStateTaskExecutor, Logger logger) {
+        ShardStartedTransportHandler(ClusterService clusterService, ShardStartedClusterStateTaskExecutor shardStartedClusterStateTaskExecutor, Logger logger) {
             this.clusterService = clusterService;
             this.shardStartedClusterStateTaskExecutor = shardStartedClusterStateTaskExecutor;
             this.logger = logger;

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/AliasOrIndex.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/AliasOrIndex.java
@@ -121,7 +121,7 @@ public interface AliasOrIndex {
                         }
 
                         @Override
-                        public final void remove() {
+                        public void remove() {
                             throw new UnsupportedOperationException();
                         }
 

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -139,7 +139,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContent {
     public static final ClusterBlock INDEX_WRITE_BLOCK = new ClusterBlock(8, "index write (api)", false, false, RestStatus.FORBIDDEN, EnumSet.of(ClusterBlockLevel.WRITE));
     public static final ClusterBlock INDEX_METADATA_BLOCK = new ClusterBlock(9, "index metadata (api)", false, false, RestStatus.FORBIDDEN, EnumSet.of(ClusterBlockLevel.METADATA_WRITE, ClusterBlockLevel.METADATA_READ));
 
-    public static enum State {
+    public enum State {
         OPEN((byte) 0),
         CLOSE((byte) 1);
 
@@ -620,7 +620,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContent {
         private final Diff<ImmutableOpenMap<String, Custom>> customs;
         private final Diff<ImmutableOpenIntMap<Set<String>>> inSyncAllocationIds;
 
-        public IndexMetaDataDiff(IndexMetaData before, IndexMetaData after) {
+        IndexMetaDataDiff(IndexMetaData before, IndexMetaData after) {
             index = after.index.getName();
             version = after.version;
             routingNumShards = after.routingNumShards;
@@ -634,7 +634,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContent {
                 DiffableUtils.getVIntKeySerializer(), DiffableUtils.StringSetValueSerializer.getInstance());
         }
 
-        public IndexMetaDataDiff(StreamInput in) throws IOException {
+        IndexMetaDataDiff(StreamInput in) throws IOException {
             index = in.readString();
             routingNumShards = in.readInt();
             version = in.readLong();

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -502,11 +502,11 @@ public class IndexNameExpressionResolver extends AbstractComponent {
             this(state, options, System.currentTimeMillis(), preserveAliases);
         }
 
-        public Context(ClusterState state, IndicesOptions options, long startTime) {
+        Context(ClusterState state, IndicesOptions options, long startTime) {
            this(state, options, startTime, false);
         }
 
-        public Context(ClusterState state, IndicesOptions options, long startTime, boolean preserveAliases) {
+        Context(ClusterState state, IndicesOptions options, long startTime, boolean preserveAliases) {
             this.state = state;
             this.options = options;
             this.startTime = startTime;
@@ -754,7 +754,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
         private final String defaultDateFormatterPattern;
         private final DateTimeFormatter defaultDateFormatter;
 
-        public DateMathExpressionResolver(Settings settings) {
+        DateMathExpressionResolver(Settings settings) {
             String defaultTimeZoneId = settings.get("date_math_expression_resolver.default_time_zone", "UTC");
             this.defaultTimeZone = DateTimeZone.forID(defaultTimeZoneId);
             defaultDateFormatterPattern = settings.get("date_math_expression_resolver.default_date_format", "YYYY.MM.dd");

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -600,7 +600,7 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
         private Diff<ImmutableOpenMap<String, IndexTemplateMetaData>> templates;
         private Diff<ImmutableOpenMap<String, Custom>> customs;
 
-        public MetaDataDiff(MetaData before, MetaData after) {
+        MetaDataDiff(MetaData before, MetaData after) {
             clusterUUID = after.clusterUUID;
             version = after.version;
             transientSettings = after.transientSettings;
@@ -610,7 +610,7 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
             customs = DiffableUtils.diff(before.customs, after.customs, DiffableUtils.getStringKeySerializer(), CUSTOM_VALUE_SERIALIZER);
         }
 
-        public MetaDataDiff(StreamInput in) throws IOException {
+        MetaDataDiff(StreamInput in) throws IOException {
             clusterUUID = in.readString();
             version = in.readLong();
             transientSettings = Settings.readSettingsFromStream(in);

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -378,12 +378,12 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
 
         private final Diff<ImmutableOpenMap<String, IndexRoutingTable>> indicesRouting;
 
-        public RoutingTableDiff(RoutingTable before, RoutingTable after) {
+        RoutingTableDiff(RoutingTable before, RoutingTable after) {
             version = after.version;
             indicesRouting = DiffableUtils.diff(before.indicesRouting, after.indicesRouting, DiffableUtils.getStringKeySerializer());
         }
 
-        public RoutingTableDiff(StreamInput in) throws IOException {
+        RoutingTableDiff(StreamInput in) throws IOException {
             version = in.readLong();
             indicesRouting = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), IndexRoutingTable::readFrom,
                 IndexRoutingTable::readDiffFrom);

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -1052,7 +1052,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
         private int numShards = 0;
         private final RoutingNode routingNode;
 
-        public ModelNode(RoutingNode routingNode) {
+        ModelNode(RoutingNode routingNode) {
             this.routingNode = routingNode;
         }
 
@@ -1130,7 +1130,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
         private final Set<ShardRouting> shards = new HashSet<>(4); // expect few shards of same index to be allocated on same node
         private int highestPrimary = -1;
 
-        public ModelIndex(String id) {
+        ModelIndex(String id) {
             this.id = id;
         }
 
@@ -1187,7 +1187,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
         private final Balancer balancer;
         private float pivotWeight;
 
-        public NodeSorter(ModelNode[] modelNodes, WeightFunction function, Balancer balancer) {
+        NodeSorter(ModelNode[] modelNodes, WeightFunction function, Balancer balancer) {
             this.function = function;
             this.balancer = balancer;
             this.modelNodes = modelNodes;

--- a/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -582,7 +582,7 @@ public class ClusterService extends AbstractLifecycleComponent {
     abstract static class SourcePrioritizedRunnable extends PrioritizedRunnable {
         protected final String source;
 
-        public SourcePrioritizedRunnable(Priority priority, String source) {
+        SourcePrioritizedRunnable(Priority priority, String source) {
             super(priority);
             this.source = source;
         }
@@ -892,7 +892,7 @@ public class ClusterService extends AbstractLifecycleComponent {
         public final List<UpdateTask> nonFailedTasks;
         public final Map<Object, ClusterStateTaskExecutor.TaskResult> executionResults;
 
-        public TaskOutputs(TaskInputs taskInputs, ClusterState previousClusterState,
+        TaskOutputs(TaskInputs taskInputs, ClusterState previousClusterState,
                            ClusterState newClusterState, List<UpdateTask> nonFailedTasks,
                            Map<Object, ClusterStateTaskExecutor.TaskResult> executionResults) {
             this.taskInputs = taskInputs;
@@ -982,7 +982,7 @@ public class ClusterService extends AbstractLifecycleComponent {
         private final ClusterStateTaskListener listener;
         private final Logger logger;
 
-        public SafeClusterStateTaskListener(ClusterStateTaskListener listener, Logger logger) {
+        SafeClusterStateTaskListener(ClusterStateTaskListener listener, Logger logger) {
             this.listener = listener;
             this.logger = logger;
         }
@@ -1029,7 +1029,7 @@ public class ClusterService extends AbstractLifecycleComponent {
         private final AckedClusterStateTaskListener listener;
         private final Logger logger;
 
-        public SafeAckedClusterStateTaskListener(AckedClusterStateTaskListener listener, Logger logger) {
+        SafeAckedClusterStateTaskListener(AckedClusterStateTaskListener listener, Logger logger) {
             super(listener, logger);
             this.listener = listener;
             this.logger = logger;

--- a/core/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
@@ -37,7 +37,7 @@ final class BytesReferenceStreamInput extends StreamInput {
     private final int length; // the total size of the stream
     private int offset; // the current position of the stream
 
-    public BytesReferenceStreamInput(BytesRefIterator iterator, final int length) throws IOException {
+    BytesReferenceStreamInput(BytesRefIterator iterator, final int length) throws IOException {
         this.iterator = iterator;
         this.slice = iterator.next();
         this.length = length;

--- a/core/src/main/java/org/elasticsearch/common/cache/Cache.java
+++ b/core/src/main/java/org/elasticsearch/common/cache/Cache.java
@@ -166,7 +166,7 @@ public class Cache<K, V> {
         Entry<K, V> after;
         State state = State.NEW;
 
-        public Entry(K key, V value, long writeTime) {
+        Entry(K key, V value, long writeTime) {
             this.key = key;
             this.value = value;
             this.writeTime = this.accessTime = writeTime;

--- a/core/src/main/java/org/elasticsearch/common/collect/CopyOnWriteHashMap.java
+++ b/core/src/main/java/org/elasticsearch/common/collect/CopyOnWriteHashMap.java
@@ -433,7 +433,7 @@ public final class CopyOnWriteHashMap<K, V> extends AbstractMap<K, V> {
         private final Deque<Map.Entry<K, V>> entries;
         private final Deque<Node<K, V>> nodes;
 
-        public EntryIterator(Node<K, V> node) {
+        EntryIterator(Node<K, V> node) {
             entries = new ArrayDeque<>();
             nodes = new ArrayDeque<>();
             node.visit(entries, nodes);

--- a/core/src/main/java/org/elasticsearch/common/collect/Iterators.java
+++ b/core/src/main/java/org/elasticsearch/common/collect/Iterators.java
@@ -36,7 +36,7 @@ public class Iterators {
         private final Iterator<? extends T>[] iterators;
         private int index = 0;
 
-        public ConcatenatedIterator(Iterator<? extends T>... iterators) {
+        ConcatenatedIterator(Iterator<? extends T>... iterators) {
             if (iterators == null) {
                 throw new NullPointerException("iterators");
             }

--- a/core/src/main/java/org/elasticsearch/common/geo/SpatialStrategy.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/SpatialStrategy.java
@@ -31,7 +31,7 @@ public enum SpatialStrategy implements Writeable {
 
     private final String strategyName;
 
-    private SpatialStrategy(String strategyName) {
+    SpatialStrategy(String strategyName) {
         this.strategyName = strategyName;
     }
 

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -381,7 +381,7 @@ public abstract class ShapeBuilder extends ToXContentToBytes implements NamedWri
         }
     }
 
-    public static enum Orientation {
+    public enum Orientation {
         LEFT,
         RIGHT;
 
@@ -427,7 +427,7 @@ public abstract class ShapeBuilder extends ToXContentToBytes implements NamedWri
     /**
      * Enumeration that lists all {@link GeoShapeType}s that can be handled
      */
-    public static enum GeoShapeType {
+    public enum GeoShapeType {
         POINT("point"),
         MULTIPOINT("multipoint"),
         LINESTRING("linestring"),
@@ -440,7 +440,7 @@ public abstract class ShapeBuilder extends ToXContentToBytes implements NamedWri
 
         private final String shapename;
 
-        private GeoShapeType(String shapename) {
+        GeoShapeType(String shapename) {
             this.shapename = shapename;
         }
 

--- a/core/src/main/java/org/elasticsearch/common/inject/ConstantFactory.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/ConstantFactory.java
@@ -30,7 +30,7 @@ class ConstantFactory<T> implements InternalFactory<T> {
 
     private final Initializable<T> initializable;
 
-    public ConstantFactory(Initializable<T> initializable) {
+    ConstantFactory(Initializable<T> initializable) {
         this.initializable = initializable;
     }
 

--- a/core/src/main/java/org/elasticsearch/common/inject/DeferredLookups.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/DeferredLookups.java
@@ -34,7 +34,7 @@ class DeferredLookups implements Lookups {
     private final InjectorImpl injector;
     private final List<Element> lookups = new ArrayList<>();
 
-    public DeferredLookups(InjectorImpl injector) {
+    DeferredLookups(InjectorImpl injector) {
         this.injector = injector;
     }
 

--- a/core/src/main/java/org/elasticsearch/common/inject/EncounterImpl.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/EncounterImpl.java
@@ -36,7 +36,7 @@ final class EncounterImpl<T> implements TypeEncounter<T> {
     private List<InjectionListener<? super T>> injectionListeners; // lazy
     private boolean valid = true;
 
-    public EncounterImpl(Errors errors, Lookups lookups) {
+    EncounterImpl(Errors errors, Lookups lookups) {
         this.errors = errors;
         this.lookups = lookups;
     }

--- a/core/src/main/java/org/elasticsearch/common/inject/ExposedKeyFactory.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/ExposedKeyFactory.java
@@ -33,7 +33,7 @@ class ExposedKeyFactory<T> implements InternalFactory<T>, BindingProcessor.Creat
     private final PrivateElements privateElements;
     private BindingImpl<T> delegate;
 
-    public ExposedKeyFactory(Key<T> key, PrivateElements privateElements) {
+    ExposedKeyFactory(Key<T> key, PrivateElements privateElements) {
         this.key = key;
         this.privateElements = privateElements;
     }

--- a/core/src/main/java/org/elasticsearch/common/inject/Initializer.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/Initializer.java
@@ -115,7 +115,7 @@ class Initializer {
         private final Object source;
         private MembersInjectorImpl<T> membersInjector;
 
-        public InjectableReference(InjectorImpl injector, T instance, Object source) {
+        InjectableReference(InjectorImpl injector, T instance, Object source) {
             this.injector = injector;
             this.instance = Objects.requireNonNull(instance, "instance");
             this.source = Objects.requireNonNull(source, "source");

--- a/core/src/main/java/org/elasticsearch/common/inject/InjectionRequestProcessor.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/InjectionRequestProcessor.java
@@ -86,7 +86,7 @@ class InjectionRequestProcessor extends AbstractProcessor {
         final StaticInjectionRequest request;
         List<SingleMemberInjector> memberInjectors;
 
-        public StaticInjection(InjectorImpl injector, StaticInjectionRequest request) {
+        StaticInjection(InjectorImpl injector, StaticInjectionRequest request) {
             this.injector = injector;
             this.source = request.getSource();
             this.request = request;

--- a/core/src/main/java/org/elasticsearch/common/inject/InternalFactoryToProviderAdapter.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/InternalFactoryToProviderAdapter.java
@@ -33,11 +33,11 @@ class InternalFactoryToProviderAdapter<T> implements InternalFactory<T> {
     private final Initializable<Provider<? extends T>> initializable;
     private final Object source;
 
-    public InternalFactoryToProviderAdapter(Initializable<Provider<? extends T>> initializable) {
+    InternalFactoryToProviderAdapter(Initializable<Provider<? extends T>> initializable) {
         this(initializable, SourceProvider.UNKNOWN_SOURCE);
     }
 
-    public InternalFactoryToProviderAdapter(
+    InternalFactoryToProviderAdapter(
             Initializable<Provider<? extends T>> initializable, Object source) {
         this.initializable = Objects.requireNonNull(initializable, "provider");
         this.source = Objects.requireNonNull(source, "source");

--- a/core/src/main/java/org/elasticsearch/common/inject/Key.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/Key.java
@@ -380,7 +380,7 @@ public class Key<T> {
         }
     }
 
-    static enum NullAnnotationStrategy implements AnnotationStrategy {
+    enum NullAnnotationStrategy implements AnnotationStrategy {
         INSTANCE;
 
         @Override

--- a/core/src/main/java/org/elasticsearch/common/inject/ProviderToInternalFactoryAdapter.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/ProviderToInternalFactoryAdapter.java
@@ -30,7 +30,7 @@ class ProviderToInternalFactoryAdapter<T> implements Provider<T> {
     private final InjectorImpl injector;
     private final InternalFactory<? extends T> internalFactory;
 
-    public ProviderToInternalFactoryAdapter(InjectorImpl injector,
+    ProviderToInternalFactoryAdapter(InjectorImpl injector,
                                             InternalFactory<? extends T> internalFactory) {
         this.injector = injector;
         this.internalFactory = internalFactory;

--- a/core/src/main/java/org/elasticsearch/common/inject/SingleFieldInjector.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/SingleFieldInjector.java
@@ -34,7 +34,7 @@ class SingleFieldInjector implements SingleMemberInjector {
     final Dependency<?> dependency;
     final InternalFactory<?> factory;
 
-    public SingleFieldInjector(InjectorImpl injector, InjectionPoint injectionPoint, Errors errors)
+    SingleFieldInjector(InjectorImpl injector, InjectionPoint injectionPoint, Errors errors)
             throws ErrorsException {
         this.injectionPoint = injectionPoint;
         this.field = (Field) injectionPoint.getMember();

--- a/core/src/main/java/org/elasticsearch/common/inject/SingleMethodInjector.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/SingleMethodInjector.java
@@ -34,7 +34,7 @@ class SingleMethodInjector implements SingleMemberInjector {
     final SingleParameterInjector<?>[] parameterInjectors;
     final InjectionPoint injectionPoint;
 
-    public SingleMethodInjector(InjectorImpl injector, InjectionPoint injectionPoint, Errors errors)
+    SingleMethodInjector(InjectorImpl injector, InjectionPoint injectionPoint, Errors errors)
             throws ErrorsException {
         this.injectionPoint = injectionPoint;
         final Method method = (Method) injectionPoint.getMember();

--- a/core/src/main/java/org/elasticsearch/common/inject/assistedinject/AssistedConstructor.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/assistedinject/AssistedConstructor.java
@@ -43,7 +43,7 @@ class AssistedConstructor<T> {
     private final List<Parameter> allParameters;
 
     @SuppressWarnings("unchecked")
-    public AssistedConstructor(Constructor<T> constructor, List<TypeLiteral<?>> parameterTypes) {
+    AssistedConstructor(Constructor<T> constructor, List<TypeLiteral<?>> parameterTypes) {
         this.constructor = constructor;
 
         Annotation[][] annotations = constructor.getParameterAnnotations();

--- a/core/src/main/java/org/elasticsearch/common/inject/assistedinject/Parameter.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/assistedinject/Parameter.java
@@ -39,7 +39,7 @@ class Parameter {
     private final Annotation bindingAnnotation;
     private final boolean isProvider;
 
-    public Parameter(Type type, Annotation[] annotations) {
+    Parameter(Type type, Annotation[] annotations) {
         this.type = type;
         this.bindingAnnotation = getBindingAnnotation(annotations);
         this.isAssisted = hasAssistedAnnotation(annotations);

--- a/core/src/main/java/org/elasticsearch/common/inject/assistedinject/ParameterListKey.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/assistedinject/ParameterListKey.java
@@ -34,11 +34,11 @@ class ParameterListKey {
 
     private final List<Type> paramList;
 
-    public ParameterListKey(List<Type> paramList) {
+    ParameterListKey(List<Type> paramList) {
         this.paramList = new ArrayList<>(paramList);
     }
 
-    public ParameterListKey(Type[] types) {
+    ParameterListKey(Type[] types) {
         this(Arrays.asList(types));
     }
 

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/NullOutputException.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/NullOutputException.java
@@ -24,7 +24,7 @@ package org.elasticsearch.common.inject.internal;
  * @author Bob Lee
  */
 class NullOutputException extends NullPointerException {
-    public NullOutputException(String s) {
+    NullOutputException(String s) {
         super(s);
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/inject/matcher/AbstractMatcher.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/matcher/AbstractMatcher.java
@@ -36,7 +36,7 @@ public abstract class AbstractMatcher<T> implements Matcher<T> {
     private static class AndMatcher<T> extends AbstractMatcher<T> {
         private final Matcher<? super T> a, b;
 
-        public AndMatcher(Matcher<? super T> a, Matcher<? super T> b) {
+        AndMatcher(Matcher<? super T> a, Matcher<? super T> b) {
             this.a = a;
             this.b = b;
         }
@@ -67,7 +67,7 @@ public abstract class AbstractMatcher<T> implements Matcher<T> {
     private static class OrMatcher<T> extends AbstractMatcher<T> {
         private final Matcher<? super T> a, b;
 
-        public OrMatcher(Matcher<? super T> a, Matcher<? super T> b) {
+        OrMatcher(Matcher<? super T> a, Matcher<? super T> b) {
             this.a = a;
             this.b = b;
         }

--- a/core/src/main/java/org/elasticsearch/common/inject/matcher/Matchers.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/matcher/Matchers.java
@@ -113,7 +113,7 @@ public class Matchers {
     private static class AnnotatedWithType extends AbstractMatcher<AnnotatedElement> {
         private final Class<? extends Annotation> annotationType;
 
-        public AnnotatedWithType(Class<? extends Annotation> annotationType) {
+        AnnotatedWithType(Class<? extends Annotation> annotationType) {
             this.annotationType = Objects.requireNonNull(annotationType, "annotation type");
             checkForRuntimeRetention(annotationType);
         }
@@ -152,7 +152,7 @@ public class Matchers {
     private static class AnnotatedWith extends AbstractMatcher<AnnotatedElement> {
         private final Annotation annotation;
 
-        public AnnotatedWith(Annotation annotation) {
+        AnnotatedWith(Annotation annotation) {
             this.annotation = Objects.requireNonNull(annotation, "annotation");
             checkForRuntimeRetention(annotation.annotationType());
         }
@@ -191,7 +191,7 @@ public class Matchers {
     private static class SubclassesOf extends AbstractMatcher<Class> {
         private final Class<?> superclass;
 
-        public SubclassesOf(Class<?> superclass) {
+        SubclassesOf(Class<?> superclass) {
             this.superclass = Objects.requireNonNull(superclass, "superclass");
         }
 
@@ -227,7 +227,7 @@ public class Matchers {
     private static class Only extends AbstractMatcher<Object> {
         private final Object value;
 
-        public Only(Object value) {
+        Only(Object value) {
             this.value = Objects.requireNonNull(value, "value");
         }
 
@@ -263,7 +263,7 @@ public class Matchers {
     private static class IdenticalTo extends AbstractMatcher<Object> {
         private final Object value;
 
-        public IdenticalTo(Object value) {
+        IdenticalTo(Object value) {
             this.value = Objects.requireNonNull(value, "value");
         }
 
@@ -301,7 +301,7 @@ public class Matchers {
         private final transient Package targetPackage;
         private final String packageName;
 
-        public InPackage(Package targetPackage) {
+        InPackage(Package targetPackage) {
             this.targetPackage = Objects.requireNonNull(targetPackage, "package");
             this.packageName = targetPackage.getName();
         }
@@ -345,7 +345,7 @@ public class Matchers {
     private static class InSubpackage extends AbstractMatcher<Class>  {
         private final String targetPackageName;
 
-        public InSubpackage(String targetPackageName) {
+        InSubpackage(String targetPackageName) {
             this.targetPackageName = targetPackageName;
         }
 
@@ -384,7 +384,7 @@ public class Matchers {
     private static class Returns extends AbstractMatcher<Method> {
         private final Matcher<? super Class<?>> returnType;
 
-        public Returns(Matcher<? super Class<?>> returnType) {
+        Returns(Matcher<? super Class<?>> returnType) {
             this.returnType = Objects.requireNonNull(returnType, "return type matcher");
         }
 

--- a/core/src/main/java/org/elasticsearch/common/inject/name/NamedImpl.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/name/NamedImpl.java
@@ -23,7 +23,7 @@ class NamedImpl implements Named {
 
     private final String value;
 
-    public NamedImpl(String value) {
+    NamedImpl(String value) {
         this.value = Objects.requireNonNull(value, "name");
     }
 

--- a/core/src/main/java/org/elasticsearch/common/io/stream/Writeable.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/Writeable.java
@@ -34,7 +34,7 @@ public interface Writeable {
     /**
      * Write this into the {@linkplain StreamOutput}.
      */
-    void writeTo(final StreamOutput out) throws IOException;
+    void writeTo(StreamOutput out) throws IOException;
 
     /**
      * Reference to a method that can write some object to a {@link StreamOutput}.
@@ -60,7 +60,7 @@ public interface Writeable {
          * @param out Output to write the {@code value} too
          * @param value The value to add
          */
-        void write(final StreamOutput out, final V value) throws IOException;
+        void write(StreamOutput out, V value) throws IOException;
 
     }
 
@@ -86,7 +86,7 @@ public interface Writeable {
          *
          * @param in Input to read the value from
          */
-        V read(final StreamInput in) throws IOException;
+        V read(StreamInput in) throws IOException;
 
     }
 

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
@@ -156,7 +156,7 @@ public class FiltersFunctionScoreQuery extends Query {
         final Weight[] filterWeights;
         final boolean needsScores;
 
-        public CustomBoostFactorWeight(Query parent, Weight subQueryWeight, Weight[] filterWeights, boolean needsScores) throws IOException {
+        CustomBoostFactorWeight(Query parent, Weight subQueryWeight, Weight[] filterWeights, boolean needsScores) throws IOException {
             super(parent);
             this.subQueryWeight = subQueryWeight;
             this.filterWeights = filterWeights;

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
@@ -109,7 +109,7 @@ public class FunctionScoreQuery extends Query {
         final Weight subQueryWeight;
         final boolean needsScores;
 
-        public CustomBoostFactorWeight(Query parent, Weight subQueryWeight, boolean needsScores) throws IOException {
+        CustomBoostFactorWeight(Query parent, Weight subQueryWeight, boolean needsScores) throws IOException {
             super(parent);
             this.subQueryWeight = subQueryWeight;
             this.needsScores = needsScores;

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunction.java
@@ -38,7 +38,7 @@ public class ScriptScoreFunction extends ScoreFunction {
         protected int docid;
         protected float score;
 
-        public CannedScorer() {
+        CannedScorer() {
             super(null);
         }
 

--- a/core/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDAndVersionLookup.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDAndVersionLookup.java
@@ -57,7 +57,7 @@ final class PerThreadIDAndVersionLookup {
     /**
      * Initialize lookup for the provided segment
      */
-    public PerThreadIDAndVersionLookup(LeafReader reader) throws IOException {
+    PerThreadIDAndVersionLookup(LeafReader reader) throws IOException {
         TermsEnum termsEnum = null;
         NumericDocValues versions = null;
 

--- a/core/src/main/java/org/elasticsearch/common/recycler/Recyclers.java
+++ b/core/src/main/java/org/elasticsearch/common/recycler/Recyclers.java
@@ -170,7 +170,7 @@ public enum Recyclers {
                 }
             }
 
-            final int slot() {
+            int slot() {
                 final long id = Thread.currentThread().getId();
                 // don't trust Thread.hashCode to have equiprobable low bits
                 int slot = (int) BitMixer.mix64(id);

--- a/core/src/main/java/org/elasticsearch/common/rounding/DateTimeUnit.java
+++ b/core/src/main/java/org/elasticsearch/common/rounding/DateTimeUnit.java
@@ -40,7 +40,7 @@ public enum DateTimeUnit {
     private final byte id;
     private final Function<DateTimeZone, DateTimeField> fieldFunction;
 
-    private DateTimeUnit(byte id, Function<DateTimeZone, DateTimeField> fieldFunction) {
+    DateTimeUnit(byte id, Function<DateTimeZone, DateTimeField> fieldFunction) {
         this.id = id;
         this.fieldFunction = fieldFunction;
     }

--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -563,7 +563,7 @@ public class Setting<T> extends ToXContentToBytes {
         private final Logger logger;
         private final Consumer<T> accept;
 
-        public Updater(Consumer<T> consumer, Logger logger, Consumer<T> accept) {
+        Updater(Consumer<T> consumer, Logger logger, Consumer<T> accept) {
             this.consumer = consumer;
             this.logger = logger;
             this.accept = accept;

--- a/core/src/main/java/org/elasticsearch/common/util/BigByteArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigByteArray.java
@@ -36,7 +36,7 @@ final class BigByteArray extends AbstractBigArray implements ByteArray {
     private byte[][] pages;
 
     /** Constructor. */
-    public BigByteArray(long size, BigArrays bigArrays, boolean clearOnResize) {
+    BigByteArray(long size, BigArrays bigArrays, boolean clearOnResize) {
         super(BYTE_PAGE_SIZE, bigArrays, clearOnResize);
         this.size = size;
         pages = new byte[numPages(size)][];

--- a/core/src/main/java/org/elasticsearch/common/util/BigDoubleArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigDoubleArray.java
@@ -35,7 +35,7 @@ final class BigDoubleArray extends AbstractBigArray implements DoubleArray {
     private long[][] pages;
 
     /** Constructor. */
-    public BigDoubleArray(long size, BigArrays bigArrays, boolean clearOnResize) {
+    BigDoubleArray(long size, BigArrays bigArrays, boolean clearOnResize) {
         super(LONG_PAGE_SIZE, bigArrays, clearOnResize);
         this.size = size;
         pages = new long[numPages(size)][];

--- a/core/src/main/java/org/elasticsearch/common/util/BigFloatArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigFloatArray.java
@@ -35,7 +35,7 @@ final class BigFloatArray extends AbstractBigArray implements FloatArray {
     private int[][] pages;
 
     /** Constructor. */
-    public BigFloatArray(long size, BigArrays bigArrays, boolean clearOnResize) {
+    BigFloatArray(long size, BigArrays bigArrays, boolean clearOnResize) {
         super(INT_PAGE_SIZE, bigArrays, clearOnResize);
         this.size = size;
         pages = new int[numPages(size)][];

--- a/core/src/main/java/org/elasticsearch/common/util/BigIntArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigIntArray.java
@@ -35,7 +35,7 @@ final class BigIntArray extends AbstractBigArray implements IntArray {
     private int[][] pages;
 
     /** Constructor. */
-    public BigIntArray(long size, BigArrays bigArrays, boolean clearOnResize) {
+    BigIntArray(long size, BigArrays bigArrays, boolean clearOnResize) {
         super(INT_PAGE_SIZE, bigArrays, clearOnResize);
         this.size = size;
         pages = new int[numPages(size)][];

--- a/core/src/main/java/org/elasticsearch/common/util/BigLongArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigLongArray.java
@@ -35,7 +35,7 @@ final class BigLongArray extends AbstractBigArray implements LongArray {
     private long[][] pages;
 
     /** Constructor. */
-    public BigLongArray(long size, BigArrays bigArrays, boolean clearOnResize) {
+    BigLongArray(long size, BigArrays bigArrays, boolean clearOnResize) {
         super(LONG_PAGE_SIZE, bigArrays, clearOnResize);
         this.size = size;
         pages = new long[numPages(size)][];

--- a/core/src/main/java/org/elasticsearch/common/util/BigObjectArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigObjectArray.java
@@ -35,7 +35,7 @@ final class BigObjectArray<T> extends AbstractBigArray implements ObjectArray<T>
     private Object[][] pages;
 
     /** Constructor. */
-    public BigObjectArray(long size, BigArrays bigArrays) {
+    BigObjectArray(long size, BigArrays bigArrays) {
         super(OBJECT_PAGE_SIZE, bigArrays, true);
         this.size = size;
         pages = new Object[numPages(size)][];

--- a/core/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -226,7 +226,7 @@ public class CollectionUtils {
         private final List<T> in;
         private final int distance;
 
-        public RotatedList(List<T> list, int distance) {
+        RotatedList(List<T> list, int distance) {
             if (distance < 0 || distance >= list.size()) {
                 throw new IllegalArgumentException();
             }

--- a/core/src/main/java/org/elasticsearch/common/util/LongObjectPagedHashMap.java
+++ b/core/src/main/java/org/elasticsearch/common/util/LongObjectPagedHashMap.java
@@ -161,7 +161,7 @@ public class LongObjectPagedHashMap<T> extends AbstractPagedHashMap implements I
             }
 
             @Override
-            public final void remove() {
+            public void remove() {
                 throw new UnsupportedOperationException();
             }
 

--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -161,7 +161,7 @@ public class EsExecutors {
         final AtomicInteger threadNumber = new AtomicInteger(1);
         final String namePrefix;
 
-        public EsThreadFactory(String namePrefix) {
+        EsThreadFactory(String namePrefix) {
             this.namePrefix = namePrefix;
             SecurityManager s = System.getSecurityManager();
             group = (s != null) ? s.getThreadGroup() :
@@ -189,7 +189,7 @@ public class EsExecutors {
 
         ThreadPoolExecutor executor;
 
-        public ExecutorScalingQueue() {
+        ExecutorScalingQueue() {
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedEsThreadPoolExecutor.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedEsThreadPoolExecutor.java
@@ -250,14 +250,14 @@ public class PrioritizedEsThreadPoolExecutor extends EsThreadPoolExecutor {
         final Priority priority;
         final long insertionOrder;
 
-        public PrioritizedFutureTask(Runnable runnable, Priority priority, T value, long insertionOrder) {
+        PrioritizedFutureTask(Runnable runnable, Priority priority, T value, long insertionOrder) {
             super(runnable, value);
             this.task = runnable;
             this.priority = priority;
             this.insertionOrder = insertionOrder;
         }
 
-        public PrioritizedFutureTask(PrioritizedCallable<T> callable, long insertionOrder) {
+        PrioritizedFutureTask(PrioritizedCallable<T> callable, long insertionOrder) {
             super(callable);
             this.task = callable;
             this.priority = callable.priority();

--- a/core/src/main/java/org/elasticsearch/common/xcontent/ConstructingObjectParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/ConstructingObjectParser.java
@@ -267,7 +267,7 @@ public final class ConstructingObjectParser<Value, Context> extends AbstractObje
          */
         private Value targetObject;
 
-        public Target(XContentParser parser) {
+        Target(XContentParser parser) {
             this.parser = parser;
         }
 
@@ -360,7 +360,7 @@ public final class ConstructingObjectParser<Value, Context> extends AbstractObje
         final ParseField field;
         final boolean required;
 
-        public ConstructorArgInfo(ParseField field, boolean required) {
+        ConstructorArgInfo(ParseField field, boolean required) {
             this.field = field;
             this.required = required;
         }

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -516,7 +516,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
             private final DiscoveryNode node;
             private final String reason;
 
-            public Task(final DiscoveryNode node, final String reason) {
+            Task(final DiscoveryNode node, final String reason) {
                 this.node = node;
                 this.reason = reason;
             }
@@ -1136,7 +1136,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
         private final AtomicBoolean running = new AtomicBoolean(false);
         private final AtomicReference<Thread> currentJoinThread = new AtomicReference<>();
 
-        public JoinThreadControl(ThreadPool threadPool) {
+        JoinThreadControl(ThreadPool threadPool) {
             this.threadPool = threadPool;
         }
 

--- a/core/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
+++ b/core/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
@@ -343,7 +343,7 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
         private boolean valueSet;
         private Throwable failure;
 
-        public NodeEntry(String nodeId) {
+        NodeEntry(String nodeId) {
             this.nodeId = nodeId;
         }
 

--- a/core/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
@@ -134,7 +134,7 @@ public class GatewayAllocator extends AbstractComponent {
 
     class InternalAsyncFetch<T extends BaseNodeResponse> extends AsyncShardFetch<T> {
 
-        public InternalAsyncFetch(Logger logger, String type, ShardId shardId, Lister<? extends BaseNodesResponse<T>, T> action) {
+        InternalAsyncFetch(Logger logger, String type, ShardId shardId, Lister<? extends BaseNodesResponse<T>, T> action) {
             super(logger, type, shardId, action);
         }
 
@@ -149,7 +149,7 @@ public class GatewayAllocator extends AbstractComponent {
 
         private final TransportNodesListGatewayStartedShards startedAction;
 
-        public InternalPrimaryShardAllocator(Settings settings, TransportNodesListGatewayStartedShards startedAction) {
+        InternalPrimaryShardAllocator(Settings settings, TransportNodesListGatewayStartedShards startedAction) {
             super(settings);
             this.startedAction = startedAction;
         }
@@ -172,7 +172,7 @@ public class GatewayAllocator extends AbstractComponent {
 
         private final TransportNodesListShardStoreMetaData storeAction;
 
-        public InternalReplicaShardAllocator(Settings settings, TransportNodesListShardStoreMetaData storeAction) {
+        InternalReplicaShardAllocator(Settings settings, TransportNodesListShardStoreMetaData storeAction) {
             super(settings);
             this.storeAction = storeAction;
         }

--- a/core/src/main/java/org/elasticsearch/gateway/MetaDataStateFormat.java
+++ b/core/src/main/java/org/elasticsearch/gateway/MetaDataStateFormat.java
@@ -184,7 +184,7 @@ public abstract class MetaDataStateFormat<T> {
      */
     public final T read(NamedXContentRegistry namedXContentRegistry, Path file) throws IOException {
         try (Directory dir = newDirectory(file.getParent())) {
-            try (final IndexInput indexInput = dir.openInput(file.getFileName().toString(), IOContext.DEFAULT)) {
+            try (IndexInput indexInput = dir.openInput(file.getFileName().toString(), IOContext.DEFAULT)) {
                  // We checksum the entire file before we even go and parse it. If it's corrupted we barf right here.
                 CodecUtil.checksumEntireFile(indexInput);
                 final int fileVersion = CodecUtil.checkHeader(indexInput, STATE_FILE_CODEC, MIN_COMPATIBLE_STATE_FILE_VERSION,

--- a/core/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
@@ -515,7 +515,7 @@ public abstract class PrimaryShardAllocator extends BaseGatewayShardAllocator {
         final List<NodeGatewayStartedShards> orderedAllocationCandidates;
         final int allocationsFound;
 
-        public NodeShardsResult(List<NodeGatewayStartedShards> orderedAllocationCandidates, int allocationsFound) {
+        NodeShardsResult(List<NodeGatewayStartedShards> orderedAllocationCandidates, int allocationsFound) {
             this.orderedAllocationCandidates = orderedAllocationCandidates;
             this.allocationsFound = allocationsFound;
         }
@@ -526,7 +526,7 @@ public abstract class PrimaryShardAllocator extends BaseGatewayShardAllocator {
         final List<DecidedNode> throttleNodeShards;
         final List<DecidedNode> noNodeShards;
 
-        public NodesToAllocate(List<DecidedNode> yesNodeShards, List<DecidedNode> throttleNodeShards, List<DecidedNode> noNodeShards) {
+        NodesToAllocate(List<DecidedNode> yesNodeShards, List<DecidedNode> throttleNodeShards, List<DecidedNode> noNodeShards) {
             this.yesNodeShards = yesNodeShards;
             this.throttleNodeShards = throttleNodeShards;
             this.noNodeShards = noNodeShards;

--- a/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -395,7 +395,7 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
         @Nullable
         private final Map<String, NodeAllocationResult> nodeDecisions;
 
-        public MatchingNodes(ObjectLongMap<DiscoveryNode> nodesToSize, @Nullable Map<String, NodeAllocationResult> nodeDecisions) {
+        MatchingNodes(ObjectLongMap<DiscoveryNode> nodesToSize, @Nullable Map<String, NodeAllocationResult> nodeDecisions) {
             this.nodesToSize = nodesToSize;
             this.nodeDecisions = nodeDecisions;
 

--- a/core/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -316,7 +316,7 @@ public final class IndexModule {
         /**
          * Returns a new IndexSearcherWrapper. This method is called once per index per node
          */
-        IndexSearcherWrapper newWrapper(final IndexService indexService);
+        IndexSearcherWrapper newWrapper(IndexService indexService);
     }
 
     public IndexService newIndexService(

--- a/core/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexService.java
@@ -517,7 +517,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         private final boolean ownsShard;
         private final Closeable[] toClose;
 
-        public StoreCloseListener(ShardId shardId, boolean ownsShard, Closeable... toClose) {
+        StoreCloseListener(ShardId shardId, boolean ownsShard, Closeable... toClose) {
             this.shardId = shardId;
             this.ownsShard = ownsShard;
             this.toClose = toClose;
@@ -572,7 +572,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private final class FieldDataCacheListener implements IndexFieldDataCache.Listener {
         final IndexService indexService;
 
-        public FieldDataCacheListener(IndexService indexService) {
+        FieldDataCacheListener(IndexService indexService) {
             this.indexService = indexService;
         }
 

--- a/core/src/main/java/org/elasticsearch/index/IndexWarmer.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexWarmer.java
@@ -111,7 +111,7 @@ public final class IndexWarmer extends AbstractComponent {
     private static class FieldDataWarmer implements IndexWarmer.Listener {
 
         private final Executor executor;
-        public FieldDataWarmer(Executor executor) {
+        FieldDataWarmer(Executor executor) {
             this.executor = executor;
         }
 

--- a/core/src/main/java/org/elasticsearch/index/SearchSlowLog.java
+++ b/core/src/main/java/org/elasticsearch/index/SearchSlowLog.java
@@ -141,7 +141,7 @@ public final class SearchSlowLog implements SearchOperationListener {
         private final SearchContext context;
         private final long tookInNanos;
 
-        public SlowLogSearchContextPrinter(SearchContext context, long tookInNanos) {
+        SlowLogSearchContextPrinter(SearchContext context, long tookInNanos) {
             this.context = context;
             this.tookInNanos = tookInNanos;
         }

--- a/core/src/main/java/org/elasticsearch/index/analysis/CharMatcher.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/CharMatcher.java
@@ -45,7 +45,7 @@ public interface CharMatcher {
         }
     }
 
-    public enum Basic implements CharMatcher {
+    enum Basic implements CharMatcher {
         LETTER {
             @Override
             public boolean isTokenChar(int c) {
@@ -97,7 +97,7 @@ public interface CharMatcher {
         }
     }
 
-    public final class Builder {
+    final class Builder {
         private final Set<CharMatcher> matchers;
         Builder() {
             matchers = new HashSet<>();

--- a/core/src/main/java/org/elasticsearch/index/cache/query/QueryCache.java
+++ b/core/src/main/java/org/elasticsearch/index/cache/query/QueryCache.java
@@ -25,7 +25,7 @@ import java.io.Closeable;
 
 public interface QueryCache extends IndexComponent, Closeable, org.apache.lucene.search.QueryCache {
 
-    static class EntriesStats {
+    class EntriesStats {
         public final long sizeInBytes;
         public final long count;
 

--- a/core/src/main/java/org/elasticsearch/index/engine/DeleteVersionValue.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/DeleteVersionValue.java
@@ -29,7 +29,7 @@ class DeleteVersionValue extends VersionValue {
 
     private final long time;
 
-    public DeleteVersionValue(long version, long time) {
+    DeleteVersionValue(long version, long time) {
         super(version);
         this.time = time;
     }

--- a/core/src/main/java/org/elasticsearch/index/engine/ElasticsearchConcurrentMergeScheduler.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/ElasticsearchConcurrentMergeScheduler.java
@@ -67,7 +67,7 @@ class ElasticsearchConcurrentMergeScheduler extends ConcurrentMergeScheduler {
     private final Set<OnGoingMerge> readOnlyOnGoingMerges = Collections.unmodifiableSet(onGoingMerges);
     private final MergeSchedulerConfig config;
 
-    public ElasticsearchConcurrentMergeScheduler(ShardId shardId, IndexSettings indexSettings) {
+    ElasticsearchConcurrentMergeScheduler(ShardId shardId, IndexSettings indexSettings) {
         this.config = indexSettings.getMergeSchedulerConfig();
         this.shardId = shardId;
         this.indexSettings = indexSettings.getSettings();

--- a/core/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -282,7 +282,7 @@ public abstract class Engine implements Closeable {
      *
      * Note: engine level failures (i.e. persistent engine failures) are thrown
      */
-    public abstract IndexResult index(final Index index) throws IOException;
+    public abstract IndexResult index(Index index) throws IOException;
 
     /**
      * Perform document delete operation on the engine
@@ -292,9 +292,9 @@ public abstract class Engine implements Closeable {
      *
      * Note: engine level failures (i.e. persistent engine failures) are thrown
      */
-    public abstract DeleteResult delete(final Delete delete) throws IOException;
+    public abstract DeleteResult delete(Delete delete) throws IOException;
 
-    public abstract NoOpResult noOp(final NoOp noOp);
+    public abstract NoOpResult noOp(NoOp noOp);
 
     /**
      * Base class for index and delete operation results
@@ -569,7 +569,7 @@ public abstract class Engine implements Closeable {
      */
     public final SegmentsStats segmentsStats(boolean includeSegmentFileSizes) {
         ensureOpen();
-        try (final Searcher searcher = acquireSearcher("segments_stats")) {
+        try (Searcher searcher = acquireSearcher("segments_stats")) {
             SegmentsStats stats = new SegmentsStats();
             for (LeafReaderContext reader : searcher.reader().leaves()) {
                 final SegmentReader segmentReader = segmentReader(reader.reader());

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -671,7 +671,7 @@ public class InternalEngine extends Engine {
                 throw new AssertionError("doc [" + index.type() + "][" + index.id() + "] exists in version map (version " + versionValue + ")");
             }
         } else {
-            try (final Searcher searcher = acquireSearcher("assert doc doesn't exist")) {
+            try (Searcher searcher = acquireSearcher("assert doc doesn't exist")) {
                 final long docsWithId = searcher.searcher().count(new TermQuery(index.uid()));
                 if (docsWithId > 0) {
                     throw new AssertionError("doc [" + index.type() + "][" + index.id() + "] exists [" + docsWithId + "] times in index");
@@ -797,7 +797,7 @@ public class InternalEngine extends Engine {
     @Override
     public NoOpResult noOp(final NoOp noOp) {
         NoOpResult noOpResult;
-        try (final ReleasableLock ignored = readLock.acquire()) {
+        try (ReleasableLock ignored = readLock.acquire()) {
             noOpResult = innerNoOp(noOp);
         } catch (final Exception e) {
             noOpResult = new NoOpResult(noOp.seqNo(), e);
@@ -1286,7 +1286,7 @@ public class InternalEngine extends Engine {
 
     private long loadCurrentVersionFromIndex(Term uid) throws IOException {
         assert incrementIndexVersionLookup();
-        try (final Searcher searcher = acquireSearcher("load_version")) {
+        try (Searcher searcher = acquireSearcher("load_version")) {
             return Versions.loadVersion(searcher.reader(), uid);
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
@@ -43,12 +43,12 @@ class LiveVersionMap implements ReferenceManager.RefreshListener, Accountable {
         // Used while refresh is running, and to hold adds/deletes until refresh finishes.  We read from both current and old on lookup:
         final Map<BytesRef,VersionValue> old;
 
-        public Maps(Map<BytesRef,VersionValue> current, Map<BytesRef,VersionValue> old) {
+        Maps(Map<BytesRef,VersionValue> current, Map<BytesRef,VersionValue> old) {
            this.current = current;
            this.old = old;
         }
 
-        public Maps() {
+        Maps() {
             this(ConcurrentCollections.<BytesRef,VersionValue>newConcurrentMapWithAggressiveConcurrency(),
                  ConcurrentCollections.<BytesRef,VersionValue>newConcurrentMapWithAggressiveConcurrency());
         }

--- a/core/src/main/java/org/elasticsearch/index/engine/VersionValue.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/VersionValue.java
@@ -31,7 +31,7 @@ class VersionValue implements Accountable {
 
     private final long version;
 
-    public VersionValue(long version) {
+    VersionValue(long version) {
         this.version = version;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
@@ -52,7 +52,7 @@ import java.io.IOException;
  */
 public interface IndexFieldData<FD extends AtomicFieldData> extends IndexComponent {
 
-    public static class CommonSettings {
+    class CommonSettings {
         public static final String SETTING_MEMORY_STORAGE_HINT = "memory_storage_hint";
 
         public enum MemoryStorageFormat {

--- a/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataCache.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataCache.java
@@ -31,7 +31,7 @@ public interface IndexFieldDataCache {
 
     <FD extends AtomicFieldData, IFD extends IndexFieldData<FD>> FD load(LeafReaderContext context, IFD indexFieldData) throws Exception;
 
-    <FD extends AtomicFieldData, IFD extends IndexFieldData.Global<FD>> IFD load(final DirectoryReader indexReader, final IFD indexFieldData) throws Exception;
+    <FD extends AtomicFieldData, IFD extends IndexFieldData.Global<FD>> IFD load(DirectoryReader indexReader, IFD indexFieldData) throws Exception;
 
     /**
      * Clears all the field data stored cached in on this index.

--- a/core/src/main/java/org/elasticsearch/index/fielddata/IndexNumericFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/IndexNumericFieldData.java
@@ -21,7 +21,7 @@ package org.elasticsearch.index.fielddata;
 
 public interface IndexNumericFieldData extends IndexFieldData<AtomicNumericFieldData> {
 
-    public static enum NumericType {
+    enum NumericType {
         BOOLEAN(false),
         BYTE(false),
         SHORT(false),
@@ -33,7 +33,7 @@ public interface IndexNumericFieldData extends IndexFieldData<AtomicNumericField
 
         private final boolean floatingPoint;
 
-        private NumericType(boolean floatingPoint) {
+        NumericType(boolean floatingPoint) {
             this.floatingPoint = floatingPoint;
         }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/SingletonSortedNumericDoubleValues.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/SingletonSortedNumericDoubleValues.java
@@ -34,7 +34,7 @@ final class SingletonSortedNumericDoubleValues extends SortedNumericDoubleValues
   private double value;
   private int count;
 
-  public SingletonSortedNumericDoubleValues(NumericDoubleValues in, Bits docsWithField) {
+  SingletonSortedNumericDoubleValues(NumericDoubleValues in, Bits docsWithField) {
     this.in = in;
     this.docsWithField = docsWithField instanceof MatchAllBits ? null : docsWithField;
   }

--- a/core/src/main/java/org/elasticsearch/index/fielddata/ordinals/SinglePackedOrdinals.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/ordinals/SinglePackedOrdinals.java
@@ -67,7 +67,7 @@ public class SinglePackedOrdinals extends Ordinals {
         private final PackedInts.Reader reader;
         private final ValuesHolder values;
 
-        public Docs(SinglePackedOrdinals parent, ValuesHolder values) {
+        Docs(SinglePackedOrdinals parent, ValuesHolder values) {
             this.maxOrd = parent.valueCount;
             this.reader = parent.reader;
             this.values = values;

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexGeoPointFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexGeoPointFieldData.java
@@ -99,7 +99,7 @@ abstract class AbstractIndexGeoPointFieldData extends AbstractIndexFieldData<Ato
         }
     }
 
-    public AbstractIndexGeoPointFieldData(IndexSettings indexSettings, String fieldName, IndexFieldDataCache cache) {
+    AbstractIndexGeoPointFieldData(IndexSettings indexSettings, String fieldName, IndexFieldDataCache cache) {
         super(indexSettings, fieldName, cache);
     }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
@@ -132,7 +132,7 @@ public abstract class AbstractIndexOrdinalsFieldData extends AbstractIndexFieldD
 
         private int minFreq;
         private int maxFreq;
-        public FrequencyFilter(TermsEnum delegate, int minFreq, int maxFreq) {
+        FrequencyFilter(TermsEnum delegate, int minFreq, int maxFreq) {
             super(delegate, false);
             this.minFreq = minFreq;
             this.maxFreq = maxFreq;

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
@@ -179,7 +179,7 @@ public class ParentChildIndexFieldData extends AbstractIndexFieldData<AtomicPare
         final OrdinalMap ordMap;
         final AtomicParentChildFieldData[] fieldData;
 
-        public OrdinalMapAndAtomicFieldData(OrdinalMap ordMap, AtomicParentChildFieldData[] fieldData) {
+        OrdinalMapAndAtomicFieldData(OrdinalMap ordMap, AtomicParentChildFieldData[] fieldData) {
             this.ordMap = ordMap;
             this.fieldData = fieldData;
         }
@@ -223,7 +223,7 @@ public class ParentChildIndexFieldData extends AbstractIndexFieldData<AtomicPare
         private final Map<String, OrdinalMapAndAtomicFieldData> atomicFD;
         private final int segmentIndex;
 
-        public GlobalAtomicFieldData(Set<String> types, Map<String, OrdinalMapAndAtomicFieldData> atomicFD, int segmentIndex) {
+        GlobalAtomicFieldData(Set<String> types, Map<String, OrdinalMapAndAtomicFieldData> atomicFD, int segmentIndex) {
             this.types = types;
             this.atomicFD = atomicFD;
             this.segmentIndex = segmentIndex;

--- a/core/src/main/java/org/elasticsearch/index/mapper/AllFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/AllFieldMapper.java
@@ -160,7 +160,7 @@ public class AllFieldMapper extends MetadataFieldMapper {
 
     static final class AllFieldType extends StringFieldType {
 
-        public AllFieldType() {
+        AllFieldType() {
         }
 
         protected AllFieldType(AllFieldType ref) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -83,7 +83,7 @@ public class BinaryFieldMapper extends FieldMapper {
 
     static final class BinaryFieldType extends MappedFieldType {
 
-        public BinaryFieldType() {}
+        BinaryFieldType() {}
 
         protected BinaryFieldType(BinaryFieldType ref) {
             super(ref);

--- a/core/src/main/java/org/elasticsearch/index/mapper/CustomDocValuesField.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/CustomDocValuesField.java
@@ -39,7 +39,7 @@ abstract class CustomDocValuesField implements IndexableField {
 
     private final String name;
 
-    public CustomDocValuesField(String  name) {
+    CustomDocValuesField(String  name) {
         this.name = name;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -47,7 +47,7 @@ final class DocumentParser {
     private final DocumentMapperParser docMapperParser;
     private final DocumentMapper docMapper;
 
-    public DocumentParser(IndexSettings indexSettings, DocumentMapperParser docMapperParser, DocumentMapper docMapper) {
+    DocumentParser(IndexSettings indexSettings, DocumentMapperParser docMapperParser, DocumentMapper docMapper) {
         this.indexSettings = indexSettings;
         this.docMapperParser = docMapperParser;
         this.docMapper = docMapper;

--- a/core/src/main/java/org/elasticsearch/index/mapper/DynamicTemplate.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DynamicTemplate.java
@@ -38,7 +38,7 @@ public class DynamicTemplate implements ToXContent {
 
     private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(DynamicTemplate.class));
 
-    public static enum MatchType {
+    public enum MatchType {
         SIMPLE {
             @Override
             public boolean matches(String pattern, String value) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -243,7 +243,7 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
                     }
 
                     @Override
-                    public final void remove() {
+                    public void remove() {
                         throw new UnsupportedOperationException();
                     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -43,7 +43,7 @@ class FieldTypeLookup implements Iterable<MappedFieldType> {
     final CopyOnWriteHashMap<String, Set<String>> fullNameToTypes;
 
     /** Create a new empty instance. */
-    public FieldTypeLookup() {
+    FieldTypeLookup() {
         fullNameToFieldType = new CopyOnWriteHashMap<>();
         fullNameToTypes = new CopyOnWriteHashMap<>();
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -88,7 +88,7 @@ public class IdFieldMapper extends MetadataFieldMapper {
 
     static final class IdFieldType extends TermBasedFieldType {
 
-        public IdFieldType() {
+        IdFieldType() {
         }
 
         protected IdFieldType(IdFieldType ref) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
@@ -92,7 +92,7 @@ public class IndexFieldMapper extends MetadataFieldMapper {
 
     static final class IndexFieldType extends MappedFieldType {
 
-        public IndexFieldType() {}
+        IndexFieldType() {}
 
         protected IndexFieldType(IndexFieldType ref) {
             super(ref);

--- a/core/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -300,7 +300,7 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         final NamedAnalyzer normalizer = fieldType().normalizer();
         if (normalizer != null) {
-            try (final TokenStream ts = normalizer.tokenStream(name(), value)) {
+            try (TokenStream ts = normalizer.tokenStream(name(), value)) {
                 final CharTermAttribute termAtt = ts.addAttribute(CharTermAttribute.class);
                 ts.reset();
                 if (ts.incrementToken() == false) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -393,7 +393,7 @@ public abstract class MappedFieldType extends FieldType {
      * An enum used to describe the relation between the range of terms in a
      * shard when compared with a query range
      */
-    public static enum Relation {
+    public enum Relation {
         WITHIN,
         INTERSECTS,
         DISJOINT;

--- a/core/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -53,7 +53,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
         public static final Dynamic DYNAMIC = null; // not set, inherited from root
     }
 
-    public static enum Dynamic {
+    public enum Dynamic {
         TRUE,
         FALSE,
         STRICT

--- a/core/src/main/java/org/elasticsearch/index/mapper/ParentFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ParentFieldMapper.java
@@ -152,7 +152,7 @@ public class ParentFieldMapper extends MetadataFieldMapper {
 
         final String documentType;
 
-        public ParentFieldType() {
+        ParentFieldType() {
             documentType = null;
             setEagerGlobalOrdinals(true);
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -105,7 +105,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
 
     static final class RoutingFieldType extends TermBasedFieldType {
 
-        public RoutingFieldType() {
+        RoutingFieldType() {
         }
 
         protected RoutingFieldType(RoutingFieldType ref) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
@@ -145,7 +145,7 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
 
     static final class SeqNoFieldType extends MappedFieldType {
 
-        public SeqNoFieldType() {
+        SeqNoFieldType() {
         }
 
         protected SeqNoFieldType(SeqNoFieldType ref) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -149,7 +149,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     static final class SourceFieldType extends MappedFieldType {
 
-        public SourceFieldType() {}
+        SourceFieldType() {}
 
         protected SourceFieldType(SourceFieldType ref) {
             super(ref);

--- a/core/src/main/java/org/elasticsearch/index/mapper/TermBasedFieldType.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TermBasedFieldType.java
@@ -35,7 +35,7 @@ import org.elasticsearch.index.query.QueryShardContext;
  *  with the inverted index. */
 abstract class TermBasedFieldType extends MappedFieldType {
 
-    public TermBasedFieldType() {}
+    TermBasedFieldType() {}
 
     protected TermBasedFieldType(MappedFieldType ref) {
         super(ref);

--- a/core/src/main/java/org/elasticsearch/index/mapper/TypeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TypeFieldMapper.java
@@ -90,7 +90,7 @@ public class TypeFieldMapper extends MetadataFieldMapper {
     static final class TypeFieldType extends StringFieldType {
         private boolean fielddata;
 
-        public TypeFieldType() {
+        TypeFieldType() {
             this.fielddata = false;
         }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/UidFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/UidFieldMapper.java
@@ -77,7 +77,7 @@ public class UidFieldMapper extends MetadataFieldMapper {
 
     static final class UidFieldType extends TermBasedFieldType {
 
-        public UidFieldType() {
+        UidFieldType() {
         }
 
         protected UidFieldType(UidFieldType ref) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
@@ -70,7 +70,7 @@ public class VersionFieldMapper extends MetadataFieldMapper {
 
     static final class VersionFieldType extends MappedFieldType {
 
-        public VersionFieldType() {
+        VersionFieldType() {
         }
 
         protected VersionFieldType(VersionFieldType ref) {

--- a/core/src/main/java/org/elasticsearch/index/query/RegexpFlag.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RegexpFlag.java
@@ -78,7 +78,7 @@ public enum RegexpFlag {
 
     final int value;
 
-    private RegexpFlag(int value) {
+    RegexpFlag(int value) {
         this.value = value;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
@@ -136,7 +136,7 @@ public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder>
         final Script script;
         final SearchScript searchScript;
 
-        public ScriptQuery(Script script, SearchScript searchScript) {
+        ScriptQuery(Script script, SearchScript searchScript) {
             this.script = script;
             this.searchScript = searchScript;
         }

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryParser.java
@@ -267,10 +267,10 @@ public class SimpleQueryParser extends org.apache.lucene.queryparser.simple.Simp
          * Generates default {@link Settings} object (uses ROOT locale, does
          * lowercase terms, no lenient parsing, no wildcard analysis).
          * */
-        public Settings() {
+        Settings() {
         }
 
-        public Settings(Settings other) {
+        Settings(Settings other) {
             this.lenient = other.lenient;
             this.analyzeWildcard = other.analyzeWildcard;
             this.quoteFieldSuffix = other.quoteFieldSuffix;

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringFlag.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringFlag.java
@@ -43,7 +43,7 @@ public enum SimpleQueryStringFlag {
 
     final int value;
 
-    private SimpleQueryStringFlag(int value) {
+    SimpleQueryStringFlag(int value) {
         this.value = value;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
@@ -245,7 +245,7 @@ public class TermsQueryBuilder extends AbstractQueryBuilder<TermsQueryBuilder> {
         final boolean allStrings = list.stream().allMatch(o -> o != null && STRING_TYPES.contains(o.getClass()));
         if (allStrings) {
             final BytesRefBuilder builder = new BytesRefBuilder();
-            try (final BytesStreamOutput bytesOut = new BytesStreamOutput()) {
+            try (BytesStreamOutput bytesOut = new BytesStreamOutput()) {
                 final int[] endOffsets = new int[list.size()];
                 int i = 0;
                 for (Object o : list) {

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -331,7 +331,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
 
         private static final GeoDistance distFunction = GeoDistance.ARC;
 
-        public GeoFieldDataScoreFunction(GeoPoint origin, double scale, double decay, double offset, DecayFunction func,
+        GeoFieldDataScoreFunction(GeoPoint origin, double scale, double decay, double offset, DecayFunction func,
                                          IndexGeoPointFieldData fieldData, MultiValueMode mode) {
             super(scale, decay, offset, func, mode);
             this.origin = origin;
@@ -413,7 +413,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
         private final IndexNumericFieldData fieldData;
         private final double origin;
 
-        public NumericFieldDataScoreFunction(double origin, double scale, double decay, double offset, DecayFunction func,
+        NumericFieldDataScoreFunction(double origin, double scale, double decay, double offset, DecayFunction func,
                                              IndexNumericFieldData fieldData, MultiValueMode mode) {
             super(scale, decay, offset, func, mode);
             this.fieldData = fieldData;

--- a/core/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -53,7 +53,7 @@ import java.util.List;
 
 public class MatchQuery {
 
-    public static enum Type implements Writeable {
+    public enum Type implements Writeable {
         /**
          * The text is analyzed and terms are added to a boolean query.
          */
@@ -69,7 +69,7 @@ public class MatchQuery {
 
         private final int ordinal;
 
-        private Type(int ordinal) {
+        Type(int ordinal) {
             this.ordinal = ordinal;
         }
 
@@ -89,13 +89,13 @@ public class MatchQuery {
         }
     }
 
-    public static enum ZeroTermsQuery implements Writeable {
+    public enum ZeroTermsQuery implements Writeable {
         NONE(0),
         ALL(1);
 
         private final int ordinal;
 
-        private ZeroTermsQuery(int ordinal) {
+        ZeroTermsQuery(int ordinal) {
             this.ordinal = ordinal;
         }
 
@@ -301,7 +301,7 @@ public class MatchQuery {
         /**
          * Creates a new QueryBuilder using the given analyzer.
          */
-        public MatchQueryBuilder(Analyzer analyzer, @Nullable MappedFieldType mapper) {
+        MatchQueryBuilder(Analyzer analyzer, @Nullable MappedFieldType mapper) {
             super(analyzer);
             this.mapper = mapper;
         }

--- a/core/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
@@ -165,7 +165,7 @@ public class MultiMatchQuery extends MatchQuery {
     final class CrossFieldsQueryBuilder extends QueryBuilder {
         private FieldAndFieldType[] blendedFields;
 
-        public CrossFieldsQueryBuilder(float tieBreaker) {
+        CrossFieldsQueryBuilder(float tieBreaker) {
             super(false, tieBreaker);
         }
 

--- a/core/src/main/java/org/elasticsearch/index/shard/CommitPoint.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/CommitPoint.java
@@ -61,7 +61,7 @@ public class CommitPoint {
         }
     }
 
-    public static enum Type {
+    public enum Type {
         GENERATED,
         SAVED
     }

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -384,7 +384,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * @throws IndexShardRelocatedException if shard is marked as relocated and relocation aborted
      * @throws IOException                  if shard state could not be persisted
      */
-    public void updateRoutingEntry(final ShardRouting newRouting) throws IOException {
+    public void updateRoutingEntry(ShardRouting newRouting) throws IOException {
         final ShardRouting currentRouting;
         synchronized (mutex) {
             currentRouting = this.shardRouting;
@@ -671,7 +671,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     public DocsStats docStats() {
-        try (final Engine.Searcher searcher = acquireSearcher("doc_stats")) {
+        try (Engine.Searcher searcher = acquireSearcher("doc_stats")) {
             return new DocsStats(searcher.reader().numDocs(), searcher.reader().numDeletedDocs());
         }
     }
@@ -754,7 +754,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
     public CompletionStats completionStats(String... fields) {
         CompletionStats completionStats = new CompletionStats();
-        try (final Engine.Searcher currentSearcher = acquireSearcher("completion_stats")) {
+        try (Engine.Searcher currentSearcher = acquireSearcher("completion_stats")) {
             completionStats.add(CompletionFieldStats.completionStats(currentSearcher.reader(), fields));
         }
         return completionStats;

--- a/core/src/main/java/org/elasticsearch/index/shard/LocalShardSnapshot.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/LocalShardSnapshot.java
@@ -41,7 +41,7 @@ final class LocalShardSnapshot implements Closeable {
     private final IndexCommit indexCommit;
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    public LocalShardSnapshot(IndexShard shard) {
+    LocalShardSnapshot(IndexShard shard) {
         this.shard = shard;
         store = shard.store();
         store.incRef();

--- a/core/src/main/java/org/elasticsearch/index/shard/SnapshotStatus.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/SnapshotStatus.java
@@ -21,7 +21,7 @@ package org.elasticsearch.index.shard;
 
 public class SnapshotStatus {
 
-    public static enum Stage {
+    public enum Stage {
         NONE,
         INDEX,
         TRANSLOG,

--- a/core/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/core/src/main/java/org/elasticsearch/index/store/Store.java
@@ -858,7 +858,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
                 Logger logger, Version version, boolean readFileAsHash) throws IOException {
             final String checksum;
             final BytesRefBuilder fileHash = new BytesRefBuilder();
-            try (final IndexInput in = directory.openInput(file, IOContext.READONCE)) {
+            try (IndexInput in = directory.openInput(file, IOContext.READONCE)) {
                 final long length;
                 try {
                     length = in.length();
@@ -1194,11 +1194,11 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         private final byte[] checksum = new byte[8];
         private long verifiedPosition = 0;
 
-        public VerifyingIndexInput(IndexInput input) {
+        VerifyingIndexInput(IndexInput input) {
             this(input, new BufferedChecksum(new CRC32()));
         }
 
-        public VerifyingIndexInput(IndexInput input, Checksum digest) {
+        VerifyingIndexInput(IndexInput input, Checksum digest) {
             super("VerifyingIndexInput(" + input + ")");
             this.input = input;
             this.digest = digest;
@@ -1366,7 +1366,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
     private static class StoreStatsCache extends SingleObjectCache<StoreStats> {
         private final Directory directory;
 
-        public StoreStatsCache(TimeValue refreshInterval, Directory directory) throws IOException {
+        StoreStatsCache(TimeValue refreshInterval, Directory directory) throws IOException {
             super(refreshInterval, new StoreStats(estimateSize(directory)));
             this.directory = directory;
         }

--- a/core/src/main/java/org/elasticsearch/index/translog/Checkpoint.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Checkpoint.java
@@ -106,7 +106,7 @@ class Checkpoint {
 
     public static Checkpoint read(Path path) throws IOException {
         try (Directory dir = new SimpleFSDirectory(path.getParent())) {
-            try (final IndexInput indexInput = dir.openInput(path.getFileName().toString(), IOContext.DEFAULT)) {
+            try (IndexInput indexInput = dir.openInput(path.getFileName().toString(), IOContext.DEFAULT)) {
                 if (indexInput.length() == LEGACY_NON_CHECKSUMMED_FILE_LENGTH) {
                     // OLD unchecksummed file that was written < ES 5.0.0
                     return Checkpoint.readNonChecksummed(indexInput);
@@ -136,7 +136,7 @@ class Checkpoint {
             }
         };
         final String resourceDesc = "checkpoint(path=\"" + checkpointFile + "\", gen=" + checkpoint + ")";
-        try (final OutputStreamIndexOutput indexOutput =
+        try (OutputStreamIndexOutput indexOutput =
                  new OutputStreamIndexOutput(resourceDesc, checkpointFile.toString(), byteOutputStream, FILE_SIZE)) {
             CodecUtil.writeHeader(indexOutput, CHECKPOINT_CODEC, CURRENT_VERSION);
             checkpoint.write(indexOutput);

--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -464,7 +464,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
      * @return the last synced checkpoint
      */
     public long getLastSyncedGlobalCheckpoint() {
-        try (final ReleasableLock ignored = readLock.acquire()) {
+        try (ReleasableLock ignored = readLock.acquire()) {
             return current.getLastSyncedCheckpoint().globalCheckpoint;
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/translog/TranslogSnapshot.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/TranslogSnapshot.java
@@ -40,7 +40,7 @@ final class TranslogSnapshot extends BaseTranslogReader implements Translog.Snap
      * Create a snapshot of translog file channel. The length parameter should be consistent with totalOperations and point
      * at the end of the last operation in this snapshot.
      */
-    public TranslogSnapshot(long generation, FileChannel channel, Path path, long firstOperationOffset, long length, int totalOperations) {
+    TranslogSnapshot(long generation, FileChannel channel, Path path, long firstOperationOffset, long length, int totalOperations) {
         super(generation, channel, path, firstOperationOffset);
         this.length = length;
         this.totalOperations = totalOperations;

--- a/core/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
@@ -374,7 +374,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
 
     private final class BufferedChannelOutputStream extends BufferedOutputStream {
 
-        public BufferedChannelOutputStream(OutputStream out, int size) throws IOException {
+        BufferedChannelOutputStream(OutputStream out, int size) throws IOException {
             super(out, size);
         }
 

--- a/core/src/main/java/org/elasticsearch/indices/IndexingMemoryController.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndexingMemoryController.java
@@ -221,7 +221,7 @@ public class IndexingMemoryController extends AbstractComponent implements Index
         final long bytesUsed;
         final IndexShard shard;
 
-        public ShardAndBytesUsed(long bytesUsed, IndexShard shard) {
+        ShardAndBytesUsed(long bytesUsed, IndexShard shard) {
             this.bytesUsed = bytesUsed;
             this.shard = shard;
         }

--- a/core/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -880,7 +880,7 @@ public class IndicesService extends AbstractLifecycleComponent
         /**
          * Creates a new pending delete of an index
          */
-        public PendingDelete(ShardId shardId, IndexSettings settings) {
+        PendingDelete(ShardId shardId, IndexSettings settings) {
             this.index = shardId.getIndex();
             this.shardId = shardId.getId();
             this.settings = settings;
@@ -890,7 +890,7 @@ public class IndicesService extends AbstractLifecycleComponent
         /**
          * Creates a new pending delete of a shard
          */
-        public PendingDelete(Index index, IndexSettings settings) {
+        PendingDelete(Index index, IndexSettings settings) {
             this.index = index;
             this.shardId = -1;
             this.settings = settings;
@@ -1030,7 +1030,7 @@ public class IndicesService extends AbstractLifecycleComponent
         private final AtomicBoolean closed = new AtomicBoolean(false);
         private final IndicesRequestCache requestCache;
 
-        public CacheCleaner(IndicesFieldDataCache cache, IndicesRequestCache requestCache, Logger logger, ThreadPool threadPool, TimeValue interval) {
+        CacheCleaner(IndicesFieldDataCache cache, IndicesRequestCache requestCache, Logger logger, ThreadPool threadPool, TimeValue interval) {
             this.cache = cache;
             this.requestCache = requestCache;
             this.logger = logger;

--- a/core/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
+++ b/core/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
@@ -658,10 +658,10 @@ public class SyncedFlushService extends AbstractComponent implements IndexEventL
 
         int opCount;
 
-        public InFlightOpsResponse() {
+        InFlightOpsResponse() {
         }
 
-        public InFlightOpsResponse(int opCount) {
+        InFlightOpsResponse(int opCount) {
             this.opCount = opCount;
         }
 

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -127,7 +127,7 @@ public class RecoverySourceHandler {
      * performs the recovery from the local engine to the target
      */
     public RecoveryResponse recoverToTarget() throws IOException {
-        try (final Translog.View translogView = shard.acquireTranslogView()) {
+        try (Translog.View translogView = shard.acquireTranslogView()) {
             logger.trace("captured translog id [{}] for recovery", translogView.minTranslogGeneration());
 
             boolean isSequenceNumberBasedRecoveryPossible = request.startingSeqNo() != SequenceNumbersService.UNASSIGNED_SEQ_NO &&
@@ -588,7 +588,7 @@ public class RecoverySourceHandler {
             ArrayUtil.timSort(files, (a, b) -> Long.compare(a.length(), b.length())); // send smallest first
             for (int i = 0; i < files.length; i++) {
                 final StoreFileMetaData md = files[i];
-                try (final IndexInput indexInput = store.directory().openInput(md.name(), IOContext.READONCE)) {
+                try (IndexInput indexInput = store.directory().openInput(md.name(), IOContext.READONCE)) {
                     // it's fine that we are only having the indexInput in the try/with block. The copy methods handles
                     // exceptions during close correctly and doesn't hide the original exception.
                     Streams.copy(new InputStreamIndexInput(indexInput, md.length()), outputStreamFactory.apply(md));

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -45,7 +45,7 @@ import java.util.Map;
  */
 public class RecoveryState implements ToXContent, Streamable {
 
-    public static enum Stage {
+    public enum Stage {
         INIT((byte) 0),
 
         /**

--- a/core/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/core/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -233,7 +233,7 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
         private final AtomicInteger awaitingResponses;
         private final AtomicInteger activeCopies;
 
-        public ShardActiveResponseHandler(ShardId shardId, long clusterStateVersion, int expectedActiveCopies) {
+        ShardActiveResponseHandler(ShardId shardId, long clusterStateVersion, int expectedActiveCopies) {
             this.shardId = shardId;
             this.expectedActiveCopies = expectedActiveCopies;
             this.clusterStateVersion = clusterStateVersion;
@@ -396,7 +396,7 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
         private String indexUUID;
         private ShardId shardId;
 
-        public ShardActiveRequest() {
+        ShardActiveRequest() {
         }
 
         ShardActiveRequest(ClusterName clusterName, String indexUUID, ShardId shardId, TimeValue timeout) {

--- a/core/src/main/java/org/elasticsearch/ingest/IngestMetadata.java
+++ b/core/src/main/java/org/elasticsearch/ingest/IngestMetadata.java
@@ -132,7 +132,7 @@ public final class IngestMetadata implements MetaData.Custom {
             this.pipelines = DiffableUtils.diff(before.pipelines, after.pipelines, DiffableUtils.getStringKeySerializer());
         }
 
-        public IngestMetadataDiff(StreamInput in) throws IOException {
+        IngestMetadataDiff(StreamInput in) throws IOException {
             pipelines = DiffableUtils.readJdkMapDiff(in, DiffableUtils.getStringKeySerializer(), PipelineConfiguration::readFrom,
                 PipelineConfiguration::readDiffFrom);
         }

--- a/core/src/main/java/org/elasticsearch/ingest/InternalTemplateService.java
+++ b/core/src/main/java/org/elasticsearch/ingest/InternalTemplateService.java
@@ -70,7 +70,7 @@ public class InternalTemplateService implements TemplateService {
 
         private final String value;
 
-        public StringTemplate(String value) {
+        StringTemplate(String value) {
             this.value = value;
         }
 

--- a/core/src/main/java/org/elasticsearch/monitor/fs/FsService.java
+++ b/core/src/main/java/org/elasticsearch/monitor/fs/FsService.java
@@ -73,7 +73,7 @@ public class FsService extends AbstractComponent {
 
         private final FsInfo initialValue;
 
-        public FsInfoCache(TimeValue interval, FsInfo initialValue) {
+        FsInfoCache(TimeValue interval, FsInfo initialValue) {
             super(interval, initialValue);
             this.initialValue = initialValue;
         }

--- a/core/src/main/java/org/elasticsearch/monitor/jvm/JvmGcMonitorService.java
+++ b/core/src/main/java/org/elasticsearch/monitor/jvm/JvmGcMonitorService.java
@@ -71,7 +71,7 @@ public class JvmGcMonitorService extends AbstractLifecycleComponent {
         final int infoThreshold;
         final int debugThreshold;
 
-        public GcOverheadThreshold(final int warnThreshold, final int infoThreshold, final int debugThreshold) {
+        GcOverheadThreshold(final int warnThreshold, final int infoThreshold, final int debugThreshold) {
             this.warnThreshold = warnThreshold;
             this.infoThreshold = infoThreshold;
             this.debugThreshold = debugThreshold;
@@ -355,7 +355,7 @@ public class JvmGcMonitorService extends AbstractLifecycleComponent {
             final JvmStats currentJvmStats;
             final ByteSizeValue maxHeapUsed;
 
-            public SlowGcEvent(
+            SlowGcEvent(
                 final GarbageCollector currentGc,
                 final long collectionCount,
                 final TimeValue collectionTime,
@@ -380,7 +380,7 @@ public class JvmGcMonitorService extends AbstractLifecycleComponent {
         private final Map<String, JvmGcMonitorService.GcThreshold> gcThresholds;
         final GcOverheadThreshold gcOverheadThreshold;
 
-        public JvmMonitor(final Map<String, GcThreshold> gcThresholds, final GcOverheadThreshold gcOverheadThreshold) {
+        JvmMonitor(final Map<String, GcThreshold> gcThresholds, final GcOverheadThreshold gcOverheadThreshold) {
             this.gcThresholds = Objects.requireNonNull(gcThresholds);
             this.gcOverheadThreshold = Objects.requireNonNull(gcOverheadThreshold);
         }
@@ -486,9 +486,9 @@ public class JvmGcMonitorService extends AbstractLifecycleComponent {
             return System.nanoTime();
         }
 
-        abstract void onSlowGc(final Threshold threshold, final long seq, final SlowGcEvent slowGcEvent);
+        abstract void onSlowGc(Threshold threshold, long seq, SlowGcEvent slowGcEvent);
 
-        abstract void onGcOverhead(final Threshold threshold, final long total, final long elapsed, final long seq);
+        abstract void onGcOverhead(Threshold threshold, long total, long elapsed, long seq);
 
     }
 

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsService.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsService.java
@@ -55,7 +55,7 @@ public class OsService extends AbstractComponent {
     }
 
     private class OsStatsCache extends SingleObjectCache<OsStats> {
-        public OsStatsCache(TimeValue interval, OsStats initValue) {
+        OsStatsCache(TimeValue interval, OsStats initValue) {
             super(interval, initValue);
         }
 

--- a/core/src/main/java/org/elasticsearch/monitor/process/ProcessService.java
+++ b/core/src/main/java/org/elasticsearch/monitor/process/ProcessService.java
@@ -54,7 +54,7 @@ public final class ProcessService extends AbstractComponent {
     }
 
     private class ProcessStatsCache extends SingleObjectCache<ProcessStats> {
-        public ProcessStatsCache(TimeValue interval, ProcessStats initValue) {
+        ProcessStatsCache(TimeValue interval, ProcessStats initValue) {
             super(interval, initValue);
         }
 

--- a/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -288,7 +288,7 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
         private int width = 50;
         private final boolean enabled;
 
-        public TerminalProgressInputStream(InputStream is, int expectedTotalSize, Terminal terminal) {
+        TerminalProgressInputStream(InputStream is, int expectedTotalSize, Terminal terminal) {
             super(is, expectedTotalSize);
             this.terminal = terminal;
             this.enabled = expectedTotalSize > 0;

--- a/core/src/main/java/org/elasticsearch/plugins/ProgressInputStream.java
+++ b/core/src/main/java/org/elasticsearch/plugins/ProgressInputStream.java
@@ -37,7 +37,7 @@ abstract class ProgressInputStream extends FilterInputStream {
     private int currentPercent;
     private int count = 0;
 
-    public ProgressInputStream(InputStream is, int expectedTotalSize) {
+    ProgressInputStream(InputStream is, int expectedTotalSize) {
         super(is);
         this.expectedTotalSize = expectedTotalSize;
         this.currentPercent = 0;

--- a/core/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/core/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -401,7 +401,7 @@ public class RepositoriesService extends AbstractComponent implements ClusterSta
 
         private final ActionListener<ClusterStateUpdateResponse> listener;
 
-        public VerifyingRegisterRepositoryListener(String name, final ActionListener<ClusterStateUpdateResponse> listener) {
+        VerifyingRegisterRepositoryListener(String name, final ActionListener<ClusterStateUpdateResponse> listener) {
             this.name = name;
             this.listener = listener;
         }

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -901,11 +901,11 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
         protected final Version version;
 
-        public Context(SnapshotId snapshotId, Version version, IndexId indexId, ShardId shardId) {
+        Context(SnapshotId snapshotId, Version version, IndexId indexId, ShardId shardId) {
             this(snapshotId, version, indexId, shardId, shardId);
         }
 
-        public Context(SnapshotId snapshotId, Version version, IndexId indexId, ShardId shardId, ShardId snapshotShardId) {
+        Context(SnapshotId snapshotId, Version version, IndexId indexId, ShardId shardId, ShardId snapshotShardId) {
             this.snapshotId = snapshotId;
             this.version = version;
             this.shardId = shardId;
@@ -1112,7 +1112,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
          * @param indexId        the id of the index being snapshotted
          * @param snapshotStatus snapshot status to report progress
          */
-        public SnapshotContext(IndexShard shard, SnapshotId snapshotId, IndexId indexId, IndexShardSnapshotStatus snapshotStatus) {
+        SnapshotContext(IndexShard shard, SnapshotId snapshotId, IndexId indexId, IndexShardSnapshotStatus snapshotStatus) {
             super(snapshotId, Version.CURRENT, indexId, shard.shardId());
             this.snapshotStatus = snapshotStatus;
             this.store = shard.store();
@@ -1315,7 +1315,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         private class AbortableInputStream extends FilterInputStream {
             private final String fileName;
 
-            public AbortableInputStream(InputStream delegate, String fileName) {
+            AbortableInputStream(InputStream delegate, String fileName) {
                 super(delegate);
                 this.fileName = fileName;
             }
@@ -1353,7 +1353,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 // we have a hash - check if our repo has a hash too otherwise we have
                 // to calculate it.
                 // we might have multiple parts even though the file is small... make sure we read all of it.
-                try (final InputStream stream = new PartSliceStream(blobContainer, fileInfo)) {
+                try (InputStream stream = new PartSliceStream(blobContainer, fileInfo)) {
                     BytesRefBuilder builder = new BytesRefBuilder();
                     Store.MetadataSnapshot.hashFile(builder, stream, fileInfo.length());
                     BytesRef hash = fileInfo.metadata().hash(); // reset the file infos metadata hash
@@ -1371,7 +1371,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         private final BlobContainer container;
         private final BlobStoreIndexShardSnapshot.FileInfo info;
 
-        public PartSliceStream(BlobContainer container, BlobStoreIndexShardSnapshot.FileInfo info) {
+        PartSliceStream(BlobContainer container, BlobStoreIndexShardSnapshot.FileInfo info) {
             super(info.numberOfParts());
             this.info = info;
             this.container = container;
@@ -1401,7 +1401,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
          * @param snapshotShardId shard in the snapshot that data should be restored from
          * @param recoveryState   recovery state to report progress
          */
-        public RestoreContext(IndexShard shard, SnapshotId snapshotId, Version version, IndexId indexId, ShardId snapshotShardId, RecoveryState recoveryState) {
+        RestoreContext(IndexShard shard, SnapshotId snapshotId, Version version, IndexId indexId, ShardId snapshotShardId, RecoveryState recoveryState) {
             super(snapshotId, version, indexId, shard.shardId(), snapshotShardId);
             this.recoveryState = recoveryState;
             this.targetShard = shard;
@@ -1563,7 +1563,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     stream = new RateLimitingInputStream(partSliceStream, restoreRateLimiter, restoreRateLimitingTimeInNanos::inc);
                 }
 
-                try (final IndexOutput indexOutput = store.createVerifyingOutput(fileInfo.physicalName(), fileInfo.metadata(), IOContext.DEFAULT)) {
+                try (IndexOutput indexOutput = store.createVerifyingOutput(fileInfo.physicalName(), fileInfo.metadata(), IOContext.DEFAULT)) {
                     final byte[] buffer = new byte[BUFFER_SIZE];
                     int length;
                     while ((length = stream.read(buffer)) > 0) {

--- a/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
+++ b/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
@@ -98,7 +98,7 @@ public class BytesRestResponse extends RestResponse {
             this.content = BytesArray.EMPTY;
             this.contentType = TEXT_CONTENT_TYPE;
         } else {
-            try (final XContentBuilder builder = build(channel, status, e)) {
+            try (XContentBuilder builder = build(channel, status, e)) {
                 this.content = builder.bytes();
                 this.contentType = builder.contentType().mediaType();
             }

--- a/core/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestController.java
@@ -343,7 +343,7 @@ public class RestController extends AbstractComponent {
         private final int contentLength;
         private final AtomicBoolean closed = new AtomicBoolean();
 
-        public ResourceHandlingHttpChannel(RestChannel delegate, CircuitBreakerService circuitBreakerService, int contentLength) {
+        ResourceHandlingHttpChannel(RestChannel delegate, CircuitBreakerService circuitBreakerService, int contentLength) {
             this.delegate = delegate;
             this.circuitBreakerService = circuitBreakerService;
             this.contentLength = contentLength;

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/AbstractCatAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/AbstractCatAction.java
@@ -43,11 +43,11 @@ public abstract class AbstractCatAction extends BaseRestHandler {
         super(settings);
     }
 
-    protected abstract RestChannelConsumer doCatRequest(final RestRequest request, final NodeClient client);
+    protected abstract RestChannelConsumer doCatRequest(RestRequest request, NodeClient client);
 
     protected abstract void documentation(StringBuilder sb);
 
-    protected abstract Table getTableWithHeader(final RestRequest request);
+    protected abstract Table getTableWithHeader(RestRequest request);
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestTable.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestTable.java
@@ -461,7 +461,7 @@ public class RestTable {
         private final String column;
         private final boolean reverse;
 
-        public ColumnOrderElement(String column, boolean reverse) {
+        ColumnOrderElement(String column, boolean reverse) {
             this.column = column;
             this.reverse = reverse;
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
@@ -49,7 +49,7 @@ public class BestBucketsDeferringCollector extends DeferringBucketCollector {
         final PackedLongValues docDeltas;
         final PackedLongValues buckets;
 
-        public Entry(LeafReaderContext context, PackedLongValues docDeltas, PackedLongValues buckets) {
+        Entry(LeafReaderContext context, PackedLongValues docDeltas, PackedLongValues buckets) {
             this.context = context;
             this.docDeltas = docDeltas;
             this.buckets = buckets;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/BestDocsDeferringCollector.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/BestDocsDeferringCollector.java
@@ -163,7 +163,7 @@ public class BestDocsDeferringCollector extends DeferringBucketCollector impleme
         private long parentBucket;
         private int matchedDocs;
 
-        public PerParentBucketSamples(long parentBucket, Scorer scorer, LeafReaderContext readerContext) {
+        PerParentBucketSamples(long parentBucket, Scorer scorer, LeafReaderContext readerContext) {
             try {
                 this.parentBucket = parentBucket;
                 tdc = createTopDocsCollector(shardSize);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/MultiBucketsAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/MultiBucketsAggregation.java
@@ -64,7 +64,7 @@ public interface MultiBucketsAggregation extends Aggregation {
 
         Object getProperty(String containingAggName, List<String> path);
 
-        static class SubAggregationComparator<B extends Bucket> implements java.util.Comparator<B> {
+        class SubAggregationComparator<B extends Bucket> implements java.util.Comparator<B> {
 
             private final AggregationPath path;
             private final boolean asc;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregator.java
@@ -149,7 +149,7 @@ public class AdjacencyMatrixAggregator extends BucketsAggregator {
         Bits a;
         Bits b;
 
-        public BitsIntersector(Bits a, Bits b) {
+        BitsIntersector(Bits a, Bits b) {
             super();
             this.a = a;
             this.b = b;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregationBuilder.java
@@ -212,7 +212,7 @@ public class GeoGridAggregationBuilder extends ValuesSourceAggregationBuilder<Va
         private final ValuesSource.GeoPoint valuesSource;
         private final int precision;
 
-        public CellIdSource(ValuesSource.GeoPoint valuesSource, int precision) {
+        CellIdSource(ValuesSource.GeoPoint valuesSource, int precision) {
             this.valuesSource = valuesSource;
             //different GeoPoints could map to the same or different geohash cells.
             this.precision = precision;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
@@ -98,7 +98,7 @@ public class GeoHashGridAggregator extends BucketsAggregator {
 
         long bucketOrd;
 
-        public OrdinalBucket() {
+        OrdinalBucket() {
             super(0, 0, (InternalAggregations) null);
         }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
@@ -52,7 +52,7 @@ public class InternalGeoHashGrid extends InternalMultiBucketAggregation<Internal
         protected long docCount;
         protected InternalAggregations aggregations;
 
-        public Bucket(long geohashAsLong, long docCount, InternalAggregations aggregations) {
+        Bucket(long geohashAsLong, long docCount, InternalAggregations aggregations) {
             this.docCount = docCount;
             this.aggregations = aggregations;
             this.geohashAsLong = geohashAsLong;
@@ -218,7 +218,7 @@ public class InternalGeoHashGrid extends InternalMultiBucketAggregation<Internal
 
     static class BucketPriorityQueue extends PriorityQueue<Bucket> {
 
-        public BucketPriorityQueue(int size) {
+        BucketPriorityQueue(int size) {
             super(size);
         }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
@@ -62,7 +62,7 @@ class DateHistogramAggregator extends BucketsAggregator {
     private final LongHash bucketOrds;
     private long offset;
 
-    public DateHistogramAggregator(String name, AggregatorFactories factories, Rounding rounding, long offset, InternalOrder order,
+    DateHistogramAggregator(String name, AggregatorFactories factories, Rounding rounding, long offset, InternalOrder order,
             boolean keyed,
             long minDocCount, @Nullable ExtendedBounds extendedBounds, @Nullable ValuesSource.Numeric valuesSource,
             DocValueFormat formatter, SearchContext aggregationContext,

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregator.java
@@ -61,7 +61,7 @@ class HistogramAggregator extends BucketsAggregator {
 
     private final LongHash bucketOrds;
 
-    public HistogramAggregator(String name, AggregatorFactories factories, double interval, double offset,
+    HistogramAggregator(String name, AggregatorFactories factories, double interval, double offset,
             InternalOrder order, boolean keyed, long minDocCount, double minBound, double maxBound,
             @Nullable ValuesSource.Numeric valuesSource, DocValueFormat formatter,
             SearchContext context, Aggregator parent,

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorFactory.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorFactory.java
@@ -59,7 +59,7 @@ public class NestedAggregatorFactory extends AggregatorFactory<NestedAggregatorF
 
     private static final class Unmapped extends NonCollectingAggregator {
 
-        public Unmapped(String name, SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
+        Unmapped(String name, SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
                 Map<String, Object> metaData) throws IOException {
             super(name, context, parent, pipelineAggregators, metaData);
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorFactory.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorFactory.java
@@ -58,7 +58,7 @@ public class ReverseNestedAggregatorFactory extends AggregatorFactory<ReverseNes
 
     private static final class Unmapped extends NonCollectingAggregator {
 
-        public Unmapped(String name, SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
+        Unmapped(String name, SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
                 Map<String, Object> metaData) throws IOException {
             super(name, context, parent, pipelineAggregators, metaData);
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceRangeAggregatorFactory.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceRangeAggregatorFactory.java
@@ -88,7 +88,7 @@ public class GeoDistanceRangeAggregatorFactory
         private final DistanceUnit units;
         private final org.elasticsearch.common.geo.GeoPoint origin;
 
-        public DistanceSource(ValuesSource.GeoPoint source, GeoDistance distanceType,
+        DistanceSource(ValuesSource.GeoPoint source, GeoDistance distanceType,
                 org.elasticsearch.common.geo.GeoPoint origin, DistanceUnit units) {
             this.source = source;
             // even if the geo points are unique, there's no guarantee the

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedBytesHashSamplerAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedBytesHashSamplerAggregator.java
@@ -70,7 +70,7 @@ public class DiversifiedBytesHashSamplerAggregator extends SamplerAggregator {
      */
     class DiverseDocsDeferringCollector extends BestDocsDeferringCollector {
 
-        public DiverseDocsDeferringCollector() {
+        DiverseDocsDeferringCollector() {
             super(shardSize, context.bigArrays());
         }
 
@@ -86,7 +86,7 @@ public class DiversifiedBytesHashSamplerAggregator extends SamplerAggregator {
 
             private SortedBinaryDocValues values;
 
-            public ValuesDiversifiedTopDocsCollector(int numHits, int maxHitsPerValue) {
+            ValuesDiversifiedTopDocsCollector(int numHits, int maxHitsPerValue) {
                 super(numHits, maxHitsPerValue);
 
             }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedMapSamplerAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedMapSamplerAggregator.java
@@ -76,7 +76,7 @@ public class DiversifiedMapSamplerAggregator extends SamplerAggregator {
      */
     class DiverseDocsDeferringCollector extends BestDocsDeferringCollector {
 
-        public DiverseDocsDeferringCollector() {
+        DiverseDocsDeferringCollector() {
             super(shardSize, context.bigArrays());
         }
 
@@ -92,7 +92,7 @@ public class DiversifiedMapSamplerAggregator extends SamplerAggregator {
 
             private SortedBinaryDocValues values;
 
-            public ValuesDiversifiedTopDocsCollector(int numHits, int maxHitsPerKey) {
+            ValuesDiversifiedTopDocsCollector(int numHits, int maxHitsPerKey) {
                 super(numHits, maxHitsPerKey);
 
             }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedNumericSamplerAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedNumericSamplerAggregator.java
@@ -63,7 +63,7 @@ public class DiversifiedNumericSamplerAggregator extends SamplerAggregator {
      * This implementation is only for use with a single bucket aggregation.
      */
     class DiverseDocsDeferringCollector extends BestDocsDeferringCollector {
-        public DiverseDocsDeferringCollector() {
+        DiverseDocsDeferringCollector() {
             super(shardSize, context.bigArrays());
         }
 
@@ -78,7 +78,7 @@ public class DiversifiedNumericSamplerAggregator extends SamplerAggregator {
 
             private SortedNumericDocValues values;
 
-            public ValuesDiversifiedTopDocsCollector(int numHits, int maxHitsPerKey) {
+            ValuesDiversifiedTopDocsCollector(int numHits, int maxHitsPerKey) {
                 super(numHits, maxHitsPerKey);
             }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedOrdinalsSamplerAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedOrdinalsSamplerAggregator.java
@@ -65,7 +65,7 @@ public class DiversifiedOrdinalsSamplerAggregator extends SamplerAggregator {
      */
     class DiverseDocsDeferringCollector extends BestDocsDeferringCollector {
 
-        public DiverseDocsDeferringCollector() {
+        DiverseDocsDeferringCollector() {
             super(shardSize, context.bigArrays());
         }
 
@@ -79,7 +79,7 @@ public class DiversifiedOrdinalsSamplerAggregator extends SamplerAggregator {
         class ValuesDiversifiedTopDocsCollector extends DiversifiedTopDocsCollector {
 
 
-            public ValuesDiversifiedTopDocsCollector(int numHits, int maxHitsPerKey) {
+            ValuesDiversifiedTopDocsCollector(int numHits, int maxHitsPerKey) {
                 super(numHits, maxHitsPerKey);
             }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
@@ -40,19 +40,19 @@ public class SignificantLongTerms extends InternalMappedSignificantTerms<Signifi
 
         long term;
 
-        public Bucket(long subsetDf, long subsetSize, long supersetDf, long supersetSize, long term, InternalAggregations aggregations,
+        Bucket(long subsetDf, long subsetSize, long supersetDf, long supersetSize, long term, InternalAggregations aggregations,
                 DocValueFormat format) {
             super(subsetDf, subsetSize, supersetDf, supersetSize, aggregations, format);
             this.term = term;
         }
 
-        public Bucket(long subsetDf, long subsetSize, long supersetDf, long supersetSize, long term, InternalAggregations aggregations,
+        Bucket(long subsetDf, long subsetSize, long supersetDf, long supersetSize, long term, InternalAggregations aggregations,
                 double score) {
             this(subsetDf, subsetSize, supersetDf, supersetSize, term, aggregations, null);
             this.score = score;
         }
 
-        public Bucket(StreamInput in, long subsetSize, long supersetSize, DocValueFormat format) throws IOException {
+        Bucket(StreamInput in, long subsetSize, long supersetSize, DocValueFormat format) throws IOException {
             super(in, subsetSize, supersetSize, format);
             subsetDf = in.readVLong();
             supersetDf = in.readVLong();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTerms.java
@@ -28,7 +28,7 @@ import java.util.List;
  * An aggregation that collects significant terms in comparison to a background set.
  */
 public interface SignificantTerms extends MultiBucketsAggregation, Iterable<SignificantTerms.Bucket> {
-    abstract static class Bucket extends InternalMultiBucketAggregation.InternalBucket {
+    abstract class Bucket extends InternalMultiBucketAggregation.InternalBucket {
 
         long subsetDf;
         long subsetSize;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractStringTermsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractStringTermsAggregator.java
@@ -36,7 +36,7 @@ abstract class AbstractStringTermsAggregator extends TermsAggregator {
 
     protected final boolean showTermDocCountError;
 
-    public AbstractStringTermsAggregator(String name, AggregatorFactories factories, SearchContext context, Aggregator parent,
+    AbstractStringTermsAggregator(String name, AggregatorFactories factories, SearchContext context, Aggregator parent,
             Terms.Order order, DocValueFormat format, BucketCountThresholds bucketCountThresholds, SubAggCollectionMode subAggCollectMode,
             boolean showTermDocCountError, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
         super(name, factories, context, parent, bucketCountThresholds, order, format, subAggCollectMode, pipelineAggregators, metaData);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
@@ -40,7 +40,7 @@ public class DoubleTerms extends InternalMappedTerms<DoubleTerms, DoubleTerms.Bu
     static class Bucket extends InternalTerms.Bucket<Bucket> {
         private final double term;
 
-        public Bucket(double term, long docCount, InternalAggregations aggregations, boolean showDocCountError, long docCountError,
+        Bucket(double term, long docCount, InternalAggregations aggregations, boolean showDocCountError, long docCountError,
                 DocValueFormat format) {
             super(docCount, aggregations, showDocCountError, docCountError, format);
             this.term = term;
@@ -49,7 +49,7 @@ public class DoubleTerms extends InternalMappedTerms<DoubleTerms, DoubleTerms.Bu
         /**
          * Read from a stream.
          */
-        public Bucket(StreamInput in, DocValueFormat format, boolean showDocCountError) throws IOException {
+        Bucket(StreamInput in, DocValueFormat format, boolean showDocCountError) throws IOException {
             super(in, format, showDocCountError);
             term = in.readDouble();
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalOrder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalOrder.java
@@ -241,11 +241,11 @@ class InternalOrder extends Terms.Order {
 
         private final List<Terms.Order> orderElements;
 
-        public CompoundOrder(List<Terms.Order> compoundOrder) {
+        CompoundOrder(List<Terms.Order> compoundOrder) {
             this(compoundOrder, true);
         }
 
-        public CompoundOrder(List<Terms.Order> compoundOrder, boolean absoluteOrdering) {
+        CompoundOrder(List<Terms.Order> compoundOrder, boolean absoluteOrdering) {
             this.orderElements = new LinkedList<>(compoundOrder);
             Terms.Order lastElement = compoundOrder.get(compoundOrder.size() - 1);
             if (absoluteOrdering && !(InternalOrder.TERM_ASC == lastElement || InternalOrder.TERM_DESC == lastElement)) {
@@ -300,7 +300,7 @@ class InternalOrder extends Terms.Order {
             private List<Terms.Order> compoundOrder;
             private Aggregator aggregator;
 
-            public CompoundOrderComparator(List<Terms.Order> compoundOrder, Aggregator aggregator) {
+            CompoundOrderComparator(List<Terms.Order> compoundOrder, Aggregator aggregator) {
                 this.compoundOrder = compoundOrder;
                 this.aggregator = aggregator;
             }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/Terms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/Terms.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public interface Terms extends MultiBucketsAggregation {
 
-    static enum ValueType {
+    enum ValueType {
 
         STRING(org.elasticsearch.search.aggregations.support.ValueType.STRING),
         LONG(org.elasticsearch.search.aggregations.support.ValueType.LONG),
@@ -41,7 +41,7 @@ public interface Terms extends MultiBucketsAggregation {
 
         final org.elasticsearch.search.aggregations.support.ValueType scriptValueType;
 
-        private ValueType(org.elasticsearch.search.aggregations.support.ValueType scriptValueType) {
+        ValueType(org.elasticsearch.search.aggregations.support.ValueType scriptValueType) {
             this.scriptValueType = scriptValueType;
         }
 
@@ -62,7 +62,7 @@ public interface Terms extends MultiBucketsAggregation {
     /**
      * A bucket that is associated with a single term
      */
-    abstract static class Bucket extends InternalMultiBucketAggregation.InternalBucket {
+    abstract class Bucket extends InternalMultiBucketAggregation.InternalBucket {
 
         public abstract Number getKeyAsNumber();
 
@@ -97,7 +97,7 @@ public interface Terms extends MultiBucketsAggregation {
     /**
      * Determines the order by which the term buckets will be sorted
      */
-    abstract static class Order implements ToXContent {
+    abstract class Order implements ToXContent {
 
         /**
          * @return a bucket ordering strategy that sorts buckets by their document counts (ascending or descending)

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/support/IncludeExclude.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/support/IncludeExclude.java
@@ -223,7 +223,7 @@ public class IncludeExclude implements Writeable, ToXContent {
         private final Set<BytesRef> valids;
         private final Set<BytesRef> invalids;
 
-        public TermListBackedStringFilter(Set<BytesRef> includeValues, Set<BytesRef> excludeValues) {
+        TermListBackedStringFilter(Set<BytesRef> includeValues, Set<BytesRef> excludeValues) {
             this.valids = includeValues;
             this.invalids = excludeValues;
         }
@@ -295,7 +295,7 @@ public class IncludeExclude implements Writeable, ToXContent {
         private final SortedSet<BytesRef> includeValues;
         private final SortedSet<BytesRef> excludeValues;
 
-        public TermListBackedOrdinalsFilter(SortedSet<BytesRef> includeValues, SortedSet<BytesRef> excludeValues) {
+        TermListBackedOrdinalsFilter(SortedSet<BytesRef> includeValues, SortedSet<BytesRef> excludeValues) {
             this.includeValues = includeValues;
             this.excludeValues = excludeValues;
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -327,7 +327,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
 
             private final SortedNumericDocValues values;
 
-            public Long(SortedNumericDocValues values) {
+            Long(SortedNumericDocValues values) {
                 this.values = values;
             }
 
@@ -351,7 +351,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
 
             private final SortedNumericDoubleValues values;
 
-            public Double(SortedNumericDoubleValues values) {
+            Double(SortedNumericDoubleValues values) {
                 this.values = values;
             }
 
@@ -377,7 +377,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
 
             private final SortedBinaryDocValues values;
 
-            public Bytes(SortedBinaryDocValues values) {
+            Bytes(SortedBinaryDocValues values) {
                 this.values = values;
             }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/HyperLogLogPlusPlus.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/HyperLogLogPlusPlus.java
@@ -433,7 +433,7 @@ public final class HyperLogLogPlusPlus implements Releasable {
         private final BytesRef readSpare;
         private final ByteBuffer writeSpare;
 
-        public Hashset(long initialBucketCount) {
+        Hashset(long initialBucketCount) {
             capacity = m / 4; // because ints take 4 bytes
             threshold = (int) (capacity * MAX_LOAD_FACTOR);
             mask = capacity - 1;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBounds.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBounds.java
@@ -188,7 +188,7 @@ public class InternalGeoBounds extends InternalMetricsAggregation implements Geo
         private final GeoPoint topLeft;
         private final GeoPoint bottomRight;
         
-        public BoundingBox(GeoPoint topLeft, GeoPoint bottomRight) {
+        BoundingBox(GeoPoint topLeft, GeoPoint bottomRight) {
             this.topLeft = topLeft;
             this.bottomRight = bottomRight;
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesMethod.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesMethod.java
@@ -41,7 +41,7 @@ public enum PercentilesMethod implements Writeable {
 
     private final ParseField parseField;
 
-    private PercentilesMethod(String name, String... deprecatedNames) {
+    PercentilesMethod(String name, String... deprecatedNames) {
         this.parseField = new ParseField(name, deprecatedNames);
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/hdr/AbstractInternalHDRPercentiles.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/hdr/AbstractInternalHDRPercentiles.java
@@ -40,7 +40,7 @@ abstract class AbstractInternalHDRPercentiles extends InternalNumericMetricsAggr
     protected final DoubleHistogram state;
     private final boolean keyed;
 
-    public AbstractInternalHDRPercentiles(String name, double[] keys, DoubleHistogram state, boolean keyed, DocValueFormat format,
+    AbstractInternalHDRPercentiles(String name, double[] keys, DoubleHistogram state, boolean keyed, DocValueFormat format,
             List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/tdigest/AbstractInternalTDigestPercentiles.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/tdigest/AbstractInternalTDigestPercentiles.java
@@ -37,7 +37,7 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
     protected final TDigestState state;
     private final boolean keyed;
 
-    public AbstractInternalTDigestPercentiles(String name, double[] keys, TDigestState state, boolean keyed, DocValueFormat formatter,
+    AbstractInternalTDigestPercentiles(String name, double[] keys, TDigestState state, boolean keyed, DocValueFormat formatter,
             List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStats.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStats.java
@@ -67,7 +67,7 @@ public interface ExtendedStats extends Stats {
     String getVarianceAsString();
 
 
-    public enum Bounds {
+    enum Bounds {
         UPPER, LOWER
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpers.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpers.java
@@ -52,7 +52,7 @@ public class BucketHelpers {
      * "insert_zeros": empty buckets will be filled with zeros for all metrics
      * "ignore": empty buckets will simply be ignored
      */
-    public static enum GapPolicy {
+    public enum GapPolicy {
         INSERT_ZEROS((byte) 0, "insert_zeros"), SKIP((byte) 1, "skip");
 
         /**
@@ -87,7 +87,7 @@ public class BucketHelpers {
         private final byte id;
         private final ParseField parseField;
 
-        private GapPolicy(byte id, String name) {
+        GapPolicy(byte id, String name) {
             this.id = id;
             this.parseField = new ParseField(name);
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValueType.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValueType.java
@@ -95,7 +95,7 @@ public enum ValueType implements Writeable {
     private final byte id;
     private String preferredName;
 
-    private ValueType(byte id, String description, String preferredName, ValuesSourceType valuesSourceType,
+    ValueType(byte id, String description, String preferredName, ValuesSourceType valuesSourceType,
             Class<? extends IndexFieldData> fieldDataType, DocValueFormat defaultFormat) {
         this.id = id;
         this.description = description;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -318,7 +318,7 @@ public abstract class ValuesSource {
                 private final SortedNumericDocValues longValues;
                 private final LeafSearchScript script;
 
-                public LongValues(SortedNumericDocValues values, LeafSearchScript script) {
+                LongValues(SortedNumericDocValues values, LeafSearchScript script) {
                     this.longValues = values;
                     this.script = script;
                 }
@@ -346,7 +346,7 @@ public abstract class ValuesSource {
                 private final SortedNumericDoubleValues doubleValues;
                 private final LeafSearchScript script;
 
-                public DoubleValues(SortedNumericDoubleValues values, LeafSearchScript script) {
+                DoubleValues(SortedNumericDoubleValues values, LeafSearchScript script) {
                     this.doubleValues = values;
                     this.script = script;
                 }
@@ -462,7 +462,7 @@ public abstract class ValuesSource {
             private final SortedBinaryDocValues bytesValues;
             private final LeafSearchScript script;
 
-            public BytesValues(SortedBinaryDocValues bytesValues, LeafSearchScript script) {
+            BytesValues(SortedBinaryDocValues bytesValues, LeafSearchScript script) {
                 this.bytesValues = bytesValues;
                 this.script = script;
             }

--- a/core/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/CustomQueryScorer.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/CustomQueryScorer.java
@@ -66,11 +66,11 @@ public final class CustomQueryScorer extends QueryScorer {
 
     private static class CustomWeightedSpanTermExtractor extends WeightedSpanTermExtractor {
 
-        public CustomWeightedSpanTermExtractor() {
+        CustomWeightedSpanTermExtractor() {
             super();
         }
 
-        public CustomWeightedSpanTermExtractor(String defaultField) {
+        CustomWeightedSpanTermExtractor(String defaultField) {
             super(defaultField);
         }
 

--- a/core/src/main/java/org/elasticsearch/search/profile/query/ProfileCollector.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/query/ProfileCollector.java
@@ -34,7 +34,7 @@ final class ProfileCollector extends FilterCollector {
     private long time;
 
     /** Sole constructor. */
-    public ProfileCollector(Collector in) {
+    ProfileCollector(Collector in) {
         super(in);
     }
 

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
@@ -108,7 +108,7 @@ public class CompletionSuggester extends Suggester<CompletionSuggestionContext> 
 
             private List<TopSuggestDocs.SuggestScoreDoc> suggestScoreDocs;
 
-            public SuggestDoc(int doc, CharSequence key, CharSequence context, float score) {
+            SuggestDoc(int doc, CharSequence key, CharSequence context, float score) {
                 super(doc, key, context, score);
             }
 
@@ -152,7 +152,7 @@ public class CompletionSuggester extends Suggester<CompletionSuggestionContext> 
 
         private static final class SuggestDocPriorityQueue extends PriorityQueue<SuggestDoc> {
 
-            public SuggestDocPriorityQueue(int maxSize) {
+            SuggestDocPriorityQueue(int maxSize) {
                 super(maxSize);
             }
 
@@ -184,7 +184,7 @@ public class CompletionSuggester extends Suggester<CompletionSuggestionContext> 
         private final SuggestDocPriorityQueue pq;
         private final Map<Integer, SuggestDoc> scoreDocMap;
 
-        public TopDocumentsCollector(int num) {
+        TopDocumentsCollector(int num) {
             super(1); // TODO hack, we don't use the underlying pq, so we allocate a size of 1
             this.num = num;
             this.scoreDocMap = new LinkedHashMap<>(num);

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
@@ -210,7 +210,7 @@ public class CompletionSuggestionBuilder extends SuggestionBuilder<CompletionSug
     private static class InnerBuilder extends CompletionSuggestionBuilder {
         private String field;
 
-        public InnerBuilder() {
+        InnerBuilder() {
             super("_na_");
         }
 

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMappings.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMappings.java
@@ -115,7 +115,7 @@ public class ContextMappings implements ToXContent {
         private final Map<String, Set<CharSequence>> contexts;
         private final ParseContext.Document document;
 
-        public TypedContextField(String name, String value, int weight, Map<String, Set<CharSequence>> contexts,
+        TypedContextField(String name, String value, int weight, Map<String, Set<CharSequence>> contexts,
                                  ParseContext.Document document) {
             super(name, value, weight);
             this.contexts = contexts;

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/CandidateScorer.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/CandidateScorer.java
@@ -29,7 +29,7 @@ final class CandidateScorer {
     private final int maxNumCorrections;
     private final int gramSize;
 
-    public CandidateScorer(WordScorer scorer, int maxNumCorrections, int gramSize) {
+    CandidateScorer(WordScorer scorer, int maxNumCorrections, int gramSize) {
         this.scorer = scorer;
         this.maxNumCorrections = maxNumCorrections;
         this.gramSize = gramSize;

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
@@ -60,7 +60,7 @@ class PhraseSuggestionContext extends SuggestionContext {
     private Map<String, Object> collateScriptParams = new HashMap<>(1);
     private WordScorer.WordScorerFactory scorer = DEFAULT_SCORER;
 
-    public PhraseSuggestionContext(QueryShardContext shardContext) {
+    PhraseSuggestionContext(QueryShardContext shardContext) {
         super(PhraseSuggester.INSTANCE, shardContext);
     }
 

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/StupidBackoffScorer.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/StupidBackoffScorer.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 class StupidBackoffScorer extends WordScorer {
     private final double discount;
 
-    public StupidBackoffScorer(IndexReader reader, Terms terms,String field, double realWordLikelyhood, BytesRef separator, double discount)
+    StupidBackoffScorer(IndexReader reader, Terms terms,String field, double realWordLikelyhood, BytesRef separator, double discount)
             throws IOException {
         super(reader, terms, field, realWordLikelyhood, separator);
         this.discount = discount;

--- a/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionContext.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionContext.java
@@ -26,7 +26,7 @@ final class TermSuggestionContext extends SuggestionContext {
 
     private final DirectSpellcheckerSettings settings = new DirectSpellcheckerSettings();
 
-    public TermSuggestionContext(QueryShardContext shardContext) {
+    TermSuggestionContext(QueryShardContext shardContext) {
         super(TermSuggester.INSTANCE, shardContext);
     }
 

--- a/core/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -636,7 +636,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
 
         private final Logger logger;
 
-        public CleanRestoreStateTaskExecutor(Logger logger) {
+        CleanRestoreStateTaskExecutor(Logger logger) {
             this.logger = logger;
         }
 

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -447,7 +447,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         private final CreateSnapshotListener userCreateSnapshotListener;
         private final Exception e;
 
-        public CleanupAfterErrorListener(SnapshotsInProgress.Entry snapshot, boolean snapshotCreated, CreateSnapshotListener userCreateSnapshotListener, Exception e) {
+        CleanupAfterErrorListener(SnapshotsInProgress.Entry snapshot, boolean snapshotCreated, CreateSnapshotListener userCreateSnapshotListener, Exception e) {
             this.snapshot = snapshot;
             this.snapshotCreated = snapshotCreated;
             this.userCreateSnapshotListener = userCreateSnapshotListener;

--- a/core/src/main/java/org/elasticsearch/tasks/TaskManager.java
+++ b/core/src/main/java/org/elasticsearch/tasks/TaskManager.java
@@ -374,7 +374,7 @@ public class TaskManager extends AbstractComponent implements ClusterStateApplie
 
         private volatile Runnable cancellationListener = null;
 
-        public CancellableTaskHolder(CancellableTask task) {
+        CancellableTaskHolder(CancellableTask task) {
             this.task = task;
         }
 

--- a/core/src/main/java/org/elasticsearch/threadpool/ExecutorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ExecutorBuilder.java
@@ -82,7 +82,7 @@ public abstract class ExecutorBuilder<U extends ExecutorBuilder.ExecutorSettings
 
         protected final String nodeName;
 
-        public ExecutorSettings(String nodeName) {
+        ExecutorSettings(String nodeName) {
             this.nodeName = nodeName;
         }
 

--- a/core/src/main/java/org/elasticsearch/threadpool/FixedExecutorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/FixedExecutorBuilder.java
@@ -123,7 +123,7 @@ public final class FixedExecutorBuilder extends ExecutorBuilder<FixedExecutorBui
         private final int size;
         private final int queueSize;
 
-        public FixedExecutorSettings(final String nodeName, final int size, final int queueSize) {
+        FixedExecutorSettings(final String nodeName, final int size, final int queueSize) {
             super(nodeName);
             this.size = size;
             this.queueSize = queueSize;

--- a/core/src/main/java/org/elasticsearch/threadpool/ScalingExecutorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ScalingExecutorBuilder.java
@@ -118,7 +118,7 @@ public final class ScalingExecutorBuilder extends ExecutorBuilder<ScalingExecuto
         private final int max;
         private final TimeValue keepAlive;
 
-        public ScalingExecutorSettings(final String nodeName, final int core, final int max, final TimeValue keepAlive) {
+        ScalingExecutorSettings(final String nodeName, final int core, final int max, final TimeValue keepAlive) {
             super(nodeName);
             this.core = core;
             this.max = max;

--- a/core/src/main/java/org/elasticsearch/transport/RequestHandlerRegistry.java
+++ b/core/src/main/java/org/elasticsearch/transport/RequestHandlerRegistry.java
@@ -96,7 +96,7 @@ public class RequestHandlerRegistry<Request extends TransportRequest> {
 
         private final TaskManager taskManager;
 
-        public TransportChannelWrapper(TaskManager taskManager, Task task, TransportChannel channel) {
+        TransportChannelWrapper(TaskManager taskManager, Task task, TransportChannel channel) {
             super(channel);
             this.task = task;
             this.taskManager = taskManager;

--- a/core/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/core/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -235,7 +235,7 @@ public abstract class TcpTransport<Channel> extends AbstractLifecycleComponent i
         final AtomicReference<Exception> exceptionRef = new AtomicReference<>();
         final Channel channel;
 
-        public HandshakeResponseHandler(Channel channel) {
+        HandshakeResponseHandler(Channel channel) {
             this.channel = channel;
         }
 
@@ -1444,7 +1444,7 @@ public abstract class TcpTransport<Channel> extends AbstractLifecycleComponent i
         private final TransportRequest request;
         private final TransportChannel transportChannel;
 
-        public RequestHandler(RequestHandlerRegistry reg, TransportRequest request, TransportChannel transportChannel) {
+        RequestHandler(RequestHandlerRegistry reg, TransportRequest request, TransportChannel transportChannel) {
             this.reg = reg;
             this.request = request;
             this.transportChannel = transportChannel;

--- a/core/src/main/java/org/elasticsearch/transport/TransportInterceptor.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportInterceptor.java
@@ -55,8 +55,8 @@ public interface TransportInterceptor {
      * {@link #sendRequest(Transport.Connection, String, TransportRequest, TransportRequestOptions, TransportResponseHandler)}
      */
     interface AsyncSender {
-        <T extends TransportResponse> void sendRequest(Transport.Connection connection, final String action,
-                                                       final TransportRequest request, final TransportRequestOptions options,
+        <T extends TransportResponse> void sendRequest(Transport.Connection connection, String action,
+                                                       TransportRequest request, TransportRequestOptions options,
                                                        TransportResponseHandler<T> handler);
     }
 }

--- a/core/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -398,10 +398,10 @@ public class TransportService extends AbstractLifecycleComponent {
         private ClusterName clusterName;
         private Version version;
 
-        public HandshakeResponse() {
+        HandshakeResponse() {
         }
 
-        public HandshakeResponse(DiscoveryNode discoveryNode, ClusterName clusterName, Version version) {
+        HandshakeResponse(DiscoveryNode discoveryNode, ClusterName clusterName, Version version) {
             this.discoveryNode = discoveryNode;
             this.version = version;
             this.clusterName = clusterName;
@@ -1049,7 +1049,7 @@ public class TransportService extends AbstractLifecycleComponent {
         final TransportServiceAdapter adapter;
         final ThreadPool threadPool;
 
-        public DirectResponseChannel(Logger logger, DiscoveryNode localNode, String action, long requestId,
+        DirectResponseChannel(Logger logger, DiscoveryNode localNode, String action, long requestId,
                                      TransportServiceAdapter adapter, ThreadPool threadPool) {
             this.logger = logger;
             this.localNode = localNode;

--- a/core/src/main/java/org/elasticsearch/watcher/FileWatcher.java
+++ b/core/src/main/java/org/elasticsearch/watcher/FileWatcher.java
@@ -80,7 +80,7 @@ public class FileWatcher extends AbstractResourceWatcher<FileChangesListener> {
         private boolean isDirectory;
         private FileObserver[] children;
 
-        public FileObserver(Path file) {
+        FileObserver(Path file) {
             this.file = file;
         }
 

--- a/core/src/test/java/org/apache/lucene/grouping/CollapsingTopDocsCollectorTests.java
+++ b/core/src/test/java/org/apache/lucene/grouping/CollapsingTopDocsCollectorTests.java
@@ -58,7 +58,7 @@ public class CollapsingTopDocsCollectorTests extends ESTestCase {
     private static class SegmentSearcher extends IndexSearcher {
         private final List<LeafReaderContext> ctx;
 
-        public SegmentSearcher(LeafReaderContext ctx, IndexReaderContext parent) {
+        SegmentSearcher(LeafReaderContext ctx, IndexReaderContext parent) {
             super(parent);
             this.ctx = Collections.singletonList(ctx);
         }

--- a/core/src/test/java/org/elasticsearch/action/ActionModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/action/ActionModuleTests.java
@@ -144,7 +144,7 @@ public class ActionModuleTests extends ESTestCase {
 
     public void testPluginCanRegisterRestHandler() {
         class FakeHandler implements RestHandler {
-            public FakeHandler(RestController restController) {
+            FakeHandler(RestController restController) {
                 restController.registerHandler(Method.GET, "/_dummy", this);
             }
             @Override

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
@@ -79,7 +79,7 @@ public class TestTaskPlugin extends Plugin implements ActionPlugin {
 
         private volatile boolean blocked = true;
 
-        public TestTask(long id, String type, String action, String description, TaskId parentTaskId) {
+        TestTask(long id, String type, String action, String description, TaskId parentTaskId) {
             super(id, type, action, description, parentTaskId);
         }
 

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -190,7 +190,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
 
         private final String status;
 
-        public TestTaskResponse(StreamInput in) throws IOException {
+        TestTaskResponse(StreamInput in) throws IOException {
             status = in.readString();
         }
 
@@ -199,7 +199,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
             out.writeString(status);
         }
 
-        public TestTaskResponse(String status) {
+        TestTaskResponse(String status) {
             this.status = status;
         }
 
@@ -216,11 +216,11 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
 
         private List<TestTaskResponse> tasks;
 
-        public TestTasksResponse() {
+        TestTasksResponse() {
 
         }
 
-        public TestTasksResponse(List<TestTaskResponse> tasks, List<TaskOperationFailure> taskFailures,
+        TestTasksResponse(List<TestTaskResponse> tasks, List<TaskOperationFailure> taskFailures,
                 List<? extends FailedNodeException> nodeFailures) {
             super(taskFailures, nodeFailures);
             this.tasks = tasks == null ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(tasks));

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
@@ -219,7 +219,7 @@ public class IndicesShardStoreRequestIT extends ESIntegTestCase {
     private static final class IndexNodePredicate implements Predicate<Settings> {
         private final Set<String> nodesWithShard;
 
-        public IndexNodePredicate(String index) {
+        IndexNodePredicate(String index) {
             this.nodesWithShard = findNodesWithShard(index);
         }
 

--- a/core/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
@@ -200,7 +200,7 @@ public class TransportBulkActionTookTests extends ESTestCase {
     }
 
     static class Resolver extends IndexNameExpressionResolver {
-        public Resolver(Settings settings) {
+        Resolver(Settings settings) {
             super(settings);
         }
 
@@ -212,7 +212,7 @@ public class TransportBulkActionTookTests extends ESTestCase {
 
     static class TestTransportBulkAction extends TransportBulkAction {
 
-        public TestTransportBulkAction(
+        TestTransportBulkAction(
                 Settings settings,
                 ThreadPool threadPool,
                 TransportService transportService,
@@ -251,7 +251,7 @@ public class TransportBulkActionTookTests extends ESTestCase {
 
     static class TestTransportCreateIndexAction extends TransportCreateIndexAction {
 
-        public TestTransportCreateIndexAction(
+        TestTransportCreateIndexAction(
                 Settings settings,
                 TransportService transportService,
                 ClusterService clusterService,

--- a/core/src/test/java/org/elasticsearch/action/bulk/byscroll/AsyncBulkByScrollActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/byscroll/AsyncBulkByScrollActionTests.java
@@ -663,7 +663,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     }
 
     private class DummyAsyncBulkByScrollAction extends AbstractAsyncBulkByScrollAction<DummyAbstractBulkByScrollRequest> {
-        public DummyAsyncBulkByScrollAction() {
+        DummyAsyncBulkByScrollAction() {
             super(testTask, AsyncBulkByScrollActionTests.this.logger, new ParentTaskAssigningClient(client, localNode, testTask),
                     client.threadPool(), testRequest, null, null, listener);
         }
@@ -691,7 +691,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     }
 
     private static class DummyAbstractBulkByScrollRequest extends AbstractBulkByScrollRequest<DummyAbstractBulkByScrollRequest> {
-        public DummyAbstractBulkByScrollRequest(SearchRequest searchRequest) {
+        DummyAbstractBulkByScrollRequest(SearchRequest searchRequest) {
             super(searchRequest, true);
         }
 
@@ -729,7 +729,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         private int searchesToReject = 0;
         private int scrollsToReject = 0;
 
-        public MyMockClient(Client in) {
+        MyMockClient(Client in) {
             super(in);
         }
 
@@ -856,7 +856,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         private final Request request;
         private final ActionListener<Response> listener;
 
-        public RequestAndListener(Request request, ActionListener<Response> listener) {
+        RequestAndListener(Request request, ActionListener<Response> listener) {
             this.request = request;
             this.listener = listener;
         }

--- a/core/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
@@ -221,7 +221,7 @@ public class TransportActionFilterChainTests extends ESTestCase {
         }
     }
 
-    private static enum RequestOperation implements RequestCallback {
+    private enum RequestOperation implements RequestCallback {
         CONTINUE_PROCESSING {
             @Override
             public <Request extends ActionRequest, Response extends ActionResponse> void execute(Task task, String action, Request request,

--- a/core/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
@@ -116,7 +116,7 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
     class TestTransportBroadcastByNodeAction extends TransportBroadcastByNodeAction<Request, Response, TransportBroadcastByNodeAction.EmptyResult> {
         private final Map<ShardRouting, Object> shards = new HashMap<>();
 
-        public TestTransportBroadcastByNodeAction(Settings settings, TransportService transportService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver, Supplier<Request> request, String executor) {
+        TestTransportBroadcastByNodeAction(Settings settings, TransportService transportService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver, Supplier<Request> request, String executor) {
             super(settings, "indices:admin/test", THREAD_POOL, TransportBroadcastByNodeActionTests.this.clusterService, transportService, actionFilters, indexNameExpressionResolver, request, executor);
         }
 
@@ -170,7 +170,7 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
     }
 
     class MyResolver extends IndexNameExpressionResolver {
-        public MyResolver() {
+        MyResolver() {
             super(Settings.EMPTY);
         }
 

--- a/core/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
@@ -202,7 +202,7 @@ public class BroadcastReplicationTests extends ESTestCase {
     private class TestBroadcastReplicationAction extends TransportBroadcastReplicationAction<DummyBroadcastRequest, BroadcastResponse, BasicReplicationRequest, ReplicationResponse> {
         protected final Set<Tuple<ShardId, ActionListener<ReplicationResponse>>> capturedShardRequests = ConcurrentCollections.newConcurrentSet();
 
-        public TestBroadcastReplicationAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
+        TestBroadcastReplicationAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                               TransportService transportService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
                                               TransportReplicationAction replicatedBroadcastShardAction) {
             super("test-broadcast-replication-action", DummyBroadcastRequest::new, settings, threadPool, clusterService, transportService,

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
@@ -403,7 +403,7 @@ public class ReplicationOperationTests extends ESTestCase {
             private final Request request;
             private ShardInfo shardInfo;
 
-            public Result(Request request) {
+            Result(Request request) {
                 this.request = request;
             }
 
@@ -517,12 +517,12 @@ public class ReplicationOperationTests extends ESTestCase {
     }
 
     class TestReplicationOperation extends ReplicationOperation<Request, Request, TestPrimary.Result> {
-        public TestReplicationOperation(Request request, Primary<Request, Request, TestPrimary.Result> primary,
+        TestReplicationOperation(Request request, Primary<Request, Request, TestPrimary.Result> primary,
                 ActionListener<TestPrimary.Result> listener, Replicas<Request> replicas, Supplier<ClusterState> clusterStateSupplier) {
             this(request, primary, listener, true, replicas, clusterStateSupplier, ReplicationOperationTests.this.logger, "test");
         }
 
-        public TestReplicationOperation(Request request, Primary<Request, Request, TestPrimary.Result> primary,
+        TestReplicationOperation(Request request, Primary<Request, Request, TestPrimary.Result> primary,
                 ActionListener<TestPrimary.Result> listener, boolean executeOnReplicas,
                 Replicas<Request> replicas, Supplier<ClusterState> clusterStateSupplier, Logger logger, String opType) {
             super(request, primary, listener, executeOnReplicas, replicas, clusterStateSupplier, logger, opType);

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -1157,7 +1157,7 @@ public class TransportReplicationActionTests extends ESTestCase {
     }
 
     class NoopReplicationOperation extends ReplicationOperation<Request, Request, Action.PrimaryResult<Request, Response>> {
-        public NoopReplicationOperation(Request request, ActionListener<Action.PrimaryResult<Request, Response>> listener) {
+        NoopReplicationOperation(Request request, ActionListener<Action.PrimaryResult<Request, Response>> listener) {
             super(request, null, listener, true, null, null, TransportReplicationActionTests.this.logger, "noop");
         }
 

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
@@ -223,7 +223,7 @@ public class TransportWriteActionTests extends ESTestCase {
     }
 
     private static class TestRequest extends ReplicatedWriteRequest<TestRequest> {
-        public TestRequest() {
+        TestRequest() {
             setShardId(new ShardId("test", "test", 1));
         }
 

--- a/core/src/test/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationActionTests.java
@@ -88,7 +88,7 @@ public class TransportInstanceSingleOperationActionTests extends ESTestCase {
     class TestTransportInstanceSingleOperationAction extends TransportInstanceSingleOperationAction<Request, Response> {
         private final Map<ShardId, Object> shards = new HashMap<>();
 
-        public TestTransportInstanceSingleOperationAction(Settings settings, String actionName, TransportService transportService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver, Supplier<Request> request) {
+        TestTransportInstanceSingleOperationAction(Settings settings, String actionName, TransportService transportService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver, Supplier<Request> request) {
             super(settings, actionName, THREAD_POOL, TransportInstanceSingleOperationActionTests.this.clusterService, transportService, actionFilters, indexNameExpressionResolver, request);
         }
 
@@ -122,7 +122,7 @@ public class TransportInstanceSingleOperationActionTests extends ESTestCase {
     }
 
     class MyResolver extends IndexNameExpressionResolver {
-        public MyResolver() {
+        MyResolver() {
             super(Settings.EMPTY);
         }
 

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCheckTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCheckTests.java
@@ -246,7 +246,7 @@ public class BootstrapCheckTests extends ESTestCase {
             private final boolean isMemoryLocked;
             private final boolean shouldFail;
 
-            public MlockallCheckTestCase(final boolean mlockallSet, final boolean isMemoryLocked, final boolean shouldFail) {
+            MlockallCheckTestCase(final boolean mlockallSet, final boolean isMemoryLocked, final boolean shouldFail) {
                 this.mlockallSet = mlockallSet;
                 this.isMemoryLocked = isMemoryLocked;
                 this.shouldFail = shouldFail;

--- a/core/src/test/java/org/elasticsearch/bwcompat/RepositoryUpgradabilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/RepositoryUpgradabilityIT.java
@@ -154,7 +154,7 @@ public class RepositoryUpgradabilityIT extends AbstractSnapshotIntegTestCase {
         final String prefix = "repo";
         final List<String> repoVersions = new ArrayList<>();
         final Path repoFiles = getBwcIndicesPath();
-        try (final DirectoryStream<Path> dirStream = Files.newDirectoryStream(repoFiles, prefix + "-*.zip")) {
+        try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(repoFiles, prefix + "-*.zip")) {
             for (final Path entry : dirStream) {
                 final String fileName = entry.getFileName().toString();
                 String version = fileName.substring(prefix.length() + 1);

--- a/core/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
@@ -203,7 +203,7 @@ public class TransportClientNodesServiceTests extends ESTestCase {
     public void testListenerFailures() throws InterruptedException {
         int iters = iterations(10, 100);
         for (int i = 0; i <iters; i++) {
-            try(final TestIteration iteration = new TestIteration()) {
+            try(TestIteration iteration = new TestIteration()) {
                 iteration.transport.endConnectMode(); // stop transport from responding early
                 final CountDownLatch latch = new CountDownLatch(1);
                 final AtomicInteger finalFailures = new AtomicInteger();
@@ -285,7 +285,7 @@ public class TransportClientNodesServiceTests extends ESTestCase {
     public void testConnectedNodes() {
         int iters = iterations(10, 100);
         for (int i = 0; i <iters; i++) {
-            try(final TestIteration iteration = new TestIteration()) {
+            try(TestIteration iteration = new TestIteration()) {
                 assertThat(iteration.transportClientNodesService.connectedNodes().size(), lessThanOrEqualTo(iteration.listNodesCount));
                 for (DiscoveryNode discoveryNode : iteration.transportClientNodesService.connectedNodes()) {
                     assertThat(discoveryNode.getHostName(), startsWith("liveness-"));
@@ -307,7 +307,7 @@ public class TransportClientNodesServiceTests extends ESTestCase {
 
     private void checkRemoveAddress(boolean sniff) {
         Object[] extraSettings = {TransportClient.CLIENT_TRANSPORT_SNIFF.getKey(), sniff};
-        try(final TestIteration iteration = new TestIteration(extraSettings)) {
+        try(TestIteration iteration = new TestIteration(extraSettings)) {
             final TransportClientNodesService service = iteration.transportClientNodesService;
             assertEquals(iteration.listNodesCount + iteration.sniffNodesCount, service.connectedNodes().size());
             final TransportAddress addressToRemove = randomFrom(iteration.listNodeAddresses);

--- a/core/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionTests.java
@@ -72,7 +72,7 @@ public class ShardStateActionTests extends ESTestCase {
     private ClusterService clusterService;
 
     private static class TestShardStateAction extends ShardStateAction {
-        public TestShardStateAction(Settings settings, ClusterService clusterService, TransportService transportService, AllocationService allocationService, RoutingService routingService) {
+        TestShardStateAction(Settings settings, ClusterService clusterService, TransportService transportService, AllocationService allocationService, RoutingService routingService) {
             super(settings, clusterService, transportService, allocationService, routingService, THREAD_POOL);
         }
 

--- a/core/src/test/java/org/elasticsearch/cluster/routing/DelayedAllocationServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/DelayedAllocationServiceTests.java
@@ -464,7 +464,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
     private static class TestDelayAllocationService extends DelayedAllocationService {
         private volatile long nanoTimeOverride = -1L;
 
-        public TestDelayAllocationService(Settings settings, ThreadPool threadPool, ClusterService clusterService,
+        TestDelayAllocationService(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                           AllocationService allocationService) {
             super(settings, threadPool, clusterService, allocationService);
         }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/RoutingServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/RoutingServiceTests.java
@@ -46,7 +46,7 @@ public class RoutingServiceTests extends ESAllocationTestCase {
 
         private AtomicBoolean rerouted = new AtomicBoolean();
 
-        public TestRoutingService() {
+        TestRoutingService() {
             super(Settings.EMPTY, null, null);
         }
 

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalanceConfigurationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalanceConfigurationTests.java
@@ -390,7 +390,7 @@ public class BalanceConfigurationTests extends ESAllocationTestCase {
 
     private class NoopGatewayAllocator extends GatewayAllocator {
 
-        public NoopGatewayAllocator() {
+        NoopGatewayAllocator() {
             super(Settings.EMPTY, null, null);
         }
 

--- a/core/src/test/java/org/elasticsearch/cluster/service/ClusterServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/service/ClusterServiceTests.java
@@ -604,7 +604,7 @@ public class ClusterServiceTests extends ESTestCase {
             private AtomicInteger batches = new AtomicInteger();
             private AtomicInteger published = new AtomicInteger();
 
-            public TaskExecutor(List<Set<Task>> taskGroups) {
+            TaskExecutor(List<Set<Task>> taskGroups) {
                 this.taskGroups = taskGroups;
             }
 
@@ -1223,7 +1223,7 @@ public class ClusterServiceTests extends ESTestCase {
     private static class BlockingTask extends ClusterStateUpdateTask implements Releasable {
         private final CountDownLatch latch = new CountDownLatch(1);
 
-        public BlockingTask(Priority priority) {
+        BlockingTask(Priority priority) {
             super(priority);
         }
 
@@ -1271,7 +1271,7 @@ public class ClusterServiceTests extends ESTestCase {
 
         public volatile Long currentTimeOverride = null;
 
-        public TimedClusterService(Settings settings, ClusterSettings clusterSettings, ThreadPool threadPool,
+        TimedClusterService(Settings settings, ClusterSettings clusterSettings, ThreadPool threadPool,
                                    Supplier<DiscoveryNode> localNodeSupplier) {
             super(settings, clusterSettings, threadPool, localNodeSupplier);
         }

--- a/core/src/test/java/org/elasticsearch/common/ChannelsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/ChannelsTests.java
@@ -165,7 +165,7 @@ public class ChannelsTests extends ESTestCase {
 
         FileChannel delegate;
 
-        public MockFileChannel(FileChannel delegate) {
+        MockFileChannel(FileChannel delegate) {
             this.delegate = delegate;
         }
 

--- a/core/src/test/java/org/elasticsearch/common/UUIDTests.java
+++ b/core/src/test/java/org/elasticsearch/common/UUIDTests.java
@@ -58,7 +58,7 @@ public class UUIDTests extends ESTestCase {
         public Set<String> uuidSet = null;
         UUIDGenerator uuidSource;
 
-        public UUIDGenRunner(int count, UUIDGenerator uuidSource) {
+        UUIDGenRunner(int count, UUIDGenerator uuidSource) {
             this.count = count;
             this.uuidSource = uuidSource;
         }

--- a/core/src/test/java/org/elasticsearch/common/cache/CacheTests.java
+++ b/core/src/test/java/org/elasticsearch/common/cache/CacheTests.java
@@ -416,7 +416,7 @@ public class CacheTests extends ESTestCase {
             private String value;
             private long weight;
 
-            public Value(String value, long weight) {
+            Value(String value, long weight) {
                 this.value = value;
                 this.weight = weight;
             }
@@ -552,7 +552,7 @@ public class CacheTests extends ESTestCase {
         class Key {
             private final int key;
 
-            public Key(int key) {
+            Key(int key) {
                 this.key = key;
             }
 

--- a/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -531,7 +531,7 @@ public class BytesStreamsTests extends ESTestCase {
             this.field2 = field2;
         }
 
-        public TestNamedWriteable(StreamInput in) throws IOException {
+        TestNamedWriteable(StreamInput in) throws IOException {
             field1 = in.readString();
             field2 = in.readString();
         }
@@ -613,9 +613,9 @@ public class BytesStreamsTests extends ESTestCase {
 
         private boolean value;
 
-        public TestStreamable() { }
+        TestStreamable() { }
 
-        public TestStreamable(boolean value) {
+        TestStreamable(boolean value) {
             this.value = value;
         }
 

--- a/core/src/test/java/org/elasticsearch/common/io/stream/NamedWriteableRegistryTests.java
+++ b/core/src/test/java/org/elasticsearch/common/io/stream/NamedWriteableRegistryTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.test.ESTestCase;
 public class NamedWriteableRegistryTests extends ESTestCase {
 
     private static class DummyNamedWriteable implements NamedWriteable {
-        public DummyNamedWriteable(StreamInput in) {}
+        DummyNamedWriteable(StreamInput in) {}
         @Override
         public String getWriteableName() {
             return "test";

--- a/core/src/test/java/org/elasticsearch/common/io/stream/StreamTests.java
+++ b/core/src/test/java/org/elasticsearch/common/io/stream/StreamTests.java
@@ -216,11 +216,11 @@ public class StreamTests extends ESTestCase {
     static final class WriteableString implements Writeable {
         final String string;
 
-        public WriteableString(String string) {
+        WriteableString(String string) {
             this.string = string;
         }
 
-        public WriteableString(StreamInput in) throws IOException {
+        WriteableString(StreamInput in) throws IOException {
             this(in.readString());
         }
 

--- a/core/src/test/java/org/elasticsearch/common/network/NetworkModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/common/network/NetworkModuleTests.java
@@ -70,7 +70,7 @@ public class NetworkModuleTests extends ModuleTestCase {
     }
 
     static class FakeHttpTransport extends AbstractLifecycleComponent implements HttpServerTransport {
-        public FakeHttpTransport() {
+        FakeHttpTransport() {
             super(null);
         }
         @Override
@@ -95,7 +95,7 @@ public class NetworkModuleTests extends ModuleTestCase {
 
 
     static class FakeRestHandler extends BaseRestHandler {
-        public FakeRestHandler() {
+        FakeRestHandler() {
             super(null);
         }
         @Override
@@ -103,7 +103,7 @@ public class NetworkModuleTests extends ModuleTestCase {
     }
 
     static class FakeCatRestHandler extends AbstractCatAction {
-        public FakeCatRestHandler() {
+        FakeCatRestHandler() {
             super(null);
         }
         @Override

--- a/core/src/test/java/org/elasticsearch/common/util/concurrent/RefCountedTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/concurrent/RefCountedTests.java
@@ -128,7 +128,7 @@ public class RefCountedTests extends ESTestCase {
 
         private final AtomicBoolean closed = new AtomicBoolean(false);
 
-        public MyRefCounted() {
+        MyRefCounted() {
             super("test");
         }
 

--- a/core/src/test/java/org/elasticsearch/common/xcontent/ConstructingObjectParserTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/ConstructingObjectParserTests.java
@@ -233,7 +233,7 @@ public class ConstructingObjectParserTests extends ESTestCase {
     public void testCalledOneTime() throws IOException {
         boolean ctorArgOptional = randomBoolean();
         class CalledOneTime {
-            public CalledOneTime(String yeah) {
+            CalledOneTime(String yeah) {
                 Matcher<String> yeahMatcher = equalTo("!");
                 if (ctorArgOptional) {
                     // either(yeahMatcher).or(nullValue) is broken by https://github.com/hamcrest/JavaHamcrest/issues/49
@@ -290,7 +290,7 @@ public class ConstructingObjectParserTests extends ESTestCase {
                 + "}");
         class TestStruct {
             public final String test;
-            public TestStruct(String test) {
+            TestStruct(String test) {
                 this.test = test;
             }
         }
@@ -313,7 +313,7 @@ public class ConstructingObjectParserTests extends ESTestCase {
         String c;
         boolean d;
 
-        public HasCtorArguments(@Nullable String animal, @Nullable Integer vegetable) {
+        HasCtorArguments(@Nullable String animal, @Nullable Integer vegetable) {
             this.animal = animal;
             this.vegetable = vegetable;
         }

--- a/core/src/test/java/org/elasticsearch/discovery/BlockingClusterStatePublishResponseHandlerTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/BlockingClusterStatePublishResponseHandlerTests.java
@@ -47,7 +47,7 @@ public class BlockingClusterStatePublishResponseHandlerTests extends ESTestCase 
         final Logger logger;
         final BlockingClusterStatePublishResponseHandler handler;
 
-        public PublishResponder(boolean fail, DiscoveryNode node, CyclicBarrier barrier, Logger logger, BlockingClusterStatePublishResponseHandler handler) {
+        PublishResponder(boolean fail, DiscoveryNode node, CyclicBarrier barrier, Logger logger, BlockingClusterStatePublishResponseHandler handler) {
             this.fail = fail;
 
             this.node = node;

--- a/core/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
@@ -304,7 +304,7 @@ public class ZenFaultDetectionTests extends ESTestCase {
         private final Set<Tuple<DiscoveryNode, Long>> completedPings = Collections.newSetFromMap(new ConcurrentHashMap<>());
         private final CountDownLatch waitForPings;
 
-        public PingProbe(int minCompletedPings) {
+        PingProbe(int minCompletedPings) {
             this.waitForPings = new CountDownLatch(minCompletedPings);
         }
 

--- a/core/src/test/java/org/elasticsearch/discovery/zen/UnicastZenPingTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/UnicastZenPingTests.java
@@ -773,7 +773,7 @@ public class UnicastZenPingTests extends ESTestCase {
         public final DiscoveryNode node;
         public final ConcurrentMap<TransportAddress, AtomicInteger> counters;
 
-        public NetworkHandle(
+        NetworkHandle(
             final TransportAddress address,
             final TransportService transportService,
             final DiscoveryNode discoveryNode,
@@ -787,7 +787,7 @@ public class UnicastZenPingTests extends ESTestCase {
 
     private static class TestUnicastZenPing extends UnicastZenPing {
 
-        public TestUnicastZenPing(Settings settings, ThreadPool threadPool, NetworkHandle networkHandle,
+        TestUnicastZenPing(Settings settings, ThreadPool threadPool, NetworkHandle networkHandle,
                                   UnicastHostsProvider unicastHostsProvider) {
             super(Settings.builder().put("node.name", networkHandle.node.getName()).put(settings).build(),
                 threadPool, networkHandle.transportService, unicastHostsProvider);

--- a/core/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
@@ -232,7 +232,7 @@ public class AsyncShardFetchTests extends ESTestCase {
             private final CountDownLatch executeLatch = new CountDownLatch(1);
             private final CountDownLatch waitLatch = new CountDownLatch(1);
 
-            public Entry(Response response, Throwable failure) {
+            Entry(Response response, Throwable failure) {
                 this.response = response;
                 this.failure = failure;
             }
@@ -242,7 +242,7 @@ public class AsyncShardFetchTests extends ESTestCase {
         private final Map<String, Entry> simulations = new ConcurrentHashMap<>();
         private AtomicInteger reroute = new AtomicInteger();
 
-        public TestFetch(ThreadPool threadPool) {
+        TestFetch(ThreadPool threadPool) {
             super(Loggers.getLogger(TestFetch.class), "test", new ShardId("test", "_na_", 1), null);
             this.threadPool = threadPool;
         }
@@ -305,7 +305,7 @@ public class AsyncShardFetchTests extends ESTestCase {
 
     static class Response extends BaseNodeResponse {
 
-        public Response(DiscoveryNode node) {
+        Response(DiscoveryNode node) {
             super(node);
         }
     }

--- a/core/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
@@ -385,7 +385,7 @@ public class GatewayMetaStateTests extends ESAllocationTestCase {
     private static class MockMetaDataIndexUpgradeService extends MetaDataIndexUpgradeService {
         private final boolean upgrade;
 
-        public MockMetaDataIndexUpgradeService(boolean upgrade) {
+        MockMetaDataIndexUpgradeService(boolean upgrade) {
             super(Settings.EMPTY, null, null, null);
             this.upgrade = upgrade;
         }

--- a/core/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
@@ -196,7 +196,7 @@ public class MetaDataStateFormatTests extends ESTestCase {
 
     public static void corruptFile(Path file, Logger logger) throws IOException {
         Path fileToCorrupt = file;
-        try (final SimpleFSDirectory dir = new SimpleFSDirectory(fileToCorrupt.getParent())) {
+        try (SimpleFSDirectory dir = new SimpleFSDirectory(fileToCorrupt.getParent())) {
             long checksumBeforeCorruption;
             try (IndexInput input = dir.openInput(fileToCorrupt.getFileName().toString(), IOContext.DEFAULT)) {
                 checksumBeforeCorruption = CodecUtil.retrieveChecksum(input);
@@ -386,7 +386,7 @@ public class MetaDataStateFormatTests extends ESTestCase {
                     '}';
         }
 
-        public DummyState(String string, int aInt, long aLong, double aDouble, boolean aBoolean) {
+        DummyState(String string, int aInt, long aLong, double aDouble, boolean aBoolean) {
             this.string = string;
             this.aInt = aInt;
             this.aLong = aLong;
@@ -394,7 +394,7 @@ public class MetaDataStateFormatTests extends ESTestCase {
             this.aBoolean = aBoolean;
         }
 
-        public DummyState() {
+        DummyState() {
 
         }
 

--- a/core/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -764,7 +764,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
 
         private Map<DiscoveryNode, TransportNodesListGatewayStartedShards.NodeGatewayStartedShards> data;
 
-        public TestAllocator() {
+        TestAllocator() {
             super(Settings.EMPTY);
         }
 

--- a/core/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
@@ -339,7 +339,7 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
         private Map<DiscoveryNode, TransportNodesListShardStoreMetaData.StoreFilesMetaData> data = null;
         private AtomicBoolean fetchDataCalled = new AtomicBoolean(false);
 
-        public TestAllocator() {
+        TestAllocator() {
             super(Settings.EMPTY);
         }
 

--- a/core/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -418,7 +418,7 @@ public class IndexModuleTests extends ESTestCase {
         private final String key;
 
 
-        public TestSimilarity(String key) {
+        TestSimilarity(String key) {
             if (key == null) {
                 throw new AssertionError("key is null");
             }

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -1642,7 +1642,7 @@ public class InternalEngineTests extends ESTestCase {
 
         public boolean sawIndexWriterIFDMessage;
 
-        public MockAppender(final String name) throws IllegalAccessException {
+        MockAppender(final String name) throws IllegalAccessException {
             super(name, RegexFilter.createFilter(".*(\n.*)*", new String[0], false, null, null), null);
         }
 
@@ -1818,8 +1818,8 @@ public class InternalEngineTests extends ESTestCase {
     // this test writes documents to the engine while concurrently flushing/commit
     // and ensuring that the commit points contain the correct sequence number data
     public void testConcurrentWritesAndCommits() throws Exception {
-        try (final Store store = createStore();
-             final InternalEngine engine = new InternalEngine(config(defaultSettings, store, createTempDir(), newMergePolicy(),
+        try (Store store = createStore();
+             InternalEngine engine = new InternalEngine(config(defaultSettings, store, createTempDir(), newMergePolicy(),
                                                                      new SnapshotDeletionPolicy(NoDeletionPolicy.INSTANCE),
                                                                      IndexRequest.UNSET_AUTO_GENERATED_TIMESTAMP, null))) {
 
@@ -2545,7 +2545,7 @@ public class InternalEngineTests extends ESTestCase {
     private static class ThrowingIndexWriter extends IndexWriter {
         private AtomicReference<Supplier<Exception>> failureToThrow = new AtomicReference<>();
 
-        public ThrowingIndexWriter(Directory d, IndexWriterConfig conf) throws IOException {
+        ThrowingIndexWriter(Directory d, IndexWriterConfig conf) throws IOException {
             super(d, conf);
         }
 
@@ -3090,7 +3090,7 @@ public class InternalEngineTests extends ESTestCase {
             IOUtils.close(initialEngine);
         }
 
-        try (final Engine recoveringEngine =
+        try (Engine recoveringEngine =
                  new InternalEngine(copy(initialEngine.config(), EngineConfig.OpenMode.OPEN_INDEX_AND_TRANSLOG))) {
             assertThat(recoveringEngine.seqNoService().getLocalCheckpoint(), greaterThanOrEqualTo((long) (docs - 1)));
         }
@@ -3128,7 +3128,7 @@ public class InternalEngineTests extends ESTestCase {
             IOUtils.close(initialEngine);
         }
 
-        try (final Engine recoveringEngine =
+        try (Engine recoveringEngine =
                  new InternalEngine(copy(initialEngine.config(), EngineConfig.OpenMode.OPEN_INDEX_AND_TRANSLOG))) {
             assertThat(recoveringEngine.seqNoService().getLocalCheckpoint(), greaterThanOrEqualTo((long) (3 * (docs - 1) + 2 - 1)));
         }
@@ -3207,7 +3207,7 @@ public class InternalEngineTests extends ESTestCase {
         }
 
         assertThat(engine.seqNoService().getLocalCheckpoint(), equalTo(expectedLocalCheckpoint));
-        try (final Engine.GetResult result = engine.get(new Engine.Get(true, uid))) {
+        try (Engine.GetResult result = engine.get(new Engine.Get(true, uid))) {
             assertThat(result.exists(), equalTo(exists));
         }
     }

--- a/core/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
@@ -43,7 +43,7 @@ public class DocumentFieldMapperTests extends LuceneTestCase {
 
         private final String output;
 
-        public FakeAnalyzer(String output) {
+        FakeAnalyzer(String output) {
             this.output = output;
         }
 
@@ -70,7 +70,7 @@ public class DocumentFieldMapperTests extends LuceneTestCase {
 
     static class FakeFieldType extends TermBasedFieldType {
 
-        public FakeFieldType() {
+        FakeFieldType() {
             super();
         }
 
@@ -94,7 +94,7 @@ public class DocumentFieldMapperTests extends LuceneTestCase {
 
         private static final Settings SETTINGS = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
 
-        public FakeFieldMapper(String simpleName, MappedFieldType fieldType) {
+        FakeFieldMapper(String simpleName, MappedFieldType fieldType) {
             super(simpleName, fieldType.clone(), fieldType.clone(), SETTINGS, null, null);
         }
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
@@ -114,7 +114,7 @@ public class ExternalMapper extends FieldMapper {
 
     static class ExternalFieldType extends TermBasedFieldType {
 
-        public ExternalFieldType() {}
+        ExternalFieldType() {}
 
         protected ExternalFieldType(ExternalFieldType ref) {
             super(ref);

--- a/core/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldMapperTests.java
@@ -175,7 +175,7 @@ public class FieldNamesFieldMapperTests extends ESSingleNodeTestCase {
 
         private static class DummyFieldType extends TermBasedFieldType {
 
-            public DummyFieldType() {
+            DummyFieldType() {
                 super();
             }
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -207,7 +207,7 @@ public class FieldTypeLookupTests extends ESTestCase {
     }
 
     static class OtherFakeFieldType extends TermBasedFieldType {
-        public OtherFakeFieldType() {
+        OtherFakeFieldType() {
         }
 
         protected OtherFakeFieldType(OtherFakeFieldType ref) {

--- a/core/src/test/java/org/elasticsearch/index/query/MockRepeatAnalyzer.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MockRepeatAnalyzer.java
@@ -35,7 +35,7 @@ public class MockRepeatAnalyzer extends Analyzer {
         PositionIncrementAttribute posIncAtt = addAttribute(PositionIncrementAttribute.class);
         String repeat;
 
-        public MockRepeatFilter(TokenStream input) {
+        MockRepeatFilter(TokenStream input) {
             super(input);
         }
 

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleQueryParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleQueryParserTests.java
@@ -47,7 +47,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class SimpleQueryParserTests extends ESTestCase {
     private static class MockSimpleQueryParser extends SimpleQueryParser {
-        public MockSimpleQueryParser(Analyzer analyzer, Map<String, Float> weights, int flags, Settings settings) {
+        MockSimpleQueryParser(Analyzer analyzer, Map<String, Float> weights, int flags, Settings settings) {
             super(analyzer, weights, flags, settings, null);
         }
 

--- a/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
@@ -772,13 +772,13 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
     static class RandomScoreFunctionBuilderWithFixedSeed extends RandomScoreFunctionBuilder {
         public static final String NAME = "random_with_fixed_seed";
 
-        public RandomScoreFunctionBuilderWithFixedSeed() {
+        RandomScoreFunctionBuilderWithFixedSeed() {
         }
 
         /**
          * Read from a stream.
          */
-        public RandomScoreFunctionBuilderWithFixedSeed(StreamInput in) throws IOException {
+        RandomScoreFunctionBuilderWithFixedSeed(StreamInput in) throws IOException {
             super(in);
         }
 

--- a/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -338,7 +338,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         private final ReplicationGroup replicationGroup;
         private final String opType;
 
-        public ReplicationAction(Request request, ActionListener<Response> listener,
+        ReplicationAction(Request request, ActionListener<Response> listener,
                                  ReplicationGroup group, String opType) {
             this.request = request;
             this.listener = listener;
@@ -445,7 +445,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             final ReplicaRequest replicaRequest;
             final Response finalResponse;
 
-            public PrimaryResult(ReplicaRequest replicaRequest, Response finalResponse) {
+            PrimaryResult(ReplicaRequest replicaRequest, Response finalResponse) {
                 this.replicaRequest = replicaRequest;
                 this.finalResponse = finalResponse;
             }
@@ -469,7 +469,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
 
     class IndexingAction extends ReplicationAction<IndexRequest, IndexRequest, IndexResponse> {
 
-        public IndexingAction(IndexRequest request, ActionListener<IndexResponse> listener, ReplicationGroup replicationGroup) {
+        IndexingAction(IndexRequest request, ActionListener<IndexResponse> listener, ReplicationGroup replicationGroup) {
             super(request, listener, replicationGroup, "indexing");
             request.process(null, true, request.index());
         }
@@ -523,7 +523,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
     class GlobalCheckpointSync extends
         ReplicationAction<GlobalCheckpointSyncAction.PrimaryRequest, GlobalCheckpointSyncAction.ReplicaRequest, ReplicationResponse> {
 
-        public GlobalCheckpointSync(ActionListener<ReplicationResponse> listener, ReplicationGroup replicationGroup) {
+        GlobalCheckpointSync(ActionListener<ReplicationResponse> listener, ReplicationGroup replicationGroup) {
             super(new GlobalCheckpointSyncAction.PrimaryRequest(replicationGroup.getPrimary().shardId()), listener,
                 replicationGroup, "global_ckp");
         }

--- a/core/src/test/java/org/elasticsearch/index/replication/RecoveryDuringReplicationTests.java
+++ b/core/src/test/java/org/elasticsearch/index/replication/RecoveryDuringReplicationTests.java
@@ -66,7 +66,7 @@ public class RecoveryDuringReplicationTests extends ESIndexLevelReplicationTestC
     }
 
     public void testRecoveryOfDisconnectedReplica() throws Exception {
-        try (final ReplicationGroup shards = createGroup(1)) {
+        try (ReplicationGroup shards = createGroup(1)) {
             shards.startAll();
             int docs = shards.indexDocs(randomInt(50));
             shards.flush();
@@ -132,7 +132,7 @@ public class RecoveryDuringReplicationTests extends ESIndexLevelReplicationTestC
 
     @TestLogging("org.elasticsearch.index.shard:TRACE,org.elasticsearch.indices.recovery:TRACE")
     public void testRecoveryAfterPrimaryPromotion() throws Exception {
-        try (final ReplicationGroup shards = createGroup(2)) {
+        try (ReplicationGroup shards = createGroup(2)) {
             shards.startAll();
             int totalDocs = shards.indexDocs(randomInt(10));
             int committedDocs = 0;

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexSearcherWrapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexSearcherWrapperTests.java
@@ -122,7 +122,7 @@ public class IndexSearcherWrapperTests extends ESTestCase {
         };
         final ConcurrentHashMap<Object, TopDocs> cache = new ConcurrentHashMap<>();
         try (Engine.Searcher engineSearcher = new Engine.Searcher("foo", searcher)) {
-            try (final Engine.Searcher wrap = wrapper.wrap(engineSearcher)) {
+            try (Engine.Searcher wrap = wrapper.wrap(engineSearcher)) {
                 ElasticsearchDirectoryReader.addReaderCloseListener(wrap.getDirectoryReader(), reader -> {
                     cache.remove(reader.getCoreCacheKey());
                 });
@@ -205,7 +205,7 @@ public class IndexSearcherWrapperTests extends ESTestCase {
         private final String field;
         private final AtomicInteger closeCalls;
 
-        public FieldMaskingReader(String field, DirectoryReader in, AtomicInteger closeCalls) throws IOException {
+        FieldMaskingReader(String field, DirectoryReader in, AtomicInteger closeCalls) throws IOException {
             super(in, new SubReaderWrapper() {
                 @Override
                 public LeafReader wrap(LeafReader reader) {
@@ -237,7 +237,7 @@ public class IndexSearcherWrapperTests extends ESTestCase {
 
         private final boolean hideDelegate;
 
-        public BrokenWrapper(DirectoryReader in, boolean hideDelegate) throws IOException {
+        BrokenWrapper(DirectoryReader in, boolean hideDelegate) throws IOException {
             super(in, new SubReaderWrapper() {
                 @Override
                 public LeafReader wrap(LeafReader reader) {

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -1461,7 +1461,7 @@ public class IndexShardTests extends IndexShardTestCase {
     private abstract static class RestoreOnlyRepository extends AbstractLifecycleComponent implements Repository {
         private final String indexName;
 
-        public RestoreOnlyRepository(String indexName) {
+        RestoreOnlyRepository(String indexName) {
             super(Settings.EMPTY);
             this.indexName = indexName;
         }

--- a/core/src/test/java/org/elasticsearch/index/shard/NewPathForShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/NewPathForShardTests.java
@@ -76,7 +76,7 @@ public class NewPathForShardTests extends ESTestCase {
     /** Mock file system that fakes usable space for each FileStore */
     static class MockUsableSpaceFileSystemProvider extends FilterFileSystemProvider {
 
-        public MockUsableSpaceFileSystemProvider(FileSystem inner) {
+        MockUsableSpaceFileSystemProvider(FileSystem inner) {
             super("mockusablespace://", inner);
             final List<FileStore> fileStores = new ArrayList<>();
             fileStores.add(aFileStore);
@@ -99,7 +99,7 @@ public class NewPathForShardTests extends ESTestCase {
 
         private final String desc;
 
-        public MockFileStore(String desc) {
+        MockFileStore(String desc) {
             this.desc = desc;
         }
 

--- a/core/src/test/java/org/elasticsearch/index/shard/ShardPathTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/ShardPathTests.java
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.is;
 
 public class ShardPathTests extends ESTestCase {
     public void testLoadShardPath() throws IOException {
-        try (final NodeEnvironment env = newNodeEnvironment(Settings.builder().build())) {
+        try (NodeEnvironment env = newNodeEnvironment(Settings.builder().build())) {
             Settings.Builder builder = Settings.builder().put(IndexMetaData.SETTING_INDEX_UUID, "0xDEADBEEF")
                     .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
             Settings settings = builder.build();
@@ -54,7 +54,7 @@ public class ShardPathTests extends ESTestCase {
     }
 
     public void testFailLoadShardPathOnMultiState() throws IOException {
-        try (final NodeEnvironment env = newNodeEnvironment(Settings.builder().build())) {
+        try (NodeEnvironment env = newNodeEnvironment(Settings.builder().build())) {
             final String indexUUID = "0xDEADBEEF";
             Settings.Builder builder = Settings.builder().put(IndexMetaData.SETTING_INDEX_UUID, indexUUID)
                     .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
@@ -71,7 +71,7 @@ public class ShardPathTests extends ESTestCase {
     }
 
     public void testFailLoadShardPathIndexUUIDMissmatch() throws IOException {
-        try (final NodeEnvironment env = newNodeEnvironment(Settings.builder().build())) {
+        try (NodeEnvironment env = newNodeEnvironment(Settings.builder().build())) {
             Settings.Builder builder = Settings.builder().put(IndexMetaData.SETTING_INDEX_UUID, "foobar")
                     .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
             Settings settings = builder.build();
@@ -127,7 +127,7 @@ public class ShardPathTests extends ESTestCase {
             indexSettings = indexSettingsBuilder.build();
             nodeSettings = Settings.EMPTY;
         }
-        try (final NodeEnvironment env = newNodeEnvironment(nodeSettings)) {
+        try (NodeEnvironment env = newNodeEnvironment(nodeSettings)) {
             ShardId shardId = new ShardId("foo", indexUUID, 0);
             Path[] paths = env.availableShardPaths(shardId);
             Path path = randomFrom(paths);

--- a/core/src/test/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStreamTests.java
+++ b/core/src/test/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStreamTests.java
@@ -121,7 +121,7 @@ public class SlicedInputStreamTests extends ESTestCase {
 
         public boolean closed = false;
 
-        public CheckClosedInputStream(InputStream in) {
+        CheckClosedInputStream(InputStream in) {
             super(in);
         }
 

--- a/core/src/test/java/org/elasticsearch/index/store/IndexStoreTests.java
+++ b/core/src/test/java/org/elasticsearch/index/store/IndexStoreTests.java
@@ -61,7 +61,7 @@ public class IndexStoreTests extends ESTestCase {
         Settings settings = settingsBuilder.build();
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("foo", settings);
         FsDirectoryService service = new FsDirectoryService(indexSettings, null, new ShardPath(false, tempDir, tempDir, new ShardId(index, 0)));
-        try (final Directory directory = service.newFSDirectory(tempDir, NoLockFactory.INSTANCE)) {
+        try (Directory directory = service.newFSDirectory(tempDir, NoLockFactory.INSTANCE)) {
             switch (type) {
                 case NIOFS:
                     assertTrue(type + " " + directory.toString(), directory instanceof NIOFSDirectory);

--- a/core/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/core/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -468,11 +468,11 @@ public class StoreTests extends ESTestCase {
         private final Directory dir;
         private final Random random;
 
-        public LuceneManagedDirectoryService(Random random) {
+        LuceneManagedDirectoryService(Random random) {
             this(random, true);
         }
 
-        public LuceneManagedDirectoryService(Random random, boolean preventDoubleWrite) {
+        LuceneManagedDirectoryService(Random random, boolean preventDoubleWrite) {
             super(new ShardId(INDEX_SETTINGS.getIndex(), 1), INDEX_SETTINGS);
             dir = StoreTests.newDirectory(random);
             this.random = random;

--- a/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -349,7 +349,7 @@ public class TranslogTests extends ESTestCase {
             assertThat(copy.estimatedNumberOfOperations(), equalTo(4L));
             assertThat(copy.getTranslogSizeInBytes(), equalTo(expectedSizeInBytes));
 
-            try (final XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
                 builder.startObject();
                 copy.toXContent(builder, ToXContent.EMPTY_PARAMS);
                 builder.endObject();
@@ -463,7 +463,7 @@ public class TranslogTests extends ESTestCase {
         final Translog.Operation operation;
         final Translog.Location location;
 
-        public LocationOperation(Translog.Operation operation, Translog.Location location) {
+        LocationOperation(Translog.Operation operation, Translog.Location location) {
             this.operation = operation;
             this.location = location;
         }
@@ -941,7 +941,7 @@ public class TranslogTests extends ESTestCase {
         translog.add(new Translog.Index("test", "" + translogOperations, Integer.toString(translogOperations).getBytes(Charset.forName("UTF-8"))));
 
         final Checkpoint checkpoint = Checkpoint.read(translog.location().resolve(Translog.CHECKPOINT_FILE_NAME));
-        try (final TranslogReader reader = translog.openReader(translog.location().resolve(Translog.getFilename(translog.currentFileGeneration())), checkpoint)) {
+        try (TranslogReader reader = translog.openReader(translog.location().resolve(Translog.getFilename(translog.currentFileGeneration())), checkpoint)) {
             assertEquals(lastSynced + 1, reader.totalOperations());
             Translog.Snapshot snapshot = reader.newSnapshot();
 
@@ -1355,7 +1355,7 @@ public class TranslogTests extends ESTestCase {
         private final Exception[] threadExceptions;
         private final Translog translog;
 
-        public TranslogThread(Translog translog, CountDownLatch downLatch, int opsPerThread, int threadId, Collection<LocationOperation> writtenOperations, Exception[] threadExceptions) {
+        TranslogThread(Translog translog, CountDownLatch downLatch, int opsPerThread, int threadId, Collection<LocationOperation> writtenOperations, Exception[] threadExceptions) {
             this.translog = translog;
             this.downLatch = downLatch;
             this.opsPerThread = opsPerThread;

--- a/core/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
@@ -65,7 +65,7 @@ public class IndexingMemoryControllerTests extends ESSingleNodeTestCase {
         // Shards that are currently throttled
         final Set<IndexShard> throttled = new HashSet<>();
 
-        public MockController(Settings settings) {
+        MockController(Settings settings) {
             super(Settings.builder()
                             .put("indices.memory.interval", "200h") // disable it
                             .put(settings)

--- a/core/src/test/java/org/elasticsearch/indices/IndicesRequestCacheTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesRequestCacheTests.java
@@ -322,7 +322,7 @@ public class IndicesRequestCacheTests extends ESTestCase {
         private final int id;
         public boolean loadedFromCache = true;
 
-        public Loader(DirectoryReader reader, int id) {
+        Loader(DirectoryReader reader, int id) {
             super();
             this.reader = reader;
             this.id = id;

--- a/core/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -636,7 +636,7 @@ public class IndexRecoveryIT extends ESIntegTestCase {
         private final String recoveryActionToBlock;
         private final CountDownLatch requestBlocked;
 
-        public RecoveryActionBlocker(boolean dropRequests, String recoveryActionToBlock, Transport delegate, CountDownLatch requestBlocked) {
+        RecoveryActionBlocker(boolean dropRequests, String recoveryActionToBlock, Transport delegate, CountDownLatch requestBlocked) {
             super(delegate);
             this.dropRequests = dropRequests;
             this.recoveryActionToBlock = recoveryActionToBlock;

--- a/core/src/test/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
@@ -244,7 +244,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
         public boolean sawUpdateMaxThreadCount;
         public boolean sawUpdateAutoThrottle;
 
-        public MockAppender(final String name) throws IllegalAccessException {
+        MockAppender(final String name) throws IllegalAccessException {
             super(name, RegexFilter.createFilter(".*(\n.*)*", new String[0], false, null, null), null);
         }
 

--- a/core/src/test/java/org/elasticsearch/ingest/PipelineExecutionServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/PipelineExecutionServiceTests.java
@@ -384,7 +384,7 @@ public class PipelineExecutionServiceTests extends ESTestCase {
 
         private final IngestDocument ingestDocument;
 
-        public IngestDocumentMatcher(String index, String type, String id, Map<String, Object> source) {
+        IngestDocumentMatcher(String index, String type, String id, Map<String, Object> source) {
             this.ingestDocument = new IngestDocument(index, type, id, null, null, source);
         }
 

--- a/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
@@ -517,7 +517,7 @@ public class RelocationIT extends ESIntegTestCase {
 
         private final CountDownLatch corruptionCount;
 
-        public RecoveryCorruption(Transport transport, CountDownLatch corruptionCount) {
+        RecoveryCorruption(Transport transport, CountDownLatch corruptionCount) {
             super(transport);
             this.corruptionCount = corruptionCount;
         }

--- a/core/src/test/java/org/elasticsearch/rest/DeprecationRestHandlerTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/DeprecationRestHandlerTests.java
@@ -138,7 +138,7 @@ public class DeprecationRestHandlerTests extends ESTestCase {
         /**
          * Create a generator for characters [32, 126].
          */
-        public ASCIIHeaderGenerator() {
+        ASCIIHeaderGenerator() {
             super(asciiFromTo(32, 126));
         }
     }

--- a/core/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -312,7 +312,7 @@ public class RestControllerTests extends ESTestCase {
     private static final class TestHttpServerTransport extends AbstractLifecycleComponent implements
         HttpServerTransport {
 
-        public TestHttpServerTransport() {
+        TestHttpServerTransport() {
             super(Settings.EMPTY);
         }
 

--- a/core/src/test/java/org/elasticsearch/search/SearchCancellationIT.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchCancellationIT.java
@@ -268,7 +268,7 @@ public class SearchCancellationIT extends ESIntegTestCase {
 
         private final AtomicBoolean shouldBlock = new AtomicBoolean(true);
 
-        public NativeTestScriptedBlockFactory() {
+        NativeTestScriptedBlockFactory() {
         }
 
         public void reset() {

--- a/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -374,7 +374,7 @@ public class SearchModuleTests extends ModuleTestCase {
         /**
          * Read from a stream.
          */
-        public TestPipelineAggregationBuilder(StreamInput in) throws IOException {
+        TestPipelineAggregationBuilder(StreamInput in) throws IOException {
             super(in, "test");
         }
 
@@ -419,7 +419,7 @@ public class SearchModuleTests extends ModuleTestCase {
         /**
          * Read from a stream.
          */
-        public TestPipelineAggregator(StreamInput in) throws IOException {
+        TestPipelineAggregator(StreamInput in) throws IOException {
             super(in);
         }
         @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -199,7 +199,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
     private static class ShardSearcher extends IndexSearcher {
         private final List<LeafReaderContext> ctx;
 
-        public ShardSearcher(LeafReaderContext ctx, IndexReaderContext parent) {
+        ShardSearcher(LeafReaderContext ctx, IndexReaderContext parent) {
             super(parent);
             this.ctx = Collections.singletonList(ctx);
         }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
@@ -76,7 +76,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 public class SignificanceHeuristicTests extends ESTestCase {
     static class SignificantTermsTestSearchContext extends TestSearchContext {
 
-        public SignificantTermsTestSearchContext() {
+        SignificantTermsTestSearchContext() {
             super(null);
         }
 

--- a/core/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatIT.java
@@ -60,7 +60,7 @@ public class BlobStoreFormatIT extends AbstractSnapshotIntegTestCase {
 
         private final String text;
 
-        public BlobObj(String text) {
+        BlobObj(String text) {
             this.text = text;
         }
 

--- a/core/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -280,7 +280,7 @@ public class MockRepository extends FsRepository {
             }
 
 
-            public MockBlobContainer(BlobContainer delegate) {
+            MockBlobContainer(BlobContainer delegate) {
                 super(delegate);
             }
 

--- a/core/src/test/java/org/elasticsearch/test/geo/RandomShapeGenerator.java
+++ b/core/src/test/java/org/elasticsearch/test/geo/RandomShapeGenerator.java
@@ -56,7 +56,7 @@ public class RandomShapeGenerator extends RandomGeoGenerator {
     protected static final double xDIVISIBLE = 2;
     protected static boolean ST_VALIDATE = true;
 
-    public static enum ShapeType {
+    public enum ShapeType {
         POINT, MULTIPOINT, LINESTRING, MULTILINESTRING, POLYGON;
         private static final ShapeType[] types = values();
 

--- a/core/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -165,7 +165,7 @@ public class TransportServiceHandshakeTests extends ESTestCase {
         private TransportService transportService;
         private DiscoveryNode discoveryNode;
 
-        public NetworkHandle(TransportService transportService, DiscoveryNode discoveryNode) {
+        NetworkHandle(TransportService transportService, DiscoveryNode discoveryNode) {
             this.transportService = transportService;
             this.discoveryNode = discoveryNode;
         }

--- a/core/src/test/java/org/elasticsearch/update/UpdateByNativeScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateByNativeScriptIT.java
@@ -90,7 +90,7 @@ public class UpdateByNativeScriptIT extends ESIntegTestCase {
         private Map<String, Object> params;
         private Map<String, Object> vars = new HashMap<>(2);
 
-        public CustomScript(Map<String, Object> params) {
+        CustomScript(Map<String, Object> params) {
             this.params = params;
         }
 

--- a/core/src/test/java/org/elasticsearch/update/UpdateIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateIT.java
@@ -886,7 +886,7 @@ public class UpdateIT extends ESIntegTestCase {
             private final Semaphore updateRequestsOutstanding = new Semaphore(maxUpdateRequests);
             private final Semaphore deleteRequestsOutstanding = new Semaphore(maxDeleteRequests);
 
-            public UpdateThread(int numberOfIds, int updatesPerId) {
+            UpdateThread(int numberOfIds, int updatesPerId) {
                 this.numberOfIds = numberOfIds;
                 this.updatesPerId = updatesPerId;
             }
@@ -894,7 +894,7 @@ public class UpdateIT extends ESIntegTestCase {
             final class UpdateListener implements ActionListener<UpdateResponse> {
                 int id;
 
-                public UpdateListener(int id) {
+                UpdateListener(int id) {
                     this.id = id;
                 }
 
@@ -916,7 +916,7 @@ public class UpdateIT extends ESIntegTestCase {
             final class DeleteListener implements ActionListener<DeleteResponse> {
                 int id;
 
-                public DeleteListener(int id) {
+                DeleteListener(int id) {
                     this.id = id;
                 }
 

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsResults.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsResults.java
@@ -39,13 +39,13 @@ class MatrixStatsResults implements Writeable {
     protected final Map<String, HashMap<String, Double>> correlation;
 
     /** Base ctor */
-    public MatrixStatsResults() {
+    MatrixStatsResults() {
         results = new RunningStats();
         this.correlation = new HashMap<>();
     }
 
     /** creates and computes result from provided stats */
-    public MatrixStatsResults(RunningStats stats) {
+    MatrixStatsResults(RunningStats stats) {
         this.results = stats.clone();
         this.correlation = new HashMap<>();
         this.compute();

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/Grok.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/Grok.java
@@ -61,12 +61,12 @@ final class Grok {
     private final String expression;
 
 
-    public Grok(Map<String, String> patternBank, String grokPattern) {
+    Grok(Map<String, String> patternBank, String grokPattern) {
         this(patternBank, grokPattern, true);
     }
 
     @SuppressWarnings("unchecked")
-    public Grok(Map<String, String> patternBank, String grokPattern, boolean namedCaptures) {
+    Grok(Map<String, String> patternBank, String grokPattern, boolean namedCaptures) {
         this.patternBank = patternBank;
         this.namedCaptures = namedCaptures;
 

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokMatchGroup.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokMatchGroup.java
@@ -26,7 +26,7 @@ final class GrokMatchGroup {
     private final String type;
     private final String groupValue;
 
-    public GrokMatchGroup(String groupName, String groupValue) {
+    GrokMatchGroup(String groupName, String groupValue) {
         String[] parts = groupName.split(":");
         patternName = parts[0];
         if (parts.length >= 2) {

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
@@ -106,7 +106,7 @@ public class CustomMustacheFactory extends DefaultMustacheFactory {
 
     class CustomMustacheVisitor extends DefaultMustacheVisitor {
 
-        public CustomMustacheVisitor(DefaultMustacheFactory df) {
+        CustomMustacheVisitor(DefaultMustacheFactory df) {
             super(df);
         }
 
@@ -133,7 +133,7 @@ public class CustomMustacheFactory extends DefaultMustacheFactory {
 
         private final String code;
 
-        public CustomCode(TemplateContext tc, DefaultMustacheFactory df, Mustache mustache, String code) {
+        CustomCode(TemplateContext tc, DefaultMustacheFactory df, Mustache mustache, String code) {
             super(tc, df, mustache, extractVariableName(code, mustache, tc));
             this.code = Objects.requireNonNull(code);
         }
@@ -188,7 +188,7 @@ public class CustomMustacheFactory extends DefaultMustacheFactory {
 
         private static final String CODE = "toJson";
 
-        public ToJsonCode(TemplateContext tc, DefaultMustacheFactory df, Mustache mustache, String variable) {
+        ToJsonCode(TemplateContext tc, DefaultMustacheFactory df, Mustache mustache, String variable) {
             super(tc, df, mustache, CODE);
             if (CODE.equalsIgnoreCase(variable) == false) {
                 throw new MustacheException("Mismatch function code [" + CODE + "] cannot be applied to [" + variable + "]");
@@ -239,12 +239,12 @@ public class CustomMustacheFactory extends DefaultMustacheFactory {
 
         private final String delimiter;
 
-        public JoinerCode(TemplateContext tc, DefaultMustacheFactory df, Mustache mustache, String delimiter) {
+        JoinerCode(TemplateContext tc, DefaultMustacheFactory df, Mustache mustache, String delimiter) {
             super(tc, df, mustache, CODE);
             this.delimiter = delimiter;
         }
 
-        public JoinerCode(TemplateContext tc, DefaultMustacheFactory df, Mustache mustache) {
+        JoinerCode(TemplateContext tc, DefaultMustacheFactory df, Mustache mustache) {
             this(tc, df, mustache, DEFAULT_DELIMITER);
         }
 
@@ -273,7 +273,7 @@ public class CustomMustacheFactory extends DefaultMustacheFactory {
 
         private static final Pattern PATTERN = Pattern.compile("^(?:" + CODE + " delimiter='(.*)')$");
 
-        public CustomJoinerCode(TemplateContext tc, DefaultMustacheFactory df, Mustache mustache, String variable) {
+        CustomJoinerCode(TemplateContext tc, DefaultMustacheFactory df, Mustache mustache, String variable) {
             super(tc, df, mustache, extractDelimiter(variable));
         }
 
@@ -299,7 +299,7 @@ public class CustomMustacheFactory extends DefaultMustacheFactory {
         private static final String CODE = "url";
         private final Encoder encoder;
 
-        public UrlEncoderCode(TemplateContext tc, DefaultMustacheFactory df, Mustache mustache, String variable) {
+        UrlEncoderCode(TemplateContext tc, DefaultMustacheFactory df, Mustache mustache, String variable) {
             super(tc, df, mustache.getCodes(), variable);
             this.encoder = new UrlEncoder();
         }
@@ -336,7 +336,7 @@ public class CustomMustacheFactory extends DefaultMustacheFactory {
          * @param s      The string to encode
          * @param writer The {@link Writer} to which the encoded string will be written to
          */
-        void encode(final String s, final Writer writer) throws IOException;
+        void encode(String s, Writer writer) throws IOException;
     }
 
     /**

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
@@ -54,7 +54,7 @@ final class CustomReflectionObjectHandler extends ReflectionObjectHandler {
         private final Object array;
         private final int length;
 
-        public ArrayMap(Object array) {
+        ArrayMap(Object array) {
             this.array = array;
             this.length = Array.getLength(array);
         }
@@ -113,7 +113,7 @@ final class CustomReflectionObjectHandler extends ReflectionObjectHandler {
 
         private final Collection<Object> col;
 
-        public CollectionMap(Collection<Object> col) {
+        CollectionMap(Collection<Object> col) {
             this.col = col;
         }
 

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
@@ -140,7 +140,7 @@ public final class MustacheScriptEngineService extends AbstractComponent impleme
          * @param template the compiled template object wrapper
          * @param vars the parameters to fill above object with
          **/
-        public MustacheExecutableScript(CompiledScript template, Map<String, Object> vars) {
+        MustacheExecutableScript(CompiledScript template, Map<String, Object> vars) {
             this.template = template;
             this.vars = vars == null ? Collections.<String, Object>emptyMap() : vars;
         }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Executable.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Executable.java
@@ -48,7 +48,7 @@ public abstract class Executable {
         return source;
     }
 
-    /** 
+    /**
      * Finds the start of the first statement boundary that is
      * on or before {@code offset}. If one is not found, {@code -1}
      * is returned.
@@ -56,8 +56,8 @@ public abstract class Executable {
     public int getPreviousStatement(int offset) {
         return statements.previousSetBit(offset);
     }
-    
-    /** 
+
+    /**
      * Finds the start of the first statement boundary that is
      * after {@code offset}. If one is not found, {@code -1}
      * is returned.
@@ -66,6 +66,5 @@ public abstract class Executable {
         return statements.nextSetBit(offset+1);
     }
 
-    public abstract Object execute(
-        final Map<String, Object> params, final Scorer scorer, final LeafDocLookup doc, final Object value);
+    public abstract Object execute(Map<String, Object> params, Scorer scorer, LeafDocLookup doc, Object value);
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubCallInvoke.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubCallInvoke.java
@@ -39,7 +39,7 @@ final class PSubCallInvoke extends AExpression {
     private final Type box;
     private final List<AExpression> arguments;
 
-    public PSubCallInvoke(Location location, Method method, Type box, List<AExpression> arguments) {
+    PSubCallInvoke(Location location, Method method, Type box, List<AExpression> arguments) {
         super(location);
 
         this.method = Objects.requireNonNull(method);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubField.java
@@ -37,7 +37,7 @@ final class PSubField extends AStoreable {
 
     private final Field field;
 
-    public PSubField(Location location, Field field) {
+    PSubField(Location location, Field field) {
         super(location);
 
         this.field = Objects.requireNonNull(field);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachArray.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachArray.java
@@ -47,7 +47,7 @@ final class SSubEachArray extends AStatement {
     private Variable index = null;
     private Type indexed = null;
 
-    public SSubEachArray(Location location, Variable variable, AExpression expression, SBlock block) {
+    SSubEachArray(Location location, Variable variable, AExpression expression, SBlock block) {
         super(location);
 
         this.variable = Objects.requireNonNull(variable);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachIterable.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachIterable.java
@@ -55,7 +55,7 @@ final class SSubEachIterable extends AStatement {
     private Variable iterator = null;
     private Method method = null;
 
-    public SSubEachIterable(Location location, Variable variable, AExpression expression, SBlock block) {
+    SSubEachIterable(Location location, Variable variable, AExpression expression, SBlock block) {
         super(location);
 
         this.variable = Objects.requireNonNull(variable);

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/QueryAnalyzer.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/QueryAnalyzer.java
@@ -380,7 +380,7 @@ public final class QueryAnalyzer {
 
         private final Query unsupportedQuery;
 
-        public UnsupportedQueryException(Query unsupportedQuery) {
+        UnsupportedQueryException(Query unsupportedQuery) {
             super(LoggerMessageFormat.format("no query terms can be extracted from query [{}]", unsupportedQuery));
             this.unsupportedQuery = unsupportedQuery;
         }

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportReindexAction.java
@@ -251,7 +251,7 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
          */
         private List<Thread> createdThreads = emptyList();
 
-        public AsyncIndexBySearchAction(WorkingBulkByScrollTask task, Logger logger, ParentTaskAssigningClient client,
+        AsyncIndexBySearchAction(WorkingBulkByScrollTask task, Logger logger, ParentTaskAssigningClient client,
                 ThreadPool threadPool, ReindexRequest request, ScriptService scriptService, ClusterState clusterState,
                 ActionListener<BulkByScrollResponse> listener) {
             super(task, logger, client, threadPool, request, scriptService, clusterState, listener);

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportUpdateByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportUpdateByQueryAction.java
@@ -90,7 +90,7 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
      * Simple implementation of update-by-query using scrolling and bulk.
      */
     static class AsyncIndexBySearchAction extends AbstractAsyncBulkByScrollAction<UpdateByQueryRequest> {
-        public AsyncIndexBySearchAction(WorkingBulkByScrollTask task, Logger logger, ParentTaskAssigningClient client,
+        AsyncIndexBySearchAction(WorkingBulkByScrollTask task, Logger logger, ParentTaskAssigningClient client,
                 ThreadPool threadPool, UpdateByQueryRequest request, ScriptService scriptService, ClusterState clusterState,
                 ActionListener<BulkByScrollResponse> listener) {
             super(task, logger, client, threadPool, request, scriptService, clusterState, listener);

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexMetadataTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexMetadataTests.java
@@ -79,7 +79,7 @@ public class ReindexMetadataTests extends AbstractAsyncBulkByScrollActionMetadat
     }
 
     private class TestAction extends TransportReindexAction.AsyncIndexBySearchAction {
-        public TestAction() {
+        TestAction() {
             super(ReindexMetadataTests.this.task, ReindexMetadataTests.this.logger, null, ReindexMetadataTests.this.threadPool, request(),
                     null, null, listener());
         }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryMetadataTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryMetadataTests.java
@@ -45,7 +45,7 @@ public class UpdateByQueryMetadataTests
     }
 
     private class TestAction extends TransportUpdateByQueryAction.AsyncIndexBySearchAction {
-        public TestAction() {
+        TestAction() {
             super(UpdateByQueryMetadataTests.this.task, UpdateByQueryMetadataTests.this.logger, null,
                     UpdateByQueryMetadataTests.this.threadPool, request(), null, null, listener());
         }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/ByteBufStreamInput.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/ByteBufStreamInput.java
@@ -36,7 +36,7 @@ class ByteBufStreamInput extends StreamInput {
     private final int startIndex;
     private final int endIndex;
 
-    public ByteBufStreamInput(ByteBuf buffer, int length) {
+    ByteBufStreamInput(ByteBuf buffer, int length) {
         if (length > buffer.readableBytes()) {
             throw new IndexOutOfBoundsException();
         }

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerPipeliningTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerPipeliningTests.java
@@ -87,7 +87,7 @@ public class Netty4HttpServerPipeliningTests extends ESTestCase {
             .put("http.pipelining", true)
             .put("http.port", "0")
             .build();
-        try (final HttpServerTransport httpServerTransport = new CustomNettyHttpServerTransport(settings)) {
+        try (HttpServerTransport httpServerTransport = new CustomNettyHttpServerTransport(settings)) {
             httpServerTransport.start();
             final TransportAddress transportAddress = randomFrom(httpServerTransport.boundAddress().boundAddresses());
 
@@ -114,7 +114,7 @@ public class Netty4HttpServerPipeliningTests extends ESTestCase {
             .put("http.pipelining", false)
             .put("http.port", "0")
             .build();
-        try (final HttpServerTransport httpServerTransport = new CustomNettyHttpServerTransport(settings)) {
+        try (HttpServerTransport httpServerTransport = new CustomNettyHttpServerTransport(settings)) {
             httpServerTransport.start();
             final TransportAddress transportAddress = randomFrom(httpServerTransport.boundAddress().boundAddresses());
 

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/network/Ec2NameResolver.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/network/Ec2NameResolver.java
@@ -59,7 +59,7 @@ public class Ec2NameResolver extends AbstractComponent implements CustomNameReso
      *
      * @author Paul_Loy
      */
-    private static enum Ec2HostnameType {
+    private enum Ec2HostnameType {
 
         PRIVATE_IPv4("ec2:privateIpv4", "local-ipv4"),
         PRIVATE_DNS("ec2:privateDns", "local-hostname"),
@@ -74,7 +74,7 @@ public class Ec2NameResolver extends AbstractComponent implements CustomNameReso
         final String configName;
         final String ec2Name;
 
-        private Ec2HostnameType(String configName, String ec2Name) {
+        Ec2HostnameType(String configName, String ec2Name) {
             this.configName = configName;
             this.ec2Name = ec2Name;
         }

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryTests.java
@@ -294,7 +294,7 @@ public class Ec2DiscoveryTests extends ESTestCase {
 
     abstract class DummyEc2HostProvider extends AwsEc2UnicastHostsProvider {
         public int fetchCount = 0;
-        public DummyEc2HostProvider(Settings settings, TransportService transportService, AwsEc2Service service) {
+        DummyEc2HostProvider(Settings settings, TransportService transportService, AwsEc2Service service) {
             super(settings, transportService, service);
         }
     }

--- a/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -317,7 +317,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
     // it with an unchecked exception.
     private static final class AddressNotFoundRuntimeException extends RuntimeException {
 
-        public AddressNotFoundRuntimeException(Throwable cause) {
+        AddressNotFoundRuntimeException(Throwable cause) {
             super(cause);
         }
     }

--- a/plugins/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentParser.java
+++ b/plugins/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentParser.java
@@ -40,11 +40,11 @@ final class UserAgentParser {
     private final List<UserAgentSubpattern> osPatterns = new ArrayList<>();
     private final List<UserAgentSubpattern> devicePatterns = new ArrayList<>();
     private final String name;
-    
-    public UserAgentParser(String name, InputStream regexStream, UserAgentCache cache) {
+
+    UserAgentParser(String name, InputStream regexStream, UserAgentCache cache) {
         this.name = name;
         this.cache = cache;
-        
+
         try {
             init(regexStream);
         } catch (IOException e) {
@@ -55,16 +55,16 @@ final class UserAgentParser {
     private void init(InputStream regexStream) throws IOException {
         // EMPTY is safe here because we don't use namedObject
         XContentParser yamlParser = XContentFactory.xContent(XContentType.YAML).createParser(NamedXContentRegistry.EMPTY, regexStream);
-        
+
         XContentParser.Token token = yamlParser.nextToken();
-        
+
         if (token == XContentParser.Token.START_OBJECT) {
             token = yamlParser.nextToken();
-            
+
             for (; token != null; token = yamlParser.nextToken()) {
                 if (token == XContentParser.Token.FIELD_NAME && yamlParser.currentName().equals("user_agent_parsers")) {
                     List<Map<String, String>> parserConfigurations = readParserConfigurations(yamlParser);
-                    
+
                     for (Map<String, String> map : parserConfigurations) {
                         uaPatterns.add(new UserAgentSubpattern(compilePattern(map.get("regex"), map.get("regex_flag")),
                                 map.get("family_replacement"), map.get("v1_replacement"), map.get("v2_replacement"),
@@ -73,7 +73,7 @@ final class UserAgentParser {
                 }
                 else if (token == XContentParser.Token.FIELD_NAME && yamlParser.currentName().equals("os_parsers")) {
                     List<Map<String, String>> parserConfigurations = readParserConfigurations(yamlParser);
-                    
+
                     for (Map<String, String> map : parserConfigurations) {
                         osPatterns.add(new UserAgentSubpattern(compilePattern(map.get("regex"), map.get("regex_flag")),
                                 map.get("os_replacement"), map.get("os_v1_replacement"), map.get("os_v2_replacement"),
@@ -82,7 +82,7 @@ final class UserAgentParser {
                 }
                 else if (token == XContentParser.Token.FIELD_NAME && yamlParser.currentName().equals("device_parsers")) {
                     List<Map<String, String>> parserConfigurations = readParserConfigurations(yamlParser);
-                    
+
                     for (Map<String, String> map : parserConfigurations) {
                         devicePatterns.add(new UserAgentSubpattern(compilePattern(map.get("regex"), map.get("regex_flag")),
                                 map.get("device_replacement"), null, null, null, null));
@@ -90,7 +90,7 @@ final class UserAgentParser {
                 }
             }
         }
-        
+
         if (uaPatterns.isEmpty() && osPatterns.isEmpty() && devicePatterns.isEmpty()) {
             throw new ElasticsearchParseException("not a valid regular expression file");
         }
@@ -107,38 +107,38 @@ final class UserAgentParser {
 
     private List<Map<String, String>> readParserConfigurations(XContentParser yamlParser) throws IOException {
         List <Map<String, String>> patternList = new ArrayList<>();
-        
+
         XContentParser.Token token = yamlParser.nextToken();
         if (token != XContentParser.Token.START_ARRAY) {
             throw new ElasticsearchParseException("malformed regular expression file, should continue with 'array' after 'object'");
         }
-        
+
         token = yamlParser.nextToken();
         if (token != XContentParser.Token.START_OBJECT) {
             throw new ElasticsearchParseException("malformed regular expression file, expecting 'object'");
         }
-        
+
         while (token == XContentParser.Token.START_OBJECT) {
             token = yamlParser.nextToken();
-            
+
             if (token != XContentParser.Token.FIELD_NAME) {
                 throw new ElasticsearchParseException("malformed regular expression file, should continue with 'field_name' after 'array'");
             }
-            
+
             Map<String, String> regexMap = new HashMap<>();
             for (; token == XContentParser.Token.FIELD_NAME; token = yamlParser.nextToken()) {
                 String fieldName = yamlParser.currentName();
-                
+
                 token = yamlParser.nextToken();
                 String fieldValue = yamlParser.text();
                 regexMap.put(fieldName, fieldValue);
             }
 
             patternList.add(regexMap);
-            
+
             token = yamlParser.nextToken();
         }
-        
+
         return patternList;
     }
 
@@ -153,21 +153,21 @@ final class UserAgentParser {
     List<UserAgentSubpattern> getDevicePatterns() {
         return devicePatterns;
     }
-    
+
     String getName() {
         return name;
     }
 
     public Details parse(String agentString) {
         Details details = cache.get(name, agentString);;
-        
+
         if (details == null) {
             VersionedName userAgent = findMatch(uaPatterns, agentString);
             VersionedName operatingSystem = findMatch(osPatterns, agentString);
             VersionedName device = findMatch(devicePatterns, agentString);
-            
+
             details = new Details(userAgent, operatingSystem, device);
-            
+
             cache.put(name, agentString, details);
         }
 
@@ -183,7 +183,7 @@ final class UserAgentParser {
                 return name;
             }
         }
-        
+
         return null;
     }
 
@@ -191,22 +191,22 @@ final class UserAgentParser {
         public final VersionedName userAgent;
         public final VersionedName operatingSystem;
         public final VersionedName device;
-        
-        public Details(VersionedName userAgent, VersionedName operatingSystem, VersionedName device) {
+
+        Details(VersionedName userAgent, VersionedName operatingSystem, VersionedName device) {
             this.userAgent = userAgent;
             this.operatingSystem = operatingSystem;
             this.device = device;
         }
     }
-    
+
     static final class VersionedName {
         public final String name;
         public final String major;
         public final String minor;
         public final String patch;
         public final String build;
-        
-        public VersionedName(String name, String major, String minor, String patch, String build) {
+
+        VersionedName(String name, String major, String minor, String patch, String build) {
             this.name = name;
             this.major = major;
             this.minor = minor;
@@ -214,7 +214,7 @@ final class UserAgentParser {
             this.build = build;
         }
     }
-    
+
     /**
      * One of: user agent, operating system, device
      */
@@ -222,7 +222,7 @@ final class UserAgentParser {
         private final Pattern pattern;
         private final String nameReplacement, v1Replacement, v2Replacement, v3Replacement, v4Replacement;
 
-        public UserAgentSubpattern(Pattern pattern, String nameReplacement,
+        UserAgentSubpattern(Pattern pattern, String nameReplacement,
                 String v1Replacement, String v2Replacement, String v3Replacement, String v4Replacement) {
           this.pattern = pattern;
           this.nameReplacement = nameReplacement;
@@ -263,19 +263,19 @@ final class UserAgentParser {
           } else if (groupCount >= 3) {
             minor = matcher.group(3);
           }
-          
+
           if (v3Replacement != null) {
               patch = v3Replacement;
           } else if (groupCount >= 4) {
               patch = matcher.group(4);
           }
-          
+
           if (v4Replacement != null) {
               build = v4Replacement;
           } else if (groupCount >= 5) {
               build = matcher.group(5);
           }
-          
+
           return name == null ? null : new VersionedName(name, major, minor, patch, build);
         }
       }

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceTests.java
@@ -147,7 +147,7 @@ public class AzureStorageServiceTests extends ESTestCase {
      * This internal class just overload createClient method which is called by AzureStorageServiceImpl.doStart()
      */
     class AzureStorageServiceMock extends AzureStorageServiceImpl {
-        public AzureStorageServiceMock(Settings settings) {
+        AzureStorageServiceMock(Settings settings) {
             super(settings);
         }
 

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
@@ -50,7 +50,7 @@ public class S3RepositoryTests extends ESTestCase {
     }
 
     private static class DummyS3Service extends AbstractLifecycleComponent implements AwsS3Service {
-        public DummyS3Service() {
+        DummyS3Service() {
             super(Settings.EMPTY);
         }
         @Override

--- a/plugins/store-smb/src/main/java/org/elasticsearch/index/store/SmbDirectoryWrapper.java
+++ b/plugins/store-smb/src/main/java/org/elasticsearch/index/store/SmbDirectoryWrapper.java
@@ -59,7 +59,7 @@ public final class SmbDirectoryWrapper extends FilterDirectory {
          */
         static final int CHUNK_SIZE = 8192;
 
-        public SmbFSIndexOutput(String name) throws IOException {
+        SmbFSIndexOutput(String name) throws IOException {
             super("SmbFSIndexOutput(path=\"" + fsDirectory.getDirectory().resolve(name) + "\")", name, new FilterOutputStream(Channels.newOutputStream(Files.newByteChannel(fsDirectory.getDirectory().resolve(name), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.READ, StandardOpenOption.WRITE))) {
                 // This implementation ensures, that we never write more than CHUNK_SIZE bytes:
                 @Override

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
@@ -108,7 +108,7 @@ public class InstallPluginCommandTests extends ESTestCase {
             private final FileSystem fileSystem;
             private final Function<String, Path> temp;
 
-            public Parameter(FileSystem fileSystem, String root) {
+            Parameter(FileSystem fileSystem, String root) {
                 this(fileSystem, s -> {
                     try {
                         return Files.createTempDirectory(fileSystem.getPath(root), s);
@@ -118,7 +118,7 @@ public class InstallPluginCommandTests extends ESTestCase {
                 });
             }
 
-            public Parameter(FileSystem fileSystem, Function<String, Path> temp) {
+            Parameter(FileSystem fileSystem, Function<String, Path> temp) {
                 this.fileSystem = fileSystem;
                 this.temp = temp;
             }

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/ESElasticsearchCliTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/ESElasticsearchCliTestCase.java
@@ -35,7 +35,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 abstract class ESElasticsearchCliTestCase extends ESTestCase {
 
     interface InitConsumer {
-        void accept(final boolean foreground, final Path pidFile, final boolean quiet, final Environment initialEnv);
+        void accept(boolean foreground, Path pidFile, boolean quiet, Environment initialEnv);
     }
 
     void runTest(

--- a/test/framework/src/main/java/org/elasticsearch/common/io/FileTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/io/FileTestUtils.java
@@ -71,7 +71,7 @@ public class FileTestUtils {
         }
         Files.createDirectories(destDir);
 
-        try (final ZipInputStream zipInput = new ZipInputStream(Files.newInputStream(zip))) {
+        try (ZipInputStream zipInput = new ZipInputStream(Files.newInputStream(zip))) {
             ZipEntry entry;
             while ((entry = zipInput.getNextEntry()) != null) {
                 final String entryPath;

--- a/test/framework/src/main/java/org/elasticsearch/repositories/ESBlobStoreContainerTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/ESBlobStoreContainerTestCase.java
@@ -46,7 +46,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 public abstract class ESBlobStoreContainerTestCase extends ESTestCase {
 
     public void testWriteRead() throws IOException {
-        try(final BlobStore store = newBlobStore()) {
+        try(BlobStore store = newBlobStore()) {
             final BlobContainer container = store.blobContainer(new BlobPath());
             byte[] data = randomBytes(randomIntBetween(10, scaledRandomIntBetween(1024, 1 << 16)));
             writeBlob(container, "foobar", new BytesArray(data));
@@ -65,7 +65,7 @@ public abstract class ESBlobStoreContainerTestCase extends ESTestCase {
     }
 
     public void testMoveAndList() throws IOException {
-        try(final BlobStore store = newBlobStore()) {
+        try(BlobStore store = newBlobStore()) {
             final BlobContainer container = store.blobContainer(new BlobPath());
             assertThat(container.listBlobs().size(), equalTo(0));
             int numberOfFooBlobs = randomIntBetween(0, 10);
@@ -113,7 +113,7 @@ public abstract class ESBlobStoreContainerTestCase extends ESTestCase {
     }
 
     public void testDeleteBlob() throws IOException {
-        try (final BlobStore store = newBlobStore()) {
+        try (BlobStore store = newBlobStore()) {
             final String blobName = "foobar";
             final BlobContainer container = store.blobContainer(new BlobPath());
             expectThrows(IOException.class, () -> container.deleteBlob(blobName));
@@ -129,7 +129,7 @@ public abstract class ESBlobStoreContainerTestCase extends ESTestCase {
     }
 
     public void testVerifyOverwriteFails() throws IOException {
-        try (final BlobStore store = newBlobStore()) {
+        try (BlobStore store = newBlobStore()) {
             final String blobName = "foobar";
             final BlobContainer container = store.blobContainer(new BlobPath());
             byte[] data = randomBytes(randomIntBetween(10, scaledRandomIntBetween(1024, 1 << 16)));

--- a/test/framework/src/main/java/org/elasticsearch/repositories/ESBlobStoreTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/ESBlobStoreTestCase.java
@@ -36,7 +36,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 public abstract class ESBlobStoreTestCase extends ESTestCase {
 
     public void testContainerCreationAndDeletion() throws IOException {
-        try(final BlobStore store = newBlobStore()) {
+        try(BlobStore store = newBlobStore()) {
             final BlobContainer containerFoo = store.blobContainer(new BlobPath().add("foo"));
             final BlobContainer containerBar = store.blobContainer(new BlobPath().add("bar"));
             byte[] data1 = randomBytes(randomIntBetween(10, scaledRandomIntBetween(1024, 1 << 16)));

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1582,7 +1582,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
     private class LatchedActionListener<Response> implements ActionListener<Response> {
         private final CountDownLatch latch;
 
-        public LatchedActionListener(CountDownLatch latch) {
+        LatchedActionListener(CountDownLatch latch) {
             this.latch = latch;
         }
 
@@ -1610,7 +1610,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
         private final CopyOnWriteArrayList<Tuple<T, Exception>> errors;
         private final T builder;
 
-        public PayloadLatchedActionListener(T builder, CountDownLatch latch, CopyOnWriteArrayList<Tuple<T, Exception>> errors) {
+        PayloadLatchedActionListener(T builder, CountDownLatch latch, CopyOnWriteArrayList<Tuple<T, Exception>> errors) {
             super(latch);
             this.errors = errors;
             this.builder = builder;

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1846,7 +1846,7 @@ public final class InternalTestCluster extends TestCluster {
     private static final class MasterNodePredicate implements Predicate<NodeAndClient> {
         private final String masterNodeName;
 
-        public MasterNodePredicate(String masterNodeName) {
+        MasterNodePredicate(String masterNodeName) {
             this.masterNodeName = masterNodeName;
         }
 
@@ -1937,8 +1937,7 @@ public final class InternalTestCluster extends TestCluster {
     private static final class NodeNamePredicate implements Predicate<Settings> {
         private final HashSet<String> nodeNames;
 
-
-        public NodeNamePredicate(HashSet<String> nodeNames) {
+        NodeNamePredicate(HashSet<String> nodeNames) {
             this.nodeNames = nodeNames;
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/engine/ThrowingLeafReaderWrapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/engine/ThrowingLeafReaderWrapper.java
@@ -147,7 +147,7 @@ public class ThrowingLeafReaderWrapper extends FilterLeafReader {
     static class ThrowingTermsEnum extends FilterTermsEnum {
         private final Thrower thrower;
 
-        public ThrowingTermsEnum(TermsEnum in, Thrower thrower) {
+        ThrowingTermsEnum(TermsEnum in, Thrower thrower) {
             super(in);
             this.thrower = thrower;
 

--- a/test/framework/src/main/java/org/elasticsearch/test/store/MockFSDirectoryService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/store/MockFSDirectoryService.java
@@ -190,7 +190,7 @@ public class MockFSDirectoryService extends FsDirectoryService {
         private final BaseDirectoryWrapper dir;
         private final TestRuleMarkFailure failureMarker;
 
-        public CloseableDirectory(BaseDirectoryWrapper dir) {
+        CloseableDirectory(BaseDirectoryWrapper dir) {
             this.dir = dir;
             this.failureMarker = ESTestCase.getSuiteFailureMarker();
         }

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -932,7 +932,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         public volatile boolean sawResponseReceived;
 
         public AtomicReference<CountDownLatch> expectedEvents = new AtomicReference<>();
-        public Tracer(Set<String> actions) {
+        Tracer(Set<String> actions) {
             this.actions = actions;
         }
         @Override
@@ -1543,10 +1543,10 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
         String info;
 
-        public TestResponse() {
+        TestResponse() {
         }
 
-        public TestResponse(String info) {
+        TestResponse(String info) {
             this.info = info;
         }
 
@@ -1690,7 +1690,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
             private final int id;
 
-            public TestResponseHandler(int id) {
+            TestResponseHandler(int id) {
                 this.id = id;
             }
 

--- a/test/logger-usage/src/main/java/org/elasticsearch/test/loggerusage/ESLoggerUsageChecker.java
+++ b/test/logger-usage/src/main/java/org/elasticsearch/test/loggerusage/ESLoggerUsageChecker.java
@@ -176,7 +176,7 @@ public class ESLoggerUsageChecker {
         private final Consumer<WrongLoggerUsage> wrongUsageCallback;
         private final Predicate<String> methodsToCheck;
 
-        public ClassChecker(Consumer<WrongLoggerUsage> wrongUsageCallback, Predicate<String> methodsToCheck) {
+        ClassChecker(Consumer<WrongLoggerUsage> wrongUsageCallback, Predicate<String> methodsToCheck) {
             super(Opcodes.ASM5);
             this.wrongUsageCallback = wrongUsageCallback;
             this.methodsToCheck = methodsToCheck;
@@ -210,7 +210,7 @@ public class ESLoggerUsageChecker {
         private final Consumer<WrongLoggerUsage> wrongUsageCallback;
         private boolean ignoreChecks;
 
-        public MethodChecker(String className, int access, String name, String desc, Consumer<WrongLoggerUsage> wrongUsageCallback) {
+        MethodChecker(String className, int access, String name, String desc, Consumer<WrongLoggerUsage> wrongUsageCallback) {
             super(Opcodes.ASM5, new MethodNode(access, name, desc, null, null));
             this.className = className;
             this.wrongUsageCallback = wrongUsageCallback;
@@ -409,13 +409,13 @@ public class ESLoggerUsageChecker {
         protected final int minValue;
         protected final int maxValue;
 
-        public IntMinMaxTrackingBasicValue(Type type, int value) {
+        IntMinMaxTrackingBasicValue(Type type, int value) {
             super(type);
             this.minValue = value;
             this.maxValue = value;
         }
 
-        public IntMinMaxTrackingBasicValue(Type type, int minValue, int maxValue) {
+        IntMinMaxTrackingBasicValue(Type type, int minValue, int maxValue) {
             super(type);
             this.minValue = minValue;
             this.maxValue = maxValue;
@@ -454,27 +454,27 @@ public class ESLoggerUsageChecker {
     private static final class PlaceHolderStringBasicValue extends IntMinMaxTrackingBasicValue {
         public static final Type STRING_OBJECT_TYPE = Type.getObjectType("java/lang/String");
 
-        public PlaceHolderStringBasicValue(int placeHolders) {
+        PlaceHolderStringBasicValue(int placeHolders) {
             super(STRING_OBJECT_TYPE, placeHolders);
         }
 
-        public PlaceHolderStringBasicValue(int minPlaceHolders, int maxPlaceHolders) {
+        PlaceHolderStringBasicValue(int minPlaceHolders, int maxPlaceHolders) {
             super(STRING_OBJECT_TYPE, minPlaceHolders, maxPlaceHolders);
         }
     }
 
     private static final class ArraySizeBasicValue extends IntMinMaxTrackingBasicValue {
-        public ArraySizeBasicValue(Type type, int minArraySize, int maxArraySize) {
+        ArraySizeBasicValue(Type type, int minArraySize, int maxArraySize) {
             super(type, minArraySize, maxArraySize);
         }
     }
 
     private static final class IntegerConstantBasicValue extends IntMinMaxTrackingBasicValue {
-        public IntegerConstantBasicValue(Type type, int constant) {
+        IntegerConstantBasicValue(Type type, int constant) {
             super(type, constant);
         }
 
-        public IntegerConstantBasicValue(Type type, int minConstant, int maxConstant) {
+        IntegerConstantBasicValue(Type type, int minConstant, int maxConstant) {
             super(type, minConstant, maxConstant);
         }
     }


### PR DESCRIPTION
This commit upgrades the checkstyle configuration from version 5.9 to
version 7.5, the latest version as of today. The main enhancement
obtained via this upgrade is better detection of redundant modifiers.
