### PR TITLE
Build: Disable fedora for packaging tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -18,7 +18,8 @@ class VagrantTestPlugin implements Plugin<Project> {
             'centos-7',
             // TODO: re-enable debian once it does not have broken openjdk packages
             //'debian-8',
-            'fedora-24',
+            // TODO: re-enable fedora once it does not have broken openjdk packages
+            //'fedora-24',
             'oel-6',
             'oel-7',
             'opensuse-13',


### PR DESCRIPTION
Now that debian is disabled, we are seeing similar failures with fedora
not able to install java. This commit temporarily disables fedora until
it is once again stable.