### PR TITLE
Add note about min_score filtering efficiency

### DIFF
--- a/docs/reference/query-dsl/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/function-score-query.asciidoc
@@ -110,6 +110,8 @@ query. The parameter `boost_mode` defines how:
 By default, modifying the score does not change which documents match. To exclude
 documents that do not meet a certain score threshold the `min_score` parameter can be set to the desired score threshold.
 
+NOTE: For `min_score` to work, **all** documents returned by the query need to be scored and then filtered out one by one. This is much less efficient than using a query filter.
+
 [[score-functions]]
 
 The `function_score` query provides several types of score functions.

--- a/docs/reference/query-dsl/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/function-score-query.asciidoc
@@ -110,7 +110,7 @@ query. The parameter `boost_mode` defines how:
 By default, modifying the score does not change which documents match. To exclude
 documents that do not meet a certain score threshold the `min_score` parameter can be set to the desired score threshold.
 
-NOTE: For `min_score` to work, **all** documents returned by the query need to be scored and then filtered out one by one. This is much less efficient than using a query filter.
+NOTE: For `min_score` to work, **all** documents returned by the query need to be scored and then filtered out one by one; you can think of it as `HAVING` in SQL.
 
 [[score-functions]]
 

--- a/docs/reference/query-dsl/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/function-score-query.asciidoc
@@ -110,7 +110,7 @@ query. The parameter `boost_mode` defines how:
 By default, modifying the score does not change which documents match. To exclude
 documents that do not meet a certain score threshold the `min_score` parameter can be set to the desired score threshold.
 
-NOTE: For `min_score` to work, **all** documents returned by the query need to be scored and then filtered out one by one; you can think of it as `HAVING` in SQL.
+NOTE: For `min_score` to work, **all** documents returned by the query need to be scored and then filtered out one by one.
 
 [[score-functions]]
 


### PR DESCRIPTION
In #23013 I explain how I expected the `min_score` filter to behave as the query filter; I find it would be useful if it were explicitly stated that the two filters - albeit having same syntax - will behave in a completely different way.

Perhaps I should add a link to the query filter page on the words "query filter"?