### PR TITLE
Don't allow casting from void to def in painless

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/AnalyzerCaster.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/AnalyzerCaster.java
@@ -722,9 +722,10 @@ public final class AnalyzerCaster {
                 break;
         }
 
-        if (actual.sort == Sort.DEF || expected.sort == Sort.DEF ||
-            expected.clazz.isAssignableFrom(actual.clazz) ||
-            explicit && actual.clazz.isAssignableFrom(expected.clazz)) {
+        if (       actual.sort == Sort.DEF
+                || (actual.sort != Sort.VOID && expected.sort == Sort.DEF)
+                || expected.clazz.isAssignableFrom(actual.clazz)
+                || (explicit && actual.clazz.isAssignableFrom(expected.clazz))) {
             return new Cast(actual, expected, explicit);
         } else {
             throw location.createError(new ClassCastException("Cannot cast from [" + actual.name + "] to [" + expected.name + "]."));

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Locals.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Locals.java
@@ -318,6 +318,19 @@ public final class Locals {
         public int getSlot() {
             return slot;
         }
+
+        @Override
+        public String toString() {
+            StringBuilder b = new StringBuilder();
+            b.append("Variable[type=").append(type);
+            b.append(",name=").append(name);
+            b.append(",slot=").append(slot);
+            if (readonly) {
+                b.append(",readonly");
+            }
+            b.append(']');
+            return b.toString();
+        }
     }
 
     public static final class Parameter {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/FunctionTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/FunctionTests.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.painless;
 
+import static org.hamcrest.Matchers.containsString;
+
 public class FunctionTests extends ScriptTestCase {
     public void testBasic() {
         assertEquals(5, exec("int get() {5;} get()"));
@@ -49,21 +51,37 @@ public class FunctionTests extends ScriptTestCase {
         Exception expected = expectScriptThrows(IllegalArgumentException.class, () -> {
             exec("void test(int x) {} test()");
         });
-        assertTrue(expected.getMessage().contains("Cannot generate an empty function"));
+        assertThat(expected.getMessage(), containsString("Cannot generate an empty function"));
     }
 
     public void testDuplicates() {
         Exception expected = expectScriptThrows(IllegalArgumentException.class, () -> {
             exec("void test(int x) {x = 2;} void test(def y) {y = 3;} test()");
         });
-        assertTrue(expected.getMessage().contains("Duplicate functions"));
+        assertThat(expected.getMessage(), containsString("Duplicate functions"));
     }
 
     public void testInfiniteLoop() {
         Error expected = expectScriptThrows(PainlessError.class, () -> {
             exec("void test() {boolean x = true; while (x) {}} test()");
         });
-        assertTrue(expected.getMessage().contains(
-            "The maximum number of statements that can be executed in a loop has been reached."));
+        assertThat(expected.getMessage(),
+                containsString("The maximum number of statements that can be executed in a loop has been reached."));
+    }
+
+    public void testReturnVoid() {
+        assertEquals(null, exec("void test(StringBuilder b, int i) {b.setLength(i)} test(new StringBuilder(), 1)"));
+        Exception expected = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("int test(StringBuilder b, int i) {b.setLength(i)} test(new StringBuilder(), 1)");
+        });
+        assertEquals("Not all paths provide a return value for method [test].", expected.getMessage());
+        expected = expectScriptThrows(ClassCastException.class, () -> {
+            exec("int test(StringBuilder b, int i) {return b.setLength(i)} test(new StringBuilder(), 1)");
+        });
+        assertEquals("Cannot cast from [void] to [int].", expected.getMessage());
+        expected = expectScriptThrows(ClassCastException.class, () -> {
+            exec("def test(StringBuilder b, int i) {return b.setLength(i)} test(new StringBuilder(), 1)");
+        });
+        assertEquals("Cannot cast from [void] to [def].", expected.getMessage());
     }
 }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/LambdaTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/LambdaTests.java
@@ -19,8 +19,11 @@
 
 package org.elasticsearch.painless;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
 
 public class LambdaTests extends ScriptTestCase {
 
@@ -230,5 +233,26 @@ public class LambdaTests extends ScriptTestCase {
             "else { return params['key'] } }, 'value')", params, true));
         assertEquals(false, exec(compare + "compare(() -> { if (params['number'] == 1) { return params['number'] }" +
             "else { return params['key'] } }, 2)", params, true));
+    }
+
+    public void testReturnVoid() {
+        Throwable expected = expectScriptThrows(ClassCastException.class, () -> {
+            exec("StringBuilder b = new StringBuilder(); List l = [1, 2]; l.stream().mapToLong(i -> b.setLength(i))");
+        });
+        assertThat(expected.getMessage(), containsString("Cannot cast from [void] to [long]."));
+    }
+
+    public void testReturnVoidDef() {
+        // If we can catch the error at compile time we do
+        Exception expected = expectScriptThrows(ClassCastException.class, () -> {
+            exec("StringBuilder b = new StringBuilder(); def l = [1, 2]; l.stream().mapToLong(i -> b.setLength(i))");
+        });
+        assertThat(expected.getMessage(), containsString("Cannot cast from [void] to [def]."));
+
+        // Otherwise we convert the void into a null
+        assertEquals(Arrays.asList(null, null),
+                exec("def b = new StringBuilder(); def l = [1, 2]; l.stream().map(i -> b.setLength(i)).collect(Collectors.toList())"));
+        assertEquals(Arrays.asList(null, null),
+                exec("def b = new StringBuilder(); List l = [1, 2]; l.stream().map(i -> b.setLength(i)).collect(Collectors.toList())"));
     }
 }


### PR DESCRIPTION
Painless can cast anything into the magic type `def` but it
really shouldn't try to cast **nothing** into `def`. That causes
the byte code generation library to freak out a little.

Closes #22908
