### PR TITLE
Move search request validations to SearchRequest#validate

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -103,6 +103,10 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
+        if (source == null) {
+            return validationException;
+        }
+
         if (scroll != null) {
             if (source.from() > 0) {
                 validationException =

--- a/core/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchService.java
@@ -692,20 +692,11 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             context.groupStats(source.stats());
         }
         if (source.searchAfter() != null && source.searchAfter().length > 0) {
-            if (context.scrollContext() != null) {
-                throw new SearchContextException(context, "`search_after` cannot be used in a scroll context.");
-            }
-            if (context.from() > 0) {
-                throw new SearchContextException(context, "`from` parameter must be set to 0 when `search_after` is used.");
-            }
             FieldDoc fieldDoc = SearchAfterBuilder.buildFieldDoc(context.sort(), source.searchAfter());
             context.searchAfter(fieldDoc);
         }
 
         if (source.slice() != null) {
-            if (context.scrollContext() == null) {
-                throw new SearchContextException(context, "`slice` cannot be used outside of a scroll context");
-            }
             context.sliceBuilder(source.slice());
         }
 

--- a/core/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
@@ -172,16 +172,6 @@ public class CollapseBuilder extends ToXContentToBytes implements Writeable {
     }
 
     public CollapseContext build(SearchContext context) {
-        if (context.scrollContext() != null) {
-            throw new SearchContextException(context, "cannot use `collapse` in a scroll context");
-        }
-        if (context.searchAfter() != null) {
-            throw new SearchContextException(context, "cannot use `collapse` in conjunction with `search_after`");
-        }
-        if (context.rescore() != null && context.rescore().isEmpty() == false) {
-            throw new SearchContextException(context, "cannot use `collapse` in conjunction with `rescore`");
-        }
-
         MappedFieldType fieldType = context.getQueryShardContext().fieldMapper(field);
         if (fieldType == null) {
             throw new SearchContextException(context, "no mapping found for `" + field + "` in order to collapse on");

--- a/core/src/test/java/org/elasticsearch/search/slice/SearchSliceIT.java
+++ b/core/src/test/java/org/elasticsearch/search/slice/SearchSliceIT.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.slice;
 
+import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequestBuilder;
@@ -27,20 +28,20 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.search.Scroll;
-import org.elasticsearch.search.SearchContextException;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 
@@ -160,15 +161,12 @@ public class SearchSliceIT extends ESIntegTestCase {
 
     public void testInvalidQuery() throws Exception {
         setupIndex(false);
-        SearchPhaseExecutionException exc = expectThrows(SearchPhaseExecutionException.class,
+        ActionRequestValidationException exc = expectThrows(ActionRequestValidationException.class,
             () -> client().prepareSearch()
                 .setQuery(matchAllQuery())
                 .slice(new SliceBuilder("invalid_random_int", 0, 10))
                 .get());
-        Throwable rootCause = findRootCause(exc);
-        assertThat(rootCause.getClass(), equalTo(SearchContextException.class));
-        assertThat(rootCause.getMessage(),
-            equalTo("`slice` cannot be used outside of a scroll context"));
+        assertThat(exc.getMessage(), containsString("`slice` cannot be used outside of a scroll context"));
     }
 
     private void assertSearchSlicesWithScroll(SearchRequestBuilder request, String field, int numSlice) {

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/10_basic.yaml
@@ -124,4 +124,3 @@
   - do:
       clear_scroll:
         scroll_id: $scroll_id
-

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/30_limits.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/30_limits.yaml
@@ -18,15 +18,6 @@ setup:
         from: 10000
 
 ---
-"Request window limits with scroll":
-  - do:
-      catch:      /Batch size is too large, size must be less than or equal to[:] \[10000\] but was \[10010\]\. Scroll batch sizes cost as much memory as result windows so they are controlled by the \[index.max_result_window\] index level setting\./
-      search:
-        index: test_1
-        scroll: 5m
-        from: 10000
-
----
 "Rescore window limits":
   - do:
       catch:      /Rescore window \[10001\] is too large\. It must be less than \[10000\]\./


### PR DESCRIPTION
This change moves codes that validate the search request in the SearchRequest#validate method.
It also adds the following validation for the search request:
* scroll cannot be used if size equals 0
* scroll cannot be used if from is greater than 0 (from was ignored in the scroll context before this change so it's not a breaking change)

Fixes #22552 and #9373