### PR TITLE
Add Index API to High Level Rest Client

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
@@ -203,12 +203,7 @@ final class Request {
 
         Params withRefreshPolicy(WriteRequest.RefreshPolicy refreshPolicy) {
             if (refreshPolicy != WriteRequest.RefreshPolicy.NONE) {
-                // TODO use refreshPolicy.toString() once it returns the appropriate value
-                if (refreshPolicy == WriteRequest.RefreshPolicy.IMMEDIATE) {
-                    putParam("refresh", Boolean.TRUE.toString());
-                } else {
-                    putParam("refresh", "wait_for");
-                }
+                putParam("refresh", refreshPolicy.getValue());
             }
             return this;
         }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
@@ -228,7 +228,12 @@ final class Request {
 
         Params withRefreshPolicy(WriteRequest.RefreshPolicy refreshPolicy) {
             if (refreshPolicy != WriteRequest.RefreshPolicy.NONE) {
-                return putParam("refresh", refreshPolicy.toString());
+                // TODO use refreshPolicy.toString() once it returns the appropriate value
+                if (refreshPolicy == WriteRequest.RefreshPolicy.IMMEDIATE) {
+                    putParam("refresh", Boolean.TRUE.toString());
+                } else {
+                    putParam("refresh", "wait_for");
+                }
             }
             return this;
         }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
@@ -20,16 +20,27 @@
 package org.elasticsearch.client;
 
 import org.apache.http.HttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.StringJoiner;
 
 final class Request {
@@ -68,38 +79,17 @@ final class Request {
     }
 
     private static Map<String, String> getParams(GetRequest getRequest) {
-        Map<String, String> params = new HashMap<>();
-        putParam("preference", getRequest.preference(), params);
-        putParam("routing", getRequest.routing(), params);
-        putParam("parent", getRequest.parent(), params);
-        if (getRequest.refresh()) {
-            params.put("refresh", Boolean.TRUE.toString());
-        }
-        if (getRequest.realtime() == false) {
-            params.put("realtime", Boolean.FALSE.toString());
-        }
-        if (getRequest.storedFields() != null && getRequest.storedFields().length > 0) {
-            params.put("stored_fields", String.join(",", getRequest.storedFields()));
-        }
-        if (getRequest.version() != Versions.MATCH_ANY) {
-            params.put("version", Long.toString(getRequest.version()));
-        }
-        if (getRequest.versionType() != VersionType.INTERNAL) {
-            params.put("version_type", getRequest.versionType().name().toLowerCase(Locale.ROOT));
-        }
-        if (getRequest.fetchSourceContext() != null) {
-            FetchSourceContext fetchSourceContext = getRequest.fetchSourceContext();
-            if (fetchSourceContext.fetchSource() == false) {
-                params.put("_source", Boolean.FALSE.toString());
-            }
-            if (fetchSourceContext.includes() != null && fetchSourceContext.includes().length > 0) {
-                params.put("_source_include", String.join(",", fetchSourceContext.includes()));
-            }
-            if (fetchSourceContext.excludes() != null && fetchSourceContext.excludes().length > 0) {
-                params.put("_source_exclude", String.join(",", fetchSourceContext.excludes()));
-            }
-        }
-        return Collections.unmodifiableMap(params);
+        Params parameters = Params.builder();
+        parameters.withPreference(getRequest.preference());
+        parameters.withRouting(getRequest.routing());
+        parameters.withParent(getRequest.parent());
+        parameters.withRefresh(getRequest.refresh());
+        parameters.withRealtime(getRequest.realtime());
+        parameters.withStoredFields(getRequest.storedFields());
+        parameters.withVersion(getRequest.version());
+        parameters.withVersionType(getRequest.versionType());
+        parameters.withFetchSourceContext(getRequest.fetchSourceContext());
+        return parameters.getParams();
     }
 
     private static String getEndpoint(GetRequest getRequest) {
@@ -107,9 +97,184 @@ final class Request {
         return pathJoiner.add(getRequest.index()).add(getRequest.type()).add(getRequest.id()).toString();
     }
 
-    private static void putParam(String key, String value, Map<String, String> params) {
-        if (Strings.hasLength(value)) {
-            params.put(key, value);
+    static Request index(IndexRequest indexRequest) {
+        String method = Strings.hasLength(indexRequest.id()) ? "PUT" : "POST";
+
+        Endpoint endpoint = Endpoint.builder();
+        endpoint.add(indexRequest.index());
+        endpoint.add(indexRequest.type());
+        endpoint.add(indexRequest.id());
+        if (indexRequest.opType() == DocWriteRequest.OpType.CREATE) {
+            endpoint.withSuffix("/_create");
+        }
+
+        Params parameters = Params.builder();
+        parameters.withRouting(indexRequest.routing());
+        parameters.withParent(indexRequest.parent());
+        parameters.withTimeout(indexRequest.timeout());
+        parameters.withVersion(indexRequest.version());
+        parameters.withVersionType(indexRequest.versionType());
+        parameters.withPipeline(indexRequest.getPipeline());
+        parameters.withRefreshPolicy(indexRequest.getRefreshPolicy());
+        parameters.withWaitForActiveShards(indexRequest.waitForActiveShards());
+
+        BytesRef source = indexRequest.source().toBytesRef();
+        ContentType contentType = ContentType.create(indexRequest.getContentType().mediaType());
+        HttpEntity entity = new ByteArrayEntity(source.bytes, source.offset, source.length, contentType);
+
+        return new Request(method, endpoint.getEndpoint(), parameters.getParams(), entity);
+    }
+
+    /**
+     * Utility class to build request's endpoint.
+     */
+    private static class Endpoint {
+        private final List<String> parts = new ArrayList<>();
+        private final String delimiter = "/";
+        private final String prefix = "/";
+        private String suffix = "";
+
+        private Endpoint() {
+        }
+
+        Endpoint withSuffix(String suffix) {
+            this.suffix = Objects.requireNonNull(suffix, "suffix must not be null");
+            return this;
+        }
+
+        Endpoint add(String part) {
+            if (Strings.hasLength(part)) {
+                parts.add(part);
+            }
+            return this;
+        }
+
+        String getEndpoint() {
+            StringJoiner joiner = new StringJoiner(delimiter, prefix, suffix);
+            for (String part : parts) {
+                joiner.add(part);
+            }
+            return joiner.toString();
+        }
+
+        static Endpoint builder() {
+            return new Endpoint();
+        }
+    }
+
+    /**
+     * Utility class to build request's parameters map and centralize all parameter names.
+     */
+    private static class Params {
+        private final Map<String, String> params = new HashMap<>();
+
+        private Params() {
+        }
+
+        Params putParam(String key, String value) {
+            if (Strings.hasLength(value)) {
+                params.put(key, value);
+            }
+            return this;
+        }
+
+        Params putParam(String key, TimeValue value) {
+            if (value != null) {
+                return putParam(key, value.getStringRep());
+            }
+            return this;
+        }
+
+        Params withFetchSourceContext(FetchSourceContext fetchSourceContext) {
+            if (fetchSourceContext != null) {
+                if (fetchSourceContext.fetchSource() == false) {
+                    putParam("_source", Boolean.FALSE.toString());
+                }
+                if (fetchSourceContext.includes() != null && fetchSourceContext.includes().length > 0) {
+                    putParam("_source_include", String.join(",", fetchSourceContext.includes()));
+                }
+                if (fetchSourceContext.excludes() != null && fetchSourceContext.excludes().length > 0) {
+                    putParam("_source_exclude", String.join(",", fetchSourceContext.excludes()));
+                }
+            }
+            return this;
+        }
+
+        Params withParent(String parent) {
+            return putParam("parent", parent);
+        }
+
+        Params withPipeline(String pipeline) {
+            return putParam("pipeline", pipeline);
+        }
+
+        Params withPreference(String preference) {
+            return putParam("preference", preference);
+        }
+
+        Params withRealtime(boolean realtime) {
+            if (realtime == false) {
+                return putParam("realtime", Boolean.FALSE.toString());
+            }
+            return this;
+        }
+
+        Params withRefresh(boolean refresh) {
+            if (refresh) {
+                return withRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+            }
+            return this;
+        }
+
+        Params withRefreshPolicy(WriteRequest.RefreshPolicy refreshPolicy) {
+            if (refreshPolicy != WriteRequest.RefreshPolicy.NONE) {
+                return putParam("refresh", refreshPolicy.toString());
+            }
+            return this;
+        }
+
+        Params withRouting(String routing) {
+            return putParam("routing", routing);
+        }
+
+        Params withStoredFields(String[] storedFields) {
+            if (storedFields != null && storedFields.length > 0) {
+                return putParam("stored_fields", String.join(",", storedFields));
+            }
+            return this;
+        }
+
+        Params withTimeout(TimeValue timeout) {
+            return putParam("timeout", timeout);
+        }
+
+        Params withVersion(long version) {
+            if (version != Versions.MATCH_ANY) {
+                return putParam("version", Long.toString(version));
+            }
+            return this;
+        }
+
+        Params withVersionType(VersionType versionType) {
+            if (versionType != VersionType.INTERNAL) {
+                return putParam("version_type", versionType.name().toLowerCase(Locale.ROOT));
+            }
+            return this;
+        }
+
+        Params withWaitForActiveShards(ActiveShardCount activeShardCount) {
+            if (activeShardCount != null && activeShardCount != ActiveShardCount.DEFAULT) {
+                return putParam("wait_for_active_shards", activeShardCount.toString().toLowerCase(Locale.ROOT));
+            }
+            return this;
+        }
+
+        Map<String, String> getParams() {
+            return Collections.unmodifiableMap(params);
+        }
+
+        static Params builder() {
+            return new Params();
         }
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -28,6 +28,8 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.main.MainRequest;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -41,6 +43,9 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 
 /**
  * High level REST client that wraps an instance of the low level {@link RestClient} and allows to build requests and read responses.
@@ -59,37 +64,61 @@ public class RestHighLevelClient {
      */
     public boolean ping(Header... headers) throws IOException {
         return performRequest(new MainRequest(), (request) -> Request.ping(), RestHighLevelClient::convertExistsResponse,
-                Collections.emptySet(), headers);
+                emptySet(), headers);
     }
 
     /**
-     * Retrieves a document by id using the get api
+     * Retrieves a document by id using the Get API
+     *
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html">Get API on elastic.co</a>
      */
     public GetResponse get(GetRequest getRequest, Header... headers) throws IOException {
-        return performRequestAndParseEntity(getRequest, Request::get, GetResponse::fromXContent, Collections.singleton(404), headers);
+        return performRequestAndParseEntity(getRequest, Request::get, GetResponse::fromXContent, singleton(404), headers);
     }
 
     /**
-     * Asynchronously retrieves a document by id using the get api
+     * Asynchronously retrieves a document by id using the Get API
+     *
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html">Get API on elastic.co</a>
      */
     public void getAsync(GetRequest getRequest, ActionListener<GetResponse> listener, Header... headers) {
-        performRequestAsyncAndParseEntity(getRequest, Request::get, GetResponse::fromXContent, listener,
-                Collections.singleton(404), headers);
+        performRequestAsyncAndParseEntity(getRequest, Request::get, GetResponse::fromXContent, listener, singleton(404), headers);
     }
 
     /**
      * Checks for the existence of a document. Returns true if it exists, false otherwise
+     *
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html">Get API on elastic.co</a>
      */
     public boolean exists(GetRequest getRequest, Header... headers) throws IOException {
-        return performRequest(getRequest, Request::exists, RestHighLevelClient::convertExistsResponse, Collections.emptySet(), headers);
+        return performRequest(getRequest, Request::exists, RestHighLevelClient::convertExistsResponse, emptySet(), headers);
     }
 
     /**
      * Asynchronously checks for the existence of a document. Returns true if it exists, false otherwise
+     *
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html">Get API on elastic.co</a>
      */
     public void existsAsync(GetRequest getRequest, ActionListener<Boolean> listener, Header... headers) {
-        performRequestAsync(getRequest, Request::exists, RestHighLevelClient::convertExistsResponse, listener,
-                Collections.emptySet(), headers);
+        performRequestAsync(getRequest, Request::exists, RestHighLevelClient::convertExistsResponse, listener, emptySet(), headers);
+    }
+
+    /**
+     * Index a document using the Index API
+     *
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html">Index API on elastic.co</a>
+     */
+    public IndexResponse index(IndexRequest indexRequest, Header... headers) throws IOException {
+        return performRequestAndParseEntity(indexRequest, Request::index, IndexResponse::fromXContent, emptySet(), headers);
+    }
+
+    /**
+     * Asynchronously index a document using the Index API
+     *
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html">Index API on elastic.co</a>
+     */
+    public void indexAsync(IndexRequest indexRequest, ActionListener<IndexResponse> listener, Header... headers) {
+        performRequestAsyncAndParseEntity(indexRequest, Request::index, IndexResponse::fromXContent, listener, emptySet(), headers);
     }
 
     private <Req extends ActionRequest, Resp> Resp performRequestAndParseEntity(Req request, Function<Req, Request>  requestConverter,

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -151,31 +151,28 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
     }
 
     public void testIndex() throws IOException {
-        {
-            for (XContentType xContentType : XContentType.values()) {
-                IndexRequest indexRequest = new IndexRequest("index", "type");
-                indexRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("test", "test").endObject());
-
-                IndexResponse indexResponse = execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync);
-                assertEquals(RestStatus.CREATED, indexResponse.status());
-                assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
-                assertEquals("index", indexResponse.getIndex());
-                assertEquals("type", indexResponse.getType());
-                assertTrue(Strings.hasLength(indexResponse.getId()));
-                assertEquals(1L, indexResponse.getVersion());
-                assertNotNull(indexResponse.getShardId());
-                assertEquals(-1, indexResponse.getShardId().getId());
-                assertEquals("index", indexResponse.getShardId().getIndexName());
-                assertEquals("index", indexResponse.getShardId().getIndex().getName());
-                assertEquals("_na_", indexResponse.getShardId().getIndex().getUUID());
-                assertNotNull(indexResponse.getShardInfo());
-                assertEquals(0, indexResponse.getShardInfo().getFailed());
-                assertTrue(indexResponse.getShardInfo().getSuccessful() > 0);
-                assertTrue(indexResponse.getShardInfo().getTotal() > 0);
-            }
-        }
-
         final XContentType xContentType = randomFrom(XContentType.values());
+        {
+            IndexRequest indexRequest = new IndexRequest("index", "type");
+            indexRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("test", "test").endObject());
+
+            IndexResponse indexResponse = execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync);
+            assertEquals(RestStatus.CREATED, indexResponse.status());
+            assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
+            assertEquals("index", indexResponse.getIndex());
+            assertEquals("type", indexResponse.getType());
+            assertTrue(Strings.hasLength(indexResponse.getId()));
+            assertEquals(1L, indexResponse.getVersion());
+            assertNotNull(indexResponse.getShardId());
+            assertEquals(-1, indexResponse.getShardId().getId());
+            assertEquals("index", indexResponse.getShardId().getIndexName());
+            assertEquals("index", indexResponse.getShardId().getIndex().getName());
+            assertEquals("_na_", indexResponse.getShardId().getIndex().getUUID());
+            assertNotNull(indexResponse.getShardInfo());
+            assertEquals(0, indexResponse.getShardInfo().getFailed());
+            assertTrue(indexResponse.getShardInfo().getSuccessful() > 0);
+            assertTrue(indexResponse.getShardInfo().getTotal() > 0);
+        }
         {
             IndexRequest indexRequest = new IndexRequest("index", "type", "id");
             indexRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("version", 1).endObject());

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -22,9 +22,17 @@ package org.elasticsearch.client;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.VersionType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
@@ -139,6 +147,125 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             Map<String, Object> sourceAsMap = getResponse.getSourceAsMap();
             assertEquals(1, sourceAsMap.size());
             assertEquals("value1", sourceAsMap.get("field1"));
+        }
+    }
+
+    public void testIndex() throws IOException {
+        {
+            for (XContentType xContentType : XContentType.values()) {
+                IndexRequest indexRequest = new IndexRequest("index", "type");
+                indexRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("test", "test").endObject());
+
+                IndexResponse indexResponse = execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync);
+                assertEquals(RestStatus.CREATED, indexResponse.status());
+                assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
+                assertEquals("index", indexResponse.getIndex());
+                assertEquals("type", indexResponse.getType());
+                assertTrue(Strings.hasLength(indexResponse.getId()));
+                assertEquals(1L, indexResponse.getVersion());
+                assertNotNull(indexResponse.getShardId());
+                assertEquals(-1, indexResponse.getShardId().getId());
+                assertEquals("index", indexResponse.getShardId().getIndexName());
+                assertEquals("index", indexResponse.getShardId().getIndex().getName());
+                assertEquals("_na_", indexResponse.getShardId().getIndex().getUUID());
+                assertNotNull(indexResponse.getShardInfo());
+                assertEquals(0, indexResponse.getShardInfo().getFailed());
+                assertTrue(indexResponse.getShardInfo().getSuccessful() > 0);
+                assertTrue(indexResponse.getShardInfo().getTotal() > 0);
+            }
+        }
+
+        final XContentType xContentType = randomFrom(XContentType.values());
+        {
+            IndexRequest indexRequest = new IndexRequest("index", "type", "id");
+            indexRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("version", 1).endObject());
+
+            IndexResponse indexResponse = execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync);
+            assertEquals(RestStatus.CREATED, indexResponse.status());
+            assertEquals("index", indexResponse.getIndex());
+            assertEquals("type", indexResponse.getType());
+            assertEquals("id", indexResponse.getId());
+            assertEquals(1L, indexResponse.getVersion());
+
+            indexRequest = new IndexRequest("index", "type", "id");
+            indexRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("version", 2).endObject());
+
+            indexResponse = execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync);
+            assertEquals(RestStatus.OK, indexResponse.status());
+            assertEquals("index", indexResponse.getIndex());
+            assertEquals("type", indexResponse.getType());
+            assertEquals("id", indexResponse.getId());
+            assertEquals(2L, indexResponse.getVersion());
+
+            ElasticsearchStatusException exception = expectThrows(ElasticsearchStatusException.class, () -> {
+                IndexRequest wrongRequest = new IndexRequest("index", "type", "id");
+                wrongRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("field", "test").endObject());
+                wrongRequest.version(5L);
+
+                execute(wrongRequest, highLevelClient()::index, highLevelClient()::indexAsync);
+            });
+            assertEquals(RestStatus.CONFLICT, exception.status());
+            assertEquals("Elasticsearch exception [type=version_conflict_engine_exception, reason=[type][id]: " +
+                         "version conflict, current version [2] is different than the one provided [5]]", exception.getMessage());
+            assertEquals("index", exception.getMetadata("es.index").get(0));
+        }
+        {
+            ElasticsearchStatusException exception = expectThrows(ElasticsearchStatusException.class, () -> {
+                IndexRequest indexRequest = new IndexRequest("index", "type", "missing_parent");
+                indexRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("field", "test").endObject());
+                indexRequest.parent("missing");
+
+                execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync);
+            });
+
+            assertEquals(RestStatus.BAD_REQUEST, exception.status());
+            assertEquals("Elasticsearch exception [type=illegal_argument_exception, " +
+                         "reason=Can't specify parent if no parent field has been configured]", exception.getMessage());
+        }
+        {
+            ElasticsearchStatusException exception = expectThrows(ElasticsearchStatusException.class, () -> {
+                IndexRequest indexRequest = new IndexRequest("index", "type", "missing_pipeline");
+                indexRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("field", "test").endObject());
+                indexRequest.setPipeline("missing");
+
+                execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync);
+            });
+
+            assertEquals(RestStatus.BAD_REQUEST, exception.status());
+            assertEquals("Elasticsearch exception [type=illegal_argument_exception, " +
+                         "reason=pipeline with id [missing] does not exist]", exception.getMessage());
+        }
+        {
+            IndexRequest indexRequest = new IndexRequest("index", "type", "external_version_type");
+            indexRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("field", "test").endObject());
+            indexRequest.version(12L);
+            indexRequest.versionType(VersionType.EXTERNAL);
+
+            IndexResponse indexResponse = execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync);
+            assertEquals(RestStatus.CREATED, indexResponse.status());
+            assertEquals("index", indexResponse.getIndex());
+            assertEquals("type", indexResponse.getType());
+            assertEquals("external_version_type", indexResponse.getId());
+            assertEquals(12L, indexResponse.getVersion());
+        }
+        {
+            final IndexRequest indexRequest = new IndexRequest("index", "type", "with_create_op_type");
+            indexRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("field", "test").endObject());
+            indexRequest.opType(DocWriteRequest.OpType.CREATE);
+
+            IndexResponse indexResponse = execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync);
+            assertEquals(RestStatus.CREATED, indexResponse.status());
+            assertEquals("index", indexResponse.getIndex());
+            assertEquals("type", indexResponse.getType());
+            assertEquals("with_create_op_type", indexResponse.getId());
+
+            ElasticsearchStatusException exception = expectThrows(ElasticsearchStatusException.class, () -> {
+                execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync);
+            });
+
+            assertEquals(RestStatus.CONFLICT, exception.status());
+            assertEquals("Elasticsearch exception [type=version_conflict_engine_exception, reason=[type][with_create_op_type]: " +
+                         "version conflict, document already exists (current version [1])]", exception.getMessage());
         }
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
@@ -175,7 +175,7 @@ public class RequestTests extends ESTestCase {
         indexRequest.id(id);
 
         Map<String, String> expectedParams = new HashMap<>();
-        long version = randomFrom(Versions.MATCH_ANY, Versions.MATCH_DELETED, Versions.NOT_FOUND, randomNonNegativeLong());
+        long version = randomFrom(Versions.MATCH_DELETED, Versions.NOT_FOUND, randomNonNegativeLong());
         indexRequest.version(version);
         expectedParams.put("version", Long.toString(version));
 
@@ -220,7 +220,12 @@ public class RequestTests extends ESTestCase {
                 WriteRequest.RefreshPolicy refreshPolicy = randomFrom(WriteRequest.RefreshPolicy.values());
                 indexRequest.setRefreshPolicy(refreshPolicy);
                 if (refreshPolicy != WriteRequest.RefreshPolicy.NONE) {
-                    expectedParams.put("refresh", refreshPolicy.toString());
+                    // TODO use refreshPolicy.toString() once it returns the appropriate value
+                    if (refreshPolicy == WriteRequest.RefreshPolicy.IMMEDIATE) {
+                        expectedParams.put("refresh", Boolean.TRUE.toString());
+                    } else {
+                        expectedParams.put("refresh", "wait_for");
+                    }
                 }
             }
             if (randomBoolean()) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
@@ -19,12 +19,24 @@
 
 package org.elasticsearch.client;
 
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.action.support.replication.ReplicationRequest;
+import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -154,5 +166,101 @@ public class RequestTests extends ESTestCase {
         assertEquals(expectedParams, request.params);
         assertNull(request.entity);
         assertEquals(method, request.method);
+    }
+
+    public void testIndex() throws IOException {
+        String index = randomAsciiOfLengthBetween(3, 10);
+        String type = randomAsciiOfLengthBetween(3, 10);
+        IndexRequest indexRequest = new IndexRequest(index, type);
+
+        String id = randomBoolean() ? randomAsciiOfLengthBetween(3, 10) : null;
+        indexRequest.id(id);
+
+        String method = "POST";
+        if (id != null) {
+            method = "PUT";
+            if (randomBoolean()) {
+                indexRequest.opType(DocWriteRequest.OpType.CREATE);
+            }
+        }
+
+        Map<String, String> expectedParams = new HashMap<>();
+        if (randomBoolean()) {
+            String timeout = randomTimeValue();
+            indexRequest.timeout(timeout);
+            expectedParams.put("timeout", timeout);
+        } else {
+            expectedParams.put("timeout", ReplicationRequest.DEFAULT_TIMEOUT.getStringRep());
+        }
+
+        if (frequently()) {
+            if (randomBoolean()) {
+                String routing = randomAsciiOfLengthBetween(3, 10);
+                indexRequest.routing(routing);
+                expectedParams.put("routing", routing);
+            }
+            if (randomBoolean()) {
+                String parent = randomAsciiOfLengthBetween(3, 10);
+                indexRequest.parent(parent);
+                expectedParams.put("parent", parent);
+            }
+            if (randomBoolean()) {
+                String pipeline = randomAsciiOfLengthBetween(3, 10);
+                indexRequest.setPipeline(pipeline);
+                expectedParams.put("pipeline", pipeline);
+            }
+
+            if (randomBoolean()) {
+                WriteRequest.RefreshPolicy refreshPolicy = randomFrom(WriteRequest.RefreshPolicy.values());
+                indexRequest.setRefreshPolicy(refreshPolicy);
+                if (refreshPolicy != WriteRequest.RefreshPolicy.NONE) {
+                    expectedParams.put("refresh", refreshPolicy.toString());
+                }
+            }
+            if (randomBoolean()) {
+                long version = randomFrom(Versions.MATCH_ANY, Versions.MATCH_DELETED, Versions.NOT_FOUND, randomNonNegativeLong());
+                indexRequest.version(version);
+                if (version != Versions.MATCH_ANY) {
+                    expectedParams.put("version", Long.toString(version));
+                }
+            }
+            if (randomBoolean()) {
+                VersionType versionType = randomFrom(VersionType.values());
+                indexRequest.versionType(versionType);
+                if (versionType != VersionType.INTERNAL) {
+                    expectedParams.put("version_type", versionType.name().toLowerCase(Locale.ROOT));
+                }
+            }
+        }
+
+        XContentType xContentType = randomFrom(XContentType.values());
+        int nbFields = randomIntBetween(0, 10);
+        try (XContentBuilder builder = XContentBuilder.builder(xContentType.xContent())) {
+            builder.startObject();
+            for (int i = 0; i < nbFields; i++) {
+                builder.field("field_" + i, i);
+            }
+            builder.endObject();
+            indexRequest.source(builder);
+        }
+
+        Request request = Request.index(indexRequest);
+        if (indexRequest.opType() == DocWriteRequest.OpType.CREATE) {
+            assertEquals("/" + index + "/" + type + "/" + id + "/_create", request.endpoint);
+        } else if (id != null) {
+            assertEquals("/" + index + "/" + type + "/" + id, request.endpoint);
+        } else {
+            assertEquals("/" + index + "/" + type, request.endpoint);
+        }
+        assertEquals(expectedParams, request.params);
+        assertEquals(method, request.method);
+
+        HttpEntity entity = request.entity;
+        assertNotNull(entity);
+        assertTrue(entity instanceof ByteArrayEntity);
+
+        try (XContentParser parser = createParser(xContentType.xContent(), entity.getContent())) {
+            assertEquals(nbFields, parser.map().size());
+        }
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
@@ -235,12 +235,7 @@ public class RequestTests extends ESTestCase {
                 WriteRequest.RefreshPolicy refreshPolicy = randomFrom(WriteRequest.RefreshPolicy.values());
                 indexRequest.setRefreshPolicy(refreshPolicy);
                 if (refreshPolicy != WriteRequest.RefreshPolicy.NONE) {
-                    // TODO use refreshPolicy.toString() once it returns the appropriate value
-                    if (refreshPolicy == WriteRequest.RefreshPolicy.IMMEDIATE) {
-                        expectedParams.put("refresh", Boolean.TRUE.toString());
-                    } else {
-                        expectedParams.put("refresh", "wait_for");
-                    }
+                    expectedParams.put("refresh", refreshPolicy.getValue());
                 }
             }
         }


### PR DESCRIPTION
This commit adds support for the Index API in the High Level Rest Client.

It changes few things in the way request's parameters map is created in the high level client and changea bit  RefreshPolicy in core.