### PR TITLE
Avoid classloading deadlock in ValuesSource.

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
@@ -77,7 +77,7 @@ public class AggregationContext {
             } else if (ValuesSource.class.isAssignableFrom(config.valueSourceType)
                     || ValuesSource.Bytes.class.isAssignableFrom(config.valueSourceType)
                     || ValuesSource.Bytes.WithOrdinals.class.isAssignableFrom(config.valueSourceType)) {
-                vs = (VS) ValuesSource.Bytes.EMPTY;
+                vs = (VS) ValuesSource.Bytes.WithOrdinals.EMPTY;
             } else {
                 throw new SearchParseException(searchContext, "Can't deal with unmapped ValuesSource type " + config.valueSourceType, null);
             }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -63,25 +63,6 @@ public abstract class ValuesSource {
 
     public static abstract class Bytes extends ValuesSource {
 
-        public static final WithOrdinals EMPTY = new WithOrdinals() {
-
-            @Override
-            public RandomAccessOrds ordinalsValues(LeafReaderContext context) {
-                return DocValues.emptySortedSet();
-            }
-
-            @Override
-            public RandomAccessOrds globalOrdinalsValues(LeafReaderContext context) {
-                return DocValues.emptySortedSet();
-            }
-
-            @Override
-            public SortedBinaryDocValues bytesValues(LeafReaderContext context) throws IOException {
-                return org.elasticsearch.index.fielddata.FieldData.emptySortedBinary(context.reader().maxDoc());
-            }
-
-        };
-
         @Override
         public Bits docsWithValue(LeafReaderContext context) throws IOException {
             final SortedBinaryDocValues bytes = bytesValues(context);
@@ -93,6 +74,25 @@ public abstract class ValuesSource {
         }
 
         public static abstract class WithOrdinals extends Bytes {
+
+            public static final WithOrdinals EMPTY = new WithOrdinals() {
+
+                @Override
+                public RandomAccessOrds ordinalsValues(LeafReaderContext context) {
+                    return DocValues.emptySortedSet();
+                }
+
+                @Override
+                public RandomAccessOrds globalOrdinalsValues(LeafReaderContext context) {
+                    return DocValues.emptySortedSet();
+                }
+
+                @Override
+                public SortedBinaryDocValues bytesValues(LeafReaderContext context) throws IOException {
+                    return org.elasticsearch.index.fielddata.FieldData.emptySortedBinary(context.reader().maxDoc());
+                }
+
+            };
 
             @Override
             public Bits docsWithValue(LeafReaderContext context) {


### PR DESCRIPTION
This issue had already been addressed on 5.x/master.

Closes #22952