### PR TITLE
Update to forbiddenapis 2.3 (improves Gradle configuration time)

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -92,7 +92,7 @@ dependencies {
   compile 'com.netflix.nebula:gradle-info-plugin:3.0.3'
   compile 'org.eclipse.jgit:org.eclipse.jgit:3.2.0.201312181205-r'
   compile 'com.perforce:p4java:2012.3.551082' // THIS IS SUPPOSED TO BE OPTIONAL IN THE FUTURE....
-  compile 'de.thetaphi:forbiddenapis:2.2'
+  compile 'de.thetaphi:forbiddenapis:2.3'
   compile 'org.apache.rat:apache-rat:0.11'
 }
 


### PR DESCRIPTION
This PR updates forbiddenapis to 2.3. This version updates ASM dependency and improves startup/configuration time of Gradle (slowness in `apply plugin`).

FYI: During testing I noticed that you cannot pass `gradle -Drepos.mavenlocal=true` to the buildSrc (bootstrap of build system). This required me to add mavenLocal() manually to `buildSrc/build.gradle` to do some testing before release. I can open an issue, if you like.