### PR TITLE
Build: Temporarily remove debian 8 for packaging tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -16,7 +16,8 @@ class VagrantTestPlugin implements Plugin<Project> {
     static List<String> BOXES = [
             'centos-6',
             'centos-7',
-            'debian-8',
+            // TODO: re-enable debian once it does not have broken openjdk packages
+            //'debian-8',
             'fedora-24',
             'oel-6',
             'oel-7',


### PR DESCRIPTION
Debian 8 has been having issues with the openjdk package dependencies
being broken. This comment comments out debian-8 from the boxes which
packaging tests will run on CI.