### PR TITLE
Add a setting to disable remote cluster connections on a node

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/RemoteClusterService.java
+++ b/core/src/main/java/org/elasticsearch/action/search/RemoteClusterService.java
@@ -97,6 +97,14 @@ public final class RemoteClusterService extends AbstractComponent implements Clo
     public static final Setting<String> REMOTE_NODE_ATTRIBUTE = Setting.simpleString("search.remote.node.attr",
         Setting.Property.NodeScope);
 
+    /**
+     * If <code>true</code> connecting to remote clusters is supported on this node. If <code>false</code> this node will not establish
+     * connections to any remote clusters configured. Search requests executed against this node (where this node is the coordinating node)
+     * will fail if remote cluster syntax is used as an index pattern. The default is <code>true</code>
+     */
+    public static final Setting<Boolean> ENABLE_REMOTE_CLUSTERS = Setting.boolSetting("search.remote.connect", true,
+        Setting.Property.NodeScope);
+
     private static final char REMOTE_CLUSTER_INDEX_SEPARATOR = ':';
 
     private final TransportService transportService;

--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -259,6 +259,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     RemoteClusterService.REMOTE_CONNECTIONS_PER_CLUSTER,
                     RemoteClusterService.REMOTE_INITIAL_CONNECTION_TIMEOUT_SETTING,
                     RemoteClusterService.REMOTE_NODE_ATTRIBUTE,
+                    RemoteClusterService.ENABLE_REMOTE_CLUSTERS,
                     TransportService.TRACE_LOG_EXCLUDE_SETTING,
                     TransportService.TRACE_LOG_INCLUDE_SETTING,
                     TransportCloseIndexAction.CLUSTER_INDICES_CLOSE_ENABLE_SETTING,

--- a/docs/reference/modules/cross-cluster-search.asciidoc
+++ b/docs/reference/modules/cross-cluster-search.asciidoc
@@ -125,3 +125,8 @@ will be prefixed with their remote cluster name:
   `node.attr.gateway: true` such that only nodes with this attribute will be
   connected to if `search.remote.node.attr` is set to `gateway`.
 
+`search.remote.connect`::
+  If set to `false` the node will not connect to any configured remote cluster. This is useful to disable cross cluster
+  search support on certain nodes if remote clusters are configured via the cluster settings. The default is `true`
+
+

--- a/docs/reference/modules/cross-cluster-search.asciidoc
+++ b/docs/reference/modules/cross-cluster-search.asciidoc
@@ -126,7 +126,9 @@ will be prefixed with their remote cluster name:
   connected to if `search.remote.node.attr` is set to `gateway`.
 
 `search.remote.connect`::
-  If set to `false` the node will not connect to any configured remote cluster. This is useful to disable cross cluster
-  search support on certain nodes if remote clusters are configured via the cluster settings. The default is `true`
+ By default, any node in the cluster can act as a cross-cluster client and connect to remote clusters.
+ The `search.remote.connect` setting can be set to `false` (defaults to `true`) to prevent certain nodes from
+ connecting to remote clusters. Cross-cluster search requests must be sent to a node that is allowed to act as a
+ cross-cluster client.
 
 

--- a/qa/multi-cluster-search/build.gradle
+++ b/qa/multi-cluster-search/build.gradle
@@ -27,6 +27,7 @@ task remoteClusterTest(type: RestIntegTestTask) {
     distribution = 'zip'
     numNodes = 2
     clusterName = 'remote-cluster'
+    setting 'search.remote.connect', false
   }
   systemProperty 'tests.rest.suite', 'remote_cluster'
 }
@@ -37,7 +38,7 @@ task mixedClusterTest(type: RestIntegTestTask) {
     distribution = 'zip'
     setting 'search.remote.my_remote_cluster.seeds', "\"${-> remoteClusterTest.nodes.get(0).transportUri()}\""
     setting 'search.remote.connections_per_cluster', 1
-
+    setting 'search.remote.connect', true
   }
   systemProperty 'tests.rest.suite', 'multi_cluster'
   finalizedBy 'remoteClusterTest#node0.stop','remoteClusterTest#node1.stop'


### PR DESCRIPTION
Today either all nodes in the cluster connect to remote clusters of only nodes
that have remote clusters configured in their node config. To allow global remote
cluster configuration but restrict connections to a set of nodes in the cluster
this change adds a new setting `search.remote.connect` (defaults to `true`) to allow
to disable remote cluster connections on a per node basis.
