### PR TITLE
Fix similarity upgrade when "default" similarity is overridden

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -418,8 +418,11 @@ public class TypeParsers {
     }
 
     private static SimilarityProvider resolveSimilarity(Mapper.TypeParser.ParserContext parserContext, String name, String value) {
-        if (parserContext.indexVersionCreated().before(Version.V_5_0_0_alpha1) && "default".equals(value)) {
-            // "default" similarity has been renamed into "classic" in 3.x.
+        if (parserContext.indexVersionCreated().before(Version.V_5_0_0_alpha1) &&
+            "default".equals(value) &&
+            // check if "default" similarity is overridden
+            parserContext.getSimilarity("default") == null) {
+            // "default" similarity has been renamed into "classic" in 5.x.
             value = "classic";
         }
         SimilarityProvider similarityProvider = parserContext.getSimilarity(value);

--- a/core/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
+++ b/core/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
@@ -259,4 +259,25 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             assertThat(e.getMessage(), equalTo("Unknown Similarity type [default] for field [field1]"));
         }
     }
+
+    public void testSimilarityDefaultOveriddenBackCompat() throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties")
+            .startObject("field1")
+            .field("similarity", "default")
+            .field("type", "text")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject().string();
+        Settings settings = Settings.builder()
+            .put(IndexMetaData.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.V_2_2_0))
+            .put("index.similarity.default.type", "BM25")
+            .build();
+
+        DocumentMapperParser parser = createIndex("test_v2.x", settings).mapperService().documentMapperParser();
+        DocumentMapper documentMapper = parser.parse("type", new CompressedXContent(mapping));
+        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(), instanceOf(BM25SimilarityProvider.class));
+        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity().name(), equalTo("default"));
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
+++ b/core/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
@@ -272,12 +272,17 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .endObject().string();
         Settings settings = Settings.builder()
             .put(IndexMetaData.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.V_2_2_0))
-            .put("index.similarity.default.type", "BM25")
+            .put("index.similarity.default.type", "LMJelinekMercer")
+            .put("index.similarity.default.lambda", 0.7f)
             .build();
 
         DocumentMapperParser parser = createIndex("test_v2.x", settings).mapperService().documentMapperParser();
         DocumentMapper documentMapper = parser.parse("type", new CompressedXContent(mapping));
-        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(), instanceOf(BM25SimilarityProvider.class));
+        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity(),
+            instanceOf(LMJelinekMercerSimilarityProvider.class));
+        LMJelinekMercerSimilarity sim =
+            (LMJelinekMercerSimilarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
+        assertThat(sim.getLambda(), equalTo(0.7f));
         assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity().name(), equalTo("default"));
     }
 }


### PR DESCRIPTION
Discovered in https://github.com/elastic/elasticsearch-migration/issues/103

In 5.x we renamed the "default" similarity to "classic". Though in 2.x it is possible to override
 the "default" similarity and to define a new type for "default":
 ````
 PUT t
{
  "settings": {
    "index": {
      "similarity": {
        "default": {
          "type": "BM25"
        }
      }
    }
  },
  "mappings": {
    "t": {
      "properties": {
        "title": {
          "type": "text",
          "similarity": "default"
        }
      }
    }
  }
}
````

When we upgrade this index to 5.x the similarity name for "text" is renamed to "classic" even though the "default" similarity type has been overriden.
This change fixes this upgrade bug and adds a test for it.