### PR TITLE
Deprecate distance_type parameter in GeoDistanceQueryBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/geo/GeoDistance.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoDistance.java
@@ -23,8 +23,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.unit.DistanceUnit;
 
 import java.io.IOException;
@@ -32,12 +30,11 @@ import java.util.Locale;
 
 /**
  * Geo distance calculation.
+ * @Deprecated geo_distance computation is handled internally to Lucene so this class is deprecated
  */
+@Deprecated
 public enum GeoDistance implements Writeable {
     PLANE, ARC;
-
-    private static final DeprecationLogger DEPRECATION_LOGGER =
-        new DeprecationLogger(Loggers.getLogger(GeoDistance.class));
 
     /** Creates a GeoDistance instance from an input stream */
     public static GeoDistance readFromStream(StreamInput in) throws IOException {
@@ -103,7 +100,6 @@ public enum GeoDistance implements Writeable {
         if ("plane".equals(name)) {
             return PLANE;
         } else if ("sloppy_arc".equals(name)) {
-            DEPRECATION_LOGGER.deprecated("[sloppy_arc] is deprecated. Use [arc] instead.");
             return ARC;
         } else if ("arc".equals(name)) {
             return ARC;

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
@@ -65,6 +65,7 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
     /** Default for distance unit computation. */
     public static final DistanceUnit DEFAULT_DISTANCE_UNIT = DistanceUnit.DEFAULT;
     /** Default for geo distance computation. */
+    @Deprecated
     public static final GeoDistance DEFAULT_GEO_DISTANCE = GeoDistance.ARC;
     /** Default for optimising query through pre computed bounding box query. */
     @Deprecated
@@ -81,7 +82,9 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
     @Deprecated
     private static final ParseField OPTIMIZE_BBOX_FIELD = new ParseField("optimize_bbox")
             .withAllDeprecated("no replacement: `optimize_bbox` is no longer supported due to recent improvements");
-    private static final ParseField DISTANCE_TYPE_FIELD = new ParseField("distance_type");
+    @Deprecated
+    private static final ParseField DISTANCE_TYPE_FIELD = new ParseField("distance_type")
+            .withAllDeprecated("no replacement: `distance_type` is no longer supported due to recent improvements");
     private static final ParseField UNIT_FIELD = new ParseField("unit");
     private static final ParseField DISTANCE_FIELD = new ParseField("distance");
     private static final ParseField IGNORE_UNMAPPED_FIELD = new ParseField("ignore_unmapped");
@@ -92,8 +95,10 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
     /** Point to use as center. */
     private GeoPoint center = new GeoPoint(Double.NaN, Double.NaN);
     /** Algorithm to use for distance computation. */
+    @Deprecated
     private GeoDistance geoDistance = GeoDistance.ARC;
     /** Whether or not to use a bbox for pre-filtering. TODO change to enum? */
+    @Deprecated
     private String optimizeBbox = null;
     /** How strict should geo coordinate validation be? */
     private GeoValidationMethod validationMethod = GeoValidationMethod.DEFAULT;
@@ -208,6 +213,7 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
     }
 
     /** Which type of geo distance calculation method to use. */
+    @Deprecated
     public GeoDistanceQueryBuilder geoDistance(GeoDistance geoDistance) {
         if (geoDistance == null) {
             throw new IllegalArgumentException("geoDistance must not be null");
@@ -217,6 +223,7 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
     }
 
     /** Returns geo distance calculation type to use. */
+    @Deprecated
     public GeoDistance geoDistance() {
         return this.geoDistance;
     }
@@ -330,9 +337,6 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
         builder.startArray(fieldName).value(center.lon()).value(center.lat()).endArray();
         builder.field(DISTANCE_FIELD.getPreferredName(), distance);
         builder.field(DISTANCE_TYPE_FIELD.getPreferredName(), geoDistance.name().toLowerCase(Locale.ROOT));
-        if (Strings.isEmpty(optimizeBbox) == false) {
-            builder.field(OPTIMIZE_BBOX_FIELD.getPreferredName(), optimizeBbox);
-        }
         builder.field(VALIDATION_METHOD_FIELD.getPreferredName(), validationMethod);
         builder.field(IGNORE_UNMAPPED_FIELD.getPreferredName(), ignoreUnmapped);
         printBoostAndQueryName(builder);

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryBuilder.java
@@ -57,6 +57,7 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
 
     public static final boolean DEFAULT_INCLUDE_LOWER = true;
     public static final boolean DEFAULT_INCLUDE_UPPER = true;
+    @Deprecated
     public static final GeoDistance DEFAULT_GEO_DISTANCE = GeoDistance.ARC;
     public static final DistanceUnit DEFAULT_UNIT = DistanceUnit.DEFAULT;
     @Deprecated
@@ -76,7 +77,9 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
     private static final ParseField LT_FIELD = new ParseField("lt");
     private static final ParseField LTE_FIELD = new ParseField("lte", "le");
     private static final ParseField UNIT_FIELD = new ParseField("unit");
-    private static final ParseField DISTANCE_TYPE_FIELD = new ParseField("distance_type");
+    @Deprecated
+    private static final ParseField DISTANCE_TYPE_FIELD = new ParseField("distance_type")
+            .withAllDeprecated("no replacement: `distance_type` is no longer supported due to recent improvements");
     private static final ParseField NAME_FIELD = new ParseField("_name");
     private static final ParseField BOOST_FIELD = new ParseField("boost");
     @Deprecated
@@ -100,10 +103,12 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
 
     private final GeoPoint point;
 
+    @Deprecated
     private GeoDistance geoDistance = DEFAULT_GEO_DISTANCE;
 
     private DistanceUnit unit = DEFAULT_UNIT;
 
+    @Deprecated
     private String optimizeBbox = null;
 
     private GeoValidationMethod validationMethod = GeoValidationMethod.DEFAULT;
@@ -226,6 +231,7 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
         return includeUpper;
     }
 
+    @Deprecated
     public GeoDistanceRangeQueryBuilder geoDistance(GeoDistance geoDistance) {
         if (geoDistance == null) {
             throw new IllegalArgumentException("geoDistance calculation mode must not be null");
@@ -234,6 +240,7 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
         return this;
     }
 
+    @Deprecated
     public GeoDistance geoDistance() {
         return geoDistance;
     }
@@ -379,9 +386,6 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
         builder.field(INCLUDE_UPPER_FIELD.getPreferredName(), includeUpper);
         builder.field(UNIT_FIELD.getPreferredName(), unit);
         builder.field(DISTANCE_TYPE_FIELD.getPreferredName(), geoDistance.name().toLowerCase(Locale.ROOT));
-        if (Strings.isEmpty(optimizeBbox) == false) {
-            builder.field(OPTIMIZE_BBOX_FIELD.getPreferredName(), optimizeBbox);
-        }
         builder.field(VALIDATION_METHOD.getPreferredName(), validationMethod);
         builder.field(IGNORE_UNMAPPED_FIELD.getPreferredName(), ignoreUnmapped);
         printBoostAndQueryName(builder);
@@ -404,7 +408,6 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
         Boolean includeUpper = null;
         DistanceUnit unit = null;
         GeoDistance geoDistance = null;
-        String optimizeBbox = null;
         boolean coerce = GeoValidationMethod.DEFAULT_LENIENT_PARSING;
         boolean ignoreMalformed = GeoValidationMethod.DEFAULT_LENIENT_PARSING;
         GeoValidationMethod validationMethod = null;
@@ -526,7 +529,6 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
                 } else if (BOOST_FIELD.match(currentFieldName)) {
                     boost = parser.floatValue();
                 } else if (OPTIMIZE_BBOX_FIELD.match(currentFieldName)) {
-                    optimizeBbox = parser.textOrNull();
                 } else if (COERCE_FIELD.match(currentFieldName)) {
                     coerce = parser.booleanValue();
                 } else if (IGNORE_MALFORMED_FIELD.match(currentFieldName)) {
@@ -589,10 +591,6 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
             queryBuilder.geoDistance(geoDistance);
         }
 
-        if (optimizeBbox != null) {
-            queryBuilder.optimizeBbox(optimizeBbox);
-        }
-
         if (validationMethod != null) {
             // if validation method is set explicitly ignore deprecated coerce/ignore malformed fields if any
             queryBuilder.setValidationMethod(validationMethod);
@@ -612,7 +610,6 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
                 (Objects.equals(includeUpper, other.includeUpper)) &&
                 (Objects.equals(includeLower, other.includeLower)) &&
                 (Objects.equals(geoDistance, other.geoDistance)) &&
-                (Objects.equals(optimizeBbox, other.optimizeBbox)) &&
                 (Objects.equals(validationMethod, other.validationMethod))) &&
                 Objects.equals(ignoreUnmapped, other.ignoreUnmapped);
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceAggregationBuilder.java
@@ -52,7 +52,8 @@ public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilde
     public static final String NAME = "geo_distance";
     static final ParseField ORIGIN_FIELD = new ParseField("origin", "center", "point", "por");
     static final ParseField UNIT_FIELD = new ParseField("unit");
-    static final ParseField DISTANCE_TYPE_FIELD = new ParseField("distance_type");
+    static final ParseField DISTANCE_TYPE_FIELD = new ParseField("distance_type")
+        .withAllDeprecated("no replacement: `distance_type` is no longer supported due to recent improvements");
 
     private static final ObjectParser<GeoDistanceAggregationBuilder, QueryParseContext> PARSER;
     static {

--- a/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -71,7 +71,9 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
     public static final GeoValidationMethod DEFAULT_VALIDATION = GeoValidationMethod.DEFAULT;
 
     private static final ParseField UNIT_FIELD = new ParseField("unit");
-    private static final ParseField DISTANCE_TYPE_FIELD = new ParseField("distance_type");
+    @Deprecated
+    private static final ParseField DISTANCE_TYPE_FIELD = new ParseField("distance_type")
+        .withAllDeprecated("no replacement: `distance_type` is no longer supported due to recent improvements");
     private static final ParseField VALIDATION_METHOD_FIELD = new ParseField("validation_method");
     private static final ParseField IGNORE_MALFORMED_FIELD = new ParseField("ignore_malformed").withAllDeprecated("validation_method");
     private static final ParseField COERCE_FIELD = new ParseField("coerce", "normalize").withAllDeprecated("validation_method");

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -77,13 +77,23 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
         }
 
         if (randomBoolean()) {
-            qb.geoDistance(randomFrom(GeoDistance.values()));
-        }
-
-        if (randomBoolean()) {
             qb.ignoreUnmapped(randomBoolean());
         }
         return qb;
+    }
+
+    @Override
+    public void testFromXContent() throws IOException {
+        super.testFromXContent();
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: `distance_type` is no longer " +
+            "supported due to recent improvements]");
+    }
+
+    @Override
+    public void testUnknownField() throws IOException {
+        super.testUnknownField();
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: `distance_type` is no longer " +
+            "supported due to recent improvements]");
     }
 
     public void testIllegalValues() {
@@ -116,9 +126,6 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
         assertEquals("geohash must not be null or empty", e.getMessage());
         e = expectThrows(IllegalArgumentException.class, () -> query.geohash(""));
         assertEquals("geohash must not be null or empty", e.getMessage());
-
-        e = expectThrows(IllegalArgumentException.class, () -> query.geoDistance(null));
-        assertEquals("geoDistance must not be null", e.getMessage());
     }
 
     /**
@@ -383,9 +390,11 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
         assertEquals(json, -70.0, parsed.point().getLon(), 0.0001);
         assertEquals(json, 40.0, parsed.point().getLat(), 0.0001);
         assertEquals(json, 12000.0, parsed.distance(), 0.0001);
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: `distance_type` is no longer " +
+            "supported due to recent improvements]");
     }
 
-    public void testSloppyArcIsDeprecated() throws IOException {
+    public void testDistanceTypeIsDeprecated() throws IOException {
         String json =
             "{\n" +
                 "  \"geo_distance\" : {\n" +
@@ -398,7 +407,8 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "  }\n" +
                 "}";
         parseQuery(json);
-        assertWarnings("[sloppy_arc] is deprecated. Use [arc] instead.");
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: " +
+            "`distance_type` is no longer supported due to recent improvements]");
     }
 
     public void testOptimizeBboxIsDeprecated() throws IOException {
@@ -407,7 +417,6 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "  \"geo_distance\" : {\n" +
                 "    \"pin.location\" : [ -70.0, 40.0 ],\n" +
                 "    \"distance\" : 12000.0,\n" +
-                "    \"distance_type\" : \"arc\",\n" +
                 "    \"optimize_bbox\" : \"memory\",\n" +
                 "    \"validation_method\" : \"STRICT\",\n" +
                 "    \"ignore_unmapped\" : false,\n" +
@@ -425,7 +434,6 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "  \"geo_distance\" : {\n" +
                 "    \"pin.location\" : [ -70.0, 40.0 ],\n" +
                 "    \"distance\" : 12000.0,\n" +
-                "    \"distance_type\" : \"arc\",\n" +
                 "    \"coerce\" : true,\n" +
                 "    \"ignore_unmapped\" : false,\n" +
                 "    \"boost\" : 1.0\n" +
@@ -441,7 +449,6 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "  \"geo_distance\" : {\n" +
                 "    \"pin.location\" : [ -70.0, 40.0 ],\n" +
                 "    \"distance\" : 12000.0,\n" +
-                "    \"distance_type\" : \"arc\",\n" +
                 "    \"ignore_malformed\" : true,\n" +
                 "    \"ignore_unmapped\" : false,\n" +
                 "    \"boost\" : 1.0\n" +

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceRangeQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceRangeQueryTests.java
@@ -104,9 +104,6 @@ public class GeoDistanceRangeQueryTests extends AbstractQueryTestCase<GeoDistanc
         if (randomBoolean()) {
             builder.includeUpper(randomBoolean());
         }
-        if (randomBoolean()) {
-            builder.geoDistance(randomFrom(GeoDistance.values()));
-        }
         builder.unit(fromToUnits);
         if (randomBoolean()) {
             builder.setValidationMethod(randomFrom(GeoValidationMethod.values()));
@@ -116,6 +113,20 @@ public class GeoDistanceRangeQueryTests extends AbstractQueryTestCase<GeoDistanc
             builder.ignoreUnmapped(randomBoolean());
         }
         return builder;
+    }
+
+    @Override
+    public void testFromXContent() throws IOException {
+        super.testFromXContent();
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: `distance_type` is no longer " +
+            "supported due to recent improvements]");
+    }
+
+    @Override
+    public void testUnknownField() throws IOException {
+        super.testUnknownField();
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: `distance_type` is no longer " +
+            "supported due to recent improvements]");
     }
 
     @Override
@@ -307,6 +318,8 @@ public class GeoDistanceRangeQueryTests extends AbstractQueryTestCase<GeoDistanc
         GeoDistanceRangeQueryBuilder parsed = (GeoDistanceRangeQueryBuilder) parseQuery(json);
         checkGeneratedJson(json, parsed);
         assertEquals(json, -70.0, parsed.point().lon(), 0.0001);
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: `distance_type` is no longer " +
+            "supported due to recent improvements]");
     }
 
     public void testFromJsonOptimizeBboxFails() throws IOException {
@@ -319,7 +332,6 @@ public class GeoDistanceRangeQueryTests extends AbstractQueryTestCase<GeoDistanc
                 "    \"include_lower\" : true,\n" +
                 "    \"include_upper\" : true,\n" +
                 "    \"unit\" : \"m\",\n" +
-                "    \"distance_type\" : \"arc\",\n" +
                 "    \"optimize_bbox\" : \"memory\",\n" +
                 "    \"ignore_unmapped\" : false,\n" +
                 "    \"boost\" : 1.0\n" +
@@ -328,6 +340,26 @@ public class GeoDistanceRangeQueryTests extends AbstractQueryTestCase<GeoDistanc
         parseQuery(json);
         assertWarnings("Deprecated field [optimize_bbox] used, replaced by [no replacement: `optimize_bbox` is no longer " +
                 "supported due to recent improvements]");
+    }
+
+    public void testFromJsonDistanceTypeFails() throws IOException {
+        String json =
+            "{\n" +
+                "  \"geo_distance_range\" : {\n" +
+                "    \"pin.location\" : [ -70.0, 40.0 ],\n" +
+                "    \"from\" : \"200km\",\n" +
+                "    \"to\" : \"400km\",\n" +
+                "    \"include_lower\" : true,\n" +
+                "    \"include_upper\" : true,\n" +
+                "    \"unit\" : \"m\",\n" +
+                "    \"distance_type\" : \"arc\",\n" +
+                "    \"ignore_unmapped\" : false,\n" +
+                "    \"boost\" : 1.0\n" +
+                "  }\n" +
+                "}";
+        parseQuery(json);
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: `distance_type` is no longer " +
+            "supported due to recent improvements]");
     }
 
     public void testFromJsonCoerceFails() throws IOException {
@@ -340,7 +372,6 @@ public class GeoDistanceRangeQueryTests extends AbstractQueryTestCase<GeoDistanc
                 "    \"include_lower\" : true,\n" +
                 "    \"include_upper\" : true,\n" +
                 "    \"unit\" : \"m\",\n" +
-                "    \"distance_type\" : \"arc\",\n" +
                 "    \"coerce\" : true,\n" +
                 "    \"ignore_unmapped\" : false,\n" +
                 "    \"boost\" : 1.0\n" +
@@ -360,7 +391,6 @@ public class GeoDistanceRangeQueryTests extends AbstractQueryTestCase<GeoDistanc
                 "    \"include_lower\" : true,\n" +
                 "    \"include_upper\" : true,\n" +
                 "    \"unit\" : \"m\",\n" +
-                "    \"distance_type\" : \"arc\",\n" +
                 "    \"ignore_malformed\" : true,\n" +
                 "    \"ignore_unmapped\" : false,\n" +
                 "    \"boost\" : 1.0\n" +

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceRangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceRangeTests.java
@@ -55,9 +55,6 @@ public class GeoDistanceRangeTests extends BaseAggregationTestCase<GeoDistanceAg
         if (randomBoolean()) {
             factory.unit(randomFrom(DistanceUnit.values()));
         }
-        if (randomBoolean()) {
-            factory.distanceType(randomFrom(GeoDistance.values()));
-        }
         return factory;
     }
 

--- a/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTests.java
@@ -195,6 +195,12 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
           }
     }
 
+    @Override
+    public void testFromXContent() throws IOException {
+        super.testFromXContent();
+        assertWarnings("no replacement: `distance_type` is no longer supported due to recent improvements");
+    }
+
     public void testReverseOptionFailsWhenNonStringField() throws IOException {
         String json = "{\n" +
                 "  \"testname\" : [ {\n" +
@@ -257,6 +263,24 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
         }
     }
 
+    public void testDistanceTypeIsDeprecated() throws IOException {
+        String json = "{\n" +
+            "  \"testname\" : [ {\n" +
+            "    \"lat\" : -6.046997540714173,\n" +
+            "    \"lon\" : -51.94128329747579\n" +
+            "  } ],\n" +
+            "  \"unit\" : \"m\",\n" +
+            "  \"distance_type\" : \"arc\",\n" +
+            "  \"mode\" : \"MAX\"\n" +
+            "}";
+        XContentParser itemParser = createParser(JsonXContent.jsonXContent, json);
+        itemParser.nextToken();
+
+        QueryParseContext context = new QueryParseContext(itemParser);
+        GeoDistanceSortBuilder.fromXContent(context, "");
+        assertWarnings("no replacement: `distance_type` is no longer supported due to recent improvements");
+    }
+
     public void testCoerceIsDeprecated() throws IOException {
         String json = "{\n" +
                 "  \"testname\" : [ {\n" +
@@ -264,7 +288,6 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
                 "    \"lon\" : -51.94128329747579\n" +
                 "  } ],\n" +
                 "  \"unit\" : \"m\",\n" +
-                "  \"distance_type\" : \"arc\",\n" +
                 "  \"mode\" : \"MAX\",\n" +
                 "  \"coerce\" : true\n" +
                 "}";
@@ -283,7 +306,6 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
                 "    \"lon\" : -51.94128329747579\n" +
                 "  } ],\n" +
                 "  \"unit\" : \"m\",\n" +
-                "  \"distance_type\" : \"arc\",\n" +
                 "  \"mode\" : \"MAX\",\n" +
                 "  \"ignore_malformed\" : true\n" +
                 "}";
@@ -302,7 +324,6 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
                 "    \"lon\" : -51.94128329747579\n" +
                 "  } ],\n" +
                 "  \"unit\" : \"m\",\n" +
-                "  \"distance_type\" : \"arc\",\n" +
                 "  \"mode\" : \"SUM\"\n" +
                 "}";
         XContentParser itemParser = createParser(JsonXContent.jsonXContent, json);
@@ -319,7 +340,6 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
                 "    \"VDcvDuFjE\" : [ \"7umzzv8eychg\", \"dmdgmt5z13uw\", " +
                 "    \"ezu09wxw6v4c\", \"kc7s3515p6k6\", \"jgeuvjwrmfzn\", \"kcpcfj7ruyf8\" ],\n" +
                 "    \"unit\" : \"m\",\n" +
-                "    \"distance_type\" : \"arc\",\n" +
                 "    \"mode\" : \"MAX\",\n" +
                 "    \"nested_filter\" : {\n" +
                 "      \"ids\" : {\n" +

--- a/docs/reference/aggregations/bucket/geodistance-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/geodistance-aggregation.asciidoc
@@ -117,7 +117,7 @@ POST /museums/_search?size=0
 
 <1> The distances will be computed in kilometers
 
-There are two distance calculation modes: `arc` (the default), and `plane`. The `arc` calculation is the most accurate.
+deprecated[5.3] There are two distance calculation modes: `arc` (the default), and `plane`. The `arc` calculation is the most accurate.
 The `plane` is the fastest but least accurate. Consider using `plane` when your search context is "narrow", and spans
 smaller geographical areas (~5km). `plane` will return higher error margins for searches across very large areas
 (e.g. cross continent search). The distance calculation type can be set using the `distance_type` parameter:
@@ -131,8 +131,6 @@ POST /museums/_search?size=0
             "geo_distance" : {
                 "field" : "location",
                 "origin" : "52.3760, 4.894",
-                "unit" : "km",
-                "distance_type" : "plane",
                 "ranges" : [
                     { "to" : 100 },
                     { "from" : 100, "to" : 300 },

--- a/docs/reference/migration/migrate_5_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_5_0/aggregations.asciidoc
@@ -31,3 +31,7 @@ than zero.
 
 Fractional time values (e.g., 0.5s) are no longer supported. For example, this means when setting
 date histogram intervals "1.5h" will be rejected and should instead be input as "90m".
+
+==== geo_distance Aggregation
+
+The `distance_type` parameter is deprecated in the `geo_distance` aggregation.

--- a/docs/reference/migration/migrate_5_0/search.asciidoc
+++ b/docs/reference/migration/migrate_5_0/search.asciidoc
@@ -164,6 +164,8 @@ This parameter was undocumented and silently ignored before for these types of `
 
 * For `geo_distance` query, aggregation, and sort the `sloppy_arc` option for the `distance_type` parameter has been deprecated.
 
+* The `distance_type` parameter is deprecated in `geo_distance` query.
+
 ==== Top level `filter` parameter
 
 Removed support for the deprecated top level `filter` in the search api,

--- a/docs/reference/query-dsl/geo-distance-query.asciidoc
+++ b/docs/reference/query-dsl/geo-distance-query.asciidoc
@@ -191,7 +191,7 @@ The following are options allowed on the filter:
 
 `distance_type`::
 
-    How to compute the distance. Can either be `arc` (default), or `plane` (faster, but inaccurate on long distances and close to the poles).
+    deprecated[5.3] How to compute the distance. Can either be `arc` (default), or `plane` (faster, but inaccurate on long distances and close to the poles).
 
 `optimize_bbox`::
 

--- a/docs/reference/search/request/sort.asciidoc
+++ b/docs/reference/search/request/sort.asciidoc
@@ -244,7 +244,7 @@ GET /_search
 
 `distance_type`::
 
-    How to compute the distance. Can either be `arc` (default), or `plane` (faster, but inaccurate on long distances and close to the poles).
+    deprecated[5.3] How to compute the distance. Can either be `arc` (default), or `plane` (faster, but inaccurate on long distances and close to the poles).
 
 `mode`::
 


### PR DESCRIPTION
This is a follow up to PR #19846 and the deprecation portion of #22914. Since Lucene optimizes Sinnot's haversine distance computation, there is no need to carry optional distance calculations. Therefore the distance_type parameter and GeoDistance class is deprecated.
