### PR TITLE
Handle BlobPath's trailing separator corner case. Add test cases to BlobPathTests.java

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
@@ -63,7 +63,7 @@ public class BlobPath implements Iterable<String> {
 
     public String buildAsString() {
         String p = String.join(SEPARATOR, paths);
-        if (p.isEmpty()) {
+        if (p.isEmpty() || p.endsWith(SEPARATOR)) {
             return p;
         }
         return p + SEPARATOR;

--- a/core/src/test/java/org/elasticsearch/common/blobstore/BlobPathTests.java
+++ b/core/src/test/java/org/elasticsearch/common/blobstore/BlobPathTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.common.blobstore;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 public class BlobPathTests extends ESTestCase {
 
@@ -35,5 +36,10 @@ public class BlobPathTests extends ESTestCase {
         path = path.add("b").add("c");
         assertThat(path.buildAsString(), is("a/b/c/"));
 
+        path = path.add("d/");
+        assertThat(path.buildAsString(), is("a/b/c/d/"));
+
+        path = path.add("e/");
+        assertThat(path.buildAsString(), is(not("a/b/c/d/e//")));
     }
 }


### PR DESCRIPTION
When a trailing / is present at the end of base_path in s3 repository creation, an extra slash still gets prepended and this causes S3 to create an empty folder. This was not a problem in our ES 2.4 cluster as we always included the / at the end and was dealt with here:

https://github.com/elastic/elasticsearch/blob/v2.4.4/plugins/cloud-aws/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java#L140-L146. 

Specifically, the splitStringToArray on L142 got rid of the trailing slashes. 

This pull request fixes the trailing / issue. It also adds extra test case to BlobPathTests.java.