### PR TITLE
Support Keyword type in Analyze API

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -132,16 +132,16 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeRe
                 }
                 MappedFieldType fieldType = indexService.mapperService().fullName(request.field());
                 if (fieldType != null) {
-                    if (fieldType.tokenized() == false && fieldType instanceof KeywordFieldMapper.KeywordFieldType == false) {
-                        throw new IllegalArgumentException("Can't process field [" + request.field() + "], Analysis requests are only supported on tokenized fields");
-                    }
-                    if (fieldType instanceof KeywordFieldMapper.KeywordFieldType) {
+                    if (fieldType.tokenized()) {
+                        analyzer = fieldType.indexAnalyzer();
+                    } else if (fieldType instanceof KeywordFieldMapper.KeywordFieldType) {
                         analyzer = ((KeywordFieldMapper.KeywordFieldType) fieldType).normalizer();
                         if (analyzer == null) {
+                            // this will be KeywordAnalyzer
                             analyzer = fieldType.indexAnalyzer();
                         }
                     } else {
-                        analyzer = fieldType.indexAnalyzer();
+                        throw new IllegalArgumentException("Can't process field [" + request.field() + "], Analysis requests are only supported on tokenized fields");
                     }
                     field = fieldType.name();
                 }

--- a/core/src/test/java/org/elasticsearch/indices/analyze/AnalyzeActionIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/analyze/AnalyzeActionIT.java
@@ -639,4 +639,36 @@ public class AnalyzeActionIT extends ESIntegTestCase {
         assertThat(analyzeResponse.detail().tokenizer().getTokens()[2].getPositionLength(), equalTo(1));
     }
 
+    public void testAnalyzeKeywordField() throws IOException {
+        assertAcked(prepareCreate("test").addAlias(new Alias("alias")).addMapping("test", "keyword", "type=keyword"));
+        ensureGreen("test");
+
+        AnalyzeResponse analyzeResponse = client().admin().indices().prepareAnalyze(indexOrAlias(), "ABC").setField("keyword").get();
+        assertThat(analyzeResponse.getTokens().size(), equalTo(1));
+        AnalyzeResponse.AnalyzeToken token = analyzeResponse.getTokens().get(0);
+        assertThat(token.getTerm(), equalTo("ABC"));
+        assertThat(token.getStartOffset(), equalTo(0));
+        assertThat(token.getEndOffset(), equalTo(3));
+        assertThat(token.getPosition(), equalTo(0));
+        assertThat(token.getPositionLength(), equalTo(1));
+    }
+
+    public void testAnalyzeNormalizedKeywordField() throws IOException {
+        assertAcked(prepareCreate("test").addAlias(new Alias("alias"))
+            .setSettings(Settings.builder().put(indexSettings())
+                .put("index.analysis.normalizer.my_normalizer.type", "custom")
+                .putArray("index.analysis.normalizer.my_normalizer.filter", "lowercase"))
+            .addMapping("test", "keyword", "type=keyword,normalizer=my_normalizer"));
+        ensureGreen("test");
+
+        AnalyzeResponse analyzeResponse = client().admin().indices().prepareAnalyze(indexOrAlias(), "ABC").setField("keyword").get();
+        assertThat(analyzeResponse.getTokens().size(), equalTo(1));
+        AnalyzeResponse.AnalyzeToken token = analyzeResponse.getTokens().get(0);
+        assertThat(token.getTerm(), equalTo("abc"));
+        assertThat(token.getStartOffset(), equalTo(0));
+        assertThat(token.getEndOffset(), equalTo(3));
+        assertThat(token.getPosition(), equalTo(0));
+        assertThat(token.getPositionLength(), equalTo(1));
+
+    }
 }


### PR DESCRIPTION
Now, analyze API doesn't support keyword type field.
This PR allow you to analyze keyword type field with/without normalizer.

If user request keyword field name, analyze API uses KeywordAnalyzer if the field doesn't have  normalizer prop or Normalizer if the field have normalizer prop.
And this PR does not support to use normalizer request param yet.