### PR TITLE
Add request version asserting during replica operation

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -365,6 +365,8 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
             BulkItemRequest item = request.items()[i];
             if (item.isIgnoreOnReplica() == false) {
                 DocWriteRequest docWriteRequest = item.request();
+                assert docWriteRequest.versionType() == docWriteRequest.versionType().versionTypeForReplicationAndRecovery()
+                        : "unexpected version in replica " + docWriteRequest.version();
                 final Engine.Result operationResult;
                 try {
                     switch (docWriteRequest.opType()) {


### PR DESCRIPTION
Today, we don't check if the replica request has the correct version during replica write operation.