### PR TITLE
Add a note about `cluster.routing.allocation.node_concurrent_recoveries`

### DIFF
--- a/docs/reference/modules/cluster/shards_allocation.asciidoc
+++ b/docs/reference/modules/cluster/shards_allocation.asciidoc
@@ -37,6 +37,11 @@ one of the active allocation ids in the cluster state.
      How many concurrent outgoing shard recoveries are allowed to happen on a node. Outgoing recoveries are the recoveries
      where the source shard (most likely the primary unless a shard is relocating) is allocated on the node. Defaults to `2`.
 
+`cluster.routing.allocation.node_concurrent_recoveries`::
+
+     A shortcut to set both `cluster.routing.allocation.node_concurrent_incoming_recoveries` & `cluster.routing.allocation.node_concurrent_outgoing_recoveries`.
+
+
 `cluster.routing.allocation.node_initial_primaries_recoveries`::
 
     While the recovery of replicas happens over the network, the recovery of

--- a/docs/reference/modules/cluster/shards_allocation.asciidoc
+++ b/docs/reference/modules/cluster/shards_allocation.asciidoc
@@ -39,7 +39,8 @@ one of the active allocation ids in the cluster state.
 
 `cluster.routing.allocation.node_concurrent_recoveries`::
 
-     A shortcut to set both `cluster.routing.allocation.node_concurrent_incoming_recoveries` & `cluster.routing.allocation.node_concurrent_outgoing_recoveries`.
+     A shortcut to set both `cluster.routing.allocation.node_concurrent_incoming_recoveries` and
+     `cluster.routing.allocation.node_concurrent_outgoing_recoveries`.
 
 
 `cluster.routing.allocation.node_initial_primaries_recoveries`::


### PR DESCRIPTION
Closes #23152
