### PR TITLE
Resolve generic inheritance in constructor

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/NamedXContentRegistry.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/NamedXContentRegistry.java
@@ -62,7 +62,7 @@ public class NamedXContentRegistry {
         private final ContextParser<Object, ?> parser;
 
         /** Creates a new entry which can be stored by the registry. */
-        public <T> Entry(Class<T> categoryClass, ParseField name, CheckedFunction<XContentParser, ? extends T, IOException> parser) {
+        public <T> Entry(Class<T> categoryClass, ParseField name, CheckedFunction<XContentParser, ?, IOException> parser) {
             this.categoryClass = Objects.requireNonNull(categoryClass);
             this.name = Objects.requireNonNull(name);
             this.parser = Objects.requireNonNull((p, c) -> parser.apply(p));


### PR DESCRIPTION
This commit to solve the warnings in new NamedXContentRegistry.Entry(...):
Cannot resolve constructor 'Entry(java.lang.Class<org.elasticsearch.search.SearchExtBuilder>, org.elasticsearch.common.ParsedField, org.elasticsearch.common.CheckedFunction<org.elasticsearch.common.xcontent.XContentParser,capture<?>, java.io.IOException>)'
Thanks for review.
