### PR TITLE
Fix get source HEAD requests

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -564,7 +564,6 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestGetAction(settings, restController));
         registerHandler.accept(new RestGetSourceAction(settings, restController));
         registerHandler.accept(new RestHeadAction.Document(settings, restController));
-        registerHandler.accept(new RestHeadAction.Source(settings, restController));
         registerHandler.accept(new RestMultiGetAction(settings, restController));
         registerHandler.accept(new RestDeleteAction(settings, restController));
         registerHandler.accept(new org.elasticsearch.rest.action.document.RestCountAction(settings, restController));

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestHeadAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestHeadAction.java
@@ -48,33 +48,18 @@ public abstract class RestHeadAction extends BaseRestHandler {
      */
     public static class Document extends RestHeadAction {
         public Document(Settings settings, RestController controller) {
-            super(settings, false);
+            super(settings);
             controller.registerHandler(HEAD, "/{index}/{type}/{id}", this);
         }
     }
 
     /**
-     * Handler to check for document source existence (may be disabled in the mapping).
-     */
-    public static class Source extends RestHeadAction {
-        public Source(Settings settings, RestController controller) {
-            super(settings, true);
-            controller.registerHandler(HEAD, "/{index}/{type}/{id}/_source", this);
-        }
-    }
-
-    private final boolean source;
-
-    /**
      * All subclasses must be registered in {@link org.elasticsearch.common.network.NetworkModule}.
+     *  @param settings injected settings
      *
-     * @param settings injected settings
-     * @param source   {@code false} to check for {@link GetResponse#isExists()}.
-     *                 {@code true} to also check for {@link GetResponse#isSourceEmpty()}.
      */
-    public RestHeadAction(Settings settings, boolean source) {
+    public RestHeadAction(Settings settings) {
         super(settings);
-        this.source = source;
     }
 
     @Override
@@ -94,8 +79,6 @@ public abstract class RestHeadAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(GetResponse response) {
                 if (!response.isExists()) {
-                    return new BytesRestResponse(NOT_FOUND, BytesRestResponse.TEXT_CONTENT_TYPE, BytesArray.EMPTY);
-                } else if (source && response.isSourceEmpty()) { // doc exists, but source might not (disabled in the mapping)
                     return new BytesRestResponse(NOT_FOUND, BytesRestResponse.TEXT_CONTENT_TYPE, BytesArray.EMPTY);
                 } else {
                     return new BytesRestResponse(OK, BytesRestResponse.TEXT_CONTENT_TYPE, BytesArray.EMPTY);

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
@@ -43,7 +44,18 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
     }
 
     private void createTestDoc() throws IOException {
-        client().performRequest("PUT", "test/test/1", emptyMap(), new StringEntity("{\"test\": \"test\"}"));
+        createTestDoc("test", "test");
+    }
+
+    private void createTestDoc(final String indexName, final String typeName) throws IOException {
+        try (XContentBuilder builder = jsonBuilder()) {
+            builder.startObject();
+            {
+                builder.field("test", "test");
+            }
+            builder.endObject();
+            client().performRequest("PUT", "/" + indexName + "/" + typeName + "/" + "1", emptyMap(), new StringEntity(builder.string()));
+        }
     }
 
     public void testDocumentExists() throws IOException {
@@ -110,9 +122,46 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
         }
     }
 
-    private void headTestCase(String url, Map<String, String> params, Matcher<Integer> matcher) throws IOException {
+    public void testGetSourceAction() throws IOException {
+        createTestDoc();
+        headTestCase("/test/test/1/_source", emptyMap(), greaterThan(0));
+        headTestCase("/test/test/2/_source", emptyMap(), 404, equalTo(0));
+
+        try (XContentBuilder builder = jsonBuilder()) {
+            builder.startObject();
+            {
+                builder.startObject("mappings");
+                {
+                    builder.startObject("test-no-source");
+                    {
+                        builder.startObject("_source");
+                        {
+                            builder.field("enabled", false);
+                        }
+                        builder.endObject();
+                    }
+                    builder.endObject();
+                }
+                builder.endObject();
+            }
+            builder.endObject();
+            client().performRequest("PUT", "/test-no-source", emptyMap(), new StringEntity(builder.string()));
+            createTestDoc("test-no-source", "test-no-source");
+            headTestCase("/test-no-source/test-no-source/1/_source", emptyMap(), 404, equalTo(0));
+        }
+    }
+
+    private void headTestCase(final String url, final Map<String, String> params, final Matcher<Integer> matcher) throws IOException {
+        headTestCase(url, params, 200, matcher);
+    }
+
+    private void headTestCase(
+            final String url,
+            final Map<String, String> params,
+            final int expectedStatusCode,
+            final Matcher<Integer> matcher) throws IOException {
         Response response = client().performRequest("HEAD", url, params);
-        assertEquals(200, response.getStatusLine().getStatusCode());
+        assertEquals(expectedStatusCode, response.getStatusLine().getStatusCode());
         assertThat(Integer.valueOf(response.getHeader("Content-Length")), matcher);
         assertNull("HEAD requests shouldn't have a response body but " + url + " did", response.getEntity());
     }

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
+import static org.elasticsearch.rest.RestStatus.OK;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -125,7 +127,7 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
     public void testGetSourceAction() throws IOException {
         createTestDoc();
         headTestCase("/test/test/1/_source", emptyMap(), greaterThan(0));
-        headTestCase("/test/test/2/_source", emptyMap(), 404, equalTo(0));
+        headTestCase("/test/test/2/_source", emptyMap(), NOT_FOUND.getStatus(), equalTo(0));
 
         try (XContentBuilder builder = jsonBuilder()) {
             builder.startObject();
@@ -147,12 +149,12 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
             builder.endObject();
             client().performRequest("PUT", "/test-no-source", emptyMap(), new StringEntity(builder.string()));
             createTestDoc("test-no-source", "test-no-source");
-            headTestCase("/test-no-source/test-no-source/1/_source", emptyMap(), 404, equalTo(0));
+            headTestCase("/test-no-source/test-no-source/1/_source", emptyMap(), NOT_FOUND.getStatus(), equalTo(0));
         }
     }
 
     private void headTestCase(final String url, final Map<String, String> params, final Matcher<Integer> matcher) throws IOException {
-        headTestCase(url, params, 200, matcher);
+        headTestCase(url, params, OK.getStatus(), matcher);
     }
 
     private void headTestCase(


### PR DESCRIPTION
Get source HEAD requests incorrectly return a content-length header of
0. This commit addresses this by removing the special handling for get
source HEAD requests, and just relying on the general mechanism that
exists for handling HEAD requests in the REST layer.

Relates #21125

