### PR TITLE
Fix some Javadoc typos

### DIFF
--- a/core/src/main/java/org/apache/lucene/search/suggest/analyzing/XAnalyzingSuggester.java
+++ b/core/src/main/java/org/apache/lucene/search/suggest/analyzing/XAnalyzingSuggester.java
@@ -486,7 +486,7 @@ public long ramBytesUsed() {
     }
   }
 
-    /** Non-null if this sugggester created a temp dir, needed only during build */
+    /** Non-null if this suggester created a temp dir, needed only during build */
     private static FSDirectory tmpBuildDir;
 
     @SuppressForbidden(reason = "access temp directory for building index")

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/PutRepositoryRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/PutRepositoryRequestBuilder.java
@@ -106,7 +106,7 @@ public class PutRepositoryRequestBuilder extends AcknowledgedRequestBuilder<PutR
      * Sets the repository settings in Json or Yaml format
      *
      * @param source repository settings
-     * @param xContentType the contenty type of the source
+     * @param xContentType the content type of the source
      * @return this builder
      */
     public PutRepositoryRequestBuilder setSettings(String source, XContentType xContentType) {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusRequestBuilder.java
@@ -29,7 +29,7 @@ import org.elasticsearch.common.util.ArrayUtils;
 public class SnapshotsStatusRequestBuilder extends MasterNodeOperationRequestBuilder<SnapshotsStatusRequest, SnapshotsStatusResponse, SnapshotsStatusRequestBuilder> {
 
     /**
-     * Constructs the new snapshotstatus request
+     * Constructs the new snapshot status request
      */
     public SnapshotsStatusRequestBuilder(ElasticsearchClient client, SnapshotsStatusAction action) {
         super(client, action, new SnapshotsStatusRequest());

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestBuilder.java
@@ -69,7 +69,7 @@ public class ClusterStateRequestBuilder extends MasterNodeReadOperationRequestBu
     }
 
     /**
-     * Should the cluster state result include teh {@link org.elasticsearch.cluster.routing.RoutingTable}. Defaults
+     * Should the cluster state result include the {@link org.elasticsearch.cluster.routing.RoutingTable}. Defaults
      * to <tt>true</tt>.
      */
     public ClusterStateRequestBuilder setRoutingTable(boolean filter) {

--- a/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStats.java
@@ -132,7 +132,7 @@ public abstract class FieldStats<T> implements Writeable, ToXContent {
     }
 
     /**
-     * @return true if min/max informations are available for this field
+     * @return true if min/max information is available for this field
      */
     public boolean hasMinMax() {
         return hasMinMax;

--- a/core/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -172,7 +172,7 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
      * @param successfulShards the total number of shards for which execution of the operation was successful
      * @param failedShards     the total number of shards for which execution of the operation failed
      * @param results          the per-node aggregated shard-level results
-     * @param shardFailures    the exceptions corresponding to shard operationa failures
+     * @param shardFailures    the exceptions corresponding to shard operation failures
      * @param clusterState     the cluster state
      * @return the response
      */

--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -334,7 +334,7 @@ public class ReplicationOperation<
          * also complete after. Deal with it.
          *
          * @param request the request to perform
-         * @return the request to send to the repicas
+         * @return the request to send to the replicas
          */
         PrimaryResultT perform(RequestT request) throws Exception;
 
@@ -362,7 +362,7 @@ public class ReplicationOperation<
          * performs the the given request on the specified replica
          *
          * @param replica        {@link ShardRouting} of the shard this request should be executed on
-         * @param replicaRequest operation to peform
+         * @param replicaRequest operation to perform
          * @param listener       a callback to call once the operation has been complicated, either successfully or with an error.
          */
         void performOn(ShardRouting replica, RequestT replicaRequest, ActionListener<ReplicaResponse> listener);

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsFields.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsFields.java
@@ -82,7 +82,7 @@ import static org.apache.lucene.util.ArrayUtil.grow;
  * If the field statistics were requested ({@code hasFieldStatistics} is true,
  * see {@code headerRef}), the following numbers are stored:
  * <ul>
- * <li>vlong: sum of total term freqencies of the field (sumTotalTermFreq)</li>
+ * <li>vlong: sum of total term frequencies of the field (sumTotalTermFreq)</li>
  * <li>vlong: sum of document frequencies for each term (sumDocFreq)</li>
  * <li>vint: number of documents in the shard that has an entry for this field
  * (docCount)</li>

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -423,7 +423,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
     }
 
     /**
-     * Explicitely set the fetch source context for this request
+     * Explicitly set the fetch source context for this request
      */
     public UpdateRequest fetchSource(FetchSourceContext context) {
         this.fetchSourceContext = context;

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
@@ -408,7 +408,7 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
 
     /**
      * Sets whether to perform extra effort to detect noop updates via docAsUpsert.
-     * Defautls to true.
+     * Defaults to true.
      */
     public UpdateRequestBuilder setDetectNoop(boolean detectNoop) {
         request.detectNoop(detectNoop);

--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -276,7 +276,7 @@ final class Security {
      * Add dynamic {@link SocketPermission} based on HTTP settings.
      *
      * @param policy the {@link Permissions} instance to apply the dynamic {@link SocketPermission}s to.
-     * @param settings the {@link Settings} instance to read the HTTP settingsfrom
+     * @param settings the {@link Settings} instance to read the HTTP settings from
      */
     private static void addSocketPermissionForHttp(final Permissions policy, final Settings settings) {
         // http is simple
@@ -357,7 +357,7 @@ final class Security {
      * @param policy current policy to add permissions to
      * @param configurationName the configuration name associated with the path (for error messages only)
      * @param path the path itself
-     * @param permissions set of filepermissions to grant to the path
+     * @param permissions set of file permissions to grant to the path
      */
     static void addPath(Permissions policy, String configurationName, Path path, String permissions) {
         // paths may not exist yet, this also checks accessibility
@@ -377,7 +377,7 @@ final class Security {
      * @param policy current policy to add permissions to
      * @param configurationName the configuration name associated with the path (for error messages only)
      * @param path the path itself
-     * @param permissions set of filepermissions to grant to the path
+     * @param permissions set of file permissions to grant to the path
      */
     static void addPathIfExists(Permissions policy, String configurationName, Path path, String permissions) {
         if (Files.isDirectory(path)) {

--- a/core/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
+++ b/core/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
@@ -346,7 +346,7 @@ public interface ClusterAdminClient extends ElasticsearchClient {
      * Cancel active tasks
      *
      * @param request  The nodes tasks request
-     * @param listener A cancelener to be notified with a result
+     * @param listener A listener to be notified with a result
      * @see org.elasticsearch.client.Requests#cancelTasksRequest()
      */
     void cancelTasks(CancelTasksRequest request, ActionListener<CancelTasksResponse> listener);

--- a/core/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
+++ b/core/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
@@ -437,7 +437,7 @@ public interface IndicesAdminClient extends ElasticsearchClient {
     void forceMerge(ForceMergeRequest request, ActionListener<ForceMergeResponse> listener);
 
     /**
-     * Explicitly force mergee one or more indices into a the number of segments.
+     * Explicitly force merge one or more indices into a the number of segments.
      */
     ForceMergeRequestBuilder prepareForceMerge(String... indices);
 

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -252,7 +252,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
     }
 
     /**
-     * a cluster state supersedes another state iff they are from the same master and the version this state is higher thant the other
+     * a cluster state supersedes another state iff they are from the same master and the version this state is higher than the other
      * state.
      * <p>
      * In essence that means that all the changes from the other cluster state are also reflected by the current one

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterStateObserver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterStateObserver.java
@@ -94,7 +94,7 @@ public class ClusterStateObserver {
         return clusterState;
     }
 
-    /** indicates whether this observer has timedout */
+    /** indicates whether this observer has timed out */
     public boolean isTimedOut() {
         return timedOut;
     }

--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -250,7 +250,7 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
     }
 
     /**
-     * Returns the version of the node with the yougest version in the cluster
+     * Returns the version of the node with the youngest version in the cluster
      *
      * @return the oldest version in the cluster
      */

--- a/core/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -58,7 +58,7 @@ import java.util.Set;
  * for operations on a specific shard.
  * <p>
  * Note: The term replica is not directly
- * reflected in the routing table or in releated classes, replicas are
+ * reflected in the routing table or in related classes, replicas are
  * represented as {@link ShardRouting}.
  * </p>
  */

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -396,7 +396,7 @@ public class AllocationService extends AbstractComponent {
         }
 
         /**
-         * thre resulting cluster state, after the commands were applied
+         * the resulting cluster state, after the commands were applied
          */
         public ClusterState getClusterState() {
             return clusterState;

--- a/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -342,7 +342,7 @@ public class ClusterService extends AbstractLifecycleComponent {
      * Adds a cluster state listener that is expected to be removed during a short period of time.
      * If provided, the listener will be notified once a specific time has elapsed.
      *
-     * NOTE: the listener is not remmoved on timeout. This is the responsibility of the caller.
+     * NOTE: the listener is not removed on timeout. This is the responsibility of the caller.
      */
     public void addTimeoutListener(@Nullable final TimeValue timeout, final TimeoutClusterStateListener listener) {
         if (lifecycle.stoppedOrClosed()) {
@@ -558,7 +558,7 @@ public class ClusterService extends AbstractLifecycleComponent {
         return true;
     }
 
-    /** asserts that the current stack trace does <b>NOT</b> invlove a cluster state applier */
+    /** asserts that the current stack trace does <b>NOT</b> involve a cluster state applier */
     private static boolean assertNotCalledFromClusterStateApplier(String reason) {
         if (Thread.currentThread().getName().contains(UPDATE_THREAD_NAME)) {
             for (StackTraceElement element: Thread.currentThread().getStackTrace()) {

--- a/core/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
@@ -481,7 +481,7 @@ public class GeoUtils {
 
     /**
      * Return the distance (in meters) between 2 lat,lon geo points using a simple tangential plane
-     * this provides a faster alternative to {@link GeoUtils#arcDistance} but is innaccurate for distances greater than
+     * this provides a faster alternative to {@link GeoUtils#arcDistance} but is inaccurate for distances greater than
      * 4 decimal degrees
      */
     public static double planeDistance(double lat1, double lon1, double lat2, double lon2) {

--- a/core/src/main/java/org/elasticsearch/common/inject/Binder.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/Binder.java
@@ -138,7 +138,7 @@ import java.lang.annotation.Annotation;
  *     bindConstant().annotatedWith(ServerHost.class).to(args[0]);</pre>
  *
  * Sets up a constant binding. Constant injections must always be annotated.
- * When a constant binding's value is a string, it is eligile for conversion to
+ * When a constant binding's value is a string, it is eligible for conversion to
  * all primitive types, to {@link Enum#valueOf all enums}, and to
  * {@link Class#forName class literals}. Conversions for other types can be
  * configured using {@link #convertToTypes(Matcher, TypeConverter)

--- a/core/src/main/java/org/elasticsearch/common/inject/TypeLiteral.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/TypeLiteral.java
@@ -47,7 +47,7 @@ import static org.elasticsearch.common.inject.internal.MoreTypes.canonicalize;
  * <p>
  * This syntax cannot be used to create type literals that have wildcard
  * parameters, such as {@code Class<?>} or {@code List<? extends CharSequence>}.
- * Such type literals must be constructed programatically, either by {@link
+ * Such type literals must be constructed programmatically, either by {@link
  * Method#getGenericReturnType extracting types from members} or by using the
  * {@link Types} factory class.
  * <p>

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/Errors.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/Errors.java
@@ -59,7 +59,7 @@ import static java.util.Collections.unmodifiableList;
  * returned instance will contain full context.
  * <p>
  * To avoid messages with redundant context, {@link #withSource} should be added sparingly. A
- * good rule of thumb is to assume a ethod's caller has already specified enough context to
+ * good rule of thumb is to assume a method's caller has already specified enough context to
  * identify that method. When calling a method that's defined in a different context, call that
  * method with an errors object that includes its context.
  *

--- a/core/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -712,7 +712,7 @@ public class Lucene {
     }
 
     /**
-     * Parses the version string lenient and returns the default value if the given string is null or emtpy
+     * Parses the version string lenient and returns the default value if the given string is null or empty
      */
     public static Version parseVersionLenient(String toParse, Version defaultValue) {
         return LenientParser.parse(toParse, defaultValue);

--- a/core/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
@@ -40,7 +40,7 @@ import java.util.Optional;
  */
 public abstract class NetworkUtils {
 
-    /** no instantation */
+    /** no instantiation */
     private NetworkUtils() {}
     
     /**

--- a/core/src/main/java/org/elasticsearch/common/xcontent/NamedXContentRegistry.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/NamedXContentRegistry.java
@@ -42,9 +42,9 @@ public class NamedXContentRegistry {
     /**
      * The empty {@link NamedXContentRegistry} for use when you are sure that you aren't going to call
      * {@link XContentParser#namedObject(Class, String, Object)}. Be *very* careful with this singleton because a parser using it will fail
-     * every call to {@linkplain XContentParser#namedObject(Class, String, Object)}. Every non-test usage really should be checked thorowly
-     * and marked with a comment about how it was checked. That way anyone that sees code that uses it knows that it is potentially
-     * dangerous.
+     * every call to {@linkplain XContentParser#namedObject(Class, String, Object)}. Every non-test usage really should be checked
+     * thoroughly and marked with a comment about how it was checked. That way anyone that sees code that uses it knows that it is
+     * potentially dangerous.
      */
     public static final NamedXContentRegistry EMPTY = new NamedXContentRegistry(emptyList());
 

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -221,7 +221,7 @@ public class XContentHelper {
 
     /**
      * Updates the provided changes into the source. If the key exists in the changes, it overrides the one in source
-     * unless both are Maps, in which case it recuersively updated it.
+     * unless both are Maps, in which case it recursively updated it.
      *
      * @param source                 the original map to be updated
      * @param changes                the changes to update into updated

--- a/core/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -488,7 +488,7 @@ public abstract class Engine implements Closeable {
 
     /**
      * Returns a new searcher instance. The consumer of this
-     * API is responsible for releasing the returned seacher in a
+     * API is responsible for releasing the returned searcher in a
      * safe manner, preferably in a try/finally block.
      *
      * @see Searcher#close()

--- a/core/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -93,7 +93,7 @@ public final class EngineConfig {
 
     /**
      * Configures an index to optimize documents with auto generated ids for append only. If this setting is updated from <code>false</code>
-     * to <code>true</code> might not take effect immediately. In other words, disabling the optimiation will be immediately applied while
+     * to <code>true</code> might not take effect immediately. In other words, disabling the optimization will be immediately applied while
      * re-enabling it might not be applied until the engine is in a safe state to do so. Depending on the engine implementation a change to
      * this setting won't be reflected re-enabled optimization until the engine is restarted or the index is closed and reopened.
      * The default is <code>true</code>

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -489,7 +489,7 @@ public abstract class QueryBuilders {
      *
      * @param type      The parent type.
      * @param query     The query.
-     * @param score     Whether the score from the parent hit should propogate to the child hit
+     * @param score     Whether the score from the parent hit should propagate to the child hit
      */
     public static HasParentQueryBuilder hasParentQuery(String type, QueryBuilder query, boolean score) {
         return new HasParentQueryBuilder(type, query, score);

--- a/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 /**
- * Query that allows wraping a {@link MultiTermQueryBuilder} (one of wildcard, fuzzy, prefix, term, range or regexp query)
+ * Query that allows wrapping a {@link MultiTermQueryBuilder} (one of wildcard, fuzzy, prefix, term, range or regexp query)
  * as a {@link SpanQueryBuilder} so it can be nested.
  */
 public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTermQueryBuilder>

--- a/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
@@ -108,7 +108,7 @@ public class SequenceNumbersService extends AbstractIndexShardComponent {
     /**
      * The current sequence number stats.
      *
-     * @return stats encapuslating the maximum sequence number, the local checkpoint and the global checkpoint
+     * @return stats encapsulating the maximum sequence number, the local checkpoint and the global checkpoint
      */
     public SeqNoStats stats() {
         return localCheckpointTracker.getStats(getGlobalCheckpoint());

--- a/core/src/main/java/org/elasticsearch/index/shard/TranslogRecoveryPerformer.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/TranslogRecoveryPerformer.java
@@ -122,7 +122,7 @@ public class TranslogRecoveryPerformer {
             out.writeInt(completedOperations);
         }
 
-        /** the number of succesful operations performed before the exception was thrown */
+        /** the number of successful operations performed before the exception was thrown */
         public int completedOperations() {
             return completedOperations;
         }

--- a/core/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/core/src/main/java/org/elasticsearch/index/store/Store.java
@@ -355,7 +355,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
     }
 
     /**
-     * Decreases the refCount of this Store instance.If the refCount drops to 0, then this
+     * Decreases the refCount of this Store instance. If the refCount drops to 0, then this
      * store is closed.
      *
      * @see #incRef

--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -72,12 +72,12 @@ import java.util.stream.Stream;
  * records the current translog generation {@link Translog#getGeneration()} in it's commit metadata using {@link #TRANSLOG_GENERATION_KEY}
  * to reference the generation that contains all operations that have not yet successfully been committed to the engines lucene index.
  * Additionally, since Elasticsearch 2.0 the engine also records a {@link #TRANSLOG_UUID_KEY} with each commit to ensure a strong association
- * between the lucene index an the transaction log file. This UUID is used to prevent accidential recovery from a transaction log that belongs to a
+ * between the lucene index an the transaction log file. This UUID is used to prevent accidental recovery from a transaction log that belongs to a
  * different engine.
  * <p>
  * Each Translog has only one translog file open at any time referenced by a translog generation ID. This ID is written to a <tt>translog.ckp</tt> file that is designed
  * to fit in a single disk block such that a write of the file is atomic. The checkpoint file is written on each fsync operation of the translog and records the number of operations
- * written, the current tranlogs file generation and it's fsynced offset in bytes.
+ * written, the current translogs file generation and it's fsynced offset in bytes.
  * </p>
  * <p>
  * When a translog is opened the checkpoint is use to retrieve the latest translog file generation and subsequently to open the last written file to recovery operations.
@@ -781,7 +781,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         long seqNo();
 
         /**
-         * Reads the type and the operation from the given stream. The operatino must be written with
+         * Reads the type and the operation from the given stream. The operation must be written with
          * {@link Operation#writeType(Operation, StreamOutput)}
          */
         static Operation readType(StreamInput input) throws IOException {
@@ -1227,7 +1227,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
          */
         ASYNC,
         /**
-         * Request durability - translogs are synced for each high levle request (bulk, index, delete)
+         * Request durability - translogs are synced for each high level request (bulk, index, delete)
          */
         REQUEST;
 
@@ -1429,7 +1429,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
     }
 
     /**
-     * Returns <code>true</code> iff the given generation is the current gbeneration of this translog
+     * Returns <code>true</code> iff the given generation is the current generation of this translog
      */
     public boolean isCurrent(TranslogGeneration generation) {
         try (ReleasableLock lock = writeLock.acquire()) {

--- a/core/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
@@ -176,7 +176,7 @@ public final class IndicesRequestCache extends AbstractComponent implements Remo
 
         /**
          * Returns <code>true</code> iff the resource behind this entity is still open ie.
-         * entities assiciated with it can remain in the cache. ie. IndexShard is still open.
+         * entities associated with it can remain in the cache. ie. IndexShard is still open.
          */
         boolean isOpen();
 

--- a/core/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -293,7 +293,7 @@ public class PeerRecoveryTargetService extends AbstractComponent implements Inde
      * Obtains a snapshot of the store metadata for the recovery target.
      *
      * @param recoveryTarget the target of the recovery
-     * @return a snapshot of the store metdata
+     * @return a snapshot of the store metadata
      */
     private Store.MetadataSnapshot getStoreMetadataSnapshot(final RecoveryTarget recoveryTarget) {
         try {

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTargetHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTargetHandler.java
@@ -30,7 +30,7 @@ import java.util.List;
 public interface RecoveryTargetHandler {
 
     /**
-     * Prepares the tranget to receive translog operations, after all file have been copied
+     * Prepares the target to receive translog operations, after all file have been copied
      *
      * @param totalTranslogOps total translog operations expected to be sent
      * @param maxUnsafeAutoIdTimestamp the max timestamp that is used to de-optimize documents with auto-generated IDs in the engine.

--- a/core/src/main/java/org/elasticsearch/script/Script.java
+++ b/core/src/main/java/org/elasticsearch/script/Script.java
@@ -386,8 +386,8 @@ public final class Script implements ToXContentObject, Writeable {
      *
      * @param parser       The {@link XContentParser} to be used.
      * @param defaultLang  The default language to use if no language is specified.  The default language isn't necessarily
-     *                     the one defined by {@link Script#DEFAULT_SCRIPT_LANG} due to backwards compatiblity requirements
-     *                     related to stored queries using previously default languauges.
+     *                     the one defined by {@link Script#DEFAULT_SCRIPT_LANG} due to backwards compatibility requirements
+     *                     related to stored queries using previously default languages.
      *
      * @return             The parsed {@link Script}.
      */

--- a/core/src/main/java/org/elasticsearch/script/ScriptType.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptType.java
@@ -37,7 +37,7 @@ public enum ScriptType implements Writeable {
      * INLINE scripts are specified in numerous queries and compiled on-the-fly.
      * They will be cached based on the lang and code of the script.
      * They are turned off by default because most languages are insecure
-     * (Groovy and others), but can be overriden by the specific {@link ScriptEngineService}
+     * (Groovy and others), but can be overridden by the specific {@link ScriptEngineService}
      * if the language is naturally secure (Painless, Mustache, and Expressions).
      */
     INLINE ( 0 , new ParseField("inline") , false ),
@@ -46,7 +46,7 @@ public enum ScriptType implements Writeable {
      * STORED scripts are saved as part of the {@link org.elasticsearch.cluster.ClusterState}
      * based on user requests.  They will be cached when they are first used in a query.
      * They are turned off by default because most languages are insecure
-     * (Groovy and others), but can be overriden by the specific {@link ScriptEngineService}
+     * (Groovy and others), but can be overridden by the specific {@link ScriptEngineService}
      * if the language is naturally secure (Painless, Mustache, and Expressions).
      */
     STORED ( 1 , new ParseField("stored", "id") , false ),
@@ -123,7 +123,7 @@ public enum ScriptType implements Writeable {
 
     /**
      * @return Whether or not a {@link ScriptType} can be run by default.  Note
-     * this can be potentially overriden by any {@link ScriptEngineService}.
+     * this can be potentially overridden by any {@link ScriptEngineService}.
      */
     public boolean isDefaultEnabled() {
         return defaultEnabled;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
@@ -186,7 +186,7 @@ public abstract class AggregatorBase extends Aggregator {
     }
 
     /**
-     * This method should be overidden by subclasses that want to defer calculation
+     * This method should be overridden by subclasses that want to defer calculation
      * of a child aggregation until a first pass is complete and a set of buckets has
      * been pruned.
      * Deferring collection will require the recording of all doc/bucketIds from the first

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/UnmappedSignificantTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/UnmappedSignificantTerms.java
@@ -43,7 +43,7 @@ public class UnmappedSignificantTerms extends InternalSignificantTerms<UnmappedS
     public static final String NAME = "umsigterms";
 
     /**
-     * Concrete type that can't be built because Java needs a concrent type so {@link InternalTerms.Bucket} can have a self type but
+     * Concrete type that can't be built because Java needs a concrete type so {@link InternalTerms.Bucket} can have a self type but
      * {@linkplain UnmappedTerms} doesn't ever need to build it because it never returns any buckets.
      */
     protected abstract static class Bucket extends InternalSignificantTerms.Bucket<Bucket> {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
@@ -39,7 +39,7 @@ public class UnmappedTerms extends InternalTerms<UnmappedTerms, UnmappedTerms.Bu
     public static final String NAME = "umterms";
 
     /**
-     * Concrete type that can't be built because Java needs a concrent type so {@link InternalTerms.Bucket} can have a self type but
+     * Concrete type that can't be built because Java needs a concrete type so {@link InternalTerms.Bucket} can have a self type but
      * {@linkplain UnmappedTerms} doesn't ever need to build it because it never returns any buckets.
      */
     protected abstract static class Bucket extends InternalTerms.Bucket<Bucket> {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregationBuilder.java
@@ -271,7 +271,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
     }
 
     /**
-     * Gets the hightlighter builder for this request.
+     * Gets the highlighter builder for this request.
      */
     public HighlightBuilder highlighter() {
         return highlightBuilder;

--- a/core/src/main/java/org/elasticsearch/search/slice/SliceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/slice/SliceBuilder.java
@@ -43,7 +43,7 @@ import java.util.Objects;
 /**
  *  A slice builder allowing to split a scroll in multiple partitions.
  *  If the provided field is the "_uid" it uses a {@link org.elasticsearch.search.slice.TermsSliceQuery}
- *  to do the slicing. The slicing is done at the shard level first and then each shard is splitted in multiple slices.
+ *  to do the slicing. The slicing is done at the shard level first and then each shard is split into multiple slices.
  *  For instance if the number of shards is equal to 2 and the user requested 4 slices
  *  then the slices 0 and 2 are assigned to the first shard and the slices 1 and 3 are assigned to the second shard.
  *  This way the total number of bitsets that we need to build on each shard is bounded by the number of slices

--- a/core/src/main/java/org/elasticsearch/transport/BytesTransportRequest.java
+++ b/core/src/main/java/org/elasticsearch/transport/BytesTransportRequest.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 
 /**
  * A specialized, bytes only request, that can potentially be optimized on the network
- * layer, specifically for teh same large buffer send to several nodes.
+ * layer, specifically for the same large buffer send to several nodes.
  */
 public class BytesTransportRequest extends TransportRequest {
 

--- a/core/src/main/java/org/elasticsearch/transport/Transport.java
+++ b/core/src/main/java/org/elasticsearch/transport/Transport.java
@@ -93,7 +93,7 @@ public interface Transport extends LifecycleComponent {
     long newRequestId();
     /**
      * Returns a connection for the given node if the node is connected.
-     * Connections returned from this method must not be closed. The lifecylce of this connection is maintained by the Transport
+     * Connections returned from this method must not be closed. The lifecycle of this connection is maintained by the Transport
      * implementation.
      *
      * @throws NodeNotConnectedException if the node is not connected

--- a/core/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1006,7 +1006,7 @@ public class TransportService extends AbstractLifecycleComponent {
     }
 
     /**
-     * This handler wrapper ensures that the response thread executes with the correct thread context. Before any of the4 handle methods
+     * This handler wrapper ensures that the response thread executes with the correct thread context. Before any of the handle methods
      * are invoked we restore the context.
      */
     public static final class ContextRestoreResponseHandler<T extends TransportResponse> implements TransportResponseHandler<T> {

--- a/core/src/main/java/org/joda/time/format/StrictISODateTimeFormat.java
+++ b/core/src/main/java/org/joda/time/format/StrictISODateTimeFormat.java
@@ -140,7 +140,7 @@ public class StrictISODateTimeFormat {
      * -20-.040      -20-.040    minute/milli *
      *   plus datetime formats like {date}T{time}
      * </pre>
-     * * indiates that this is not an official ISO format and can be excluded
+     * * indicates that this is not an official ISO format and can be excluded
      * by passing in <code>strictISO</code> as <code>true</code>.
      * <p>
      * This method can side effect the input collection of fields.


### PR DESCRIPTION
I found a number of typos in the Javadocs and fixed them.

I have run `gradle checkstyle` to verify coding conventions are OK.