### PR TITLE
[DOCS] Documentation fixes (various typos, etc.)

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -26,7 +26,7 @@ support wildcards, for example: `test*`, and the ability to "add" (`+`)
 and "remove" (`-`), for example: `+test*,-test3`.
 
 All multi indices API support the `ignore_indices` option. Setting it to
-`missing` will cause indices that do not exists to be ignored from the
+`missing` will cause indices that do not exist to be ignored from the
 execution. By default, when it's not set, the request will fail.
 
 NOTE: Single index APIs such as the <<docs>> and the
@@ -61,7 +61,7 @@ consumption.  The default for the `human` flag is
 [float]
 === Parameters
 
-Rest parameters (when using HTTP, map to HTTP URL parameters) follow the
+REST parameters (when using HTTP, map to HTTP URL parameters) follow the
 convention of using underscore casing.
 
 [float]

--- a/docs/reference/docs/bulk-udp.asciidoc
+++ b/docs/reference/docs/bulk-udp.asciidoc
@@ -23,7 +23,7 @@ then flushes it based on several parameters:
 	 An interval after which the current
 	request is flushed, regardless of the above limits. Defaults to `5s`. 
 `bulk.udp.concurrent_requests`:: 
-	 The number on max in flight bulk
+	 The number of max in flight bulk
 	requests allowed. Defaults to `4`.
 
 The allowed network settings are:

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -91,7 +91,7 @@ chunks, as this will slow things down.
 Each bulk item can include the version value using the
 `_version`/`version` field. It automatically follows the behavior of the
 index / delete operation based on the `_version` mapping. It also
-support the `version_type`/`_version_type` when using `external`
+supports the `version_type`/`_version_type` when using `external`
 versioning.
 
 [float]
@@ -169,8 +169,9 @@ times an update should be retried in the case of a version conflict.
 
 The `update` action payload, supports the following options: `doc`
 (partial document), `upsert`, `doc_as_upsert`, `script`, `params` (for
-script), `lang` (for script). See update documentation for details on
-the options. Curl example with update actions:
+script), `lang` (for script). See the <<docs-update,update>>
+documentation for details on the options. Curl example with update
+actions:
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -110,13 +110,13 @@ as a REST parameter named `source`.
 === Distributed
 
 The delete by query API is broadcast across all primary shards, and from
-there, replicated across all shards replicas.
+there, replicated across all shards' replicas.
 
 [float]
 [[delete-by-query-routing]]
 === Routing
 
-The routing value (a comma separated list of the routing values) can be
+The routing value (a comma-separated list of the routing values) can be
 specified to control which shards the delete by query request will be
 executed on.
 

--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -103,7 +103,7 @@ curl 'localhost:9200/_mget' -d '{
 
 added[0.90.6]
 
-You can specify also specify routing value as a parameter:
+You can also specify a routing value as a parameter:
 
 [source,js]
 --------------------------------------------------
@@ -124,8 +124,8 @@ curl 'localhost:9200/_mget?routing=key1' -d '{
 }'
 --------------------------------------------------
 
-In this example, document `test/type/2` will be fetch from shard corresponding to routing key `key1` but
-document `test/type/1` will be fetch from shard corresponding to routing key `key2`.
+In this example, document `test/type/2` will be fetched from a shard corresponding to routing key `key1` but
+document `test/type/1` will be fetched from a shard corresponding to routing key `key2`.
 
 [float]
 [[mget-security]]

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -4,13 +4,13 @@
 The update API allows to update a document based on a script provided.
 The operation gets the document (collocated with the shard) from the
 index, runs the script (with optional script language and parameters),
-and index back the result (also allows to delete, or ignore the
+and indexes back the result (also allows to delete, or ignore the
 operation). It uses versioning to make sure no updates have happened
 during the "get" and "reindex". (available from `0.19` onwards).
 
-Note, this operation still means full reindex of the document, it just
+Note, this operation still means a full reindex of the document, it just
 removes some network roundtrips and reduces chances of version conflicts
-between the get and the index. The `_source` field need to be enabled
+between the get and the index. The `_source` field needs to be enabled
 for this feature to work.
 
 For example, lets index a simple doc:
@@ -36,7 +36,7 @@ curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
 --------------------------------------------------
 
 We can also add a tag to the list of tags (note, if the tag exists, it
-will still add it, since its a list):
+will still add it, since it's a list):
 
 [source,js]
 --------------------------------------------------
@@ -92,7 +92,7 @@ ctx._source.tags.contains(tag) ? (ctx.op = \"none\") : ctx._source.tags += tag
 if (ctx._source.tags.contains(tag)) { ctx.op = \"none\" } else { ctx._source.tags += tag }
 --------------------------------------------------
 
-The update API also support passing a partial document (since 0.20),
+The update API also supports passing a partial document (since 0.20),
 which will be merged into the existing document (simple recursive merge,
 inner merging of objects, replacing core "keys/values" and arrays). For
 example:
@@ -110,7 +110,7 @@ If both `doc` and `script` is specified, then `doc` is ignored. Best is
 to put your field pairs of the partial document in the script itself.
 
 There is also support for `upsert` (since 0.20). If the document does
-not already exists, the content of the `upsert` element will be used to
+not already exist, the content of the `upsert` element will be used to
 index the fresh doc:
 
 [source,js]

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -4,7 +4,7 @@
 [partintro]
 --
 Index Modules are modules created per index and control all aspects
-related to an index. Since those modules lifecycle are tied to an index,
+related to an index. Since those modules' lifecycle are tied to an index,
 all the relevant modules settings can be provided when creating an index
 (and it is actually the recommended way to configure an index).
 
@@ -21,7 +21,7 @@ specific module. These include:
 	The compound format was created to reduce the number of open
 	file handles when using file based storage. However, by default it is set
 	to `false` as the non-compound format gives better performance. It is important
-	that OS is configured to give Elasticsearch ``enough'' file handles.
+	that the OS is configured to give Elasticsearch ``enough'' file handles.
     See <<file-descriptors>>.
 +
 Alternatively, `compound_format` can be set to a number between `0` and

--- a/docs/reference/setup/as-a-service.asciidoc
+++ b/docs/reference/setup/as-a-service.asciidoc
@@ -28,7 +28,7 @@ Each package features a configuration file, which allows you to set the followin
 
 ==== Debian/Ubuntu
 
-The debian package ships with everything you need as it uses standard debian tools like update `update-rc.d` to define the runlevels it runs on. The init script is placed at `/etc/init.d/elasticsearch` is you would expect it. The configuration file is placed at `/etc/default/elasticsearch`.
+The debian package ships with everything you need as it uses standard debian tools like `update-rc.d` to define the runlevels it runs on. The init script is placed at `/etc/init.d/elasticsearch` as you would expect it. The configuration file is placed at `/etc/default/elasticsearch`.
 
 ===== Installing the oracle JDK
 

--- a/docs/reference/setup/dir-layout.asciidoc
+++ b/docs/reference/setup/dir-layout.asciidoc
@@ -40,7 +40,7 @@ people that don't want to mess with RAID. Here is how it is configured:
 path.data: /mnt/first,/mnt/second
 ---------------------------------
 
-Or the in an array format:
+Or the same in an array format:
 
 ----------------------------------------
 path.data: ["/mnt/first", "/mnt/second"]


### PR DESCRIPTION
Hi there, new GitHub/ElasticSearch user here so please bear with me if this PR doesn't fully comply with the official guidelines (well, at least I've managed to sign the contributor agreement :-)
I've been perusing the ElasticSearch reference at version 0.90 (since the ES package in my Debian 8.7 system comes at version 1.0.3) and spotted a few things that needed fixing along the way.
So far I've covered the _Setup_, _API Conventions_, and _Document APIs_ sections.
After a few commits I thought I'd submit a pull request at this point to see if you're interested :-)