### PR TITLE
Add term extraction support for MultiPhraseQuery

### DIFF
--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/QueryAnalyzer.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/QueryAnalyzer.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.MultiPhraseQuery;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SynonymQuery;
@@ -44,6 +45,7 @@ import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -66,6 +68,7 @@ public final class QueryAnalyzer {
         map.put(CommonTermsQuery.class, commonTermsQuery());
         map.put(BlendedTermQuery.class, blendedTermQuery());
         map.put(PhraseQuery.class, phraseQuery());
+        map.put(MultiPhraseQuery.class, multiPhraseQuery());
         map.put(SpanTermQuery.class, spanTermQuery());
         map.put(SpanNearQuery.class, spanNearQuery());
         map.put(SpanOrQuery.class, spanOrQuery());
@@ -194,6 +197,21 @@ public final class QueryAnalyzer {
                 }
             }
             return new Result(false, Collections.singleton(longestTerm));
+        };
+    }
+
+    static Function<Query, Result> multiPhraseQuery() {
+        return query -> {
+            Term[][] terms = ((MultiPhraseQuery) query).getTermArrays();
+            if (terms.length == 0) {
+                return new Result(true, Collections.emptySet());
+            }
+
+            Set<Term> bestTermArr = null;
+            for (Term[] termArr : terms) {
+                bestTermArr = selectTermListWithTheLongestShortestTerm(bestTermArr, new HashSet<>(Arrays.asList(termArr)));
+            }
+            return new Result(false, bestTermArr);
         };
     }
 

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryAnalyzerTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryAnalyzerTests.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.MultiPhraseQuery;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.SynonymQuery;
 import org.apache.lucene.search.TermInSetQuery;
@@ -91,6 +92,21 @@ public class QueryAnalyzerTests extends ESTestCase {
         assertThat(terms.size(), equalTo(1));
         assertThat(terms.get(0).field(), equalTo(phraseQuery.getTerms()[0].field()));
         assertThat(terms.get(0).bytes(), equalTo(phraseQuery.getTerms()[0].bytes()));
+    }
+
+    public void testExtractQueryMetadata_multiPhraseQuery() {
+        MultiPhraseQuery multiPhraseQuery = new MultiPhraseQuery.Builder()
+                .add(new Term("_field", "_long_term"))
+                .add(new Term[] {new Term("_field", "_long_term"), new Term("_field", "_term")})
+                .add(new Term[] {new Term("_field", "_long_term"), new Term("_field", "_very_long_term")})
+                .add(new Term[] {new Term("_field", "_very_long_term")})
+                .build();
+        Result result = analyze(multiPhraseQuery);
+        assertThat(result.verified, is(false));
+        List<Term> terms = new ArrayList<>(result.terms);
+        assertThat(terms.size(), equalTo(1));
+        assertThat(terms.get(0).field(), equalTo("_field"));
+        assertThat(terms.get(0).bytes().utf8ToString(), equalTo("_very_long_term"));
     }
 
     public void testExtractQueryMetadata_booleanQuery() {


### PR DESCRIPTION
The `MultiPhraseQuery` isn't exposed directly in the query dsl, but can endup being used if simple query parser is used or third party plugin uses this query.