### PR TITLE
Add support for auto_generate_synonyms_phrase_query in match_query, multi_match_query, query_string and simple_query_string

### DIFF
--- a/core/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
+++ b/core/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
@@ -107,6 +107,7 @@ public class MapperQueryParser extends AnalyzingQueryParser {
         setDefaultOperator(settings.defaultOperator());
         setFuzzyPrefixLength(settings.fuzzyPrefixLength());
         setSplitOnWhitespace(settings.splitOnWhitespace());
+        setAutoGenerateMultiTermSynonymsPhraseQuery(settings.autoGenerateMultiTermsSynonymsPhraseQuery());
     }
 
     /**

--- a/core/src/main/java/org/apache/lucene/queryparser/classic/QueryParserSettings.java
+++ b/core/src/main/java/org/apache/lucene/queryparser/classic/QueryParserSettings.java
@@ -76,6 +76,8 @@ public class QueryParserSettings {
 
     private boolean splitOnWhitespace;
 
+    private boolean autoGenerateMultiTermsSynonymsPhraseQuery;
+
     public QueryParserSettings(String queryString) {
         this.queryString = queryString;
     }
@@ -278,5 +280,13 @@ public class QueryParserSettings {
 
     public boolean splitOnWhitespace() {
         return splitOnWhitespace;
+    }
+
+    public void autoGenerateMultiTermSynonymsPhraseQuery(boolean value) {
+        this.autoGenerateMultiTermsSynonymsPhraseQuery = value;
+    }
+
+    public boolean autoGenerateMultiTermsSynonymsPhraseQuery() {
+        return autoGenerateMultiTermsSynonymsPhraseQuery;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -100,7 +100,7 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
 
     private Float cutoffFrequency = null;
 
-    private boolean autoGenerateMultiTermsSynonymsPhraseQuery = false;
+    private boolean autoGenerateMultiTermsSynonymsPhraseQuery = true;
 
     /**
      * Constructs a new match query.
@@ -407,7 +407,7 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
 
     /**
      * Whether phrase queries should be automatically generated for multi terms synonyms.
-     * Default is <tt>false</tt>.
+     * Default is <tt>true</tt>.
      */
     public MatchQueryBuilder autoGenerateMultiTermsSynonymsPhraseQuery(boolean enable) {
         this.autoGenerateMultiTermsSynonymsPhraseQuery = enable;
@@ -454,9 +454,7 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
         if (cutoffFrequency != null) {
             builder.field(CUTOFF_FREQUENCY_FIELD.getPreferredName(), cutoffFrequency);
         }
-        if (autoGenerateMultiTermsSynonymsPhraseQuery) {
-            builder.field(GENERATE_SYNONYMS_PHRASE_QUERY.getPreferredName(), autoGenerateMultiTermsSynonymsPhraseQuery);
-        }
+        builder.field(GENERATE_SYNONYMS_PHRASE_QUERY.getPreferredName(), autoGenerateMultiTermsSynonymsPhraseQuery);
         printBoostAndQueryName(builder);
         builder.endObject();
         builder.endObject();
@@ -539,7 +537,7 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
         boolean lenient = MatchQuery.DEFAULT_LENIENCY;
         Float cutOffFrequency = null;
         ZeroTermsQuery zeroTermsQuery = MatchQuery.DEFAULT_ZERO_TERMS_QUERY;
-        boolean autoGenerateSynonymsPhraseQuery = false;
+        boolean autoGenerateSynonymsPhraseQuery = true;
         String queryName = null;
         String currentFieldName = null;
         XContentParser.Token token;

--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -93,7 +93,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
     private boolean lenient = DEFAULT_LENIENCY;
     private Float cutoffFrequency = null;
     private MatchQuery.ZeroTermsQuery zeroTermsQuery = DEFAULT_ZERO_TERMS_QUERY;
-    private boolean autoGenerateMultiTermsSynonymsPhraseQuery = false;
+    private boolean autoGenerateMultiTermsSynonymsPhraseQuery = true;
 
     public enum Type implements Writeable {
 
@@ -530,7 +530,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
 
     /**
      * Whether phrase queries should be automatically generated for multi terms synonyms.
-     * Default is <tt>false</tt>.
+     * Default is <tt>true</tt>.
      */
     public boolean autoGenerateMultiTermsSynonymsPhraseQuery() {
         return autoGenerateMultiTermsSynonymsPhraseQuery;
@@ -573,9 +573,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
             builder.field(CUTOFF_FREQUENCY_FIELD.getPreferredName(), cutoffFrequency);
         }
         builder.field(ZERO_TERMS_QUERY_FIELD.getPreferredName(), zeroTermsQuery.toString());
-        if (autoGenerateMultiTermsSynonymsPhraseQuery) {
-            builder.field(GENERATE_SYNONYMS_PHRASE_QUERY.getPreferredName(), autoGenerateMultiTermsSynonymsPhraseQuery);
-        }
+        builder.field(GENERATE_SYNONYMS_PHRASE_QUERY.getPreferredName(), autoGenerateMultiTermsSynonymsPhraseQuery);
         printBoostAndQueryName(builder);
         builder.endObject();
     }
@@ -599,7 +597,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         Float cutoffFrequency = null;
         boolean lenient = DEFAULT_LENIENCY;
         MatchQuery.ZeroTermsQuery zeroTermsQuery = DEFAULT_ZERO_TERMS_QUERY;
-        boolean autoGenerateSynonymsPhraseQuery = false;
+        boolean autoGenerateSynonymsPhraseQuery = true;
 
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         String queryName = null;

--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -189,7 +189,7 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
 
     private boolean splitOnWhitespace = DEFAULT_SPLIT_ON_WHITESPACE;
 
-    private boolean autoGenerateMultiTermsSynonymsPhraseQuery = false;
+    private boolean autoGenerateMultiTermsSynonymsPhraseQuery = true;
 
     public QueryStringQueryBuilder(String queryString) {
         if (queryString == null) {
@@ -633,7 +633,7 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
 
     /**
      * Whether phrase queries should be automatically generated for multi terms synonyms.
-     * Default is <tt>false</tt>.
+     * Default is <tt>true</tt>.
      */
     public QueryStringQueryBuilder autoGenerateMultiTermsSynonymsPhraseQuery(boolean enable) {
         this.autoGenerateMultiTermsSynonymsPhraseQuery = enable;
@@ -702,9 +702,7 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         if (this.useAllFields != null) {
             builder.field(ALL_FIELDS_FIELD.getPreferredName(), this.useAllFields);
         }
-        if (autoGenerateMultiTermsSynonymsPhraseQuery) {
-            builder.field(GENERATE_SYNONYMS_PHRASE_QUERY.getPreferredName(), autoGenerateMultiTermsSynonymsPhraseQuery);
-        }
+        builder.field(GENERATE_SYNONYMS_PHRASE_QUERY.getPreferredName(), autoGenerateMultiTermsSynonymsPhraseQuery);
         printBoostAndQueryName(builder);
         builder.endObject();
     }
@@ -740,7 +738,7 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         String rewrite = null;
         boolean splitOnWhitespace = DEFAULT_SPLIT_ON_WHITESPACE;
         Boolean useAllFields = null;
-        boolean autoGenerateSynonymsPhraseQuery = false;
+        boolean autoGenerateSynonymsPhraseQuery = true;
         Map<String, Float> fieldsAndWeights = new HashMap<>();
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryParser.java
@@ -54,6 +54,7 @@ public class SimpleQueryParser extends org.apache.lucene.queryparser.simple.Simp
         super(analyzer, weights, flags);
         this.settings = settings;
         this.context = context;
+        setAutoGenerateMultiTermSynonymsPhraseQuery(settings.autoGenerateMultiTermsSynonymsPhraseQuery);
     }
 
     /**
@@ -262,6 +263,7 @@ public class SimpleQueryParser extends org.apache.lucene.queryparser.simple.Simp
         private boolean analyzeWildcard = SimpleQueryStringBuilder.DEFAULT_ANALYZE_WILDCARD;
         /** Specifies a suffix, if any, to apply to field names for phrase matching. */
         private String quoteFieldSuffix = null;
+        private boolean autoGenerateMultiTermsSynonymsPhraseQuery = false;
 
         /**
          * Generates default {@link Settings} object (uses ROOT locale, does
@@ -274,6 +276,7 @@ public class SimpleQueryParser extends org.apache.lucene.queryparser.simple.Simp
             this.lenient = other.lenient;
             this.analyzeWildcard = other.analyzeWildcard;
             this.quoteFieldSuffix = other.quoteFieldSuffix;
+            this.autoGenerateMultiTermsSynonymsPhraseQuery = other.autoGenerateMultiTermsSynonymsPhraseQuery;
         }
 
         /** Specifies whether to use lenient parsing, defaults to false. */
@@ -311,9 +314,17 @@ public class SimpleQueryParser extends org.apache.lucene.queryparser.simple.Simp
             return quoteFieldSuffix;
         }
 
+        public void autoGenerateMultiTermsSynonymsPhraseQuery(boolean enable) {
+            this.autoGenerateMultiTermsSynonymsPhraseQuery = enable;
+        }
+
+        public boolean autoGenerateMultiTermsSynonymsPhraseQuery() {
+            return autoGenerateMultiTermsSynonymsPhraseQuery;
+        }
+
         @Override
         public int hashCode() {
-            return Objects.hash(lenient, analyzeWildcard, quoteFieldSuffix);
+            return Objects.hash(lenient, analyzeWildcard, quoteFieldSuffix, autoGenerateMultiTermsSynonymsPhraseQuery);
         }
 
         @Override
@@ -325,8 +336,10 @@ public class SimpleQueryParser extends org.apache.lucene.queryparser.simple.Simp
                 return false;
             }
             Settings other = (Settings) obj;
-            return Objects.equals(lenient, other.lenient) && Objects.equals(analyzeWildcard, other.analyzeWildcard)
-                    && Objects.equals(quoteFieldSuffix, other.quoteFieldSuffix);
+            return Objects.equals(lenient, other.lenient) &&
+                Objects.equals(analyzeWildcard, other.analyzeWildcard) &&
+                Objects.equals(quoteFieldSuffix, other.quoteFieldSuffix) &&
+                autoGenerateMultiTermsSynonymsPhraseQuery == autoGenerateMultiTermsSynonymsPhraseQuery;
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -134,7 +134,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
     /** Further search settings needed by the ES specific query string parser only. */
     private Settings settings = new Settings();
 
-    private boolean autoGenerateMultiTermsSynonymsPhraseQuery = false;
+    private boolean autoGenerateMultiTermsSynonymsPhraseQuery = true;
 
     /** Construct a new simple query with this query string. */
     public SimpleQueryStringBuilder(String queryText) {
@@ -370,7 +370,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
 
     /**
      * Whether phrase queries should be automatically generated for multi terms synonyms.
-     * Default is <tt>false</tt>.
+     * Default is <tt>true</tt>.
      */
     public SimpleQueryStringBuilder autoGenerateMultiTermsSynonymsPhraseQuery(boolean enable) {
         this.autoGenerateMultiTermsSynonymsPhraseQuery = enable;
@@ -481,9 +481,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
         if (useAllFields != null) {
             builder.field(ALL_FIELDS_FIELD.getPreferredName(), useAllFields);
         }
-        if (autoGenerateMultiTermsSynonymsPhraseQuery) {
-            builder.field(GENERATE_SYNONYMS_PHRASE_QUERY.getPreferredName(), autoGenerateMultiTermsSynonymsPhraseQuery);
-        }
+        builder.field(GENERATE_SYNONYMS_PHRASE_QUERY.getPreferredName(), autoGenerateMultiTermsSynonymsPhraseQuery);
 
         printBoostAndQueryName(builder);
         builder.endObject();
@@ -505,7 +503,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
         boolean analyzeWildcard = SimpleQueryStringBuilder.DEFAULT_ANALYZE_WILDCARD;
         String quoteFieldSuffix = null;
         Boolean useAllFields = null;
-        boolean autoGenerateSynonymsPhraseQuery = false;
+        boolean autoGenerateSynonymsPhraseQuery = true;
 
         XContentParser.Token token;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {

--- a/core/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -156,6 +156,8 @@ public class MatchQuery {
 
     protected Float commonTermsCutoff = null;
 
+    protected boolean autoGenerateMultiTermsSynonymsPhraseQuery = false;
+
     public MatchQuery(QueryShardContext context) {
         this.context = context;
     }
@@ -208,6 +210,10 @@ public class MatchQuery {
         this.zeroTermsQuery = zeroTermsQuery;
     }
 
+    public void setAutoGenerateMultiTermsSynonymsPhraseQuery(boolean enable) {
+        this.autoGenerateMultiTermsSynonymsPhraseQuery = enable;
+    }
+
     protected Analyzer getAnalyzer(MappedFieldType fieldType) {
         if (this.analyzer == null) {
             if (fieldType != null) {
@@ -249,6 +255,7 @@ public class MatchQuery {
         assert analyzer != null;
         MatchQueryBuilder builder = new MatchQueryBuilder(analyzer, fieldType);
         builder.setEnablePositionIncrements(this.enablePositionIncrements);
+        builder.setAutoGenerateMultiTermSynonymsPhraseQuery(this.autoGenerateMultiTermsSynonymsPhraseQuery);
 
         Query query = null;
         switch (type) {

--- a/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -282,6 +282,7 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
                 "      \"fuzzy_transpositions\" : true,\n" +
                 "      \"lenient\" : false,\n" +
                 "      \"zero_terms_query\" : \"ALL\",\n" +
+                "      \"auto_generate_synonyms_phrase_query\" : true,\n" +
                 "      \"boost\" : 1.0\n" +
                 "    }\n" +
                 "  }\n" +
@@ -310,6 +311,7 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
                 "      \"fuzzy_transpositions\" : true,\n" +
                 "      \"lenient\" : false,\n" +
                 "      \"zero_terms_query\" : \"NONE\",\n" +
+                "      \"auto_generate_synonyms_phrase_query\" : true,\n" +
                 "      \"boost\" : 1.0\n" +
                 "    }\n" +
                 "  }\n" +
@@ -341,6 +343,7 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
                 "      \"fuzzy_transpositions\" : true,\n" +
                 "      \"lenient\" : false,\n" +
                 "      \"zero_terms_query\" : \"NONE\",\n" +
+                "      \"auto_generate_synonyms_phrase_query\" : true,\n" +
                 "      \"boost\" : 1.0\n" +
                 "    }\n" +
                 "  }\n" +

--- a/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -123,6 +123,10 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
         if (randomBoolean()) {
             matchQuery.cutoffFrequency((float) 10 / randomIntBetween(1, 100));
         }
+
+        if (randomBoolean()) {
+            matchQuery.autoGenerateMultiTermsSynonymsPhraseQuery(randomBoolean());
+        }
         return matchQuery;
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -243,6 +243,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
                 "    \"max_expansions\" : 50,\n" +
                 "    \"lenient\" : false,\n" +
                 "    \"zero_terms_query\" : \"NONE\",\n" +
+                "      \"auto_generate_synonyms_phrase_query\" : true,\n" +
                 "    \"boost\" : 1.0\n" +
                 "  }\n" +
                 "}";

--- a/core/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -125,6 +125,9 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
         if (randomBoolean()) {
             query.zeroTermsQuery(randomFrom(MatchQuery.ZeroTermsQuery.values()));
         }
+        if (randomBoolean()) {
+            query.autoGenerateMultiTermsSynonymsPhraseQuery(randomBoolean());
+        }
         // test with fields with boost and patterns delegated to the tests further below
         return query;
     }

--- a/core/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
@@ -138,6 +138,7 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
                 "              \"fuzzy_transpositions\" : true,\n" +
                 "              \"lenient\" : false,\n" +
                 "              \"zero_terms_query\" : \"NONE\",\n" +
+                "      \"auto_generate_synonyms_phrase_query\" : true,\n" +
                 "              \"boost\" : 1.0\n" +
                 "            }\n" +
                 "          }\n" +

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -156,6 +156,9 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             // setSplitOnWhitespace(false) is disallowed when getAutoGeneratePhraseQueries() == true
             queryStringQueryBuilder.splitOnWhitespace(randomBoolean());
         }
+        if (randomBoolean()) {
+            queryStringQueryBuilder.autoGenerateMultiTermsSynonymsPhraseQuery(randomBoolean());
+        }
         return queryStringQueryBuilder;
     }
 
@@ -405,6 +408,18 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             );
             assertThat(query, Matchers.equalTo(expectedQuery));
 
+            // simple multi-term with phrase query
+            queryParser.setAutoGenerateMultiTermSynonymsPhraseQuery(true);
+            query = queryParser.parse("guinea pig");
+            expectedQuery = new GraphQuery(
+                new PhraseQuery.Builder()
+                    .add(new Term(STRING_FIELD_NAME, "guinea"))
+                    .add(new Term(STRING_FIELD_NAME, "pig"))
+                    .build(),
+                new TermQuery(new Term(STRING_FIELD_NAME, "cavy")));
+            assertThat(query, Matchers.equalTo(expectedQuery));
+            queryParser.setAutoGenerateMultiTermSynonymsPhraseQuery(false);
+
             // simple with additional tokens
             query = queryParser.parse("that guinea pig smells");
             expectedQuery = new BooleanQuery.Builder()
@@ -436,7 +451,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
             assertThat(query, Matchers.equalTo(expectedQuery));
 
-            // no paren should cause guinea and pig to be treated as separate tokens
+            // no parent should cause guinea and pig to be treated as separate tokens
             query = queryParser.parse("+that -guinea pig +smells");
             expectedQuery = new BooleanQuery.Builder()
                 .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "that")), BooleanClause.Occur.MUST))

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -398,6 +398,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             queryParser.reset(settings);
 
             // simple multi-term
+            queryParser.setAutoGenerateMultiTermSynonymsPhraseQuery(false);
             Query query = queryParser.parse("guinea pig");
             Query expectedQuery = new GraphQuery(
                 new BooleanQuery.Builder()
@@ -408,8 +409,8 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             );
             assertThat(query, Matchers.equalTo(expectedQuery));
 
-            // simple multi-term with phrase query
             queryParser.setAutoGenerateMultiTermSynonymsPhraseQuery(true);
+            // simple multi-term with phrase query
             query = queryParser.parse("guinea pig");
             expectedQuery = new GraphQuery(
                 new PhraseQuery.Builder()
@@ -852,6 +853,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                 "    \"phrase_slop\" : 0,\n" +
                 "    \"escape\" : false,\n" +
                 "    \"split_on_whitespace\" : true,\n" +
+                "    \"auto_generate_synonyms_phrase_query\" : true,\n" +
                 "    \"boost\" : 1.0\n" +
                 "  }\n" +
                 "}";

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -321,6 +321,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
                 "    \"lenient\" : false,\n" +
                 "    \"analyze_wildcard\" : false,\n" +
                 "    \"quote_field_suffix\" : \".quote\",\n" +
+                "      \"auto_generate_synonyms_phrase_query\" : true,\n" +
                 "    \"boost\" : 1.0\n" +
                 "  }\n" +
                 "}";

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -82,6 +82,9 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
                 result.flags(flagSet.toArray(new SimpleQueryStringFlag[flagSet.size()]));
             }
         }
+        if (randomBoolean()) {
+            result.autoGenerateMultiTermsSynonymsPhraseQuery(randomBoolean());
+        }
 
         int fieldCount = randomIntBetween(0, 10);
         Map<String, Float> fields = new HashMap<>();

--- a/core/src/test/java/org/elasticsearch/index/search/MatchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/index/search/MatchQueryIT.java
@@ -141,8 +141,12 @@ public class MatchQueryIT extends ESIntegTestCase {
         indexRandom(true, false, getDocs());
 
         // no min should match
-        SearchResponse searchResponse = client().prepareSearch(INDEX).setQuery(QueryBuilders.matchQuery("field", "three what the fudge foo")
-            .operator(Operator.OR).analyzer("lower_graphsyns")).get();
+        SearchResponse searchResponse = client().prepareSearch(INDEX)
+            .setQuery(
+                QueryBuilders.matchQuery("field", "three what the fudge foo")
+                    .operator(Operator.OR).analyzer("lower_graphsyns").autoGenerateMultiTermsSynonymsPhraseQuery(false)
+            )
+            .get();
 
         assertHitCount(searchResponse, 6L);
         assertSearchHits(searchResponse, "1", "2", "3", "4", "5", "6");
@@ -209,8 +213,7 @@ public class MatchQueryIT extends ESIntegTestCase {
             .setQuery(
                 QueryBuilders.matchQuery("field", "wtf")
                     .analyzer("lower_graphsyns")
-                    .operator(Operator.AND)
-                    .autoGenerateMultiTermsSynonymsPhraseQuery(true)).get();
+                    .operator(Operator.AND)).get();
 
         assertHitCount(searchResponse, 3L);
         assertSearchHits(searchResponse, "1", "2", "3");

--- a/core/src/test/java/org/elasticsearch/index/search/MatchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/index/search/MatchQueryIT.java
@@ -200,4 +200,19 @@ public class MatchQueryIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
     }
+
+    public void testMultiTermsSynonymsPhrase() throws ExecutionException, InterruptedException {
+        List<IndexRequestBuilder> builders = getDocs();
+        indexRandom(true, false, builders);
+
+        SearchResponse searchResponse = client().prepareSearch(INDEX)
+            .setQuery(
+                QueryBuilders.matchQuery("field", "wtf")
+                    .analyzer("lower_graphsyns")
+                    .operator(Operator.AND)
+                    .autoGenerateMultiTermsSynonymsPhraseQuery(true)).get();
+
+        assertHitCount(searchResponse, 3L);
+        assertSearchHits(searchResponse, "1", "2", "3");
+    }
 }

--- a/core/src/test/java/org/elasticsearch/search/query/QueryStringIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/QueryStringIT.java
@@ -324,6 +324,7 @@ public class QueryStringIT extends ESIntegTestCase {
                 .defaultField("field")
                 .splitOnWhitespace(true)
                 .defaultOperator(Operator.AND)
+                .autoGenerateMultiTermsSynonymsPhraseQuery(false)
                 .analyzer("lower_graphsyns")).get();
 
         assertNoSearchHits(searchResponse);
@@ -334,6 +335,7 @@ public class QueryStringIT extends ESIntegTestCase {
                 .defaultField("field")
                 .splitOnWhitespace(false)
                 .defaultOperator(Operator.OR)
+                .autoGenerateMultiTermsSynonymsPhraseQuery(false)
                 .analyzer("lower_graphsyns")).get();
 
         assertHitCount(searchResponse, 6L);
@@ -346,6 +348,7 @@ public class QueryStringIT extends ESIntegTestCase {
                 .splitOnWhitespace(false)
                 .defaultOperator(Operator.OR)
                 .analyzer("lower_graphsyns")
+                .autoGenerateMultiTermsSynonymsPhraseQuery(false)
                 .minimumShouldMatch("80%")).get();
 
         assertHitCount(searchResponse, 3L);
@@ -357,7 +360,6 @@ public class QueryStringIT extends ESIntegTestCase {
                 .defaultField("field")
                 .splitOnWhitespace(false)
                 .defaultOperator(Operator.AND)
-                .autoGenerateMultiTermsSynonymsPhraseQuery(true)
                 .analyzer("lower_graphsyns"))
             .get();
         assertHitCount(searchResponse, 3L);

--- a/core/src/test/java/org/elasticsearch/search/query/QueryStringIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/QueryStringIT.java
@@ -19,16 +19,6 @@
 
 package org.elasticsearch.search.query;
 
-import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
-import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoSearchHits;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-
 import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
@@ -55,6 +45,16 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
+import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoSearchHits;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 public class QueryStringIT extends ESIntegTestCase {
     @Override
@@ -350,6 +350,18 @@ public class QueryStringIT extends ESIntegTestCase {
 
         assertHitCount(searchResponse, 3L);
         assertSearchHits(searchResponse, "1", "2", "6");
+
+        // multi terms synonyms phrase
+        searchResponse = client().prepareSearch(index).setQuery(
+            QueryBuilders.queryStringQuery("what the fudge")
+                .defaultField("field")
+                .splitOnWhitespace(false)
+                .defaultOperator(Operator.AND)
+                .autoGenerateMultiTermsSynonymsPhraseQuery(true)
+                .analyzer("lower_graphsyns"))
+            .get();
+        assertHitCount(searchResponse, 3L);
+        assertSearchHits(searchResponse,  "1", "2", "3");
     }
 
     private void assertHits(SearchHits hits, String... ids) {

--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -156,3 +156,37 @@ provide a great "as you type" behavior to automatically load search
 results.
 
 **************************************************
+
+[[query-dsl-match-query-synonyms]]
+===== Synonyms
+
+The match query supports multi-terms synonym expansion with the <<analysis-synonym-graph-tokenfilter, synonym_graph>> token filter.
+When this filter is used, the match query creates a single boolean clause for each multi-terms synonyms.
+For example, the following synonym "ny, new york" would produce a boolean query:
+
+`(ny OR (new AND york))`
+
+It is also possible to match multi terms synonyms with phrase query:
+
+[source,js]
+--------------------------------------------------
+GET /_search
+{
+    "query": {
+        "match" : {
+            "message" : {
+                "query" : "ny city",
+                "auto_generate_synonyms_phrase_query" : true
+            }
+        }
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+The example above creates a boolean query:
+
+`(ny OR ("new york")) city)`
+
+that matches documents with the term `ny` or the phrase query `new york`.
+By default the parameter `auto_generate_synonyms_phrase_query` is set to `false`.

--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -161,12 +161,12 @@ results.
 ===== Synonyms
 
 The match query supports multi-terms synonym expansion with the <<analysis-synonym-graph-tokenfilter, synonym_graph>> token filter.
-When this filter is used, the match query creates a single boolean clause for each multi-terms synonyms.
-For example, the following synonym "ny, new york" would produce a boolean query:
+When this filter is used, the match query creates a phrase query for each multi-terms synonyms.
+For example, the following synonym "ny, new york" would produce:
 
-`(ny OR (new AND york))`
+`(ny OR ("new york"))`
 
-It is also possible to match multi terms synonyms with phrase query:
+It is also possible to match multi terms synonyms with boolean queries instead:
 
 [source,js]
 --------------------------------------------------
@@ -176,7 +176,7 @@ GET /_search
         "match" : {
             "message" : {
                 "query" : "ny city",
-                "auto_generate_synonyms_phrase_query" : true
+                "auto_generate_synonyms_phrase_query" : false
             }
         }
     }
@@ -186,7 +186,7 @@ GET /_search
 
 The example above creates a boolean query:
 
-`(ny OR ("new york")) city)`
+`(ny OR (new AND york)) city)`
 
-that matches documents with the term `ny` or the phrase query `new york`.
-By default the parameter `auto_generate_synonyms_phrase_query` is set to `false`.
+that matches documents with the term `ny` or the boolean query `new AND york`.
+By default the parameter `auto_generate_synonyms_phrase_query` is set to `true`.

--- a/docs/reference/query-dsl/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/multi-match-query.asciidoc
@@ -137,7 +137,7 @@ follows:
 
 Also, accepts `analyzer`, `boost`, `operator`, `minimum_should_match`,
 `fuzziness`, `lenient`, `prefix_length`, `max_expansions`, `rewrite`, `zero_terms_query`
-and `cutoff_frequency`, as explained in <<query-dsl-match-query, match query>>.
+, `cutoff_frequency` and `auto_generate_synonyms_phrase_query` as explained in <<query-dsl-match-query, match query>>.
 
 [IMPORTANT]
 [[operator-min]]

--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -89,7 +89,7 @@ Instead  the queryparser would parse around only real 'operators'. Default to `f
 It is not allowed to set this option to `false` if `autoGeneratePhraseQueries` is already set to `true`.
 
 |`auto_generate_synonyms_phrase_query` |Whether phrase queries should be automatically generated for multi terms synonyms.
-Default to `false.
+Default to `true`.
 
 |`all_fields` | Perform the query on all fields detected in the mapping that can
 be queried. Will be used by default when the `_all` field is disabled and no

--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -88,6 +88,9 @@ comprehensive example.
 Instead  the queryparser would parse around only real 'operators'. Default to `false`.
 It is not allowed to set this option to `false` if `autoGeneratePhraseQueries` is already set to `true`.
 
+|`auto_generate_synonyms_phrase_query` |Whether phrase queries should be automatically generated for multi terms synonyms.
+Default to `false.
+
 |`all_fields` | Perform the query on all fields detected in the mapping that can
 be queried. Will be used by default when the `_all` field is disabled and no
 `default_field` is specified (either in the index settings or in the request

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -63,7 +63,7 @@ for exact matching. Look <<mixing-exact-search-with-stemming,here>> for a
 comprehensive example.
 
 |`auto_generate_synonyms_phrase_query` |Whether phrase queries should be automatically generated for multi terms synonyms.
-Default to `false.
+Default to `true`.
 
 |`all_fields` | Perform the query on all fields detected in the mapping that can
 be queried. Will be used by default when the `_all` field is disabled and no

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -62,6 +62,9 @@ the query string. This allows to use a field that has a different analysis chain
 for exact matching. Look <<mixing-exact-search-with-stemming,here>> for a
 comprehensive example.
 
+|`auto_generate_synonyms_phrase_query` |Whether phrase queries should be automatically generated for multi terms synonyms.
+Default to `false.
+
 |`all_fields` | Perform the query on all fields detected in the mapping that can
 be queried. Will be used by default when the `_all` field is disabled and no
 `default_field` is specified index settings, and no `fields` are specified.


### PR DESCRIPTION

This change adds a new parameter called `auto_generate_synonyms_phrase_query`.
This param can be used in conjunction with `synonym_graph` token filter to generate phrase queries
when multi terms synonyms are encountered.
For example, a synonym like "ny, new york" would produce the following boolean query when "ny city" is parsed:
((ny OR "new york") AND city)

Note how the multi terms synonym "new york" produces a phrase query. By default this parameter is set to false.