### PR TITLE
Expose WriteRequest.RefreshPolicy string representation

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/WriteRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/WriteRequest.java
@@ -110,6 +110,7 @@ public interface WriteRequest<R extends WriteRequest<R>> extends Streamable {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeByte((byte) ordinal());        }
+            out.writeByte((byte) ordinal());
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/support/WriteRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/WriteRequest.java
@@ -65,28 +65,22 @@ public interface WriteRequest<R extends WriteRequest<R>> extends Streamable {
         /**
          * Don't refresh after this request. The default.
          */
-        NONE((byte) 0, Boolean.FALSE.toString()),
+        NONE("false"),
         /**
          * Force a refresh as part of this request. This refresh policy does not scale for high indexing or search throughput but is useful
          * to present a consistent view to for indices with very low traffic. And it is wonderful for tests!
          */
-        IMMEDIATE((byte) 1, Boolean.TRUE.toString()),
+        IMMEDIATE("true"),
         /**
          * Leave this request open until a refresh has made the contents of this request visible to search. This refresh policy is
          * compatible with high indexing and search throughput but it causes the request to wait to reply until a refresh occurs.
          */
-        WAIT_UNTIL((byte) 2, "wait_for");
+        WAIT_UNTIL("wait_for");
 
-        private final byte id;
         private final String value;
 
-        RefreshPolicy(byte id, String value) {
-            this.id = id;
+        RefreshPolicy(String value) {
             this.value = value;
-        }
-
-        public byte getId() {
-            return id;
         }
 
         public String getValue() {
@@ -110,25 +104,12 @@ public interface WriteRequest<R extends WriteRequest<R>> extends Streamable {
             throw new IllegalArgumentException("Unknown value for refresh: [" + value + "].");
         }
 
-        /**
-         * Returns the {@link RefreshPolicy} associated to the given id.
-         */
-        public static RefreshPolicy fromId(byte id) {
-            for (RefreshPolicy policy : values()) {
-                if (policy.getId() == id) {
-                    return policy;
-                }
-            }
-            throw new IllegalArgumentException("No cluster block level matching [" + id + "]");
-        }
-
         public static RefreshPolicy readFrom(StreamInput in) throws IOException {
-            return fromId(in.readByte());
+            return RefreshPolicy.values()[in.readByte()];
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeByte(getId());
-        }
+            out.writeByte((byte) ordinal());        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/support/RefreshPolicyTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/RefreshPolicyTests.java
@@ -38,11 +38,6 @@ public class RefreshPolicyTests extends ESTestCase {
         }
     }
 
-    public void testFromId() throws IOException {
-        final WriteRequest.RefreshPolicy refreshPolicy = randomFrom(WriteRequest.RefreshPolicy.values());
-        assertEquals(refreshPolicy, WriteRequest.RefreshPolicy.fromId(refreshPolicy.getId()));
-    }
-
     public void testParse() throws IOException {
         final String refreshPolicyValue = randomFrom(WriteRequest.RefreshPolicy.values()).getValue();
         assertEquals(refreshPolicyValue, WriteRequest.RefreshPolicy.parse(refreshPolicyValue).getValue());

--- a/core/src/test/java/org/elasticsearch/action/support/RefreshPolicyTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/RefreshPolicyTests.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+public class RefreshPolicyTests extends ESTestCase {
+
+    public void testSerialization() throws IOException {
+        final WriteRequest.RefreshPolicy refreshPolicy = randomFrom(WriteRequest.RefreshPolicy.values());
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            refreshPolicy.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                WriteRequest.RefreshPolicy deserializedRefreshPolicy = WriteRequest.RefreshPolicy.readFrom(in);
+                assertEquals(refreshPolicy, deserializedRefreshPolicy);
+            }
+        }
+    }
+
+    public void testFromId() throws IOException {
+        final WriteRequest.RefreshPolicy refreshPolicy = randomFrom(WriteRequest.RefreshPolicy.values());
+        assertEquals(refreshPolicy, WriteRequest.RefreshPolicy.fromId(refreshPolicy.getId()));
+    }
+
+    public void testParse() throws IOException {
+        final String refreshPolicyValue = randomFrom(WriteRequest.RefreshPolicy.values()).getValue();
+        assertEquals(refreshPolicyValue, WriteRequest.RefreshPolicy.parse(refreshPolicyValue).getValue());
+    }
+
+    public void testParseEmpty() throws IOException {
+        assertEquals(WriteRequest.RefreshPolicy.IMMEDIATE, WriteRequest.RefreshPolicy.parse(""));
+    }
+
+    public void testParseUnknown() throws IOException {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> WriteRequest.RefreshPolicy.parse("unknown"));
+        assertEquals("Unknown value for refresh: [unknown].", e.getMessage());
+    }
+}


### PR DESCRIPTION
This commit changes the `RefreshPolicy` enum so that string representation are exposed. This will help the high level rest client to simply use `refreshPolicy.getValue()` to get the corresponding parameter value of a given refresh policy.